### PR TITLE
Missing artwork image label background on conversation page

### DIFF
--- a/src/v2/Apps/Conversation/Components/Item.tsx
+++ b/src/v2/Apps/Conversation/Components/Item.tsx
@@ -1,8 +1,6 @@
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Flex, Image, Link, Text } from "@artsy/palette"
-import { themeGet } from "@styled-system/theme-get"
-
 import { Item_item } from "v2/__generated__/Item_item.graphql"
 
 interface ItemProps {
@@ -78,7 +76,7 @@ export const Item: React.FC<ItemProps> = props => {
             p={1}
             flexDirection="column"
             justifyContent="center"
-            background={`${themeGet("colors.black100")}`}
+            backgroundColor="black100"
             borderRadius="0 0 15px 15px"
           >
             {itemDetails(item)}


### PR DESCRIPTION
# PURCHASE-2925

Correct background color is being passed in but for some reason is not showing up correctly. This was likely caused by the v3 migration

__Before:__
<img width="406" alt="Screen Shot 2021-09-23 at 3 37 08 PM" src="https://user-images.githubusercontent.com/5643895/134572538-6589adcf-e6aa-413d-a5da-4e8adc861c23.png">

__After:__
<img width="402" alt="Screen Shot 2021-09-23 at 1 22 47 PM" src="https://user-images.githubusercontent.com/5643895/134572455-3df3450b-ab4b-49f4-9e4c-e1782a7e97ef.png">
