### PR TITLE
fix(relay cache): Properly cache for logged in users

### DIFF
--- a/src/v2/System/Relay/middleware/cache/cacheMiddleware.ts
+++ b/src/v2/System/Relay/middleware/cache/cacheMiddleware.ts
@@ -40,6 +40,8 @@ export function cacheMiddleware(opts?: CacheMiddlewareOpts) {
   }
 
   return next => async req => {
+    const isServer = typeof window === "undefined"
+
     if (req.isMutation()) {
       if (clearOnMutation) {
         await cache.clear()
@@ -53,7 +55,10 @@ export function cacheMiddleware(opts?: CacheMiddlewareOpts) {
       return next(req)
     }
 
-    if (disableServerSideCache || (req.cacheConfig && req.cacheConfig.force)) {
+    if (
+      (isServer && disableServerSideCache) ||
+      (req.cacheConfig && req.cacheConfig.force)
+    ) {
       return next(req)
     }
 


### PR DESCRIPTION
Noticed that we're improperly avoiding cache _on the client_ when logged in, which was never intended. This should speed things up significantly for logged in users browsing around. 

The flow: 

**Logged Out**: 

1. User is logged out
1. User visits route
1. Cache relay network request response in redis (for all users to retrieve)
1. Different logged out user visits route, cache is returned
1. Client mounts 
1. Network requests then cached on the client for remaining browsing session unless otherwise set


**Logged In**: 

1. User is logged in 
1. User visits route; request is not persisted to server-side redis cache as it may contain PII, etc 
1. Client mounts 
1. Network requests then cached on the client for remaining browsing session unless otherwise set

The only time routes aren't cached is if we have `cacheConfig: { force: true }` set on the route config, as seen [on artwork pages](https://github.com/artsy/force/blob/master/src/v2/Apps/Artwork/artworkRoutes.tsx). 