### PR TITLE
feat: [Home] Add new featured galleries rail 

### DIFF
--- a/src/v2/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
@@ -2,17 +2,25 @@ import {
   Box,
   Image,
   Text,
-  GridColumns,
-  Column,
-  ResponsiveBox,
   Flex,
+  Spacer,
+  Shelf,
+  EntityHeader,
+  Skeleton,
+  SkeletonText,
+  SkeletonBox,
+  Sup,
 } from "@artsy/palette"
-import { compact, take } from "lodash"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useSystemContext } from "v2/System"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { RouterLink } from "v2/System/Router/RouterLink"
-import { Media } from "v2/Utils/Responsive"
 import { HomeFeaturedGalleriesRail_orderedSet } from "v2/__generated__/HomeFeaturedGalleriesRail_orderedSet.graphql"
+import { HomeFeaturedGalleriesRailQuery } from "v2/__generated__/HomeFeaturedGalleriesRailQuery.graphql"
+import { extractNodes } from "v2/Utils/extractNodes"
+import { FollowProfileButtonFragmentContainer } from "v2/Components/FollowButton/FollowProfileButton"
+import { ContextModule } from "@artsy/cohesion"
 
 interface HomeFeaturedGalleriesRailProps {
   orderedSet: HomeFeaturedGalleriesRail_orderedSet
@@ -21,113 +29,134 @@ interface HomeFeaturedGalleriesRailProps {
 const HomeFeaturedGalleriesRail: React.FC<HomeFeaturedGalleriesRailProps> = ({
   orderedSet,
 }) => {
-  const events = take(
-    compact(orderedSet.items).flatMap(item =>
-      item.__typename === "FeaturedLink" ? [item] : []
-    ),
-    4
-  )
+  const { user } = useSystemContext()
+  const nodes = extractNodes(orderedSet.orderedItemsConnection)
 
-  if (events.length === 0) return null
+  if (nodes.length === 0) {
+    return null
+  }
 
   return (
-    <>
-      <Text variant="lg" mb={4}>
-        Featured
-      </Text>
-
-      <GridColumns gridRowGap={2}>
-        {events.map((event, i) => {
-          const image = event.image
-
+    <HomeFeaturedGalleriesContainer galleriesCount={nodes.length}>
+      <Shelf>
+        {nodes.map((node, index) => {
+          if (node.__typename !== "Profile") {
+            return <></>
+          }
           return (
-            <Column key={event.internalID ?? i} span={3}>
-              <RouterLink
-                to={event.href ?? ""}
-                style={{ display: "block", textDecoration: "none" }}
-              >
-                <Media lessThan="sm">
-                  <Flex>
-                    {image?.small ? (
-                      <Image
-                        src={image.small.src}
-                        srcSet={image.small.srcSet}
-                        width={image.small.width}
-                        height={image.small.height}
-                        alt=""
-                        lazyLoad
-                      />
-                    ) : (
-                      <Box bg="black10" width={95} height={63} />
-                    )}
-
-                    <Box ml={2}>
-                      <Text variant="xs" textTransform="uppercase">
-                        {event.title}
-                      </Text>
-
-                      <Text variant="lg">{event.subtitle}</Text>
-                    </Box>
-                  </Flex>
-                </Media>
-
-                <Media greaterThanOrEqual="sm">
-                  <ResponsiveBox
-                    aspectWidth={3}
-                    aspectHeight={2}
-                    maxWidth="100%"
-                  >
-                    {image?.large ? (
-                      <Image
-                        src={image.large.src}
-                        srcSet={image.large.srcSet}
-                        width="100%"
-                        height="100%"
-                        alt=""
-                        lazyLoad
-                      />
-                    ) : (
-                      <Box bg="black10" width="100%" height="100%" />
-                    )}
-                  </ResponsiveBox>
-
-                  <Text variant="xs" textTransform="uppercase" mt={1}>
-                    {event.title}
-                  </Text>
-
-                  <Text variant="lg">{event.subtitle}</Text>
-                </Media>
-              </RouterLink>
-            </Column>
+            <RouterLink
+              to={`/partner${node.href}`}
+              textDecoration="none"
+              key={index}
+            >
+              <Box width={325} key={index}>
+                <EntityHeader
+                  name={node.name!}
+                  meta={node.location!}
+                  smallVariant
+                  FollowButton={
+                    <FollowProfileButtonFragmentContainer
+                      user={user}
+                      profile={node as any}
+                      contextModule={ContextModule.partnerHeader}
+                      buttonProps={{
+                        size: "small",
+                        variant: "secondaryOutline",
+                      }}
+                    />
+                  }
+                />
+                {node.image?.cropped?.src && (
+                  <Box mt={1}>
+                    <Image
+                      src={node.image.cropped.src}
+                      srcSet={node.image.cropped.srcSet}
+                      width={node.image.cropped.width}
+                      height={node.image.cropped.height}
+                      lazyLoad
+                    />
+                  </Box>
+                )}
+              </Box>
+            </RouterLink>
           )
         })}
-      </GridColumns>
+      </Shelf>
+    </HomeFeaturedGalleriesContainer>
+  )
+}
+
+const HomeFeaturedGalleriesContainer: React.FC<{ galleriesCount: number }> = ({
+  children,
+  galleriesCount,
+}) => {
+  return (
+    <>
+      <Flex justifyContent="space-between" alignItems="center">
+        <Text variant="lg">
+          Featured Galleries{" "}
+          {galleriesCount > 1 && <Sup color="brand">{galleriesCount}</Sup>}
+        </Text>
+
+        <Text
+          variant="sm"
+          as={RouterLink}
+          // @ts-ignore
+          to="/galleries"
+        >
+          View All Galleries
+        </Text>
+      </Flex>
+
+      <Spacer mt={4} />
+
+      {children}
     </>
   )
 }
+
+const PLACEHOLDER = (
+  <Skeleton>
+    <HomeFeaturedGalleriesContainer galleriesCount={0}>
+      <Shelf>
+        {[...new Array(8)].map((_, i) => {
+          return (
+            <Box width={325} key={i}>
+              <SkeletonText variant="lg">Some Gallery</SkeletonText>
+              <SkeletonText variant="md">Location</SkeletonText>
+              <SkeletonBox width={325} height={230} />
+            </Box>
+          )
+        })}
+      </Shelf>
+    </HomeFeaturedGalleriesContainer>
+  </Skeleton>
+)
 
 export const HomeFeaturedGalleriesRailFragmentContainer = createFragmentContainer(
   HomeFeaturedGalleriesRail,
   {
     orderedSet: graphql`
       fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
-        items {
-          __typename
-          ... on FeaturedLink {
-            internalID
-            title
-            subtitle
-            href
-            image {
-              small: cropped(width: 95, height: 63) {
-                src
-                srcSet
-                width
-                height
-              }
-              large: cropped(width: 445, height: 297) {
-                src
-                srcSet
+        orderedItemsConnection(first: 20) {
+          edges {
+            node {
+              __typename
+              ... on Profile {
+                ...FollowProfileButton_profile
+                internalID
+                name
+                slug
+                href
+                location
+                image {
+                  cropped(width: 325, height: 230) {
+                    src
+                    srcSet
+                    width
+                    height
+                  }
+                }
               }
             }
           }
@@ -136,3 +165,41 @@ export const HomeFeaturedGalleriesRailFragmentContainer = createFragmentContaine
     `,
   }
 )
+
+export const HomeFeaturedGalleriesRailQueryRenderer: React.FC = () => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <SystemQueryRenderer<HomeFeaturedGalleriesRailQuery>
+      environment={relayEnvironment}
+      query={graphql`
+        query HomeFeaturedGalleriesRailQuery {
+          orderedSet(id: "5638fdfb7261690296000031") {
+            ...HomeFeaturedGalleriesRail_orderedSet
+          }
+        }
+      `}
+      placeholder={PLACEHOLDER}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props) {
+          return PLACEHOLDER
+        }
+
+        if (props.orderedSet) {
+          return (
+            <HomeFeaturedGalleriesRailFragmentContainer
+              orderedSet={props.orderedSet}
+            />
+          )
+        }
+
+        return null
+      }}
+    />
+  )
+}

--- a/src/v2/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
@@ -1,0 +1,138 @@
+import {
+  Box,
+  Image,
+  Text,
+  GridColumns,
+  Column,
+  ResponsiveBox,
+  Flex,
+} from "@artsy/palette"
+import { compact, take } from "lodash"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { RouterLink } from "v2/System/Router/RouterLink"
+import { Media } from "v2/Utils/Responsive"
+import { HomeFeaturedGalleriesRail_orderedSet } from "v2/__generated__/HomeFeaturedGalleriesRail_orderedSet.graphql"
+
+interface HomeFeaturedGalleriesRailProps {
+  orderedSet: HomeFeaturedGalleriesRail_orderedSet
+}
+
+const HomeFeaturedGalleriesRail: React.FC<HomeFeaturedGalleriesRailProps> = ({
+  orderedSet,
+}) => {
+  const events = take(
+    compact(orderedSet.items).flatMap(item =>
+      item.__typename === "FeaturedLink" ? [item] : []
+    ),
+    4
+  )
+
+  if (events.length === 0) return null
+
+  return (
+    <>
+      <Text variant="lg" mb={4}>
+        Featured
+      </Text>
+
+      <GridColumns gridRowGap={2}>
+        {events.map((event, i) => {
+          const image = event.image
+
+          return (
+            <Column key={event.internalID ?? i} span={3}>
+              <RouterLink
+                to={event.href ?? ""}
+                style={{ display: "block", textDecoration: "none" }}
+              >
+                <Media lessThan="sm">
+                  <Flex>
+                    {image?.small ? (
+                      <Image
+                        src={image.small.src}
+                        srcSet={image.small.srcSet}
+                        width={image.small.width}
+                        height={image.small.height}
+                        alt=""
+                        lazyLoad
+                      />
+                    ) : (
+                      <Box bg="black10" width={95} height={63} />
+                    )}
+
+                    <Box ml={2}>
+                      <Text variant="xs" textTransform="uppercase">
+                        {event.title}
+                      </Text>
+
+                      <Text variant="lg">{event.subtitle}</Text>
+                    </Box>
+                  </Flex>
+                </Media>
+
+                <Media greaterThanOrEqual="sm">
+                  <ResponsiveBox
+                    aspectWidth={3}
+                    aspectHeight={2}
+                    maxWidth="100%"
+                  >
+                    {image?.large ? (
+                      <Image
+                        src={image.large.src}
+                        srcSet={image.large.srcSet}
+                        width="100%"
+                        height="100%"
+                        alt=""
+                        lazyLoad
+                      />
+                    ) : (
+                      <Box bg="black10" width="100%" height="100%" />
+                    )}
+                  </ResponsiveBox>
+
+                  <Text variant="xs" textTransform="uppercase" mt={1}>
+                    {event.title}
+                  </Text>
+
+                  <Text variant="lg">{event.subtitle}</Text>
+                </Media>
+              </RouterLink>
+            </Column>
+          )
+        })}
+      </GridColumns>
+    </>
+  )
+}
+
+export const HomeFeaturedGalleriesRailFragmentContainer = createFragmentContainer(
+  HomeFeaturedGalleriesRail,
+  {
+    orderedSet: graphql`
+      fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
+        items {
+          __typename
+          ... on FeaturedLink {
+            internalID
+            title
+            subtitle
+            href
+            image {
+              small: cropped(width: 95, height: 63) {
+                src
+                srcSet
+                width
+                height
+              }
+              large: cropped(width: 445, height: 297) {
+                src
+                srcSet
+              }
+            }
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Home/Components/HomeFeaturedMarketNews.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedMarketNews.tsx
@@ -124,7 +124,7 @@ const HomeFeaturedMarketNews: React.FC<HomeFeaturedMarketNewsProps> = ({
 const HomeFeaturedMarketNewsContainer: React.FC = ({ children }) => {
   return (
     <>
-      <Flex justifyContent="space-between">
+      <Flex justifyContent="space-between" alignItems="center">
         <Text variant="xl">Market News</Text>
 
         <Text

--- a/src/v2/Apps/Home/Components/HomeFeaturedMarketNews.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedMarketNews.tsx
@@ -20,16 +20,16 @@ import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { useLazyLoadComponent } from "v2/Utils/Hooks/useLazyLoadComponent"
 import { Media } from "v2/Utils/Responsive"
-import { HomeFeaturedArticlesQuery } from "v2/__generated__/HomeFeaturedArticlesQuery.graphql"
-import { HomeFeaturedArticles_articles } from "v2/__generated__/HomeFeaturedArticles_articles.graphql"
+import { HomeFeaturedMarketNewsQuery } from "v2/__generated__/HomeFeaturedMarketNewsQuery.graphql"
+import { HomeFeaturedMarketNews_articles } from "v2/__generated__/HomeFeaturedMarketNews_articles.graphql"
 
 const ARTICLE_COUNT = 6
 
-interface HomeFeaturedArticlesProps {
-  articles: HomeFeaturedArticles_articles
+interface HomeFeaturedMarketNewsProps {
+  articles: HomeFeaturedMarketNews_articles
 }
 
-const HomeFeaturedArticles: React.FC<HomeFeaturedArticlesProps> = ({
+const HomeFeaturedMarketNews: React.FC<HomeFeaturedMarketNewsProps> = ({
   articles,
 }) => {
   const [firstArticle, ...restOfArticles] = articles
@@ -37,7 +37,7 @@ const HomeFeaturedArticles: React.FC<HomeFeaturedArticlesProps> = ({
   const articlesList = take(restOfArticles, ARTICLE_COUNT)
 
   return (
-    <HomeFeaturedArticlesContainer>
+    <HomeFeaturedMarketNewsContainer>
       <GridColumns>
         <Column span={[12, 6]} mb={[4, 0]}>
           <RouterLink
@@ -117,11 +117,11 @@ const HomeFeaturedArticles: React.FC<HomeFeaturedArticlesProps> = ({
           </Masonry>
         </Column>
       </GridColumns>
-    </HomeFeaturedArticlesContainer>
+    </HomeFeaturedMarketNewsContainer>
   )
 }
 
-const HomeFeaturedArticlesContainer: React.FC = ({ children }) => {
+const HomeFeaturedMarketNewsContainer: React.FC = ({ children }) => {
   return (
     <>
       <Flex justifyContent="space-between">
@@ -144,11 +144,11 @@ const HomeFeaturedArticlesContainer: React.FC = ({ children }) => {
   )
 }
 
-export const HomeFeaturedArticlesFragmentContainer = createFragmentContainer(
-  HomeFeaturedArticles,
+export const HomeFeaturedMarketNewsFragmentContainer = createFragmentContainer(
+  HomeFeaturedMarketNews,
   {
     articles: graphql`
-      fragment HomeFeaturedArticles_articles on Article @relay(plural: true) {
+      fragment HomeFeaturedMarketNews_articles on Article @relay(plural: true) {
         internalID
         href
         title
@@ -180,7 +180,7 @@ export const HomeFeaturedArticlesFragmentContainer = createFragmentContainer(
 
 const PLACEHOLDER = (
   <Skeleton>
-    <HomeFeaturedArticlesContainer>
+    <HomeFeaturedMarketNewsContainer>
       <GridColumns>
         <Column span={6}>
           <Media greaterThan="xs">
@@ -247,20 +247,20 @@ const PLACEHOLDER = (
           </Masonry>
         </Column>
       </GridColumns>
-    </HomeFeaturedArticlesContainer>
+    </HomeFeaturedMarketNewsContainer>
   </Skeleton>
 )
 
-export const HomeFeaturedArticlesQueryRenderer: React.FC = () => {
+export const HomeFeaturedMarketNewsQueryRenderer: React.FC = () => {
   const { relayEnvironment } = useSystemContext()
 
   return (
-    <SystemQueryRenderer<HomeFeaturedArticlesQuery>
+    <SystemQueryRenderer<HomeFeaturedMarketNewsQuery>
       environment={relayEnvironment}
       query={graphql`
-        query HomeFeaturedArticlesQuery {
+        query HomeFeaturedMarketNewsQuery {
           articles(featured: true, published: true, sort: PUBLISHED_AT_DESC) {
-            ...HomeFeaturedArticles_articles
+            ...HomeFeaturedMarketNews_articles
           }
         }
       `}
@@ -277,7 +277,7 @@ export const HomeFeaturedArticlesQueryRenderer: React.FC = () => {
 
         if (props.articles) {
           return (
-            <HomeFeaturedArticlesFragmentContainer
+            <HomeFeaturedMarketNewsFragmentContainer
               articles={compact(props.articles)}
             />
           )
@@ -289,14 +289,14 @@ export const HomeFeaturedArticlesQueryRenderer: React.FC = () => {
   )
 }
 
-export const HomeFeaturedArticlesLazyQueryRenderer: React.FC = () => {
+export const HomeFeaturedMarketNewsLazyQueryRenderer: React.FC = () => {
   const { Waypoint, isEnteredView } = useLazyLoadComponent()
 
   return (
     <>
       <Waypoint />
 
-      {isEnteredView ? <HomeFeaturedArticlesQueryRenderer /> : PLACEHOLDER}
+      {isEnteredView ? <HomeFeaturedMarketNewsQueryRenderer /> : PLACEHOLDER}
     </>
   )
 }

--- a/src/v2/Apps/Home/Components/HomeFeaturedShows.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedShows.tsx
@@ -56,7 +56,7 @@ const HomeFeaturedShows: React.FC<HomeFeaturedShowsProps> = ({
 const HomeFeaturedShowsContainer: React.FC = ({ children }) => {
   return (
     <>
-      <Flex justifyContent="space-between">
+      <Flex justifyContent="space-between" alignItems="center">
         <Text variant="xl">Featured shows</Text>
 
         <Text

--- a/src/v2/Apps/Home/HomeApp.tsx
+++ b/src/v2/Apps/Home/HomeApp.tsx
@@ -9,13 +9,17 @@ import { HomeFeaturedMarketNewsLazyQueryRenderer } from "./Components/HomeFeatur
 import { HomeFeaturedEventsRailFragmentContainer } from "./Components/HomeFeaturedEventsRail"
 import { HomeMeta } from "./Components/HomeMeta"
 import { FlashBannerQueryRenderer } from "v2/Components/FlashBanner"
+import { HomeFeaturedGalleriesRailQueryRenderer } from "./Components/HomeFeaturedGalleriesRail"
 
 interface HomeAppProps {
   homePage: HomeApp_homePage | null
-  orderedSet: HomeApp_featuredEventsOrderedSet | null
+  featuredEventsOrderedSet: HomeApp_featuredEventsOrderedSet | null
 }
 
-export const HomeApp: React.FC<HomeAppProps> = ({ homePage, orderedSet }) => {
+export const HomeApp: React.FC<HomeAppProps> = ({
+  homePage,
+  featuredEventsOrderedSet,
+}) => {
   return (
     <>
       <HomeMeta />
@@ -31,9 +35,11 @@ export const HomeApp: React.FC<HomeAppProps> = ({ homePage, orderedSet }) => {
       <Spacer mt={4} />
 
       <Join separator={<Spacer mt={6} />}>
-        {orderedSet && (
+        {featuredEventsOrderedSet && (
           <>
-            <HomeFeaturedEventsRailFragmentContainer orderedSet={orderedSet} />
+            <HomeFeaturedEventsRailFragmentContainer
+              orderedSet={featuredEventsOrderedSet}
+            />
 
             <Separator />
           </>
@@ -44,6 +50,8 @@ export const HomeApp: React.FC<HomeAppProps> = ({ homePage, orderedSet }) => {
         )}
 
         <HomeFeaturedMarketNewsLazyQueryRenderer />
+
+        <HomeFeaturedGalleriesRailQueryRenderer />
       </Join>
     </>
   )

--- a/src/v2/Apps/Home/HomeApp.tsx
+++ b/src/v2/Apps/Home/HomeApp.tsx
@@ -2,17 +2,17 @@ import { Spacer, Join, Separator, FullBleed } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { HomeApp_homePage } from "v2/__generated__/HomeApp_homePage.graphql"
-import { HomeApp_orderedSet } from "v2/__generated__/HomeApp_orderedSet.graphql"
+import { HomeApp_featuredEventsOrderedSet } from "v2/__generated__/HomeApp_featuredEventsOrderedSet.graphql"
 import { HomeArtworkModulesFragmentContainer } from "./Components/HomeArtworkModules"
 import { HomeHeroUnitsFragmentContainer } from "./Components/HomeHeroUnits/HomeHeroUnits"
-import { HomeFeaturedArticlesLazyQueryRenderer } from "./Components/HomeFeaturedArticles"
+import { HomeFeaturedMarketNewsLazyQueryRenderer } from "./Components/HomeFeaturedMarketNews"
 import { HomeFeaturedEventsRailFragmentContainer } from "./Components/HomeFeaturedEventsRail"
 import { HomeMeta } from "./Components/HomeMeta"
 import { FlashBannerQueryRenderer } from "v2/Components/FlashBanner"
 
 interface HomeAppProps {
   homePage: HomeApp_homePage | null
-  orderedSet: HomeApp_orderedSet | null
+  orderedSet: HomeApp_featuredEventsOrderedSet | null
 }
 
 export const HomeApp: React.FC<HomeAppProps> = ({ homePage, orderedSet }) => {
@@ -43,7 +43,7 @@ export const HomeApp: React.FC<HomeAppProps> = ({ homePage, orderedSet }) => {
           <HomeArtworkModulesFragmentContainer homePage={homePage} />
         )}
 
-        <HomeFeaturedArticlesLazyQueryRenderer />
+        <HomeFeaturedMarketNewsLazyQueryRenderer />
       </Join>
     </>
   )
@@ -56,8 +56,8 @@ export const HomeAppFragmentContainer = createFragmentContainer(HomeApp, {
       ...HomeArtworkModules_homePage
     }
   `,
-  orderedSet: graphql`
-    fragment HomeApp_orderedSet on OrderedSet {
+  featuredEventsOrderedSet: graphql`
+    fragment HomeApp_featuredEventsOrderedSet on OrderedSet {
       ...HomeFeaturedEventsRail_orderedSet
     }
   `,

--- a/src/v2/Apps/Home/__tests__/HomeApp.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeApp.jest.tsx
@@ -24,7 +24,7 @@ describe("HomeApp", () => {
           ...HomeApp_homePage
         }
         orderedSet(id: "example") {
-          ...HomeApp_orderedSet
+          ...HomeApp_featuredEventsOrderedSet
         }
       }
     `,

--- a/src/v2/Apps/Home/__tests__/HomeApp.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeApp.jest.tsx
@@ -23,7 +23,7 @@ describe("HomeApp", () => {
         homePage {
           ...HomeApp_homePage
         }
-        orderedSet(id: "example") {
+        featuredEventsOrderedSet: orderedSet(id: "example") {
           ...HomeApp_featuredEventsOrderedSet
         }
       }

--- a/src/v2/Apps/Home/__tests__/HomeFeaturedGalleriesRail.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeFeaturedGalleriesRail.jest.tsx
@@ -1,0 +1,49 @@
+import React from "react"
+import { graphql } from "relay-runtime"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { HomeFeaturedGalleriesRailFragmentContainer } from "../Components/HomeFeaturedGalleriesRail"
+import { HomeFeaturedGalleriesRail_Test_Query } from "v2/__generated__/HomeFeaturedGalleriesRail_Test_Query.graphql"
+
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper<HomeFeaturedGalleriesRail_Test_Query>({
+  Component: props => {
+    return (
+      <HomeFeaturedGalleriesRailFragmentContainer
+        orderedSet={props.orderedSet!}
+      />
+    )
+  },
+  query: graphql`
+    query HomeFeaturedGalleriesRail_Test_Query {
+      orderedSet(id: "5638fdfb7261690296000031") {
+        ...HomeFeaturedGalleriesRail_orderedSet
+      }
+    }
+  `,
+})
+
+describe("HomeFeaturedGalleriesRail", () => {
+  it("renders correctly", () => {
+    const wrapper = getWrapper({
+      OrderedSet: () => ({
+        orderedItemsConnection: {
+          edges: [
+            {
+              node: {
+                name: "Test Gallery",
+                href: "test-href",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(wrapper.text()).toContain("Featured Galleries")
+    expect(wrapper.text()).toContain("View All Galleries")
+    expect(wrapper.text()).toContain("Test Gallery")
+    expect(wrapper.text()).toContain("Following")
+    expect(wrapper.html()).toContain("test-href")
+  })
+})

--- a/src/v2/Apps/Home/__tests__/HomeFeaturedMarketNews.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeFeaturedMarketNews.jest.tsx
@@ -1,22 +1,22 @@
 import { graphql } from "relay-runtime"
 import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
-import { HomeFeaturedArticlesFragmentContainer } from "../Components/HomeFeaturedArticles"
-import { HomeFeaturedArticles_Test_Query } from "v2/__generated__/HomeFeaturedArticles_Test_Query.graphql"
+import { HomeFeaturedMarketNewsFragmentContainer } from "../Components/HomeFeaturedMarketNews"
+import { HomeFeaturedMarketNews_Test_Query } from "v2/__generated__/HomeFeaturedMarketNews_Test_Query.graphql"
 
 jest.unmock("react-relay")
 
-const { getWrapper } = setupTestWrapper<HomeFeaturedArticles_Test_Query>({
-  Component: HomeFeaturedArticlesFragmentContainer,
+const { getWrapper } = setupTestWrapper<HomeFeaturedMarketNews_Test_Query>({
+  Component: HomeFeaturedMarketNewsFragmentContainer,
   query: graphql`
-    query HomeFeaturedArticles_Test_Query {
+    query HomeFeaturedMarketNews_Test_Query {
       articles {
-        ...HomeFeaturedArticles_articles
+        ...HomeFeaturedMarketNews_articles
       }
     }
   `,
 })
 
-describe("HomeFeaturedArticles", () => {
+describe("HomeFeaturedMarketNews", () => {
   it("renders correctly", () => {
     const wrapper = getWrapper({
       Article: () => ({

--- a/src/v2/Apps/Home/homeRoutes.tsx
+++ b/src/v2/Apps/Home/homeRoutes.tsx
@@ -20,8 +20,8 @@ export const homeRoutes: AppRouteConfig[] = [
         homePage {
           ...HomeApp_homePage
         }
-        orderedSet(id: "529939e2275b245e290004a0") {
-          ...HomeApp_orderedSet
+        featuredEventsOrderedSet: orderedSet(id: "529939e2275b245e290004a0") {
+          ...HomeApp_featuredEventsOrderedSet
         }
       }
     `,

--- a/src/v2/__generated__/HomeApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeApp_Test_Query.graphql.ts
@@ -9,7 +9,7 @@ export type HomeApp_Test_QueryResponse = {
         readonly " $fragmentRefs": FragmentRefs<"HomeApp_homePage">;
     } | null;
     readonly orderedSet: {
-        readonly " $fragmentRefs": FragmentRefs<"HomeApp_orderedSet">;
+        readonly " $fragmentRefs": FragmentRefs<"HomeApp_featuredEventsOrderedSet">;
     } | null;
 };
 export type HomeApp_Test_Query = {
@@ -25,18 +25,18 @@ query HomeApp_Test_Query {
     ...HomeApp_homePage
   }
   orderedSet(id: "example") {
-    ...HomeApp_orderedSet
+    ...HomeApp_featuredEventsOrderedSet
     id
   }
+}
+
+fragment HomeApp_featuredEventsOrderedSet on OrderedSet {
+  ...HomeFeaturedEventsRail_orderedSet
 }
 
 fragment HomeApp_homePage on HomePage {
   ...HomeHeroUnits_homePage
   ...HomeArtworkModules_homePage
-}
-
-fragment HomeApp_orderedSet on OrderedSet {
-  ...HomeFeaturedEventsRail_orderedSet
 }
 
 fragment HomeArtworkModules_homePage on HomePage {
@@ -193,7 +193,7 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "HomeApp_orderedSet"
+            "name": "HomeApp_featuredEventsOrderedSet"
           }
         ],
         "storageKey": "orderedSet(id:\"example\")"
@@ -473,9 +473,9 @@ return {
     "metadata": {},
     "name": "HomeApp_Test_Query",
     "operationKind": "query",
-    "text": "query HomeApp_Test_Query {\n  homePage {\n    ...HomeApp_homePage\n  }\n  orderedSet(id: \"example\") {\n    ...HomeApp_orderedSet\n    id\n  }\n}\n\nfragment HomeApp_homePage on HomePage {\n  ...HomeHeroUnits_homePage\n  ...HomeArtworkModules_homePage\n}\n\nfragment HomeApp_orderedSet on OrderedSet {\n  ...HomeFeaturedEventsRail_orderedSet\n}\n\nfragment HomeArtworkModules_homePage on HomePage {\n  artworkModules(exclude: [POPULAR_ARTISTS, GENERIC_GENES], maxRails: -1, maxFollowedGeneRails: -1, order: [ACTIVE_BIDS, RECENTLY_VIEWED_WORKS, SIMILAR_TO_RECENTLY_VIEWED, SAVED_WORKS, SIMILAR_TO_SAVED_WORKS, FOLLOWED_ARTISTS, FOLLOWED_GALLERIES, RECOMMENDED_WORKS, RELATED_ARTISTS, LIVE_AUCTIONS, CURRENT_FAIRS, FOLLOWED_GENES, GENERIC_GENES]) {\n    title\n    key\n    params {\n      internalID\n      relatedArtistID\n      followedArtistID\n    }\n    id\n  }\n}\n\nfragment HomeFeaturedEventsRail_orderedSet on OrderedSet {\n  items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      title\n      subtitle\n      href\n      image {\n        small: cropped(width: 95, height: 63) {\n          src\n          srcSet\n          width\n          height\n        }\n        large: cropped(width: 445, height: 297) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    ... on Node {\n      id\n    }\n    ... on Profile {\n      id\n    }\n  }\n}\n\nfragment HomeHeroUnit_heroUnit on HomePageHeroUnit {\n  backgroundImageURL\n  heading\n  title\n  subtitle\n  linkText\n  href\n  creditLine\n}\n\nfragment HomeHeroUnits_homePage on HomePage {\n  heroUnits(platform: DESKTOP) {\n    internalID\n    ...HomeHeroUnit_heroUnit\n    id\n  }\n}\n"
+    "text": "query HomeApp_Test_Query {\n  homePage {\n    ...HomeApp_homePage\n  }\n  orderedSet(id: \"example\") {\n    ...HomeApp_featuredEventsOrderedSet\n    id\n  }\n}\n\nfragment HomeApp_featuredEventsOrderedSet on OrderedSet {\n  ...HomeFeaturedEventsRail_orderedSet\n}\n\nfragment HomeApp_homePage on HomePage {\n  ...HomeHeroUnits_homePage\n  ...HomeArtworkModules_homePage\n}\n\nfragment HomeArtworkModules_homePage on HomePage {\n  artworkModules(exclude: [POPULAR_ARTISTS, GENERIC_GENES], maxRails: -1, maxFollowedGeneRails: -1, order: [ACTIVE_BIDS, RECENTLY_VIEWED_WORKS, SIMILAR_TO_RECENTLY_VIEWED, SAVED_WORKS, SIMILAR_TO_SAVED_WORKS, FOLLOWED_ARTISTS, FOLLOWED_GALLERIES, RECOMMENDED_WORKS, RELATED_ARTISTS, LIVE_AUCTIONS, CURRENT_FAIRS, FOLLOWED_GENES, GENERIC_GENES]) {\n    title\n    key\n    params {\n      internalID\n      relatedArtistID\n      followedArtistID\n    }\n    id\n  }\n}\n\nfragment HomeFeaturedEventsRail_orderedSet on OrderedSet {\n  items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      title\n      subtitle\n      href\n      image {\n        small: cropped(width: 95, height: 63) {\n          src\n          srcSet\n          width\n          height\n        }\n        large: cropped(width: 445, height: 297) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    ... on Node {\n      id\n    }\n    ... on Profile {\n      id\n    }\n  }\n}\n\nfragment HomeHeroUnit_heroUnit on HomePageHeroUnit {\n  backgroundImageURL\n  heading\n  title\n  subtitle\n  linkText\n  href\n  creditLine\n}\n\nfragment HomeHeroUnits_homePage on HomePage {\n  heroUnits(platform: DESKTOP) {\n    internalID\n    ...HomeHeroUnit_heroUnit\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '5f7995f203716d2452ee619753de7715';
+(node as any).hash = '31109676cb4c44f834e1463a84b74773';
 export default node;

--- a/src/v2/__generated__/HomeApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeApp_Test_Query.graphql.ts
@@ -8,7 +8,7 @@ export type HomeApp_Test_QueryResponse = {
     readonly homePage: {
         readonly " $fragmentRefs": FragmentRefs<"HomeApp_homePage">;
     } | null;
-    readonly orderedSet: {
+    readonly featuredEventsOrderedSet: {
         readonly " $fragmentRefs": FragmentRefs<"HomeApp_featuredEventsOrderedSet">;
     } | null;
 };
@@ -24,7 +24,7 @@ query HomeApp_Test_Query {
   homePage {
     ...HomeApp_homePage
   }
-  orderedSet(id: "example") {
+  featuredEventsOrderedSet: orderedSet(id: "example") {
     ...HomeApp_featuredEventsOrderedSet
     id
   }
@@ -183,7 +183,7 @@ return {
         "storageKey": null
       },
       {
-        "alias": null,
+        "alias": "featuredEventsOrderedSet",
         "args": (v0/*: any*/),
         "concreteType": "OrderedSet",
         "kind": "LinkedField",
@@ -353,7 +353,7 @@ return {
         "storageKey": null
       },
       {
-        "alias": null,
+        "alias": "featuredEventsOrderedSet",
         "args": (v0/*: any*/),
         "concreteType": "OrderedSet",
         "kind": "LinkedField",
@@ -473,9 +473,9 @@ return {
     "metadata": {},
     "name": "HomeApp_Test_Query",
     "operationKind": "query",
-    "text": "query HomeApp_Test_Query {\n  homePage {\n    ...HomeApp_homePage\n  }\n  orderedSet(id: \"example\") {\n    ...HomeApp_featuredEventsOrderedSet\n    id\n  }\n}\n\nfragment HomeApp_featuredEventsOrderedSet on OrderedSet {\n  ...HomeFeaturedEventsRail_orderedSet\n}\n\nfragment HomeApp_homePage on HomePage {\n  ...HomeHeroUnits_homePage\n  ...HomeArtworkModules_homePage\n}\n\nfragment HomeArtworkModules_homePage on HomePage {\n  artworkModules(exclude: [POPULAR_ARTISTS, GENERIC_GENES], maxRails: -1, maxFollowedGeneRails: -1, order: [ACTIVE_BIDS, RECENTLY_VIEWED_WORKS, SIMILAR_TO_RECENTLY_VIEWED, SAVED_WORKS, SIMILAR_TO_SAVED_WORKS, FOLLOWED_ARTISTS, FOLLOWED_GALLERIES, RECOMMENDED_WORKS, RELATED_ARTISTS, LIVE_AUCTIONS, CURRENT_FAIRS, FOLLOWED_GENES, GENERIC_GENES]) {\n    title\n    key\n    params {\n      internalID\n      relatedArtistID\n      followedArtistID\n    }\n    id\n  }\n}\n\nfragment HomeFeaturedEventsRail_orderedSet on OrderedSet {\n  items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      title\n      subtitle\n      href\n      image {\n        small: cropped(width: 95, height: 63) {\n          src\n          srcSet\n          width\n          height\n        }\n        large: cropped(width: 445, height: 297) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    ... on Node {\n      id\n    }\n    ... on Profile {\n      id\n    }\n  }\n}\n\nfragment HomeHeroUnit_heroUnit on HomePageHeroUnit {\n  backgroundImageURL\n  heading\n  title\n  subtitle\n  linkText\n  href\n  creditLine\n}\n\nfragment HomeHeroUnits_homePage on HomePage {\n  heroUnits(platform: DESKTOP) {\n    internalID\n    ...HomeHeroUnit_heroUnit\n    id\n  }\n}\n"
+    "text": "query HomeApp_Test_Query {\n  homePage {\n    ...HomeApp_homePage\n  }\n  featuredEventsOrderedSet: orderedSet(id: \"example\") {\n    ...HomeApp_featuredEventsOrderedSet\n    id\n  }\n}\n\nfragment HomeApp_featuredEventsOrderedSet on OrderedSet {\n  ...HomeFeaturedEventsRail_orderedSet\n}\n\nfragment HomeApp_homePage on HomePage {\n  ...HomeHeroUnits_homePage\n  ...HomeArtworkModules_homePage\n}\n\nfragment HomeArtworkModules_homePage on HomePage {\n  artworkModules(exclude: [POPULAR_ARTISTS, GENERIC_GENES], maxRails: -1, maxFollowedGeneRails: -1, order: [ACTIVE_BIDS, RECENTLY_VIEWED_WORKS, SIMILAR_TO_RECENTLY_VIEWED, SAVED_WORKS, SIMILAR_TO_SAVED_WORKS, FOLLOWED_ARTISTS, FOLLOWED_GALLERIES, RECOMMENDED_WORKS, RELATED_ARTISTS, LIVE_AUCTIONS, CURRENT_FAIRS, FOLLOWED_GENES, GENERIC_GENES]) {\n    title\n    key\n    params {\n      internalID\n      relatedArtistID\n      followedArtistID\n    }\n    id\n  }\n}\n\nfragment HomeFeaturedEventsRail_orderedSet on OrderedSet {\n  items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      title\n      subtitle\n      href\n      image {\n        small: cropped(width: 95, height: 63) {\n          src\n          srcSet\n          width\n          height\n        }\n        large: cropped(width: 445, height: 297) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    ... on Node {\n      id\n    }\n    ... on Profile {\n      id\n    }\n  }\n}\n\nfragment HomeHeroUnit_heroUnit on HomePageHeroUnit {\n  backgroundImageURL\n  heading\n  title\n  subtitle\n  linkText\n  href\n  creditLine\n}\n\nfragment HomeHeroUnits_homePage on HomePage {\n  heroUnits(platform: DESKTOP) {\n    internalID\n    ...HomeHeroUnit_heroUnit\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '31109676cb4c44f834e1463a84b74773';
+(node as any).hash = 'f7d9a9714371bb688918675db4fdc69e';
 export default node;

--- a/src/v2/__generated__/HomeApp_featuredEventsOrderedSet.graphql.ts
+++ b/src/v2/__generated__/HomeApp_featuredEventsOrderedSet.graphql.ts
@@ -3,14 +3,14 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type HomeApp_orderedSet = {
+export type HomeApp_featuredEventsOrderedSet = {
     readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedEventsRail_orderedSet">;
-    readonly " $refType": "HomeApp_orderedSet";
+    readonly " $refType": "HomeApp_featuredEventsOrderedSet";
 };
-export type HomeApp_orderedSet$data = HomeApp_orderedSet;
-export type HomeApp_orderedSet$key = {
-    readonly " $data"?: HomeApp_orderedSet$data;
-    readonly " $fragmentRefs": FragmentRefs<"HomeApp_orderedSet">;
+export type HomeApp_featuredEventsOrderedSet$data = HomeApp_featuredEventsOrderedSet;
+export type HomeApp_featuredEventsOrderedSet$key = {
+    readonly " $data"?: HomeApp_featuredEventsOrderedSet$data;
+    readonly " $fragmentRefs": FragmentRefs<"HomeApp_featuredEventsOrderedSet">;
 };
 
 
@@ -19,7 +19,7 @@ const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
-  "name": "HomeApp_orderedSet",
+  "name": "HomeApp_featuredEventsOrderedSet",
   "selections": [
     {
       "args": null,
@@ -29,5 +29,5 @@ const node: ReaderFragment = {
   ],
   "type": "OrderedSet"
 };
-(node as any).hash = 'f11ea8c99b658c32463730fa54b8b73c';
+(node as any).hash = 'e5316349296555e9aaf1e6896746cc3f';
 export default node;

--- a/src/v2/__generated__/HomeFeaturedGalleriesRailQuery.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRailQuery.graphql.ts
@@ -1,0 +1,296 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeFeaturedGalleriesRailQueryVariables = {};
+export type HomeFeaturedGalleriesRailQueryResponse = {
+    readonly orderedSet: {
+        readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedGalleriesRail_orderedSet">;
+    } | null;
+};
+export type HomeFeaturedGalleriesRailQuery = {
+    readonly response: HomeFeaturedGalleriesRailQueryResponse;
+    readonly variables: HomeFeaturedGalleriesRailQueryVariables;
+};
+
+
+
+/*
+query HomeFeaturedGalleriesRailQuery {
+  orderedSet(id: "5638fdfb7261690296000031") {
+    ...HomeFeaturedGalleriesRail_orderedSet
+    id
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  is_followed: isFollowed
+}
+
+fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
+  orderedItemsConnection(first: 20) {
+    edges {
+      node {
+        __typename
+        ... on Profile {
+          ...FollowProfileButton_profile
+          internalID
+          name
+          slug
+          href
+          location
+          image {
+            cropped(width: 325, height: 230) {
+              src
+              srcSet
+              width
+              height
+            }
+          }
+          id
+        }
+        ... on Node {
+          id
+        }
+        ... on FeaturedLink {
+          id
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "5638fdfb7261690296000031"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeFeaturedGalleriesRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSet",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "HomeFeaturedGalleriesRail_orderedSet"
+          }
+        ],
+        "storageKey": "orderedSet(id:\"5638fdfb7261690296000031\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeFeaturedGalleriesRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSet",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 20
+              }
+            ],
+            "concreteType": "OrderedSetItemConnection",
+            "kind": "LinkedField",
+            "name": "orderedItemsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "OrderedSetItemEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/),
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "slug",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "internalID",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_followed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isFollowed",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "href",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "location",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "height",
+                                    "value": 230
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 325
+                                  }
+                                ],
+                                "concreteType": "CroppedImageUrl",
+                                "kind": "LinkedField",
+                                "name": "cropped",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "src",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "srcSet",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "width",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "height",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": "cropped(height:230,width:325)"
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "type": "Profile"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "orderedItemsConnection(first:20)"
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": "orderedSet(id:\"5638fdfb7261690296000031\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "HomeFeaturedGalleriesRailQuery",
+    "operationKind": "query",
+    "text": "query HomeFeaturedGalleriesRailQuery {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          ...FollowProfileButton_profile\n          internalID\n          name\n          slug\n          href\n          location\n          image {\n            cropped(width: 325, height: 230) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          id\n        }\n        ... on Node {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '2ba946f2a1e9916ac12d7481531b6f9f';
+export default node;

--- a/src/v2/__generated__/HomeFeaturedGalleriesRail_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRail_Test_Query.graphql.ts
@@ -1,0 +1,296 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeFeaturedGalleriesRail_Test_QueryVariables = {};
+export type HomeFeaturedGalleriesRail_Test_QueryResponse = {
+    readonly orderedSet: {
+        readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedGalleriesRail_orderedSet">;
+    } | null;
+};
+export type HomeFeaturedGalleriesRail_Test_Query = {
+    readonly response: HomeFeaturedGalleriesRail_Test_QueryResponse;
+    readonly variables: HomeFeaturedGalleriesRail_Test_QueryVariables;
+};
+
+
+
+/*
+query HomeFeaturedGalleriesRail_Test_Query {
+  orderedSet(id: "5638fdfb7261690296000031") {
+    ...HomeFeaturedGalleriesRail_orderedSet
+    id
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  is_followed: isFollowed
+}
+
+fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
+  orderedItemsConnection(first: 20) {
+    edges {
+      node {
+        __typename
+        ... on Profile {
+          ...FollowProfileButton_profile
+          internalID
+          name
+          slug
+          href
+          location
+          image {
+            cropped(width: 325, height: 230) {
+              src
+              srcSet
+              width
+              height
+            }
+          }
+          id
+        }
+        ... on Node {
+          id
+        }
+        ... on FeaturedLink {
+          id
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "5638fdfb7261690296000031"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeFeaturedGalleriesRail_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSet",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "HomeFeaturedGalleriesRail_orderedSet"
+          }
+        ],
+        "storageKey": "orderedSet(id:\"5638fdfb7261690296000031\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeFeaturedGalleriesRail_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSet",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 20
+              }
+            ],
+            "concreteType": "OrderedSetItemConnection",
+            "kind": "LinkedField",
+            "name": "orderedItemsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "OrderedSetItemEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/),
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "slug",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "internalID",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_followed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isFollowed",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "href",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "location",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "height",
+                                    "value": 230
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 325
+                                  }
+                                ],
+                                "concreteType": "CroppedImageUrl",
+                                "kind": "LinkedField",
+                                "name": "cropped",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "src",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "srcSet",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "width",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "height",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": "cropped(height:230,width:325)"
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "type": "Profile"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "orderedItemsConnection(first:20)"
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": "orderedSet(id:\"5638fdfb7261690296000031\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "HomeFeaturedGalleriesRail_Test_Query",
+    "operationKind": "query",
+    "text": "query HomeFeaturedGalleriesRail_Test_Query {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          ...FollowProfileButton_profile\n          internalID\n          name\n          slug\n          href\n          location\n          image {\n            cropped(width: 325, height: 230) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          id\n        }\n        ... on Node {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'c26bfa9b5a68842c47e367169ff48acc';
+export default node;

--- a/src/v2/__generated__/HomeFeaturedGalleriesRail_orderedSet.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRail_orderedSet.graphql.ts
@@ -4,29 +4,31 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type HomeFeaturedGalleriesRail_orderedSet = {
-    readonly items: ReadonlyArray<({
-        readonly __typename: "FeaturedLink";
-        readonly internalID: string | null;
-        readonly title: string | null;
-        readonly subtitle: string | null;
-        readonly href: string | null;
-        readonly image: {
-            readonly small: {
-                readonly src: string;
-                readonly srcSet: string;
-                readonly width: number;
-                readonly height: number;
-            } | null;
-            readonly large: {
-                readonly src: string;
-                readonly srcSet: string;
-            } | null;
-        } | null;
-    } | {
-        /*This will never be '%other', but we need some
-        value in case none of the concrete values match.*/
-        readonly __typename: "%other";
-    }) | null> | null;
+    readonly orderedItemsConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: ({
+                readonly __typename: "Profile";
+                readonly internalID: string;
+                readonly name: string | null;
+                readonly slug: string;
+                readonly href: string | null;
+                readonly location: string | null;
+                readonly image: {
+                    readonly cropped: {
+                        readonly src: string;
+                        readonly srcSet: string;
+                        readonly width: number;
+                        readonly height: number;
+                    } | null;
+                } | null;
+                readonly " $fragmentRefs": FragmentRefs<"FollowProfileButton_profile">;
+            } | {
+                /*This will never be '%other', but we need some
+                value in case none of the concrete values match.*/
+                readonly __typename: "%other";
+            }) | null;
+        } | null> | null;
+    };
     readonly " $refType": "HomeFeaturedGalleriesRail_orderedSet";
 };
 export type HomeFeaturedGalleriesRail_orderedSet$data = HomeFeaturedGalleriesRail_orderedSet;
@@ -37,22 +39,7 @@ export type HomeFeaturedGalleriesRail_orderedSet$key = {
 
 
 
-const node: ReaderFragment = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "src",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-};
-return {
+const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -60,132 +47,159 @@ return {
   "selections": [
     {
       "alias": null,
-      "args": null,
-      "concreteType": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 20
+        }
+      ],
+      "concreteType": "OrderedSetItemConnection",
       "kind": "LinkedField",
-      "name": "items",
-      "plural": true,
+      "name": "orderedItemsConnection",
+      "plural": false,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "__typename",
-          "storageKey": null
-        },
-        {
-          "kind": "InlineFragment",
+          "concreteType": "OrderedSetItemEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
           "selections": [
             {
               "alias": null,
               "args": null,
-              "kind": "ScalarField",
-              "name": "internalID",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "title",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "subtitle",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "href",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "Image",
+              "concreteType": null,
               "kind": "LinkedField",
-              "name": "image",
+              "name": "node",
               "plural": false,
               "selections": [
                 {
-                  "alias": "small",
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "height",
-                      "value": 63
-                    },
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 95
-                    }
-                  ],
-                  "concreteType": "CroppedImageUrl",
-                  "kind": "LinkedField",
-                  "name": "cropped",
-                  "plural": false,
-                  "selections": [
-                    (v0/*: any*/),
-                    (v1/*: any*/),
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "width",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "height",
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": "cropped(height:63,width:95)"
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
                 },
                 {
-                  "alias": "large",
-                  "args": [
+                  "kind": "InlineFragment",
+                  "selections": [
                     {
-                      "kind": "Literal",
-                      "name": "height",
-                      "value": 297
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "internalID",
+                      "storageKey": null
                     },
                     {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 445
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "name",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "slug",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "href",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "location",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Image",
+                      "kind": "LinkedField",
+                      "name": "image",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": [
+                            {
+                              "kind": "Literal",
+                              "name": "height",
+                              "value": 230
+                            },
+                            {
+                              "kind": "Literal",
+                              "name": "width",
+                              "value": 325
+                            }
+                          ],
+                          "concreteType": "CroppedImageUrl",
+                          "kind": "LinkedField",
+                          "name": "cropped",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "src",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "srcSet",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "width",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "height",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": "cropped(height:230,width:325)"
+                        }
+                      ],
+                      "storageKey": null
+                    },
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "FollowProfileButton_profile"
                     }
                   ],
-                  "concreteType": "CroppedImageUrl",
-                  "kind": "LinkedField",
-                  "name": "cropped",
-                  "plural": false,
-                  "selections": [
-                    (v0/*: any*/),
-                    (v1/*: any*/)
-                  ],
-                  "storageKey": "cropped(height:297,width:445)"
+                  "type": "Profile"
                 }
               ],
               "storageKey": null
             }
           ],
-          "type": "FeaturedLink"
+          "storageKey": null
         }
       ],
-      "storageKey": null
+      "storageKey": "orderedItemsConnection(first:20)"
     }
   ],
   "type": "OrderedSet"
 };
-})();
-(node as any).hash = '8741c46b608f476fcde0f4298bb54586';
+(node as any).hash = '7326b5dabc44a4be0621c7bec35ff111';
 export default node;

--- a/src/v2/__generated__/HomeFeaturedGalleriesRail_orderedSet.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRail_orderedSet.graphql.ts
@@ -1,0 +1,191 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeFeaturedGalleriesRail_orderedSet = {
+    readonly items: ReadonlyArray<({
+        readonly __typename: "FeaturedLink";
+        readonly internalID: string | null;
+        readonly title: string | null;
+        readonly subtitle: string | null;
+        readonly href: string | null;
+        readonly image: {
+            readonly small: {
+                readonly src: string;
+                readonly srcSet: string;
+                readonly width: number;
+                readonly height: number;
+            } | null;
+            readonly large: {
+                readonly src: string;
+                readonly srcSet: string;
+            } | null;
+        } | null;
+    } | {
+        /*This will never be '%other', but we need some
+        value in case none of the concrete values match.*/
+        readonly __typename: "%other";
+    }) | null> | null;
+    readonly " $refType": "HomeFeaturedGalleriesRail_orderedSet";
+};
+export type HomeFeaturedGalleriesRail_orderedSet$data = HomeFeaturedGalleriesRail_orderedSet;
+export type HomeFeaturedGalleriesRail_orderedSet$key = {
+    readonly " $data"?: HomeFeaturedGalleriesRail_orderedSet$data;
+    readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedGalleriesRail_orderedSet">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "src",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "srcSet",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "HomeFeaturedGalleriesRail_orderedSet",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "items",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__typename",
+          "storageKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "internalID",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "title",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "subtitle",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "href",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Image",
+              "kind": "LinkedField",
+              "name": "image",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": "small",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "height",
+                      "value": 63
+                    },
+                    {
+                      "kind": "Literal",
+                      "name": "width",
+                      "value": 95
+                    }
+                  ],
+                  "concreteType": "CroppedImageUrl",
+                  "kind": "LinkedField",
+                  "name": "cropped",
+                  "plural": false,
+                  "selections": [
+                    (v0/*: any*/),
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "width",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "height",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": "cropped(height:63,width:95)"
+                },
+                {
+                  "alias": "large",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "height",
+                      "value": 297
+                    },
+                    {
+                      "kind": "Literal",
+                      "name": "width",
+                      "value": 445
+                    }
+                  ],
+                  "concreteType": "CroppedImageUrl",
+                  "kind": "LinkedField",
+                  "name": "cropped",
+                  "plural": false,
+                  "selections": [
+                    (v0/*: any*/),
+                    (v1/*: any*/)
+                  ],
+                  "storageKey": "cropped(height:297,width:445)"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "type": "FeaturedLink"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "OrderedSet"
+};
+})();
+(node as any).hash = '8741c46b608f476fcde0f4298bb54586';
+export default node;

--- a/src/v2/__generated__/HomeFeaturedMarketNewsQuery.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedMarketNewsQuery.graphql.ts
@@ -3,28 +3,28 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type HomeFeaturedArticles_Test_QueryVariables = {};
-export type HomeFeaturedArticles_Test_QueryResponse = {
+export type HomeFeaturedMarketNewsQueryVariables = {};
+export type HomeFeaturedMarketNewsQueryResponse = {
     readonly articles: ReadonlyArray<{
-        readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedArticles_articles">;
+        readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedMarketNews_articles">;
     } | null> | null;
 };
-export type HomeFeaturedArticles_Test_Query = {
-    readonly response: HomeFeaturedArticles_Test_QueryResponse;
-    readonly variables: HomeFeaturedArticles_Test_QueryVariables;
+export type HomeFeaturedMarketNewsQuery = {
+    readonly response: HomeFeaturedMarketNewsQueryResponse;
+    readonly variables: HomeFeaturedMarketNewsQueryVariables;
 };
 
 
 
 /*
-query HomeFeaturedArticles_Test_Query {
-  articles {
-    ...HomeFeaturedArticles_articles
+query HomeFeaturedMarketNewsQuery {
+  articles(featured: true, published: true, sort: PUBLISHED_AT_DESC) {
+    ...HomeFeaturedMarketNews_articles
     id
   }
 }
 
-fragment HomeFeaturedArticles_articles on Article {
+fragment HomeFeaturedMarketNews_articles on Article {
   internalID
   href
   title
@@ -55,6 +55,23 @@ fragment HomeFeaturedArticles_articles on Article {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
+    "kind": "Literal",
+    "name": "featured",
+    "value": true
+  },
+  {
+    "kind": "Literal",
+    "name": "published",
+    "value": true
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "PUBLISHED_AT_DESC"
+  }
+],
+v1 = [
+  {
     "alias": null,
     "args": null,
     "kind": "ScalarField",
@@ -83,7 +100,7 @@ var v0 = [
     "storageKey": null
   }
 ],
-v1 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -95,11 +112,11 @@ return {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "HomeFeaturedArticles_Test_Query",
+    "name": "HomeFeaturedMarketNewsQuery",
     "selections": [
       {
         "alias": null,
-        "args": null,
+        "args": (v0/*: any*/),
         "concreteType": "Article",
         "kind": "LinkedField",
         "name": "articles",
@@ -108,10 +125,10 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "HomeFeaturedArticles_articles"
+            "name": "HomeFeaturedMarketNews_articles"
           }
         ],
-        "storageKey": null
+        "storageKey": "articles(featured:true,published:true,sort:\"PUBLISHED_AT_DESC\")"
       }
     ],
     "type": "Query"
@@ -120,11 +137,11 @@ return {
   "operation": {
     "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "HomeFeaturedArticles_Test_Query",
+    "name": "HomeFeaturedMarketNewsQuery",
     "selections": [
       {
         "alias": null,
-        "args": null,
+        "args": (v0/*: any*/),
         "concreteType": "Article",
         "kind": "LinkedField",
         "name": "articles",
@@ -204,7 +221,7 @@ return {
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v0/*: any*/),
+                "selections": (v1/*: any*/),
                 "storageKey": "cropped(height:720,width:670)"
               },
               {
@@ -225,7 +242,7 @@ return {
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v0/*: any*/),
+                "selections": (v1/*: any*/),
                 "storageKey": "cropped(height:240,width:325)"
               }
             ],
@@ -246,24 +263,24 @@ return {
                 "name": "name",
                 "storageKey": null
               },
-              (v1/*: any*/)
+              (v2/*: any*/)
             ],
             "storageKey": null
           },
-          (v1/*: any*/)
+          (v2/*: any*/)
         ],
-        "storageKey": null
+        "storageKey": "articles(featured:true,published:true,sort:\"PUBLISHED_AT_DESC\")"
       }
     ]
   },
   "params": {
     "id": null,
     "metadata": {},
-    "name": "HomeFeaturedArticles_Test_Query",
+    "name": "HomeFeaturedMarketNewsQuery",
     "operationKind": "query",
-    "text": "query HomeFeaturedArticles_Test_Query {\n  articles {\n    ...HomeFeaturedArticles_articles\n    id\n  }\n}\n\nfragment HomeFeaturedArticles_articles on Article {\n  internalID\n  href\n  title\n  publishedAt(format: \"MMM D YYYY\")\n  vertical\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n  author {\n    name\n    id\n  }\n}\n"
+    "text": "query HomeFeaturedMarketNewsQuery {\n  articles(featured: true, published: true, sort: PUBLISHED_AT_DESC) {\n    ...HomeFeaturedMarketNews_articles\n    id\n  }\n}\n\nfragment HomeFeaturedMarketNews_articles on Article {\n  internalID\n  href\n  title\n  publishedAt(format: \"MMM D YYYY\")\n  vertical\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n  author {\n    name\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '7557499b993fbf4e016df8e0f0e952f6';
+(node as any).hash = '484565658b47f40dd52c68e8e8dabde1';
 export default node;

--- a/src/v2/__generated__/HomeFeaturedMarketNews_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedMarketNews_Test_Query.graphql.ts
@@ -3,28 +3,28 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type HomeFeaturedArticlesQueryVariables = {};
-export type HomeFeaturedArticlesQueryResponse = {
+export type HomeFeaturedMarketNews_Test_QueryVariables = {};
+export type HomeFeaturedMarketNews_Test_QueryResponse = {
     readonly articles: ReadonlyArray<{
-        readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedArticles_articles">;
+        readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedMarketNews_articles">;
     } | null> | null;
 };
-export type HomeFeaturedArticlesQuery = {
-    readonly response: HomeFeaturedArticlesQueryResponse;
-    readonly variables: HomeFeaturedArticlesQueryVariables;
+export type HomeFeaturedMarketNews_Test_Query = {
+    readonly response: HomeFeaturedMarketNews_Test_QueryResponse;
+    readonly variables: HomeFeaturedMarketNews_Test_QueryVariables;
 };
 
 
 
 /*
-query HomeFeaturedArticlesQuery {
-  articles(featured: true, published: true, sort: PUBLISHED_AT_DESC) {
-    ...HomeFeaturedArticles_articles
+query HomeFeaturedMarketNews_Test_Query {
+  articles {
+    ...HomeFeaturedMarketNews_articles
     id
   }
 }
 
-fragment HomeFeaturedArticles_articles on Article {
+fragment HomeFeaturedMarketNews_articles on Article {
   internalID
   href
   title
@@ -55,23 +55,6 @@ fragment HomeFeaturedArticles_articles on Article {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "kind": "Literal",
-    "name": "featured",
-    "value": true
-  },
-  {
-    "kind": "Literal",
-    "name": "published",
-    "value": true
-  },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "PUBLISHED_AT_DESC"
-  }
-],
-v1 = [
-  {
     "alias": null,
     "args": null,
     "kind": "ScalarField",
@@ -100,7 +83,7 @@ v1 = [
     "storageKey": null
   }
 ],
-v2 = {
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -112,11 +95,11 @@ return {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "HomeFeaturedArticlesQuery",
+    "name": "HomeFeaturedMarketNews_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": null,
         "concreteType": "Article",
         "kind": "LinkedField",
         "name": "articles",
@@ -125,10 +108,10 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "HomeFeaturedArticles_articles"
+            "name": "HomeFeaturedMarketNews_articles"
           }
         ],
-        "storageKey": "articles(featured:true,published:true,sort:\"PUBLISHED_AT_DESC\")"
+        "storageKey": null
       }
     ],
     "type": "Query"
@@ -137,11 +120,11 @@ return {
   "operation": {
     "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "HomeFeaturedArticlesQuery",
+    "name": "HomeFeaturedMarketNews_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": null,
         "concreteType": "Article",
         "kind": "LinkedField",
         "name": "articles",
@@ -221,7 +204,7 @@ return {
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v1/*: any*/),
+                "selections": (v0/*: any*/),
                 "storageKey": "cropped(height:720,width:670)"
               },
               {
@@ -242,7 +225,7 @@ return {
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v1/*: any*/),
+                "selections": (v0/*: any*/),
                 "storageKey": "cropped(height:240,width:325)"
               }
             ],
@@ -263,24 +246,24 @@ return {
                 "name": "name",
                 "storageKey": null
               },
-              (v2/*: any*/)
+              (v1/*: any*/)
             ],
             "storageKey": null
           },
-          (v2/*: any*/)
+          (v1/*: any*/)
         ],
-        "storageKey": "articles(featured:true,published:true,sort:\"PUBLISHED_AT_DESC\")"
+        "storageKey": null
       }
     ]
   },
   "params": {
     "id": null,
     "metadata": {},
-    "name": "HomeFeaturedArticlesQuery",
+    "name": "HomeFeaturedMarketNews_Test_Query",
     "operationKind": "query",
-    "text": "query HomeFeaturedArticlesQuery {\n  articles(featured: true, published: true, sort: PUBLISHED_AT_DESC) {\n    ...HomeFeaturedArticles_articles\n    id\n  }\n}\n\nfragment HomeFeaturedArticles_articles on Article {\n  internalID\n  href\n  title\n  publishedAt(format: \"MMM D YYYY\")\n  vertical\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n  author {\n    name\n    id\n  }\n}\n"
+    "text": "query HomeFeaturedMarketNews_Test_Query {\n  articles {\n    ...HomeFeaturedMarketNews_articles\n    id\n  }\n}\n\nfragment HomeFeaturedMarketNews_articles on Article {\n  internalID\n  href\n  title\n  publishedAt(format: \"MMM D YYYY\")\n  vertical\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n  author {\n    name\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '1f3bf55b1a5fc5c758b6fccefdabf628';
+(node as any).hash = '40dca964711f6194bf54326edad403cc';
 export default node;

--- a/src/v2/__generated__/HomeFeaturedMarketNews_articles.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedMarketNews_articles.graphql.ts
@@ -3,7 +3,7 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type HomeFeaturedArticles_articles = ReadonlyArray<{
+export type HomeFeaturedMarketNews_articles = ReadonlyArray<{
     readonly internalID: string;
     readonly href: string | null;
     readonly title: string | null;
@@ -27,12 +27,12 @@ export type HomeFeaturedArticles_articles = ReadonlyArray<{
     readonly author: {
         readonly name: string | null;
     } | null;
-    readonly " $refType": "HomeFeaturedArticles_articles";
+    readonly " $refType": "HomeFeaturedMarketNews_articles";
 }>;
-export type HomeFeaturedArticles_articles$data = HomeFeaturedArticles_articles;
-export type HomeFeaturedArticles_articles$key = ReadonlyArray<{
-    readonly " $data"?: HomeFeaturedArticles_articles$data;
-    readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedArticles_articles">;
+export type HomeFeaturedMarketNews_articles$data = HomeFeaturedMarketNews_articles;
+export type HomeFeaturedMarketNews_articles$key = ReadonlyArray<{
+    readonly " $data"?: HomeFeaturedMarketNews_articles$data;
+    readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedMarketNews_articles">;
 }>;
 
 
@@ -74,7 +74,7 @@ return {
   "metadata": {
     "plural": true
   },
-  "name": "HomeFeaturedArticles_articles",
+  "name": "HomeFeaturedMarketNews_articles",
   "selections": [
     {
       "alias": null,
@@ -199,5 +199,5 @@ return {
   "type": "Article"
 };
 })();
-(node as any).hash = 'd2bf5222fa0e5e98a988a99574fe0e1f';
+(node as any).hash = '9d20317d7100f669742294f87ddbebbf';
 export default node;

--- a/src/v2/__generated__/homeRoutes_HomeQuery.graphql.ts
+++ b/src/v2/__generated__/homeRoutes_HomeQuery.graphql.ts
@@ -8,8 +8,8 @@ export type homeRoutes_HomeQueryResponse = {
     readonly homePage: {
         readonly " $fragmentRefs": FragmentRefs<"HomeApp_homePage">;
     } | null;
-    readonly orderedSet: {
-        readonly " $fragmentRefs": FragmentRefs<"HomeApp_orderedSet">;
+    readonly featuredEventsOrderedSet: {
+        readonly " $fragmentRefs": FragmentRefs<"HomeApp_featuredEventsOrderedSet">;
     } | null;
 };
 export type homeRoutes_HomeQuery = {
@@ -24,19 +24,19 @@ query homeRoutes_HomeQuery {
   homePage {
     ...HomeApp_homePage
   }
-  orderedSet(id: "529939e2275b245e290004a0") {
-    ...HomeApp_orderedSet
+  featuredEventsOrderedSet: orderedSet(id: "529939e2275b245e290004a0") {
+    ...HomeApp_featuredEventsOrderedSet
     id
   }
+}
+
+fragment HomeApp_featuredEventsOrderedSet on OrderedSet {
+  ...HomeFeaturedEventsRail_orderedSet
 }
 
 fragment HomeApp_homePage on HomePage {
   ...HomeHeroUnits_homePage
   ...HomeArtworkModules_homePage
-}
-
-fragment HomeApp_orderedSet on OrderedSet {
-  ...HomeFeaturedEventsRail_orderedSet
 }
 
 fragment HomeArtworkModules_homePage on HomePage {
@@ -183,7 +183,7 @@ return {
         "storageKey": null
       },
       {
-        "alias": null,
+        "alias": "featuredEventsOrderedSet",
         "args": (v0/*: any*/),
         "concreteType": "OrderedSet",
         "kind": "LinkedField",
@@ -193,7 +193,7 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "HomeApp_orderedSet"
+            "name": "HomeApp_featuredEventsOrderedSet"
           }
         ],
         "storageKey": "orderedSet(id:\"529939e2275b245e290004a0\")"
@@ -353,7 +353,7 @@ return {
         "storageKey": null
       },
       {
-        "alias": null,
+        "alias": "featuredEventsOrderedSet",
         "args": (v0/*: any*/),
         "concreteType": "OrderedSet",
         "kind": "LinkedField",
@@ -473,9 +473,9 @@ return {
     "metadata": {},
     "name": "homeRoutes_HomeQuery",
     "operationKind": "query",
-    "text": "query homeRoutes_HomeQuery {\n  homePage {\n    ...HomeApp_homePage\n  }\n  orderedSet(id: \"529939e2275b245e290004a0\") {\n    ...HomeApp_orderedSet\n    id\n  }\n}\n\nfragment HomeApp_homePage on HomePage {\n  ...HomeHeroUnits_homePage\n  ...HomeArtworkModules_homePage\n}\n\nfragment HomeApp_orderedSet on OrderedSet {\n  ...HomeFeaturedEventsRail_orderedSet\n}\n\nfragment HomeArtworkModules_homePage on HomePage {\n  artworkModules(exclude: [POPULAR_ARTISTS, GENERIC_GENES], maxRails: -1, maxFollowedGeneRails: -1, order: [ACTIVE_BIDS, RECENTLY_VIEWED_WORKS, SIMILAR_TO_RECENTLY_VIEWED, SAVED_WORKS, SIMILAR_TO_SAVED_WORKS, FOLLOWED_ARTISTS, FOLLOWED_GALLERIES, RECOMMENDED_WORKS, RELATED_ARTISTS, LIVE_AUCTIONS, CURRENT_FAIRS, FOLLOWED_GENES, GENERIC_GENES]) {\n    title\n    key\n    params {\n      internalID\n      relatedArtistID\n      followedArtistID\n    }\n    id\n  }\n}\n\nfragment HomeFeaturedEventsRail_orderedSet on OrderedSet {\n  items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      title\n      subtitle\n      href\n      image {\n        small: cropped(width: 95, height: 63) {\n          src\n          srcSet\n          width\n          height\n        }\n        large: cropped(width: 445, height: 297) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    ... on Node {\n      id\n    }\n    ... on Profile {\n      id\n    }\n  }\n}\n\nfragment HomeHeroUnit_heroUnit on HomePageHeroUnit {\n  backgroundImageURL\n  heading\n  title\n  subtitle\n  linkText\n  href\n  creditLine\n}\n\nfragment HomeHeroUnits_homePage on HomePage {\n  heroUnits(platform: DESKTOP) {\n    internalID\n    ...HomeHeroUnit_heroUnit\n    id\n  }\n}\n"
+    "text": "query homeRoutes_HomeQuery {\n  homePage {\n    ...HomeApp_homePage\n  }\n  featuredEventsOrderedSet: orderedSet(id: \"529939e2275b245e290004a0\") {\n    ...HomeApp_featuredEventsOrderedSet\n    id\n  }\n}\n\nfragment HomeApp_featuredEventsOrderedSet on OrderedSet {\n  ...HomeFeaturedEventsRail_orderedSet\n}\n\nfragment HomeApp_homePage on HomePage {\n  ...HomeHeroUnits_homePage\n  ...HomeArtworkModules_homePage\n}\n\nfragment HomeArtworkModules_homePage on HomePage {\n  artworkModules(exclude: [POPULAR_ARTISTS, GENERIC_GENES], maxRails: -1, maxFollowedGeneRails: -1, order: [ACTIVE_BIDS, RECENTLY_VIEWED_WORKS, SIMILAR_TO_RECENTLY_VIEWED, SAVED_WORKS, SIMILAR_TO_SAVED_WORKS, FOLLOWED_ARTISTS, FOLLOWED_GALLERIES, RECOMMENDED_WORKS, RELATED_ARTISTS, LIVE_AUCTIONS, CURRENT_FAIRS, FOLLOWED_GENES, GENERIC_GENES]) {\n    title\n    key\n    params {\n      internalID\n      relatedArtistID\n      followedArtistID\n    }\n    id\n  }\n}\n\nfragment HomeFeaturedEventsRail_orderedSet on OrderedSet {\n  items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      title\n      subtitle\n      href\n      image {\n        small: cropped(width: 95, height: 63) {\n          src\n          srcSet\n          width\n          height\n        }\n        large: cropped(width: 445, height: 297) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    ... on Node {\n      id\n    }\n    ... on Profile {\n      id\n    }\n  }\n}\n\nfragment HomeHeroUnit_heroUnit on HomePageHeroUnit {\n  backgroundImageURL\n  heading\n  title\n  subtitle\n  linkText\n  href\n  creditLine\n}\n\nfragment HomeHeroUnits_homePage on HomePage {\n  heroUnits(platform: DESKTOP) {\n    internalID\n    ...HomeHeroUnit_heroUnit\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '0d22f918f8f73556e256708e40ef93a2';
+(node as any).hash = 'f030323f431f45ee405e86ffac831e6c';
 export default node;


### PR DESCRIPTION
Related https://github.com/artsy/force/pull/8398, https://github.com/artsy/metaphysics/pull/3425
Addresses https://artsyproduct.atlassian.net/browse/GRO-518 

This adds a new featured galleries rail to the home page: 

<img width="1070" alt="Screen Shot 2021-09-15 at 4 24 00 PM" src="https://user-images.githubusercontent.com/236943/133525839-30f5cb4f-8791-4f81-a64f-1108767093bf.png">

There's some weird type weirdness around `extractNodes` that I need to figure out but otherwise ready to review. 


