### PR TITLE
GROW-510: Curatorial Rail reorder

### DIFF
--- a/src/v2/Apps/Auctions/Components/CuritorialRailsTabBar.tsx
+++ b/src/v2/Apps/Auctions/Components/CuritorialRailsTabBar.tsx
@@ -28,11 +28,11 @@ export const CuritorialRailsTabBar: React.FC<CuritorialRailsTabBarProps> = ({
           </Join>
         </Tab>
       )}
-      <Tab name="Trending Lots">
-        <TrendingLotsRailFragmentContainer viewer={viewer} />
-      </Tab>
       <Tab name="Standout Lots">
         <StandoutLotsRailFragmentContainer viewer={viewer} />
+      </Tab>
+      <Tab name="Trending Lots">
+        <TrendingLotsRailFragmentContainer viewer={viewer} />
       </Tab>
     </Tabs>
   )


### PR DESCRIPTION
[GRO-510]
This is to rearrange the curatorial rails, due to the ongoing work that needs to be looked into for TrendingAuctions.
<img width="1782" alt="Screen Shot 2021-10-11 at 2 14 17 PM" src="https://user-images.githubusercontent.com/30025439/136857396-43ca1a72-e100-442d-93e0-f8b8e6a1ff2d.png">



[GRO-510]: https://artsyproduct.atlassian.net/browse/GRO-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ