### PR TITLE
refactor: Rename useMatchMedia to __internal__useMatchMedia

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -24,7 +24,7 @@ import { LoadingArea } from "v2/Components/LoadingArea"
 import { PaginationFragmentContainer as Pagination } from "v2/Components/Pagination"
 import { AnalyticsSchema, SystemContext } from "v2/System"
 import { useRouter } from "v2/System/Router/useRouter"
-import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { usePrevious } from "v2/Utils/Hooks/usePrevious"
 import createLogger from "v2/Utils/logger"
 import { openAuthModal } from "v2/Utils/openAuthModal"
@@ -59,7 +59,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
   artist,
   relay,
 }) => {
-  const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
+  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
   const { user, mediator } = useContext(SystemContext)
   const {
     filters,

--- a/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -20,7 +20,7 @@ jest.mock("v2/System/Router/Utils/catchLinks", () => ({
   userIsForcingNavigation: () => false,
 }))
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 jest.mock("v2/System/Router/useRouter", () => ({
   useRouter: jest.fn(),

--- a/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/SizeFilter.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/SizeFilter.jest.tsx
@@ -8,7 +8,7 @@ import {
 import { SizeFilter } from "../Components/AuctionFilters/SizeFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("SizeFilter", () => {

--- a/src/v2/Apps/BuyerGuarantee/Components/Feature.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Components/Feature.tsx
@@ -9,7 +9,7 @@ import {
   themeProps,
 } from "@artsy/palette"
 import { Media } from "v2/Utils/Responsive"
-import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 
 interface ConditionalWrapperProps {
   condition: boolean
@@ -38,7 +38,7 @@ export const Feature: React.FC<FeatureProps> = ({
   icon,
   onClick,
 }) => {
-  const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
+  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
   const Icon = icon
   const learnMore = (
     <Flex pt={2} justifyContent="center">

--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -25,11 +25,11 @@ import {
 import { Feature } from "../Components/Feature"
 import { MOBILE_NAV_HEIGHT, DESKTOP_NAV_BAR_HEIGHT } from "v2/Components/NavBar"
 import { scrollIntoView } from "v2/Utils/scrollHelpers"
-import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { BuyerGuaranteeMeta } from "../Components/BuyerGuaranteeMeta"
 
 export const BuyerGuaranteeIndex: React.FC = () => {
-  const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
+  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
 
   const authenticityText = `We are dedicated to being the world’s most trustworthy marketplace
   to buy and sell art. In the rare case that a work purchased
@@ -130,7 +130,7 @@ export const BuyerGuaranteeIndex: React.FC = () => {
     },
   }
 
-  const tableColor = useMatchMedia(themeProps.mediaQueries.xs)
+  const tableColor = __internal__useMatchMedia(themeProps.mediaQueries.xs)
     ? "black10"
     : "black100"
 

--- a/src/v2/Apps/BuyerGuarantee/Routes/__tests__/BuyerGuaranteeIndex.jest.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/__tests__/BuyerGuaranteeIndex.jest.tsx
@@ -4,7 +4,7 @@ import { MockBoot } from "v2/DevTools"
 import { mount } from "enzyme"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => false,
+  __internal__useMatchMedia: () => false,
 }))
 
 describe("BuyerGuaranteeIndex", () => {

--- a/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
@@ -5,7 +5,7 @@ import { Text, Flex, Swiper, themeProps } from "@artsy/palette"
 import { Media } from "v2/Utils/Responsive"
 import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { ExhibitorsLetterNav_fair } from "v2/__generated__/ExhibitorsLetterNav_fair.graphql"
-import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 import { getExhibitorSectionId } from "../Utils/getExhibitorSectionId"
 
@@ -23,7 +23,7 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
     height: [mobileNavBarHeight, desktopNavBarHeight],
   } = useNavBarHeight()
 
-  const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
+  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
   const stickyTabsHeight = 150
 
   const offset =

--- a/src/v2/Apps/Fair/Components/__tests__/ExhibitorsLetterNav.jest.tsx
+++ b/src/v2/Apps/Fair/Components/__tests__/ExhibitorsLetterNav.jest.tsx
@@ -8,7 +8,7 @@ import { Breakpoint } from "v2/Utils/Responsive"
 
 jest.unmock("react-relay")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => false,
+  __internal__useMatchMedia: () => false,
 }))
 
 const getWrapperWithBreakpoint = (breakpoint: Breakpoint = "lg") =>

--- a/src/v2/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
@@ -15,7 +15,7 @@ jest.mock("v2/System/Router/useRouter", () => ({
 }))
 jest.mock("v2/System/Analytics/useTracking")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("FairArtworks", () => {

--- a/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
@@ -5,7 +5,7 @@ import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 
 jest.unmock("react-relay")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => false,
+  __internal__useMatchMedia: () => false,
 }))
 
 describe("FairExhibitors", () => {

--- a/src/v2/Apps/Order/Components/__tests__/AddressModal.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/AddressModal.jest.tsx
@@ -12,7 +12,7 @@ import { SavedAddressType } from "../../Utils/shippingUtils"
 import { useSystemContext } from "v2/System/useSystemContext"
 jest.mock("v2/System/useSystemContext")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 jest.mock("v2/Utils/user", () => ({
   userHasLabFeature: jest.fn(),

--- a/src/v2/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
@@ -11,7 +11,7 @@ import { SavedAddressItem } from "v2/Apps/Order/Components/SavedAddressItem"
 
 jest.unmock("react-relay")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 class SavedAddressesTestPage extends RootTestPage {

--- a/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -34,7 +34,7 @@ import {
 
 jest.unmock("react-relay")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 const testOrder: ShippingTestQueryRawResponse["order"] = {

--- a/src/v2/Apps/Partner/Components/ScrollToPartnerHeader/index.tsx
+++ b/src/v2/Apps/Partner/Components/ScrollToPartnerHeader/index.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Clickable, BoxProps, themeProps } from "@artsy/palette"
-import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 
@@ -9,7 +9,7 @@ export const ScrollToPartnerHeader: React.FC<BoxProps> = ({
   ...rest
 }) => {
   const { mobile, desktop } = useNavBarHeight()
-  const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
+  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
 
   return (
     <Clickable

--- a/src/v2/Apps/Partner/Components/__tests__/Overview/ArtistsRail.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/Overview/ArtistsRail.jest.tsx
@@ -9,7 +9,7 @@ import {
 import { ViewAllButton } from "../../Overview/ViewAllButton"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 jest.unmock("react-relay")
 

--- a/src/v2/Apps/Partner/Routes/Artists/ArtistsRoute.tsx
+++ b/src/v2/Apps/Partner/Routes/Artists/ArtistsRoute.tsx
@@ -13,7 +13,7 @@ import { createFragmentContainer } from "react-relay"
 import { Media } from "v2/Utils/Responsive"
 import { usePartnerArtistsLoadingContext } from "../../Utils/PartnerArtistsLoadingContext"
 import { scrollIntoView } from "v2/Utils/scrollHelpers"
-import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 
 export interface ArtistsRouteProps {
@@ -26,7 +26,7 @@ export const ArtistsRoute: React.FC<ArtistsRouteProps> = ({
   match,
 }) => {
   const { mobile, desktop } = useNavBarHeight()
-  const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
+  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
   const { isLoaded } = usePartnerArtistsLoadingContext()
 
   useEffect(() => {

--- a/src/v2/Apps/Partner/Routes/__tests__/Works.jest.tsx
+++ b/src/v2/Apps/Partner/Routes/__tests__/Works.jest.tsx
@@ -22,7 +22,7 @@ jest.mock("v2/System/Router/useRouter", () => ({
 }))
 jest.mock("v2/System/Analytics/useTracking")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 const { getWrapper } = setupTestWrapper<Works_Query>({

--- a/src/v2/Apps/Shipping/__tests__/ShippingApp.jest.tsx
+++ b/src/v2/Apps/Shipping/__tests__/ShippingApp.jest.tsx
@@ -8,7 +8,7 @@ import { HeadProvider } from "react-head"
 jest.mock("react-tracking")
 jest.unmock("react-relay")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 const { getWrapper } = setupTestWrapper<ShippingApp_Test_Query>({
   Component: ({ me }) => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ArtistNationalityFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ArtistNationalityFilter.jest.tsx
@@ -10,7 +10,7 @@ import {
 } from "../ArtistNationalityFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("ArtworkLocationFilter", () => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ArtistsFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ArtistsFilter.jest.tsx
@@ -8,7 +8,7 @@ import {
 import { ArtistsFilter, ArtistsFilterProps } from "../ArtistsFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("ArtistsFilter", () => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ArtworkLocationFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ArtworkLocationFilter.jest.tsx
@@ -10,7 +10,7 @@ import {
 } from "../ArtworkLocationFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("ArtworkLocationFilter", () => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/AttributionClassFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/AttributionClassFilter.jest.tsx
@@ -11,7 +11,7 @@ import {
 } from "../AttributionClassFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("AttributionClassFilter", () => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
@@ -7,7 +7,7 @@ import {
 import { ColorFilter, ColorFilterProps } from "../ColorFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("ColorFilter", () => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
@@ -9,7 +9,7 @@ import {
 import { MaterialsFilter, MaterialsFilterProps } from "../MaterialsFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("MaterialsTermFilter", () => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/MediumFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/MediumFilter.jest.tsx
@@ -7,7 +7,7 @@ import {
 import { MediumFilter, MediumFilterProps } from "../MediumFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("MediumFilter", () => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PartnersFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PartnersFilter.jest.tsx
@@ -7,7 +7,7 @@ import {
 import { PartnersFilter, PartnersFilterProps } from "../PartnersFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("PartnersFilter", () => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
@@ -10,7 +10,7 @@ import {
 import { PriceRangeFilter, PriceRangeFilterProps } from "../PriceRangeFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("PriceRangeFilter", () => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ResultsFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ResultsFilter.jest.tsx
@@ -4,7 +4,7 @@ import { ArtworkFilterContextProvider } from "../../ArtworkFilterContext"
 import { ResultsFilter, sortResults } from "../ResultsFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("ArtworkLocationFilter", () => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
@@ -7,7 +7,7 @@ import {
 import { TimePeriodFilter, TimePeriodFilterProps } from "../TimePeriodFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("TimePeriodFilter", () => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/WaysToBuyFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/WaysToBuyFilter.jest.tsx
@@ -7,7 +7,7 @@ import {
 import { WaysToBuyFilter, WaysToBuyFilterProps } from "../WaysToBuyFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("WaysToBuyFilter", () => {

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -13,7 +13,7 @@ jest.unmock("react-relay")
 jest.mock("v2/System/Analytics/useTracking")
 jest.mock("v2/Components/Pagination/useComputeHref")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 describe("ArtworkFilter", () => {

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
@@ -9,7 +9,7 @@ import { ArtworkFilterMobileActionSheet } from "../ArtworkFilterMobileActionShee
 import { ArtworkFilters } from "../ArtworkFilters"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({ sm: true }),
+  __internal__useMatchMedia: () => ({ sm: true }),
 }))
 
 describe("ArtworkFilterMobileActionSheet", () => {

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -26,7 +26,7 @@ import { ContextModule, Intent } from "@artsy/cohesion"
 import { AnalyticsSchema } from "v2/System"
 import { track, useTracking } from "v2/System/Analytics"
 import Events from "v2/Utils/Events"
-import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { NavBarPrimaryLogo } from "./NavBarPrimaryLogo"
 import { NavBarSkipLink } from "./NavBarSkipLink"
 import { NavBarLoggedInActionsQueryRenderer } from "./NavBarLoggedInActions"
@@ -71,8 +71,8 @@ export const NavBar: React.FC = track(
   }
   const { trackEvent } = useTracking()
   const [showMobileMenu, toggleMobileNav] = useState(false)
-  const xs = useMatchMedia(themeProps.mediaQueries.xs)
-  const sm = useMatchMedia(themeProps.mediaQueries.sm)
+  const xs = __internal__useMatchMedia(themeProps.mediaQueries.xs)
+  const sm = __internal__useMatchMedia(themeProps.mediaQueries.sm)
   const isMobile = xs || sm
   const isLoggedIn = Boolean(user)
   const showNotificationCount = isLoggedIn && !showMobileMenu

--- a/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -15,7 +15,7 @@ jest.mock("v2/Components/Search/SearchBar", () => {
 
 jest.mock("v2/System/Analytics/useTracking")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 
 jest.mock("lib/isServer", () => ({

--- a/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
@@ -7,7 +7,7 @@ import { NavBar } from "../NavBar"
 
 jest.mock("v2/System/Analytics/useTracking")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({ sm: false }),
+  __internal__useMatchMedia: () => ({ sm: false }),
 }))
 
 jest.mock("lib/isServer", () => ({

--- a/src/v2/Components/Toast/ToastComponent.tsx
+++ b/src/v2/Components/Toast/ToastComponent.tsx
@@ -1,7 +1,7 @@
 import { Banner, Box, Text, themeProps } from "@artsy/palette"
 import React, { useEffect, useState } from "react"
 import { useNavBarHeight } from "../NavBar/useNavBarHeight"
-import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 
 interface ToastComponentProps {
   showNotification: boolean
@@ -18,7 +18,7 @@ const ToastComponent: React.FC<ToastComponentProps> = ({
   duration,
   onCloseToast,
 }) => {
-  const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
+  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
   const navHeight = useNavBarHeight()
 
   useEffect(() => {

--- a/src/v2/Components/UserSettings/__tests__/UserSettingsAddresses.jest.tsx
+++ b/src/v2/Components/UserSettings/__tests__/UserSettingsAddresses.jest.tsx
@@ -7,7 +7,7 @@ import { deleteUserAddress } from "v2/Apps/Order/Mutations/DeleteUserAddress"
 
 jest.unmock("react-relay")
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
+  __internal__useMatchMedia: () => ({}),
 }))
 jest.mock("v2/Apps/Order/Mutations/DeleteUserAddress")
 

--- a/src/v2/Utils/Hooks/useMatchMedia.ts
+++ b/src/v2/Utils/Hooks/useMatchMedia.ts
@@ -1,6 +1,14 @@
 import { useEffect, useState } from "react"
 
 /**
+ * @note This function ***IS NOT*** server-side rendering friendly, and should be
+ * avoided in the vast majority of  use-cases. For writing responsive UI, please
+ * see our docs on:
+ *
+ * - Responsive Props: https://palette.artsy.net/guides/responsive/ and
+ * - Server-side Rendering Responsively: https://artsy.github.io/blog/2019/05/24/server-rendering-responsively/
+ *
+ *
  * Checks to see if the browser matches a particular media query
  *
  * Thanks! https://github.com/olistic/react-use-media/
@@ -8,17 +16,17 @@ import { useEffect, useState } from "react"
  * @example
 
     import { themeProps } from '@artsy/palette'
-    import { useMatchMedia } from 'Utils/Hooks/useMatchMedia'
+    import { __internal__useMatchMedia } from 'Utils/Hooks/useMatchMedia'
 
     const App = () => {
-      const isMobile = useMatchMedia(themeProps.mediaQueries.sm)
+      const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.sm)
 
       return (
         <div>Mobile view? {isMobile}</div>
       )
     }
  */
-export function useMatchMedia(
+export function __internal__useMatchMedia(
   mediaQueryString: string,
   { initialMatches = null } = {}
 ) {


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/WP-71 

This has come up quite a bit lately, where folks have been relying on this client-side-only, SSR-incompatable hook for writing responsive code. Since Palette's responsive props and fresnel's `<Media>` approaches will cover the vast majority of responsive use-cases, we're going to rename this hook in order to discourage use as well as add some documentation around where devs should go if they encounter it. 