### PR TITLE
chore: More // @ts-expect-error cleanup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     "styled-components-a11y",
     "jest",
     "jest-dom",
-    "testing-library"
+    "testing-library",
   ],
   extends: [
     "eslint:recommended",
@@ -18,7 +18,7 @@ module.exports = {
     "plugin:styled-components-a11y/recommended",
     "plugin:jest/recommended",
     "plugin:jest-dom/recommended",
-    "plugin:testing-library/react"
+    "plugin:testing-library/react",
   ],
   parserOptions: {
     ecmaFeatures: {
@@ -50,6 +50,10 @@ module.exports = {
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/no-unused-vars": 0,
     "@typescript-eslint/no-var-requires": 0,
+    // Looks like their logic fails to account for the original location of the
+    // import; meaninig: any variable named `wrapper` or function called `render`
+    // from libs such as `enzyme` will throw. Disabling until we have an approach.
+    "testing-library/render-result-naming-convention": 0,
     "no-console": [
       "error",
       {

--- a/src/desktop/apps/article/__tests__/helpers.jest.tsx
+++ b/src/desktop/apps/article/__tests__/helpers.jest.tsx
@@ -27,7 +27,6 @@ describe("ad display logic in Feature and Standard Articles", () => {
 
   const getWrapper = (passedProps = props) => {
     return mount(
-      // @ts-expect-error STRICT_NULL_CHECK
       <SystemContextProvider user={null}>
         <ArticleLayout {...passedProps} />
       </SystemContextProvider>
@@ -90,7 +89,6 @@ describe("ad display frequency logic in News Articles", () => {
 
   const getWrapper = (passedProps = props) => {
     return mount(
-      // @ts-expect-error STRICT_NULL_CHECK
       <SystemContextProvider user={null}>
         <NewsArticle {...passedProps} />
       </SystemContextProvider>

--- a/src/desktop/apps/article/components/__tests__/EditButton.jest.tsx
+++ b/src/desktop/apps/article/components/__tests__/EditButton.jest.tsx
@@ -20,7 +20,6 @@ describe("EditButton", () => {
   let props
   const getWrapper = () => {
     return mount(
-      // @ts-expect-error STRICT_NULL_CHECK
       <SystemContextProvider user={null}>
         <EditButton {...props} />
       </SystemContextProvider>

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollArticle.jest.tsx
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollArticle.jest.tsx
@@ -20,7 +20,6 @@ describe("InfiniteScrollArticle", () => {
 
   const getWrapper = (passedProps = props) => {
     return mount(
-      // @ts-expect-error STRICT_NULL_CHECK
       <SystemContextProvider user={null}>
         <InfiniteScrollArticle {...passedProps} showTooltips={false} />
       </SystemContextProvider>

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
@@ -6,6 +6,7 @@ import { NewsArticle } from "@artsy/reaction/dist/Components/Publishing/Fixtures
 import { NewsLayout } from "@artsy/reaction/dist/Components/Publishing/Layouts/NewsLayout"
 import { NewsNav } from "@artsy/reaction/dist/Components/Publishing/Nav/NewsNav"
 import { extend, times } from "lodash"
+// eslint-disable-next-line no-restricted-imports
 import moment from "moment"
 import Waypoint from "react-waypoint"
 import { Environment } from "react-relay"
@@ -47,7 +48,6 @@ describe("InfiniteScrollNewsArticle", () => {
   const getWrapper = (passedProps = props) => {
     return mount(
       <SystemContextProvider
-        // @ts-expect-error STRICT_NULL_CHECK
         user={null}
         // @ts-ignore
         relayEnvironment={{ environment: {} } as Environment}

--- a/src/desktop/apps/article/components/__tests__/NewsArticle.jest.tsx
+++ b/src/desktop/apps/article/components/__tests__/NewsArticle.jest.tsx
@@ -9,7 +9,6 @@ describe("InfiniteScrollArticle", () => {
 
   const getWrapper = (passedProps = props) => {
     return mount(
-      // @ts-expect-error STRICT_NULL_CHECK
       <SystemContextProvider user={null}>
         <NewsArticle {...passedProps} />
       </SystemContextProvider>

--- a/src/desktop/apps/article/components/layouts/__tests__/Article.jest.tsx
+++ b/src/desktop/apps/article/components/layouts/__tests__/Article.jest.tsx
@@ -20,7 +20,6 @@ describe("Article Layout", () => {
   let props
   const getWrapper = (passedProps = props) => {
     return mount(
-      // @ts-expect-error STRICT_NULL_CHECK
       <SystemContextProvider user={null}>
         <ArticleLayout {...passedProps} />
       </SystemContextProvider>
@@ -78,7 +77,7 @@ describe("Article Layout", () => {
       expect(component.find(InfiniteScrollArticle).length).toBe(0)
     })
 
-    it("it mounts backbone views for super articles", () => {
+    it("mounts backbone views for super articles", () => {
       props.templates = {
         SuperArticleFooter: "sa-footer",
         SuperArticleHeader: "sa-header",

--- a/src/desktop/apps/articles/components/__tests__/AuthWrapper.jest.tsx
+++ b/src/desktop/apps/articles/components/__tests__/AuthWrapper.jest.tsx
@@ -30,7 +30,6 @@ describe("AuthWrapper", () => {
     jest.spyOn(mediator, "on")
     // @ts-expect-error STRICT_NULL_CHECK
     delete sd.IS_MOBILE
-    // @ts-expect-error STRICT_NULL_CHECK
     delete sd.CURRENT_USER
     window.addEventListener = jest.fn()
   })

--- a/src/desktop/apps/consign/client/analytics_middleware.ts
+++ b/src/desktop/apps/consign/client/analytics_middleware.ts
@@ -12,13 +12,12 @@ const analyticsMiddleware = store => next => action => {
     }
 
     case actions.SUBMISSION_CREATED: {
-      // @ts-expect-error STRICT_NULL_CHECK
-      window.analytics.track("consignment_submitted", {
+      window.analytics?.track("consignment_submitted", {
         contextPath: nextState.submissionFlow.contextPath,
         submissionId: action.payload.submissionId,
         subject: nextState.submissionFlow.subject,
-        userId: sd.CURRENT_USER.id,
-        userEmail: sd.CURRENT_USER.email,
+        userId: sd.CURRENT_USER?.id,
+        userEmail: sd.CURRENT_USER?.email,
       })
       return result
     }

--- a/src/desktop/components/marketing_signup_modal/__test__/triggerMarketingModal.jest.ts
+++ b/src/desktop/components/marketing_signup_modal/__test__/triggerMarketingModal.jest.ts
@@ -30,13 +30,12 @@ describe("MarketingSignupModal", () => {
   })
 
   afterEach(() => {
-    // @ts-expect-error STRICT_NULL_CHECK
     delete sd.CURRENT_USER
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-ignore
     delete sd.TARGET_CAMPAIGN_URL
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-ignore
     delete sd.CURRENT_PATH
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-ignore
     delete sd.IS_MOBILE
     // @ts-ignore
     window.addEventListener.mockClear()

--- a/src/desktop/lib/buildClientAppContext.ts
+++ b/src/desktop/lib/buildClientAppContext.ts
@@ -4,7 +4,7 @@ import { AnalyticsContextProps } from "v2/System/Analytics/AnalyticsContext"
 import { Mediator, mediator } from "lib/mediator"
 
 export interface ClientContext {
-  user: object
+  user: User
   mediator: Mediator
   analytics: AnalyticsContextProps
 }

--- a/src/desktop/lib/deprecated_global_client_setup.tsx
+++ b/src/desktop/lib/deprecated_global_client_setup.tsx
@@ -5,7 +5,7 @@
 import "lib/webpackPublicPath"
 import $ from "jquery"
 import Backbone from "backbone"
-import _ from "underscore"
+import _ from "lodash"
 import Cookies from "cookies-js"
 import { configureScope } from "@sentry/browser"
 import { data as sd } from "sharify"

--- a/src/typings/gravity.d.ts
+++ b/src/typings/gravity.d.ts
@@ -1,14 +1,17 @@
-interface User {
-  roles?: UserRole[]
-  accessToken?: string
-  appToken?: string
-  email?: string
-  has_partner_access?: string
-  id?: string
-  lab_features?: string[]
-  type?: string
-  name?: string
-}
+type User =
+  | {
+      roles?: UserRole[]
+      accessToken?: string
+      appToken?: string
+      email?: string
+      has_partner_access?: string
+      id?: string
+      lab_features?: string[]
+      type?: string
+      name?: string
+    }
+  | null
+  | undefined
 
 /**
  * Determinies permissions/access granted to CurrentUser.

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -505,7 +505,7 @@ export const ArtworkSidebarCommercial: FC<ArtworkSidebarCommercialProps> = ({
       artworkID={artwork.internalID}
       artwork={artwork}
       mediator={mediator!}
-      router={router}
+      router={router!}
       user={user}
       {...inquiry}
       {...rest}

--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -4,9 +4,9 @@ import { findCurrentRoute } from "v2/System/Router/Utils/findCurrentRoute"
 import { useMaybeReloadAfterInquirySignIn } from "v2/System/Router/Utils/useMaybeReloadAfterInquirySignIn"
 import {
   DESKTOP_NAV_BAR_HEIGHT,
-  NavBar,
   MOBILE_NAV_HEIGHT,
   MOBILE_LOGGED_IN_NAV_HEIGHT,
+  NavBar,
 } from "v2/Components/NavBar"
 import { Match } from "found"
 import { isFunction } from "lodash"

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -340,7 +340,6 @@ describe("ViewingRoomApp", () => {
       return renderRelayTree({
         Component: ({ viewingRoom }) => {
           return (
-            // @ts-expect-error STRICT_NULL_CHECK
             <MockBoot breakpoint={breakpoint} user={null}>
               <ViewingRoomAppFragmentContainer viewingRoom={viewingRoom}>
                 some child

--- a/src/v2/Components/FlashBanner/__tests__/FlashBanner.jest.tsx
+++ b/src/v2/Components/FlashBanner/__tests__/FlashBanner.jest.tsx
@@ -319,7 +319,6 @@ describe("Email Confirmation CTA", () => {
 
     it("does not request user-specific data from metaphysics if there is no user", () => {
       const wrapper = mount(
-        // @ts-expect-error STRICT_NULL_CHECK
         <SystemContextProvider user={null}>
           <FlashBannerQueryRenderer />
         </SystemContextProvider>

--- a/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -31,7 +31,6 @@ describe("NavBar", () => {
 
   const getWrapper = ({ user = null, isEigen = false } = {}) => {
     return mount(
-      // @ts-expect-error STRICT_NULL_CHECK
       <SystemContextProvider user={user} isEigen={isEigen}>
         <NavBar />
       </SystemContextProvider>

--- a/src/v2/System/Analytics/__tests__/trackingMiddleware.jest.ts
+++ b/src/v2/System/Analytics/__tests__/trackingMiddleware.jest.ts
@@ -17,9 +17,7 @@ describe("trackingMiddleware", () => {
   const noop = x => x
 
   beforeEach(() => {
-    // FIXME: reaction migration
-    // @ts-ignore
-    window.analytics = { page: jest.fn() }
+    window.analytics = { page: jest.fn() } as any
   })
 
   afterEach(() => {
@@ -138,8 +136,7 @@ describe("trackingMiddleware", () => {
           { integrations: { Marketo: false } }
         )
 
-        // @ts-expect-error STRICT_NULL_CHECK
-        expect(window.analytics.__artsyClientSideRoutingReferrer).toEqual(
+        expect(window.analytics!.__artsyClientSideRoutingReferrer).toEqual(
           "http://testing.com/referrer?with=queryparams"
         )
       })

--- a/src/v2/System/Relay/__tests__/createRelaySSREnvironment.jest.ts
+++ b/src/v2/System/Relay/__tests__/createRelaySSREnvironment.jest.ts
@@ -8,8 +8,7 @@ describe("#hydrateCacheFromSSR", () => {
   }) as any) as { _responses: Map<any, any> }
 
   it("does not update cache if no ssr data", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
-    window.__RELAY_BOOTSTRAP__ = null
+    window.__RELAY_BOOTSTRAP__
     hydrateCacheFromSSR(relayResponseCache)
     expect(relayResponseCache._responses.size).toBe(0)
   })

--- a/src/v2/System/Relay/createRelaySSREnvironment.ts
+++ b/src/v2/System/Relay/createRelaySSREnvironment.ts
@@ -84,8 +84,8 @@ export function createRelaySSREnvironment(config: Config = {}) {
   const authenticatedHeaders = !!user
     ? {
         ...headers,
-        "X-USER-ID": user && user.id,
-        "X-ACCESS-TOKEN": user && user.accessToken,
+        "X-USER-ID": user && user.id!,
+        "X-ACCESS-TOKEN": user && user.accessToken!,
       }
     : headers
 
@@ -93,7 +93,6 @@ export function createRelaySSREnvironment(config: Config = {}) {
     searchBarImmediateResolveMiddleware(),
     urlMiddleware({
       url: METAPHYSICS_ENDPOINT,
-      // @ts-expect-error STRICT_NULL_CHECK
       headers: authenticatedHeaders,
     }),
     relaySSRMiddleware.getMiddleware(),
@@ -109,7 +108,6 @@ export function createRelaySSREnvironment(config: Config = {}) {
       },
     }),
     principalFieldErrorHandlerMiddleware(),
-    // @ts-expect-error STRICT_NULL_CHECK
     metaphysicsErrorHandlerMiddleware({ checkStatus }),
     loggingEnabled && loggerMiddleware(),
     loggingEnabled && metaphysicsExtensionsLoggerMiddleware(),
@@ -118,7 +116,6 @@ export function createRelaySSREnvironment(config: Config = {}) {
     ...(sd.ENABLE_QUERY_BATCHING
       ? [
           batchMiddleware({
-            // @ts-expect-error STRICT_NULL_CHECK
             headers: authenticatedHeaders,
             batchUrl: `${METAPHYSICS_ENDPOINT}/batch`,
             // Period of time (integer in milliseconds) for gathering multiple requests

--- a/src/v2/System/Relay/middleware/cache/cacheMiddleware.ts
+++ b/src/v2/System/Relay/middleware/cache/cacheMiddleware.ts
@@ -1,4 +1,3 @@
-import { QueryResponseCache } from "relay-runtime"
 import createLogger from "v2/Utils/logger"
 import { Cache, CacheConfig } from "./Cache"
 import { isFunction } from "lodash"
@@ -6,7 +5,7 @@ import { isFunction } from "lodash"
 const logger = createLogger("v2/System/middleware/cache/cacheMiddleware")
 
 interface CacheMiddlewareOpts extends CacheConfig {
-  onInit?: (cache: QueryResponseCache) => any
+  onInit?: (cache: Cache) => any
   allowMutations?: boolean
   allowFormData?: boolean
   clearOnMutation?: boolean
@@ -37,7 +36,6 @@ export function cacheMiddleware(opts?: CacheMiddlewareOpts) {
   })
 
   if (isFunction(onInit)) {
-    // @ts-expect-error STRICT_NULL_CHECK
     onInit(cache)
   }
 

--- a/src/v2/System/Relay/middleware/metaphysicsErrorHandlerMiddleware.ts
+++ b/src/v2/System/Relay/middleware/metaphysicsErrorHandlerMiddleware.ts
@@ -3,7 +3,7 @@ import { NetworkError } from "v2/Utils/errors"
 export function metaphysicsErrorHandlerMiddleware({
   checkStatus,
 }: {
-  checkStatus: boolean
+  checkStatus?: boolean
 }) {
   return next => async req => {
     const response = await next(req)

--- a/src/v2/System/SystemContext.tsx
+++ b/src/v2/System/SystemContext.tsx
@@ -23,8 +23,8 @@ export type SystemContextState = Partial<{
   /**
    * The current router instance
    */
-  router: Router
-  setRouter: (router: Router) => void
+  router: Router | null
+  setRouter: (router?: Router) => void
 
   /**
    * The currently signed-in user.
@@ -89,9 +89,11 @@ export const SystemContextProvider: FC<SystemContextProps> = ({
   children,
   ...props
 }) => {
-  const [isFetching, setFetching] = useState(false)
-  const [router, setRouter] = useState(null)
-  const [user, setUser] = useState(getUser(props.user))
+  const [isFetching, setFetching] = useState<boolean>(false)
+  const [router, setRouter] = useState<SystemContextProps["router"]>(null)
+  const [user, setUser] = useState<SystemContextProps["user"]>(
+    getUser(props.user!)
+  )
 
   const relayEnvironment =
     props.relayEnvironment || createRelaySSREnvironment({ user })
@@ -110,7 +112,6 @@ export const SystemContextProvider: FC<SystemContextProps> = ({
   }
 
   return (
-    // @ts-expect-error STRICT_NULL_CHECK
     <SystemContext.Provider value={providerValues}>
       {children}
     </SystemContext.Provider>

--- a/src/v2/System/__tests__/SystemContext.jest.tsx
+++ b/src/v2/System/__tests__/SystemContext.jest.tsx
@@ -83,10 +83,9 @@ describe("Artsy context", () => {
   })
 
   describe("concerning the current user", () => {
-    let originalEnv = null
+    let originalEnv
 
     beforeAll(() => {
-      // @ts-expect-error STRICT_NULL_CHECK
       originalEnv = process.env
       process.env = Object.assign({}, originalEnv, {
         USER_ID: "user-id-from-env",
@@ -95,8 +94,7 @@ describe("Artsy context", () => {
     })
 
     afterAll(() => {
-      // @ts-expect-error STRICT_NULL_CHECK
-      process.env = originalEnv
+      process.env = originalEnv!
     })
 
     it("exposes the currently signed-in user", () => {
@@ -119,7 +117,6 @@ describe("Artsy context", () => {
 
     it("does not default to environment variables when explicitly passing null", () => {
       const wrapper = render(
-        // @ts-expect-error STRICT_NULL_CHECK
         <Artsy.SystemContextProvider user={null}>
           <WithCurrentUser />
         </Artsy.SystemContextProvider>

--- a/src/v2/Utils/__tests__/user.jest.ts
+++ b/src/v2/Utils/__tests__/user.jest.ts
@@ -16,7 +16,6 @@ describe("user", () => {
     it("returns false when user doesn't exist", () => {
       const featureName = "my feature"
 
-      // @ts-expect-error STRICT_NULL_CHECK
       const result = userHasLabFeature(null, featureName)
 
       expect(result).toEqual(false)
@@ -44,7 +43,6 @@ describe("user", () => {
 
   describe("userIsAdmin", () => {
     it("returns undefined if user is undefined", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
       const user: User = undefined
 
       const result = userIsAdmin(user)
@@ -75,7 +73,6 @@ describe("user", () => {
 
   describe("userIsTeam", () => {
     it("returns undefined if user is undefined", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
       const user: User = undefined
 
       const result = userIsTeam(user)

--- a/src/v2/Utils/user.ts
+++ b/src/v2/Utils/user.ts
@@ -23,12 +23,11 @@ export function getUser(user: User | null | undefined): User | null {
     }
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
   return _user
 }
 
 export function userHasLabFeature(user: User, featureName: string): boolean {
-  const lab_features = get(user, u => u.lab_features, [])
+  const lab_features = get(user, u => u?.lab_features, [])
   // @ts-expect-error STRICT_NULL_CHECK
   const hasLabFeature = lab_features.includes(featureName)
   return hasLabFeature
@@ -47,7 +46,7 @@ export function userIsTeam(user?: User): boolean {
 }
 
 export function userHasAccessToPartner(user: User, partnerId: string): boolean {
-  const token = get(user, u => u.accessToken)
+  const token = get(user, u => u?.accessToken)
   if (!token) {
     return false
   }


### PR DESCRIPTION
Following up on work in https://github.com/artsy/force/pull/8471, this cleans up more `// @ts-expect-error` strict null-check migration flags (this time from the entire `System` folder) and cleans up some long-standing type issues around our `User` type. 