### PR TITLE
fix(navbar): corrects casing

### DIFF
--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -360,7 +360,7 @@ export const NavBar: React.FC = track(
                   Fairs
                 </NavBarItemLink>
 
-                <NavBarItemLink href="/Shows" onClick={handleClick}>
+                <NavBarItemLink href="/shows" onClick={handleClick}>
                   Shows
                 </NavBarItemLink>
 


### PR DESCRIPTION
Very minor thing: This route has been capitalized like this for a while — it was just never noticed because the old app would downcase everything.