### PR TITLE
chore(analytics): Replace manual list with dynamic paths

### DIFF
--- a/src/desktop/assets/analytics.ts
+++ b/src/desktop/assets/analytics.ts
@@ -1,35 +1,14 @@
 import { beforeAnalyticsReady, onAnalyticsReady } from "lib/analytics/helpers"
 import { trackPageView } from "lib/analytics/trackPageView"
+import { getRouteConfig } from "v2/System/Router/getRouteConfig"
+
 window.Cookies = require("cookies-js")
+
+const { routePaths } = getRouteConfig()
 
 // We exclude these routes from analytics.page calls because
 // they're already tracked in v2/System/Analytics/trackingMiddleware
-const excludedRoutes = [
-  "/art-fairs",
-  "/artist(.*)",
-  "/artists",
-  "/artwork(.*)",
-  "/auctions(.*)",
-  "/auction-faq",
-  "/auction-registration(2)?/:saleID",
-  "/auction/:saleID/bid(2)?/:artworkID",
-  "/campaign(.*)",
-  "/collect(.*)",
-  "/collection(.*)",
-  "/collections(.*)",
-  "/consign(.*)",
-  "/fair(.*)",
-  "/feature(.*)",
-  "/identity-verification(.*)",
-  "/orders(.*)",
-  "/search(.*)",
-  "/show/(.*)",
-  "/shows",
-  "/user/conversations(.*)",
-  "/user/purchases(.*)",
-  "/viewing-room(.*)",
-  "/user/payments(.*)",
-]
+const excludedRoutes = routePaths
 
 beforeAnalyticsReady()
 trackPageView(excludedRoutes)

--- a/src/lib/analytics/trackPageView.ts
+++ b/src/lib/analytics/trackPageView.ts
@@ -4,12 +4,13 @@ import { OwnerType } from "@artsy/cohesion"
 import { data as sd } from "sharify"
 
 const foundExcludedPath = excludedRoutes => {
-  return excludedRoutes.some(excludedPath => {
+  const isFound = excludedRoutes.some(excludedPath => {
     const { path } = getContextPageFromClient()
     const matcher = match(excludedPath, { decode: decodeURIComponent })
     const foundMatch = !!matcher(path)
     return foundMatch
   })
+  return isFound
 }
 
 export const trackPageView = (excludedRoutes: string[] = []) => {


### PR DESCRIPTION
This replaces our previously hand-curated manual route list exclusions with something dynamic so that we no longer have to worry about updating this when building new routes. 