### PR TITLE
feat(Settings2): Add /settings2 app scaffold

### DIFF
--- a/src/v2/Apps/Settings/Routes/Auctions/SettingsAuctionsRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/Auctions/SettingsAuctionsRoute.tsx
@@ -1,0 +1,29 @@
+import { Text } from "@artsy/palette"
+import React from "react"
+import { SettingsAuctionsRoute_me } from "v2/__generated__/SettingsAuctionsRoute_me.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface SettingsAuctionsRouteProps {
+  me: SettingsAuctionsRoute_me
+}
+
+const SettingsAuctionsRoute: React.FC<SettingsAuctionsRouteProps> = ({
+  me,
+}) => {
+  return (
+    <>
+      <Text>Auctions Route</Text>
+    </>
+  )
+}
+
+export const SettingsAuctionsRouteFragmentContainer = createFragmentContainer(
+  SettingsAuctionsRoute,
+  {
+    me: graphql`
+      fragment SettingsAuctionsRoute_me on Me {
+        name
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Settings/Routes/EditProfile/SettingsEditProfileRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/EditProfile/SettingsEditProfileRoute.tsx
@@ -1,0 +1,29 @@
+import { Text } from "@artsy/palette"
+import React from "react"
+import { SettingsEditProfileRoute_me } from "v2/__generated__/SettingsEditProfileRoute_me.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface SettingsEditProfileRouteProps {
+  me: SettingsEditProfileRoute_me
+}
+
+const SettingsEditProfileRoute: React.FC<SettingsEditProfileRouteProps> = ({
+  me,
+}) => {
+  return (
+    <>
+      <Text>Edit Profile Route</Text>
+    </>
+  )
+}
+
+export const SettingsEditProfileRouteFragmentContainer = createFragmentContainer(
+  SettingsEditProfileRoute,
+  {
+    me: graphql`
+      fragment SettingsEditProfileRoute_me on Me {
+        name
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Settings/Routes/Overview/SettingsOverviewRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/Overview/SettingsOverviewRoute.tsx
@@ -1,0 +1,29 @@
+import { Text } from "@artsy/palette"
+import React from "react"
+import { SettingsOverviewRoute_me } from "v2/__generated__/SettingsOverviewRoute_me.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface SettingsOverviewRouteProps {
+  me: SettingsOverviewRoute_me
+}
+
+const SettingsOverviewRoute: React.FC<SettingsOverviewRouteProps> = ({
+  me,
+}) => {
+  return (
+    <>
+      <Text>Overview Route</Text>
+    </>
+  )
+}
+
+export const SettingsOverviewRouteFragmentContainer = createFragmentContainer(
+  SettingsOverviewRoute,
+  {
+    me: graphql`
+      fragment SettingsOverviewRoute_me on Me {
+        name
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Settings/Routes/Payments/SettingsPaymentsRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/Payments/SettingsPaymentsRoute.tsx
@@ -1,0 +1,29 @@
+import { Text } from "@artsy/palette"
+import React from "react"
+import { SettingsPaymentsRoute_me } from "v2/__generated__/SettingsPaymentsRoute_me.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface SettingsPaymentsRouteProps {
+  me: SettingsPaymentsRoute_me
+}
+
+const SettingsPaymentsRoute: React.FC<SettingsPaymentsRouteProps> = ({
+  me,
+}) => {
+  return (
+    <>
+      <Text>Payments Route</Text>
+    </>
+  )
+}
+
+export const SettingsPaymentsRouteFragmentContainer = createFragmentContainer(
+  SettingsPaymentsRoute,
+  {
+    me: graphql`
+      fragment SettingsPaymentsRoute_me on Me {
+        name
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Settings/Routes/Purchases/SettingsPurchasesRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/Purchases/SettingsPurchasesRoute.tsx
@@ -1,0 +1,29 @@
+import { Text } from "@artsy/palette"
+import React from "react"
+import { SettingsPurchasesRoute_me } from "v2/__generated__/SettingsPurchasesRoute_me.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface SettingsPurchasesRouteProps {
+  me: SettingsPurchasesRoute_me
+}
+
+const SettingsPurchasesRoute: React.FC<SettingsPurchasesRouteProps> = ({
+  me,
+}) => {
+  return (
+    <>
+      <Text>Purchases Route</Text>
+    </>
+  )
+}
+
+export const SettingsPurchasesRouteFragmentContainer = createFragmentContainer(
+  SettingsPurchasesRoute,
+  {
+    me: graphql`
+      fragment SettingsPurchasesRoute_me on Me {
+        name
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Settings/Routes/Saves/SettingsSavesRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/Saves/SettingsSavesRoute.tsx
@@ -1,0 +1,27 @@
+import { Text } from "@artsy/palette"
+import React from "react"
+import { SettingsSavesRoute_me } from "v2/__generated__/SettingsSavesRoute_me.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface SettingsSavesRouteProps {
+  me: SettingsSavesRoute_me
+}
+
+const SettingsSavesRoute: React.FC<SettingsSavesRouteProps> = ({ me }) => {
+  return (
+    <>
+      <Text>Saves Route</Text>
+    </>
+  )
+}
+
+export const SettingsSavesRouteFragmentContainer = createFragmentContainer(
+  SettingsSavesRoute,
+  {
+    me: graphql`
+      fragment SettingsSavesRoute_me on Me {
+        name
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Settings/Routes/Settings/SettingsEditRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/Settings/SettingsEditRoute.tsx
@@ -1,0 +1,27 @@
+import { Text } from "@artsy/palette"
+import React from "react"
+import { SettingsEditRoute_me } from "v2/__generated__/SettingsEditRoute_me.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface SettingsEditRouteProps {
+  me: SettingsEditRoute_me
+}
+
+const SettingsEditRoute: React.FC<SettingsEditRouteProps> = ({ me }) => {
+  return (
+    <>
+      <Text>Settings Route</Text>
+    </>
+  )
+}
+
+export const SettingsEditRouteFragmentContainer = createFragmentContainer(
+  SettingsEditRoute,
+  {
+    me: graphql`
+      fragment SettingsEditRoute_me on Me {
+        name
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Settings/Routes/Shipping/SettingsShippingRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/Shipping/SettingsShippingRoute.tsx
@@ -1,0 +1,29 @@
+import { Text } from "@artsy/palette"
+import React from "react"
+import { SettingsShippingRoute_me } from "v2/__generated__/SettingsShippingRoute_me.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface SettingsShippingRouteProps {
+  me: SettingsShippingRoute_me
+}
+
+const SettingsShippingRoute: React.FC<SettingsShippingRouteProps> = ({
+  me,
+}) => {
+  return (
+    <>
+      <Text>Shipping Route</Text>
+    </>
+  )
+}
+
+export const SettingsShippingRouteFragmentContainer = createFragmentContainer(
+  SettingsShippingRoute,
+  {
+    me: graphql`
+      fragment SettingsShippingRoute_me on Me {
+        name
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Settings/SettingsApp.tsx
+++ b/src/v2/Apps/Settings/SettingsApp.tsx
@@ -1,0 +1,69 @@
+import { Box, Text } from "@artsy/palette"
+import React from "react"
+import { SettingsApp_me } from "v2/__generated__/SettingsApp_me.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+import { RouteTab, RouteTabs } from "v2/Components/RouteTabs"
+
+interface SettingsAppProps {
+  me: SettingsApp_me
+}
+
+const tabs = [
+  {
+    name: "Saves & Follows",
+    url: "/settings2/saves",
+  },
+  {
+    name: "Collector Profile",
+    url: "/settings2/edit-profile",
+  },
+  {
+    name: "Order History",
+    url: "/settings2/purchases",
+  },
+  {
+    name: "Bids",
+    url: "/settings2/auctions",
+  },
+  {
+    name: "Edit Settings",
+    url: "/settings2/edit-settings",
+  },
+  {
+    name: "Payments",
+    url: "/settings2/payments",
+  },
+  {
+    name: "Shipping",
+    url: "/settings2/shipping",
+  },
+]
+
+const SettingsApp: React.FC<SettingsAppProps> = ({ me, children }) => {
+  return (
+    <>
+      <Text variant="lg" mt={[2, 4]}>
+        Hi {me.name}!
+      </Text>
+
+      <RouteTabs my={4}>
+        {tabs.map((tab, index) => {
+          return <RouteTab to={tab.url}>{tab.name}</RouteTab>
+        })}
+      </RouteTabs>
+
+      <Box>{children}</Box>
+    </>
+  )
+}
+
+export const SettingsAppFragmentContainer = createFragmentContainer(
+  SettingsApp,
+  {
+    me: graphql`
+      fragment SettingsApp_me on Me {
+        name
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Settings/settingsRoutes.tsx
+++ b/src/v2/Apps/Settings/settingsRoutes.tsx
@@ -1,0 +1,175 @@
+import loadable from "@loadable/component"
+import { graphql } from "relay-runtime"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const SettingsApp = loadable(
+  () => import(/* webpackChunkName: "settingsBundle" */ "./SettingsApp"),
+  {
+    resolveComponent: component => component.SettingsAppFragmentContainer,
+  }
+)
+const OverviewRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "settingsBundle" */ "./Routes/Overview/SettingsOverviewRoute"
+    ),
+  {
+    resolveComponent: component =>
+      component.SettingsOverviewRouteFragmentContainer,
+  }
+)
+const AuctionsRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "settingsBundle" */ "./Routes/Auctions/SettingsAuctionsRoute"
+    ),
+  {
+    resolveComponent: component =>
+      component.SettingsAuctionsRouteFragmentContainer,
+  }
+)
+const EditProfileRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "settingsBundle" */ "./Routes/EditProfile/SettingsEditProfileRoute"
+    ),
+  {
+    resolveComponent: component =>
+      component.SettingsEditProfileRouteFragmentContainer,
+  }
+)
+const PaymentsRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "settingsBundle" */ "./Routes/Payments/SettingsPaymentsRoute"
+    ),
+  {
+    resolveComponent: component =>
+      component.SettingsPaymentsRouteFragmentContainer,
+  }
+)
+const PurchasesRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "settingsBundle" */ "./Routes/Purchases/SettingsPurchasesRoute"
+    ),
+  {
+    resolveComponent: component =>
+      component.SettingsPurchasesRouteFragmentContainer,
+  }
+)
+const SavesRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "settingsBundle" */ "./Routes/Saves/SettingsSavesRoute"
+    ),
+  {
+    resolveComponent: component =>
+      component.SettingsSavesRouteFragmentContainer,
+  }
+)
+const SettingsRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "settingsBundle" */ "./Routes/Settings/SettingsEditRoute"
+    ),
+  {
+    resolveComponent: component => component.SettingsEditRouteFragmentContainer,
+  }
+)
+const ShippingRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "settingsBundle" */ "./Routes/Shipping/SettingsShippingRoute"
+    ),
+  {
+    resolveComponent: component =>
+      component.SettingsShippingRouteFragmentContainer,
+  }
+)
+
+export const settingsRoutes: AppRouteConfig[] = [
+  {
+    path: "/settings2",
+    theme: "v3",
+    getComponent: () => SettingsApp,
+    prepare: () => {
+      SettingsApp.preload()
+    },
+    query: graphql`
+      query settingsRoutes_SettingsQuery {
+        me {
+          ...SettingsApp_me
+        }
+      }
+    `,
+    children: [
+      {
+        path: "/",
+        theme: "v3",
+        getComponent: () => OverviewRoute,
+        prepare: () => {
+          OverviewRoute.preload()
+        },
+      },
+      {
+        path: "auctions",
+        theme: "v3",
+        getComponent: () => AuctionsRoute,
+        prepare: () => {
+          AuctionsRoute.preload()
+        },
+      },
+      {
+        path: "edit-profile",
+        theme: "v3",
+        getComponent: () => EditProfileRoute,
+        prepare: () => {
+          EditProfileRoute.preload()
+        },
+      },
+      {
+        path: "payments",
+        theme: "v3",
+        getComponent: () => PaymentsRoute,
+        prepare: () => {
+          PaymentsRoute.preload()
+        },
+      },
+      {
+        path: "purchases",
+        theme: "v3",
+        getComponent: () => PurchasesRoute,
+        prepare: () => {
+          PurchasesRoute.preload()
+        },
+      },
+      {
+        path: "saves",
+        theme: "v3",
+        getComponent: () => SavesRoute,
+        prepare: () => {
+          SavesRoute.preload()
+        },
+      },
+
+      {
+        path: "edit-settings",
+        theme: "v3",
+        getComponent: () => SettingsRoute,
+        prepare: () => {
+          SettingsRoute.preload()
+        },
+      },
+
+      {
+        path: "shipping",
+        theme: "v3",
+        getComponent: () => ShippingRoute,
+        prepare: () => {
+          ShippingRoute.preload()
+        },
+      },
+    ],
+  },
+]

--- a/src/v2/Components/ErrorPage.tsx
+++ b/src/v2/Components/ErrorPage.tsx
@@ -30,7 +30,7 @@ export const ErrorPage: React.FC<ErrorPageProps> = ({
 
   return (
     <ThemeProviderV3>
-      <GridColumns my={4} gridRowGap={4}>
+      <GridColumns gridRowGap={4} m={4}>
         <Column span={6} wrap>
           <Text variant="xl">{defaultMessage}</Text>
 

--- a/src/v2/__generated__/SettingsApp_me.graphql.ts
+++ b/src/v2/__generated__/SettingsApp_me.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SettingsApp_me = {
+    readonly name: string | null;
+    readonly " $refType": "SettingsApp_me";
+};
+export type SettingsApp_me$data = SettingsApp_me;
+export type SettingsApp_me$key = {
+    readonly " $data"?: SettingsApp_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SettingsApp_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SettingsApp_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = '56be5a9c920e4e6f4c10ae60edaeaedc';
+export default node;

--- a/src/v2/__generated__/SettingsAuctionsRoute_me.graphql.ts
+++ b/src/v2/__generated__/SettingsAuctionsRoute_me.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SettingsAuctionsRoute_me = {
+    readonly name: string | null;
+    readonly " $refType": "SettingsAuctionsRoute_me";
+};
+export type SettingsAuctionsRoute_me$data = SettingsAuctionsRoute_me;
+export type SettingsAuctionsRoute_me$key = {
+    readonly " $data"?: SettingsAuctionsRoute_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SettingsAuctionsRoute_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SettingsAuctionsRoute_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = 'e13f015b332f823b731cdf2c3c2995ee';
+export default node;

--- a/src/v2/__generated__/SettingsEditProfileRoute_me.graphql.ts
+++ b/src/v2/__generated__/SettingsEditProfileRoute_me.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SettingsEditProfileRoute_me = {
+    readonly name: string | null;
+    readonly " $refType": "SettingsEditProfileRoute_me";
+};
+export type SettingsEditProfileRoute_me$data = SettingsEditProfileRoute_me;
+export type SettingsEditProfileRoute_me$key = {
+    readonly " $data"?: SettingsEditProfileRoute_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SettingsEditProfileRoute_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SettingsEditProfileRoute_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = '57f19d27ac6573fc5a1b53ac83eb74ae';
+export default node;

--- a/src/v2/__generated__/SettingsEditRoute_me.graphql.ts
+++ b/src/v2/__generated__/SettingsEditRoute_me.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SettingsEditRoute_me = {
+    readonly name: string | null;
+    readonly " $refType": "SettingsEditRoute_me";
+};
+export type SettingsEditRoute_me$data = SettingsEditRoute_me;
+export type SettingsEditRoute_me$key = {
+    readonly " $data"?: SettingsEditRoute_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SettingsEditRoute_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SettingsEditRoute_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = 'f23bdd89fb65ecb7c7571bda2d515049';
+export default node;

--- a/src/v2/__generated__/SettingsOverviewRoute_me.graphql.ts
+++ b/src/v2/__generated__/SettingsOverviewRoute_me.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SettingsOverviewRoute_me = {
+    readonly name: string | null;
+    readonly " $refType": "SettingsOverviewRoute_me";
+};
+export type SettingsOverviewRoute_me$data = SettingsOverviewRoute_me;
+export type SettingsOverviewRoute_me$key = {
+    readonly " $data"?: SettingsOverviewRoute_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SettingsOverviewRoute_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SettingsOverviewRoute_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = '7028392d42eec203025d4055c5543eb0';
+export default node;

--- a/src/v2/__generated__/SettingsPaymentsRoute_me.graphql.ts
+++ b/src/v2/__generated__/SettingsPaymentsRoute_me.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SettingsPaymentsRoute_me = {
+    readonly name: string | null;
+    readonly " $refType": "SettingsPaymentsRoute_me";
+};
+export type SettingsPaymentsRoute_me$data = SettingsPaymentsRoute_me;
+export type SettingsPaymentsRoute_me$key = {
+    readonly " $data"?: SettingsPaymentsRoute_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SettingsPaymentsRoute_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SettingsPaymentsRoute_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = 'e34e5f50a7a3ac02756c2a43c506d523';
+export default node;

--- a/src/v2/__generated__/SettingsPurchasesRoute_me.graphql.ts
+++ b/src/v2/__generated__/SettingsPurchasesRoute_me.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SettingsPurchasesRoute_me = {
+    readonly name: string | null;
+    readonly " $refType": "SettingsPurchasesRoute_me";
+};
+export type SettingsPurchasesRoute_me$data = SettingsPurchasesRoute_me;
+export type SettingsPurchasesRoute_me$key = {
+    readonly " $data"?: SettingsPurchasesRoute_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SettingsPurchasesRoute_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SettingsPurchasesRoute_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = 'd0810f50c8abc162df5bb80601d2e746';
+export default node;

--- a/src/v2/__generated__/SettingsSavesRoute_me.graphql.ts
+++ b/src/v2/__generated__/SettingsSavesRoute_me.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SettingsSavesRoute_me = {
+    readonly name: string | null;
+    readonly " $refType": "SettingsSavesRoute_me";
+};
+export type SettingsSavesRoute_me$data = SettingsSavesRoute_me;
+export type SettingsSavesRoute_me$key = {
+    readonly " $data"?: SettingsSavesRoute_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SettingsSavesRoute_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SettingsSavesRoute_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = '1982b79a39acf2359161c14affbb6914';
+export default node;

--- a/src/v2/__generated__/SettingsShippingRoute_me.graphql.ts
+++ b/src/v2/__generated__/SettingsShippingRoute_me.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SettingsShippingRoute_me = {
+    readonly name: string | null;
+    readonly " $refType": "SettingsShippingRoute_me";
+};
+export type SettingsShippingRoute_me$data = SettingsShippingRoute_me;
+export type SettingsShippingRoute_me$key = {
+    readonly " $data"?: SettingsShippingRoute_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SettingsShippingRoute_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SettingsShippingRoute_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = '613daa2b2e49638aab047365489da964';
+export default node;

--- a/src/v2/__generated__/settingsRoutes_SettingsQuery.graphql.ts
+++ b/src/v2/__generated__/settingsRoutes_SettingsQuery.graphql.ts
@@ -1,0 +1,100 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type settingsRoutes_SettingsQueryVariables = {};
+export type settingsRoutes_SettingsQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"SettingsApp_me">;
+    } | null;
+};
+export type settingsRoutes_SettingsQuery = {
+    readonly response: settingsRoutes_SettingsQueryResponse;
+    readonly variables: settingsRoutes_SettingsQueryVariables;
+};
+
+
+
+/*
+query settingsRoutes_SettingsQuery {
+  me {
+    ...SettingsApp_me
+    id
+  }
+}
+
+fragment SettingsApp_me on Me {
+  name
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "settingsRoutes_SettingsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SettingsApp_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "settingsRoutes_SettingsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "settingsRoutes_SettingsQuery",
+    "operationKind": "query",
+    "text": "query settingsRoutes_SettingsQuery {\n  me {\n    ...SettingsApp_me\n    id\n  }\n}\n\nfragment SettingsApp_me on Me {\n  name\n}\n"
+  }
+};
+(node as any).hash = '41ffd02fc8cd23db2c073a63982eb3c0';
+export default node;

--- a/src/v2/routes.tsx
+++ b/src/v2/routes.tsx
@@ -26,6 +26,7 @@ import { paymentRoutes } from "v2/Apps/Payment/paymentRoutes"
 import { priceDatabaseRoutes } from "./Apps/PriceDatabase/priceDatabaseRoutes"
 import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
 import { searchRoutes } from "v2/Apps/Search/searchRoutes"
+import { settingsRoutes } from "v2/Apps/Settings/settingsRoutes"
 import { shippingRoutes } from "v2/Apps/Shipping/shippingRoutes"
 import { showRoutes } from "v2/Apps/Show/showRoutes"
 import { showsRoutes } from "v2/Apps/Shows/showsRoutes"
@@ -60,6 +61,7 @@ export function getAppRoutes(): AppRouteConfig[] {
     { routes: priceDatabaseRoutes },
     { routes: purchaseRoutes },
     { routes: searchRoutes },
+    { routes: settingsRoutes },
     { routes: shippingRoutes },
     { routes: showRoutes },
     { routes: showsRoutes },

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -22,6 +22,8 @@ if (!NOVO_MANIFEST) {
 const app = express()
 const { routes, routePaths } = getRouteConfig()
 
+console.log(routePaths)
+
 /**
  * Mount routes that will connect to global SSR router
  */


### PR DESCRIPTION
This PR scaffolds out the new /settings2 app by stubbing out routes and dropping in some empty components. Now we just need to fill out the detail. 

![settings2](https://user-images.githubusercontent.com/236943/137851982-10164a96-c01f-4d8e-b033-04345179dc08.gif)

cc @artsy/grow-devs 