### PR TITLE
cleanup: Use responsive props instead of media

### DIFF
--- a/src/v2/Apps/PriceDatabase/Components/PriceDatabaseBenefits.tsx
+++ b/src/v2/Apps/PriceDatabase/Components/PriceDatabaseBenefits.tsx
@@ -17,20 +17,11 @@ export const PriceDatabaseBenefits: React.FC = () => {
     <Flex py={[1, 4]} flexDirection="column">
       <GridColumns mt={4} gridRowGap={[2, 0]}>
         <Column span={12}>
-          <Media lessThan="md">
-            <Text as="h1" variant="xl">
-              Auction records from 340,000
-              <br />
-              artists—and counting
-            </Text>
-          </Media>
-          <Media greaterThanOrEqual="md">
-            <Text as="h1" variant="xxl">
-              Auction records from 340,000
-              <br />
-              artists—and counting
-            </Text>
-          </Media>
+          <Text as="h1" variant={["xl", "xxl"]}>
+            Auction records from 340,000
+            <br />
+            artists—and counting
+          </Text>
         </Column>
       </GridColumns>
 

--- a/src/v2/Apps/PriceDatabase/Components/PriceDatabaseSearch.tsx
+++ b/src/v2/Apps/PriceDatabase/Components/PriceDatabaseSearch.tsx
@@ -67,30 +67,20 @@ export const PriceDatabaseSearch: React.FC = () => {
     <>
       <GridColumns my={4} gridRowGap={[2, 0]}>
         <Column span={12}>
-          <Media lessThan="md">
-            <Text as="h1" variant="xl">
-              Artsy Price
+          <Text as="h1" variant={["xl", "xxl"]}>
+            <Media lessThan="sm">
+              Artsy
               <br />
-              Database
-            </Text>
-            <Text variant="sm" mb={[0, 2]}>
-              Unlimited access to auction results and art market data—for free.
-              <br />
-              Browse 6.5 million auction records from 2,400 top auction houses,
-              from 1986 to today.
-            </Text>
-          </Media>
-          <Media greaterThanOrEqual="md">
-            <Text as="h1" variant="xxl">
-              Artsy Price Database
-            </Text>
-            <Text variant="lg" mb={[0, 2]}>
-              Unlimited access to auction results and art market data—for free.
-              <br />
-              Browse 6.5 million auction records from 2,400 top auction houses,
-              from 1986 to today.
-            </Text>
-          </Media>
+              Price Database
+            </Media>
+            <Media greaterThanOrEqual="sm">Artsy Price Database</Media>
+          </Text>
+          <Text variant={["sm", "lg"]} mb={[0, 2]}>
+            Unlimited access to auction results and art market data—for free.
+            <br />
+            Browse 6.5 million auction records from 2,400 top auction houses,
+            from 1986 to today.
+          </Text>
         </Column>
       </GridColumns>
       <Flex


### PR DESCRIPTION

This PR removes some `Media` wrappers in favour of Palette's responsive props.