### PR TITLE
fix: Improve artist auction result scrolling behavior

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -205,6 +205,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
     // Scroll to auction results if param flag is present
     if (!scrollToMarketSignals) return
 
+    // Scroll to auction results if the market signals section is not visible
     setImmediate(visible ? scrollToMarketSignalsTop : scrollToAuctionResultsTop)
   }
 

--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -194,7 +194,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
     // Scroll to auction results if param flag is present
     if (!scrollToAuctionResults) return
 
-    setImmediate(() => scrollToAuctionResultsTop(), 0)
+    setImmediate(scrollToAuctionResultsTop)
   }
 
   return (

--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react"
+import { ContextModule, Intent } from "@artsy/cohesion"
 import {
   Box,
   Column,
@@ -10,21 +10,28 @@ import {
   themeProps,
 } from "@artsy/palette"
 import { isEqual } from "lodash"
+import React, { useContext, useState } from "react"
 import { Title } from "react-head"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { useTracking } from "react-tracking"
 import useDeepCompareEffect from "use-deep-compare-effect"
-import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
-import { ContextModule, Intent } from "@artsy/cohesion"
+import {
+  paramsToCamelCase,
+  updateUrl,
+} from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { ModalType } from "v2/Components/Authentication/Types"
 import { LoadingArea } from "v2/Components/LoadingArea"
 import { PaginationFragmentContainer as Pagination } from "v2/Components/Pagination"
 import { AnalyticsSchema, SystemContext } from "v2/System"
+import { useRouter } from "v2/System/Router/useRouter"
+import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { usePrevious } from "v2/Utils/Hooks/usePrevious"
 import createLogger from "v2/Utils/logger"
 import { openAuthModal } from "v2/Utils/openAuthModal"
 import { Media } from "v2/Utils/Responsive"
 import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { ArtistAuctionResults_artist } from "v2/__generated__/ArtistAuctionResults_artist.graphql"
+import { allowedAuctionResultFilters } from "../../Utils/allowedAuctionResultFilters"
 import { ArtistAuctionResultItemFragmentContainer as AuctionResultItem } from "./ArtistAuctionResultItem"
 import {
   AuctionResultsFilterContextProvider,
@@ -33,18 +40,11 @@ import {
 } from "./AuctionResultsFilterContext"
 import { AuctionFilterMobileActionSheet } from "./Components/AuctionFilterMobileActionSheet"
 import { AuctionFilters } from "./Components/AuctionFilters"
-import { KeywordFilter } from "./Components/KeywordFilter"
 import { AuctionResultsControls } from "./Components/AuctionResultsControls"
+import { KeywordFilter } from "./Components/KeywordFilter"
 import { MarketStatsQueryRenderer } from "./Components/MarketStats"
 import { SortSelect } from "./Components/SortSelect"
 import { TableSidebar } from "./Components/TableSidebar"
-import { useRouter } from "v2/System/Router/useRouter"
-import {
-  paramsToCamelCase,
-  updateUrl,
-} from "v2/Components/ArtworkFilter/Utils/urlBuilder"
-import { allowedAuctionResultFilters } from "../../Utils/allowedAuctionResultFilters"
-import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 
 const logger = createLogger("ArtistAuctionResults.tsx")
 
@@ -71,9 +71,9 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
   const artistName = artist.name
 
   const { match } = useRouter()
-  const { scrollToAuctionResults } = paramsToCamelCase(
+  const { scrollToMarketSignals } = paramsToCamelCase(
     match?.location.query
-  ) as { scrollToAuctionResults?: boolean }
+  ) as { scrollToMarketSignals?: boolean }
 
   const scrollToAuctionResultsTop = () => {
     // Increasing offset if the user is not logged in to compensate the top log in container height
@@ -81,6 +81,17 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
     scrollIntoView({
       selector: "#scrollTo--artistAuctionResultsTop",
+      behavior: "smooth",
+      offset,
+    })
+  }
+
+  const scrollToMarketSignalsTop = () => {
+    // Increasing offset if the user is not logged in to compensate the top log in container height
+    const offset = isMobile && !user ? 120 : 75
+
+    scrollIntoView({
+      selector: "#scrollTo--marketSignalsTop",
       behavior: "smooth",
       offset,
     })
@@ -190,16 +201,18 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
   const titleString = `${artist.name} - Auction Results on Artsy`
 
-  const handleMarketStatsRendered = () => {
+  const handleMarketStatsRendered = (visible: boolean) => {
     // Scroll to auction results if param flag is present
-    if (!scrollToAuctionResults) return
+    if (!scrollToMarketSignals) return
 
-    setImmediate(scrollToAuctionResultsTop)
+    setImmediate(visible ? scrollToMarketSignalsTop : scrollToAuctionResultsTop)
   }
 
   return (
     <>
       <Title>{titleString}</Title>
+
+      <Box id="scrollTo--marketSignalsTop" />
 
       <MarketStatsQueryRenderer
         artistInternalID={artist.internalID}

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -224,7 +224,17 @@ export const MarketStatsFragmentContainer = createFragmentContainer(
 export const MarketStatsQueryRenderer: React.FC<{
   artistInternalID: string
   environment: RelayModernEnvironment
-}> = ({ artistInternalID, environment }) => {
+  onRendered?: () => void
+}> = ({ artistInternalID, environment, onRendered }) => {
+  const [hasRendered, setHasRendered] = useState(false)
+
+  const onRender = () => {
+    if (hasRendered) return
+
+    setImmediate(() => setHasRendered(true))
+    onRendered?.()
+  }
+
   return (
     <SystemQueryRenderer<MarketStatsQuery>
       environment={environment}
@@ -241,6 +251,8 @@ export const MarketStatsQueryRenderer: React.FC<{
         }
       `}
       render={({ props, error }) => {
+        if (error || props) onRender()
+
         if (error) {
           console.error(error)
           return null

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -1,7 +1,7 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Box, Column, GridColumns, Select, Text } from "@artsy/palette"
 import { rest } from "lodash"
-import React, { useRef, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
@@ -16,14 +16,18 @@ import { MarketStatsPlaceholder } from "./MarketStatsPlaceholder"
 
 interface MarketStatsProps {
   priceInsightsConnection: MarketStats_priceInsightsConnection
+  onRendered: (visible: boolean) => void
 }
 
 export const MarketStats: React.FC<MarketStatsProps> = ({
   priceInsightsConnection,
+  onRendered,
 }) => {
   const { trackEvent } = useTracking()
 
   const priceInsights = extractNodes(priceInsightsConnection)
+
+  useEffect(() => onRendered(priceInsights.length > 0), [priceInsights])
 
   const [selectedPriceInsight, setSelectedPriceInsight] = useState(
     priceInsights[0]
@@ -224,15 +228,15 @@ export const MarketStatsFragmentContainer = createFragmentContainer(
 export const MarketStatsQueryRenderer: React.FC<{
   artistInternalID: string
   environment: RelayModernEnvironment
-  onRendered?: () => void
+  onRendered?: (visible: boolean) => void
 }> = ({ artistInternalID, environment, onRendered }) => {
   const [hasRendered, setHasRendered] = useState(false)
 
-  const onRender = () => {
+  const onRender = (visible: boolean) => {
     if (hasRendered) return
 
     setImmediate(() => setHasRendered(true))
-    onRendered?.()
+    onRendered?.(visible)
   }
 
   return (
@@ -251,9 +255,9 @@ export const MarketStatsQueryRenderer: React.FC<{
         }
       `}
       render={({ props, error }) => {
-        if (error || props) onRender()
-
         if (error) {
+          onRender(false)
+
           console.error(error)
           return null
         }
@@ -265,6 +269,7 @@ export const MarketStatsQueryRenderer: React.FC<{
         return (
           <MarketStatsFragmentContainer
             priceInsightsConnection={props.priceInsightsConnection!}
+            onRendered={onRender}
           />
         )
       }}

--- a/src/v2/Apps/PriceDatabase/Components/PriceDatabaseSearch.tsx
+++ b/src/v2/Apps/PriceDatabase/Components/PriceDatabaseSearch.tsx
@@ -3,8 +3,8 @@ import {
   Column,
   Flex,
   GridColumns,
-  Text,
   MultiSelect,
+  Text,
 } from "@artsy/palette"
 import qs from "qs"
 import React, { useState } from "react"
@@ -38,7 +38,7 @@ export const PriceDatabaseSearch: React.FC = () => {
     const pathName = `/artist/${artistSlug}/auction-results`
     const searchFilters = filterSearchFilters(filters, ALLOWED_FILTERS)
     const queryString = qs.stringify(paramsToSnakeCase(searchFilters))
-    const paramFlag = "scroll_to_auction_results=true"
+    const paramFlag = "scroll_to_market_signals=true"
 
     // TODO: Add tracking for search
 

--- a/src/v2/Apps/PriceDatabase/__tests__/PriceDatabaseApp.jest.tsx
+++ b/src/v2/Apps/PriceDatabase/__tests__/PriceDatabaseApp.jest.tsx
@@ -1,9 +1,9 @@
-import React from "react"
-import { PriceDatabase } from "../PriceDatabase"
+import { Button, MultiSelect } from "@artsy/palette"
 import { mount, ReactWrapper } from "enzyme"
+import React from "react"
 import { HeadProvider } from "react-head"
 import { PriceDatabaseArtistAutosuggest } from "../Components/PriceDatabaseArtistAutosuggest"
-import { Button, MultiSelect } from "@artsy/palette"
+import { PriceDatabase } from "../PriceDatabase"
 
 jest.mock("v2/System/Router/useRouter", () => {
   return {
@@ -40,7 +40,7 @@ describe("PriceDatabaseApp", () => {
     wrapper.find(Button).simulate("click")
 
     expect(mockRouterPush).toHaveBeenCalledWith(
-      "/artist/gerhard-richter/auction-results?scroll_to_auction_results=true"
+      "/artist/gerhard-richter/auction-results?scroll_to_market_signals=true"
     )
   })
 
@@ -64,7 +64,7 @@ describe("PriceDatabaseApp", () => {
     wrapper.find(Button).simulate("click")
 
     expect(mockRouterPush).toHaveBeenCalledWith(
-      "/artist/banksy/auction-results?organizations%5B0%5D=Phillips&categories%5B0%5D=Painting&sizes%5B0%5D=SMALL&sizes%5B1%5D=MEDIUM&scroll_to_auction_results=true"
+      "/artist/banksy/auction-results?organizations%5B0%5D=Phillips&categories%5B0%5D=Painting&sizes%5B0%5D=SMALL&sizes%5B1%5D=MEDIUM&scroll_to_market_signals=true"
     )
   })
 })


### PR DESCRIPTION
## Description

🟥 Do not merge yet, this PR might need an update.

Fixes the scrolling behavior on the artist's auction results page by waiting for `MarketStatsQueryRenderer` to load and setting the offset depending on the breakpoint.

https://user-images.githubusercontent.com/4691889/134305465-8caf6848-37ff-43b3-9e3b-e6bd12d032cc.mov

