### PR TITLE
fix cypress test

### DIFF
--- a/cypress/integration/shows.spec.ts
+++ b/cypress/integration/shows.spec.ts
@@ -15,6 +15,6 @@ describe("Shows", () => {
     const showLink = cy.get('a[href*="/show/"]:first')
     showLink.click()
     cy.url().should("contain", "/show/")
-    cy.contains("Presented by")
+    cy.contains("Show")
   })
 })


### PR DESCRIPTION
The reason for this error was "Presented by" string that is a bit specific for different show items(_show/daniel-cooney-fine-art-daniel-cooney-fine-art-at-art-on-paper-2021?sort=partner_show_position_). It was replaced by **Sow** because this string is common for all items!
Thanks @copperkraft for paring!
![Screen Shot 2021-09-14 at 3 02 15 PM](https://user-images.githubusercontent.com/37010996/133265382-9fc9d663-3e7a-4707-8dd6-e9c2ea0494d1.png)

