### PR TITLE
fix(FX-3282): encode search query param

### DIFF
--- a/src/v2/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/v2/Apps/Search/Components/NavigationTabs.tsx
@@ -83,7 +83,8 @@ export class NavigationTabs extends React.Component<Props> {
   tabs() {
     const { term, artworkCount } = this.props
 
-    const route = tab => `/search${tab.replace(/\s/g, "_")}?term=${term}`
+    const route = tab =>
+      `/search${tab.replace(/\s/g, "_")}?term=${encodeURIComponent(term)}`
 
     let restAggregationCount: number = 0
     MORE_TABS.forEach(

--- a/src/v2/Components/Search/SearchBar.tsx
+++ b/src/v2/Components/Search/SearchBar.tsx
@@ -1,3 +1,4 @@
+import React, { Component, useContext } from "react"
 import { Box, BoxProps } from "@artsy/palette"
 import { SearchBar_viewer } from "v2/__generated__/SearchBar_viewer.graphql"
 import { SearchBarSuggestQuery } from "v2/__generated__/SearchBarSuggestQuery.graphql"
@@ -15,7 +16,6 @@ import { Router } from "found"
 import { isEmpty } from "lodash"
 import { throttle } from "lodash"
 import qs from "qs"
-import React, { Component, useContext } from "react"
 import Autosuggest from "react-autosuggest"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
@@ -385,7 +385,7 @@ export class SearchBar extends Component<Props, State> {
       node: {
         displayLabel: term,
         displayType: "FirstItem",
-        href: `/search?term=${term}`,
+        href: `/search?term=${encodeURIComponent(term)}`,
         isFirstItem: true,
       },
     }
@@ -427,11 +427,12 @@ export class SearchBar extends Component<Props, State> {
         onSubmit={event => {
           if (router) {
             event.preventDefault()
+            const encodedTerm = encodeURIComponent(this.state.term)
+
             // TODO: Reenable in-router push once all routes have been moved over
             // to new novo app
             // router.push(`/search?term=${this.state.term}`)
-
-            window.location.assign(`/search?term=${this.state.term}`)
+            window.location.assign(`/search?term=${encodedTerm}`)
             this.onBlur(event)
           } else {
             console.error(


### PR DESCRIPTION
Jira: [FX-3282](https://artsyproduct.atlassian.net/browse/FX-3282)

### Description
When you type a query into the search bar and click "Enter", you'll normally be taken to the search results page when you're not choosing one of the results shown in the dropdown menu.
In the case of `&gallery` redirecting you back to the home page, I think that is a bug that we should ticket.
When andgallery is entered, the result of `&Gallery` appears in the dropdown meny, but instead of selecting that result (by clicking on it or using your arrow keys + Enter), hitting Enter takes you to the search results page (as expected). The search results page shows artworks by default but none match the query andgallery. If you click on the Galleries tab, you'll see the one result for &Gallery listed.
It's a bit strange that we're hiding the Artworks tab for the empty state there. Might be clearer to show "Artworks (0) and Galleries (1)".

### Changes
- Encode `term` in query

### Demo

https://user-images.githubusercontent.com/56556580/133775695-3f403b70-1a28-414f-ac51-a149919fdfa6.mov


