### PR TITLE
fix(FX-3231): Removed max width of fair article

### DIFF
--- a/src/v2/Apps/Fair/Components/FairEditorial/FairEditorialItem.tsx
+++ b/src/v2/Apps/Fair/Components/FairEditorial/FairEditorialItem.tsx
@@ -94,7 +94,7 @@ export const FairEditorialItem: React.FC<FairEditorialItemProps> = ({
   }
 
   return (
-    <Box maxWidth={image.width}>
+    <Box>
       {/* Devided link into separate parts in order to avoid linking via empty
         space when responsive box is applied */}
       <ItemLink>
@@ -102,7 +102,7 @@ export const FairEditorialItem: React.FC<FairEditorialItemProps> = ({
           <ResponsiveBox
             aspectWidth={image.width}
             aspectHeight={image.height}
-            maxWidth={image.width}
+            maxWidth="100%"
           >
             <ItemImage />
           </ResponsiveBox>


### PR DESCRIPTION
[FX-3231]

This fixes broken layout of articles on fair organizer page at large screen width 

**Before**

![Screenshot 2021-09-16 at 14 37 51](https://user-images.githubusercontent.com/44819355/133605459-606917bf-c63c-49bc-894d-ec4eca69d5ca.png)

![Screenshot 2021-09-16 at 16 17 28](https://user-images.githubusercontent.com/44819355/133619148-9d1432f4-2b01-4eb6-a957-888e21a412cf.png)



**After**

![Screenshot 2021-09-16 at 16 17 53](https://user-images.githubusercontent.com/44819355/133619212-78ea5278-532b-4f4e-a1a5-d942da9e21a0.png)

![Screenshot 2021-09-16 at 16 18 12](https://user-images.githubusercontent.com/44819355/133619254-bfe2e2fd-fab3-4d76-bd62-111c40a30236.png)



[FX-3231]: https://artsyproduct.atlassian.net/browse/FX-3231