### PR TITLE
GRO-552: Updated Nav Bar for text case

### DIFF
--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -147,7 +147,7 @@ export const NavBar: React.FC = track(
                   flex={1}
                   size="small"
                 >
-                  Sign up
+                  Sign Up
                 </Button>
 
                 <Button
@@ -158,7 +158,7 @@ export const NavBar: React.FC = track(
                   ml={1}
                   size="small"
                 >
-                  Log in
+                  Log In
                 </Button>
               </Flex>
             )}
@@ -216,7 +216,7 @@ export const NavBar: React.FC = track(
                         })
                       }}
                     >
-                      Log in
+                      Log In
                     </Button>
 
                     <Button
@@ -230,7 +230,7 @@ export const NavBar: React.FC = track(
                         })
                       }}
                     >
-                      Sign up
+                      Sign Up
                     </Button>
                   </Flex>
                 )}

--- a/src/v2/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
+++ b/src/v2/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
@@ -146,11 +146,11 @@ const NavBarMobileMenuLoggedOut: React.FC = () => {
   return (
     <>
       <NavBarMobileMenuItemLink to={authLink(ModalType.signup)}>
-        Sign up
+        Sign Up
       </NavBarMobileMenuItemLink>
 
       <NavBarMobileMenuItemLink to={authLink(ModalType.login)}>
-        Log in
+        Log In
       </NavBarMobileMenuItemLink>
     </>
   )

--- a/src/v2/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
+++ b/src/v2/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
@@ -68,8 +68,8 @@ describe("NavBarMobileMenu", () => {
         ["/institutions", "Museums"],
         ["/consign", "Sell"],
         ["/articles", "Editorial"],
-        ["/signup?intent=signup&contextModule=header", "Sign up"],
-        ["/login?intent=login&contextModule=header", "Log in"],
+        ["/signup?intent=signup&contextModule=header", "Sign Up"],
+        ["/login?intent=login&contextModule=header", "Log In"],
       ].map(link => link.join(""))
 
       const linkContainer = getWrapper({})

--- a/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -63,8 +63,8 @@ describe("NavBar", () => {
   describe("desktop", () => {
     it("renders logged out items", () => {
       const wrapper = getWrapper()
-      expect(wrapper.html()).toContain("Log in")
-      expect(wrapper.html()).toContain("Sign up")
+      expect(wrapper.html()).toContain("Log In")
+      expect(wrapper.html()).toContain("Sign Up")
       expect(wrapper.find(BellIcon).length).toEqual(0)
       expect(wrapper.find(SoloIcon).length).toEqual(0)
     })
@@ -72,8 +72,8 @@ describe("NavBar", () => {
     it("renders logged in items", () => {
       // @ts-expect-error STRICT_NULL_CHECK
       const wrapper = getWrapper({ user: true })
-      expect(wrapper.html()).not.toContain("Log in")
-      expect(wrapper.html()).not.toContain("Sign up")
+      expect(wrapper.html()).not.toContain("Log In")
+      expect(wrapper.html()).not.toContain("Sign Up")
       expect(wrapper.find(BellIcon).length).toEqual(1)
       expect(wrapper.find(SoloIcon).length).toEqual(1)
     })


### PR DESCRIPTION
[GRO-552]

Current Behavior:
<img width="644" alt="Screen Shot 2021-10-01 at 2 38 23 PM" src="https://user-images.githubusercontent.com/30025439/135689107-9c147dde-83de-4696-b1c6-9db23715e0f3.png">

New Behavior:
<img width="745" alt="Screen Shot 2021-10-01 at 2 38 03 PM" src="https://user-images.githubusercontent.com/30025439/135689119-420f9778-5789-40de-856c-7aeb1d84dee7.png">



[GRO-552]: https://artsyproduct.atlassian.net/browse/GRO-552