### PR TITLE
feat: Track user interactions in new checkout flow - order review page [PX-4617]

### DIFF
--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -55,6 +55,9 @@ export interface ReviewProps {
 
 const logger = createLogger("Order/Routes/Review/index.tsx")
 
+// TODO: move this to cohesion
+const OrdersReviewOwnerType = "orders-review"
+
 @track()
 export class ReviewRoute extends Component<ReviewProps> {
   @track<ReviewProps>(props => ({
@@ -318,7 +321,7 @@ export class ReviewRoute extends Component<ReviewProps> {
       ({
         action: ActionType.clickedChangePaymentMethod,
         context_module: ContextModule.ordersReview,
-        context_page_owner_type: "orders_review", // TODO: add this to cohesion
+        context_page_owner_type: OrdersReviewOwnerType,
       } as ClickedChangePaymentMethod)
   )
   onChangePayment() {
@@ -330,7 +333,7 @@ export class ReviewRoute extends Component<ReviewProps> {
       ({
         action: ActionType.clickedChangeShippingAddress,
         context_module: ContextModule.ordersReview,
-        context_page_owner_type: "orders_review", // TODO: add this to cohesion
+        context_page_owner_type: OrdersReviewOwnerType,
       } as ClickedChangeShippingAddress)
   )
   onChangeShippingAddress() {
@@ -342,7 +345,7 @@ export class ReviewRoute extends Component<ReviewProps> {
       ({
         action: ActionType.clickedChangeShippingMethod,
         context_module: ContextModule.ordersReview,
-        context_page_owner_type: "orders_review", // TODO: add this to cohesion
+        context_page_owner_type: OrdersReviewOwnerType,
       } as ClickedChangeShippingMethod)
   )
   onChangeShippingMethod() {

--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -35,6 +35,7 @@ import { withSystemContext } from "v2/System"
 import { ShippingArtaSummaryItemFragmentContainer } from "../../Components/ShippingArtaSummaryItem"
 import {
   ActionType,
+  ClickedChangePaymentMethod,
   ClickedChangeShippingAddress,
   ContextModule,
 } from "@artsy/cohesion"
@@ -311,17 +312,26 @@ export class ReviewRoute extends Component<ReviewProps> {
     this.props.router.push(`/orders/${this.props.order.internalID}/offer`)
   }
 
-  onChangePayment = () => {
+  @track<ReviewProps>(
+    () =>
+      ({
+        action: ActionType.clickedChangePaymentMethod,
+        context_module: ContextModule.ordersReview,
+        context_page_owner_type: "orders_review", // TODO: add this to cohesion
+      } as ClickedChangePaymentMethod)
+  )
+  onChangePayment() {
     this.props.router.push(`/orders/${this.props.order.internalID}/payment`)
   }
 
-  @track<ReviewProps>(() => {
-    return {
-      action: ActionType.clickedChangeShippingAddress,
-      context_module: ContextModule.ordersReview,
-      context_page_owner_type: "orders_review", // TODO: add this to cohesion
-    } as ClickedChangeShippingAddress
-  })
+  @track<ReviewProps>(
+    () =>
+      ({
+        action: ActionType.clickedChangeShippingAddress,
+        context_module: ContextModule.ordersReview,
+        context_page_owner_type: "orders_review", // TODO: add this to cohesion
+      } as ClickedChangeShippingAddress)
+  )
   onChangeShipping() {
     this.props.router.push(`/orders/${this.props.order.internalID}/shipping`)
   }
@@ -374,7 +384,7 @@ export class ReviewRoute extends Component<ReviewProps> {
                   />
                   <CreditCardSummaryItem
                     order={order}
-                    onChange={this.onChangePayment}
+                    onChange={this.onChangePayment.bind(this)}
                     title="Payment method"
                   />
                   <ShippingArtaSummaryItemFragmentContainer

--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -37,6 +37,7 @@ import {
   ActionType,
   ClickedChangePaymentMethod,
   ClickedChangeShippingAddress,
+  ClickedChangeShippingMethod,
   ContextModule,
 } from "@artsy/cohesion"
 export interface ReviewProps {
@@ -332,7 +333,19 @@ export class ReviewRoute extends Component<ReviewProps> {
         context_page_owner_type: "orders_review", // TODO: add this to cohesion
       } as ClickedChangeShippingAddress)
   )
-  onChangeShipping() {
+  onChangeShippingAddress() {
+    this.props.router.push(`/orders/${this.props.order.internalID}/shipping`)
+  }
+
+  @track<ReviewProps>(
+    () =>
+      ({
+        action: ActionType.clickedChangeShippingMethod,
+        context_module: ContextModule.ordersReview,
+        context_page_owner_type: "orders_review", // TODO: add this to cohesion
+      } as ClickedChangeShippingMethod)
+  )
+  onChangeShippingMethod() {
     this.props.router.push(`/orders/${this.props.order.internalID}/shipping`)
   }
 
@@ -380,7 +393,7 @@ export class ReviewRoute extends Component<ReviewProps> {
                   )}
                   <ShippingSummaryItem
                     order={order}
-                    onChange={this.onChangeShipping.bind(this)}
+                    onChange={this.onChangeShippingAddress.bind(this)}
                   />
                   <CreditCardSummaryItem
                     order={order}
@@ -389,7 +402,7 @@ export class ReviewRoute extends Component<ReviewProps> {
                   />
                   <ShippingArtaSummaryItemFragmentContainer
                     order={order}
-                    onChange={this.onChangeShipping}
+                    onChange={this.onChangeShippingMethod.bind(this)}
                     title="Shipping"
                   />
                 </Flex>

--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -33,6 +33,11 @@ import { createStripeWrapper } from "v2/Utils/createStripeWrapper"
 import type { Stripe, StripeElements } from "@stripe/stripe-js"
 import { withSystemContext } from "v2/System"
 import { ShippingArtaSummaryItemFragmentContainer } from "../../Components/ShippingArtaSummaryItem"
+import {
+  ActionType,
+  ClickedChangeShippingAddress,
+  ContextModule,
+} from "@artsy/cohesion"
 export interface ReviewProps {
   stripe: Stripe
   elements: StripeElements
@@ -310,7 +315,14 @@ export class ReviewRoute extends Component<ReviewProps> {
     this.props.router.push(`/orders/${this.props.order.internalID}/payment`)
   }
 
-  onChangeShipping = () => {
+  @track<ReviewProps>(() => {
+    return {
+      action: ActionType.clickedChangeShippingAddress,
+      context_module: ContextModule.ordersReview,
+      context_page_owner_type: "orders_review", // TODO: add this to cohesion
+    } as ClickedChangeShippingAddress
+  })
+  onChangeShipping() {
     this.props.router.push(`/orders/${this.props.order.internalID}/shipping`)
   }
 
@@ -358,7 +370,7 @@ export class ReviewRoute extends Component<ReviewProps> {
                   )}
                   <ShippingSummaryItem
                     order={order}
-                    onChange={this.onChangeShipping}
+                    onChange={this.onChangeShipping.bind(this)}
                   />
                   <CreditCardSummaryItem
                     order={order}


### PR DESCRIPTION
Partially addresses [PX-4617]

Collaboration with @annacarey, @ansor4, and @jpotts244 

@brendamanganelli the only event **from the order review page events** not included in this PR is `clickedOnSubmitOrder` -- we skipped this one because [we're already tracking something for that event](https://github.com/artsy/force/blob/5afd5f6f6e3de5d87dfa70d34058e23f3a41dd14/src/v2/Apps/Order/Routes/Review/index.tsx#L54-L66). Let us know if we need to make changes to the existing tracked event, or if it's something you can use on your end without changes.

## follow-up work
- There is a TODO to move an OwnerType constant to cohesion, but we're hoping to launch shipping tomorrow and we plan to do that after launch.
- Tests!

[PX-4617]: https://artsyproduct.atlassian.net/browse/PX-4617