### PR TITLE
fix(PURCHASE-2919): "Continue" CTA styling

### DIFF
--- a/src/v2/Apps/Order/Routes/Respond/index.tsx
+++ b/src/v2/Apps/Order/Routes/Respond/index.tsx
@@ -329,7 +329,7 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
                   <Button
                     onClick={this.onContinueButtonPressed}
                     loading={isCommittingMutation}
-                    size="large"
+                    variant="primaryBlack"
                     width="100%"
                   >
                     Continue


### PR DESCRIPTION
**Addresses:** [PURCHASE-2919](https://artsyproduct.atlassian.net/browse/PURCHASE-2919)

This PR fixes the styling of the "Continue" CTA button on the make offer counteroffer page on mobile web view and on the Eigen modal. 

**Before:**

<img width="493" alt="Screenshot 2021-09-21 at 12 46 59 PM" src="https://user-images.githubusercontent.com/50849237/134159170-0589fbab-f416-4683-9c53-8ad6833af368.png">

**After:**

<img width="492" alt="Screenshot 2021-09-21 at 12 47 28 PM" src="https://user-images.githubusercontent.com/50849237/134159206-37afd2be-cf31-48bd-905b-1a4276c1348d.png">

