### PR TITLE
chore: track analytics for all buyer guarantee clicks (px-4631)

### DIFF
--- a/src/v2/Apps/Order/Components/BuyerGuarantee.tsx
+++ b/src/v2/Apps/Order/Components/BuyerGuarantee.tsx
@@ -7,8 +7,8 @@ export const BUYER_GUARANTEE_URL =
   "https://support.artsy.net/hc/en-us/articles/360048946973-How-does-Artsy-protect-me"
 
 interface BuyerGuaranteeProps {
-  contextModule?: ContextModule
-  contextPageOwnerType?: string
+  contextModule: ContextModule
+  contextPageOwnerType: string
 }
 
 export const BuyerGuarantee: React.FC<BuyerGuaranteeProps> = ({

--- a/src/v2/Apps/Order/Routes/Accept/index.tsx
+++ b/src/v2/Apps/Order/Routes/Accept/index.tsx
@@ -27,6 +27,7 @@ import createLogger from "v2/Utils/logger"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "../../Components/ArtworkSummaryItem"
 import { CreditCardSummaryItemFragmentContainer as CreditCardSummaryItem } from "../../Components/CreditCardSummaryItem"
 import { BuyerGuarantee } from "../../Components/BuyerGuarantee"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 
 interface AcceptProps {
   order: Accept_order
@@ -218,7 +219,10 @@ export class Accept extends Component<AcceptProps> {
                 <ShippingSummaryItem order={order} locked />
                 <CreditCardSummaryItem order={order} locked />
               </Flex>
-              <BuyerGuarantee />
+              <BuyerGuarantee
+                contextModule={ContextModule.ordersAccept}
+                contextPageOwnerType={OwnerType.ordersAccept}
+              />
               <Media greaterThan="xs">
                 <Spacer mb={2} />
               </Media>

--- a/src/v2/Apps/Order/Routes/Counter/index.tsx
+++ b/src/v2/Apps/Order/Routes/Counter/index.tsx
@@ -25,6 +25,7 @@ import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 import createLogger from "v2/Utils/logger"
 import { Media } from "v2/Utils/Responsive"
 import { BuyerGuarantee } from "../../Components/BuyerGuarantee"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 
 export interface CounterProps {
   order: Counter_order
@@ -175,7 +176,10 @@ export class CounterRoute extends Component<CounterProps> {
                 <ShippingSummaryItem order={order} locked />
                 <CreditCardSummaryItem order={order} locked />
               </Flex>
-              <BuyerGuarantee />
+              <BuyerGuarantee
+                contextModule={ContextModule.ordersCounter}
+                contextPageOwnerType={OwnerType.ordersCounter}
+              />
               <Media greaterThan="xs">
                 <Spacer mb={2} />
               </Media>

--- a/src/v2/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/v2/Apps/Order/Routes/NewPayment/index.tsx
@@ -27,6 +27,7 @@ import {
 import { get } from "v2/Utils/get"
 import { BuyerGuarantee } from "../../Components/BuyerGuarantee"
 import { createStripeWrapper } from "v2/Utils/createStripeWrapper"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 
 export const ContinueButton = props => (
   <Button variant="primaryBlack" width="100%" {...props}>
@@ -182,7 +183,10 @@ export class NewPaymentRoute extends Component<
                 <ArtworkSummaryItem order={order} />
                 <TransactionDetailsSummaryItem order={order} />
               </Flex>
-              <BuyerGuarantee />
+              <BuyerGuarantee
+                contextModule={ContextModule.ordersNewPayment}
+                contextPageOwnerType={OwnerType.ordersNewPayment}
+              />
               <Spacer mb={[2, 4]} />
               <Media at="xs">
                 <>

--- a/src/v2/Apps/Order/Routes/Offer/index.tsx
+++ b/src/v2/Apps/Order/Routes/Offer/index.tsx
@@ -29,6 +29,7 @@ import { Media } from "v2/Utils/Responsive"
 import { OrderStepper, offerFlowSteps } from "../../Components/OrderStepper"
 import { BuyerGuarantee } from "../../Components/BuyerGuarantee"
 import { getOfferItemFromOrder } from "v2/Apps/Order/Utils/offerItemExtractor"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 
 export interface OfferProps {
   order: Offer_order
@@ -294,7 +295,10 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
                   }
                 />
               </Flex>
-              <BuyerGuarantee />
+              <BuyerGuarantee
+                contextModule={ContextModule.ordersOffer}
+                contextPageOwnerType={OwnerType.ordersOffer}
+              />
               <Spacer mb={[2, 4]} />
               <Media at="xs">
                 <>

--- a/src/v2/Apps/Order/Routes/Payment/index.tsx
+++ b/src/v2/Apps/Order/Routes/Payment/index.tsx
@@ -29,6 +29,7 @@ import {
 } from "v2/Apps/Order/Utils/commitMutation"
 import { AnalyticsSchema, track } from "v2/System"
 import { BuyerGuarantee } from "../../Components/BuyerGuarantee"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 
 export const ContinueButton = props => (
   <Button variant="primaryBlack" width="100%" {...props}>
@@ -152,7 +153,10 @@ export class PaymentRoute extends Component<
                 <ArtworkSummaryItem order={order} />
                 <TransactionDetailsSummaryItem order={order} />
               </Flex>
-              <BuyerGuarantee />
+              <BuyerGuarantee
+                contextModule={ContextModule.ordersPayment}
+                contextPageOwnerType={OwnerType.ordersPayment}
+              />
               <Spacer mb={[2, 4]} />
               <Media at="xs">
                 <>

--- a/src/v2/Apps/Order/Routes/Respond/index.tsx
+++ b/src/v2/Apps/Order/Routes/Respond/index.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../Components/OrderStepper"
 import { ShippingSummaryItemFragmentContainer as ShippingSummaryItem } from "../../Components/ShippingSummaryItem"
 import { BuyerGuarantee } from "../../Components/BuyerGuarantee"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 
 export interface RespondProps extends RouterState {
   order: Respond_order
@@ -322,7 +323,10 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
                 <ShippingSummaryItem order={order} locked />
                 <CreditCardSummaryItem order={order} locked />
               </Flex>
-              <BuyerGuarantee />
+              <BuyerGuarantee
+                contextModule={ContextModule.ordersRespond}
+                contextPageOwnerType={OwnerType.ordersRespond}
+              />
               <Spacer mb={2} />
               <Media at="xs">
                 <>


### PR DESCRIPTION
Addresses [PX-4631].

This is more follow-up work to the tracking changes we made right before launching ARTA. We were tracking clicks on the BuyerGuarantee component when it was rendered from the Order app's Shipping route, but _only_ that route. This PR updates the Order app to track those clicks from every route.

[PX-4631]: https://artsyproduct.atlassian.net/browse/PX-4631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ