### PR TITLE
fix: Route to artist page without partner prefix

### DIFF
--- a/src/v2/Apps/Home/Components/HomeTrendingArtistsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeTrendingArtistsRail.tsx
@@ -40,11 +40,7 @@ const HomeTrendingArtistsRail: React.FC<HomeTrendingArtistsRailProps> = ({
       <Shelf alignItems="flex-start">
         {nodes.map((node, index) => {
           return (
-            <RouterLink
-              to={`/partner${node.href}`}
-              textDecoration="none"
-              key={index}
-            >
+            <RouterLink to={node.href} textDecoration="none" key={index}>
               <Box width={325} key={index}>
                 {node.image?.cropped?.src ? (
                   <Box>


### PR DESCRIPTION
Over on Slack our pal @admbtlr bumped into this bug and noted it here:

https://artsy.slack.com/archives/C02BC3HEJ/p1632922829278000

So then all I did here was boot force, reproduce and then remove the `partner` bit out of the link. I don't have much more context here so I'm assuming this is the fix but lmk if I'm missing something!

/cc @artsy/grow-devs