### PR TITLE
fix(PURCHASE-2909): Show zendesk only for BNMO artworks exceeding price threshold

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkMeta.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkMeta.tsx
@@ -31,21 +31,18 @@ export class ArtworkMeta extends Component<ArtworkMetaProps> {
 
   renderImageMetaTags() {
     const { artwork } = this.props
-    const { meta_image, is_shareable } = artwork
-    // @ts-expect-error STRICT_NULL_CHECK
-    const imageURL = get(meta_image, img => img.resized.url)
+    const { metaImage, isShareable } = artwork
+    const imageURL = get(metaImage, img => img?.resized?.url)
 
-    if (is_shareable && imageURL) {
+    if (isShareable && imageURL) {
       return (
         <>
           <Meta property="twitter:card" content="summary_large_image" />
           <Meta property="og:image" content={imageURL} />
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
-          <Meta property="og:image:width" content={meta_image.resized.width} />
+          <Meta property="og:image:width" content={metaImage?.resized?.width} />
           <Meta
             property="og:image:height"
-            // @ts-expect-error STRICT_NULL_CHECK
-            content={meta_image.resized.height}
+            content={metaImage?.resized?.height}
           />
         </>
       )
@@ -136,26 +133,20 @@ export class ArtworkMeta extends Component<ArtworkMetaProps> {
 
   render() {
     const { artwork } = this.props
-    // @ts-expect-error STRICT_NULL_CHECK
-    const imageURL = get(artwork, a => a.meta_image.resized.url)
+    const imageURL = get(artwork, a => a.metaImage?.resized?.url)
 
     return (
       <>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
-        <Title>{artwork.meta.title}</Title>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
-        <Meta name="description" content={artwork.meta.description} />
+        <Title>{artwork.meta?.title}</Title>
+        <Meta name="description" content={artwork.meta?.description} />
         {imageURL && <Meta name="thumbnail" content={imageURL} />}
         <Link rel="canonical" href={`${sd.APP_URL}${artwork.href}`} />
         <Meta
           property="twitter:description"
-          // @ts-expect-error STRICT_NULL_CHECK
-          content={artwork.meta.long_description}
+          content={artwork.meta?.longDescription}
         />
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
-        <Meta property="og:title" content={artwork.meta.title} />
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
-        <Meta property="og:description" content={artwork.meta.description} />
+        <Meta property="og:title" content={artwork.meta?.title} />
+        <Meta property="og:description" content={artwork.meta?.description} />
         <Meta property="og:url" content={`${sd.APP_URL}${artwork.href}`} />
         <Meta
           property="og:type"
@@ -197,13 +188,12 @@ export const ArtworkMetaFragmentContainer = createFragmentContainer(
         partner {
           name
         }
-        image_rights: imageRights
-        isInAuction: isInAuction
+        isInAuction
         isAcquireable
         isInquireable
         isOfferable
-        is_shareable: isShareable
-        meta_image: image {
+        isShareable
+        metaImage: image {
           resized(
             width: 640
             height: 640
@@ -217,7 +207,7 @@ export const ArtworkMetaFragmentContainer = createFragmentContainer(
         meta {
           title
           description(limit: 155)
-          long_description: description(limit: 200)
+          longDescription: description(limit: 200)
         }
         context {
           __typename

--- a/src/v2/Apps/Artwork/Components/ArtworkMeta.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkMeta.tsx
@@ -8,18 +8,7 @@ import { get } from "v2/Utils/get"
 import { withSystemContext } from "v2/System"
 import { SeoDataForArtworkFragmentContainer as SeoDataForArtwork } from "./Seo/SeoDataForArtwork"
 import { ZendeskWrapper } from "v2/Components/ZendeskWrapper"
-
-const isExceededZendeskThreshold = ({ major: amount, currencyCode }) => {
-  return (
-    {
-      USD: 10000,
-      AUD: 13000,
-      EUR: 8000,
-      HKD: 77000,
-      GBP: 7000,
-    }[currencyCode] < amount
-  )
-}
+import { isExceededZendeskThreshold } from "v2/Utils/isExceededZendeskThreshold"
 
 interface ArtworkMetaProps {
   artwork: ArtworkMeta_artwork
@@ -112,8 +101,7 @@ export class ArtworkMeta extends Component<ArtworkMetaProps> {
 
   get isInquiryArtwork() {
     const { isAcquireable, isInquireable, isOfferable } = this.props.artwork
-    const isInquiryArtwork = isInquireable && !isAcquireable && !isOfferable
-    return isInquiryArtwork
+    return isInquireable && !isAcquireable && !isOfferable
   }
 
   renderZendeskScript() {
@@ -124,14 +112,18 @@ export class ArtworkMeta extends Component<ArtworkMetaProps> {
       return
     }
 
+    const listPrice = this.props.artwork.listPrice
     const price =
-      this.props.artwork.listPrice?.__typename === "Money"
-        ? this.props.artwork.listPrice
-        : this.props.artwork.listPrice?.__typename === "PriceRange"
-        ? this.props.artwork.listPrice.maxPrice
+      listPrice?.__typename === "Money"
+        ? listPrice
+        : listPrice?.__typename === "PriceRange"
+        ? listPrice.maxPrice
         : null
 
-    if (!price || !isExceededZendeskThreshold(price)) {
+    if (
+      !price ||
+      !isExceededZendeskThreshold(price.major, price.currencyCode)
+    ) {
       return
     }
 

--- a/src/v2/Apps/Order/OrderApp.tsx
+++ b/src/v2/Apps/Order/OrderApp.tsx
@@ -19,7 +19,8 @@ import { data as sd } from "sharify"
 import { ZendeskWrapper } from "v2/Components/ZendeskWrapper"
 import { HorizontalPadding } from "../Components/HorizontalPadding"
 import { AppContainer } from "../Components/AppContainer"
-import { LegacyArtworkDllContainer } from "../../Utils/LegacyArtworkDllContainer"
+import { LegacyArtworkDllContainer } from "v2/Utils/LegacyArtworkDllContainer"
+import { isExceededZendeskThreshold } from "v2/Utils/isExceededZendeskThreshold"
 
 export interface OrderAppProps extends RouterState {
   params: {
@@ -90,6 +91,12 @@ class OrderApp extends React.Component<OrderAppProps, {}> {
   }
 
   renderZendeskScript() {
+    const { itemsTotalCents, currencyCode } = this.props.order
+
+    const price = itemsTotalCents! / 100
+
+    if (!price || !isExceededZendeskThreshold(price, currencyCode)) return
+
     if (typeof window !== "undefined" && window.zEmbed) return
 
     return <ZendeskWrapper zdKey={sd.ZENDESK_KEY} />
@@ -179,6 +186,8 @@ const SafeAreaContainer = styled(Box)`
 graphql`
   fragment OrderApp_order on CommerceOrder {
     mode
+    currencyCode
+    itemsTotalCents
     lineItems {
       edges {
         node {

--- a/src/v2/Apps/__tests__/Fixtures/Order.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Order.ts
@@ -187,6 +187,7 @@ const OrderArtworkFulfillmentsNode = {
 
 export const UntouchedOrder = {
   buyerTotal: "$12,000",
+  itemsTotalCents: 1200000,
   code: "abcdefg",
   createdAt: "2019-12-19T06:01:17.171Z",
   creditCard: null,

--- a/src/v2/Utils/isExceededZendeskThreshold.ts
+++ b/src/v2/Utils/isExceededZendeskThreshold.ts
@@ -1,0 +1,11 @@
+export const isExceededZendeskThreshold = (amount, currencyCode) => {
+  return (
+    {
+      USD: 10000,
+      AUD: 13000,
+      EUR: 8000,
+      HKD: 77000,
+      GBP: 7000,
+    }[currencyCode] < amount
+  )
+}

--- a/src/v2/__generated__/ArtworkMeta_artwork.graphql.ts
+++ b/src/v2/__generated__/ArtworkMeta_artwork.graphql.ts
@@ -9,16 +9,30 @@ export type ArtworkMeta_artwork = {
     readonly date: string | null;
     readonly artistNames: string | null;
     readonly sale_message: string | null;
+    readonly listPrice: ({
+        readonly __typename: "Money";
+        readonly currencyCode: string;
+        readonly major: number;
+    } | {
+        readonly __typename: "PriceRange";
+        readonly maxPrice: {
+            readonly currencyCode: string;
+            readonly major: number;
+        } | null;
+    } | {
+        /*This will never be '%other', but we need some
+        value in case none of the concrete values match.*/
+        readonly __typename: "%other";
+    }) | null;
     readonly partner: {
         readonly name: string | null;
     } | null;
-    readonly image_rights: string | null;
-    readonly is_in_auction: boolean | null;
+    readonly isInAuction: boolean | null;
     readonly isAcquireable: boolean | null;
     readonly isInquireable: boolean | null;
     readonly isOfferable: boolean | null;
-    readonly is_shareable: boolean | null;
-    readonly meta_image: {
+    readonly isShareable: boolean | null;
+    readonly metaImage: {
         readonly resized: {
             readonly width: number | null;
             readonly height: number | null;
@@ -28,7 +42,7 @@ export type ArtworkMeta_artwork = {
     readonly meta: {
         readonly title: string | null;
         readonly description: string | null;
-        readonly long_description: string | null;
+        readonly longDescription: string | null;
     } | null;
     readonly context: ({
         readonly __typename: "Fair";
@@ -52,6 +66,29 @@ export type ArtworkMeta_artwork$key = {
 
 const node: ReaderFragment = (function(){
 var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "currencyCode",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "major",
+    "storageKey": null
+  }
+],
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -102,24 +139,50 @@ return {
     {
       "alias": null,
       "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "listPrice",
+      "plural": false,
+      "selections": [
+        (v0/*: any*/),
+        {
+          "kind": "InlineFragment",
+          "selections": (v1/*: any*/),
+          "type": "Money"
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Money",
+              "kind": "LinkedField",
+              "name": "maxPrice",
+              "plural": false,
+              "selections": (v1/*: any*/),
+              "storageKey": null
+            }
+          ],
+          "type": "PriceRange"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "Partner",
       "kind": "LinkedField",
       "name": "partner",
       "plural": false,
       "selections": [
-        (v0/*: any*/)
+        (v2/*: any*/)
       ],
       "storageKey": null
     },
     {
-      "alias": "image_rights",
-      "args": null,
-      "kind": "ScalarField",
-      "name": "imageRights",
-      "storageKey": null
-    },
-    {
-      "alias": "is_in_auction",
+      "alias": null,
       "args": null,
       "kind": "ScalarField",
       "name": "isInAuction",
@@ -147,14 +210,14 @@ return {
       "storageKey": null
     },
     {
-      "alias": "is_shareable",
+      "alias": null,
       "args": null,
       "kind": "ScalarField",
       "name": "isShareable",
       "storageKey": null
     },
     {
-      "alias": "meta_image",
+      "alias": "metaImage",
       "args": null,
       "concreteType": "Image",
       "kind": "LinkedField",
@@ -245,7 +308,7 @@ return {
           "storageKey": "description(limit:155)"
         },
         {
-          "alias": "long_description",
+          "alias": "longDescription",
           "args": [
             {
               "kind": "Literal",
@@ -268,13 +331,7 @@ return {
       "name": "context",
       "plural": false,
       "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "__typename",
-          "storageKey": null
-        },
+        (v0/*: any*/),
         {
           "kind": "InlineFragment",
           "selections": [
@@ -285,7 +342,7 @@ return {
               "name": "slug",
               "storageKey": null
             },
-            (v0/*: any*/)
+            (v2/*: any*/)
           ],
           "type": "Fair"
         }
@@ -301,5 +358,5 @@ return {
   "type": "Artwork"
 };
 })();
-(node as any).hash = '9a762b2eee90cdd725d9494cef0fe4c0';
+(node as any).hash = '31f3bd396402fb7d7c0f370fe4b9bf2d';
 export default node;

--- a/src/v2/__generated__/OrderApp_order.graphql.ts
+++ b/src/v2/__generated__/OrderApp_order.graphql.ts
@@ -6,6 +6,8 @@ import { FragmentRefs } from "relay-runtime";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type OrderApp_order = {
     readonly mode: CommerceOrderModeEnum | null;
+    readonly currencyCode: string;
+    readonly itemsTotalCents: number | null;
     readonly lineItems: {
         readonly edges: ReadonlyArray<{
             readonly node: {
@@ -39,6 +41,20 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "ScalarField",
       "name": "mode",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "currencyCode",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "itemsTotalCents",
       "storageKey": null
     },
     {
@@ -116,5 +132,5 @@ const node: ReaderFragment = {
   ],
   "type": "CommerceOrder"
 };
-(node as any).hash = '22f0547ca97d2ba0d33dbc5db1aa4c77';
+(node as any).hash = '44860aea11d75dca20feda64a964481d';
 export default node;

--- a/src/v2/__generated__/artworkRoutes_ArtworkQuery.graphql.ts
+++ b/src/v2/__generated__/artworkRoutes_ArtworkQuery.graphql.ts
@@ -543,17 +543,29 @@ fragment ArtworkMeta_artwork on Artwork {
   date
   artistNames
   sale_message: saleMessage
+  listPrice {
+    __typename
+    ... on Money {
+      currencyCode
+      major
+    }
+    ... on PriceRange {
+      maxPrice {
+        currencyCode
+        major
+      }
+    }
+  }
   partner {
     name
     id
   }
-  image_rights: imageRights
-  is_in_auction: isInAuction
+  isInAuction
   isAcquireable
   isInquireable
   isOfferable
-  is_shareable: isShareable
-  meta_image: image {
+  isShareable
+  metaImage: image {
     resized(width: 640, height: 640, version: ["large", "medium", "tall"]) {
       width
       height
@@ -563,7 +575,7 @@ fragment ArtworkMeta_artwork on Artwork {
   meta {
     title
     description(limit: 155)
-    long_description: description(limit: 200)
+    longDescription: description(limit: 200)
   }
   context {
     __typename
@@ -1329,14 +1341,14 @@ v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "major",
+  "name": "currencyCode",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "currencyCode",
+  "name": "major",
   "storageKey": null
 },
 v10 = {
@@ -1934,21 +1946,57 @@ v52 = {
   "name": "type",
   "storageKey": null
 },
-v53 = {
+v53 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Literal",
+        "name": "height",
+        "value": 640
+      },
+      {
+        "kind": "Literal",
+        "name": "version",
+        "value": [
+          "large",
+          "medium",
+          "tall"
+        ]
+      },
+      {
+        "kind": "Literal",
+        "name": "width",
+        "value": 640
+      }
+    ],
+    "concreteType": "ResizedImageUrl",
+    "kind": "LinkedField",
+    "name": "resized",
+    "plural": false,
+    "selections": [
+      (v14/*: any*/),
+      (v15/*: any*/),
+      (v36/*: any*/)
+    ],
+    "storageKey": "resized(height:640,version:[\"large\",\"medium\",\"tall\"],width:640)"
+  }
+],
+v54 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v54 = {
+v55 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "category",
   "storageKey": null
 },
-v55 = {
+v56 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
@@ -1973,31 +2021,31 @@ v55 = {
   ],
   "storageKey": null
 },
-v56 = {
+v57 = {
   "alias": "cultural_maker",
   "args": null,
   "kind": "ScalarField",
   "name": "culturalMaker",
   "storageKey": null
 },
-v57 = {
+v58 = {
   "alias": "is_biddable",
   "args": null,
   "kind": "ScalarField",
   "name": "isBiddable",
   "storageKey": null
 },
-v58 = {
+v59 = {
   "alias": "edition_of",
   "args": null,
   "kind": "ScalarField",
   "name": "editionOf",
   "storageKey": null
 },
-v59 = [
+v60 = [
   (v7/*: any*/)
 ],
-v60 = {
+v61 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -2015,24 +2063,24 @@ v60 = {
   ],
   "storageKey": null
 },
-v61 = {
+v62 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cents",
   "storageKey": null
 },
-v62 = {
+v63 = {
   "alias": "is_inquireable",
   "args": null,
   "kind": "ScalarField",
   "name": "isInquireable",
   "storageKey": null
 },
-v63 = [
+v64 = [
   (v44/*: any*/)
 ],
-v64 = [
+v65 = [
   {
     "alias": null,
     "args": null,
@@ -2048,19 +2096,19 @@ v64 = [
     "storageKey": null
   }
 ],
-v65 = {
+v66 = {
   "kind": "Literal",
   "name": "width",
   "value": 200
 },
-v66 = {
+v67 = {
   "alias": "is_saved",
   "args": null,
   "kind": "ScalarField",
   "name": "isSaved",
   "storageKey": null
 },
-v67 = [
+v68 = [
   {
     "kind": "Literal",
     "name": "height",
@@ -2077,22 +2125,22 @@ v67 = [
   },
   (v35/*: any*/)
 ],
-v68 = [
+v69 = [
   (v14/*: any*/),
   (v15/*: any*/),
   (v12/*: any*/),
   (v13/*: any*/)
 ],
-v69 = [
+v70 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v70 = {
+v71 = {
   "alias": null,
-  "args": (v69/*: any*/),
+  "args": (v70/*: any*/),
   "concreteType": "Artist",
   "kind": "LinkedField",
   "name": "artists",
@@ -2104,16 +2152,16 @@ v70 = {
   ],
   "storageKey": "artists(shallow:true)"
 },
-v71 = {
+v72 = {
   "alias": "collecting_institution",
   "args": null,
   "kind": "ScalarField",
   "name": "collectingInstitution",
   "storageKey": null
 },
-v72 = {
+v73 = {
   "alias": null,
-  "args": (v69/*: any*/),
+  "args": (v70/*: any*/),
   "concreteType": "Partner",
   "kind": "LinkedField",
   "name": "partner",
@@ -2126,7 +2174,7 @@ v72 = {
   ],
   "storageKey": "partner(shallow:true)"
 },
-v73 = {
+v74 = {
   "alias": null,
   "args": null,
   "concreteType": "Sale",
@@ -2150,7 +2198,7 @@ v73 = {
   ],
   "storageKey": null
 },
-v74 = {
+v75 = {
   "alias": "sale_artwork",
   "args": null,
   "concreteType": "SaleArtwork",
@@ -2158,7 +2206,7 @@ v74 = {
   "name": "saleArtwork",
   "plural": false,
   "selections": [
-    (v60/*: any*/),
+    (v61/*: any*/),
     {
       "alias": "highest_bid",
       "args": null,
@@ -2166,7 +2214,7 @@ v74 = {
       "kind": "LinkedField",
       "name": "highestBid",
       "plural": false,
-      "selections": (v59/*: any*/),
+      "selections": (v60/*: any*/),
       "storageKey": null
     },
     {
@@ -2176,14 +2224,14 @@ v74 = {
       "kind": "LinkedField",
       "name": "openingBid",
       "plural": false,
-      "selections": (v59/*: any*/),
+      "selections": (v60/*: any*/),
       "storageKey": null
     },
     (v11/*: any*/)
   ],
   "storageKey": null
 },
-v75 = {
+v76 = {
   "alias": null,
   "args": [
     {
@@ -2256,7 +2304,7 @@ v75 = {
               ],
               "storageKey": null
             },
-            (v53/*: any*/),
+            (v54/*: any*/),
             {
               "alias": "image_title",
               "args": null,
@@ -2265,17 +2313,17 @@ v75 = {
               "storageKey": null
             },
             (v50/*: any*/),
-            (v66/*: any*/),
+            (v67/*: any*/),
             (v49/*: any*/),
             (v51/*: any*/),
-            (v56/*: any*/),
-            (v70/*: any*/),
+            (v57/*: any*/),
             (v71/*: any*/),
             (v72/*: any*/),
             (v73/*: any*/),
             (v74/*: any*/),
-            (v62/*: any*/),
-            (v57/*: any*/)
+            (v75/*: any*/),
+            (v63/*: any*/),
+            (v58/*: any*/)
           ],
           "storageKey": null
         },
@@ -2286,7 +2334,7 @@ v75 = {
   ],
   "storageKey": "artworksConnection(first:8)"
 },
-v76 = [
+v77 = [
   (v42/*: any*/)
 ];
 return {
@@ -2374,7 +2422,7 @@ return {
                     "args": null,
                     "concreteType": "Money",
                     "kind": "LinkedField",
-                    "name": "minPrice",
+                    "name": "maxPrice",
                     "plural": false,
                     "selections": [
                       (v8/*: any*/),
@@ -2388,9 +2436,10 @@ return {
                     "args": null,
                     "concreteType": "Money",
                     "kind": "LinkedField",
-                    "name": "maxPrice",
+                    "name": "minPrice",
                     "plural": false,
                     "selections": [
+                      (v9/*: any*/),
                       (v8/*: any*/),
                       (v10/*: any*/)
                     ],
@@ -2919,10 +2968,10 @@ return {
             "storageKey": null
           },
           {
-            "alias": "image_rights",
+            "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "imageRights",
+            "name": "isInAuction",
             "storageKey": null
           },
           {
@@ -2947,55 +2996,20 @@ return {
             "storageKey": null
           },
           {
-            "alias": "is_shareable",
+            "alias": null,
             "args": null,
             "kind": "ScalarField",
             "name": "isShareable",
             "storageKey": null
           },
           {
-            "alias": "meta_image",
+            "alias": "metaImage",
             "args": null,
             "concreteType": "Image",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "height",
-                    "value": 640
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": [
-                      "large",
-                      "medium",
-                      "tall"
-                    ]
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "width",
-                    "value": 640
-                  }
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": [
-                  (v14/*: any*/),
-                  (v15/*: any*/),
-                  (v36/*: any*/)
-                ],
-                "storageKey": "resized(height:640,version:[\"large\",\"medium\",\"tall\"],width:640)"
-              }
-            ],
+            "selections": (v53/*: any*/),
             "storageKey": null
           },
           {
@@ -3006,7 +3020,7 @@ return {
             "name": "meta",
             "plural": false,
             "selections": [
-              (v53/*: any*/),
+              (v54/*: any*/),
               {
                 "alias": null,
                 "args": [
@@ -3021,7 +3035,7 @@ return {
                 "storageKey": "description(limit:155)"
               },
               {
-                "alias": "long_description",
+                "alias": "longDescription",
                 "args": [
                   {
                     "kind": "Literal",
@@ -3127,10 +3141,20 @@ return {
             "name": "isPriceRange",
             "storageKey": null
           },
-          (v54/*: any*/),
+          {
+            "alias": "meta_image",
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": (v53/*: any*/),
+            "storageKey": null
+          },
           (v55/*: any*/),
           (v56/*: any*/),
           (v57/*: any*/),
+          (v58/*: any*/),
           {
             "alias": "edition_sets",
             "args": null,
@@ -3145,8 +3169,8 @@ return {
               (v4/*: any*/),
               (v5/*: any*/),
               (v51/*: any*/),
-              (v55/*: any*/),
-              (v58/*: any*/)
+              (v56/*: any*/),
+              (v59/*: any*/)
             ],
             "storageKey": null
           },
@@ -3201,10 +3225,10 @@ return {
                 "kind": "LinkedField",
                 "name": "currentBid",
                 "plural": false,
-                "selections": (v59/*: any*/),
+                "selections": (v60/*: any*/),
                 "storageKey": null
               },
-              (v60/*: any*/),
+              (v61/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -3213,7 +3237,7 @@ return {
                 "name": "increments",
                 "plural": true,
                 "selections": [
-                  (v61/*: any*/),
+                  (v62/*: any*/),
                   (v7/*: any*/)
                 ],
                 "storageKey": null
@@ -3221,7 +3245,7 @@ return {
             ],
             "storageKey": null
           },
-          (v53/*: any*/),
+          (v54/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -3229,7 +3253,7 @@ return {
             "name": "medium",
             "storageKey": null
           },
-          (v58/*: any*/),
+          (v59/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -3299,7 +3323,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v7/*: any*/),
-                      (v61/*: any*/)
+                      (v62/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -3317,7 +3341,7 @@ return {
             "name": "isForSale",
             "storageKey": null
           },
-          (v62/*: any*/),
+          (v63/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -3348,14 +3372,14 @@ return {
           },
           {
             "alias": null,
-            "args": (v63/*: any*/),
+            "args": (v64/*: any*/),
             "kind": "ScalarField",
             "name": "description",
             "storageKey": "description(format:\"HTML\")"
           },
           {
             "alias": "additional_information",
-            "args": (v63/*: any*/),
+            "args": (v64/*: any*/),
             "kind": "ScalarField",
             "name": "additionalInformation",
             "storageKey": "additionalInformation(format:\"HTML\")"
@@ -3382,6 +3406,13 @@ return {
             "storageKey": null
           },
           {
+            "alias": "image_rights",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "imageRights",
+            "storageKey": null
+          },
+          {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
@@ -3395,7 +3426,7 @@ return {
             "kind": "LinkedField",
             "name": "framed",
             "plural": false,
-            "selections": (v64/*: any*/),
+            "selections": (v65/*: any*/),
             "storageKey": null
           },
           {
@@ -3405,7 +3436,7 @@ return {
             "kind": "LinkedField",
             "name": "signatureInfo",
             "plural": false,
-            "selections": (v64/*: any*/),
+            "selections": (v65/*: any*/),
             "storageKey": null
           },
           {
@@ -3415,7 +3446,7 @@ return {
             "kind": "LinkedField",
             "name": "conditionDescription",
             "plural": false,
-            "selections": (v64/*: any*/),
+            "selections": (v65/*: any*/),
             "storageKey": null
           },
           {
@@ -3425,7 +3456,7 @@ return {
             "kind": "LinkedField",
             "name": "certificateOfAuthenticity",
             "plural": false,
-            "selections": (v64/*: any*/),
+            "selections": (v65/*: any*/),
             "storageKey": null
           },
           {
@@ -3502,7 +3533,7 @@ return {
                         "name": "height",
                         "value": 150
                       },
-                      (v65/*: any*/)
+                      (v66/*: any*/)
                     ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
@@ -3528,27 +3559,27 @@ return {
           },
           {
             "alias": null,
-            "args": (v63/*: any*/),
+            "args": (v64/*: any*/),
             "kind": "ScalarField",
             "name": "literature",
             "storageKey": "literature(format:\"HTML\")"
           },
           {
             "alias": "exhibition_history",
-            "args": (v63/*: any*/),
+            "args": (v64/*: any*/),
             "kind": "ScalarField",
             "name": "exhibitionHistory",
             "storageKey": "exhibitionHistory(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v63/*: any*/),
+            "args": (v64/*: any*/),
             "kind": "ScalarField",
             "name": "provenance",
             "storageKey": "provenance(format:\"HTML\")"
           },
           (v11/*: any*/),
-          (v66/*: any*/),
+          (v67/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -3583,22 +3614,22 @@ return {
               },
               {
                 "alias": "fallback",
-                "args": (v67/*: any*/),
+                "args": (v68/*: any*/),
                 "concreteType": "CroppedImageUrl",
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v68/*: any*/),
+                "selections": (v69/*: any*/),
                 "storageKey": "cropped(height:800,version:[\"normalized\",\"larger\",\"large\"],width:800)"
               },
               {
                 "alias": null,
-                "args": (v67/*: any*/),
+                "args": (v68/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v68/*: any*/),
+                "selections": (v69/*: any*/),
                 "storageKey": "resized(height:800,version:[\"normalized\",\"larger\",\"large\"],width:800)"
               },
               (v3/*: any*/),
@@ -3736,7 +3767,7 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": (v67/*: any*/),
+                "args": (v68/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
@@ -3793,7 +3824,7 @@ return {
             "plural": true,
             "selections": [
               (v6/*: any*/),
-              (v53/*: any*/),
+              (v54/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -3808,7 +3839,7 @@ return {
                 "name": "ctaHref",
                 "storageKey": null
               },
-              (v75/*: any*/)
+              (v76/*: any*/)
             ],
             "storageKey": null
           },
@@ -3835,14 +3866,14 @@ return {
             "plural": false,
             "selections": [
               (v22/*: any*/),
-              (v75/*: any*/),
+              (v76/*: any*/),
               (v11/*: any*/)
             ],
             "storageKey": null
           },
           {
             "alias": null,
-            "args": (v76/*: any*/),
+            "args": (v77/*: any*/),
             "concreteType": "ArtistSeriesConnection",
             "kind": "LinkedField",
             "name": "artistSeriesConnection",
@@ -3914,7 +3945,7 @@ return {
                                       {
                                         "alias": null,
                                         "args": [
-                                          (v65/*: any*/)
+                                          (v66/*: any*/)
                                         ],
                                         "concreteType": "ResizedImageUrl",
                                         "kind": "LinkedField",
@@ -3941,20 +3972,20 @@ return {
                                     "name": "imageTitle",
                                     "storageKey": null
                                   },
-                                  (v53/*: any*/),
+                                  (v54/*: any*/),
                                   (v23/*: any*/),
-                                  (v66/*: any*/),
+                                  (v67/*: any*/),
                                   (v49/*: any*/),
                                   (v51/*: any*/),
-                                  (v56/*: any*/),
-                                  (v70/*: any*/),
+                                  (v57/*: any*/),
                                   (v71/*: any*/),
                                   (v72/*: any*/),
                                   (v73/*: any*/),
                                   (v74/*: any*/),
-                                  (v62/*: any*/),
+                                  (v75/*: any*/),
+                                  (v63/*: any*/),
                                   (v11/*: any*/),
-                                  (v57/*: any*/)
+                                  (v58/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -3976,7 +4007,7 @@ return {
           },
           {
             "alias": "seriesArtist",
-            "args": (v69/*: any*/),
+            "args": (v70/*: any*/),
             "concreteType": "Artist",
             "kind": "LinkedField",
             "name": "artist",
@@ -4013,7 +4044,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v3/*: any*/),
-                          (v53/*: any*/),
+                          (v54/*: any*/),
                           (v2/*: any*/),
                           {
                             "alias": null,
@@ -4055,7 +4086,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "cropped",
                                 "plural": false,
-                                "selections": (v68/*: any*/),
+                                "selections": (v69/*: any*/),
                                 "storageKey": "cropped(height:244,width:325)"
                               }
                             ],
@@ -4076,7 +4107,7 @@ return {
           },
           {
             "alias": "seriesForCounts",
-            "args": (v76/*: any*/),
+            "args": (v77/*: any*/),
             "concreteType": "ArtistSeriesConnection",
             "kind": "LinkedField",
             "name": "artistSeriesConnection",
@@ -4144,7 +4175,7 @@ return {
                     "name": "dimension",
                     "storageKey": null
                   },
-                  (v54/*: any*/)
+                  (v55/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -4239,7 +4270,7 @@ return {
     "metadata": {},
     "name": "artworkRoutes_ArtworkQuery",
     "operationKind": "query",
-    "text": "query artworkRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...ArtworkApp_artwork\n    id\n  }\n  me {\n    ...ArtworkApp_me\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML, partnerBio: false) {\n    credit\n    partnerID\n    text\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  slug\n  href\n  image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistSeriesArtworkRail_artwork on Artwork {\n  internalID\n  slug\n  artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        slug\n        internalID\n        filterArtworksConnection(sort: \"-decayed_merch\", first: 20) {\n          edges {\n            node {\n              slug\n              internalID\n              ...ShelfArtwork_artwork\n              id\n            }\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  featured\n  internalID\n  artworksCountMessage\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  internalID\n  id\n  slug\n  title\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkSharePanel_artwork\n  ...ViewInRoom_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  slug\n  internalID\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  availability\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  is_in_auction: isInAuction\n  sale {\n    internalID\n    slug\n    id\n  }\n  artists {\n    id\n    slug\n    ...ArtistInfo_artist\n  }\n  artist {\n    ...ArtistInfo_artist\n    id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork\n  ...ArtworkArtistSeries_artwork\n  ...PricingContext_artwork\n}\n\nfragment ArtworkApp_me on Me {\n  ...ArtworkSidebar_me\n}\n\nfragment ArtworkArtistSeries_artwork on Artwork {\n  ...ArtistSeriesArtworkRail_artwork\n  internalID\n  slug\n  seriesArtist: artist(shallow: true) {\n    artistSeriesConnection(first: 50) {\n      edges {\n        node {\n          internalID\n        }\n      }\n    }\n    ...ArtistSeriesRail_artist\n    id\n  }\n  seriesForCounts: artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        artworksCount\n      }\n    }\n  }\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale {\n    isAuction\n    isBenefit\n    isGalleryAuction\n    coverImage {\n      cropped(width: 30, height: 30, version: \"square\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  context {\n    __typename\n    ... on Sale {\n      name\n      href\n    }\n    ... on Fair {\n      name\n      href\n      profile {\n        icon {\n          cropped(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n            width\n            height\n          }\n        }\n        id\n      }\n    }\n    ... on Show {\n      name\n      href\n      status\n      thumbnail: coverImage {\n        cropped(width: 30, height: 30, version: \"square\") {\n          src\n          srcSet\n          width\n          height\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        cropped(width: 45, height: 45) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    publishedAt(format: \"MMM Do, YYYY\")\n    thumbnailImage {\n      cropped(width: 200, height: 150) {\n        src\n        srcSet\n      }\n    }\n    thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetailsMediumModal_artwork on Artwork {\n  mediumType {\n    name\n    longDescription\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  images {\n    internalID\n    isZoomable\n    ...DeepZoom_image\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  images {\n    internalID\n    isZoomable\n    ...DeepZoom_image\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkActions_artwork\n  ...ArtworkImageBrowserSmall_artwork\n  ...ArtworkImageBrowserLarge_artwork\n  internalID\n  images {\n    internalID\n    isDefault\n  }\n}\n\nfragment ArtworkLightbox_artwork on Artwork {\n  formattedMetadata\n  images {\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    fallback: cropped(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  internalID\n  date\n  artistNames\n  sale_message: saleMessage\n  partner {\n    name\n    id\n  }\n  image_rights: imageRights\n  is_in_auction: isInAuction\n  isAcquireable\n  isInquireable\n  isOfferable\n  is_shareable: isShareable\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    long_description: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on Fair {\n      slug\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...SeoDataForArtwork_artwork\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  slug\n  artist {\n    href\n    related {\n      artistsConnection(kind: MAIN, first: 4, after: \"\") {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            ...ArtistCard_artist\n            id\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    formattedNationalityAndBirthday\n    href\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    requireIdentityVerification\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_me on Me {\n  identityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attributionClass {\n    shortDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    isBenefit\n    partner {\n      name\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  ...BuyerGuarantee_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment ArtworkSidebar_me on Me {\n  ...ArtworkSidebarBidAction_me\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment BuyerGuarantee_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  formattedNationalityAndBirthday\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherWorks_artwork on Artwork {\n  contextGrids {\n    __typename\n    title\n    ctaTitle\n    ctaHref\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  ...RelatedWorksArtworkGrid_artwork\n  ...ArtistSeriesArtworkRail_artwork\n  slug\n  internalID\n  sale {\n    is_closed: isClosed\n    id\n  }\n  context {\n    __typename\n    ... on Node {\n      id\n    }\n  }\n  seriesArtist: artist(shallow: true) {\n    ...ArtistSeriesRail_artist\n    id\n  }\n}\n\nfragment PricingContext_artwork on Artwork {\n  listPrice {\n    __typename\n    ... on PriceRange {\n      maxPrice {\n        minor\n      }\n      minPrice {\n        minor\n      }\n    }\n    ... on Money {\n      minor\n    }\n  }\n  artists {\n    slug\n    id\n  }\n  category\n  pricingContext {\n    appliedFiltersDisplay\n    appliedFilters {\n      dimension\n      category\n    }\n    bins {\n      maxPrice\n      maxPriceCents\n      minPrice\n      minPriceCents\n      numArtworks\n    }\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      minPrice {\n        major\n        currencyCode\n      }\n      maxPrice {\n        major\n      }\n    }\n    ... on Money {\n      major\n      currencyCode\n    }\n  }\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
+    "text": "query artworkRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...ArtworkApp_artwork\n    id\n  }\n  me {\n    ...ArtworkApp_me\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML, partnerBio: false) {\n    credit\n    partnerID\n    text\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  slug\n  href\n  image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistSeriesArtworkRail_artwork on Artwork {\n  internalID\n  slug\n  artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        slug\n        internalID\n        filterArtworksConnection(sort: \"-decayed_merch\", first: 20) {\n          edges {\n            node {\n              slug\n              internalID\n              ...ShelfArtwork_artwork\n              id\n            }\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  featured\n  internalID\n  artworksCountMessage\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  internalID\n  id\n  slug\n  title\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkSharePanel_artwork\n  ...ViewInRoom_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  slug\n  internalID\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  availability\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  is_in_auction: isInAuction\n  sale {\n    internalID\n    slug\n    id\n  }\n  artists {\n    id\n    slug\n    ...ArtistInfo_artist\n  }\n  artist {\n    ...ArtistInfo_artist\n    id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork\n  ...ArtworkArtistSeries_artwork\n  ...PricingContext_artwork\n}\n\nfragment ArtworkApp_me on Me {\n  ...ArtworkSidebar_me\n}\n\nfragment ArtworkArtistSeries_artwork on Artwork {\n  ...ArtistSeriesArtworkRail_artwork\n  internalID\n  slug\n  seriesArtist: artist(shallow: true) {\n    artistSeriesConnection(first: 50) {\n      edges {\n        node {\n          internalID\n        }\n      }\n    }\n    ...ArtistSeriesRail_artist\n    id\n  }\n  seriesForCounts: artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        artworksCount\n      }\n    }\n  }\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale {\n    isAuction\n    isBenefit\n    isGalleryAuction\n    coverImage {\n      cropped(width: 30, height: 30, version: \"square\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  context {\n    __typename\n    ... on Sale {\n      name\n      href\n    }\n    ... on Fair {\n      name\n      href\n      profile {\n        icon {\n          cropped(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n            width\n            height\n          }\n        }\n        id\n      }\n    }\n    ... on Show {\n      name\n      href\n      status\n      thumbnail: coverImage {\n        cropped(width: 30, height: 30, version: \"square\") {\n          src\n          srcSet\n          width\n          height\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        cropped(width: 45, height: 45) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    publishedAt(format: \"MMM Do, YYYY\")\n    thumbnailImage {\n      cropped(width: 200, height: 150) {\n        src\n        srcSet\n      }\n    }\n    thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetailsMediumModal_artwork on Artwork {\n  mediumType {\n    name\n    longDescription\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  images {\n    internalID\n    isZoomable\n    ...DeepZoom_image\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  images {\n    internalID\n    isZoomable\n    ...DeepZoom_image\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkActions_artwork\n  ...ArtworkImageBrowserSmall_artwork\n  ...ArtworkImageBrowserLarge_artwork\n  internalID\n  images {\n    internalID\n    isDefault\n  }\n}\n\nfragment ArtworkLightbox_artwork on Artwork {\n  formattedMetadata\n  images {\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    fallback: cropped(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  internalID\n  date\n  artistNames\n  sale_message: saleMessage\n  listPrice {\n    __typename\n    ... on Money {\n      currencyCode\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        currencyCode\n        major\n      }\n    }\n  }\n  partner {\n    name\n    id\n  }\n  isInAuction\n  isAcquireable\n  isInquireable\n  isOfferable\n  isShareable\n  metaImage: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    longDescription: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on Fair {\n      slug\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...SeoDataForArtwork_artwork\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  slug\n  artist {\n    href\n    related {\n      artistsConnection(kind: MAIN, first: 4, after: \"\") {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            ...ArtistCard_artist\n            id\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    formattedNationalityAndBirthday\n    href\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    requireIdentityVerification\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_me on Me {\n  identityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attributionClass {\n    shortDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    isBenefit\n    partner {\n      name\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  ...BuyerGuarantee_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment ArtworkSidebar_me on Me {\n  ...ArtworkSidebarBidAction_me\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment BuyerGuarantee_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  formattedNationalityAndBirthday\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherWorks_artwork on Artwork {\n  contextGrids {\n    __typename\n    title\n    ctaTitle\n    ctaHref\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  ...RelatedWorksArtworkGrid_artwork\n  ...ArtistSeriesArtworkRail_artwork\n  slug\n  internalID\n  sale {\n    is_closed: isClosed\n    id\n  }\n  context {\n    __typename\n    ... on Node {\n      id\n    }\n  }\n  seriesArtist: artist(shallow: true) {\n    ...ArtistSeriesRail_artist\n    id\n  }\n}\n\nfragment PricingContext_artwork on Artwork {\n  listPrice {\n    __typename\n    ... on PriceRange {\n      maxPrice {\n        minor\n      }\n      minPrice {\n        minor\n      }\n    }\n    ... on Money {\n      minor\n    }\n  }\n  artists {\n    slug\n    id\n  }\n  category\n  pricingContext {\n    appliedFiltersDisplay\n    appliedFilters {\n      dimension\n      category\n    }\n    bins {\n      maxPrice\n      maxPriceCents\n      minPrice\n      minPriceCents\n      numArtworks\n    }\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      minPrice {\n        major\n        currencyCode\n      }\n      maxPrice {\n        major\n      }\n    }\n    ... on Money {\n      major\n      currencyCode\n    }\n  }\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/orderRoutes_OrderQuery.graphql.ts
+++ b/src/v2/__generated__/orderRoutes_OrderQuery.graphql.ts
@@ -42,6 +42,8 @@ export type orderRoutes_OrderQueryResponse = {
         readonly creditCard: {
             readonly internalID: string;
         } | null;
+        readonly currencyCode: string;
+        readonly itemsTotalCents: number | null;
         readonly myLastOffer?: {
             readonly internalID: string;
             readonly createdAt: string;
@@ -93,6 +95,8 @@ export type orderRoutes_OrderQueryRawResponse = {
             readonly internalID: string;
             readonly id: string | null;
         }) | null;
+        readonly currencyCode: string;
+        readonly itemsTotalCents: number | null;
         readonly id: string | null;
         readonly myLastOffer: ({
             readonly internalID: string;
@@ -140,6 +144,8 @@ export type orderRoutes_OrderQueryRawResponse = {
             readonly internalID: string;
             readonly id: string | null;
         }) | null;
+        readonly currencyCode: string;
+        readonly itemsTotalCents: number | null;
         readonly id: string | null;
     }) | null;
 };
@@ -207,6 +213,8 @@ query orderRoutes_OrderQuery(
       internalID
       id
     }
+    currencyCode
+    itemsTotalCents
     id
   }
 }
@@ -321,31 +329,45 @@ v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "currencyCode",
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "itemsTotalCents",
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v15 = [
+v17 = [
   (v3/*: any*/),
-  (v14/*: any*/)
+  (v16/*: any*/)
 ],
-v16 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "awaitingResponseFrom",
   "storageKey": null
 },
-v17 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v18 = [
+v20 = [
   (v3/*: any*/),
-  (v14/*: any*/),
-  (v17/*: any*/)
+  (v16/*: any*/),
+  (v19/*: any*/)
 ];
 return {
   "fragment": {
@@ -473,6 +495,8 @@ return {
             ],
             "storageKey": null
           },
+          (v14/*: any*/),
+          (v15/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
@@ -483,7 +507,7 @@ return {
                 "kind": "LinkedField",
                 "name": "myLastOffer",
                 "plural": false,
-                "selections": (v15/*: any*/),
+                "selections": (v17/*: any*/),
                 "storageKey": null
               },
               {
@@ -493,10 +517,10 @@ return {
                 "kind": "LinkedField",
                 "name": "lastOffer",
                 "plural": false,
-                "selections": (v15/*: any*/),
+                "selections": (v17/*: any*/),
                 "storageKey": null
               },
-              (v16/*: any*/)
+              (v18/*: any*/)
             ],
             "type": "CommerceOfferOrder"
           }
@@ -521,7 +545,7 @@ return {
         "plural": false,
         "selections": [
           (v1/*: any*/),
-          (v17/*: any*/)
+          (v19/*: any*/)
         ],
         "storageKey": null
       },
@@ -572,7 +596,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v9/*: any*/),
-                          (v17/*: any*/),
+                          (v19/*: any*/),
                           (v10/*: any*/),
                           (v11/*: any*/),
                           (v12/*: any*/)
@@ -604,7 +628,7 @@ return {
                                 "plural": false,
                                 "selections": [
                                   (v13/*: any*/),
-                                  (v17/*: any*/)
+                                  (v19/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -614,7 +638,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v17/*: any*/)
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -633,11 +657,13 @@ return {
             "plural": false,
             "selections": [
               (v3/*: any*/),
-              (v17/*: any*/)
+              (v19/*: any*/)
             ],
             "storageKey": null
           },
-          (v17/*: any*/),
+          (v14/*: any*/),
+          (v15/*: any*/),
+          (v19/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
@@ -648,7 +674,7 @@ return {
                 "kind": "LinkedField",
                 "name": "myLastOffer",
                 "plural": false,
-                "selections": (v18/*: any*/),
+                "selections": (v20/*: any*/),
                 "storageKey": null
               },
               {
@@ -658,10 +684,10 @@ return {
                 "kind": "LinkedField",
                 "name": "lastOffer",
                 "plural": false,
-                "selections": (v18/*: any*/),
+                "selections": (v20/*: any*/),
                 "storageKey": null
               },
-              (v16/*: any*/)
+              (v18/*: any*/)
             ],
             "type": "CommerceOfferOrder"
           }
@@ -675,7 +701,7 @@ return {
     "metadata": {},
     "name": "orderRoutes_OrderQuery",
     "operationKind": "query",
-    "text": "query orderRoutes_OrderQuery(\n  $orderID: ID!\n) {\n  me {\n    name\n    id\n  }\n  order: commerceOrder(id: $orderID) @principalField {\n    __typename\n    internalID\n    mode\n    state\n    lastTransactionFailed\n    ... on CommerceOfferOrder {\n      myLastOffer {\n        internalID\n        createdAt\n        id\n      }\n      lastOffer {\n        internalID\n        createdAt\n        id\n      }\n      awaitingResponseFrom\n    }\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            slug\n            id\n            href\n            is_acquireable: isAcquireable\n            is_offerable: isOfferable\n          }\n          shippingQuoteOptions {\n            edges {\n              node {\n                isSelected\n                id\n              }\n            }\n          }\n          id\n        }\n      }\n    }\n    creditCard {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query orderRoutes_OrderQuery(\n  $orderID: ID!\n) {\n  me {\n    name\n    id\n  }\n  order: commerceOrder(id: $orderID) @principalField {\n    __typename\n    internalID\n    mode\n    state\n    lastTransactionFailed\n    ... on CommerceOfferOrder {\n      myLastOffer {\n        internalID\n        createdAt\n        id\n      }\n      lastOffer {\n        internalID\n        createdAt\n        id\n      }\n      awaitingResponseFrom\n    }\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            slug\n            id\n            href\n            is_acquireable: isAcquireable\n            is_offerable: isOfferable\n          }\n          shippingQuoteOptions {\n            edges {\n              node {\n                isSelected\n                id\n              }\n            }\n          }\n          id\n        }\n      }\n    }\n    creditCard {\n      internalID\n      id\n    }\n    currencyCode\n    itemsTotalCents\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Solves [PURCHASE-2909]

Makes the behaviour of the Zendesk "help" chat bubble match the acceptance criteria detailed in the ticket [https://artsyproduct.atlassian.net/browse/PURCHASE-2442] that implemented it.

* On the artwork page, the widget needs to appear if the artwork price is over $10,000 or equivalent (see below)
* On the checkout / make offer flow, the widget needs to appear if the artwork price is over $10,000 or equivalent (see below)

Threshold:
* USD: US$10000
* AUD: A$13000
* EUR: €8000
* HKD: HK$77000
* GBP: £7000

[PURCHASE-2909]: https://artsyproduct.atlassian.net/browse/PURCHASE-2909