### PR TITLE
fix(integrity): Re-add missing data-test attributes for integrity, round 2

### DIFF
--- a/src/v2/Apps/Artist/Routes/Overview/Components/ArtistRelatedArtistsRail.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/ArtistRelatedArtistsRail.tsx
@@ -1,5 +1,5 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import { EntityHeader, Image } from "@artsy/palette"
+import { Box, EntityHeader, Image } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -31,78 +31,80 @@ const ArtistRelatedArtistsRail: React.FC<ArtistRelatedArtistsRailProps> = ({
   }
 
   return (
-    <Rail
-      title="Related Artists"
-      alignItems="flex-start"
-      getItems={() => {
-        return nodes.map((node, index) => {
-          const artworkImage = extractNodes(node.filterArtworksConnection)?.[0]
-            ?.image
+    <Box data-test="relatedArtistsRail">
+      <Rail
+        title="Related Artists"
+        alignItems="flex-start"
+        getItems={() => {
+          return nodes.map((node, index) => {
+            const artworkImage = extractNodes(
+              node.filterArtworksConnection
+            )?.[0]?.image
 
-          if (!artworkImage) {
-            return null as any
-          }
+            if (!artworkImage) {
+              return null as any
+            }
 
-          return (
-            <React.Fragment key={index}>
-              <RouterLink
-                to={node.href}
-                display="block"
-                textDecoration="none"
-                onClick={() => {
-                  tracking.trackEvent({
-                    action_type: AnalyticsSchema.ActionType.Click,
-                    contextModule: ContextModule.relatedArtistsRail,
-                    contextPageOwnerId,
-                    contextPageOwnerSlug,
-                    contextPageOwnerType,
-                    destination_path: node.href,
-                    destinationPageOwnerId: node.internalID,
-                    destinationPageOwnerSlug: node.slug,
-                    destinationPageOwnerType: OwnerType.artwork,
-                    horizontalSlidePosition: index + 1,
-                    type: "thumbnail",
-                  })
-                }}
-              >
-                <Image
-                  width={325}
-                  maxHeight={230}
-                  height={230}
-                  src={artworkImage?.cropped?.src}
-                  srcSet={artworkImage?.cropped?.srcSet}
-                />
-              </RouterLink>
-
-              <EntityHeader
-                mt={1}
-                width={325}
-                name={node.name!}
-                imageUrl={node?.image?.cropped?.url}
-                href={`/artist/${node.slug}`}
-                meta={
-                  node.nationality && node.birthday
-                    ? `${node.nationality}, b. ${node.birthday}`
-                    : undefined
-                }
-                FollowButton={
-                  <FollowArtistButtonFragmentContainer
-                    artist={node}
-                    contextModule={ContextModule.featuredArtistsRail}
-                    buttonProps={{
-                      size: "small",
-                      variant: "secondaryOutline",
-                      width: null,
-                    }}
+            return (
+              <React.Fragment key={index}>
+                <RouterLink
+                  to={node.href}
+                  display="block"
+                  textDecoration="none"
+                  onClick={() => {
+                    tracking.trackEvent({
+                      action_type: AnalyticsSchema.ActionType.Click,
+                      contextModule: ContextModule.relatedArtistsRail,
+                      contextPageOwnerId,
+                      contextPageOwnerSlug,
+                      contextPageOwnerType,
+                      destination_path: node.href,
+                      destinationPageOwnerId: node.internalID,
+                      destinationPageOwnerSlug: node.slug,
+                      destinationPageOwnerType: OwnerType.artwork,
+                      horizontalSlidePosition: index + 1,
+                      type: "thumbnail",
+                    })
+                  }}
+                >
+                  <Image
+                    width={325}
+                    maxHeight={230}
+                    height={230}
+                    src={artworkImage?.cropped?.src}
+                    srcSet={artworkImage?.cropped?.srcSet}
                   />
-                }
-              />
-            </React.Fragment>
-          )
-        })
-      }}
-      data-test="relatedArtistsRail"
-    />
+                </RouterLink>
+
+                <EntityHeader
+                  mt={1}
+                  width={325}
+                  name={node.name!}
+                  imageUrl={node?.image?.cropped?.url}
+                  href={`/artist/${node.slug}`}
+                  meta={
+                    node.nationality && node.birthday
+                      ? `${node.nationality}, b. ${node.birthday}`
+                      : undefined
+                  }
+                  FollowButton={
+                    <FollowArtistButtonFragmentContainer
+                      artist={node}
+                      contextModule={ContextModule.featuredArtistsRail}
+                      buttonProps={{
+                        size: "small",
+                        variant: "secondaryOutline",
+                        width: null,
+                      }}
+                    />
+                  }
+                />
+              </React.Fragment>
+            )
+          })
+        }}
+      />
+    </Box>
   )
 }
 

--- a/src/v2/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
@@ -8,6 +8,7 @@ import { extractNodes } from "v2/Utils/extractNodes"
 import { ArtistWorksForSaleRail_artist } from "v2/__generated__/ArtistWorksForSaleRail_artist.graphql"
 import { scrollToTop } from "../Utils/scrollToTop"
 import { Rail } from "v2/Components/Rail"
+import { Box } from "@artsy/palette"
 
 interface ArtistWorksForSaleRailProps {
   artist: ArtistWorksForSaleRail_artist
@@ -53,32 +54,33 @@ const ArtistWorksForSaleRail: React.FC<ArtistWorksForSaleRailProps> = ({
       getItems={() => {
         return nodes.map((node, index) => {
           return (
-            <ShelfArtworkFragmentContainer
-              artwork={node}
-              contextModule={ContextModule.worksForSaleRail}
-              hidePartnerName
-              key={index}
-              showExtended={false}
-              showMetadata
-              lazyLoad
-              onClick={() => {
-                tracking.trackEvent(
-                  clickedEntityGroup({
-                    contextModule: ContextModule.worksForSaleRail,
-                    contextPageOwnerId,
-                    contextPageOwnerSlug,
-                    // @ts-expect-error STRICT_NULL_CHECK
-                    contextPageOwnerType,
-                    destinationPageOwnerType: OwnerType.artwork,
-                    destinationPageOwnerId: node.internalID,
-                    destinationPageOwnerSlug: node.slug,
-                    horizontalSlidePosition: index + 1,
-                    type: "thumbnail",
-                  })
-                )
-              }}
-              data-test="worksForSaleRail"
-            />
+            <Box data-test="worksForSaleRail">
+              <ShelfArtworkFragmentContainer
+                artwork={node}
+                contextModule={ContextModule.worksForSaleRail}
+                hidePartnerName
+                key={index}
+                showExtended={false}
+                showMetadata
+                lazyLoad
+                onClick={() => {
+                  tracking.trackEvent(
+                    clickedEntityGroup({
+                      contextModule: ContextModule.worksForSaleRail,
+                      contextPageOwnerId,
+                      contextPageOwnerSlug,
+                      // @ts-expect-error STRICT_NULL_CHECK
+                      contextPageOwnerType,
+                      destinationPageOwnerType: OwnerType.artwork,
+                      destinationPageOwnerId: node.internalID,
+                      destinationPageOwnerSlug: node.slug,
+                      horizontalSlidePosition: index + 1,
+                      type: "thumbnail",
+                    })
+                  )
+                }}
+              />
+            </Box>
           )
         })
       }}


### PR DESCRIPTION
Follow-up as it appears react won't pass data attributes down to children as if they were attached to a dom node. 

Fixes test failures after rail refactor. 

See 
- https://app.circleci.com/pipelines/github/artsy/integrity/9095/workflows/dc8c92dd-e98e-4ef6-b2d7-502730b6a43c/jobs/43935 
- https://github.com/artsy/force/pull/8555