### PR TITLE
fix(homepage): fixes missing image state

### DIFF
--- a/src/v2/Apps/Home/Components/HomeFeaturedEventsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedEventsRail.tsx
@@ -58,7 +58,7 @@ const HomeFeaturedEventsRail: React.FC<HomeFeaturedEventsRailProps> = ({
                         lazyLoad
                       />
                     ) : (
-                      <Box bg="black10" width="100%" height="100%" />
+                      <Box bg="black10" width={95} height={63} />
                     )}
 
                     <Box ml={2}>


### PR DESCRIPTION
Minor thing; staging looks like it's missing part of the fragment for these (don't know why); which is causing the broken layout. This is an actual bug; though generally we shouldn't see this state as anything that is going to be featured is probably going to have an image. Regardless.

![](https://static.damonzucconi.com/_capture/O182gICq.png)