### PR TITLE
chore: Move detect-secrets call to formal lit-staged list

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cypress:run": "./node_modules/.bin/cypress run",
     "cypress": "./node_modules/.bin/cypress open",
     "delete-review-app": "kubectl --context staging delete namespace",
+    "detect-secrets": "scripts/detect-secrets.sh",
     "docker": "DOCKER_BUILDKIT=1; BUILDKIT_PROGRESS=plain; COMPOSE_DOCKER_CLI_BUILD=1; docker build .",
     "docker:builder": "yarn docker --target builder -t force:builder",
     "docker:electron": "yarn docker --target electron-runner -t force:electron",
@@ -50,7 +51,7 @@
     "sync-schema-local": "scripts/sync-schema-local.sh",
     "test": "concurrently 'yarn test:ci:jest:legacy' 'yarn test:ci:jest:v2' 'yarn test:ci:mocha'",
     "test:smoke": "scripts/smoke_test.sh",
-		"test:smoke:spec": "./node_modules/.bin/cypress run -s",
+    "test:smoke:spec": "./node_modules/.bin/cypress run -s",
     "test:ci:jest:legacy": "scripts/jest.sh legacy",
     "test:ci:jest:v2": "scripts/jest.sh v2",
     "test:ci:mocha": "NODE_ENV=test yarn mocha src/**/*.test.js src/**/*.test.ts",
@@ -414,11 +415,12 @@
   "husky": {
     "hooks": {
       "post-merge": "sh scripts/pull-lock.sh",
-      "pre-commit": "lint-staged && scripts/detect-secrets.sh",
+      "pre-commit": "lint-staged",
       "pre-push": "yarn type-check"
     }
   },
   "lint-staged": {
+    "*": "yarn detect-secrets",
     "*.@(md)": [
       "yarn prettier-write"
     ],


### PR DESCRIPTION
This formalizes our use of `detect-secrets` + git hooks by placing it within the `lint-staged` chain of command:
 
<img width="399" alt="Screen Shot 2021-10-14 at 11 57 24 AM" src="https://user-images.githubusercontent.com/236943/137380598-9c732154-f3bd-4683-87b5-defdf8295ed1.png">

This also fixes the cannot use `--no-verify` issue. 