### PR TITLE
Update URL for typography components [ci skip]

### DIFF
--- a/src/v2/Components/Text.tsx
+++ b/src/v2/Components/Text.tsx
@@ -47,7 +47,7 @@ const RawText: React.SFC<TextProps> = (props: TextProps) => {
 
 /**
  * @deprecated in favor of our Design System Typography components in @artsy/palette
- * https://palette.artsy.net/tokens/typography
+ * https://palette.artsy.net/atoms/typography
  */
 const Text = styled(RawText)`
   ${props =>

--- a/src/v2/Components/Title.tsx
+++ b/src/v2/Components/Title.tsx
@@ -20,7 +20,7 @@ const titleSizes = {
 
 /**
  * @deprecated in favor of our Design System Typography components in @artsy/palette
- * https://palette.artsy.net/tokens/typography
+ * https://palette.artsy.net/atoms/typography
  */
 const Title: React.SFC<TitleProps> = props => {
   const newProps: TitleProps = { ...props }


### PR DESCRIPTION
I noticed this URL was broken. I'm not sure this is the right change, but it seems like it! 🤷 