### PR TITLE
feat(gro-517): improved sticky

### DIFF
--- a/src/v2/Components/Sticky/Sticky.story.tsx
+++ b/src/v2/Components/Sticky/Sticky.story.tsx
@@ -1,4 +1,12 @@
-import { Box, FullBleed, Separator, Spacer, Text } from "@artsy/palette"
+import {
+  Box,
+  Column,
+  FullBleed,
+  GridColumns,
+  Separator,
+  Spacer,
+  Text,
+} from "@artsy/palette"
 import React from "react"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
@@ -10,9 +18,9 @@ export default {
   title: "Components/Sticky",
 }
 
-export const Example = () => {
+const HeaderPlaceholder: React.FC = () => {
   return (
-    <StickyProvider>
+    <>
       <Box
         position="fixed"
         top={0}
@@ -26,14 +34,30 @@ export const Example = () => {
       </Box>
 
       <Spacer height={[MOBILE_NAV_HEIGHT, DESKTOP_NAV_BAR_HEIGHT]} />
+    </>
+  )
+}
 
-      {[...new Array(10)].map((_, i) => {
+const Filler: React.FC<{ amount?: number }> = ({ amount = 10 }) => {
+  return (
+    <>
+      {[...new Array(amount)].map((_, i) => {
         return (
           <Text variant="sm" key={i}>
             Static content
           </Text>
         )
       })}
+    </>
+  )
+}
+
+export const Example = () => {
+  return (
+    <StickyProvider>
+      <HeaderPlaceholder />
+
+      <Filler />
 
       <Sticky>
         <Box bg="black10" p={1}>
@@ -41,13 +65,7 @@ export const Example = () => {
         </Box>
       </Sticky>
 
-      {[...new Array(10)].map((_, i) => {
-        return (
-          <Text variant="sm" key={i}>
-            Static content
-          </Text>
-        )
-      })}
+      <Filler />
 
       <Sticky>
         {({ stuck }) => {
@@ -61,13 +79,7 @@ export const Example = () => {
         }}
       </Sticky>
 
-      {[...new Array(10)].map((_, i) => {
-        return (
-          <Text variant="sm" key={i}>
-            Static content
-          </Text>
-        )
-      })}
+      <Filler />
 
       <Sticky>
         <Box bg="green10" p={1}>
@@ -75,14 +87,34 @@ export const Example = () => {
         </Box>
       </Sticky>
 
-      {[...new Array(100)].map((_, i) => {
-        return (
-          <Text variant="sm" key={i}>
-            Static content
-          </Text>
-        )
-      })}
+      <Filler amount={100} />
     </StickyProvider>
+  )
+}
+
+export const ContainedExample = () => {
+  return (
+    <AppContainer>
+      <HorizontalPadding>
+        <HeaderPlaceholder />
+
+        <Filler />
+
+        <GridColumns my={2}>
+          <Column span={6}>
+            <Sticky proportional>
+              <Box bg="black10" height={400} width="100%" />
+            </Sticky>
+          </Column>
+
+          <Column span={6}>
+            <Filler amount={30} />
+          </Column>
+        </GridColumns>
+
+        <Filler amount={100} />
+      </HorizontalPadding>
+    </AppContainer>
   )
 }
 
@@ -90,6 +122,8 @@ export const GridExample = () => {
   return (
     <AppContainer>
       <HorizontalPadding>
+        <HeaderPlaceholder />
+
         <Text variant="sm">
           This is a bit verbose but we currently don't match{" "}
           <code>position: sticky;</code>
@@ -104,13 +138,7 @@ export const GridExample = () => {
 
         <Separator my={1} />
 
-        {[...new Array(10)].map((_, i) => {
-          return (
-            <Text variant="sm" key={i}>
-              Static content
-            </Text>
-          )
-        })}
+        <Filler />
 
         <Sticky>
           <FullBleed>

--- a/src/v2/Components/Sticky/Sticky.story.tsx
+++ b/src/v2/Components/Sticky/Sticky.story.tsx
@@ -1,9 +1,8 @@
 import {
   Box,
   Column,
-  FullBleed,
   GridColumns,
-  Separator,
+  ResponsiveBox,
   Spacer,
   Text,
 } from "@artsy/palette"
@@ -28,7 +27,8 @@ const HeaderPlaceholder: React.FC = () => {
         right={0}
         height={[MOBILE_NAV_HEIGHT, DESKTOP_NAV_BAR_HEIGHT]}
         p={1}
-        bg="black5"
+        bg="black10"
+        zIndex={2}
       >
         <Text variant="sm">Header placeholder</Text>
       </Box>
@@ -102,13 +102,28 @@ export const ContainedExample = () => {
 
         <GridColumns my={2}>
           <Column span={6}>
-            <Sticky proportional>
-              <Box bg="black10" height={400} width="100%" />
+            <Sticky proportional contained>
+              <ResponsiveBox
+                aspectWidth={6}
+                aspectHeight={4}
+                maxWidth="100%"
+                bg="black60"
+              >
+                <img
+                  src="https://picsum.photos/seed/example/600/400"
+                  alt=""
+                  style={{
+                    width: "100%",
+                    height: "100%",
+                    display: "block",
+                  }}
+                />
+              </ResponsiveBox>
             </Sticky>
           </Column>
 
           <Column span={6}>
-            <Filler amount={30} />
+            <Filler amount={25} />
           </Column>
         </GridColumns>
 
@@ -124,32 +139,12 @@ export const GridExample = () => {
       <HorizontalPadding>
         <HeaderPlaceholder />
 
-        <Text variant="sm">
-          This is a bit verbose but we currently don't match{" "}
-          <code>position: sticky;</code>
-          exactly. One of the side effects of this is that content when stuck
-          will break out of the container completely. At the moment this is
-          desireable though we may revisit in the future. In the meantime simply
-          break out of the container with the <code>FullBleed</code> component,
-          then wrap it in our <code>AppContainer</code>, which controls
-          max-width; and <code>HorizontalPadding</code> which controls the
-          page's padding.
-        </Text>
-
-        <Separator my={1} />
-
         <Filler />
 
-        <Sticky>
-          <FullBleed>
-            <AppContainer bg="black100">
-              <HorizontalPadding>
-                <Text variant="sm" color="white100">
-                  Is aligned with underlying content
-                </Text>
-              </HorizontalPadding>
-            </AppContainer>
-          </FullBleed>
+        <Sticky proportional>
+          <Text variant="sm" color="white100" bg="black100" px={2} mx={-2}>
+            Is aligned with underlying content
+          </Text>
         </Sticky>
 
         {[...new Array(100)].map((_, i) => {
@@ -168,4 +163,38 @@ GridExample.story = {
   parameters: {
     layout: "fullscreen",
   },
+}
+
+export const SidebarStory = () => {
+  return (
+    <AppContainer>
+      <HorizontalPadding>
+        <HeaderPlaceholder />
+        <GridColumns>
+          <Column span={3}>
+            <Sticky proportional>
+              {({ stuck }) => {
+                return (
+                  <Box bg={stuck ? "black10" : "black5"} height="100%">
+                    Sidebar example
+                    <br />
+                    Etcetera
+                    <br />
+                    Etc.
+                    <br />
+                    &c.
+                    <br />
+                  </Box>
+                )
+              }}
+            </Sticky>
+          </Column>
+
+          <Column span={9}>
+            <Filler amount={100} />
+          </Column>
+        </GridColumns>
+      </HorizontalPadding>
+    </AppContainer>
+  )
 }

--- a/src/v2/Components/Sticky/Sticky.tsx
+++ b/src/v2/Components/Sticky/Sticky.tsx
@@ -1,11 +1,26 @@
 import styled from "styled-components"
-import { Box } from "@artsy/palette"
-import React, { cloneElement, useEffect, useRef, useState } from "react"
+import { Box, useIsomorphicLayoutEffect } from "@artsy/palette"
+import React, {
+  cloneElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { useSticky } from "./StickyProvider"
 import { useNavBarHeight } from "../NavBar/useNavBarHeight"
 
 interface StickyProps {
+  /**
+   * Maintains the original dimensions and horizontal position on page.
+   * Useful for sidebars.
+   **/
   proportional?: boolean
+  /**
+   * Sticks only within the bounds of the containing element.
+   * Useful for split screen editorial.
+   **/
+  contained?: boolean
 }
 
 interface Rect {
@@ -15,76 +30,125 @@ interface Rect {
   height: number
 }
 
-const DEFAULT_RECT = {
+const DEFAULT_RECT: Rect = {
   right: 0,
   left: 0,
   width: 0,
   height: 0,
 }
 
+enum State {
+  Pending,
+  AtTop,
+  AtBottom,
+}
+
 /**
  * Wrap a component to have it stick below the main nav.
  * Use render props `{({ stuck }) => {}` to swap styles.
- * See the stories for examples.
- *
- * FAQ:
- * - Q: Why can't I simply use `position: sticky`?
- * - A: We use `overflow-x: hidden` on the main layout container so that we can
- *      utilize the `FullBleed` component. When you set `overflow: hidden` on
- *      any ancestor of your sticky element, this element becomes the scrolling
- *      container for your sticky element.
- *
- *      See: https://github.com/w3c/csswg-drafts/issues/865 for more detail.
- *      TLDR: `overflow: clip` solves this and support is growing.
- *
- * - Q: How can I maintain the original horizontal position of the element I
- *      want to be sticky?
- * - A: Currently this implementation does not inherit any horizontal positioning.
- *      Everything that is stuck is the full width of the screen. See the
- *      `GridExample` story for an example that works around this by re-wrapping
- *      everything in an AppContainer + HorizontalPadding. (This is non-ideal)
- *
- * - Q: How do I unstick an element once it reaches the end of its parent container?
- * - A: This is also not currently supported.
  */
-export const Sticky: React.FC<StickyProps> = ({ children, proportional }) => {
-  const sentinelRef = useRef<HTMLDivElement | null>(null)
+export const Sticky: React.FC<StickyProps> = ({
+  children,
+  proportional,
+  contained,
+}) => {
+  const topSentinelRef = useRef<HTMLDivElement | null>(null)
+  const bottomSentinelRef = useRef<HTMLDivElement | null>(null)
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const contentRef = useRef<HTMLDivElement | null>(null)
   const placeholderRef = useRef<HTMLDivElement | null>(null)
 
-  const [stuck, setStuck] = useState(false)
+  const [state, setState] = useState<State>(State.Pending)
   const [rect, setRect] = useState<Rect>(DEFAULT_RECT)
 
   const { mobile, desktop } = useNavBarHeight()
 
-  useEffect(() => {
-    if (sentinelRef.current === null) return
+  // Returns the container that can be safely used to gauge size
+  // for each possible state
+  const getEl = useCallback(() => {
+    return {
+      [State.Pending]: containerRef.current,
+      [State.AtTop]: placeholderRef.current,
+      [State.AtBottom]: contentRef.current,
+    }[state]
+  }, [state])
 
+  // Set initial rect
+  useEffect(() => {
+    if (!containerRef.current) return
+    setRect(containerRef.current.getBoundingClientRect())
+  }, [])
+
+  const [visibilities, setVisisbilities] = useState({
+    top: false,
+    bottom: false,
+  })
+
+  // Observe edges
+  useEffect(() => {
+    if (topSentinelRef.current === null) return
+    if (contained && bottomSentinelRef.current === null) return
     if (!("IntersectionObserver" in window)) return
 
     const observer = new IntersectionObserver(
       entries => {
-        const [entry] = entries
-        if (
-          // Intersecting
-          entry.intersectionRatio === 0 &&
-          // Only stick when scrolling down
-          entry.boundingClientRect.y < 0
-        ) {
-          setStuck(true)
-        } else if (entry.intersectionRatio === 1) {
-          setStuck(false)
-        }
+        entries.forEach(entry => {
+          setVisisbilities(prevState => ({
+            ...prevState,
+            [entry.target === topSentinelRef.current
+              ? "top"
+              : "bottom"]: entry.isIntersecting,
+          }))
+        })
       },
       { threshold: [0, 1] }
     )
 
-    observer.observe(sentinelRef.current)
+    observer.observe(topSentinelRef.current)
+
+    // Only observe the bottom edge if contained
+    if (contained && bottomSentinelRef.current) {
+      observer.observe(bottomSentinelRef.current)
+    }
 
     return () => {
       observer.disconnect()
     }
-  }, [])
+  }, [contained])
+
+  // Stick/un-stick
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const el = getEl()
+
+    // If we are tracking two different edges
+    if (contained) {
+      switch (true) {
+        case visibilities.top && !visibilities.bottom:
+          setRect(el!.getBoundingClientRect())
+          setState(State.Pending)
+          return
+        case visibilities.top && visibilities.bottom:
+          setRect(el!.getBoundingClientRect())
+          setState(State.Pending)
+          return
+        case !visibilities.top && visibilities.bottom:
+          setRect(el!.getBoundingClientRect())
+          setState(State.AtTop)
+          return
+        case !visibilities.top && !visibilities.bottom:
+          setRect(el!.getBoundingClientRect())
+          setState(State.AtBottom)
+          return
+      }
+
+      return
+    }
+
+    // Otherwise we're just tracking the top edge
+    setState(visibilities.top ? State.Pending : State.AtTop)
+  }, [contained, getEl, visibilities])
 
   const { offsetTop, registerSticky, deregisterSticky } = useSticky()
 
@@ -94,20 +158,24 @@ export const Sticky: React.FC<StickyProps> = ({ children, proportional }) => {
     return deregisterSticky
   }, [registerSticky, deregisterSticky])
 
-  // Set initial rect
-  useEffect(() => {
-    if (!containerRef.current) return
-    setRect(containerRef.current.getBoundingClientRect())
-  }, [])
-
   const content =
-    typeof children === "function" ? children({ stuck }) : children
-  const placeholder = cloneElement(content)
+    typeof children === "function"
+      ? children({ stuck: state !== State.Pending })
+      : children
+  const placeholder = cloneElement(content as JSX.Element)
 
-  useEffect(() => {
+  // Keeps rect in sync
+  useIsomorphicLayoutEffect(() => {
     const handleResize = () => {
-      if (!containerRef.current || (stuck && !placeholderRef.current)) return
-      const el = stuck ? placeholderRef.current : containerRef.current
+      if (
+        !containerRef.current ||
+        (state === State.AtTop && !placeholderRef.current)
+      ) {
+        return
+      }
+
+      const el = getEl()
+
       setRect(el!.getBoundingClientRect())
     }
 
@@ -115,46 +183,70 @@ export const Sticky: React.FC<StickyProps> = ({ children, proportional }) => {
     return () => {
       window.removeEventListener("resize", handleResize)
     }
-  }, [stuck])
+  }, [getEl, state])
 
   return (
-    <>
+    <Box {...(contained ? { height: "100%", position: "relative" } : {})}>
       <Sentinel
-        ref={sentinelRef as any}
+        ref={topSentinelRef as any}
         top={[-(mobile + offsetTop), -(desktop + offsetTop)]}
       />
 
       <Container
         ref={containerRef as any}
         bg="white100"
-        position={stuck ? "fixed" : "static"}
-        top={[mobile + offsetTop, desktop + offsetTop]}
+        {...{
+          [State.Pending]: {
+            top: [mobile + offsetTop, desktop + offsetTop],
+          },
+          [State.AtTop]: {
+            position: "fixed" as any,
+            top: [mobile + offsetTop, desktop + offsetTop],
+          },
+          [State.AtBottom]: {
+            display: "flex",
+            alignItems: "flex-end",
+            height: "100%",
+          },
+        }[state]}
       >
-        {proportional && stuck ? (
-          <div
-            style={{
-              position: "absolute",
-              right: `${rect.right}px`,
-              left: `${rect.left}px`,
-              width: `${rect.width}px`,
-              height: `${rect.height}px`,
-            }}
-          >
-            {content}
-          </div>
-        ) : (
-          content
-        )}
+        <div
+          ref={contentRef}
+          style={{
+            ...(proportional && state === State.AtTop
+              ? {
+                  position: "absolute",
+                  right: `${rect.right}px`,
+                  left: `${rect.left}px`,
+                  width: `${rect.width}px`,
+                  height: `${rect.height}px`,
+                }
+              : {
+                  width: "100%",
+                }),
+          }}
+        >
+          {content}
+        </div>
       </Container>
 
-      {stuck && (
+      {state === State.AtTop && (
         // Inserts a copy of the underlying content to prevent scroll from changing
         // as well as allowing us to track the size
         <div ref={placeholderRef} style={{ opacity: 0, pointerEvents: "none" }}>
           {placeholder}
         </div>
       )}
-    </>
+
+      {contained && (
+        <Sentinel
+          ref={bottomSentinelRef as any}
+          position="absolute"
+          bottom={[mobile + offsetTop, desktop + offsetTop]}
+          style={{ marginBottom: `${rect.height}px` }}
+        />
+      )}
+    </Box>
   )
 }
 
@@ -167,7 +259,10 @@ export const Container = styled(Box)`
 // This <div> is positioned such that when it leaves the top of
 // the browser the <Container> reaches it's `top` value and sticking.
 const Sentinel = styled(Box)`
-  position: relative;
   width: 100%;
   height: 0;
 `
+
+Sentinel.defaultProps = {
+  position: "relative",
+}


### PR DESCRIPTION
I'm going to let this bake in draft over the weekend and take a closer look on Monday; but here's the general idea:

You can see the two sentinels as red lines. The top one corresponds with when the content hits the bottom edge of the nav, the bottom sentinel corresponds with when the bottom edge of the content hits the bottom edge of its container.  The gap between them is the distance from the bottom edge of the content to the bottom edge of its container. You can see that when resized wide enough such that the content is as tall or taller than the right-hand side, nothing happens: ie: when both sentinels are in the screen at the same time, we don't need to stick anything.

https://user-images.githubusercontent.com/112297/134717009-9ad6621f-a600-438f-bc18-9f0e0021d604.mov

Now the problem I just ran into with integration is that we don't actually want to start sticking immediately in some instances, we want to wait to get to the bottom of the content then stick with that offset. This only manifests itself as a possibility when the content you want to stick is taller than the entire screen. 😅 