### PR TITLE
chore: replace hardcoded values with new cohesion constants

### DIFF
--- a/src/v2/Apps/Order/Components/SavedAddresses.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddresses.tsx
@@ -31,7 +31,7 @@ import { extractNodes } from "v2/Utils/extractNodes"
 import { UpdateUserAddressMutationResponse } from "v2/__generated__/UpdateUserAddressMutation.graphql"
 import { CreateUserAddressMutationResponse } from "v2/__generated__/CreateUserAddressMutation.graphql"
 import { useTracking } from "v2/System"
-import { ActionType, ContextModule } from "@artsy/cohesion"
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 
 export const NEW_ADDRESS = "NEW_ADDRESS"
 const PAGE_SIZE = 30
@@ -164,8 +164,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
   const trackAddAddressClick = () => {
     trackEvent({
       action: ActionType.clickedAddNewShippingAddress,
-      // TODO: move this constant to cohesion!
-      context_page_owner_type: "orders-shipping",
+      context_page_owner_type: OwnerType.ordersShipping,
       context_module: ContextModule.ordersShipping,
     })
   }

--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -39,6 +39,7 @@ import {
   ClickedChangeShippingAddress,
   ClickedChangeShippingMethod,
   ContextModule,
+  OwnerType,
 } from "@artsy/cohesion"
 export interface ReviewProps {
   stripe: Stripe
@@ -55,8 +56,7 @@ export interface ReviewProps {
 
 const logger = createLogger("Order/Routes/Review/index.tsx")
 
-// TODO: move this to cohesion
-const OrdersReviewOwnerType = "orders-review"
+const OrdersReviewOwnerType = OwnerType.ordersReview
 
 @track()
 export class ReviewRoute extends Component<ReviewProps> {
@@ -437,8 +437,7 @@ export class ReviewRoute extends Component<ReviewProps> {
               </Flex>
               <BuyerGuarantee
                 contextModule={ContextModule.ordersReview}
-                // TODO: move this constant to cohesion!
-                contextPageOwnerType="orders-review"
+                contextPageOwnerType={OwnerType.ordersReview}
               />
               {order.myLastOffer && !order.myLastOffer?.hasDefiniteTotal && (
                 <Text variant="xs" color="black60">

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -81,6 +81,7 @@ import {
   ClickedSelectShippingOption,
   ClickedShippingAddress,
   ContextModule,
+  OwnerType,
 } from "@artsy/cohesion"
 
 export interface ShippingProps extends SystemContextProps {
@@ -771,8 +772,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
               </Flex>
               <BuyerGuarantee
                 contextModule={ContextModule.ordersShipping}
-                // TODO: move this constant to cohesion!
-                contextPageOwnerType="orders-shipping"
+                contextPageOwnerType={OwnerType.ordersShipping}
               />
               <Spacer mb={[2, 4]} />
               <Media at="xs">


### PR DESCRIPTION
Addresses [PX-4630].

In order to ship shipping last week, we took some shortcuts, including leaving hardcoded values in Force rather than putting them in cohesion where they belong.

[cohesion#243](https://github.com/artsy/cohesion/pull/243) adds the new constants; this PR utilizes them.

[PX-4630]: https://artsyproduct.atlassian.net/browse/PX-4630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


## coming soon in follow-up PRs

- tests around this tracking!
- update all usages of `<BuyerGuarantee` to track, not just the couple we needed for the shipping release.