### PR TITLE
fix(FX-2249): Search autosuggest dropdown sometimes fails to display

### DIFF
--- a/src/v2/Components/Search/SearchBar.tsx
+++ b/src/v2/Components/Search/SearchBar.tsx
@@ -409,6 +409,7 @@ export class SearchBar extends Component<Props, State> {
 
     return (
       <Autosuggest
+        focusInputOnSuggestionClick={false}
         alwaysRenderSuggestions={this.userClickedOnDescendant}
         suggestions={suggestions}
         onSuggestionsClearRequested={this.onSuggestionsClearRequested}


### PR DESCRIPTION
[FX-2249]

After landing on autosuggest result page search input remains focused but dropdown is not appearing when typing new term. This bug is caused by the fact that dropdown appears depending not on the actual state of the input but on [local state value `focused`](https://github.com/artsy/force/blob/b4328ce11a835e1c06a11df51e22b632564f9655/src/v2/Components/Search/SearchBar.tsx#L305) which [turns to `true` on input focus](https://github.com/artsy/force/blob/b4328ce11a835e1c06a11df51e22b632564f9655/src/v2/Components/Search/SearchBar.tsx#L212)

This fixes current behavior by disabling input autofocus so that user need to explicitly focus the input

### Demo

#### Before
https://user-images.githubusercontent.com/44819355/137691500-35311e61-2bc1-4e28-ae66-e606e3c8645b.mp4


#### After
https://user-images.githubusercontent.com/44819355/137691833-fe3a604a-d893-4c7e-84bd-fec281bd859f.mp4



[FX-2249]: https://artsyproduct.atlassian.net/browse/FX-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ