### PR TITLE
feat: edit detect-secrets CI step to recover from a bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,19 @@ jobs:
     working_directory: /usr/src/app
     steps:
       - checkout
-      - run: detect-secrets-hook --baseline .secrets.baseline $(git ls-files)
+      - run: |
+            cp .secrets.baseline /tmp/.secrets.baseline
+            set +e && set +o pipefail
+            detect-secrets-hook --baseline .secrets.baseline $(git ls-files)
+            code=$?
+            if [[ $code -ne 3 ]]; then
+              exit $code
+            else
+              lines=$(diff -y --suppress-common-lines .secrets.baseline /tmp/.secrets.baseline | wc -l)
+              [ $lines -eq 1 ] && git restore .secrets.baseline && exit 0
+              echo "changes to baseline results need to be committed."
+              exit $code
+            fi
 
 not_master_or_staging_or_release: &not_master_or_staging_or_release
   filters:


### PR DESCRIPTION
This updates the CircleCI detect-secrets step to recover from a bug seen with detect-secrets-hook command which causes the `.secrets.baseline` file to be updated (mutated) randomly with the only difference being the `generated_at` field. This causes random failures in CI and makes this tool less reliable forcing contributors to have to re-run workflows or re-check the code.

The updated command checks the exit code of detect-secrets-hook when encountering an error, if the exit code is `3` we check the number of changed lines and either ignore the change and exit with `0` or log a message indicating that the changes to `results` field need to be committed.

An example of a [failing CI](https://app.circleci.com/pipelines/github/artsy/force/19725/workflows/0d16c952-afa0-476b-a350-fa1c094dff91/jobs/149520) run that this change addresses.