### PR TITLE
fix(artworkgriditem): uses correct max width; supports srcset

### DIFF
--- a/src/v2/Components/Artwork/Badge.tsx
+++ b/src/v2/Components/Artwork/Badge.tsx
@@ -1,9 +1,10 @@
-import { Box, Flex, Sans, space } from "@artsy/palette"
+import { Flex, Text } from "@artsy/palette"
 import { Badge_artwork } from "v2/__generated__/Badge_artwork.graphql"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { get } from "v2/Utils/get"
+import { themeGet } from "@styled-system/theme-get"
 
 interface BadgeProps {
   artwork: Badge_artwork
@@ -34,16 +35,15 @@ class Badge extends React.Component<BadgeProps> {
     // E.g.(ENDS IN 59M)
     const saleTimingHint =
       sale && sale.display_timely_at ? ` (${sale.display_timely_at})` : ""
+
     return (
-      <>
-        <Badges flexDirection={this.stackedLayout ? "column" : "row"}>
-          {includeBidBadge && (
-            <Label>
-              <Sans size="0">Bid{saleTimingHint}</Sans>
-            </Label>
-          )}
-        </Badges>
-      </>
+      <Badges flexDirection={this.stackedLayout ? "column" : "row"}>
+        {includeBidBadge && (
+          <Label ml={1} mb={1}>
+            Bid{saleTimingHint}
+          </Label>
+        )}
+      </Badges>
     )
   }
 }
@@ -61,20 +61,20 @@ export default createFragmentContainer(Badge, {
   `,
 })
 
-const Label = styled(Box)`
+const Label = styled(Text)`
+  background-color: ${themeGet("colors.white100")};
   border-radius: 2px;
-  letter-spacing: 0.3px;
-  padding: 3px 5px 1px 6px;
-  background-color: white;
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.1);
+  font-size: 8px;
+  letter-spacing: 0.3px;
+  line-height: 1;
+  padding: 2px 5px;
   text-transform: uppercase;
-  margin-left: ${space(0.5)}px;
-  margin-top: ${space(0.5)}px;
 `
 
 const Badges = styled(Flex)`
   position: absolute;
-  bottom: 8px;
-  left: 3px;
+  bottom: 0;
+  left: 0;
   pointer-events: none;
 `

--- a/src/v2/Components/Artwork/GridItem.tsx
+++ b/src/v2/Components/Artwork/GridItem.tsx
@@ -34,18 +34,16 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
   })
 
   const aspectRatio = artwork.image?.aspect_ratio ?? 1
-  const width = 400
+  const width = 445
   const height = Math.floor(width / aspectRatio)
   const transform = aspectRatio === 1 ? cropped : resized
   const imageURL = artwork.image?.url
-  const { src } = imageURL
-    ? transform(imageURL, { width, height, quality: 80 })
-    : { src: "" }
+  const { src, srcSet } = imageURL
+    ? transform(imageURL, { width, height })
+    : { src: "", srcSet: "" }
 
   const handleClick = () => {
-    if (onClick) {
-      onClick()
-    }
+    onClick?.()
   }
 
   return (
@@ -59,7 +57,7 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
         position="relative"
         width="100%"
         bg="black10"
-        pb={artwork.image?.placeholder}
+        style={{ paddingBottom: artwork.image?.placeholder ?? undefined }}
       >
         <Link
           to={artwork.href}
@@ -69,7 +67,8 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
           <Image
             title={artwork.title ?? undefined}
             alt={artwork.image_title ?? ""}
-            src={src} // TODO: Support srcSet
+            src={src}
+            srcSet={srcSet}
             lazyLoad={lazyLoad}
             preventRightClick={!isTeam}
           />


### PR DESCRIPTION
Closes [GRO-499](https://artsyproduct.atlassian.net/browse/GRO-499)

Simple fix; just pulls out and uses the `srcSet`, also adjusts the max-width to be the rendered size at our max breakpoint.

This PR also includes a quick fix for the tiny auction badge which no longer needs to be manually offset 🎈 