### PR TITLE
fix(FX-3387): broken links in "current fairs" section

### DIFF
--- a/src/v2/Apps/Home/Components/HomeCurrentFairsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeCurrentFairsRail.tsx
@@ -37,11 +37,7 @@ const HomeCurrentFairsRail: React.FC<HomeCurrentFairsRailProps> = ({
           }
 
           return (
-            <RouterLink
-              to={`/fair${fair.href}`}
-              textDecoration="none"
-              key={index}
-            >
+            <RouterLink to={fair.href} textDecoration="none" key={index}>
               <Box key={index}>
                 {fair.image?.cropped?.src ? (
                   <Image

--- a/src/v2/Apps/Home/__tests__/HomeCurrentFairsRail.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeCurrentFairsRail.jest.tsx
@@ -26,7 +26,7 @@ describe("HomeCurrentFairsRail", () => {
         fairs: [
           {
             name: "Test Fair",
-            href: "test-href",
+            href: "/fair/test-href",
           },
         ],
       }),
@@ -35,6 +35,6 @@ describe("HomeCurrentFairsRail", () => {
     expect(wrapper.text()).toContain("Current Fairs")
     expect(wrapper.text()).toContain("View All Fairs")
     expect(wrapper.text()).toContain("Test Fair")
-    expect(wrapper.html()).toContain("test-href")
+    expect(wrapper.html()).toContain("/fair/test-href")
   })
 })


### PR DESCRIPTION
Jira: [FX-3387](https://artsyproduct.atlassian.net/browse/FX-3387)

### Before

https://user-images.githubusercontent.com/56556580/135301257-07e50e1b-0715-4d96-be4f-a30c01551afd.mov

### After

https://user-images.githubusercontent.com/56556580/135301339-2a927886-735f-48c7-aa9d-a6d1d2634591.mov


