### PR TITLE
fix(PURCHASE-2923): add zIndex to toast component

### DIFF
--- a/src/v2/Components/Toast/ToastComponent.tsx
+++ b/src/v2/Components/Toast/ToastComponent.tsx
@@ -53,12 +53,12 @@ const ToastComponent: React.FC<ToastComponentProps> = ({
         boxShadow:
           "0px 0px 1px 2rgba (0, 0, 0, 0.08), 0px 2px 8px rgba(0, 0, 0, 0.12)",
         left: isMoveToRight ? "100%" : 0,
-        zIndex: 1,
       }}
       borderRadius={2}
       position="fixed"
       left={0}
       width="100%"
+      zIndex={1}
       opacity={showNotification ? 1 : 0}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}

--- a/src/v2/Components/Toast/ToastComponent.tsx
+++ b/src/v2/Components/Toast/ToastComponent.tsx
@@ -53,6 +53,7 @@ const ToastComponent: React.FC<ToastComponentProps> = ({
         boxShadow:
           "0px 0px 1px 2rgba (0, 0, 0, 0.08), 0px 2px 8px rgba(0, 0, 0, 0.12)",
         left: isMoveToRight ? "100%" : 0,
+        zIndex: 1,
       }}
       borderRadius={2}
       position="fixed"


### PR DESCRIPTION
[PURCHASE-2923]
Added zIndex to prevent other elements from overlapping the toast component. If overlapping happens in the future, should be enough to increase the zIndex number.

Before:
<img width="436" alt="Screenshot 2021-09-22 at 12 33 52" src="https://user-images.githubusercontent.com/17580625/134330138-dbb3aa97-2a02-41ff-9db0-52daf38d66ad.png">

After:
<img width="450" alt="Screenshot 2021-09-22 at 12 35 25" src="https://user-images.githubusercontent.com/17580625/134330170-c5f9a55e-a729-4a9e-95ab-8e1ef70b2c22.png">




[PURCHASE-2923]: https://artsyproduct.atlassian.net/browse/PURCHASE-2923