### PR TITLE
fix(PX-4608): Checkout: Artsy Shipping prices should be right-justified

### DIFF
--- a/src/v2/Apps/Order/Components/ShippingQuotes.tsx
+++ b/src/v2/Apps/Order/Components/ShippingQuotes.tsx
@@ -54,10 +54,11 @@ export const ShippingQuotes: React.FC<ShippingQuotesProps> = ({
             key={id}
             position="relative"
           >
-            <Flex flexDirection="column">
-              <Text textTransform="capitalize">
-                {displayName} ({price})
-              </Text>
+            <Flex flexDirection="column" width="100%">
+              <Flex justifyContent="space-between">
+                <Text textTransform="capitalize">{displayName}</Text>
+                <Text textTransform="capitalize">{price}</Text>
+              </Flex>
               <Text textColor="black60">{description}</Text>
             </Flex>
           </BorderedRadio>

--- a/src/v2/Apps/Order/Components/__tests__/ShippingQuotes.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/ShippingQuotes.jest.tsx
@@ -112,7 +112,7 @@ describe("ShippingQuotes", () => {
     const ascendingPrices = ["$1.00", "$2.00", "$3.00", "$4.00", "$5.00"]
 
     shippingQuotes.forEach((node: ReactWrapper, index: number) => {
-      expect(node.find("Text").first().text()).toContain(ascendingPrices[index])
+      expect(node.find("Text").at(1).text()).toContain(ascendingPrices[index])
     })
   })
 


### PR DESCRIPTION
Jira Ticket:ticket: : [PX-4608](https://artsyproduct.atlassian.net/browse/PX-4608)

This PR changes the shipping prices alignment.

Now the prices of shipping options in checkout are `right-justified`, so they're `easier to scan by buyers`.

