### PR TITLE
feat(SystemQueryRenderer): Add new `lazyLoad` prop and update HomeApp rails to support 

### DIFF
--- a/src/v2/Apps/Auctions/Components/MyBids/MyBids.tsx
+++ b/src/v2/Apps/Auctions/Components/MyBids/MyBids.tsx
@@ -211,6 +211,7 @@ export const MyBidsQueryRenderer: React.FC = () => {
 
   return (
     <SystemQueryRenderer<MyBidsQuery>
+      lazyLoad
       environment={relayEnvironment}
       query={graphql`
         query MyBidsQuery {

--- a/src/v2/Apps/Home/Components/HomeAuctionLotsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeAuctionLotsRail.tsx
@@ -136,6 +136,7 @@ export const HomeAuctionLotsRailQueryRenderer: React.FC = () => {
 
   return (
     <SystemQueryRenderer<HomeAuctionLotsRailQuery>
+      lazyLoad
       environment={relayEnvironment}
       query={graphql`
         query HomeAuctionLotsRailQuery {

--- a/src/v2/Apps/Home/Components/HomeCurrentFairs.tsx
+++ b/src/v2/Apps/Home/Components/HomeCurrentFairs.tsx
@@ -202,6 +202,7 @@ export const HomeCurrentFairsQueryRenderer: React.FC = () => {
 
   return (
     <SystemQueryRenderer<HomeCurrentFairsQuery>
+      lazyLoad
       environment={relayEnvironment}
       query={graphql`
         query HomeCurrentFairsQuery {

--- a/src/v2/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
@@ -191,6 +191,7 @@ export const HomeFeaturedGalleriesRailQueryRenderer: React.FC = () => {
 
   return (
     <SystemQueryRenderer<HomeFeaturedGalleriesRailQuery>
+      lazyLoad
       environment={relayEnvironment}
       query={graphql`
         query HomeFeaturedGalleriesRailQuery {

--- a/src/v2/Apps/Home/Components/HomeFeaturedMarketNews.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedMarketNews.tsx
@@ -302,6 +302,7 @@ export const HomeFeaturedMarketNewsQueryRenderer: React.FC = () => {
 
   return (
     <SystemQueryRenderer<HomeFeaturedMarketNewsQuery>
+      lazyLoad
       environment={relayEnvironment}
       query={graphql`
         query HomeFeaturedMarketNewsQuery {

--- a/src/v2/Apps/Home/Components/HomeFeaturedShowsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedShowsRail.tsx
@@ -122,6 +122,7 @@ export const HomeFeaturedShowsRailQueryRenderer: React.FC = () => {
 
   return (
     <SystemQueryRenderer<HomeFeaturedShowsRailQuery>
+      lazyLoad
       environment={relayEnvironment}
       query={graphql`
         query HomeFeaturedShowsRailQuery {

--- a/src/v2/Apps/Home/Components/HomeRecentlyViewedRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeRecentlyViewedRail.tsx
@@ -111,6 +111,7 @@ export const HomeRecentlyViewedRailQueryRenderer: React.FC = () => {
 
   return (
     <SystemQueryRenderer<HomeRecentlyViewedRailQuery>
+      lazyLoad
       environment={relayEnvironment}
       query={graphql`
         query HomeRecentlyViewedRailQuery {

--- a/src/v2/Apps/Home/Components/HomeTrendingArtistsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeTrendingArtistsRail.tsx
@@ -183,6 +183,7 @@ export const HomeTrendingArtistsRailQueryRenderer: React.FC = () => {
 
   return (
     <SystemQueryRenderer<HomeTrendingArtistsRailQuery>
+      lazyLoad
       environment={relayEnvironment}
       query={graphql`
         query HomeTrendingArtistsRailQuery {

--- a/src/v2/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
@@ -111,6 +111,7 @@ export const HomeWorksByArtistsYouFollowRailQueryRenderer: React.FC = () => {
 
   return (
     <SystemQueryRenderer<HomeWorksByArtistsYouFollowRailQuery>
+      lazyLoad
       environment={relayEnvironment}
       query={graphql`
         query HomeWorksByArtistsYouFollowRailQuery {

--- a/src/v2/System/Relay/__tests__/SystemQueryRenderer.jest.tsx
+++ b/src/v2/System/Relay/__tests__/SystemQueryRenderer.jest.tsx
@@ -1,0 +1,81 @@
+import React from "react"
+import { mount } from "enzyme"
+import { SystemQueryRenderer } from "../SystemQueryRenderer"
+import { useDidMount } from "v2/Utils/Hooks/useDidMount"
+import { useLazyLoadComponent } from "v2/Utils/Hooks/useLazyLoadComponent"
+
+jest.mock("v2/Utils/Hooks/useDidMount")
+jest.mock("v2/Utils/Hooks/useLazyLoadComponent")
+
+describe("SystemQueryRenderer", () => {
+  const getWrapper = (props = {}) => {
+    return mount(
+      <SystemQueryRenderer
+        query={null}
+        render={null as any} // we don't need to test underlying QueryRenderer
+        environment={true as any}
+        {...props}
+      />
+    )
+  }
+
+  let mockuseDidMount = useDidMount as jest.Mock
+  let mockuseLazyLoadComponent = useLazyLoadComponent as jest.Mock
+
+  beforeEach(() => {
+    mockuseLazyLoadComponent.mockImplementation(() => ({
+      Waypoint: () => <div />,
+      isEnteredView: false,
+    }))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("doesn't return anything if environment is null", () => {
+    const wrapper = getWrapper({ environment: null })
+    expect(wrapper.find("QueryRenderer").length).toBe(0)
+  })
+
+  it("does not render if not mounted on client", () => {
+    mockuseDidMount.mockImplementation(() => false)
+    const wrapper = getWrapper()
+    expect(wrapper.find("QueryRenderer").length).toBe(0)
+  })
+
+  it("renders a placeholder if provided", () => {
+    const wrapper = getWrapper({ placeholder: <>placeholder</> })
+    expect(wrapper.text()).toContain("placeholder")
+  })
+
+  it("renders a QueryRenderer", () => {
+    mockuseDidMount.mockImplementation(() => true)
+    const wrapper = getWrapper()
+    expect(wrapper.find("QueryRenderer").length).toBe(1)
+  })
+
+  describe("lazyLoad = true", () => {
+    it("injects a <Waypoint />", () => {
+      const wrapper = getWrapper({
+        placeholder: <>lazyload placeholder</>,
+        lazyLoad: true,
+      })
+      expect(wrapper.find("Waypoint").length).toBe(1)
+      expect(wrapper.text()).toContain("lazyload placeholder")
+      expect(wrapper.find("QueryRenderer").length).toBe(0)
+    })
+
+    it("renders if isEnteredView is true", () => {
+      mockuseLazyLoadComponent.mockImplementation(() => ({
+        Waypoint: () => <div />,
+        isEnteredView: true,
+      }))
+      const wrapper = getWrapper({
+        placeholder: <>lazyload placeholder</>,
+        lazyLoad: true,
+      })
+      expect(wrapper.find("QueryRenderer").length).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a new `lazyLoad` prop to our `SystemQueryRenderer` which aggregates some functionality we've been using around force. 

**The flow:** 
- For performance reasons we've started offloading some queries to "below the fold" client-side-only query renderers (versus loading _all_ page data upfront on the SSR render pass and thereby being required to wait until the slowest request returns before showing anything to the user) 
- It's common to put a bunch of query renderers on the page and fire off requests in parallel on page load
- We have a nice mechanism for lazy loading via `useLazyLoadComponent`
- We should only fire said query when the user scrolls into the view, otherwise just show the placeholder

**Next up:** 
- [x] Look through force at our [voluminous `SystemQueryRenderer` usage](https://github.com/artsy/force/pull/8588) and make lazy (if appropriate) 
- Start deferring query fragments on `/artist/:id` and `/artwork/:id` apps to the client via lazyLoad + SystemQueryRenderer