### PR TITLE
feat(Home): Add initials fallback to FeaturesGalleries rail

### DIFF
--- a/src/v2/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
@@ -6,6 +6,7 @@ import {
   Skeleton,
   SkeletonText,
   SkeletonBox,
+  Text,
 } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -120,7 +121,17 @@ const HomeFeaturedGalleriesRail: React.FC<HomeFeaturedGalleriesRailProps> = ({
                     />
                   </Box>
                 ) : (
-                  <Box bg="black30" width={325} height={230} />
+                  <Text
+                    variant="lg"
+                    bg="black10"
+                    width={325}
+                    height={230}
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                  >
+                    {node.initials}
+                  </Text>
                 )}
               </Box>
             </RouterLink>
@@ -163,6 +174,7 @@ export const HomeFeaturedGalleriesRailFragmentContainer = createFragmentContaine
               __typename
               ... on Profile {
                 ...FollowProfileButton_profile
+                initials
                 internalID
                 isFollowed
                 name

--- a/src/v2/Apps/Home/Components/HomeFeaturedShowsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedShowsRail.tsx
@@ -45,6 +45,7 @@ const HomeFeaturedShowsRail: React.FC<HomeFeaturedShowsRailProps> = ({
 
   return (
     <Rail
+      alignItems="flex-start"
       title="Featured shows"
       countLabel={shows.length}
       viewAllLabel="Explore All Shows"

--- a/src/v2/Apps/Home/__tests__/HomeFeaturedGalleriesRail.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeFeaturedGalleriesRail.jest.tsx
@@ -59,6 +59,31 @@ describe("HomeFeaturedGalleriesRail", () => {
     expect(wrapper.html()).toContain("test-href")
   })
 
+  it("shows initials if no images", () => {
+    const wrapper = getWrapper({
+      OrderedSet: () => ({
+        orderedItemsConnection: {
+          edges: [
+            {
+              node: {
+                name: "Test Gallery",
+                href: "test-href",
+                initials: "initials",
+                image: {
+                  cropped: {
+                    src: null,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(wrapper.html()).toContain("initials")
+  })
+
   describe("tracking", () => {
     it("tracks item clicks", () => {
       const wrapper = getWrapper()

--- a/src/v2/__generated__/HomeFeaturedGalleriesRailQuery.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRailQuery.graphql.ts
@@ -39,6 +39,7 @@ fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
         __typename
         ... on Profile {
           ...FollowProfileButton_profile
+          initials
           internalID
           isFollowed
           name
@@ -195,6 +196,13 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
+                            "name": "initials",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
                             "name": "isFollowed",
                             "storageKey": null
                           },
@@ -296,7 +304,7 @@ return {
     "metadata": {},
     "name": "HomeFeaturedGalleriesRailQuery",
     "operationKind": "query",
-    "text": "query HomeFeaturedGalleriesRailQuery {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          ...FollowProfileButton_profile\n          internalID\n          isFollowed\n          name\n          slug\n          href\n          location\n          image {\n            cropped(width: 325, height: 230) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          id\n        }\n        ... on Node {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query HomeFeaturedGalleriesRailQuery {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          ...FollowProfileButton_profile\n          initials\n          internalID\n          isFollowed\n          name\n          slug\n          href\n          location\n          image {\n            cropped(width: 325, height: 230) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          id\n        }\n        ... on Node {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/HomeFeaturedGalleriesRail_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRail_Test_Query.graphql.ts
@@ -39,6 +39,7 @@ fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
         __typename
         ... on Profile {
           ...FollowProfileButton_profile
+          initials
           internalID
           isFollowed
           name
@@ -195,6 +196,13 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
+                            "name": "initials",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
                             "name": "isFollowed",
                             "storageKey": null
                           },
@@ -296,7 +304,7 @@ return {
     "metadata": {},
     "name": "HomeFeaturedGalleriesRail_Test_Query",
     "operationKind": "query",
-    "text": "query HomeFeaturedGalleriesRail_Test_Query {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          ...FollowProfileButton_profile\n          internalID\n          isFollowed\n          name\n          slug\n          href\n          location\n          image {\n            cropped(width: 325, height: 230) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          id\n        }\n        ... on Node {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query HomeFeaturedGalleriesRail_Test_Query {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          ...FollowProfileButton_profile\n          initials\n          internalID\n          isFollowed\n          name\n          slug\n          href\n          location\n          image {\n            cropped(width: 325, height: 230) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          id\n        }\n        ... on Node {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/HomeFeaturedGalleriesRail_orderedSet.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRail_orderedSet.graphql.ts
@@ -8,6 +8,7 @@ export type HomeFeaturedGalleriesRail_orderedSet = {
         readonly edges: ReadonlyArray<{
             readonly node: ({
                 readonly __typename: "Profile";
+                readonly initials: string | null;
                 readonly internalID: string;
                 readonly isFollowed: boolean | null;
                 readonly name: string | null;
@@ -86,6 +87,13 @@ const node: ReaderFragment = {
                 {
                   "kind": "InlineFragment",
                   "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "initials",
+                      "storageKey": null
+                    },
                     {
                       "alias": null,
                       "args": null,
@@ -209,5 +217,5 @@ const node: ReaderFragment = {
   ],
   "type": "OrderedSet"
 };
-(node as any).hash = 'f8ae1e1bb759b8b9931b20689894a3fc';
+(node as any).hash = 'ad6d002279e9b40dd32d5e3f8c72602f';
 export default node;


### PR DESCRIPTION
This partially addresses the issue identified in [this thread](https://artsy.slack.com/archives/C04KVDZU6/p1634561074117000). Since we don't have images, lets fall back on initials. 

Also addresses issue with featured shows baseline images being off: https://artsyproduct.atlassian.net/browse/GRO-604 

<img width="1049" alt="Screen Shot 2021-10-18 at 11 43 53 AM" src="https://user-images.githubusercontent.com/236943/137788661-9668a80e-7093-4f65-b992-2a2ff7cc5a2f.png">

<img width="1391" alt="Screen Shot 2021-10-18 at 11 44 01 AM" src="https://user-images.githubusercontent.com/236943/137788668-aafc5657-a753-4de3-817c-979c3c208c1c.png">

cc @artsy/grow-devs 

