### PR TITLE
fix(FX-3391): Fix copy in web hover menu for Artists

### DIFF
--- a/src/v2/Components/NavBar/menuData.ts
+++ b/src/v2/Components/NavBar/menuData.ts
@@ -98,9 +98,9 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
         dividerBelow: true,
       },
       {
-        text: "Artist Nationality or Ethicity",
+        text: "Artist Nationality or Ethnicity",
         menu: {
-          title: "Artist Nationality or Ethicity",
+          title: "Artist Nationality or Ethnicity",
           links: [
             {
               text: "American",


### PR DESCRIPTION
Jira ticket: [FX-3391]

### Description
The header for the Artist Nationality and Ethnicity section has a misspelling. It should read "Artist Nationality or Ethnicity" 

### Demo
#### Web
![web](https://user-images.githubusercontent.com/3513494/135306267-2c4e9859-7b56-4bab-8f5c-781572cf165d.png)

#### Mobile
![mobile](https://user-images.githubusercontent.com/3513494/135306354-2df58955-183a-4daf-a5aa-f393cb4ab199.png)




[FX-3391]: https://artsyproduct.atlassian.net/browse/FX-3391