### PR TITLE
fix: Expand auction house filter by default

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
@@ -30,7 +30,7 @@ export const AuctionHouseFilter: React.FC = () => {
   }
 
   return (
-    <FilterExpandable label="Auction House">
+    <FilterExpandable label="Auction House" expanded>
       <Flex flexDirection="column" alignItems="left">
         <ShowMore>
           {auctionHouseMap.map((checkbox, index) => {

--- a/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -7,7 +7,6 @@ import React from "react"
 import { act } from "react-dom/test-utils"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
-import { Expandable } from "@artsy/palette"
 import { Breakpoint } from "v2/Utils/Responsive"
 import { openAuthModal } from "v2/Utils/openAuthModal"
 import { Pagination } from "v2/Components/Pagination"
@@ -364,9 +363,6 @@ describe("AuctionResults", () => {
         })
         describe("auction house filter", () => {
           it("triggers relay refetch with organization list, and re-shows sign up to see price", done => {
-            const filter = wrapper.find("AuctionHouseFilter")
-            filter.find(Expandable).find("button").simulate("click")
-
             const checkboxes = wrapper
               .find("AuctionHouseFilter")
               .find("Checkbox")
@@ -403,11 +399,6 @@ describe("AuctionResults", () => {
 
               done()
             })
-          })
-
-          it("is not expanded by default", () => {
-            const filter = wrapper.find("AuctionHouseFilter")
-            expect(filter.find(Expandable).prop("expanded")).toEqual(false)
           })
         })
         describe("size filter", () => {

--- a/src/v2/__generated__/CreateUserAddressMutation.graphql.ts
+++ b/src/v2/__generated__/CreateUserAddressMutation.graphql.ts
@@ -14,7 +14,6 @@ export type UserAddressAttributes = {
     country: string;
     name: string;
     phoneNumber?: string | null;
-    phoneNumberCountryCode?: string | null;
     postalCode?: string | null;
     region?: string | null;
 };

--- a/src/v2/__generated__/UpdateUserAddressMutation.graphql.ts
+++ b/src/v2/__generated__/UpdateUserAddressMutation.graphql.ts
@@ -15,7 +15,6 @@ export type UserAddressAttributes = {
     country: string;
     name: string;
     phoneNumber?: string | null;
-    phoneNumberCountryCode?: string | null;
     postalCode?: string | null;
     region?: string | null;
 };


### PR DESCRIPTION
## Description

Expands the `auction house` filter by default to show the filter to improve the UX when the user searches for auction results on the new price database landing page.

<img width="573" alt="Screenshot 2021-09-22 at 11 08 43" src="https://user-images.githubusercontent.com/4691889/134315828-7a0e1665-dc78-49b1-b51d-98e6b191e542.png">
