### PR TITLE
fix(FX-2915): resized header image

### DIFF
--- a/src/v2/Components/FullBleedHeader.tsx
+++ b/src/v2/Components/FullBleedHeader.tsx
@@ -17,16 +17,22 @@ export const FullBleedHeader: React.FC<FullBleedHeaderProps> = ({
   caption,
   ...rest
 }) => {
-  const xs = cropped(src, { width: 450, height: 320 })
-  const sm = cropped(src, { width: 767, height: 320 })
-  const md = cropped(src, { width: 1024, height: 600 })
-  const lg = cropped(src, { width: 1440, height: 600 })
-  const xl = cropped(src, { width: 2000, height: 600 })
+  const xs = cropped(src, { width: 320, height: 600 })
+  const sm = cropped(src, { width: 767, height: 600 })
+  const md = cropped(src, { width: 896, height: 600 })
+  const lg = cropped(src, { width: 1000, height: 600 })
+  const xl = cropped(src, { width: 1600, height: 600 })
 
   const height = useFullBleedHeaderHeight()
 
   return (
-    <Container bg="black10" height={height} position="relative" {...rest}>
+    <Container
+      bg="black10"
+      height={height}
+      position="relative"
+      overflow="hidden"
+      {...rest}
+    >
       <picture>
         <source srcSet={xl.srcSet} media="(min-width: 1720px)" />
         <source srcSet={lg.srcSet} media="(min-width: 1232px)" />


### PR DESCRIPTION
Jira: [FX-2915](https://artsyproduct.atlassian.net/browse/FX-2915)

### Description
See https://www.artsy.net/collection/already-home-aapi-artists-on-belonging for example

### Changes
- Resized image in `<FullBleedHeader />`

### Demo

https://user-images.githubusercontent.com/56556580/135274749-9a187820-49aa-47ce-94e1-9246861fbaaf.mov

### Note
The main problem is backend send only image url. The header image for collection linked in description looks like this:
![image](https://user-images.githubusercontent.com/56556580/135278732-a0143d09-200d-4b6c-bc26-57aee0661322.png)
So we should crop image for the smallest height of included in header image (black-white in this case) to hide white areas
For this collection it looks good, but every header used `<FullBleedHeader />`was changed. You can see the result of changes below.

The example of [Liste Art Fair Basel 2021](https://staging.artsy.net/fair/liste-art-fair-basel-2021)

_1440px_
| Before  | Current |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/56556580/135276051-9bd685f6-0420-4c14-a2f8-5f72d5a03e11.png)| ![image](https://user-images.githubusercontent.com/56556580/135276131-3f008584-78f5-4f9a-95ec-20ad414284fc.png)|


_1024px_
| Before  | Current |
| ------------- | ------------- |
|![image](https://user-images.githubusercontent.com/56556580/135276259-c6ef4b51-31c3-4163-99d4-78e19ebb3eeb.png)|![image](https://user-images.githubusercontent.com/56556580/135276300-def4242b-d42d-4938-85e9-8e604c221f99.png)|


_768px_
| Before  | Current |
| ------------- | ------------- |
|![image](https://user-images.githubusercontent.com/56556580/135279973-2e764f20-af99-4874-aa8d-697081748342.png)|![image](https://user-images.githubusercontent.com/56556580/135280018-44a0bf3c-db8f-44bf-8ca7-42d29fa8f39d.png)|


_375px_
| Before  | Current |
| ------------- | ------------- |
|![image](https://user-images.githubusercontent.com/56556580/135280078-aff9a897-63e0-4803-aaf1-692037313fd8.png)|![image](https://user-images.githubusercontent.com/56556580/135280119-28af04f3-23b5-4584-ba3e-71a3098373f2.png)|


