### PR TITLE
feat(FX-3280): navigation banner at fair show page

### DIFF
--- a/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
@@ -1,13 +1,12 @@
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
-import { Text, Flex, Swiper, themeProps } from "@artsy/palette"
+import { Text, Flex, Swiper } from "@artsy/palette"
 import { Media } from "v2/Utils/Responsive"
 import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { ExhibitorsLetterNav_fair } from "v2/__generated__/ExhibitorsLetterNav_fair.graphql"
-import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
-import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 import { getExhibitorSectionId } from "../Utils/getExhibitorSectionId"
+import { useExhibitorsTabOffset } from "../Utils/useExhibitorsTabOffset"
 
 const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ#".split("")
 
@@ -19,15 +18,7 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
   fair,
 }) => {
   const letters = fair?.exhibitorsGroupedByName?.map(group => group?.letter)
-  const {
-    height: [mobileNavBarHeight, desktopNavBarHeight],
-  } = useNavBarHeight()
-
-  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
-  const stickyTabsHeight = 150
-
-  const offset =
-    (isMobile ? mobileNavBarHeight : desktopNavBarHeight) + stickyTabsHeight
+  const offset = useExhibitorsTabOffset()
 
   const Letters = ({ withSwiper = false }) => {
     return (

--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
@@ -12,6 +12,7 @@ import {
 import { FairExhibitorCard_exhibitor } from "v2/__generated__/FairExhibitorCard_exhibitor.graphql"
 import { FollowProfileButtonFragmentContainer as FollowProfileButton } from "v2/Components/FollowButton/FollowProfileButton"
 import { RouterLink } from "v2/System/Router/RouterLink"
+import { useRouter } from "v2/System/Router/useRouter"
 
 interface FairExhibitorCardProps {
   exhibitor: FairExhibitorCard_exhibitor
@@ -30,6 +31,7 @@ export const FairExhibitorCard: React.FC<FairExhibitorCardProps> = ({
     contextPageOwnerSlug,
     contextPageOwnerType,
   } = useAnalyticsContext()
+  const { match } = useRouter()
 
   const tappedPartnerTrackingData: ClickedPartnerCard = {
     context_module: ContextModule.galleryBoothRail,
@@ -42,6 +44,9 @@ export const FairExhibitorCard: React.FC<FairExhibitorCardProps> = ({
     type: "thumbnail",
     action: ActionType.clickedPartnerCard,
   }
+
+  const { focused_exhibitor: focusedExhibitorID } = match.location.query
+  const focused = focusedExhibitorID === exhibitor?.partner?.internalID
 
   const partnerAddress = (cities: readonly (string | null)[]) => {
     const visibleCities = cities.slice(0, VISIBLE_CITIES_NUM).join(", ")
@@ -95,6 +100,7 @@ export const FairExhibitorCard: React.FC<FairExhibitorCardProps> = ({
                 variant: "secondaryOutline",
                 width: 70,
                 height: 30,
+                focus: focused,
               }}
             />
           </Box>

--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
@@ -55,11 +55,13 @@ export const FairExhibitorCard: React.FC<FairExhibitorCardProps> = ({
 
   return (
     <RouterLink
-      to={`/show/${exhibitor.profileID}`}
-      noUnderline
+      // use this param to display navigation banner on show
+      to={`/show/${exhibitor.profileID}?from_fair=true`}
+      textDecoration="none"
+      display="block"
       onClick={() => tracking.trackEvent(tappedPartnerTrackingData)}
     >
-      <Flex mb={1} flex={1}>
+      <Flex id={`jump--${exhibitor.partner?.internalID}`}>
         <BorderBox width={52} height={52} p={0} mr={1}>
           {profile?.icon?.cropped && (
             <Image

--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorsGroup.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorsGroup.tsx
@@ -1,9 +1,10 @@
 import React from "react"
-import { Column, GridColumns } from "@artsy/palette"
+import { Column, GridColumns, themeProps } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairExhibitorsGroup_exhibitorsGroup } from "v2/__generated__/FairExhibitorsGroup_exhibitorsGroup.graphql"
 import { FairExhibitorCardFragmentContainer as FairExhibitorCard } from "./FairExhibitorCard"
 import { useRouter } from "v2/System/Router/useRouter"
+import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 
 interface FairExhibitorsGroupProps {
   exhibitorsGroup: FairExhibitorsGroup_exhibitorsGroup
@@ -14,6 +15,7 @@ export const FairExhibitorsGroup: React.FC<FairExhibitorsGroupProps> = ({
 }) => {
   const { match } = useRouter()
   const { focused_exhibitor: focusedExhibitorID } = match.location.query
+  const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
 
   const focusedExhibitorStyles = {
     borderColor: "brand",
@@ -30,7 +32,8 @@ export const FairExhibitorsGroup: React.FC<FairExhibitorsGroupProps> = ({
         }
 
         const focused = focusedExhibitorID === exhibitor.partner.internalID
-        const exhibitorCardStyle = focused ? focusedExhibitorStyles : {}
+        const exhibitorCardStyle =
+          focused && !isMobile ? focusedExhibitorStyles : {}
 
         return (
           <Column

--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorsGroup.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorsGroup.tsx
@@ -3,6 +3,7 @@ import { Column, GridColumns } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairExhibitorsGroup_exhibitorsGroup } from "v2/__generated__/FairExhibitorsGroup_exhibitorsGroup.graphql"
 import { FairExhibitorCardFragmentContainer as FairExhibitorCard } from "./FairExhibitorCard"
+import { useRouter } from "v2/System/Router/useRouter"
 
 interface FairExhibitorsGroupProps {
   exhibitorsGroup: FairExhibitorsGroup_exhibitorsGroup
@@ -11,6 +12,16 @@ interface FairExhibitorsGroupProps {
 export const FairExhibitorsGroup: React.FC<FairExhibitorsGroupProps> = ({
   exhibitorsGroup: { exhibitors },
 }) => {
+  const { match } = useRouter()
+  const { focused_exhibitor: focusedExhibitorID } = match.location.query
+
+  const focusedExhibitorStyles = {
+    borderColor: "brand",
+    borderStyle: "solid",
+    borderWidth: "1px",
+    padding: "2px",
+  }
+
   return (
     <GridColumns position="relative" gridRowGap={4}>
       {exhibitors?.map(exhibitor => {
@@ -18,8 +29,15 @@ export const FairExhibitorsGroup: React.FC<FairExhibitorsGroupProps> = ({
           return null
         }
 
+        const focused = focusedExhibitorID === exhibitor.partner.internalID
+        const exhibitorCardStyle = focused ? focusedExhibitorStyles : {}
+
         return (
-          <Column key={exhibitor.partner.internalID} span={[12, 6, 3]}>
+          <Column
+            {...exhibitorCardStyle}
+            key={exhibitor.partner.internalID}
+            span={[12, 6, 3]}
+          >
             <FairExhibitorCard exhibitor={exhibitor} />
           </Column>
         )

--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorsGroup.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorsGroup.tsx
@@ -1,10 +1,8 @@
 import React from "react"
-import { Column, GridColumns, themeProps } from "@artsy/palette"
+import { Column, GridColumns } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairExhibitorsGroup_exhibitorsGroup } from "v2/__generated__/FairExhibitorsGroup_exhibitorsGroup.graphql"
 import { FairExhibitorCardFragmentContainer as FairExhibitorCard } from "./FairExhibitorCard"
-import { useRouter } from "v2/System/Router/useRouter"
-import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 
 interface FairExhibitorsGroupProps {
   exhibitorsGroup: FairExhibitorsGroup_exhibitorsGroup
@@ -13,17 +11,6 @@ interface FairExhibitorsGroupProps {
 export const FairExhibitorsGroup: React.FC<FairExhibitorsGroupProps> = ({
   exhibitorsGroup: { exhibitors },
 }) => {
-  const { match } = useRouter()
-  const { focused_exhibitor: focusedExhibitorID } = match.location.query
-  const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
-
-  const focusedExhibitorStyles = {
-    borderColor: "brand",
-    borderStyle: "solid",
-    borderWidth: "1px",
-    padding: "2px",
-  }
-
   return (
     <GridColumns position="relative" gridRowGap={4}>
       {exhibitors?.map(exhibitor => {
@@ -31,16 +18,8 @@ export const FairExhibitorsGroup: React.FC<FairExhibitorsGroupProps> = ({
           return null
         }
 
-        const focused = focusedExhibitorID === exhibitor.partner.internalID
-        const exhibitorCardStyle =
-          focused && !isMobile ? focusedExhibitorStyles : {}
-
         return (
-          <Column
-            {...exhibitorCardStyle}
-            key={exhibitor.partner.internalID}
-            span={[12, 6, 3]}
-          >
+          <Column key={exhibitor.partner.internalID} span={[12, 6, 3]}>
             <FairExhibitorCard exhibitor={exhibitor} />
           </Column>
         )

--- a/src/v2/Apps/Fair/Components/__tests__/FairExhibitorsGroup.jest.tsx
+++ b/src/v2/Apps/Fair/Components/__tests__/FairExhibitorsGroup.jest.tsx
@@ -2,10 +2,6 @@ import React from "react"
 import { FairExhibitorsGroupFragmentContainer } from "../FairExhibitors"
 import { mount } from "enzyme"
 
-jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
-}))
-
 jest.mock("v2/System/Router/useRouter", () => ({
   useRouter: () => ({
     match: {

--- a/src/v2/Apps/Fair/Components/__tests__/FairExhibitorsGroup.jest.tsx
+++ b/src/v2/Apps/Fair/Components/__tests__/FairExhibitorsGroup.jest.tsx
@@ -2,6 +2,20 @@ import React from "react"
 import { FairExhibitorsGroupFragmentContainer } from "../FairExhibitors"
 import { mount } from "enzyme"
 
+jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
+  useMatchMedia: () => ({}),
+}))
+
+jest.mock("v2/System/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      location: {
+        query: "",
+      },
+    },
+  }),
+}))
+
 describe("FairExhibitorsGroup", () => {
   const getWrapper = () => {
     return mount(

--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -1,27 +1,38 @@
-import React from "react"
+import React, { useEffect } from "react"
 import { Box, DROP_SHADOW, FullBleed, Spacer, Text } from "@artsy/palette"
 import { graphql, createFragmentContainer } from "react-relay"
 import { FairExhibitors_fair } from "v2/__generated__/FairExhibitors_fair.graphql"
 import { FairExhibitorsGroupFragmentContainer as FairExhibitorsGroup } from "../Components/FairExhibitors"
-import { FairExhibitorsGroupPlaceholder } from "../Components/FairExhibitors/FairExhibitorGroupPlaceholder"
-import { useLazyLoadComponent } from "v2/Utils/Hooks/useLazyLoadComponent"
 import { ExhibitorsLetterNavFragmentContainer as ExhibitorsLetterNav } from "../Components/ExhibitorsLetterNav"
 import { Sticky } from "v2/Components/Sticky"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 import { getExhibitorSectionId } from "../Utils/getExhibitorSectionId"
+import { useRouter } from "v2/System/Router/useRouter"
+import { useExhibitorsTabOffset } from "../Utils/useExhibitorsTabOffset"
+import { scrollIntoView } from "v2/Utils/scrollHelpers"
 
 interface FairExhibitorsProps {
   fair: FairExhibitors_fair
 }
 
 const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair }) => {
-  const { isEnteredView, Waypoint } = useLazyLoadComponent()
+  const { match } = useRouter()
+  const { focused_exhibitor: focusedExhibitorID } = match.location.query
+  const offset = useExhibitorsTabOffset()
+
+  useEffect(() => {
+    if (focusedExhibitorID) {
+      scrollIntoView({
+        selector: `#jump--${focusedExhibitorID}`,
+        offset,
+        behavior: "smooth",
+      })
+    }
+  }, [focusedExhibitorID, offset])
 
   return (
     <>
-      <Waypoint />
-
       <Spacer mt={4} />
 
       <Sticky>
@@ -47,11 +58,7 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair }) => {
             <Text variant="lg" my={4}>
               {letter}
             </Text>
-            {isEnteredView ? (
-              <FairExhibitorsGroup exhibitorsGroup={exhibitorsGroup} />
-            ) : (
-              <FairExhibitorsGroupPlaceholder />
-            )}
+            <FairExhibitorsGroup exhibitorsGroup={exhibitorsGroup} />
           </Box>
         )
       })}

--- a/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
@@ -4,8 +4,19 @@ import { FairExhibitorsFragmentContainer } from "../FairExhibitors"
 import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 
 jest.unmock("react-relay")
+
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => false,
+}))
+
+jest.mock("v2/System/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      location: {
+        query: "",
+      },
+    },
+  }),
 }))
 
 describe("FairExhibitors", () => {
@@ -51,7 +62,7 @@ describe("FairExhibitors", () => {
   it("renders the exhibitors group", () => {
     const wrapper = getWrapper(FAIR_FIXTURE)
 
-    const exhibitorsGroups = wrapper.find("FairExhibitorsGroupPlaceholder")
+    const exhibitorsGroups = wrapper.find("FairExhibitorsGroup")
 
     expect(exhibitorsGroups.length).toBe(3)
   })

--- a/src/v2/Apps/Fair/Utils/useExhibitorsTabOffset.ts
+++ b/src/v2/Apps/Fair/Utils/useExhibitorsTabOffset.ts
@@ -1,0 +1,17 @@
+import { themeProps } from "@artsy/palette"
+import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
+import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+
+export const useExhibitorsTabOffset = () => {
+  const {
+    height: [mobileNavBarHeight, desktopNavBarHeight],
+  } = useNavBarHeight()
+
+  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
+  const stickyTabsHeight = 150
+
+  const offset =
+    (isMobile ? mobileNavBarHeight : desktopNavBarHeight) + stickyTabsHeight
+
+  return offset
+}

--- a/src/v2/Apps/Show/Components/ShowNavigationBanner.tsx
+++ b/src/v2/Apps/Show/Components/ShowNavigationBanner.tsx
@@ -1,0 +1,51 @@
+import React from "react"
+import { BoxProps } from "@artsy/palette"
+import { BackLink } from "v2/Components/Links/BackLink"
+import { ShowNavigationBanner_show } from "v2/__generated__/ShowNavigationBanner_show.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface ShowNavigationBannerProps {
+  show: ShowNavigationBanner_show
+}
+
+const ShowNavigationBanner: React.FC<ShowNavigationBannerProps & BoxProps> = ({
+  show,
+  ...rest
+}) => {
+  const { fair, partner } = show
+
+  if (!fair?.name) {
+    return null
+  }
+
+  return (
+    <BackLink
+      {...rest}
+      to={`${fair?.href}/exhibitors?focused_exhibitor=${partner?.internalID}`}
+    >
+      Back to {fair.name}
+    </BackLink>
+  )
+}
+
+export const ShowNavigationBannerFragmentContainer = createFragmentContainer(
+  ShowNavigationBanner,
+  {
+    show: graphql`
+      fragment ShowNavigationBanner_show on Show {
+        partner {
+          ... on Partner {
+            internalID
+          }
+          ... on ExternalPartner {
+            internalID
+          }
+        }
+        fair {
+          name
+          href
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Show/ShowApp.tsx
+++ b/src/v2/Apps/Show/ShowApp.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import {
   Box,
@@ -26,6 +26,8 @@ import {
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { RouterLink } from "v2/System/Router/RouterLink"
+import { ShowNavigationBannerFragmentContainer as ShowNavigationBanner } from "./Components/ShowNavigationBanner"
+import { useRouter } from "v2/System/Router/useRouter"
 
 interface ShowAppProps {
   show: ShowApp_show
@@ -33,6 +35,11 @@ interface ShowAppProps {
 
 export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
   const { contextPageOwnerSlug, contextPageOwnerType } = useAnalyticsContext()
+  const { match } = useRouter()
+  const { from_fair } = match.location.query
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const arrivedFromFair = useMemo(() => from_fair ?? false, [])
 
   const hasViewingRoom = (show.viewingRoomsConnection?.edges?.length ?? 0) > 0
   const hasAbout = !!show.about
@@ -52,11 +59,17 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
             contextPageOwnerType,
           }}
         >
-          <Box mt={4} mb={[4, 6]}>
-            <ShowInstallShots show={show} mt={4} mb={6} />
-          </Box>
+          {arrivedFromFair && (
+            <ShowNavigationBanner show={show} mt={2} mb={4} />
+          )}
 
-          <GridColumns>
+          {Number(show?.images?.length) > 0 && (
+            <Box my={4}>
+              <ShowInstallShots show={show} mt={4} mb={6} />
+            </Box>
+          )}
+
+          <GridColumns mt={2}>
             <Column span={hasWideHeader ? [12, 8, 6] : 6} wrap={hasWideHeader}>
               <ShowHeader show={show} />
 
@@ -157,6 +170,10 @@ export const ShowAppFragmentContainer = createFragmentContainer(ShowApp, {
           }
         }
       }
+      images(default: false, size: 100) {
+        url
+      }
+      ...ShowNavigationBanner_show
       ...ShowHeader_show
       ...ShowAbout_show
       ...ShowMeta_show

--- a/src/v2/Apps/Show/__tests__/ShowApp.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowApp.jest.tsx
@@ -18,6 +18,18 @@ jest.mock("v2/Apps/Show/Components/ShowInstallShots", () => ({
   ShowInstallShotsFragmentContainer: () => null,
 }))
 
+jest.mock("v2/System/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      location: {
+        query: "",
+      },
+    },
+  }),
+}))
+
+const useRouter = jest.spyOn(require("v2/System/Router/useRouter"), "useRouter")
+
 const { getWrapper } = setupTestWrapper<ShowApp_Test_Query>({
   Component: ShowAppFragmentContainer,
   query: graphql`
@@ -75,5 +87,39 @@ describe("ShowApp", () => {
     })
 
     expect(wrapper.find(ShowViewingRoom)).toHaveLength(1)
+  })
+
+  it("do not render navigation banner if have not param", () => {
+    const wrapper = getWrapper({
+      Show: () => ({
+        name: "Example Show",
+        fair: { name: "Example Fair", href: "example" },
+      }),
+    })
+
+    expect(wrapper.find("ShowNavigationBanner").length).toEqual(0)
+  })
+
+  it("render navigation baner when redirect from fair page", () => {
+    useRouter.mockImplementation(() => ({
+      match: {
+        location: {
+          query: {
+            from_fair: true,
+          },
+        },
+      },
+    }))
+
+    const wrapper = getWrapper({
+      Show: () => ({
+        name: "Example Show",
+        fair: { name: "Example Fair", href: "example" },
+      }),
+    })
+
+    expect(wrapper.find("ShowNavigationBanner").text()).toContain(
+      "Back to Example Fair"
+    )
   })
 })

--- a/src/v2/__generated__/ShowApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowApp_Test_Query.graphql.ts
@@ -236,6 +236,10 @@ fragment ShowApp_show on Show {
     }
     id
   }
+  images(default: false, size: 100) {
+    url
+  }
+  ...ShowNavigationBanner_show
   ...ShowHeader_show
   ...ShowAbout_show
   ...ShowMeta_show
@@ -395,6 +399,27 @@ fragment ShowMeta_show on Show {
   formattedEndAt: endAt(format: "MMMM D, YYYY")
 }
 
+fragment ShowNavigationBanner_show on Show {
+  partner {
+    __typename
+    ... on Partner {
+      internalID
+    }
+    ... on ExternalPartner {
+      internalID
+      id
+    }
+    ... on Node {
+      id
+    }
+  }
+  fair {
+    name
+    href
+    id
+  }
+}
+
 fragment ShowViewingRoom_show on Show {
   partner {
     __typename
@@ -529,32 +554,32 @@ v13 = {
   "name": "srcSet",
   "storageKey": null
 },
-v14 = [
-  {
-    "kind": "Literal",
-    "name": "version",
-    "value": "large"
-  }
-],
-v15 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v16 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v17 = [
+v16 = [
   (v12/*: any*/),
   (v13/*: any*/),
-  (v15/*: any*/),
-  (v16/*: any*/)
+  (v14/*: any*/),
+  (v15/*: any*/)
+],
+v17 = [
+  {
+    "kind": "Literal",
+    "name": "version",
+    "value": "large"
+  }
 ],
 v18 = {
   "alias": null,
@@ -764,6 +789,7 @@ return {
                 "storageKey": null
               },
               (v9/*: any*/),
+              (v1/*: any*/),
               (v2/*: any*/),
               {
                 "alias": null,
@@ -772,7 +798,6 @@ return {
                 "name": "isActive",
                 "storageKey": null
               },
-              (v1/*: any*/),
               (v3/*: any*/),
               (v4/*: any*/),
               {
@@ -889,34 +914,106 @@ return {
             ],
             "storageKey": "filterArtworksConnection(first:1)"
           },
-          (v10/*: any*/),
-          (v11/*: any*/),
-          (v6/*: any*/),
           {
-            "alias": "formattedStartAt",
+            "alias": null,
             "args": [
               {
                 "kind": "Literal",
-                "name": "format",
-                "value": "MMMM D"
-              }
-            ],
-            "kind": "ScalarField",
-            "name": "startAt",
-            "storageKey": "startAt(format:\"MMMM D\")"
-          },
-          {
-            "alias": "formattedEndAt",
-            "args": [
+                "name": "default",
+                "value": false
+              },
               {
                 "kind": "Literal",
-                "name": "format",
-                "value": "MMMM D, YYYY"
+                "name": "size",
+                "value": 100
               }
             ],
-            "kind": "ScalarField",
-            "name": "endAt",
-            "storageKey": "endAt(format:\"MMMM D, YYYY\")"
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "images",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": null
+              },
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "caption",
+                "storageKey": null
+              },
+              {
+                "alias": "mobile",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 200
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": [
+                  (v14/*: any*/),
+                  (v15/*: any*/)
+                ],
+                "storageKey": "resized(width:200)"
+              },
+              {
+                "alias": "desktop",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 325
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v16/*: any*/),
+                "storageKey": "resized(width:325)"
+              },
+              {
+                "alias": "zoom",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 900
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": [
+                      "larger",
+                      "large"
+                    ]
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 900
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v16/*: any*/),
+                "storageKey": "resized(height:900,version:[\"larger\",\"large\"],width:900)"
+              }
+            ],
+            "storageKey": "images(default:false,size:100)"
           },
           {
             "alias": null,
@@ -931,6 +1028,7 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
+                  (v3/*: any*/),
                   (v1/*: any*/),
                   {
                     "alias": null,
@@ -940,7 +1038,6 @@ return {
                     "storageKey": null
                   },
                   (v2/*: any*/),
-                  (v3/*: any*/),
                   (v4/*: any*/),
                   {
                     "alias": null,
@@ -1036,12 +1133,42 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
+                  (v3/*: any*/),
                   (v1/*: any*/)
                 ],
                 "type": "ExternalPartner"
               }
             ],
             "storageKey": null
+          },
+          (v10/*: any*/),
+          (v11/*: any*/),
+          (v6/*: any*/),
+          {
+            "alias": "formattedStartAt",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "MMMM D"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "startAt",
+            "storageKey": "startAt(format:\"MMMM D\")"
+          },
+          {
+            "alias": "formattedEndAt",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "MMMM D, YYYY"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "endAt",
+            "storageKey": "endAt(format:\"MMMM D, YYYY\")"
           },
           {
             "alias": null,
@@ -1067,107 +1194,13 @@ return {
             "selections": [
               {
                 "alias": "src",
-                "args": (v14/*: any*/),
+                "args": (v17/*: any*/),
                 "kind": "ScalarField",
                 "name": "url",
                 "storageKey": "url(version:\"large\")"
               }
             ],
             "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "default",
-                "value": false
-              },
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 100
-              }
-            ],
-            "concreteType": "Image",
-            "kind": "LinkedField",
-            "name": "images",
-            "plural": true,
-            "selections": [
-              (v3/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "caption",
-                "storageKey": null
-              },
-              {
-                "alias": "mobile",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "width",
-                    "value": 200
-                  }
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": [
-                  (v15/*: any*/),
-                  (v16/*: any*/)
-                ],
-                "storageKey": "resized(width:200)"
-              },
-              {
-                "alias": "desktop",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "width",
-                    "value": 325
-                  }
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v17/*: any*/),
-                "storageKey": "resized(width:325)"
-              },
-              {
-                "alias": "zoom",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "height",
-                    "value": 900
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": [
-                      "larger",
-                      "large"
-                    ]
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "width",
-                    "value": 900
-                  }
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v17/*: any*/),
-                "storageKey": "resized(height:900,version:[\"larger\",\"large\"],width:900)"
-              }
-            ],
-            "storageKey": "images(default:false,size:100)"
           },
           {
             "alias": "filtered_artworks",
@@ -1307,7 +1340,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v14/*: any*/),
+                            "args": (v17/*: any*/),
                             "kind": "ScalarField",
                             "name": "url",
                             "storageKey": "url(version:\"large\")"
@@ -1539,7 +1572,7 @@ return {
     "metadata": {},
     "name": "ShowApp_Test_Query",
     "operationKind": "query",
-    "text": "query ShowApp_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowArtworks_show_4g78v5\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowArtworks_show_4g78v5 on Show {\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    mobile: resized(width: 200) {\n      width\n      height\n    }\n    desktop: resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ShowApp_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  images(default: false, size: 100) {\n    url\n  }\n  ...ShowNavigationBanner_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowArtworks_show_4g78v5\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowArtworks_show_4g78v5 on Show {\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    mobile: resized(width: 200) {\n      width\n      height\n    }\n    desktop: resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowNavigationBanner_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n    }\n    ... on ExternalPartner {\n      internalID\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  fair {\n    name\n    href\n    id\n  }\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ShowApp_show.graphql.ts
+++ b/src/v2/__generated__/ShowApp_show.graphql.ts
@@ -34,7 +34,10 @@ export type ShowApp_show = {
             } | null> | null;
         } | null> | null;
     } | null;
-    readonly " $fragmentRefs": FragmentRefs<"ShowHeader_show" | "ShowAbout_show" | "ShowMeta_show" | "ShowInstallShots_show" | "ShowViewingRoom_show" | "ShowArtworksEmptyState_show" | "ShowArtworks_show" | "ShowContextCard_show">;
+    readonly images: ReadonlyArray<{
+        readonly url: string | null;
+    } | null> | null;
+    readonly " $fragmentRefs": FragmentRefs<"ShowNavigationBanner_show" | "ShowHeader_show" | "ShowAbout_show" | "ShowMeta_show" | "ShowInstallShots_show" | "ShowViewingRoom_show" | "ShowArtworksEmptyState_show" | "ShowArtworks_show" | "ShowContextCard_show">;
     readonly " $refType": "ShowApp_show";
 };
 export type ShowApp_show$data = ShowApp_show;
@@ -264,6 +267,40 @@ return {
       "storageKey": null
     },
     {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "default",
+          "value": false
+        },
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 100
+        }
+      ],
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "images",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "url",
+          "storageKey": null
+        }
+      ],
+      "storageKey": "images(default:false,size:100)"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ShowNavigationBanner_show"
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "ShowHeader_show"
@@ -313,5 +350,5 @@ return {
   "type": "Show"
 };
 })();
-(node as any).hash = 'a153e4de51af149150d242013360b2a3';
+(node as any).hash = '338edf3be7508a8349a7c0a5e55f4456';
 export default node;

--- a/src/v2/__generated__/ShowNavigationBanner_show.graphql.ts
+++ b/src/v2/__generated__/ShowNavigationBanner_show.graphql.ts
@@ -1,0 +1,91 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowNavigationBanner_show = {
+    readonly partner: {
+        readonly internalID?: string;
+    } | null;
+    readonly fair: {
+        readonly name: string | null;
+        readonly href: string | null;
+    } | null;
+    readonly " $refType": "ShowNavigationBanner_show";
+};
+export type ShowNavigationBanner_show$data = ShowNavigationBanner_show;
+export type ShowNavigationBanner_show$key = {
+    readonly " $data"?: ShowNavigationBanner_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"ShowNavigationBanner_show">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "internalID",
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ShowNavigationBanner_show",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "partner",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "InlineFragment",
+          "selections": (v0/*: any*/),
+          "type": "Partner"
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": (v0/*: any*/),
+          "type": "ExternalPartner"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Fair",
+      "kind": "LinkedField",
+      "name": "fair",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "href",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Show"
+};
+})();
+(node as any).hash = 'd30ab7b1227f1703a550d00c5fa3f5a5';
+export default node;

--- a/src/v2/__generated__/showRoutes_ShowQuery.graphql.ts
+++ b/src/v2/__generated__/showRoutes_ShowQuery.graphql.ts
@@ -300,6 +300,10 @@ fragment ShowApp_show_3TMxyn on Show {
     }
     id
   }
+  images(default: false, size: 100) {
+    url
+  }
+  ...ShowNavigationBanner_show
   ...ShowHeader_show
   ...ShowAbout_show
   ...ShowMeta_show
@@ -457,6 +461,27 @@ fragment ShowMeta_show on Show {
   }
   formattedStartAt: startAt(format: "MMMM D")
   formattedEndAt: endAt(format: "MMMM D, YYYY")
+}
+
+fragment ShowNavigationBanner_show on Show {
+  partner {
+    __typename
+    ... on Partner {
+      internalID
+    }
+    ... on ExternalPartner {
+      internalID
+      id
+    }
+    ... on Node {
+      id
+    }
+  }
+  fair {
+    name
+    href
+    id
+  }
 }
 
 fragment ShowViewingRoom_show on Show {
@@ -629,32 +654,32 @@ v16 = {
   "name": "srcSet",
   "storageKey": null
 },
-v17 = [
-  {
-    "kind": "Literal",
-    "name": "version",
-    "value": "large"
-  }
-],
-v18 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v19 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v20 = [
+v19 = [
   (v15/*: any*/),
   (v16/*: any*/),
-  (v18/*: any*/),
-  (v19/*: any*/)
+  (v17/*: any*/),
+  (v18/*: any*/)
+],
+v20 = [
+  {
+    "kind": "Literal",
+    "name": "version",
+    "value": "large"
+  }
 ],
 v21 = {
   "alias": null,
@@ -872,6 +897,7 @@ return {
                 "storageKey": null
               },
               (v12/*: any*/),
+              (v4/*: any*/),
               (v5/*: any*/),
               {
                 "alias": null,
@@ -880,7 +906,6 @@ return {
                 "name": "isActive",
                 "storageKey": null
               },
-              (v4/*: any*/),
               (v6/*: any*/),
               (v7/*: any*/),
               {
@@ -1023,34 +1048,106 @@ return {
             ],
             "storageKey": null
           },
-          (v13/*: any*/),
-          (v14/*: any*/),
-          (v9/*: any*/),
           {
-            "alias": "formattedStartAt",
+            "alias": null,
             "args": [
               {
                 "kind": "Literal",
-                "name": "format",
-                "value": "MMMM D"
-              }
-            ],
-            "kind": "ScalarField",
-            "name": "startAt",
-            "storageKey": "startAt(format:\"MMMM D\")"
-          },
-          {
-            "alias": "formattedEndAt",
-            "args": [
+                "name": "default",
+                "value": false
+              },
               {
                 "kind": "Literal",
-                "name": "format",
-                "value": "MMMM D, YYYY"
+                "name": "size",
+                "value": 100
               }
             ],
-            "kind": "ScalarField",
-            "name": "endAt",
-            "storageKey": "endAt(format:\"MMMM D, YYYY\")"
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "images",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": null
+              },
+              (v6/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "caption",
+                "storageKey": null
+              },
+              {
+                "alias": "mobile",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 200
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": [
+                  (v17/*: any*/),
+                  (v18/*: any*/)
+                ],
+                "storageKey": "resized(width:200)"
+              },
+              {
+                "alias": "desktop",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 325
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v19/*: any*/),
+                "storageKey": "resized(width:325)"
+              },
+              {
+                "alias": "zoom",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 900
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": [
+                      "larger",
+                      "large"
+                    ]
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 900
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v19/*: any*/),
+                "storageKey": "resized(height:900,version:[\"larger\",\"large\"],width:900)"
+              }
+            ],
+            "storageKey": "images(default:false,size:100)"
           },
           {
             "alias": null,
@@ -1065,6 +1162,7 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
+                  (v6/*: any*/),
                   (v4/*: any*/),
                   {
                     "alias": null,
@@ -1074,7 +1172,6 @@ return {
                     "storageKey": null
                   },
                   (v5/*: any*/),
-                  (v6/*: any*/),
                   (v7/*: any*/),
                   {
                     "alias": null,
@@ -1170,12 +1267,42 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
+                  (v6/*: any*/),
                   (v4/*: any*/)
                 ],
                 "type": "ExternalPartner"
               }
             ],
             "storageKey": null
+          },
+          (v13/*: any*/),
+          (v14/*: any*/),
+          (v9/*: any*/),
+          {
+            "alias": "formattedStartAt",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "MMMM D"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "startAt",
+            "storageKey": "startAt(format:\"MMMM D\")"
+          },
+          {
+            "alias": "formattedEndAt",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "MMMM D, YYYY"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "endAt",
+            "storageKey": "endAt(format:\"MMMM D, YYYY\")"
           },
           {
             "alias": null,
@@ -1201,107 +1328,13 @@ return {
             "selections": [
               {
                 "alias": "src",
-                "args": (v17/*: any*/),
+                "args": (v20/*: any*/),
                 "kind": "ScalarField",
                 "name": "url",
                 "storageKey": "url(version:\"large\")"
               }
             ],
             "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "default",
-                "value": false
-              },
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 100
-              }
-            ],
-            "concreteType": "Image",
-            "kind": "LinkedField",
-            "name": "images",
-            "plural": true,
-            "selections": [
-              (v6/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "caption",
-                "storageKey": null
-              },
-              {
-                "alias": "mobile",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "width",
-                    "value": 200
-                  }
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": [
-                  (v18/*: any*/),
-                  (v19/*: any*/)
-                ],
-                "storageKey": "resized(width:200)"
-              },
-              {
-                "alias": "desktop",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "width",
-                    "value": 325
-                  }
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v20/*: any*/),
-                "storageKey": "resized(width:325)"
-              },
-              {
-                "alias": "zoom",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "height",
-                    "value": 900
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": [
-                      "larger",
-                      "large"
-                    ]
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "width",
-                    "value": 900
-                  }
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v20/*: any*/),
-                "storageKey": "resized(height:900,version:[\"larger\",\"large\"],width:900)"
-              }
-            ],
-            "storageKey": "images(default:false,size:100)"
           },
           {
             "alias": "filtered_artworks",
@@ -1442,7 +1475,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v17/*: any*/),
+                            "args": (v20/*: any*/),
                             "kind": "ScalarField",
                             "name": "url",
                             "storageKey": "url(version:\"large\")"
@@ -1674,7 +1707,7 @@ return {
     "metadata": {},
     "name": "showRoutes_ShowQuery",
     "operationKind": "query",
-    "text": "query showRoutes_ShowQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  show(id: $slug) @principalField {\n    ...ShowApp_show_3TMxyn\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show_3TMxyn on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowArtworks_show_2VV6jB\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowArtworks_show_2VV6jB on Show {\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    mobile: resized(width: 200) {\n      width\n      height\n    }\n    desktop: resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query showRoutes_ShowQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  show(id: $slug) @principalField {\n    ...ShowApp_show_3TMxyn\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show_3TMxyn on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  images(default: false, size: 100) {\n    url\n  }\n  ...ShowNavigationBanner_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowArtworks_show_2VV6jB\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowArtworks_show_2VV6jB on Show {\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    mobile: resized(width: 200) {\n      width\n      height\n    }\n    desktop: resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowNavigationBanner_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n    }\n    ... on ExternalPartner {\n      internalID\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  fair {\n    name\n    href\n    id\n  }\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Jira: [FX-3280](https://artsyproduct.atlassian.net/browse/FX-3280)

### Description
As a collector, I should be able to go back to the Fairs 'Exhibitors A-Z' tab after clicking through to view a Fairs 'Show'. Currently, there is no navigational banner making it explicit and easy for the collector to go back to the Fair page to continue browsing exhibitors within a Fair.

[Figma](https://www.figma.com/file/aM3b5sodn04vMTigbQXACi/Fairs-2021?node-id=3474%3A17827)

### Changes
- Added navigation banner
- Small refactor of fair components

### Demo

https://user-images.githubusercontent.com/56556580/134356999-ce1b8cd1-9361-4b25-94d1-428fba855752.mov

https://user-images.githubusercontent.com/56556580/134358180-52d99e9a-77dd-4da2-888e-221a7d3611f1.mov


