### PR TITLE
fix: [Router] Fix cannot update state after unmount error + cleanup

### DIFF
--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -30,11 +30,9 @@ export const AppShell: React.FC<AppShellProps> = props => {
   useAuthIntent()
 
   const { children, match } = props
-  const routeConfig = findCurrentRoute(match)
+  const routeConfig = findCurrentRoute(match)!
   const { user, isEigen } = useSystemContext()
-  // @ts-expect-error STRICT_NULL_CHECK
   const showFooter = !isEigen && !routeConfig.hideFooter
-  // @ts-expect-error STRICT_NULL_CHECK
   const appContainerMaxWidth = routeConfig.displayFullPage ? "100%" : null
   const isLoggedIn = Boolean(user)
   /**
@@ -43,10 +41,8 @@ export const AppShell: React.FC<AppShellProps> = props => {
    * in the background.
    */
   useEffect(() => {
-    // @ts-expect-error STRICT_NULL_CHECK
     if (isFunction(routeConfig.prepare)) {
       try {
-        // @ts-expect-error STRICT_NULL_CHECK
         routeConfig.prepare()
       } catch (error) {
         logger.error(error)
@@ -68,7 +64,6 @@ export const AppShell: React.FC<AppShellProps> = props => {
    * will cause the styles to update out of sync with the page change. Here we
    * wait for the route to finish rendering before setting the next theme.
    */
-  // @ts-expect-error STRICT_NULL_CHECK
   const nextTheme = routeConfig.theme ?? "v2"
   const [theme, setTheme] = useState<"v2" | "v3">(nextTheme)
   useRouteComplete({ onComplete: () => setTheme(nextTheme) })

--- a/src/v2/DevTools/MockBoot.tsx
+++ b/src/v2/DevTools/MockBoot.tsx
@@ -15,7 +15,6 @@ export const MockBoot: React.SFC<{
       onlyMatchMediaQueries={[breakpoint]}
       headTags={headTags}
       context={mockContext}
-      // @ts-expect-error STRICT_NULL_CHECK
       user={user}
       relayEnvironment={null as any}
       routes={null as any}

--- a/src/v2/System/Router/Boot.tsx
+++ b/src/v2/System/Router/Boot.tsx
@@ -28,13 +28,12 @@ export interface BootProps {
   onlyMatchMediaQueries?: MatchingMediaQueries
   relayEnvironment: Environment
   routes: AppRouteConfig[]
-  user: User
+  user: User | null
 }
 
 const { GlobalStyles } = injectGlobalStyles()
 
-// @ts-expect-error STRICT_NULL_CHECK
-export const Boot = track(null, {
+export const Boot = track(undefined, {
   dispatch: Events.postEvent,
 })((props: BootProps) => {
   /**

--- a/src/v2/System/Router/PageLoader.tsx
+++ b/src/v2/System/Router/PageLoader.tsx
@@ -26,8 +26,7 @@ export class PageLoader extends React.Component<
 > {
   state = {
     progress: 0,
-    // @ts-expect-error STRICT_NULL_CHECK
-    step: random(1, this.props.step),
+    step: random(1, this.props.step!),
   }
 
   static defaultProps = {

--- a/src/v2/System/Router/RenderStatus.tsx
+++ b/src/v2/System/Router/RenderStatus.tsx
@@ -22,8 +22,7 @@ export const RenderPending = () => {
    * duration of the fetch.
    */
   if (!isFetching) {
-    // @ts-expect-error STRICT_NULL_CHECK
-    setFetching(true)
+    setImmediate(() => setFetching?.(true))
   }
 
   if (isFetching) {
@@ -50,15 +49,11 @@ export const RenderPending = () => {
   }
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
-export const RenderReady: React.FC<{
-  elements: React.ReactNode
-}> = props => {
+export const RenderReady = (props: { elements: React.ReactNode }) => {
   const { isFetching, setFetching } = useSystemContext()
 
   if (isFetching) {
-    // @ts-expect-error STRICT_NULL_CHECK
-    setFetching(false)
+    setImmediate(() => setFetching?.(false))
   }
 
   if (!isFetching) {
@@ -78,8 +73,7 @@ export const RenderError: React.FC<{
   const { isFetching, setFetching } = useSystemContext()
 
   if (isFetching) {
-    // @ts-expect-error STRICT_NULL_CHECK
-    setFetching(false)
+    setImmediate(() => setFetching?.(false))
   }
 
   const message =

--- a/src/v2/System/Router/Utils/findCurrentRoute.tsx
+++ b/src/v2/System/Router/Utils/findCurrentRoute.tsx
@@ -1,25 +1,19 @@
-import { Match } from "found"
 import { AppRouteConfig } from "../Route"
 
-export const findCurrentRoute = ({
-  route: baseRoute,
-  routes,
-  routeIndices,
-}: Match & { route?: AppRouteConfig }) => {
+export const findCurrentRoute = (
+  { route: baseRoute, routes, routeIndices }: any /* FIXME: Add type */
+): AppRouteConfig => {
   if (!routeIndices || routeIndices.length === 0) {
     return baseRoute
   }
   let remainingRouteIndicies = [...routeIndices]
-  // @ts-expect-error STRICT_NULL_CHECK
-  let route: AppRouteConfig = routes[remainingRouteIndicies.shift()]
+  let route = routes[remainingRouteIndicies.shift()]
 
   while (remainingRouteIndicies.length > 0) {
-    // @ts-expect-error STRICT_NULL_CHECK
     route = route.children[remainingRouteIndicies.shift()]
   }
 
   if (!route) {
-    // @ts-expect-error STRICT_NULL_CHECK
     route = baseRoute
   }
 

--- a/src/v2/System/Router/Utils/matchingMediaQueriesForUserAgent.ts
+++ b/src/v2/System/Router/Utils/matchingMediaQueriesForUserAgent.ts
@@ -19,14 +19,14 @@ export function matchingMediaQueriesForUserAgent(
 
   const device = findDevice(userAgent)
   if (!device) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-ignore
     return undefined
   } else {
     const supportsHover = device.touch ? "notHover" : "hover"
     const onlyMatch: MatchingMediaQueries = device.resizable
       ? [
           supportsHover,
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-ignore
           ...findBreakpointsForWidths(device.minWidth, device.maxWidth),
         ]
       : [

--- a/src/v2/System/Router/Utils/useMaybeReloadAfterInquirySignIn.tsx
+++ b/src/v2/System/Router/Utils/useMaybeReloadAfterInquirySignIn.tsx
@@ -8,21 +8,17 @@ import { useEffect } from "react"
  * logged in state.
  */
 export function useMaybeReloadAfterInquirySignIn() {
-  const { mediator } = useSystemContext()
+  const mediator = useSystemContext().mediator!
 
   useEffect(() => {
-    // @ts-expect-error STRICT_NULL_CHECK
     mediator.on("auth:login:inquiry_form", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
       mediator.on("auth:login:inquiry_form:maybeReloadOnModalClose", () => {
         window.location.reload()
       })
     })
 
     return () => {
-      // @ts-expect-error STRICT_NULL_CHECK
       mediator.off("auth:login:inquiry_form")
-      // @ts-expect-error STRICT_NULL_CHECK
       mediator.off("auth:login:inquiry_form:maybeReloadOnModalClose")
     }
   }, [mediator])

--- a/src/v2/System/Router/__tests__/RouterLink.jest.tsx
+++ b/src/v2/System/Router/__tests__/RouterLink.jest.tsx
@@ -22,12 +22,12 @@ describe("RouterLink", () => {
           },
         ]}
       />
-      // @ts-expect-error STRICT_NULL_CHECK
     ).renderUntil(enzyme => {
       try {
         return enzyme.html().length > 0
       } catch {
         // Guard against enzyme == null, which is the first render pass
+        return false
       }
     })
   }

--- a/src/v2/System/Router/__tests__/buildAppRoutes.jest.tsx
+++ b/src/v2/System/Router/__tests__/buildAppRoutes.jest.tsx
@@ -40,8 +40,7 @@ describe("buildAppRoutes", () => {
       },
     ])
 
-    // @ts-expect-error STRICT_NULL_CHECK
-    expect(routes[0].Component.displayName).toEqual("withRouter(Component)")
+    expect(routes[0].Component?.displayName).toEqual("withRouter(Component)")
 
     expect(routes[0].children).toEqual([
       {

--- a/src/v2/System/Router/__tests__/buildServerApp.jest.tsx
+++ b/src/v2/System/Router/__tests__/buildServerApp.jest.tsx
@@ -40,7 +40,7 @@ describe("buildServerApp", () => {
   let options: Pick<
     ServerRouterConfig,
     Exclude<keyof ServerRouterConfig, "routes">
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-ignore
   > = { req, res }
 
   beforeEach(() => {
@@ -82,12 +82,10 @@ describe("buildServerApp", () => {
       ],
       ...passedOptions,
     })
-    // @ts-expect-error STRICT_NULL_CHECK
     const ServerApp = Object.getOwnPropertyDescriptor(
-      result,
-      // @ts-expect-error STRICT_NULL_CHECK
-      __TEST_INTERNAL_SERVER_APP__
-    ).value
+      result!,
+      __TEST_INTERNAL_SERVER_APP__!
+    )?.value
     return {
       ...result,
       ServerApp,
@@ -143,10 +141,8 @@ describe("buildServerApp", () => {
     const { headTags } = await getWrapper(component)
     // Enzyme won't render the right results for the title for whatever reason
     // It renders fine with renderToString though. ¯\_(ツ)_/¯
-    // @ts-expect-error STRICT_NULL_CHECK
-    expect(headTags[headTags.length - 1].type).toBe("title")
-    // @ts-expect-error STRICT_NULL_CHECK
-    expect(headTags[headTags.length - 1].props.children).toBe("test")
+    expect(headTags?.[headTags.length - 1].type).toBe("title")
+    expect(headTags?.[headTags.length - 1].props.children).toBe("test")
   })
 
   // eslint-disable-next-line jest/no-done-callback

--- a/src/v2/System/Router/buildAppRoutes.tsx
+++ b/src/v2/System/Router/buildAppRoutes.tsx
@@ -29,8 +29,7 @@ export function buildAppRoutes(routeList: RouteList[]): AppRouteConfig[] {
     // Store global reference to router instance
     useEffect(() => {
       if (props.router !== router) {
-        // @ts-expect-error STRICT_NULL_CHECK
-        setRouter(props.router)
+        setRouter?.(props.router)
       }
 
       interceptLinks({

--- a/src/v2/System/Router/buildClientApp.tsx
+++ b/src/v2/System/Router/buildClientApp.tsx
@@ -109,7 +109,6 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
         return (
           <Boot
             context={clientContext}
-            // @ts-expect-error STRICT_NULL_CHECK
             user={user}
             relayEnvironment={relayEnvironment}
             routes={routes}

--- a/src/v2/System/Router/buildServerApp.tsx
+++ b/src/v2/System/Router/buildServerApp.tsx
@@ -106,14 +106,16 @@ export function buildServerApp(
         const matchingMediaQueries =
           userAgent && matchingMediaQueriesForUserAgent(userAgent)
 
-        const ServerApp = ({ tags = [] }) => {
+        const ServerApp: React.FC<{ tags: JSX.Element[] }> = ({
+          tags = [],
+        }) => {
           return (
             <Boot
               context={serverContext}
-              // @ts-expect-error STRICT_NULL_CHECK
               user={user}
               headTags={tags}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // FIXME:
+              // @ts-ignore
               onlyMatchMediaQueries={matchingMediaQueries}
               relayEnvironment={relayEnvironment}
               routes={routes}
@@ -157,7 +159,6 @@ export function buildServerApp(
 
         // Wrap component tree in library contexts to extract usage
         bundleJSX = extractor.collectChunks(
-          // @ts-expect-error STRICT_NULL_CHECK
           sheet.collectStyles(<ServerApp tags={headTags} />)
         )
 


### PR DESCRIPTION
Noticed that after our React 17 upgrade we started getting "cannot set state after unmount" errors when transitioning between routes. Wrapping our state calls with `setImmediate` fixes it. 

Also cleans up all of the `// @ts-expect-error` flags in `v2/System/Router`. 