### PR TITLE
feat: [Home] Add trending artists & auction lots rail

### DIFF
--- a/src/v2/Apps/Home/Components/HomeAuctionLotsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeAuctionLotsRail.tsx
@@ -1,0 +1,160 @@
+import {
+  Box,
+  Text,
+  Flex,
+  Spacer,
+  Shelf,
+  Skeleton,
+  SkeletonText,
+  SkeletonBox,
+  Sup,
+} from "@artsy/palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useSystemContext } from "v2/System"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { RouterLink } from "v2/System/Router/RouterLink"
+import { HomeAuctionLotsRail_viewer } from "v2/__generated__/HomeAuctionLotsRail_viewer.graphql"
+import { HomeAuctionLotsRailQuery } from "v2/__generated__/HomeAuctionLotsRailQuery.graphql"
+import { extractNodes } from "v2/Utils/extractNodes"
+import { ShelfArtworkFragmentContainer } from "v2/Components/Artwork/ShelfArtwork"
+
+interface HomeAuctionLotsRailProps {
+  viewer: HomeAuctionLotsRail_viewer
+}
+
+const HomeAuctionLotsRail: React.FC<HomeAuctionLotsRailProps> = ({
+  viewer,
+}) => {
+  const nodes = extractNodes(viewer.saleArtworksConnection).filter(node => {
+    return !node.sale?.isClosed
+  })
+
+  if (nodes.length === 0) {
+    return null
+  }
+
+  return (
+    <HomeAuctionLotsRailContainer lotCount={nodes.length}>
+      <Shelf>
+        {nodes.map((node, index) => {
+          return (
+            <ShelfArtworkFragmentContainer
+              artwork={node}
+              key={node.slug}
+              // TODO: Add home type to cohesion once we have tracking
+              contextModule={null as any}
+              hidePartnerName
+              // FIXME: For some reason this is leaves the gray loading
+              // background post load
+              lazyLoad
+            />
+          )
+        })}
+      </Shelf>
+    </HomeAuctionLotsRailContainer>
+  )
+}
+
+const HomeAuctionLotsRailContainer: React.FC<{ lotCount: number }> = ({
+  children,
+  lotCount,
+}) => {
+  return (
+    <>
+      <Flex justifyContent="space-between" alignItems="center">
+        <Text variant="lg">
+          Auction Lots {lotCount > 1 && <Sup color="brand">{lotCount}</Sup>}
+        </Text>
+
+        <Text
+          variant="sm"
+          as={RouterLink}
+          // @ts-ignore
+          to="/auctions"
+        >
+          View All Auctions
+        </Text>
+      </Flex>
+
+      <Spacer mt={4} />
+
+      {children}
+    </>
+  )
+}
+
+const PLACEHOLDER = (
+  <Skeleton>
+    <HomeAuctionLotsRailContainer lotCount={0}>
+      <Shelf>
+        {[...new Array(8)].map((_, i) => {
+          return (
+            <Box width={325} key={i}>
+              <SkeletonBox width={325} height={230} />
+              <SkeletonText variant="lg">Some Artist</SkeletonText>
+              <SkeletonText variant="md">Location</SkeletonText>
+            </Box>
+          )
+        })}
+      </Shelf>
+    </HomeAuctionLotsRailContainer>
+  </Skeleton>
+)
+
+export const HomeAuctionLotsRailFragmentContainer = createFragmentContainer(
+  HomeAuctionLotsRail,
+  {
+    viewer: graphql`
+      fragment HomeAuctionLotsRail_viewer on Viewer {
+        saleArtworksConnection(first: 50, geneIDs: "highlights-at-auction") {
+          edges {
+            node {
+              ...ShelfArtwork_artwork @arguments(width: 210)
+              internalID
+              slug
+              href
+              sale {
+                isClosed
+              }
+            }
+          }
+        }
+      }
+    `,
+  }
+)
+
+export const HomeAuctionLotsRailQueryRenderer: React.FC = () => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <SystemQueryRenderer<HomeAuctionLotsRailQuery>
+      environment={relayEnvironment}
+      query={graphql`
+        query HomeAuctionLotsRailQuery {
+          viewer {
+            ...HomeAuctionLotsRail_viewer
+          }
+        }
+      `}
+      placeholder={PLACEHOLDER}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props) {
+          return PLACEHOLDER
+        }
+
+        if (props.viewer) {
+          return <HomeAuctionLotsRailFragmentContainer viewer={props.viewer} />
+        }
+
+        return null
+      }}
+    />
+  )
+}

--- a/src/v2/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
@@ -37,7 +37,7 @@ const HomeFeaturedGalleriesRail: React.FC<HomeFeaturedGalleriesRailProps> = ({
   }
 
   return (
-    <HomeFeaturedGalleriesContainer galleriesCount={nodes.length}>
+    <HomeFeaturedGalleriesRailContainer galleriesCount={nodes.length}>
       <Shelf>
         {nodes.map((node, index) => {
           if (node.__typename !== "Profile") {
@@ -66,8 +66,11 @@ const HomeFeaturedGalleriesRail: React.FC<HomeFeaturedGalleriesRailProps> = ({
                     />
                   }
                 />
+
+                <Spacer mt={1} />
+
                 {node.image?.cropped?.src ? (
-                  <Box mt={1}>
+                  <Box>
                     <Image
                       src={node.image.cropped.src}
                       srcSet={node.image.cropped.srcSet}
@@ -85,14 +88,13 @@ const HomeFeaturedGalleriesRail: React.FC<HomeFeaturedGalleriesRailProps> = ({
           )
         })}
       </Shelf>
-    </HomeFeaturedGalleriesContainer>
+    </HomeFeaturedGalleriesRailContainer>
   )
 }
 
-const HomeFeaturedGalleriesContainer: React.FC<{ galleriesCount: number }> = ({
-  children,
-  galleriesCount,
-}) => {
+const HomeFeaturedGalleriesRailContainer: React.FC<{
+  galleriesCount: number
+}> = ({ children, galleriesCount }) => {
   return (
     <>
       <Flex justifyContent="space-between" alignItems="center">
@@ -120,7 +122,7 @@ const HomeFeaturedGalleriesContainer: React.FC<{ galleriesCount: number }> = ({
 
 const PLACEHOLDER = (
   <Skeleton>
-    <HomeFeaturedGalleriesContainer galleriesCount={0}>
+    <HomeFeaturedGalleriesRailContainer galleriesCount={0}>
       <Shelf>
         {[...new Array(8)].map((_, i) => {
           return (
@@ -132,7 +134,7 @@ const PLACEHOLDER = (
           )
         })}
       </Shelf>
-    </HomeFeaturedGalleriesContainer>
+    </HomeFeaturedGalleriesRailContainer>
   </Skeleton>
 )
 

--- a/src/v2/Apps/Home/Components/HomeTrendingArtistsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeTrendingArtistsRail.tsx
@@ -70,7 +70,7 @@ const HomeTrendingArtistsRail: React.FC<HomeTrendingArtistsRailProps> = ({
                   FollowButton={
                     <FollowArtistButtonFragmentContainer
                       user={user}
-                      artist={node as any}
+                      artist={node}
                       contextModule={ContextModule.artistHeader}
                       buttonProps={{
                         size: "small",

--- a/src/v2/Apps/Home/Components/HomeTrendingArtistsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeTrendingArtistsRail.tsx
@@ -1,0 +1,196 @@
+import {
+  Box,
+  Image,
+  Text,
+  Flex,
+  Spacer,
+  Shelf,
+  EntityHeader,
+  Skeleton,
+  SkeletonText,
+  SkeletonBox,
+} from "@artsy/palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useSystemContext } from "v2/System"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { RouterLink } from "v2/System/Router/RouterLink"
+import { HomeTrendingArtistsRail_viewer } from "v2/__generated__/HomeTrendingArtistsRail_viewer.graphql"
+import { HomeTrendingArtistsRailQuery } from "v2/__generated__/HomeTrendingArtistsRailQuery.graphql"
+import { extractNodes } from "v2/Utils/extractNodes"
+import { ContextModule } from "@artsy/cohesion"
+import { FollowArtistButtonFragmentContainer } from "v2/Components/FollowButton/FollowArtistButton"
+
+interface HomeTrendingArtistsRailProps {
+  viewer: HomeTrendingArtistsRail_viewer
+}
+
+const HomeTrendingArtistsRail: React.FC<HomeTrendingArtistsRailProps> = ({
+  viewer,
+}) => {
+  const { user } = useSystemContext()
+  const nodes = extractNodes(viewer.artistsConnection)
+
+  if (nodes.length === 0) {
+    return null
+  }
+
+  return (
+    <HomeTrendingArtistsRailContainer>
+      <Shelf alignItems="flex-start">
+        {nodes.map((node, index) => {
+          return (
+            <RouterLink
+              to={`/partner${node.href}`}
+              textDecoration="none"
+              key={index}
+            >
+              <Box width={325} key={index}>
+                {node.image?.cropped?.src ? (
+                  <Box>
+                    <Image
+                      src={node.image.cropped.src}
+                      srcSet={node.image.cropped.srcSet}
+                      width={node.image.cropped.width}
+                      height={node.image.cropped.height}
+                      alt=""
+                      lazyLoad
+                    />
+                  </Box>
+                ) : (
+                  <Box bg="black30" width={325} height={230} />
+                )}
+
+                <Spacer mt={1} />
+
+                <EntityHeader
+                  name={node.name!}
+                  meta={node.formattedNationalityAndBirthday!}
+                  smallVariant
+                  FollowButton={
+                    <FollowArtistButtonFragmentContainer
+                      user={user}
+                      artist={node as any}
+                      contextModule={ContextModule.artistHeader}
+                      buttonProps={{
+                        size: "small",
+                        variant: "secondaryOutline",
+                      }}
+                    />
+                  }
+                />
+              </Box>
+            </RouterLink>
+          )
+        })}
+      </Shelf>
+    </HomeTrendingArtistsRailContainer>
+  )
+}
+
+const HomeTrendingArtistsRailContainer: React.FC = ({ children }) => {
+  return (
+    <>
+      <Flex justifyContent="space-between" alignItems="center">
+        <Text variant="lg">Trending Artists on Artsy</Text>
+
+        <Text
+          variant="sm"
+          as={RouterLink}
+          // @ts-ignore
+          to="/artists"
+        >
+          View All Artists
+        </Text>
+      </Flex>
+
+      <Spacer mt={4} />
+
+      {children}
+    </>
+  )
+}
+
+const PLACEHOLDER = (
+  <Skeleton>
+    <HomeTrendingArtistsRailContainer>
+      <Shelf>
+        {[...new Array(8)].map((_, i) => {
+          return (
+            <Box width={325} key={i}>
+              <SkeletonBox width={325} height={230} />
+              <SkeletonText variant="lg">Some Artist</SkeletonText>
+              <SkeletonText variant="md">Location</SkeletonText>
+            </Box>
+          )
+        })}
+      </Shelf>
+    </HomeTrendingArtistsRailContainer>
+  </Skeleton>
+)
+
+export const HomeTrendingArtistsRailFragmentContainer = createFragmentContainer(
+  HomeTrendingArtistsRail,
+  {
+    viewer: graphql`
+      fragment HomeTrendingArtistsRail_viewer on Viewer {
+        artistsConnection(sort: TRENDING_DESC, first: 99) {
+          edges {
+            node {
+              ...FollowArtistButton_artist
+              internalID
+              name
+              slug
+              href
+              formattedNationalityAndBirthday
+              image {
+                cropped(width: 325, height: 230) {
+                  src
+                  srcSet
+                  width
+                  height
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+  }
+)
+
+export const HomeTrendingArtistsRailQueryRenderer: React.FC = () => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <SystemQueryRenderer<HomeTrendingArtistsRailQuery>
+      environment={relayEnvironment}
+      query={graphql`
+        query HomeTrendingArtistsRailQuery {
+          viewer {
+            ...HomeTrendingArtistsRail_viewer
+          }
+        }
+      `}
+      placeholder={PLACEHOLDER}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props) {
+          return PLACEHOLDER
+        }
+
+        if (props.viewer) {
+          return (
+            <HomeTrendingArtistsRailFragmentContainer viewer={props.viewer} />
+          )
+        }
+
+        return null
+      }}
+    />
+  )
+}

--- a/src/v2/Apps/Home/HomeApp.tsx
+++ b/src/v2/Apps/Home/HomeApp.tsx
@@ -12,6 +12,7 @@ import { FlashBannerQueryRenderer } from "v2/Components/FlashBanner"
 import { HomeFeaturedGalleriesRailQueryRenderer } from "./Components/HomeFeaturedGalleriesRail"
 import { HomeFeaturedShowsRailQueryRenderer } from "./Components/HomeFeaturedShowsRail"
 import { HomeCurrentFairsRailQueryRenderer } from "./Components/HomeCurrentFairsRail"
+import { HomeTrendingArtistsRailQueryRenderer } from "./Components/HomeTrendingArtistsRail"
 
 interface HomeAppProps {
   homePage: HomeApp_homePage | null
@@ -52,12 +53,10 @@ export const HomeApp: React.FC<HomeAppProps> = ({
         )}
 
         <HomeFeaturedMarketNewsLazyQueryRenderer />
-
         <HomeFeaturedGalleriesRailQueryRenderer />
-
         <HomeFeaturedShowsRailQueryRenderer />
-
         <HomeCurrentFairsRailQueryRenderer />
+        <HomeTrendingArtistsRailQueryRenderer />
       </Join>
     </>
   )

--- a/src/v2/Apps/Home/HomeApp.tsx
+++ b/src/v2/Apps/Home/HomeApp.tsx
@@ -13,6 +13,7 @@ import { HomeFeaturedGalleriesRailQueryRenderer } from "./Components/HomeFeature
 import { HomeFeaturedShowsRailQueryRenderer } from "./Components/HomeFeaturedShowsRail"
 import { HomeCurrentFairsRailQueryRenderer } from "./Components/HomeCurrentFairsRail"
 import { HomeTrendingArtistsRailQueryRenderer } from "./Components/HomeTrendingArtistsRail"
+import { HomeAuctionLotsRailQueryRenderer } from "./Components/HomeAuctionLotsRail"
 
 interface HomeAppProps {
   homePage: HomeApp_homePage | null
@@ -53,6 +54,7 @@ export const HomeApp: React.FC<HomeAppProps> = ({
         )}
 
         <HomeFeaturedMarketNewsLazyQueryRenderer />
+        <HomeAuctionLotsRailQueryRenderer />
         <HomeFeaturedGalleriesRailQueryRenderer />
         <HomeFeaturedShowsRailQueryRenderer />
         <HomeCurrentFairsRailQueryRenderer />

--- a/src/v2/Apps/Home/__tests__/HomeAuctionLotsRail.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeAuctionLotsRail.jest.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import { graphql } from "relay-runtime"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { HomeAuctionLotsRailFragmentContainer } from "../Components/HomeAuctionLotsRail"
+import { HomeAuctionLotsRail_Test_Query } from "v2/__generated__/HomeAuctionLotsRail_Test_Query.graphql"
+
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper<HomeAuctionLotsRail_Test_Query>({
+  Component: props => {
+    return <HomeAuctionLotsRailFragmentContainer viewer={props.viewer!} />
+  },
+  query: graphql`
+    query HomeAuctionLotsRail_Test_Query {
+      viewer {
+        ...HomeAuctionLotsRail_viewer
+      }
+    }
+  `,
+})
+
+describe("HomeAuctionLotsRail", () => {
+  it("renders correctly", () => {
+    const wrapper = getWrapper({
+      Viewer: () => ({
+        saleArtworksConnection: {
+          edges: [
+            {
+              node: {
+                title: "Test Auction",
+                href: "test-href",
+                sale: {
+                  isClosed: false,
+                },
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(wrapper.text()).toContain("Auction Lots")
+    expect(wrapper.text()).toContain("View All Auctions")
+    expect(wrapper.text()).toContain("Test Auction")
+    expect(wrapper.html()).toContain("test-href")
+  })
+})

--- a/src/v2/Apps/Home/__tests__/HomeTrendingArtistsRail.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeTrendingArtistsRail.jest.tsx
@@ -1,0 +1,45 @@
+import React from "react"
+import { graphql } from "relay-runtime"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { HomeTrendingArtistsRailFragmentContainer } from "../Components/HomeTrendingArtistsRail"
+import { HomeTrendingArtistsRail_Test_Query } from "v2/__generated__/HomeTrendingArtistsRail_Test_Query.graphql"
+
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper<HomeTrendingArtistsRail_Test_Query>({
+  Component: props => {
+    return <HomeTrendingArtistsRailFragmentContainer viewer={props.viewer!} />
+  },
+  query: graphql`
+    query HomeTrendingArtistsRail_Test_Query {
+      viewer {
+        ...HomeTrendingArtistsRail_viewer
+      }
+    }
+  `,
+})
+
+describe("HomeTrendingArtistsRail", () => {
+  it("renders correctly", () => {
+    const wrapper = getWrapper({
+      Viewer: () => ({
+        artistsConnection: {
+          edges: [
+            {
+              node: {
+                name: "Test Artist",
+                href: "test-href",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(wrapper.text()).toContain("Trending Artists on Artsy")
+    expect(wrapper.text()).toContain("View All Artists")
+    expect(wrapper.text()).toContain("Test Artist")
+    expect(wrapper.text()).toContain("Following")
+    expect(wrapper.html()).toContain("test-href")
+  })
+})

--- a/src/v2/__generated__/HomeAuctionLotsRailQuery.graphql.ts
+++ b/src/v2/__generated__/HomeAuctionLotsRailQuery.graphql.ts
@@ -1,0 +1,582 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeAuctionLotsRailQueryVariables = {};
+export type HomeAuctionLotsRailQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"HomeAuctionLotsRail_viewer">;
+    } | null;
+};
+export type HomeAuctionLotsRailQuery = {
+    readonly response: HomeAuctionLotsRailQueryResponse;
+    readonly variables: HomeAuctionLotsRailQueryVariables;
+};
+
+
+
+/*
+query HomeAuctionLotsRailQuery {
+  viewer {
+    ...HomeAuctionLotsRail_viewer
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment HomeAuctionLotsRail_viewer on Viewer {
+  saleArtworksConnection(first: 50, geneIDs: "highlights-at-auction") {
+    edges {
+      node {
+        ...ShelfArtwork_artwork_1s6r3G
+        internalID
+        slug
+        href
+        sale {
+          isClosed
+          id
+        }
+        id
+      }
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment ShelfArtwork_artwork_1s6r3G on Artwork {
+  image {
+    resized(width: 210) {
+      src
+      srcSet
+      width
+      height
+    }
+    aspectRatio
+    height
+  }
+  imageTitle
+  title
+  href
+  is_saved: isSaved
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeAuctionLotsRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "HomeAuctionLotsRail_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeAuctionLotsRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 50
+              },
+              {
+                "kind": "Literal",
+                "name": "geneIDs",
+                "value": "highlights-at-auction"
+              }
+            ],
+            "concreteType": "SaleArtworksConnection",
+            "kind": "LinkedField",
+            "name": "saleArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "SaleArtwork",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 210
+                              }
+                            ],
+                            "concreteType": "ResizedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "resized",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "width",
+                                "storageKey": null
+                              },
+                              (v0/*: any*/)
+                            ],
+                            "storageKey": "resized(width:210)"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          },
+                          (v0/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "imageTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/),
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v3/*: any*/),
+                          (v1/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v1/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "type",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/),
+                          {
+                            "alias": "is_live_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isLiveOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_preview",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isPreview",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "display_timely_at",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "displayTimelyAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_inquireable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isInquireable",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_biddable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isBiddable",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v3/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "saleArtworksConnection(first:50,geneIDs:\"highlights-at-auction\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "HomeAuctionLotsRailQuery",
+    "operationKind": "query",
+    "text": "query HomeAuctionLotsRailQuery {\n  viewer {\n    ...HomeAuctionLotsRail_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment HomeAuctionLotsRail_viewer on Viewer {\n  saleArtworksConnection(first: 50, geneIDs: \"highlights-at-auction\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork_1s6r3G\n        internalID\n        slug\n        href\n        sale {\n          isClosed\n          id\n        }\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+  }
+};
+})();
+(node as any).hash = '161dd5f595054240f09e56ce38b1136b';
+export default node;

--- a/src/v2/__generated__/HomeAuctionLotsRail_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeAuctionLotsRail_Test_Query.graphql.ts
@@ -1,0 +1,582 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeAuctionLotsRail_Test_QueryVariables = {};
+export type HomeAuctionLotsRail_Test_QueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"HomeAuctionLotsRail_viewer">;
+    } | null;
+};
+export type HomeAuctionLotsRail_Test_Query = {
+    readonly response: HomeAuctionLotsRail_Test_QueryResponse;
+    readonly variables: HomeAuctionLotsRail_Test_QueryVariables;
+};
+
+
+
+/*
+query HomeAuctionLotsRail_Test_Query {
+  viewer {
+    ...HomeAuctionLotsRail_viewer
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment HomeAuctionLotsRail_viewer on Viewer {
+  saleArtworksConnection(first: 50, geneIDs: "highlights-at-auction") {
+    edges {
+      node {
+        ...ShelfArtwork_artwork_1s6r3G
+        internalID
+        slug
+        href
+        sale {
+          isClosed
+          id
+        }
+        id
+      }
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment ShelfArtwork_artwork_1s6r3G on Artwork {
+  image {
+    resized(width: 210) {
+      src
+      srcSet
+      width
+      height
+    }
+    aspectRatio
+    height
+  }
+  imageTitle
+  title
+  href
+  is_saved: isSaved
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeAuctionLotsRail_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "HomeAuctionLotsRail_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeAuctionLotsRail_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 50
+              },
+              {
+                "kind": "Literal",
+                "name": "geneIDs",
+                "value": "highlights-at-auction"
+              }
+            ],
+            "concreteType": "SaleArtworksConnection",
+            "kind": "LinkedField",
+            "name": "saleArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "SaleArtwork",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 210
+                              }
+                            ],
+                            "concreteType": "ResizedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "resized",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "width",
+                                "storageKey": null
+                              },
+                              (v0/*: any*/)
+                            ],
+                            "storageKey": "resized(width:210)"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          },
+                          (v0/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "imageTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/),
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v3/*: any*/),
+                          (v1/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v1/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "type",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/),
+                          {
+                            "alias": "is_live_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isLiveOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_preview",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isPreview",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "display_timely_at",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "displayTimelyAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_inquireable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isInquireable",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_biddable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isBiddable",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v3/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "saleArtworksConnection(first:50,geneIDs:\"highlights-at-auction\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "HomeAuctionLotsRail_Test_Query",
+    "operationKind": "query",
+    "text": "query HomeAuctionLotsRail_Test_Query {\n  viewer {\n    ...HomeAuctionLotsRail_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment HomeAuctionLotsRail_viewer on Viewer {\n  saleArtworksConnection(first: 50, geneIDs: \"highlights-at-auction\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork_1s6r3G\n        internalID\n        slug\n        href\n        sale {\n          isClosed\n          id\n        }\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+  }
+};
+})();
+(node as any).hash = 'da2db0992993d4662d3e7734f734000b';
+export default node;

--- a/src/v2/__generated__/HomeAuctionLotsRail_viewer.graphql.ts
+++ b/src/v2/__generated__/HomeAuctionLotsRail_viewer.graphql.ts
@@ -1,0 +1,134 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeAuctionLotsRail_viewer = {
+    readonly saleArtworksConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly slug: string;
+                readonly href: string | null;
+                readonly sale: {
+                    readonly isClosed: boolean | null;
+                } | null;
+                readonly " $fragmentRefs": FragmentRefs<"ShelfArtwork_artwork">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "HomeAuctionLotsRail_viewer";
+};
+export type HomeAuctionLotsRail_viewer$data = HomeAuctionLotsRail_viewer;
+export type HomeAuctionLotsRail_viewer$key = {
+    readonly " $data"?: HomeAuctionLotsRail_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"HomeAuctionLotsRail_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "HomeAuctionLotsRail_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 50
+        },
+        {
+          "kind": "Literal",
+          "name": "geneIDs",
+          "value": "highlights-at-auction"
+        }
+      ],
+      "concreteType": "SaleArtworksConnection",
+      "kind": "LinkedField",
+      "name": "saleArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SaleArtwork",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "slug",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "href",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Sale",
+                  "kind": "LinkedField",
+                  "name": "sale",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "isClosed",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "width",
+                      "value": 210
+                    }
+                  ],
+                  "kind": "FragmentSpread",
+                  "name": "ShelfArtwork_artwork"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "saleArtworksConnection(first:50,geneIDs:\"highlights-at-auction\")"
+    }
+  ],
+  "type": "Viewer"
+};
+(node as any).hash = 'a430e2aaa5acc09f5768303f6c22c5c8';
+export default node;

--- a/src/v2/__generated__/HomeTrendingArtistsRailQuery.graphql.ts
+++ b/src/v2/__generated__/HomeTrendingArtistsRailQuery.graphql.ts
@@ -1,0 +1,288 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeTrendingArtistsRailQueryVariables = {};
+export type HomeTrendingArtistsRailQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"HomeTrendingArtistsRail_viewer">;
+    } | null;
+};
+export type HomeTrendingArtistsRailQuery = {
+    readonly response: HomeTrendingArtistsRailQueryResponse;
+    readonly variables: HomeTrendingArtistsRailQueryVariables;
+};
+
+
+
+/*
+query HomeTrendingArtistsRailQuery {
+  viewer {
+    ...HomeTrendingArtistsRail_viewer
+  }
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  slug
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+
+fragment HomeTrendingArtistsRail_viewer on Viewer {
+  artistsConnection(sort: TRENDING_DESC, first: 99) {
+    edges {
+      node {
+        ...FollowArtistButton_artist
+        internalID
+        name
+        slug
+        href
+        formattedNationalityAndBirthday
+        image {
+          cropped(width: 325, height: 230) {
+            src
+            srcSet
+            width
+            height
+          }
+        }
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeTrendingArtistsRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "HomeTrendingArtistsRail_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeTrendingArtistsRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 99
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "TRENDING_DESC"
+              }
+            ],
+            "concreteType": "ArtistConnection",
+            "kind": "LinkedField",
+            "name": "artistsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtistEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_followed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFollowed",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtistCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "follows",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "formattedNationalityAndBirthday",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 230
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 325
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "width",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "height",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "cropped(height:230,width:325)"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "artistsConnection(first:99,sort:\"TRENDING_DESC\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "HomeTrendingArtistsRailQuery",
+    "operationKind": "query",
+    "text": "query HomeTrendingArtistsRailQuery {\n  viewer {\n    ...HomeTrendingArtistsRail_viewer\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment HomeTrendingArtistsRail_viewer on Viewer {\n  artistsConnection(sort: TRENDING_DESC, first: 99) {\n    edges {\n      node {\n        ...FollowArtistButton_artist\n        internalID\n        name\n        slug\n        href\n        formattedNationalityAndBirthday\n        image {\n          cropped(width: 325, height: 230) {\n            src\n            srcSet\n            width\n            height\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+(node as any).hash = 'ba5b4a81fc58c141a3f8c4e5deb9fb8a';
+export default node;

--- a/src/v2/__generated__/HomeTrendingArtistsRail_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeTrendingArtistsRail_Test_Query.graphql.ts
@@ -1,0 +1,288 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeTrendingArtistsRail_Test_QueryVariables = {};
+export type HomeTrendingArtistsRail_Test_QueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"HomeTrendingArtistsRail_viewer">;
+    } | null;
+};
+export type HomeTrendingArtistsRail_Test_Query = {
+    readonly response: HomeTrendingArtistsRail_Test_QueryResponse;
+    readonly variables: HomeTrendingArtistsRail_Test_QueryVariables;
+};
+
+
+
+/*
+query HomeTrendingArtistsRail_Test_Query {
+  viewer {
+    ...HomeTrendingArtistsRail_viewer
+  }
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  slug
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+
+fragment HomeTrendingArtistsRail_viewer on Viewer {
+  artistsConnection(sort: TRENDING_DESC, first: 99) {
+    edges {
+      node {
+        ...FollowArtistButton_artist
+        internalID
+        name
+        slug
+        href
+        formattedNationalityAndBirthday
+        image {
+          cropped(width: 325, height: 230) {
+            src
+            srcSet
+            width
+            height
+          }
+        }
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeTrendingArtistsRail_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "HomeTrendingArtistsRail_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeTrendingArtistsRail_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 99
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "TRENDING_DESC"
+              }
+            ],
+            "concreteType": "ArtistConnection",
+            "kind": "LinkedField",
+            "name": "artistsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtistEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_followed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFollowed",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtistCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "follows",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "formattedNationalityAndBirthday",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 230
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 325
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "width",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "height",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "cropped(height:230,width:325)"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "artistsConnection(first:99,sort:\"TRENDING_DESC\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "HomeTrendingArtistsRail_Test_Query",
+    "operationKind": "query",
+    "text": "query HomeTrendingArtistsRail_Test_Query {\n  viewer {\n    ...HomeTrendingArtistsRail_viewer\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment HomeTrendingArtistsRail_viewer on Viewer {\n  artistsConnection(sort: TRENDING_DESC, first: 99) {\n    edges {\n      node {\n        ...FollowArtistButton_artist\n        internalID\n        name\n        slug\n        href\n        formattedNationalityAndBirthday\n        image {\n          cropped(width: 325, height: 230) {\n            src\n            srcSet\n            width\n            height\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+(node as any).hash = '28228066e3aff7d576bfa284d276a113';
+export default node;

--- a/src/v2/__generated__/HomeTrendingArtistsRail_viewer.graphql.ts
+++ b/src/v2/__generated__/HomeTrendingArtistsRail_viewer.graphql.ts
@@ -1,0 +1,192 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeTrendingArtistsRail_viewer = {
+    readonly artistsConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly name: string | null;
+                readonly slug: string;
+                readonly href: string | null;
+                readonly formattedNationalityAndBirthday: string | null;
+                readonly image: {
+                    readonly cropped: {
+                        readonly src: string;
+                        readonly srcSet: string;
+                        readonly width: number;
+                        readonly height: number;
+                    } | null;
+                } | null;
+                readonly " $fragmentRefs": FragmentRefs<"FollowArtistButton_artist">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "HomeTrendingArtistsRail_viewer";
+};
+export type HomeTrendingArtistsRail_viewer$data = HomeTrendingArtistsRail_viewer;
+export type HomeTrendingArtistsRail_viewer$key = {
+    readonly " $data"?: HomeTrendingArtistsRail_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"HomeTrendingArtistsRail_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "HomeTrendingArtistsRail_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 99
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "TRENDING_DESC"
+        }
+      ],
+      "concreteType": "ArtistConnection",
+      "kind": "LinkedField",
+      "name": "artistsConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtistEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artist",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "slug",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "href",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "formattedNationalityAndBirthday",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Image",
+                  "kind": "LinkedField",
+                  "name": "image",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": [
+                        {
+                          "kind": "Literal",
+                          "name": "height",
+                          "value": 230
+                        },
+                        {
+                          "kind": "Literal",
+                          "name": "width",
+                          "value": 325
+                        }
+                      ],
+                      "concreteType": "CroppedImageUrl",
+                      "kind": "LinkedField",
+                      "name": "cropped",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "src",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "srcSet",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "width",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "height",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": "cropped(height:230,width:325)"
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "FollowArtistButton_artist"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artistsConnection(first:99,sort:\"TRENDING_DESC\")"
+    }
+  ],
+  "type": "Viewer"
+};
+(node as any).hash = '8b151902bc8376812b5231b9eb02fe03';
+export default node;


### PR DESCRIPTION
Addresses 
- https://artsyproduct.atlassian.net/browse/GRO-524
- https://artsyproduct.atlassian.net/browse/GRO-520

This adds a new Trending Artists rail to the home page: 

<img width="1066" alt="Screen Shot 2021-09-20 at 4 19 44 PM" src="https://user-images.githubusercontent.com/236943/134094768-b2b87e76-f2f5-4cc9-b69d-12ef69c28636.png">

As well as the Auction Lots rail: 

<img width="1677" alt="Screen Shot 2021-09-20 at 5 28 15 PM" src="https://user-images.githubusercontent.com/236943/134094810-13986dcc-bd96-416d-88ae-99dc57e0b134.png">


