### PR TITLE
GRO-561:  Sign up homepage banner color palette adjustment

### DIFF
--- a/src/v2/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
+++ b/src/v2/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
@@ -39,7 +39,6 @@ export interface HomeHeroUnitProps {
   heroUnit: HomeHeroUnit_heroUnit | StaticHeroUnit
   layout: "a" | "b"
   index: number
-  bg?: string
 }
 
 export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({

--- a/src/v2/Apps/Home/Components/HomeHeroUnits/HomeHeroUnits.tsx
+++ b/src/v2/Apps/Home/Components/HomeHeroUnits/HomeHeroUnits.tsx
@@ -35,7 +35,6 @@ const HomeHeroUnits: React.FC<HomeHeroUnitsProps> = ({ homePage }) => {
           index={i}
           heroUnit={heroUnit as StaticHeroUnit}
           layout={i % 2 === 0 ? "b" : "a"}
-          bg="black100"
         />
       )
     }
@@ -46,7 +45,6 @@ const HomeHeroUnits: React.FC<HomeHeroUnitsProps> = ({ homePage }) => {
         index={i}
         heroUnit={heroUnit}
         layout={i % 2 === 0 ? "b" : "a"}
-        bg="black5"
       />
     )
   })


### PR DESCRIPTION
[GRO-561]

The 1st sign up banner on the homepage for logged out users has black background white text vs. the others with grey background and black text (examples attached) 

Team would like to move to keep these all the same color. Marketing can update all other banners with the admin tool but the Sign up one will need to be updated separately 

New Behavior
<img width="1789" alt="Screen Shot 2021-10-08 at 11 59 15 AM" src="https://user-images.githubusercontent.com/30025439/136811760-f34bfc40-14fc-47a5-b9b1-4e8d76574838.png">
:


[GRO-561]: https://artsyproduct.atlassian.net/browse/GRO-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ