### PR TITLE
fix(searchbar): prevents menu item hit areas from presenting over the results

### DIFF
--- a/src/v2/Components/Search/SearchBar.tsx
+++ b/src/v2/Components/Search/SearchBar.tsx
@@ -65,7 +65,7 @@ const SuggestionContainer = ({ children, containerProps }) => {
         borderColor="black10"
         bg="white100"
         position="absolute"
-        zIndex={1}
+        zIndex={2}
       >
         {children}
       </Box>


### PR DESCRIPTION
Thanks for raising.