### PR TITLE
dont run detect-secrets on renovate branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,11 +200,21 @@ only_release: &only_release
     branches:
       only: release
 
+not_master_or_staging_or_release_or_renovate:
+  &not_master_or_staging_or_release_or_renovate
+  filters:
+    branches:
+      ignore:
+        - master
+        - staging
+        - release
+        - /renovate.*/
+
 workflows:
   default:
     jobs:
       - detect-secrets:
-          <<: *not_master_or_staging_or_release
+          <<: *not_master_or_staging_or_release_or_renovate
 
       # Main build
       - artsy-remote-docker/buildkit-build:


### PR DESCRIPTION
This change prevents running `detect-secrets` in CI on renovate branches.

Test: https://app.circleci.com/pipelines/github/artsy/force?branch=renovate%2Fdetect-secrets-ci-change