### PR TITLE
feat: Add autosuggest quick navigation (second try)

### DIFF
--- a/src/v2/Components/Search/SearchBar.tsx
+++ b/src/v2/Components/Search/SearchBar.tsx
@@ -249,7 +249,7 @@ export class SearchBar extends Component<Props, State> {
       [
         {
           suggestion: {
-            node: { href, displayType, id },
+            node: { href, displayType, id, __typename },
           },
           suggestionIndex,
         },
@@ -257,7 +257,7 @@ export class SearchBar extends Component<Props, State> {
     ) => ({
       action_type: Schema.ActionType.SelectedItemFromSearch,
       destination_path:
-        displayType === "Artist" ? `${href}/works-for-sale` : href,
+        __typename === "Artist" ? `${href}/works-for-sale` : href,
       item_id: id,
       item_number: suggestionIndex,
       item_type: displayType,
@@ -266,11 +266,11 @@ export class SearchBar extends Component<Props, State> {
   )
   onSuggestionSelected({
     suggestion: {
-      node: { href, displayType },
+      node: { href },
     },
+    method,
   }) {
     this.userClickedOnDescendant = true
-    const newHref = displayType === "Artist" ? `${href}/works-for-sale` : href
 
     if (this.props.router) {
       // @ts-ignore (routeConfig not found; need to update DT types)
@@ -278,19 +278,19 @@ export class SearchBar extends Component<Props, State> {
       // @ts-ignore (matchRoutes not found; need to update DT types)
       const isSupportedInRouter = !!this.props.router.matcher.matchRoutes(
         routes,
-        newHref
+        href
       )
 
       // Check if url exists within the global router context
       if (isSupportedInRouter) {
-        this.props.router.push(newHref)
+        this.props.router.push(href)
         this.onBlur({})
       } else {
-        window.location.assign(newHref)
+        window.location.assign(href)
       }
       // Outside of router context
     } else {
-      window.location.assign(newHref)
+      window.location.assign(href)
     }
   }
 
@@ -320,6 +320,9 @@ export class SearchBar extends Component<Props, State> {
     return displayLabel
   }
 
+  getLabel = ({ displayType, __typename }) =>
+    displayType || (__typename === "Artist" ? "Artist" : null)
+
   renderSuggestion = (edge, rest) => {
     const renderer = edge.node.isFirstItem
       ? this.renderFirstSuggestion
@@ -329,29 +332,38 @@ export class SearchBar extends Component<Props, State> {
   }
 
   renderFirstSuggestion = (edge, { query, isHighlighted }) => {
-    const { displayLabel, displayType, href } = edge.node
+    const { displayLabel, href } = edge.node
+
+    const label = this.getLabel(edge.node)
+
     return (
       <FirstSuggestionItem
         display={displayLabel}
         href={href}
         isHighlighted={isHighlighted}
-        label={displayType}
+        label={label}
         query={query}
       />
     )
   }
 
   renderDefaultSuggestion = (edge, { query, isHighlighted }) => {
-    const { displayLabel, displayType, href } = edge.node
-    const newHref = displayType === "Artist" ? `${href}/works-for-sale` : href
+    const { displayLabel, href, counts } = edge.node
+
+    const label = this.getLabel(edge.node)
+
+    const showArtworksButton = !!counts?.artworks
+    const showAuctionResultsButton = !!counts?.auctionResults
 
     return (
       <SuggestionItem
         display={displayLabel}
-        href={newHref}
+        href={href}
         isHighlighted={isHighlighted}
-        label={displayType}
+        label={label}
         query={query}
+        showArtworksButton={showArtworksButton}
+        showAuctionResultsButton={showAuctionResultsButton}
       />
     )
   }
@@ -464,9 +476,16 @@ export const SearchBarRefetchContainer = createRefetchContainer(
             node {
               displayLabel
               href
+              __typename
               ... on SearchableItem {
                 displayType
                 slug
+              }
+              ... on Artist {
+                counts {
+                  artworks
+                  auctionResults
+                }
               }
             }
           }

--- a/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
@@ -1,11 +1,4 @@
-import {
-  ArtworkIcon,
-  AuctionIcon,
-  Clickable,
-  Flex,
-  Pill,
-  Text,
-} from "@artsy/palette"
+import { ArtworkIcon, AuctionIcon, Flex, Pill, Text } from "@artsy/palette"
 import match from "autosuggest-highlight/match"
 import parse from "autosuggest-highlight/parse"
 import React from "react"

--- a/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
@@ -126,7 +126,8 @@ const QuickNavigationItem: React.FC<{ to: string }> = ({ children, to }) => {
     event.stopPropagation()
     event.preventDefault()
 
-    router ? router.push(to) : window.location.assign(to)
+    // Fixme: Using `window.location.assign(to)` instead of `router.push(to)` to prevent a bug where the search bar won't hide anymore.
+    window.location.assign(to)
   }
   return (
     <ClickableFlex onClick={onClick} mt={1} mr={1}>

--- a/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
@@ -1,9 +1,18 @@
-import { Text } from "@artsy/palette"
+import {
+  ArtworkIcon,
+  AuctionIcon,
+  Clickable,
+  Flex,
+  Pill,
+  Text,
+} from "@artsy/palette"
 import match from "autosuggest-highlight/match"
 import parse from "autosuggest-highlight/parse"
 import React from "react"
 import styled from "styled-components"
+import { Container } from "v2/Components/Sticky"
 import { RouterLink } from "v2/System/Router/RouterLink"
+import { useRouter } from "v2/System/Router/useRouter"
 
 interface SuggestionItemProps {
   display: string
@@ -11,6 +20,8 @@ interface SuggestionItemProps {
   isHighlighted: boolean
   label: string
   query: string
+  showArtworksButton?: boolean
+  showAuctionResultsButton?: boolean
 }
 
 export const FirstSuggestionItem: React.FC<SuggestionItemProps> = ({
@@ -31,11 +42,21 @@ export const FirstSuggestionItem: React.FC<SuggestionItemProps> = ({
 }
 
 export const SuggestionItem: React.FC<SuggestionItemProps> = props => {
-  const { href, isHighlighted } = props
+  const {
+    href,
+    isHighlighted,
+    showArtworksButton,
+    showAuctionResultsButton,
+  } = props
 
   return (
     <SuggestionItemLink to={href} bg={isHighlighted ? "black5" : "white100"}>
       <DefaultSuggestion {...props} />
+      <QuickNavigation
+        href={href}
+        showArtworksButton={!!showArtworksButton}
+        showAuctionResultsButton={!!showAuctionResultsButton}
+      />
     </SuggestionItemLink>
   )
 }
@@ -77,4 +98,61 @@ const DefaultSuggestion: React.FC<SuggestionItemProps> = ({
       </Text>
     </>
   )
+}
+
+const QuickNavigation: React.FC<{
+  href: string
+  showArtworksButton: boolean
+  showAuctionResultsButton: boolean
+}> = ({ href, showArtworksButton, showAuctionResultsButton }) => {
+  if (!showArtworksButton && !showAuctionResultsButton) return null
+
+  return (
+    <Flex mt={1}>
+      {!!showArtworksButton && (
+        <QuickNavigationItem to={`${href}/works-for-sale`}>
+          <ArtworkIcon mr={0.5} />
+          Artworks
+        </QuickNavigationItem>
+      )}
+      {!!showAuctionResultsButton && (
+        <QuickNavigationItem to={`${href}/auction-results`}>
+          <AuctionIcon mr={0.5} />
+          Auction Results
+        </QuickNavigationItem>
+      )}
+    </Flex>
+  )
+}
+
+const QuickNavigationItem: React.FC<{ to: string }> = ({ children, to }) => {
+  const { router } = useRouter()
+
+  const onClick = event => {
+    event.preventDefault()
+
+    // router ? router.push(to) : window.location.assign(to)
+  }
+  return (
+    <RouterLink
+      tabIndex={0}
+      role="button"
+      display="flex"
+      onClick={onClick}
+      to={to}
+      position="absolute"
+    >
+      <Pill variant="textSquare" mr="1" tabIndex={10}>
+        <Flex alignItems="center">{children}</Flex>
+      </Pill>
+    </RouterLink>
+  )
+
+  // return (
+  //   <Clickable display="flex" onClick={onClick} as="div">
+  //     <Pill variant="textSquare" mr="1">
+  //       <Flex alignItems="center">{children}</Flex>
+  //     </Pill>
+  //   </Clickable>
+  // )
 }

--- a/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
@@ -1,16 +1,9 @@
-import {
-  ArtworkIcon,
-  AuctionIcon,
-  Clickable,
-  Flex,
-  Pill,
-  Text,
-} from "@artsy/palette"
+import { ArtworkIcon, AuctionIcon, Flex, Pill, Text } from "@artsy/palette"
 import match from "autosuggest-highlight/match"
 import parse from "autosuggest-highlight/parse"
 import React from "react"
 import styled from "styled-components"
-import { Container } from "v2/Components/Sticky"
+import { ClickableFlex } from "v2/Apps/Conversation/Components/ReviewOfferCTA"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { useRouter } from "v2/System/Router/useRouter"
 
@@ -108,7 +101,7 @@ const QuickNavigation: React.FC<{
   if (!showArtworksButton && !showAuctionResultsButton) return null
 
   return (
-    <Flex mt={1}>
+    <Flex flexWrap="wrap">
       {!!showArtworksButton && (
         <QuickNavigationItem to={`${href}/works-for-sale`}>
           <ArtworkIcon mr={0.5} />
@@ -129,30 +122,17 @@ const QuickNavigationItem: React.FC<{ to: string }> = ({ children, to }) => {
   const { router } = useRouter()
 
   const onClick = event => {
+    // Stopping the event from propagating to prevent SearchBar from navigation to the main suggestion item url.
+    event.stopPropagation()
     event.preventDefault()
 
-    // router ? router.push(to) : window.location.assign(to)
+    router ? router.push(to) : window.location.assign(to)
   }
   return (
-    <RouterLink
-      tabIndex={0}
-      role="button"
-      display="flex"
-      onClick={onClick}
-      to={to}
-      position="absolute"
-    >
-      <Pill variant="textSquare" mr="1" tabIndex={10}>
+    <ClickableFlex tabIndex={0} role="button" onClick={onClick} mt={1} mr={1}>
+      <Pill variant="textSquare">
         <Flex alignItems="center">{children}</Flex>
       </Pill>
-    </RouterLink>
+    </ClickableFlex>
   )
-
-  // return (
-  //   <Clickable display="flex" onClick={onClick} as="div">
-  //     <Pill variant="textSquare" mr="1">
-  //       <Flex alignItems="center">{children}</Flex>
-  //     </Pill>
-  //   </Clickable>
-  // )
 }

--- a/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
@@ -129,7 +129,7 @@ const QuickNavigationItem: React.FC<{ to: string }> = ({ children, to }) => {
     router ? router.push(to) : window.location.assign(to)
   }
   return (
-    <ClickableFlex tabIndex={0} role="button" onClick={onClick} mt={1} mr={1}>
+    <ClickableFlex onClick={onClick} mt={1} mr={1}>
       <Pill variant="textSquare">
         <Flex alignItems="center">{children}</Flex>
       </Pill>

--- a/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
@@ -124,7 +124,7 @@ const QuickNavigationItem: React.FC<{ to: string }> = ({ children, to }) => {
     event.stopPropagation()
     event.preventDefault()
 
-    // Fixme: Using `window.location.assign(to)` instead of `router.push(to)` to prevent a bug where the search bar won't hide anymore.
+    // FIXME: Using `window.location.assign(to)` instead of `router.push(to)` to prevent a bug where the search bar won't hide anymore.
     window.location.assign(to)
   }
   return (

--- a/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
@@ -1,11 +1,16 @@
-import { ArtworkIcon, AuctionIcon, Flex, Pill, Text } from "@artsy/palette"
+import {
+  ArtworkIcon,
+  AuctionIcon,
+  Clickable,
+  Flex,
+  Pill,
+  Text,
+} from "@artsy/palette"
 import match from "autosuggest-highlight/match"
 import parse from "autosuggest-highlight/parse"
 import React from "react"
 import styled from "styled-components"
-import { ClickableFlex } from "v2/Apps/Conversation/Components/ReviewOfferCTA"
 import { RouterLink } from "v2/System/Router/RouterLink"
-import { useRouter } from "v2/System/Router/useRouter"
 
 interface SuggestionItemProps {
   display: string
@@ -128,10 +133,10 @@ const QuickNavigationItem: React.FC<{ to: string }> = ({ children, to }) => {
     window.location.assign(to)
   }
   return (
-    <ClickableFlex onClick={onClick} mt={1} mr={1}>
+    <Flex onClick={onClick} mt={1} mr={1}>
       <Pill variant="textSquare">
         <Flex alignItems="center">{children}</Flex>
       </Pill>
-    </ClickableFlex>
+    </Flex>
   )
 }

--- a/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
@@ -119,8 +119,6 @@ const QuickNavigation: React.FC<{
 }
 
 const QuickNavigationItem: React.FC<{ to: string }> = ({ children, to }) => {
-  const { router } = useRouter()
-
   const onClick = event => {
     // Stopping the event from propagating to prevent SearchBar from navigation to the main suggestion item url.
     event.stopPropagation()

--- a/src/v2/Components/Search/__tests__/SearchBar.jest.tsx
+++ b/src/v2/Components/Search/__tests__/SearchBar.jest.tsx
@@ -4,15 +4,21 @@ import {
   SearchBarRefetchContainer as SearchBar,
   getSearchTerm,
 } from "v2/Components/Search/SearchBar"
-import { SuggestionItem } from "v2/Components/Search/Suggestions/SuggestionItem"
 import { renderRelayTree } from "v2/DevTools"
 import { MockBoot } from "v2/DevTools/MockBoot"
 import { ReactWrapper } from "enzyme"
 import React from "react"
 import { graphql } from "react-relay"
 import { flushPromiseQueue } from "v2/DevTools"
-import { mockLocation } from "v2/DevTools/mockLocation"
 
+const mockPush = jest.fn()
+jest.mock("v2/System/Router/useRouter", () => ({
+  useRouter: () => ({
+    router: {
+      push: mockPush,
+    },
+  }),
+}))
 jest.unmock("react-relay")
 
 const searchResults: SearchBarTestQueryRawResponse["viewer"] = {
@@ -26,6 +32,30 @@ const searchResults: SearchBarTestQueryRawResponse["viewer"] = {
           displayType: "Cat",
           slug: "percy-z",
           id: "opaque-searchable-item-id",
+        },
+      },
+      {
+        node: {
+          displayLabel: "Banksy",
+          href: "/artist/banksy",
+          __typename: "Artist",
+          counts: {
+            artworks: 3390,
+            auctionResults: 734,
+          },
+          id: "opaque-searchable-item-id2",
+        },
+      },
+      {
+        node: {
+          displayLabel: "Not Banksy",
+          href: "/artist/not-banksy",
+          __typename: "Artist",
+          counts: {
+            artworks: 0,
+            auctionResults: 0,
+          },
+          id: "opaque-searchable-item-id3",
         },
       },
     ],
@@ -78,6 +108,34 @@ describe("SearchBar", () => {
     expect(component.text()).toContain("Cat")
   })
 
+  it("displays quick navigation links only for artists with artworks or auction results", async () => {
+    const component = await getWrapper(searchResults)
+
+    simulateTyping(component, "blah") // Any text of non-zero length.
+    await flushPromiseQueue()
+
+    const quickNavigationItems = component.find("QuickNavigationItem")
+
+    expect(quickNavigationItems.length).toBe(2)
+    expect(quickNavigationItems.at(0).text()).toContain("Artworks")
+    expect(quickNavigationItems.at(1).text()).toContain("Auction Results")
+  })
+
+  it("navigates when clicking quick navigation items", async () => {
+    const component = await getWrapper(searchResults)
+
+    simulateTyping(component, "blah") // Any text of non-zero length.
+    await flushPromiseQueue()
+
+    const quickNavigationItems = component.find("QuickNavigationItem")
+
+    quickNavigationItems.at(0).simulate("click")
+    expect(mockPush).toHaveBeenCalledWith("/artist/banksy/works-for-sale")
+
+    quickNavigationItems.at(1).simulate("click")
+    expect(mockPush).toHaveBeenCalledWith("/artist/banksy/auction-results")
+  })
+
   it("displays long placeholder text at sizes greater than xs", async () => {
     const component = await getWrapper(searchResults)
     await flushPromiseQueue()
@@ -91,18 +149,6 @@ describe("SearchBar", () => {
     await flushPromiseQueue()
 
     expect(component.find(Input).props().placeholder).toBe("Search Artsy")
-  })
-
-  it("navigates the user when clicking on an item", async () => {
-    const component = await getWrapper(searchResults)
-
-    simulateTyping(component, "blah") // Any text of non-zero length.
-    await flushPromiseQueue()
-
-    mockLocation()
-    component.find(SuggestionItem).at(0).simulate("click")
-
-    expect(window.location.assign).toHaveBeenCalledWith("/cat/percy-z")
   })
 
   it("highlights matching parts of suggestions", async () => {

--- a/src/v2/Components/Search/__tests__/SearchBar.jest.tsx
+++ b/src/v2/Components/Search/__tests__/SearchBar.jest.tsx
@@ -11,14 +11,8 @@ import React from "react"
 import { graphql } from "react-relay"
 import { flushPromiseQueue } from "v2/DevTools"
 
-const mockPush = jest.fn()
-jest.mock("v2/System/Router/useRouter", () => ({
-  useRouter: () => ({
-    router: {
-      push: mockPush,
-    },
-  }),
-}))
+const mockAssign = jest.fn()
+
 jest.unmock("react-relay")
 
 const searchResults: SearchBarTestQueryRawResponse["viewer"] = {
@@ -98,6 +92,10 @@ const getWrapper = (
 }
 
 describe("SearchBar", () => {
+  beforeEach(() => {
+    window.location.assign = mockAssign
+  })
+
   it("displays search results", async () => {
     const component = await getWrapper(searchResults)
 
@@ -130,10 +128,10 @@ describe("SearchBar", () => {
     const quickNavigationItems = component.find("QuickNavigationItem")
 
     quickNavigationItems.at(0).simulate("click")
-    expect(mockPush).toHaveBeenCalledWith("/artist/banksy/works-for-sale")
+    expect(mockAssign).toHaveBeenCalledWith("/artist/banksy/works-for-sale")
 
     quickNavigationItems.at(1).simulate("click")
-    expect(mockPush).toHaveBeenCalledWith("/artist/banksy/auction-results")
+    expect(mockAssign).toHaveBeenCalledWith("/artist/banksy/auction-results")
   })
 
   it("displays long placeholder text at sizes greater than xs", async () => {

--- a/src/v2/__generated__/SearchBarRefetchQuery.graphql.ts
+++ b/src/v2/__generated__/SearchBarRefetchQuery.graphql.ts
@@ -33,12 +33,18 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
   searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
-        __typename
         displayLabel
         href
+        __typename
         ... on SearchableItem {
           displayType
           slug
+        }
+        ... on Artist {
+          counts {
+            artworks
+            auctionResults
+          }
         }
         ... on Node {
           id
@@ -164,13 +170,6 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "__typename",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
                             "name": "displayLabel",
                             "storageKey": null
                           },
@@ -179,6 +178,13 @@ return {
                             "args": null,
                             "kind": "ScalarField",
                             "name": "href",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "__typename",
                             "storageKey": null
                           },
                           {
@@ -207,6 +213,37 @@ return {
                               }
                             ],
                             "type": "SearchableItem"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "ArtistCounts",
+                                "kind": "LinkedField",
+                                "name": "counts",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "artworks",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "auctionResults",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "Artist"
                           }
                         ],
                         "storageKey": null
@@ -229,7 +266,7 @@ return {
     "metadata": {},
     "name": "SearchBarRefetchQuery",
     "operationKind": "query",
-    "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        displayLabel\n        href\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          counts {\n            artworks\n            auctionResults\n          }\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/SearchBarSuggestQuery.graphql.ts
+++ b/src/v2/__generated__/SearchBarSuggestQuery.graphql.ts
@@ -33,12 +33,18 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
   searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
-        __typename
         displayLabel
         href
+        __typename
         ... on SearchableItem {
           displayType
           slug
+        }
+        ... on Artist {
+          counts {
+            artworks
+            auctionResults
+          }
         }
         ... on Node {
           id
@@ -164,13 +170,6 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "__typename",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
                             "name": "displayLabel",
                             "storageKey": null
                           },
@@ -179,6 +178,13 @@ return {
                             "args": null,
                             "kind": "ScalarField",
                             "name": "href",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "__typename",
                             "storageKey": null
                           },
                           {
@@ -207,6 +213,37 @@ return {
                               }
                             ],
                             "type": "SearchableItem"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "ArtistCounts",
+                                "kind": "LinkedField",
+                                "name": "counts",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "artworks",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "auctionResults",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "Artist"
                           }
                         ],
                         "storageKey": null
@@ -229,7 +266,7 @@ return {
     "metadata": {},
     "name": "SearchBarSuggestQuery",
     "operationKind": "query",
-    "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        displayLabel\n        href\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          counts {\n            artworks\n            auctionResults\n          }\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/SearchBarTestQuery.graphql.ts
+++ b/src/v2/__generated__/SearchBarTestQuery.graphql.ts
@@ -17,16 +17,25 @@ export type SearchBarTestQueryRawResponse = {
         readonly searchConnection: ({
             readonly edges: ReadonlyArray<({
                 readonly node: ({
-                    readonly __typename: "SearchableItem";
                     readonly displayLabel: string | null;
                     readonly href: string | null;
+                    readonly __typename: "SearchableItem";
                     readonly id: string | null;
                     readonly displayType: string | null;
                     readonly slug: string;
                 } | {
-                    readonly __typename: string | null;
                     readonly displayLabel: string | null;
                     readonly href: string | null;
+                    readonly __typename: "Artist";
+                    readonly id: string | null;
+                    readonly counts: ({
+                        readonly artworks: number | null;
+                        readonly auctionResults: number | null;
+                    }) | null;
+                } | {
+                    readonly displayLabel: string | null;
+                    readonly href: string | null;
+                    readonly __typename: string;
                     readonly id: string | null;
                 }) | null;
             }) | null> | null;
@@ -55,12 +64,18 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
   searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
-        __typename
         displayLabel
         href
+        __typename
         ... on SearchableItem {
           displayType
           slug
+        }
+        ... on Artist {
+          counts {
+            artworks
+            auctionResults
+          }
         }
         ... on Node {
           id
@@ -186,13 +201,6 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "__typename",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
                             "name": "displayLabel",
                             "storageKey": null
                           },
@@ -201,6 +209,13 @@ return {
                             "args": null,
                             "kind": "ScalarField",
                             "name": "href",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "__typename",
                             "storageKey": null
                           },
                           {
@@ -229,6 +244,37 @@ return {
                               }
                             ],
                             "type": "SearchableItem"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "ArtistCounts",
+                                "kind": "LinkedField",
+                                "name": "counts",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "artworks",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "auctionResults",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "Artist"
                           }
                         ],
                         "storageKey": null
@@ -251,7 +297,7 @@ return {
     "metadata": {},
     "name": "SearchBarTestQuery",
     "operationKind": "query",
-    "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        displayLabel\n        href\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          counts {\n            artworks\n            auctionResults\n          }\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/SearchBar_viewer.graphql.ts
+++ b/src/v2/__generated__/SearchBar_viewer.graphql.ts
@@ -9,8 +9,13 @@ export type SearchBar_viewer = {
             readonly node: {
                 readonly displayLabel: string | null;
                 readonly href: string | null;
+                readonly __typename: string;
                 readonly displayType?: string | null;
                 readonly slug?: string;
+                readonly counts?: {
+                    readonly artworks: number | null;
+                    readonly auctionResults: number | null;
+                } | null;
             } | null;
         } | null> | null;
     } | null;
@@ -103,6 +108,13 @@ const node: ReaderFragment = {
                       "storageKey": null
                     },
                     {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "__typename",
+                      "storageKey": null
+                    },
+                    {
                       "kind": "InlineFragment",
                       "selections": [
                         {
@@ -121,6 +133,37 @@ const node: ReaderFragment = {
                         }
                       ],
                       "type": "SearchableItem"
+                    },
+                    {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "ArtistCounts",
+                          "kind": "LinkedField",
+                          "name": "counts",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "artworks",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "auctionResults",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "type": "Artist"
                     }
                   ],
                   "storageKey": null
@@ -136,5 +179,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = '3aeb38b1dc5d0bfda3a165193d2b7a27';
+(node as any).hash = 'a6694021e48afcf170cda92cb611ed97';
 export default node;


### PR DESCRIPTION
Addresses [CX-1761]

## Description

Adds quick navigation items ("Artworks" & "Auction Results") to the search bar's autosuggest items for artists.

<img width="1521" alt="Screenshot 2021-09-17 at 10 19 53" src="https://user-images.githubusercontent.com/4691889/133749629-63b1043f-3d47-4a63-8477-ec2b79fa960e.png">

[CX-1761]: https://artsyproduct.atlassian.net/browse/CX-1761