### PR TITLE
fix(PURCHASE-2931):Editing saved address in form cause page to crash

### DIFF
--- a/cypress/integration/shows.spec.ts
+++ b/cypress/integration/shows.spec.ts
@@ -15,6 +15,6 @@ describe("Shows", () => {
     const showLink = cy.get('a[href*="/show/"]:first')
     showLink.click()
     cy.url().should("contain", "/show/")
-    cy.contains("Presented by")
+    cy.contains("Show")
   })
 })

--- a/src/v2/Apps/Order/Components/AddressModal.tsx
+++ b/src/v2/Apps/Order/Components/AddressModal.tsx
@@ -107,7 +107,7 @@ export const AddressModal: React.FC<Props> = ({
       >
         <Formik
           validateOnMount
-          initialValues={createMutation ? { country: "US" } : address}
+          initialValues={createMutation ? { country: "US" } : { ...address }}
           validate={validator}
           onSubmit={(
             values: SavedAddressType,

--- a/src/v2/Components/Inquiry/Hooks/useArtworkInquiryRequest.ts
+++ b/src/v2/Components/Inquiry/Hooks/useArtworkInquiryRequest.ts
@@ -8,7 +8,12 @@ import {
 type UseArtworkInquiryRequestInput = Omit<
   SubmitInquiryRequestMutationInput,
   "inquireableID" | "inquireableType" | "message"
-> & { relayEnvironment?: Environment; artworkID: string; message: string }
+> & {
+  relayEnvironment?: Environment
+  artworkID: string
+  message: string
+  contactGallery?: boolean | null
+}
 
 export const useArtworkInquiryRequest = () => {
   const { relayEnvironment: defaultRelayEnvironment } = useSystemContext()

--- a/src/v2/__generated__/useArtworkInquiryRequestMutation.graphql.ts
+++ b/src/v2/__generated__/useArtworkInquiryRequestMutation.graphql.ts
@@ -4,7 +4,6 @@
 import { ConcreteRequest } from "relay-runtime";
 export type SubmitInquiryRequestMutationInput = {
     clientMutationId?: string | null;
-    contactGallery?: boolean | null;
     inquireableID: string;
     inquireableType: string;
     message?: string | null;


### PR DESCRIPTION
I found a small bug, I don't know the reason for it. Initial values for Formik is gotten from relay and marked like readonly. So we get an error when we try to change this field.An Spread operator solved this issue. (https://artsyproduct.atlassian.net/browse/PURCHASE-2931)