### PR TITLE
chore: hide artist follow counts for mid breakpoints

### DIFF
--- a/src/v2/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -80,7 +80,11 @@ const ArtistHeader: React.FC<ArtistHeaderProps> = ({ artist }) => {
             </Column>
 
             {!!artist.counts?.follows && (
-              <Column span={6} display={["block", "flex"]} alignItems="center">
+              <Column
+                span={6}
+                display={["block", "none", "none", "flex"]}
+                alignItems="center"
+              >
                 <Text
                   variant="xs"
                   color="black60"


### PR DESCRIPTION
Before:
<img width="781" alt="Screen Shot 2021-10-12 at 5 17 22 PM" src="https://user-images.githubusercontent.com/5361806/137112894-308a87f9-e597-433e-ad14-3374ebe41146.png">

After:
![breakpoints](https://user-images.githubusercontent.com/5361806/137112847-3b0b456c-c617-42f5-bc24-eb4acf918ec6.gif)
