### PR TITLE
fix(inquiry): reload on close after authentication

### DIFF
--- a/src/v2/Apps/Debug/DebugInquiryApp.tsx
+++ b/src/v2/Apps/Debug/DebugInquiryApp.tsx
@@ -10,7 +10,7 @@ export const DebugInquiryApp: React.FC<{}> = () => {
 
   return (
     <>
-      <Button onClick={() => showInquiry({ askSpecialist: true })}>
+      <Button onClick={() => showInquiry({ askSpecialist: false })}>
         Open inquiry questionnaire
       </Button>
 

--- a/src/v2/Components/Inquiry/Components/InquiryBackdrop.tsx
+++ b/src/v2/Components/Inquiry/Components/InquiryBackdrop.tsx
@@ -2,12 +2,19 @@ import { ModalBase, ModalBaseProps } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 import { useDidMount } from "v2/Utils/Hooks/useDidMount"
+import { useInquiryContext } from "../Hooks/useInquiryContext"
 
 export const InquiryBackdrop: React.FC<ModalBaseProps> = props => {
   const isMounted = useDidMount()
 
+  const { onClose } = useInquiryContext()
+
   return (
-    <Modal bg={isMounted ? "rgba(0, 0, 0, 0.8)" : "transparent"} {...props} />
+    <Modal
+      bg={isMounted ? "rgba(0, 0, 0, 0.8)" : "transparent"}
+      onClose={onClose}
+      {...props}
+    />
   )
 }
 

--- a/src/v2/Components/Inquiry/Inquiry.tsx
+++ b/src/v2/Components/Inquiry/Inquiry.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import {
-  InquiryProviderQueryRenderer,
+  InquiryContextContextQueryRenderer,
+  InquiryProvider,
   useInquiryContext,
 } from "./Hooks/useInquiryContext"
 import { InquiryBackdrop } from "./Components/InquiryBackdrop"
@@ -18,15 +19,17 @@ export const Inquiry: React.FC<InquiryProps> = ({
   onClose,
 }) => {
   return (
-    <InquiryBackdrop onClose={onClose}>
-      <InquiryProviderQueryRenderer
-        artworkID={artworkID}
-        askSpecialist={askSpecialist}
-        onClose={onClose}
-      >
-        <InquiryDialog />
-      </InquiryProviderQueryRenderer>
-    </InquiryBackdrop>
+    <InquiryProvider
+      artworkID={artworkID}
+      askSpecialist={askSpecialist}
+      onClose={onClose}
+    >
+      <InquiryBackdrop>
+        <InquiryContextContextQueryRenderer>
+          <InquiryDialog />
+        </InquiryContextContextQueryRenderer>
+      </InquiryBackdrop>
+    </InquiryProvider>
   )
 }
 

--- a/src/v2/Components/Inquiry/Views/InquiryBasicInfo.tsx
+++ b/src/v2/Components/Inquiry/Views/InquiryBasicInfo.tsx
@@ -16,7 +16,6 @@ import { useInquiryContext } from "../Hooks/useInquiryContext"
 import { InquiryBasicInfo_artwork } from "v2/__generated__/InquiryBasicInfo_artwork.graphql"
 import { InquiryBasicInfo_me } from "v2/__generated__/InquiryBasicInfo_me.graphql"
 import { InquiryBasicInfoQuery } from "v2/__generated__/InquiryBasicInfoQuery.graphql"
-import { useSystemContext } from "v2/System"
 import {
   Location,
   LocationAutocompleteInput,
@@ -204,12 +203,11 @@ export const InquiryBasicInfoFragmentContainer = createFragmentContainer(
 )
 
 export const InquiryBasicInfoQueryRenderer: React.FC = () => {
-  const { relayEnvironment } = useSystemContext()
-  const { artworkID } = useInquiryContext()
+  const { artworkID, relayEnvironment } = useInquiryContext()
 
   return (
     <SystemQueryRenderer<InquiryBasicInfoQuery>
-      environment={relayEnvironment}
+      environment={relayEnvironment.current!}
       placeholder={<InquiryBasicInfoPlaceholder />}
       query={graphql`
         query InquiryBasicInfoQuery($id: String!) {

--- a/src/v2/Components/Inquiry/Views/InquiryLogin.tsx
+++ b/src/v2/Components/Inquiry/Views/InquiryLogin.tsx
@@ -42,11 +42,12 @@ interface InquiryLoginState {
 
 export const InquiryLogin: React.FC = () => {
   const {
-    inquiry,
     artworkID,
-    next,
-    setRelayEnvironment,
     engine,
+    inquiry,
+    next,
+    setContext,
+    setRelayEnvironment,
   } = useInquiryContext()
   const { navigateTo } = useInquiryAccountContext()
 
@@ -68,6 +69,22 @@ export const InquiryLogin: React.FC = () => {
 
     try {
       const { user } = await login({ email: inquiry.email!, ...state })
+
+      setContext({
+        collectorLevel: user.collector_level,
+        isLoggedIn: true,
+        location: {
+          city: user.location?.city,
+          state: user.location?.state,
+          stateCode: user.location?.stateCode,
+          postalCode: user.location?.postalCode,
+          country: user.location?.country,
+        },
+        phone: user.phone,
+        profession: user.profession,
+        requiresReload: true,
+        shareFollows: user.share_follows,
+      })
 
       // Creates an authenticated relay environment now that we have a user
       const relayEnvironment = createRelaySSREnvironment({ user })

--- a/src/v2/Components/Inquiry/Views/InquirySignUp.tsx
+++ b/src/v2/Components/Inquiry/Views/InquirySignUp.tsx
@@ -36,11 +36,12 @@ export const InquirySignUp: React.FC = () => {
   const [error, setError] = useState("")
 
   const {
-    inquiry,
     artworkID,
-    next,
-    setRelayEnvironment,
     engine,
+    inquiry,
+    next,
+    setContext,
+    setRelayEnvironment,
   } = useInquiryContext()
 
   const { submitArtworkInquiryRequest } = useArtworkInquiryRequest()
@@ -60,6 +61,8 @@ export const InquirySignUp: React.FC = () => {
 
     try {
       const { user } = await signUp(state)
+
+      setContext({ isLoggedIn: true, requiresReload: true })
 
       // Creates an authenticated relay environment now that we have a user
       const relayEnvironment = createRelaySSREnvironment({ user })

--- a/src/v2/Components/Inquiry/__tests__/Views/InquiryLogin.jest.tsx
+++ b/src/v2/Components/Inquiry/__tests__/Views/InquiryLogin.jest.tsx
@@ -24,11 +24,12 @@ describe("InquiryLogin", () => {
       submitArtworkInquiryRequest,
     }))
     ;(useInquiryContext as jest.Mock).mockImplementation(() => ({
-      next,
       artworkID: "example",
-      inquiry: { email: "example@example.com", message: "Hello world" },
-      setRelayEnvironment: jest.fn(),
       engine: { decide: jest.fn().mockReturnValue(false) },
+      inquiry: { email: "example@example.com", message: "Hello world" },
+      next,
+      setContext: jest.fn(),
+      setRelayEnvironment: jest.fn(),
     }))
     ;(useTracking as jest.Mock).mockImplementation(() => ({ trackEvent }))
   })

--- a/src/v2/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
+++ b/src/v2/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
@@ -24,11 +24,12 @@ describe("InquirySignUp", () => {
       submitArtworkInquiryRequest,
     }))
     ;(useInquiryContext as jest.Mock).mockImplementation(() => ({
-      next,
       artworkID: "example",
-      inquiry: { email: "example@example.com", message: "Hello world" },
-      setRelayEnvironment: jest.fn(),
       engine: { decide: jest.fn().mockReturnValue(false) },
+      inquiry: { email: "example@example.com", message: "Hello world" },
+      next,
+      setContext: jest.fn(),
+      setRelayEnvironment: jest.fn(),
     }))
     ;(useTracking as jest.Mock).mockImplementation(() => ({ trackEvent }))
   })

--- a/src/v2/Components/Inquiry/config.ts
+++ b/src/v2/Components/Inquiry/config.ts
@@ -129,27 +129,27 @@ export const useEngine = ({ context, onDone }: UseEngine) => {
           )
         },
         hasCompletedProfile: () => {
-          return (
-            // Has all the basic info
+          const hasBasicInfo =
             !!context.current?.profession &&
-              !!context.current.location?.city &&
-              !!context.current.phone &&
-              !!context.current.shareFollows &&
-              // And is a collector
-              (context.current.collectorLevel ?? 0) >= 3
-              ? // If you're a collector then you should have seen all of these
-                // before "completing" your profile
-                visited.current.hasSeen(
-                  "CommercialInterest",
-                  "ArtistsInCollection",
-                  "GalleriesYouWorkWith",
-                  "AuctionHousesYouWorkWith",
-                  "FairsYouAttend",
-                  "InstitutionalAffiliations"
-                )
-              : // If you've never bought art then you only saw this step
-                visited.current.hasSeen("CommercialInterest")
-          )
+            !!context.current?.location?.city &&
+            !!context.current?.phone &&
+            !!context.current?.shareFollows
+
+          const isCollector = (context.current?.collectorLevel ?? 0) >= 3
+
+          return hasBasicInfo && isCollector
+            ? // If you're a collector then you should have seen all of these
+              // before "completing" your profile
+              visited.current.hasSeen(
+                "CommercialInterest",
+                "ArtistsInCollection",
+                "GalleriesYouWorkWith",
+                "AuctionHousesYouWorkWith",
+                "FairsYouAttend",
+                "InstitutionalAffiliations"
+              )
+            : // If you've never bought art then you only saw this step
+              visited.current.hasSeen("CommercialInterest")
         },
         hasSeenArtistsInCollection: () => {
           return visited.current.hasSeen("ArtistsInCollection")
@@ -192,13 +192,6 @@ export const useEngine = ({ context, onDone }: UseEngine) => {
   }, [current, visited])
 
   const next = () => {
-    // At the end, and previously logged out; refresh the page
-    // to log in the entire stack
-    if (engine.current.isEnd() && !context.current?.isLoggedIn) {
-      window.location.reload()
-      return
-    }
-
     // At the end; closes the modal
     if (engine.current.isEnd()) {
       onDone()


### PR DESCRIPTION
Re: https://github.com/artsy/integrity/pull/251

@anipetrov noticed while Q/A-ing the inquiry analytics that if she drops off the flow before reaching the end then we don't actually trigger the reload; which has caused some problems in the past.

This was a little tricky to do because the initial user fetch has to happen _inside_ of the modal; but the modal also needs to be inside of the context provider. Previously the modal was on the outside. Relay hooks would have made this _much_ easier but here we go. I had to separate out the initial context fetch into its own component where all it does is fetch, then set the context in the hook. This lets us pull it out so the provider can be moved up, and as a result so can the `onClose` function.

I _also_ happened to notice a small bug where we weren't properly populating basic info after login — so this fixes that as well.

Will leave some comments throughout.