### PR TITLE
feat(FX-3286): redirect to fair overview

### DIFF
--- a/src/v2/Apps/Fair/Components/FairBoothRail/FairBoothRailArtworks.tsx
+++ b/src/v2/Apps/Fair/Components/FairBoothRail/FairBoothRailArtworks.tsx
@@ -58,6 +58,7 @@ const FairBoothRailArtworks: React.FC<FairBoothRailArtworksProps> = ({
       {artworks.map((artwork, index) => {
         return (
           <ShelfArtworkFragmentContainer
+            key={artwork.internalID}
             contextModule={ContextModule.fairRail}
             artwork={artwork}
             hidePartnerName

--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -9,6 +9,7 @@ import {
 } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { defaultSort, isValidSort } from "./Utils/IsValidSort"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
+import { data as sd } from "sharify"
 
 const FairApp = loadable(
   () => import(/* webpackChunkName: "fairBundle" */ "./FairApp"),
@@ -128,6 +129,11 @@ export const fairRoutes: AppRouteConfig[] = [
         render: ({ Component, props, match }) => {
           if (!(Component && props)) {
             return undefined
+          }
+
+          if (sd.ENABLE_FAIR_PAGE_EXHIBITORS_TAB) {
+            const slug = match.params.slug
+            throw new RedirectException(`/fair/${slug}`, 301)
           }
 
           const {


### PR DESCRIPTION
Jira: [FX-3286](https://artsyproduct.atlassian.net/browse/FX-3286)

### Description
We’ve removed the Booths tab in favor of placing the booths under the overview tab.
This ticket involves adding a 301 redirect to /booths to the root fair URL. Should also be placed under the same feature flag as AZ + booths switch.

### Changes
- Added redirect to booths route
- Fix warning in booth rail artworks (each component should have unique key)

### Demo

https://user-images.githubusercontent.com/56556580/132510677-5b9be3c5-0511-420d-bb22-e213b2e53fbb.mov

