### PR TITLE
feat(partners): roughs in /galleries2, /institutions2 routes

### DIFF
--- a/src/v2/Apps/Partners/Components/PartnersRail.tsx
+++ b/src/v2/Apps/Partners/Components/PartnersRail.tsx
@@ -1,0 +1,88 @@
+import { compact, take } from "lodash"
+import React, { useMemo } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { PartnerCellFragmentContainer } from "v2/Components/Cells/PartnerCell"
+import { Rail } from "v2/Components/Rail"
+import { PartnersRail_partnerCategory } from "v2/__generated__/PartnersRail_partnerCategory.graphql"
+
+interface PartnersRailProps {
+  partnerCategory: PartnersRail_partnerCategory
+}
+
+const PartnersRail: React.FC<PartnersRailProps> = ({ partnerCategory }) => {
+  const partners = useMemo(() => {
+    return mergeBuckets(
+      compact(partnerCategory.primary),
+      compact(partnerCategory.secondary)
+    )
+  }, [partnerCategory.primary, partnerCategory.secondary])
+
+  return (
+    <Rail
+      title={partnerCategory.name!}
+      getItems={() => {
+        return partners.map(partner => {
+          return (
+            <PartnerCellFragmentContainer
+              key={partner.internalID}
+              partner={partner}
+            />
+          )
+        })
+      }}
+    />
+  )
+}
+
+export const PartnersRailFragmentContainer = createFragmentContainer(
+  PartnersRail,
+  {
+    partnerCategory: graphql`
+      fragment PartnersRail_partnerCategory on PartnerCategory
+        @argumentDefinitions(type: { type: "[PartnerClassification!]!" }) {
+        name
+        primary: partners(
+          eligibleForListing: true
+          eligibleForPrimaryBucket: true
+          type: $type
+          sort: RANDOM_SCORE_DESC
+          defaultProfilePublic: true
+        ) {
+          internalID
+          ...PartnerCell_partner
+        }
+        secondary: partners(
+          eligibleForListing: true
+          eligibleForSecondaryBucket: true
+          type: $type
+          sort: RANDOM_SCORE_DESC
+          defaultProfilePublic: true
+        ) {
+          internalID
+          ...PartnerCell_partner
+        }
+      }
+    `,
+  }
+)
+
+const desiredTotal = 9
+const desiredPrimary = 6
+const desiredSecondary = 3
+
+// TODO: In the original implemntation, each section was independently shuffled.
+// We need a way to do a SSR-stable shuffle for this to work.
+const mergeBuckets = <T,>(primary: T[], secondary: T[]): T[] => {
+  if (primary.length < desiredPrimary) {
+    return [...primary, ...take(secondary, desiredTotal - primary.length)]
+  }
+
+  if (secondary.length < desiredSecondary) {
+    return [...take(primary, desiredTotal - secondary.length), ...secondary]
+  }
+
+  return [
+    ...take(primary, desiredPrimary),
+    ...take(secondary, desiredSecondary),
+  ]
+}

--- a/src/v2/Apps/Partners/Routes/GalleriesRoute.tsx
+++ b/src/v2/Apps/Partners/Routes/GalleriesRoute.tsx
@@ -1,0 +1,137 @@
+import {
+  AutocompleteInput,
+  Button,
+  Column,
+  GridColumns,
+  Join,
+  Separator,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { compact } from "lodash"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { MetaTags } from "v2/Components/MetaTags"
+import { GalleriesRoute_viewer } from "v2/__generated__/GalleriesRoute_viewer.graphql"
+import { PartnersRailFragmentContainer } from "v2/Apps/Partners/Components/PartnersRail"
+
+interface GalleriesRouteProps {
+  viewer: GalleriesRoute_viewer
+}
+
+const GalleriesRoute: React.FC<GalleriesRouteProps> = ({ viewer }) => {
+  // TODO: In the original implementation these categories are shuffled.
+  // We need a way to do SSR-stable shuffle.
+  const categories = compact(viewer.partnerCategories)
+
+  return (
+    <>
+      <MetaTags
+        title="Galleries | Artsy"
+        description="Browse art and design galleries around the globe by location and specialty and explore artists, artworks, shows, and fair booths."
+      />
+
+      <Join separator={<Spacer mt={4} />}>
+        <Text variant="xl" mt={4}>
+          Browse Galleries
+        </Text>
+
+        <GridColumns>
+          <Column span={4}>
+            <AutocompleteInput
+              options={[]}
+              placeholder="All Locations"
+              mb={2}
+              onChange={() => {
+                // TODO
+              }}
+              value=""
+            />
+          </Column>
+
+          <Column span={4}>
+            <AutocompleteInput
+              options={[]}
+              placeholder="All Specialties"
+              mb={2}
+              onChange={() => {
+                // TODO
+              }}
+              value=""
+            />
+          </Column>
+
+          <Column span={4}>
+            <AutocompleteInput
+              options={[]}
+              placeholder="All Galleries"
+              mb={2}
+              onChange={() => {
+                // TODO
+              }}
+              value=""
+            />
+          </Column>
+        </GridColumns>
+
+        {categories.map((partnerCategory, i) => {
+          return (
+            <PartnersRailFragmentContainer
+              key={i}
+              partnerCategory={partnerCategory}
+            />
+          )
+        })}
+
+        <Separator />
+
+        <GridColumns>
+          <Column span={6} textAlign="center">
+            <Text variant="lg" mb={2}>
+              Interested in Listing Your Gallery on Artsy?
+            </Text>
+
+            <Button
+              variant="secondaryOutline"
+              // @ts-ignore
+              as="a"
+              href="https://partners.artsy.net/"
+            >
+              Learn more
+            </Button>
+          </Column>
+
+          <Column span={6} textAlign="center">
+            <Text variant="lg" mb={2}>
+              Read Artsy Insights for Galleries
+            </Text>
+
+            <Button
+              variant="secondaryOutline"
+              // @ts-ignore
+              as="a"
+              href="https://partners.artsy.net/"
+            >
+              Explore
+            </Button>
+          </Column>
+        </GridColumns>
+      </Join>
+    </>
+  )
+}
+
+export const GalleriesRouteFragmentContainer = createFragmentContainer(
+  GalleriesRoute,
+  {
+    viewer: graphql`
+      fragment GalleriesRoute_viewer on Viewer {
+        partnerCategories(categoryType: GALLERY, size: 50, internal: false) {
+          name
+          slug
+          ...PartnersRail_partnerCategory @arguments(type: GALLERY)
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Partners/Routes/InstitutionsRoute.tsx
+++ b/src/v2/Apps/Partners/Routes/InstitutionsRoute.tsx
@@ -1,0 +1,126 @@
+import {
+  AutocompleteInput,
+  Button,
+  Column,
+  GridColumns,
+  Join,
+  Separator,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { compact } from "lodash"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { MetaTags } from "v2/Components/MetaTags"
+import { InstitutionsRoute_viewer } from "v2/__generated__/InstitutionsRoute_viewer.graphql"
+import { PartnersRailFragmentContainer } from "../Components/PartnersRail"
+
+interface InstitutionsRouteProps {
+  viewer: InstitutionsRoute_viewer
+}
+
+const InstitutionsRoute: React.FC<InstitutionsRouteProps> = ({ viewer }) => {
+  // TODO: In the original implementation these categories are shuffled.
+  // We need a way to do SSR-stable shuffle.
+  const categories = compact(viewer.partnerCategories)
+
+  return (
+    <>
+      <MetaTags
+        title="Institutions | Artsy"
+        description="Artsy promotes the collections, shows, and programs of the Louvre, Getty Museum, Robert Rauschenberg Foundation, and 600+ other museums and institutions worldwide."
+      />
+
+      <Join separator={<Spacer mt={4} />}>
+        <Text variant="xl" mt={4}>
+          Browse Institutions
+        </Text>
+
+        <GridColumns>
+          <Column span={4}>
+            <AutocompleteInput
+              options={[]}
+              placeholder="All Locations"
+              mb={2}
+              onChange={() => {
+                // TODO
+              }}
+              value=""
+            />
+          </Column>
+
+          <Column span={4}>
+            <AutocompleteInput
+              options={[]}
+              placeholder="All Specialties"
+              mb={2}
+              onChange={() => {
+                // TODO
+              }}
+              value=""
+            />
+          </Column>
+
+          <Column span={4}>
+            <AutocompleteInput
+              options={[]}
+              placeholder="All Institutions"
+              mb={2}
+              onChange={() => {
+                // TODO
+              }}
+              value=""
+            />
+          </Column>
+        </GridColumns>
+
+        {categories.map((partnerCategory, i) => {
+          return (
+            <PartnersRailFragmentContainer
+              key={i}
+              partnerCategory={partnerCategory}
+            />
+          )
+        })}
+
+        <Separator />
+
+        <GridColumns>
+          <Column span={6} start={4} textAlign="center">
+            <Text variant="lg" mb={2}>
+              Interested in Listing Your Museum on Artsy?
+            </Text>
+
+            <Button
+              variant="secondaryOutline"
+              // @ts-ignore
+              as="a"
+              href="https://partners.artsy.net/"
+            >
+              Learn more
+            </Button>
+          </Column>
+        </GridColumns>
+      </Join>
+    </>
+  )
+}
+
+export const InstitutionsRouteFragmentContainer = createFragmentContainer(
+  InstitutionsRoute,
+  {
+    viewer: graphql`
+      fragment InstitutionsRoute_viewer on Viewer {
+        partnerCategories(
+          categoryType: INSTITUTION
+          size: 50
+          internal: false
+        ) {
+          name
+          slug
+          ...PartnersRail_partnerCategory @arguments(type: INSTITUTION)
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Partners/__tests__/GalleriesRoute.jest.tsx
+++ b/src/v2/Apps/Partners/__tests__/GalleriesRoute.jest.tsx
@@ -1,0 +1,53 @@
+import React from "react"
+import { graphql } from "react-relay"
+import { GalleriesRouteFragmentContainer } from "../Routes/GalleriesRoute"
+import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
+import { GalleriesRouteFragmentContainer_Test_Query } from "v2/__generated__/GalleriesRouteFragmentContainer_Test_Query.graphql"
+import { MockBoot } from "v2/DevTools"
+import { screen } from "@testing-library/react"
+import { useTracking } from "react-tracking"
+
+jest.unmock("react-relay")
+
+jest.mock("v2/Components/FollowButton/FollowProfileButton", () => ({
+  FollowProfileButtonFragmentContainer: () => null,
+}))
+
+jest.mock("v2/System/Analytics/useTracking", () => ({
+  useTracking: () => ({}),
+}))
+
+const { renderWithRelay } = setupTestWrapperTL<
+  GalleriesRouteFragmentContainer_Test_Query
+>({
+  Component: ({ viewer }) => {
+    return (
+      <MockBoot>
+        <GalleriesRouteFragmentContainer viewer={viewer!} />
+      </MockBoot>
+    )
+  },
+  query: graphql`
+    query GalleriesRouteFragmentContainer_Test_Query {
+      viewer {
+        ...GalleriesRoute_viewer
+      }
+    }
+  `,
+})
+
+describe("GalleriesRoute", () => {
+  const trackEvent = jest.fn()
+  beforeEach(() => {
+    renderWithRelay()
+    ;(useTracking as jest.Mock).mockImplementation(() => ({ trackEvent }))
+  })
+
+  afterEach(() => {
+    trackEvent.mockReset()
+  })
+
+  it("renders the page", () => {
+    expect(screen.getByText("Browse Galleries")).toBeInTheDocument()
+  })
+})

--- a/src/v2/Apps/Partners/__tests__/InstitutionsRoute.jest.tsx
+++ b/src/v2/Apps/Partners/__tests__/InstitutionsRoute.jest.tsx
@@ -1,0 +1,53 @@
+import React from "react"
+import { graphql } from "react-relay"
+import { InstitutionsRouteFragmentContainer } from "../Routes/InstitutionsRoute"
+import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
+import { InstitutionsRouteFragmentContainer_Test_Query } from "v2/__generated__/InstitutionsRouteFragmentContainer_Test_Query.graphql"
+import { MockBoot } from "v2/DevTools"
+import { screen } from "@testing-library/react"
+import { useTracking } from "react-tracking"
+
+jest.unmock("react-relay")
+
+jest.mock("v2/Components/FollowButton/FollowProfileButton", () => ({
+  FollowProfileButtonFragmentContainer: () => null,
+}))
+
+jest.mock("v2/System/Analytics/useTracking", () => ({
+  useTracking: () => ({}),
+}))
+
+const { renderWithRelay } = setupTestWrapperTL<
+  InstitutionsRouteFragmentContainer_Test_Query
+>({
+  Component: ({ viewer }) => {
+    return (
+      <MockBoot>
+        <InstitutionsRouteFragmentContainer viewer={viewer!} />
+      </MockBoot>
+    )
+  },
+  query: graphql`
+    query InstitutionsRouteFragmentContainer_Test_Query {
+      viewer {
+        ...InstitutionsRoute_viewer
+      }
+    }
+  `,
+})
+
+describe("InstitutionsRoute", () => {
+  const trackEvent = jest.fn()
+  beforeEach(() => {
+    renderWithRelay()
+    ;(useTracking as jest.Mock).mockImplementation(() => ({ trackEvent }))
+  })
+
+  afterEach(() => {
+    trackEvent.mockReset()
+  })
+
+  it("renders the page", () => {
+    expect(screen.getByText("Browse Institutions")).toBeInTheDocument()
+  })
+})

--- a/src/v2/Apps/Partners/partnersRoutes.ts
+++ b/src/v2/Apps/Partners/partnersRoutes.ts
@@ -1,0 +1,52 @@
+import loadable from "@loadable/component"
+import { graphql } from "react-relay"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const GalleriesRoute = loadable(
+  () =>
+    import(/* webpackChunkName: "partnersBundle" */ "./Routes/GalleriesRoute"),
+  { resolveComponent: component => component.GalleriesRouteFragmentContainer }
+)
+
+const InstitutionsRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "partnersBundle" */ "./Routes/InstitutionsRoute"
+    ),
+  {
+    resolveComponent: component => component.InstitutionsRouteFragmentContainer,
+  }
+)
+
+export const partnersRoutes: AppRouteConfig[] = [
+  {
+    theme: "v3",
+    path: "/galleries2",
+    getComponent: () => GalleriesRoute,
+    prepare: () => {
+      return GalleriesRoute.preload()
+    },
+    query: graphql`
+      query partnersRoutes_GalleriesRouteQuery {
+        viewer {
+          ...GalleriesRoute_viewer
+        }
+      }
+    `,
+  },
+  {
+    theme: "v3",
+    path: "/institutions2",
+    getComponent: () => InstitutionsRoute,
+    prepare: () => {
+      return InstitutionsRoute.preload()
+    },
+    query: graphql`
+      query partnersRoutes_InstitutionsRouteQuery {
+        viewer {
+          ...InstitutionsRoute_viewer
+        }
+      }
+    `,
+  },
+]

--- a/src/v2/Components/Cells/PartnerCell.tsx
+++ b/src/v2/Components/Cells/PartnerCell.tsx
@@ -1,0 +1,160 @@
+import {
+  ActionType,
+  ClickedGalleryGroup,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
+import {
+  Box,
+  EntityHeader,
+  Image,
+  SkeletonBox,
+  SkeletonText,
+  Text,
+} from "@artsy/palette"
+import { uniq } from "lodash"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "v2/System/Analytics/useTracking"
+import { useSystemContext } from "v2/System"
+import { RouterLink } from "v2/System/Router/RouterLink"
+import { extractNodes } from "v2/Utils/extractNodes"
+import { PartnerCell_partner } from "v2/__generated__/PartnerCell_partner.graphql"
+import { FollowProfileButtonFragmentContainer } from "v2/Components/FollowButton/FollowProfileButton"
+
+interface PartnerCellProps {
+  partner: PartnerCell_partner
+}
+
+const PartnerCell: React.FC<PartnerCellProps> = ({ partner }) => {
+  const { user } = useSystemContext()
+  const { trackEvent } = useTracking()
+
+  const locations = extractNodes(partner.locationsConnection)
+  const meta = uniq(locations.map(location => location.city?.trim())).join(", ")
+  const image = partner.profile?.image?.cropped
+
+  if (!partner.profile) {
+    return null
+  }
+
+  return (
+    <RouterLink
+      to={`/partner${partner.href}`}
+      display="block"
+      textDecoration="none"
+      width={325}
+      onClick={() => {
+        const trackingEvent: ClickedGalleryGroup = {
+          action: ActionType.clickedGalleryGroup,
+          context_module: ContextModule.featuredGalleriesRail,
+          context_page_owner_type: OwnerType.home,
+          destination_page_owner_id: partner.internalID,
+          destination_page_owner_slug: partner.slug,
+          destination_page_owner_type: OwnerType.galleries,
+          type: "thumbnail",
+        }
+
+        trackEvent(trackingEvent)
+      }}
+    >
+      <EntityHeader
+        name={partner.name!}
+        meta={meta}
+        smallVariant
+        mb={1}
+        FollowButton={
+          <FollowProfileButtonFragmentContainer
+            user={user}
+            profile={partner.profile}
+            contextModule={ContextModule.partnerHeader}
+            buttonProps={{ size: "small", variant: "secondaryOutline" }}
+            onClick={() => {
+              const trackingEvent: any = {
+                action: partner.profile?.isFollowed
+                  ? ActionType.unfollowedPartner
+                  : ActionType.followedPartner,
+                context_module: ContextModule.featuredGalleriesRail,
+                context_owner_type: OwnerType.partner,
+              }
+
+              trackEvent(trackingEvent)
+            }}
+          />
+        }
+      />
+
+      {image?.src ? (
+        <Image
+          src={image.src}
+          srcSet={image.srcSet}
+          width={325}
+          height={244}
+          alt=""
+          lazyLoad
+          style={{ display: "block" }}
+        />
+      ) : (
+        <Text
+          variant="lg"
+          bg="black10"
+          width={325}
+          height={244}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          {partner.initials}
+        </Text>
+      )}
+    </RouterLink>
+  )
+}
+
+export const PARTNER_CELL_PLACEHOLDER = (
+  <Box width={325}>
+    <SkeletonText variant="lg">Example Gallery</SkeletonText>
+
+    <SkeletonText variant="md" mb={1}>
+      Location
+    </SkeletonText>
+
+    <SkeletonBox width={325} height={244} />
+  </Box>
+)
+
+export const PartnerCellFragmentContainer = createFragmentContainer(
+  PartnerCell,
+  {
+    partner: graphql`
+      fragment PartnerCell_partner on Partner {
+        internalID
+        slug
+        name
+        href
+        initials
+        locationsConnection(first: 15) {
+          edges {
+            node {
+              city
+            }
+          }
+        }
+        profile {
+          ...FollowProfileButton_profile
+          isFollowed
+          image {
+            cropped(
+              width: 325
+              height: 244
+              version: ["wide", "large", "featured", "larger"]
+            ) {
+              src
+              srcSet
+            }
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Components/Cells/__tests__/PartnerCell.jest.tsx
+++ b/src/v2/Components/Cells/__tests__/PartnerCell.jest.tsx
@@ -1,0 +1,56 @@
+import { graphql } from "react-relay"
+import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
+import { PartnerCellFragmentContainer_Test_Query } from "v2/__generated__/PartnerCellFragmentContainer_Test_Query.graphql"
+import { screen } from "@testing-library/react"
+import { PartnerCellFragmentContainer } from "../PartnerCell"
+
+jest.unmock("react-relay")
+
+jest.mock("v2/Components/FollowButton/FollowProfileButton", () => ({
+  FollowProfileButtonFragmentContainer: () => null,
+}))
+
+jest.mock("v2/System/Analytics/useTracking", () => ({
+  useTracking: () => ({}),
+}))
+
+const { renderWithRelay } = setupTestWrapperTL<
+  PartnerCellFragmentContainer_Test_Query
+>({
+  Component: PartnerCellFragmentContainer,
+  query: graphql`
+    query PartnerCellFragmentContainer_Test_Query {
+      partner(id: "example") {
+        ...PartnerCell_partner
+      }
+    }
+  `,
+})
+
+describe("PartnerCell", () => {
+  it("renders the component", () => {
+    renderWithRelay({
+      Partner: () => ({
+        name: "Example Gallery",
+      }),
+    })
+
+    expect(screen.getByText("Example Gallery")).toBeInTheDocument()
+  })
+
+  describe("without image", () => {
+    it("renders the initials instead", () => {
+      renderWithRelay({
+        Profile: () => ({
+          image: null,
+        }),
+        Partner: () => ({
+          name: "Example Gallery",
+          initials: "EG",
+        }),
+      })
+
+      expect(screen.getByText("EG")).toBeInTheDocument()
+    })
+  })
+})

--- a/src/v2/__generated__/GalleriesRouteFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/GalleriesRouteFragmentContainer_Test_Query.graphql.ts
@@ -1,0 +1,412 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type GalleriesRouteFragmentContainer_Test_QueryVariables = {};
+export type GalleriesRouteFragmentContainer_Test_QueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"GalleriesRoute_viewer">;
+    } | null;
+};
+export type GalleriesRouteFragmentContainer_Test_Query = {
+    readonly response: GalleriesRouteFragmentContainer_Test_QueryResponse;
+    readonly variables: GalleriesRouteFragmentContainer_Test_QueryVariables;
+};
+
+
+
+/*
+query GalleriesRouteFragmentContainer_Test_Query {
+  viewer {
+    ...GalleriesRoute_viewer
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  is_followed: isFollowed
+}
+
+fragment GalleriesRoute_viewer on Viewer {
+  partnerCategories(categoryType: GALLERY, size: 50, internal: false) {
+    name
+    slug
+    ...PartnersRail_partnerCategory_uMgyM
+    id
+  }
+}
+
+fragment PartnerCell_partner on Partner {
+  internalID
+  slug
+  name
+  href
+  initials
+  locationsConnection(first: 15) {
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
+  profile {
+    ...FollowProfileButton_profile
+    isFollowed
+    image {
+      cropped(width: 325, height: 244, version: ["wide", "large", "featured", "larger"]) {
+        src
+        srcSet
+      }
+    }
+    id
+  }
+}
+
+fragment PartnersRail_partnerCategory_uMgyM on PartnerCategory {
+  name
+  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
+    internalID
+    ...PartnerCell_partner
+    id
+  }
+  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
+    internalID
+    ...PartnerCell_partner
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v2 = {
+  "kind": "Literal",
+  "name": "defaultProfilePublic",
+  "value": true
+},
+v3 = {
+  "kind": "Literal",
+  "name": "eligibleForListing",
+  "value": true
+},
+v4 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "RANDOM_SCORE_DESC"
+},
+v5 = {
+  "kind": "Literal",
+  "name": "type",
+  "value": "GALLERY"
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = [
+  (v6/*: any*/),
+  (v1/*: any*/),
+  (v0/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "href",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "initials",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Literal",
+        "name": "first",
+        "value": 15
+      }
+    ],
+    "concreteType": "LocationConnection",
+    "kind": "LinkedField",
+    "name": "locationsConnection",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "LocationEdge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "city",
+                "storageKey": null
+              },
+              (v7/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": "locationsConnection(first:15)"
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Profile",
+    "kind": "LinkedField",
+    "name": "profile",
+    "plural": false,
+    "selections": [
+      (v7/*: any*/),
+      (v1/*: any*/),
+      (v0/*: any*/),
+      (v6/*: any*/),
+      {
+        "alias": "is_followed",
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isFollowed",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isFollowed",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Image",
+        "kind": "LinkedField",
+        "name": "image",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "height",
+                "value": 244
+              },
+              {
+                "kind": "Literal",
+                "name": "version",
+                "value": [
+                  "wide",
+                  "large",
+                  "featured",
+                  "larger"
+                ]
+              },
+              {
+                "kind": "Literal",
+                "name": "width",
+                "value": 325
+              }
+            ],
+            "concreteType": "CroppedImageUrl",
+            "kind": "LinkedField",
+            "name": "cropped",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "src",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "srcSet",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  (v7/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "GalleriesRouteFragmentContainer_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "GalleriesRoute_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "GalleriesRouteFragmentContainer_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "categoryType",
+                "value": "GALLERY"
+              },
+              {
+                "kind": "Literal",
+                "name": "internal",
+                "value": false
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 50
+              }
+            ],
+            "concreteType": "PartnerCategory",
+            "kind": "LinkedField",
+            "name": "partnerCategories",
+            "plural": true,
+            "selections": [
+              (v0/*: any*/),
+              (v1/*: any*/),
+              {
+                "alias": "primary",
+                "args": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "eligibleForPrimaryBucket",
+                    "value": true
+                  },
+                  (v4/*: any*/),
+                  (v5/*: any*/)
+                ],
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "partners",
+                "plural": true,
+                "selections": (v8/*: any*/),
+                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForPrimaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"GALLERY\")"
+              },
+              {
+                "alias": "secondary",
+                "args": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "eligibleForSecondaryBucket",
+                    "value": true
+                  },
+                  (v4/*: any*/),
+                  (v5/*: any*/)
+                ],
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "partners",
+                "plural": true,
+                "selections": (v8/*: any*/),
+                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForSecondaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"GALLERY\")"
+              },
+              (v7/*: any*/)
+            ],
+            "storageKey": "partnerCategories(categoryType:\"GALLERY\",internal:false,size:50)"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "GalleriesRouteFragmentContainer_Test_Query",
+    "operationKind": "query",
+    "text": "query GalleriesRouteFragmentContainer_Test_Query {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  partnerCategories(categoryType: GALLERY, size: 50, internal: false) {\n    name\n    slug\n    ...PartnersRail_partnerCategory_uMgyM\n    id\n  }\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 325, height: 244, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersRail_partnerCategory_uMgyM on PartnerCategory {\n  name\n  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '74c43632d60863464e10806c61ddb4f4';
+export default node;

--- a/src/v2/__generated__/GalleriesRoute_viewer.graphql.ts
+++ b/src/v2/__generated__/GalleriesRoute_viewer.graphql.ts
@@ -1,0 +1,84 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type GalleriesRoute_viewer = {
+    readonly partnerCategories: ReadonlyArray<{
+        readonly name: string | null;
+        readonly slug: string;
+        readonly " $fragmentRefs": FragmentRefs<"PartnersRail_partnerCategory">;
+    } | null> | null;
+    readonly " $refType": "GalleriesRoute_viewer";
+};
+export type GalleriesRoute_viewer$data = GalleriesRoute_viewer;
+export type GalleriesRoute_viewer$key = {
+    readonly " $data"?: GalleriesRoute_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"GalleriesRoute_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "GalleriesRoute_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "categoryType",
+          "value": "GALLERY"
+        },
+        {
+          "kind": "Literal",
+          "name": "internal",
+          "value": false
+        },
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 50
+        }
+      ],
+      "concreteType": "PartnerCategory",
+      "kind": "LinkedField",
+      "name": "partnerCategories",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "slug",
+          "storageKey": null
+        },
+        {
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "type",
+              "value": "GALLERY"
+            }
+          ],
+          "kind": "FragmentSpread",
+          "name": "PartnersRail_partnerCategory"
+        }
+      ],
+      "storageKey": "partnerCategories(categoryType:\"GALLERY\",internal:false,size:50)"
+    }
+  ],
+  "type": "Viewer"
+};
+(node as any).hash = '207bd1fb31af8c812f263a02cd0bd870';
+export default node;

--- a/src/v2/__generated__/InstitutionsRouteFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/InstitutionsRouteFragmentContainer_Test_Query.graphql.ts
@@ -1,0 +1,412 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type InstitutionsRouteFragmentContainer_Test_QueryVariables = {};
+export type InstitutionsRouteFragmentContainer_Test_QueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"InstitutionsRoute_viewer">;
+    } | null;
+};
+export type InstitutionsRouteFragmentContainer_Test_Query = {
+    readonly response: InstitutionsRouteFragmentContainer_Test_QueryResponse;
+    readonly variables: InstitutionsRouteFragmentContainer_Test_QueryVariables;
+};
+
+
+
+/*
+query InstitutionsRouteFragmentContainer_Test_Query {
+  viewer {
+    ...InstitutionsRoute_viewer
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  is_followed: isFollowed
+}
+
+fragment InstitutionsRoute_viewer on Viewer {
+  partnerCategories(categoryType: INSTITUTION, size: 50, internal: false) {
+    name
+    slug
+    ...PartnersRail_partnerCategory_q3ILp
+    id
+  }
+}
+
+fragment PartnerCell_partner on Partner {
+  internalID
+  slug
+  name
+  href
+  initials
+  locationsConnection(first: 15) {
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
+  profile {
+    ...FollowProfileButton_profile
+    isFollowed
+    image {
+      cropped(width: 325, height: 244, version: ["wide", "large", "featured", "larger"]) {
+        src
+        srcSet
+      }
+    }
+    id
+  }
+}
+
+fragment PartnersRail_partnerCategory_q3ILp on PartnerCategory {
+  name
+  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
+    internalID
+    ...PartnerCell_partner
+    id
+  }
+  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
+    internalID
+    ...PartnerCell_partner
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v2 = {
+  "kind": "Literal",
+  "name": "defaultProfilePublic",
+  "value": true
+},
+v3 = {
+  "kind": "Literal",
+  "name": "eligibleForListing",
+  "value": true
+},
+v4 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "RANDOM_SCORE_DESC"
+},
+v5 = {
+  "kind": "Literal",
+  "name": "type",
+  "value": "INSTITUTION"
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = [
+  (v6/*: any*/),
+  (v1/*: any*/),
+  (v0/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "href",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "initials",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Literal",
+        "name": "first",
+        "value": 15
+      }
+    ],
+    "concreteType": "LocationConnection",
+    "kind": "LinkedField",
+    "name": "locationsConnection",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "LocationEdge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "city",
+                "storageKey": null
+              },
+              (v7/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": "locationsConnection(first:15)"
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Profile",
+    "kind": "LinkedField",
+    "name": "profile",
+    "plural": false,
+    "selections": [
+      (v7/*: any*/),
+      (v1/*: any*/),
+      (v0/*: any*/),
+      (v6/*: any*/),
+      {
+        "alias": "is_followed",
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isFollowed",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isFollowed",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Image",
+        "kind": "LinkedField",
+        "name": "image",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "height",
+                "value": 244
+              },
+              {
+                "kind": "Literal",
+                "name": "version",
+                "value": [
+                  "wide",
+                  "large",
+                  "featured",
+                  "larger"
+                ]
+              },
+              {
+                "kind": "Literal",
+                "name": "width",
+                "value": 325
+              }
+            ],
+            "concreteType": "CroppedImageUrl",
+            "kind": "LinkedField",
+            "name": "cropped",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "src",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "srcSet",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  (v7/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "InstitutionsRouteFragmentContainer_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "InstitutionsRoute_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "InstitutionsRouteFragmentContainer_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "categoryType",
+                "value": "INSTITUTION"
+              },
+              {
+                "kind": "Literal",
+                "name": "internal",
+                "value": false
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 50
+              }
+            ],
+            "concreteType": "PartnerCategory",
+            "kind": "LinkedField",
+            "name": "partnerCategories",
+            "plural": true,
+            "selections": [
+              (v0/*: any*/),
+              (v1/*: any*/),
+              {
+                "alias": "primary",
+                "args": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "eligibleForPrimaryBucket",
+                    "value": true
+                  },
+                  (v4/*: any*/),
+                  (v5/*: any*/)
+                ],
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "partners",
+                "plural": true,
+                "selections": (v8/*: any*/),
+                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForPrimaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"INSTITUTION\")"
+              },
+              {
+                "alias": "secondary",
+                "args": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "eligibleForSecondaryBucket",
+                    "value": true
+                  },
+                  (v4/*: any*/),
+                  (v5/*: any*/)
+                ],
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "partners",
+                "plural": true,
+                "selections": (v8/*: any*/),
+                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForSecondaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"INSTITUTION\")"
+              },
+              (v7/*: any*/)
+            ],
+            "storageKey": "partnerCategories(categoryType:\"INSTITUTION\",internal:false,size:50)"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "InstitutionsRouteFragmentContainer_Test_Query",
+    "operationKind": "query",
+    "text": "query InstitutionsRouteFragmentContainer_Test_Query {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  partnerCategories(categoryType: INSTITUTION, size: 50, internal: false) {\n    name\n    slug\n    ...PartnersRail_partnerCategory_q3ILp\n    id\n  }\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 325, height: 244, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersRail_partnerCategory_q3ILp on PartnerCategory {\n  name\n  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '978a70b910e94f284ba793638cd3acd8';
+export default node;

--- a/src/v2/__generated__/InstitutionsRoute_viewer.graphql.ts
+++ b/src/v2/__generated__/InstitutionsRoute_viewer.graphql.ts
@@ -1,0 +1,84 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type InstitutionsRoute_viewer = {
+    readonly partnerCategories: ReadonlyArray<{
+        readonly name: string | null;
+        readonly slug: string;
+        readonly " $fragmentRefs": FragmentRefs<"PartnersRail_partnerCategory">;
+    } | null> | null;
+    readonly " $refType": "InstitutionsRoute_viewer";
+};
+export type InstitutionsRoute_viewer$data = InstitutionsRoute_viewer;
+export type InstitutionsRoute_viewer$key = {
+    readonly " $data"?: InstitutionsRoute_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"InstitutionsRoute_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "InstitutionsRoute_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "categoryType",
+          "value": "INSTITUTION"
+        },
+        {
+          "kind": "Literal",
+          "name": "internal",
+          "value": false
+        },
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 50
+        }
+      ],
+      "concreteType": "PartnerCategory",
+      "kind": "LinkedField",
+      "name": "partnerCategories",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "slug",
+          "storageKey": null
+        },
+        {
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "type",
+              "value": "INSTITUTION"
+            }
+          ],
+          "kind": "FragmentSpread",
+          "name": "PartnersRail_partnerCategory"
+        }
+      ],
+      "storageKey": "partnerCategories(categoryType:\"INSTITUTION\",internal:false,size:50)"
+    }
+  ],
+  "type": "Viewer"
+};
+(node as any).hash = 'f6c5793e52e4ab9945be3a6669d1102a';
+export default node;

--- a/src/v2/__generated__/PartnerCellFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerCellFragmentContainer_Test_Query.graphql.ts
@@ -1,0 +1,305 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PartnerCellFragmentContainer_Test_QueryVariables = {};
+export type PartnerCellFragmentContainer_Test_QueryResponse = {
+    readonly partner: {
+        readonly " $fragmentRefs": FragmentRefs<"PartnerCell_partner">;
+    } | null;
+};
+export type PartnerCellFragmentContainer_Test_Query = {
+    readonly response: PartnerCellFragmentContainer_Test_QueryResponse;
+    readonly variables: PartnerCellFragmentContainer_Test_QueryVariables;
+};
+
+
+
+/*
+query PartnerCellFragmentContainer_Test_Query {
+  partner(id: "example") {
+    ...PartnerCell_partner
+    id
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  is_followed: isFollowed
+}
+
+fragment PartnerCell_partner on Partner {
+  internalID
+  slug
+  name
+  href
+  initials
+  locationsConnection(first: 15) {
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
+  profile {
+    ...FollowProfileButton_profile
+    isFollowed
+    image {
+      cropped(width: 325, height: 244, version: ["wide", "large", "featured", "larger"]) {
+        src
+        srcSet
+      }
+    }
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PartnerCellFragmentContainer_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "PartnerCell_partner"
+          }
+        ],
+        "storageKey": "partner(id:\"example\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "PartnerCellFragmentContainer_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "initials",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 15
+              }
+            ],
+            "concreteType": "LocationConnection",
+            "kind": "LinkedField",
+            "name": "locationsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "LocationEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Location",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "city",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "locationsConnection(first:15)"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Profile",
+            "kind": "LinkedField",
+            "name": "profile",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/),
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v1/*: any*/),
+              {
+                "alias": "is_followed",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isFollowed",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isFollowed",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "image",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 244
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": [
+                          "wide",
+                          "large",
+                          "featured",
+                          "larger"
+                        ]
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 325
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "src",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "srcSet",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": "partner(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "PartnerCellFragmentContainer_Test_Query",
+    "operationKind": "query",
+    "text": "query PartnerCellFragmentContainer_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerCell_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 325, height: 244, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '020b76a81076a4d2d71231a7d54d4348';
+export default node;

--- a/src/v2/__generated__/PartnerCell_partner.graphql.ts
+++ b/src/v2/__generated__/PartnerCell_partner.graphql.ts
@@ -1,0 +1,210 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PartnerCell_partner = {
+    readonly internalID: string;
+    readonly slug: string;
+    readonly name: string | null;
+    readonly href: string | null;
+    readonly initials: string | null;
+    readonly locationsConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly city: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly profile: {
+        readonly isFollowed: boolean | null;
+        readonly image: {
+            readonly cropped: {
+                readonly src: string;
+                readonly srcSet: string;
+            } | null;
+        } | null;
+        readonly " $fragmentRefs": FragmentRefs<"FollowProfileButton_profile">;
+    } | null;
+    readonly " $refType": "PartnerCell_partner";
+};
+export type PartnerCell_partner$data = PartnerCell_partner;
+export type PartnerCell_partner$key = {
+    readonly " $data"?: PartnerCell_partner$data;
+    readonly " $fragmentRefs": FragmentRefs<"PartnerCell_partner">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "PartnerCell_partner",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "initials",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 15
+        }
+      ],
+      "concreteType": "LocationConnection",
+      "kind": "LinkedField",
+      "name": "locationsConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "LocationEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Location",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "city",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "locationsConnection(first:15)"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Profile",
+      "kind": "LinkedField",
+      "name": "profile",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isFollowed",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Image",
+          "kind": "LinkedField",
+          "name": "image",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "height",
+                  "value": 244
+                },
+                {
+                  "kind": "Literal",
+                  "name": "version",
+                  "value": [
+                    "wide",
+                    "large",
+                    "featured",
+                    "larger"
+                  ]
+                },
+                {
+                  "kind": "Literal",
+                  "name": "width",
+                  "value": 325
+                }
+              ],
+              "concreteType": "CroppedImageUrl",
+              "kind": "LinkedField",
+              "name": "cropped",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "src",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "srcSet",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "FollowProfileButton_profile"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Partner"
+};
+(node as any).hash = '495d4620a9747f42d1cb6fb93b7365d0';
+export default node;

--- a/src/v2/__generated__/PartnersRail_partnerCategory.graphql.ts
+++ b/src/v2/__generated__/PartnersRail_partnerCategory.graphql.ts
@@ -1,0 +1,126 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PartnersRail_partnerCategory = {
+    readonly name: string | null;
+    readonly primary: ReadonlyArray<{
+        readonly internalID: string;
+        readonly " $fragmentRefs": FragmentRefs<"PartnerCell_partner">;
+    } | null> | null;
+    readonly secondary: ReadonlyArray<{
+        readonly internalID: string;
+        readonly " $fragmentRefs": FragmentRefs<"PartnerCell_partner">;
+    } | null> | null;
+    readonly " $refType": "PartnersRail_partnerCategory";
+};
+export type PartnersRail_partnerCategory$data = PartnersRail_partnerCategory;
+export type PartnersRail_partnerCategory$key = {
+    readonly " $data"?: PartnersRail_partnerCategory$data;
+    readonly " $fragmentRefs": FragmentRefs<"PartnersRail_partnerCategory">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "kind": "Literal",
+  "name": "defaultProfilePublic",
+  "value": true
+},
+v1 = {
+  "kind": "Literal",
+  "name": "eligibleForListing",
+  "value": true
+},
+v2 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "RANDOM_SCORE_DESC"
+},
+v3 = {
+  "kind": "Variable",
+  "name": "type",
+  "variableName": "type"
+},
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "internalID",
+    "storageKey": null
+  },
+  {
+    "args": null,
+    "kind": "FragmentSpread",
+    "name": "PartnerCell_partner"
+  }
+];
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "type",
+      "type": "[PartnerClassification!]!"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "PartnersRail_partnerCategory",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": "primary",
+      "args": [
+        (v0/*: any*/),
+        (v1/*: any*/),
+        {
+          "kind": "Literal",
+          "name": "eligibleForPrimaryBucket",
+          "value": true
+        },
+        (v2/*: any*/),
+        (v3/*: any*/)
+      ],
+      "concreteType": "Partner",
+      "kind": "LinkedField",
+      "name": "partners",
+      "plural": true,
+      "selections": (v4/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": "secondary",
+      "args": [
+        (v0/*: any*/),
+        (v1/*: any*/),
+        {
+          "kind": "Literal",
+          "name": "eligibleForSecondaryBucket",
+          "value": true
+        },
+        (v2/*: any*/),
+        (v3/*: any*/)
+      ],
+      "concreteType": "Partner",
+      "kind": "LinkedField",
+      "name": "partners",
+      "plural": true,
+      "selections": (v4/*: any*/),
+      "storageKey": null
+    }
+  ],
+  "type": "PartnerCategory"
+};
+})();
+(node as any).hash = '32505a6b0834102961161984a8464b59';
+export default node;

--- a/src/v2/__generated__/partnersRoutes_GalleriesRouteQuery.graphql.ts
+++ b/src/v2/__generated__/partnersRoutes_GalleriesRouteQuery.graphql.ts
@@ -1,0 +1,412 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type partnersRoutes_GalleriesRouteQueryVariables = {};
+export type partnersRoutes_GalleriesRouteQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"GalleriesRoute_viewer">;
+    } | null;
+};
+export type partnersRoutes_GalleriesRouteQuery = {
+    readonly response: partnersRoutes_GalleriesRouteQueryResponse;
+    readonly variables: partnersRoutes_GalleriesRouteQueryVariables;
+};
+
+
+
+/*
+query partnersRoutes_GalleriesRouteQuery {
+  viewer {
+    ...GalleriesRoute_viewer
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  is_followed: isFollowed
+}
+
+fragment GalleriesRoute_viewer on Viewer {
+  partnerCategories(categoryType: GALLERY, size: 50, internal: false) {
+    name
+    slug
+    ...PartnersRail_partnerCategory_uMgyM
+    id
+  }
+}
+
+fragment PartnerCell_partner on Partner {
+  internalID
+  slug
+  name
+  href
+  initials
+  locationsConnection(first: 15) {
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
+  profile {
+    ...FollowProfileButton_profile
+    isFollowed
+    image {
+      cropped(width: 325, height: 244, version: ["wide", "large", "featured", "larger"]) {
+        src
+        srcSet
+      }
+    }
+    id
+  }
+}
+
+fragment PartnersRail_partnerCategory_uMgyM on PartnerCategory {
+  name
+  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
+    internalID
+    ...PartnerCell_partner
+    id
+  }
+  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
+    internalID
+    ...PartnerCell_partner
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v2 = {
+  "kind": "Literal",
+  "name": "defaultProfilePublic",
+  "value": true
+},
+v3 = {
+  "kind": "Literal",
+  "name": "eligibleForListing",
+  "value": true
+},
+v4 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "RANDOM_SCORE_DESC"
+},
+v5 = {
+  "kind": "Literal",
+  "name": "type",
+  "value": "GALLERY"
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = [
+  (v6/*: any*/),
+  (v1/*: any*/),
+  (v0/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "href",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "initials",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Literal",
+        "name": "first",
+        "value": 15
+      }
+    ],
+    "concreteType": "LocationConnection",
+    "kind": "LinkedField",
+    "name": "locationsConnection",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "LocationEdge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "city",
+                "storageKey": null
+              },
+              (v7/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": "locationsConnection(first:15)"
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Profile",
+    "kind": "LinkedField",
+    "name": "profile",
+    "plural": false,
+    "selections": [
+      (v7/*: any*/),
+      (v1/*: any*/),
+      (v0/*: any*/),
+      (v6/*: any*/),
+      {
+        "alias": "is_followed",
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isFollowed",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isFollowed",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Image",
+        "kind": "LinkedField",
+        "name": "image",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "height",
+                "value": 244
+              },
+              {
+                "kind": "Literal",
+                "name": "version",
+                "value": [
+                  "wide",
+                  "large",
+                  "featured",
+                  "larger"
+                ]
+              },
+              {
+                "kind": "Literal",
+                "name": "width",
+                "value": 325
+              }
+            ],
+            "concreteType": "CroppedImageUrl",
+            "kind": "LinkedField",
+            "name": "cropped",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "src",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "srcSet",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  (v7/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "partnersRoutes_GalleriesRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "GalleriesRoute_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "partnersRoutes_GalleriesRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "categoryType",
+                "value": "GALLERY"
+              },
+              {
+                "kind": "Literal",
+                "name": "internal",
+                "value": false
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 50
+              }
+            ],
+            "concreteType": "PartnerCategory",
+            "kind": "LinkedField",
+            "name": "partnerCategories",
+            "plural": true,
+            "selections": [
+              (v0/*: any*/),
+              (v1/*: any*/),
+              {
+                "alias": "primary",
+                "args": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "eligibleForPrimaryBucket",
+                    "value": true
+                  },
+                  (v4/*: any*/),
+                  (v5/*: any*/)
+                ],
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "partners",
+                "plural": true,
+                "selections": (v8/*: any*/),
+                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForPrimaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"GALLERY\")"
+              },
+              {
+                "alias": "secondary",
+                "args": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "eligibleForSecondaryBucket",
+                    "value": true
+                  },
+                  (v4/*: any*/),
+                  (v5/*: any*/)
+                ],
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "partners",
+                "plural": true,
+                "selections": (v8/*: any*/),
+                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForSecondaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"GALLERY\")"
+              },
+              (v7/*: any*/)
+            ],
+            "storageKey": "partnerCategories(categoryType:\"GALLERY\",internal:false,size:50)"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "partnersRoutes_GalleriesRouteQuery",
+    "operationKind": "query",
+    "text": "query partnersRoutes_GalleriesRouteQuery {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  partnerCategories(categoryType: GALLERY, size: 50, internal: false) {\n    name\n    slug\n    ...PartnersRail_partnerCategory_uMgyM\n    id\n  }\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 325, height: 244, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersRail_partnerCategory_uMgyM on PartnerCategory {\n  name\n  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'e7feb546a82ac4ed2adae49ca1c03d63';
+export default node;

--- a/src/v2/__generated__/partnersRoutes_InstitutionsRouteQuery.graphql.ts
+++ b/src/v2/__generated__/partnersRoutes_InstitutionsRouteQuery.graphql.ts
@@ -1,0 +1,412 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type partnersRoutes_InstitutionsRouteQueryVariables = {};
+export type partnersRoutes_InstitutionsRouteQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"InstitutionsRoute_viewer">;
+    } | null;
+};
+export type partnersRoutes_InstitutionsRouteQuery = {
+    readonly response: partnersRoutes_InstitutionsRouteQueryResponse;
+    readonly variables: partnersRoutes_InstitutionsRouteQueryVariables;
+};
+
+
+
+/*
+query partnersRoutes_InstitutionsRouteQuery {
+  viewer {
+    ...InstitutionsRoute_viewer
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  is_followed: isFollowed
+}
+
+fragment InstitutionsRoute_viewer on Viewer {
+  partnerCategories(categoryType: INSTITUTION, size: 50, internal: false) {
+    name
+    slug
+    ...PartnersRail_partnerCategory_q3ILp
+    id
+  }
+}
+
+fragment PartnerCell_partner on Partner {
+  internalID
+  slug
+  name
+  href
+  initials
+  locationsConnection(first: 15) {
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
+  profile {
+    ...FollowProfileButton_profile
+    isFollowed
+    image {
+      cropped(width: 325, height: 244, version: ["wide", "large", "featured", "larger"]) {
+        src
+        srcSet
+      }
+    }
+    id
+  }
+}
+
+fragment PartnersRail_partnerCategory_q3ILp on PartnerCategory {
+  name
+  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
+    internalID
+    ...PartnerCell_partner
+    id
+  }
+  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
+    internalID
+    ...PartnerCell_partner
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v2 = {
+  "kind": "Literal",
+  "name": "defaultProfilePublic",
+  "value": true
+},
+v3 = {
+  "kind": "Literal",
+  "name": "eligibleForListing",
+  "value": true
+},
+v4 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "RANDOM_SCORE_DESC"
+},
+v5 = {
+  "kind": "Literal",
+  "name": "type",
+  "value": "INSTITUTION"
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = [
+  (v6/*: any*/),
+  (v1/*: any*/),
+  (v0/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "href",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "initials",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Literal",
+        "name": "first",
+        "value": 15
+      }
+    ],
+    "concreteType": "LocationConnection",
+    "kind": "LinkedField",
+    "name": "locationsConnection",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "LocationEdge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "city",
+                "storageKey": null
+              },
+              (v7/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": "locationsConnection(first:15)"
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Profile",
+    "kind": "LinkedField",
+    "name": "profile",
+    "plural": false,
+    "selections": [
+      (v7/*: any*/),
+      (v1/*: any*/),
+      (v0/*: any*/),
+      (v6/*: any*/),
+      {
+        "alias": "is_followed",
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isFollowed",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isFollowed",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Image",
+        "kind": "LinkedField",
+        "name": "image",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "height",
+                "value": 244
+              },
+              {
+                "kind": "Literal",
+                "name": "version",
+                "value": [
+                  "wide",
+                  "large",
+                  "featured",
+                  "larger"
+                ]
+              },
+              {
+                "kind": "Literal",
+                "name": "width",
+                "value": 325
+              }
+            ],
+            "concreteType": "CroppedImageUrl",
+            "kind": "LinkedField",
+            "name": "cropped",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "src",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "srcSet",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  (v7/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "partnersRoutes_InstitutionsRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "InstitutionsRoute_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "partnersRoutes_InstitutionsRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "categoryType",
+                "value": "INSTITUTION"
+              },
+              {
+                "kind": "Literal",
+                "name": "internal",
+                "value": false
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 50
+              }
+            ],
+            "concreteType": "PartnerCategory",
+            "kind": "LinkedField",
+            "name": "partnerCategories",
+            "plural": true,
+            "selections": [
+              (v0/*: any*/),
+              (v1/*: any*/),
+              {
+                "alias": "primary",
+                "args": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "eligibleForPrimaryBucket",
+                    "value": true
+                  },
+                  (v4/*: any*/),
+                  (v5/*: any*/)
+                ],
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "partners",
+                "plural": true,
+                "selections": (v8/*: any*/),
+                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForPrimaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"INSTITUTION\")"
+              },
+              {
+                "alias": "secondary",
+                "args": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "eligibleForSecondaryBucket",
+                    "value": true
+                  },
+                  (v4/*: any*/),
+                  (v5/*: any*/)
+                ],
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "partners",
+                "plural": true,
+                "selections": (v8/*: any*/),
+                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForSecondaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"INSTITUTION\")"
+              },
+              (v7/*: any*/)
+            ],
+            "storageKey": "partnerCategories(categoryType:\"INSTITUTION\",internal:false,size:50)"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "partnersRoutes_InstitutionsRouteQuery",
+    "operationKind": "query",
+    "text": "query partnersRoutes_InstitutionsRouteQuery {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  partnerCategories(categoryType: INSTITUTION, size: 50, internal: false) {\n    name\n    slug\n    ...PartnersRail_partnerCategory_q3ILp\n    id\n  }\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 325, height: 244, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersRail_partnerCategory_q3ILp on PartnerCategory {\n  name\n  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '3d638da9726e83cbc4faa0be3fe71145';
+export default node;

--- a/src/v2/routes.tsx
+++ b/src/v2/routes.tsx
@@ -6,11 +6,13 @@ import { artworkRoutes } from "v2/Apps/Artwork/artworkRoutes"
 import { auctionsRoutes } from "v2/Apps/Auctions/auctionsRoutes"
 import { buildAppRoutes } from "v2/System/Router/buildAppRoutes"
 import { buyerGuaranteeRoutes } from "v2/Apps/BuyerGuarantee/buyerGuaranteeRoutes"
+import { categoriesRoutes } from "./Apps/Categories/categoriesRoutes"
 import { collectRoutes } from "v2/Apps/Collect/collectRoutes"
 import { consignRoutes } from "v2/Apps/Consign/consignRoutes"
 import { conversationRoutes } from "v2/Apps/Conversation/conversationRoutes"
 import { debugRoutes } from "v2/Apps/Debug/debugRoutes"
 import { exampleRoutes } from "v2/Apps/Example/exampleRoutes"
+import { fairOrganizerRoutes } from "./Apps/FairOrginizer/fairOrganizerRoutes"
 import { fairRoutes } from "v2/Apps/Fair/fairRoutes"
 import { fairsRoutes } from "v2/Apps/Fairs/fairsRoutes"
 import { featureRoutes } from "v2/Apps/Feature/featureRoutes"
@@ -19,18 +21,17 @@ import { homeRoutes } from "v2/Apps/Home/homeRoutes"
 import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identityVerificationRoutes"
 import { orderRoutes } from "v2/Apps/Order/orderRoutes"
 import { partnerRoutes } from "v2/Apps/Partner/partnerRoutes"
+import { partnersRoutes } from "v2/Apps/Partners/partnersRoutes"
 import { paymentRoutes } from "v2/Apps/Payment/paymentRoutes"
-import { shippingRoutes } from "v2/Apps/Shipping/shippingRoutes"
+import { priceDatabaseRoutes } from "./Apps/PriceDatabase/priceDatabaseRoutes"
 import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
 import { searchRoutes } from "v2/Apps/Search/searchRoutes"
+import { shippingRoutes } from "v2/Apps/Shipping/shippingRoutes"
 import { showRoutes } from "v2/Apps/Show/showRoutes"
 import { showsRoutes } from "v2/Apps/Shows/showsRoutes"
 import { tagRoutes } from "./Apps/Tag/tagRoutes"
 import { unsubscribeRoutes } from "./Apps/Unsubscribe/unsubscribeRoutes"
 import { viewingRoomRoutes } from "v2/Apps/ViewingRoom/viewingRoomRoutes"
-import { fairOrganizerRoutes } from "./Apps/FairOrginizer/fairOrganizerRoutes"
-import { priceDatabaseRoutes } from "./Apps/PriceDatabase/priceDatabaseRoutes"
-import { categoriesRoutes } from "./Apps/Categories/categoriesRoutes"
 
 export function getAppRoutes(): AppRouteConfig[] {
   return buildAppRoutes([
@@ -54,11 +55,12 @@ export function getAppRoutes(): AppRouteConfig[] {
     { routes: identityVerificationRoutes },
     { routes: orderRoutes },
     { routes: partnerRoutes },
+    { routes: partnersRoutes },
     { routes: paymentRoutes },
     { routes: priceDatabaseRoutes },
-    { routes: shippingRoutes },
     { routes: purchaseRoutes },
     { routes: searchRoutes },
+    { routes: shippingRoutes },
     { routes: showRoutes },
     { routes: showsRoutes },
     { routes: tagRoutes },


### PR DESCRIPTION
This PR just sets up the two routes and scaffolds in some basic page structure and rails.

![](https://static.damonzucconi.com/_capture/zJ8Q2ozB.png)

-----

A preliminary TODO:

- [ ] Implement a server-side stable shuffle and use it to shuffle both the order of the rails and the positions of the primary and secondary partners within them on each page load.
- [ ] Implement a featured carousel at the top (design TBD)
- [ ] Implement dropdown filters — the first two filters pre-fetch their options and match based on typing; the last is a full partner search
- [ ] Implement filtered rails — we accept 2 query params which filter the rails on the page
- [ ] Implement filtered search — I find this UX very confusing but apparently the galleries search input is filtered by the 2 query params as well