### PR TITLE
feat(inquiry): implements specialist form

### DIFF
--- a/src/v2/Components/Inquiry/Hooks/useArtworkInquiryRequest.ts
+++ b/src/v2/Components/Inquiry/Hooks/useArtworkInquiryRequest.ts
@@ -1,23 +1,23 @@
 import { commitMutation, graphql, Environment } from "relay-runtime"
 import { useSystemContext } from "v2/System"
-import { useArtworkInquiryRequestMutation } from "v2/__generated__/useArtworkInquiryRequestMutation.graphql"
+import {
+  SubmitInquiryRequestMutationInput,
+  useArtworkInquiryRequestMutation,
+} from "v2/__generated__/useArtworkInquiryRequestMutation.graphql"
 
-interface UseInquiryRequest {
-  artworkID: string
-  message: string
-}
+type UseArtworkInquiryRequestInput = Omit<
+  SubmitInquiryRequestMutationInput,
+  "inquireableID" | "inquireableType" | "message"
+> & { relayEnvironment?: Environment; artworkID: string; message: string }
 
-export const useArtworkInquiryRequest = ({
-  artworkID,
-  message,
-}: UseInquiryRequest) => {
+export const useArtworkInquiryRequest = () => {
   const { relayEnvironment: defaultRelayEnvironment } = useSystemContext()
 
   const submitArtworkInquiryRequest = ({
     relayEnvironment = defaultRelayEnvironment,
-  }: {
-    relayEnvironment?: Environment
-  } = {}) => {
+    artworkID,
+    ...rest
+  }: UseArtworkInquiryRequestInput) => {
     return new Promise((resolve, reject) => {
       commitMutation<useArtworkInquiryRequestMutation>(relayEnvironment!, {
         onCompleted: (res, errors) => {
@@ -41,7 +41,7 @@ export const useArtworkInquiryRequest = ({
           input: {
             inquireableID: artworkID,
             inquireableType: "Artwork",
-            message,
+            ...rest,
           },
         },
       })

--- a/src/v2/Components/Inquiry/Views/InquiryInquiry.tsx
+++ b/src/v2/Components/Inquiry/Views/InquiryInquiry.tsx
@@ -48,10 +48,7 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
 
   const [mode, setMode] = useState<Mode>(Mode.Pending)
 
-  const { submitArtworkInquiryRequest } = useArtworkInquiryRequest({
-    artworkID,
-    message: inquiry.message,
-  })
+  const { submitArtworkInquiryRequest } = useArtworkInquiryRequest()
 
   const handleTextAreaChange = ({ value }: { value: string }) => {
     if (mode === Mode.Confirm && value !== DEFAULT_MESSAGE) {
@@ -85,7 +82,10 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
     setMode(Mode.Sending)
 
     try {
-      await submitArtworkInquiryRequest()
+      await submitArtworkInquiryRequest({
+        artworkID,
+        message: inquiry.message,
+      })
       setMode(Mode.Success)
       await wait(500)
       next()

--- a/src/v2/Components/Inquiry/Views/InquiryInquiry.tsx
+++ b/src/v2/Components/Inquiry/Views/InquiryInquiry.tsx
@@ -27,6 +27,7 @@ import {
   InquiryState,
 } from "../Hooks/useInquiryContext"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { logger } from "../util"
 
 enum Mode {
   Pending,
@@ -74,8 +75,11 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
       return
     }
 
+    // If the user is logged out we just go to the next view which should
+    // be the authentication step. The inquiry gets sent after login or sign up.
     if (!user) {
       next()
+      return
     }
 
     setMode(Mode.Sending)
@@ -86,7 +90,7 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
       await wait(500)
       next()
     } catch (err) {
-      console.error(err)
+      logger.error(err)
       setMode(Mode.Error)
     }
   }

--- a/src/v2/Components/Inquiry/Views/InquiryLogin.tsx
+++ b/src/v2/Components/Inquiry/Views/InquiryLogin.tsx
@@ -41,10 +41,7 @@ export const InquiryLogin: React.FC = () => {
     authenticationCode: "",
   })
 
-  const { submitArtworkInquiryRequest } = useArtworkInquiryRequest({
-    artworkID,
-    message: inquiry.message,
-  })
+  const { submitArtworkInquiryRequest } = useArtworkInquiryRequest()
 
   const handleSubmit = async (event: React.FormEvent<HTMLElement>) => {
     event.preventDefault()
@@ -56,6 +53,8 @@ export const InquiryLogin: React.FC = () => {
 
       await submitArtworkInquiryRequest({
         relayEnvironment: createRelaySSREnvironment({ user }),
+        artworkID,
+        message: inquiry.message,
       })
 
       setMode(Mode.Success)

--- a/src/v2/Components/Inquiry/Views/InquirySignUp.tsx
+++ b/src/v2/Components/Inquiry/Views/InquirySignUp.tsx
@@ -29,10 +29,7 @@ export const InquirySignUp: React.FC = () => {
 
   const { inquiry, artworkID, next } = useInquiryContext()
 
-  const { submitArtworkInquiryRequest } = useArtworkInquiryRequest({
-    artworkID,
-    message: inquiry.message,
-  })
+  const { submitArtworkInquiryRequest } = useArtworkInquiryRequest()
 
   const [state, setState] = useState<InquirySignUpState>({
     name: inquiry.name ?? "",
@@ -50,6 +47,8 @@ export const InquirySignUp: React.FC = () => {
 
       await submitArtworkInquiryRequest({
         relayEnvironment: createRelaySSREnvironment({ user }),
+        artworkID,
+        message: inquiry.message,
       })
 
       setMode(Mode.Success)

--- a/src/v2/Components/Inquiry/Views/InquirySpecialist.tsx
+++ b/src/v2/Components/Inquiry/Views/InquirySpecialist.tsx
@@ -38,10 +38,7 @@ export const InquirySpecialist: React.FC = () => {
     setInquiry(prevState => ({ ...prevState, [name]: event.target.value }))
   }
 
-  const { submitArtworkInquiryRequest } = useArtworkInquiryRequest({
-    artworkID,
-    message: inquiry.message,
-  })
+  const { submitArtworkInquiryRequest } = useArtworkInquiryRequest()
 
   const handleSubmit = async (event: React.FormEvent<HTMLElement>) => {
     event.preventDefault()
@@ -56,7 +53,11 @@ export const InquirySpecialist: React.FC = () => {
     setMode(Mode.Sending)
 
     try {
-      await submitArtworkInquiryRequest()
+      await submitArtworkInquiryRequest({
+        artworkID,
+        message: inquiry.message,
+        contactGallery: false,
+      })
       setMode(Mode.Success)
       await wait(500)
       next()

--- a/src/v2/Components/Inquiry/Views/InquirySpecialist.tsx
+++ b/src/v2/Components/Inquiry/Views/InquirySpecialist.tsx
@@ -1,19 +1,155 @@
-import { Button, Text } from "@artsy/palette"
-import React from "react"
-import { useInquiryContext } from "../Hooks/useInquiryContext"
+import {
+  Box,
+  Button,
+  Input,
+  Separator,
+  Spacer,
+  Text,
+  TextArea,
+} from "@artsy/palette"
+import React, { useState } from "react"
+import { useSystemContext } from "v2/System/useSystemContext"
+import { wait } from "v2/Utils/wait"
+import { useArtworkInquiryRequest } from "../Hooks/useArtworkInquiryRequest"
+import { InquiryState, useInquiryContext } from "../Hooks/useInquiryContext"
+import { logger } from "../util"
+
+enum Mode {
+  Pending,
+  Sending,
+  Error,
+  Success,
+}
 
 export const InquirySpecialist: React.FC = () => {
-  const { next } = useInquiryContext()
+  const { user } = useSystemContext()
+
+  const { next, setInquiry, inquiry, artworkID } = useInquiryContext()
+
+  const [mode, setMode] = useState<Mode>(Mode.Pending)
+
+  const handleTextAreaChange = ({ value }: { value: string }) => {
+    setInquiry(prevState => ({ ...prevState, message: value }))
+  }
+
+  const handleInputChange = (name: keyof InquiryState) => (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setInquiry(prevState => ({ ...prevState, [name]: event.target.value }))
+  }
+
+  const { submitArtworkInquiryRequest } = useArtworkInquiryRequest({
+    artworkID,
+    message: inquiry.message,
+  })
+
+  const handleSubmit = async (event: React.FormEvent<HTMLElement>) => {
+    event.preventDefault()
+
+    // If the user is logged out we just go to the next view which should
+    // be the authentication step. The inquiry gets sent after login or sign up.
+    if (!user) {
+      next()
+      return
+    }
+
+    setMode(Mode.Sending)
+
+    try {
+      await submitArtworkInquiryRequest()
+      setMode(Mode.Success)
+      await wait(500)
+      next()
+    } catch (err) {
+      logger.error(err)
+      setMode(Mode.Error)
+    }
+  }
+
+  const label = {
+    [Mode.Pending]: "Send",
+    [Mode.Sending]: "Send",
+    [Mode.Success]: "Sent",
+    [Mode.Error]: "Error",
+  }[mode]
 
   return (
-    <>
-      <Text variant="sm" mb={1}>
-        Specialist
+    <Box as="form" onSubmit={handleSubmit}>
+      <Text variant="lg" mr={4}>
+        Send message to Artsy
       </Text>
 
-      <Button width="100%" onClick={next}>
-        Next
+      <Separator my={2} />
+
+      <Text variant="sm">
+        An Artsy Specialist is available to answer your questions and help you
+        collect through Artsy.
+      </Text>
+
+      <Separator my={2} />
+
+      {user && (
+        <>
+          <Text variant="md" my={2}>
+            <Box display="inline-block" width={60} color="black60">
+              From
+            </Box>
+            {user.name} ({user.email})
+          </Text>
+
+          <Separator my={2} />
+        </>
+      )}
+
+      <TextArea
+        name="message"
+        placeholder="Leave your comments"
+        title="Your message"
+        onChange={handleTextAreaChange}
+        required
+      />
+
+      {!user && (
+        <>
+          <Input
+            name="name"
+            title="Your name"
+            placeholder="Your full name"
+            onChange={handleInputChange("name")}
+            required
+            my={1}
+          />
+
+          <Input
+            name="email"
+            title="Your email"
+            placeholder="Your email address"
+            onChange={handleInputChange("email")}
+            type="email"
+            required
+            my={1}
+          />
+
+          <Text variant="xs">
+            By clicking send, you accept our{" "}
+            <a href="/privacy" target="_blank">
+              Privacy Policy.
+            </a>
+          </Text>
+        </>
+      )}
+
+      <Spacer mt={2} />
+
+      <Button
+        type="submit"
+        display="block"
+        width="100%"
+        loading={mode === Mode.Sending}
+        disabled={mode === Mode.Success}
+      >
+        {label}
       </Button>
-    </>
+    </Box>
   )
 }

--- a/src/v2/Components/Inquiry/__tests__/Views/InquirySpecialist.jest.tsx
+++ b/src/v2/Components/Inquiry/__tests__/Views/InquirySpecialist.jest.tsx
@@ -1,0 +1,114 @@
+import { mount } from "enzyme"
+import React from "react"
+import { InquirySpecialist } from "../../Views/InquirySpecialist"
+import { useArtworkInquiryRequest } from "../../Hooks/useArtworkInquiryRequest"
+import { useInquiryContext } from "../../Hooks/useInquiryContext"
+import { fill } from "../util"
+import { flushPromiseQueue } from "v2/DevTools"
+import { useSystemContext } from "v2/System/useSystemContext"
+
+jest.mock("../../Hooks/useArtworkInquiryRequest")
+jest.mock("../../Hooks/useInquiryContext")
+jest.mock("v2/Utils/wait", () => ({ wait: () => Promise.resolve() }))
+jest.mock("v2/System/useSystemContext")
+
+describe("InquirySpecialist", () => {
+  const next = jest.fn()
+  const setInquiry = jest.fn()
+  const submitArtworkInquiryRequest = jest.fn()
+
+  beforeEach(() => {
+    ;(useArtworkInquiryRequest as jest.Mock).mockImplementation(() => ({
+      submitArtworkInquiryRequest,
+    }))
+    ;(useInquiryContext as jest.Mock).mockImplementation(() => ({
+      next,
+      inquiry: {},
+      setInquiry,
+    }))
+  })
+
+  afterEach(() => {
+    next.mockReset()
+    submitArtworkInquiryRequest.mockReset()
+    setInquiry.mockReset()
+  })
+
+  describe("logged out", () => {
+    beforeEach(() => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => ({
+        user: null,
+      }))
+    })
+
+    it("renders correctly", () => {
+      const wrapper = mount(<InquirySpecialist />)
+      const html = wrapper.html()
+
+      expect(html).toContain(
+        "An Artsy Specialist is available to answer your questions and help you collect through Artsy."
+      )
+      expect(html).toContain("Your email address")
+    })
+
+    it("fills out the inquiry and nexts", async () => {
+      const wrapper = mount(<InquirySpecialist />)
+
+      // Fill inputs
+      fill(wrapper, "message", "Hello world.")
+      fill(wrapper, "name", "Example Example")
+      fill(wrapper, "email", "example@example.com")
+
+      expect(setInquiry).toHaveBeenCalledTimes(3)
+
+      // Submit form
+      wrapper.find("form").simulate("submit")
+      await flushPromiseQueue()
+
+      // Doesn't send the inquiry
+      expect(submitArtworkInquiryRequest).not.toBeCalled()
+
+      // Calls next
+      expect(next).toBeCalled()
+    })
+  })
+
+  describe("logged in", () => {
+    beforeEach(() => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => ({
+        user: { name: "Logged In", email: "loggedin@example.com" },
+      }))
+    })
+
+    it("renders correctly", () => {
+      const wrapper = mount(<InquirySpecialist />)
+      const html = wrapper.html()
+
+      expect(html).toContain(
+        "An Artsy Specialist is available to answer your questions and help you collect through Artsy."
+      )
+      expect(html).not.toContain("Your email address")
+      expect(html).toContain("Logged In")
+      expect(html).toContain("loggedin@example.com")
+    })
+
+    it("sends the inquiry and nexts", async () => {
+      const wrapper = mount(<InquirySpecialist />)
+
+      // Fill input
+      fill(wrapper, "message", "Hello world.")
+
+      expect(setInquiry).toHaveBeenCalledTimes(1)
+
+      // Submit form
+      wrapper.find("form").simulate("submit")
+      await flushPromiseQueue()
+
+      // Sends the inquiry
+      expect(submitArtworkInquiryRequest).toBeCalled()
+
+      // Calls next
+      expect(next).toBeCalled()
+    })
+  })
+})


### PR DESCRIPTION
Allows the form to be opened in specialist-mode — for instance, for artworks that are in auctions.

<del>Draft because I realized I need to add the `contact_gallery` boolean to the Metaphysics mutation 😅 </del>

```tsx
useInquiry({ artworkID: 'example', askSpecialist: true })
```

![](https://static.damonzucconi.com/_capture/ZQZ0At24.png)