### PR TITLE
refactor(PURCHASE-2978): remove authImpression deprecated helper

### DIFF
--- a/src/v2/Components/Authentication/FormSwitcher.tsx
+++ b/src/v2/Components/Authentication/FormSwitcher.tsx
@@ -1,4 +1,4 @@
-import { AuthModalType, authImpression } from "@artsy/cohesion"
+import { ActionType, AuthImpression, AuthModalType } from "@artsy/cohesion"
 import { Theme } from "@artsy/palette"
 import qs from "querystring"
 import React from "react"
@@ -72,27 +72,17 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
       tracking,
     } = this.props
 
-    // Analytics
-    const event = Object.assign(
-      {
-        contextModule,
-        copy: copy || title,
-        intent,
-        triggerSeconds,
-        type: AuthModalType[type],
-      },
-      type === "signup"
-        ? {
-            onboarding: !redirectTo,
-          }
-        : null
-    )
-
-    const trackingArgs = authImpression(event)
-
-    if (tracking) {
-      tracking.trackEvent(trackingArgs)
+    const trackingArgs: AuthImpression = {
+      action: ActionType.authImpression,
+      context_module: contextModule,
+      modal_copy: copy || title,
+      intent,
+      trigger: triggerSeconds ? "timed" : "click",
+      trigger_seconds: triggerSeconds,
+      type: AuthModalType[type],
+      onboarding: type === "signup" ? !redirectTo : false,
     }
+    tracking?.trackEvent(trackingArgs)
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {

--- a/src/v2/Components/Authentication/__tests__/FormSwitcher.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/FormSwitcher.jest.tsx
@@ -129,31 +129,39 @@ describe("FormSwitcher", () => {
     it("tracks login impressions", () => {
       const tracking = { trackEvent: jest.fn() }
       getWrapper({ tracking, type: ModalType.login })
-      expect(tracking.trackEvent).toBeCalledWith({
-        action: "authImpression",
-        context_module: "header",
-        intent: "followArtist",
-        modal_copy: "Foo Bar",
-        onboarding: false,
-        trigger: "timed",
-        trigger_seconds: 1,
-        type: "login",
-      })
+      expect(tracking.trackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action": "authImpression",
+            "context_module": "header",
+            "intent": "followArtist",
+            "modal_copy": "Foo Bar",
+            "onboarding": false,
+            "trigger": "timed",
+            "trigger_seconds": 1,
+            "type": "login",
+          },
+        ]
+      `)
     })
 
     it("tracks forgot password impressions", () => {
       const tracking = { trackEvent: jest.fn() }
       getWrapper({ tracking, type: ModalType.forgot })
-      expect(tracking.trackEvent).toBeCalledWith({
-        action: "authImpression",
-        context_module: "header",
-        intent: "followArtist",
-        modal_copy: "Foo Bar",
-        onboarding: false,
-        trigger: "timed",
-        trigger_seconds: 1,
-        type: "forgot",
-      })
+      expect(tracking.trackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action": "authImpression",
+            "context_module": "header",
+            "intent": "followArtist",
+            "modal_copy": "Foo Bar",
+            "onboarding": false,
+            "trigger": "timed",
+            "trigger_seconds": 1,
+            "type": "forgot",
+          },
+        ]
+      `)
     })
 
     it("tracks signup impressions", () => {
@@ -162,16 +170,20 @@ describe("FormSwitcher", () => {
         tracking,
         type: ModalType.signup,
       })
-      expect(tracking.trackEvent).toBeCalledWith({
-        action: "authImpression",
-        context_module: "header",
-        intent: "followArtist",
-        modal_copy: "Foo Bar",
-        onboarding: false,
-        trigger: "timed",
-        trigger_seconds: 1,
-        type: "signup",
-      })
+      expect(tracking.trackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action": "authImpression",
+            "context_module": "header",
+            "intent": "followArtist",
+            "modal_copy": "Foo Bar",
+            "onboarding": false,
+            "trigger": "timed",
+            "trigger_seconds": 1,
+            "type": "signup",
+          },
+        ]
+      `)
     })
   })
 })


### PR DESCRIPTION
The type of this ticket is **Enhancement**

[Ticket](https://artsyproduct.atlassian.net/browse/PURCHASE-2978)

This PR removes the deprecated helper authImpression.

Sibling of [#248](https://github.com/artsy/cohesion/pull/248)
