### PR TITLE
fix(SWA-48): Default value of rarity and medium shouldn't be a valid field value

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -15,8 +15,20 @@ const ArtworkDetailsSchema = Yup.object().shape({
   artistId: Yup.string().label("Artist").required(),
   year: Yup.string().required(),
   title: Yup.string().required(),
-  medium: Yup.string().required(),
-  rarity: Yup.string().required(),
+  medium: Yup.string()
+    .required()
+    .test(
+      "isDefault",
+      "Medium field not selected",
+      medium => medium !== "default"
+    ),
+  rarity: Yup.string()
+    .required()
+    .test(
+      "isDefault",
+      "Rarity field not selected",
+      rarity => rarity !== "default"
+    ),
   editionNumber: Yup.string(),
   editionSize: Yup.number(),
   height: Yup.number().positive().required(),


### PR DESCRIPTION
Jira Ticket:ticket: : [SWA-48](https://artsyproduct.atlassian.net/browse/SWA-47)

This PR adds the correct validation to `ArtworkDetailsForm` for defaults values of `Rarity` and `Medium` selects
 
**VIDEO:clapper: :**

https://user-images.githubusercontent.com/55637696/137743031-a81875cc-3d37-4dbb-8334-02da93d23994.mov

