### PR TITLE
chore(Auctions): Remove rail counts for now

### DIFF
--- a/src/v2/Apps/Auctions/Components/AuctionArtworksRail.tsx
+++ b/src/v2/Apps/Auctions/Components/AuctionArtworksRail.tsx
@@ -49,7 +49,6 @@ export const AuctionArtworksRail: React.FC<AuctionArtworksRailProps> = ({
     <Rail
       title={sale.name!}
       subTitle={sale.formattedStartDateTime!}
-      countLabel={nodes.length}
       viewAllLabel="View All"
       viewAllHref={sale.href!}
       viewAllOnClick={() => {

--- a/src/v2/Apps/Auctions/Components/StandoutLotsRail.tsx
+++ b/src/v2/Apps/Auctions/Components/StandoutLotsRail.tsx
@@ -34,7 +34,6 @@ const StandoutLotsRail: React.FC<StandoutLotsRailProps> = ({ viewer }) => {
   return (
     <Rail
       title="Standout Lots"
-      countLabel={liveSaleArtworks.length}
       subTitle="Works that Artsy curators love"
       getItems={() => {
         return liveSaleArtworks.map((node, index) => {

--- a/src/v2/Apps/Auctions/Components/TrendingLotsRail.tsx
+++ b/src/v2/Apps/Auctions/Components/TrendingLotsRail.tsx
@@ -33,7 +33,6 @@ const TrendingLotsRail: React.FC<TrendingLotsRailProps> = ({ viewer }) => {
     <Rail
       title="Trending lots"
       subTitle="Works with the most bids today"
-      countLabel={liveSaleArtworks.length}
       getItems={() => {
         return liveSaleArtworks.map((node, index) => {
           return (

--- a/src/v2/Apps/Auctions/Components/WorksByArtistsYouFollowRail.tsx
+++ b/src/v2/Apps/Auctions/Components/WorksByArtistsYouFollowRail.tsx
@@ -32,7 +32,6 @@ const WorksByArtistsYouFollowRail: React.FC<WorksByArtistsYouFollowRailProps> = 
     <Rail
       title="Works for you"
       subTitle="Works at auction by artists you follow"
-      countLabel={nodes.length}
       getItems={() => {
         return nodes.map((node, index) => {
           return (


### PR DESCRIPTION
This removes the rail counts for now as we need a more holistic solution for the variability of items in the rail (and the cap that often occurs at 99) 

cc @artsy/grow-devs 