### PR TITLE
fix(FX-3328): search term is undefined when redirect to other page

### DIFF
--- a/src/v2/Apps/Search/SearchApp.tsx
+++ b/src/v2/Apps/Search/SearchApp.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { Box, DROP_SHADOW, FullBleed, Spacer, Text } from "@artsy/palette"
 import { SearchApp_viewer } from "v2/__generated__/SearchApp_viewer.graphql"
 import { NavigationTabsFragmentContainer as NavigationTabs } from "v2/Apps/Search/Components/NavigationTabs"
@@ -35,11 +35,10 @@ export const SearchApp: React.FC<SearchAppProps> = ({ viewer, children }) => {
     match: { location },
   } = useRouter()
   const { searchConnection, artworksConnection } = viewer
-  const {
-    query: { term },
-  } = location
+  const { query } = location
   const { aggregations } = searchConnection!
 
+  const term = useMemo(() => query.term ?? "", [])
   const typeAggregation = aggregations?.find(agg => agg?.slice === "TYPE")
     ?.counts
 


### PR DESCRIPTION
Jira: [FX-3328](https://artsyproduct.atlassian.net/browse/FX-3328)

### Description
On search results page when user click on searched item `undefined` term is displayed

![444c04c4-3861-44cd-a465-5fac338d9df5](https://user-images.githubusercontent.com/56556580/134916089-d7479fcf-4828-4b17-ba45-6429dcbc2724.gif)

### Changes
- Save search term with `useMemo`

### Demo


https://user-images.githubusercontent.com/56556580/134915366-358a1b3e-4c31-4ded-a5ee-48fd323854b9.mov


https://user-images.githubusercontent.com/56556580/134917282-b4f2d057-d504-4041-a6a8-a0fc10e58386.mov


