### PR TITLE
feat: Handle malformed auth tokens for unsubscribe

### DIFF
--- a/src/v2/Apps/Unsubscribe/UnsubscribeApp.tsx
+++ b/src/v2/Apps/Unsubscribe/UnsubscribeApp.tsx
@@ -11,10 +11,15 @@ interface UnsubscribeAppProps {
   me: UnsubscribeApp_me | null
 }
 
+export const parseTokenFromQuery = (query): string => {
+  const tokenFromQuery = query.authentication_token || ""
+  return tokenFromQuery.split("?")[0]
+}
+
 export const UnsubscribeApp: React.FC<UnsubscribeAppProps> = ({ me }) => {
   const { match } = useRouter()
 
-  const { authentication_token: authenticationToken } = match.location.query
+  const authenticationToken = parseTokenFromQuery(match.location.query)
 
   return (
     <>

--- a/src/v2/Apps/Unsubscribe/__tests__/UnsubscribeApp.jest.tsx
+++ b/src/v2/Apps/Unsubscribe/__tests__/UnsubscribeApp.jest.tsx
@@ -2,6 +2,7 @@ import { MockBoot } from "v2/DevTools"
 import React from "react"
 import { mount } from "enzyme"
 import {
+  parseTokenFromQuery,
   UnsubscribeApp,
   UnsubscribeAppFragmentContainer,
 } from "../UnsubscribeApp"
@@ -93,5 +94,27 @@ describe("UnsubscribeApp", () => {
 
       expect(html).not.toContain("Email Preferences")
     })
+  })
+})
+
+describe("parseTokenFromQuery", () => {
+  it("returns an empty string without a token in query", () => {
+    const query = {}
+    const authenticationToken = parseTokenFromQuery(query)
+    expect(authenticationToken).toEqual("")
+  })
+
+  it("returns the token from the query", () => {
+    const token = "abcd1234"
+    const query = { authentication_token: token }
+    const authenticationToken = parseTokenFromQuery(query)
+    expect(authenticationToken).toEqual(token)
+  })
+
+  it("returns the token from the query and cleans up any malformed values", () => {
+    const token = "abcd1234"
+    const query = { authentication_token: `${token}?foo=bar` }
+    const authenticationToken = parseTokenFromQuery(query)
+    expect(authenticationToken).toEqual(token)
   })
 })


### PR DESCRIPTION
We have some number of emails in circulation that have a malformed unsubscribe URL:

```
expected:
https://www.artsy.net/unsubscribe?authentication_token=shhhh

malformed:
https://www.artsy.net/unsubscribe?authentication_token=shhhh?utm=braze
```

So all this PR does is attempt to detect and fix a malformed token.

https://artsy.slack.com/archives/C9RK0BLEP/p1633557767012900

/cc @artsy/grow-devs @isakelaris 