### PR TITLE
test(categories): convert spec to RTL

### DIFF
--- a/src/v2/Apps/Categories/Components/GeneFamily.tsx
+++ b/src/v2/Apps/Categories/Components/GeneFamily.tsx
@@ -27,7 +27,9 @@ export const GeneFamily: React.FC<GeneFamilyProps> = props => {
 
   return (
     <Box id={`jump--${geneFamily.slug}`}>
-      <Text variant="xl">{name}</Text>
+      <Text as="h2" variant="xl">
+        {name}
+      </Text>
       <Spacer mt={4} />
       <Masonry columnCount={[1, 3]}>
         {sortedGenes?.map(gene => {

--- a/src/v2/Apps/Categories/__tests__/CategoriesApp.jest.tsx
+++ b/src/v2/Apps/Categories/__tests__/CategoriesApp.jest.tsx
@@ -30,4 +30,31 @@ describe("CategoriesApp", () => {
     renderWithRelay()
     expect(screen.getByText("The Art Genome Project")).toBeInTheDocument()
   })
+
+  it("displays families and genes", () => {
+    renderWithRelay({
+      GeneFamilyConnection: () => ({
+        edges: [
+          {
+            node: {
+              name: "Styles and Movements",
+              genes: [
+                {
+                  displayName: "Early Randomcore",
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(
+      screen.getByRole("heading", { name: "Styles and Movements" })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole("link", { name: "Early Randomcore" })
+    ).toBeInTheDocument()
+  })
 })

--- a/src/v2/Apps/Categories/__tests__/CategoriesApp.jest.tsx
+++ b/src/v2/Apps/Categories/__tests__/CategoriesApp.jest.tsx
@@ -1,17 +1,14 @@
 import React from "react"
 import { graphql } from "react-relay"
 import { MockBoot } from "v2/DevTools"
-import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
+import { screen } from "@testing-library/react"
 import { CategoriesAppFragmentContainer } from "../CategoriesApp"
 import { CategoriesApp_Test_Query } from "v2/__generated__/CategoriesApp_Test_Query.graphql"
 
 jest.unmock("react-relay")
 
-jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
-}))
-
-const { getWrapper } = setupTestWrapper<CategoriesApp_Test_Query>({
+const { renderWithRelay } = setupTestWrapperTL<CategoriesApp_Test_Query>({
   Component: props => {
     return (
       <MockBoot>
@@ -30,7 +27,7 @@ const { getWrapper } = setupTestWrapper<CategoriesApp_Test_Query>({
 
 describe("CategoriesApp", () => {
   it("renders", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.find("CategoriesApp").exists()).toBe(true)
+    renderWithRelay()
+    expect(screen.getByText("The Art Genome Project")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Lil Friday exercise to work those React Testing Library muscles, now that it's been [added to Force](https://artsy.slack.com/archives/C2TQ4PT8R/p1632434644096600).

- converts the basic rendering spec for the `CategoriesApp` to use RTL instead of Enzyme:
- demonstrates the basic boilerplate required by our current pattern
- demonstrates how following the grain of RTL leads to more a11y-friendly markup