### PR TITLE
fix(FX-3289): Group all numeral together

### DIFF
--- a/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
@@ -7,8 +7,9 @@ import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { ExhibitorsLetterNav_fair } from "v2/__generated__/ExhibitorsLetterNav_fair.graphql"
 import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
+import { getExhibitorSectionId } from "../Utils/getExhibitorSectionId"
 
-const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("").concat(["0-9"])
+const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ#".split("")
 
 interface ExhibitorsLetterNavProps {
   fair: ExhibitorsLetterNav_fair
@@ -34,18 +35,20 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
         {LETTERS.map((letter, i) => {
           const isEnabled = letters?.includes(letter)
           const isLast = i === LETTERS.length - 1
+          const sectionLabel =
+            letter === "#" ? "special character or number" : `“${letter}”`
           return (
             <Letter
               key={letter}
               color={isEnabled ? "black100" : "black10"}
               title={
-                isEnabled ? `View exhibitors starting with “${letter}”` : ""
+                isEnabled ? `View exhibitors starting with ${sectionLabel}` : ""
               }
               mr={!withSwiper || isLast ? 0 : 4}
               onClick={() => {
                 if (isEnabled) {
                   scrollIntoView({
-                    selector: `#jump--letter${letter}`,
+                    selector: `#${getExhibitorSectionId(letter)}`,
                     offset,
                     behavior: "smooth",
                   })

--- a/src/v2/Apps/Fair/Components/__tests__/ExhibitorsLetterNav.jest.tsx
+++ b/src/v2/Apps/Fair/Components/__tests__/ExhibitorsLetterNav.jest.tsx
@@ -80,7 +80,7 @@ describe("ExhibitorsLetterNav", () => {
       expect(letter.at(i).prop("title")).toEqual("")
     }
     expect(letter.at(26).prop("title")).toEqual(
-      `View exhibitors starting with “0-9”`
+      `View exhibitors starting with special character or number`
     )
   })
 
@@ -98,5 +98,5 @@ const exhibitorsGroupedByName = [
   { letter: "K" },
   { letter: "L" },
   { letter: "M" },
-  { letter: "0-9" },
+  { letter: "#" },
 ]

--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -9,6 +9,7 @@ import { ExhibitorsLetterNavFragmentContainer as ExhibitorsLetterNav } from "../
 import { Sticky } from "v2/Components/Sticky"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
+import { getExhibitorSectionId } from "../Utils/getExhibitorSectionId"
 
 interface FairExhibitorsProps {
   fair: FairExhibitors_fair
@@ -42,7 +43,7 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair }) => {
         }
 
         return (
-          <Box key={letter} id={`jump--letter${letter}`}>
+          <Box key={letter} id={getExhibitorSectionId(letter)}>
             <Text variant="lg" my={4}>
               {letter}
             </Text>

--- a/src/v2/Apps/Fair/Utils/getExhibitorSectionId.ts
+++ b/src/v2/Apps/Fair/Utils/getExhibitorSectionId.ts
@@ -1,0 +1,9 @@
+export const getExhibitorSectionId = (letter: string) => {
+  const prefix = "jump--section-"
+
+  if (letter === "#") {
+    return `${prefix}special-characters-or-numeric`
+  }
+
+  return `${prefix}${letter}`
+}


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3289]

### Demo
https://user-images.githubusercontent.com/3513494/133285078-a7e68e97-19d1-4fc8-9bad-cbc33cd5a98a.mp4

### Acceptance criteria
* numeral, special characters sections are grouped into one
* `#` section is enabled if there are some numerals, special characters and scrolls to it
* `#` section is after letter sections

For more context: [Slack discussion](https://artsy.slack.com/archives/C9SATFLUU/p1631175036487800?thread_ts=1631117497.458800&cid=C9SATFLUU)

[FX-3289]: https://artsyproduct.atlassian.net/browse/FX-3289