### PR TITLE
fix(SWA-47): Edition number and edition size are not required if limited edition selected

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -29,8 +29,14 @@ const ArtworkDetailsSchema = Yup.object().shape({
       "Rarity field not selected",
       rarity => rarity !== "default"
     ),
-  editionNumber: Yup.string(),
-  editionSize: Yup.number(),
+  editionNumber: Yup.string().when("rarity", {
+    is: "limited edition",
+    then: Yup.string().required(),
+  }),
+  editionSize: Yup.number().when("rarity", {
+    is: "limited edition",
+    then: Yup.number().required(),
+  }),
   height: Yup.number().positive().required(),
   width: Yup.number().positive().required(),
   depth: Yup.number().positive(),


### PR DESCRIPTION
Jira Ticket:ticket: : [SWA-47](https://artsyproduct.atlassian.net/browse/SWA-47)

This PR adds the correct validation to `ArtworkDetailsForm` for `Edition Size` and `Edition Number` fields  
depending on the chosen `Rarity` field.
 
**VIDEO:clapper: :**

https://user-images.githubusercontent.com/55637696/137733398-293d1236-0eaa-44b9-9425-bda6c41e147e.mov

