### PR TITLE
bugfix: [Home] Fix homepage module display

### DIFF
--- a/src/v2/Apps/Home/Components/HomeArtworkModules.tsx
+++ b/src/v2/Apps/Home/Components/HomeArtworkModules.tsx
@@ -30,7 +30,7 @@ const HomeArtworkModules: React.FC<HomeArtworkModulesProps> = ({
               <HomeArtworkModuleRailLazyQueryRenderer
                 title={artworkModule.title}
                 params={{
-                  key: artworkModule.key as HomeArtworkModuleKey,
+                  key: artworkModule.key.toUpperCase() as HomeArtworkModuleKey,
                   id: artworkModule.params?.internalID,
                   relatedArtistID: artworkModule.params?.relatedArtistID,
                   followedArtistID: artworkModule.params?.followedArtistID,


### PR DESCRIPTION
A bit of fallout from https://github.com/artsy/force/pull/8455. 

Fixes issue where we updated module string type to a union, but didn't `toUpperCase` on the module key when making a request to MP, leading to a type error. 

Example of auth'd rails now coming through: 

<img width="508" alt="Screen Shot 2021-09-23 at 1 15 09 PM" src="https://user-images.githubusercontent.com/236943/134577632-480cfe11-c97d-4460-a58c-85d3f8588044.png">

