### PR TITLE
refactor: improve user prompt for on-demand otp

### DIFF
--- a/src/v2/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/LoginForm.tsx
@@ -47,8 +47,8 @@ const ConditionalOtpInput: React.FC<ConditionalOtpInputProps> = props => {
     <>
       {showOtpOnDemandPrompt && (
         <Message>
-          This login requires additional authorization. Please check your email
-          for a one-time authentication code.
+          Your safety and security are important to us. Please check your email
+          for a one-time authentication code to complete your login.
         </Message>
       )}
       {showOtpInput && (

--- a/src/v2/Components/Authentication/__tests__/Desktop/LoginForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Desktop/LoginForm.jest.tsx
@@ -280,7 +280,7 @@ describe("LoginForm", () => {
         "missing on-demand authentication code"
       )
       expect(wrapper.html()).toMatch(
-        "This login requires additional authorization. Please check your email for a one-time authentication code."
+        "Your safety and security are important to us. Please check your email for a one-time authentication code to complete your login."
       )
       console.log(wrapper.state())
       expect(props.handleSubmit.mock.calls[0][0]).toEqual({


### PR DESCRIPTION
This PR updates the user prompt copy when an on-demand OTP is required to complete a login. 

The updated copy was suggested by the design team in the Slack thread 🔒 [here](https://artsy.slack.com/archives/C02BGC5PW/p1630601789004800). 

![Screen Shot 2021-09-20 at 9 32 59 AM](https://user-images.githubusercontent.com/38149304/134014868-abe48497-1d32-4abd-a086-e374b19f1077.png)

