### PR TITLE
refactor(router): Default to palette v3 in route config

### DIFF
--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -84,7 +84,6 @@ const ConsignRoute = loadable(
 export const artistRoutes: AppRouteConfig[] = [
   {
     path: "/artist/:artistID",
-    theme: "v3",
     ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => ArtistApp,
     prepare: () => {
@@ -104,7 +103,6 @@ export const artistRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "/",
-        theme: "v3",
         getComponent: () => OverviewRoute,
         prepare: () => {
           OverviewRoute.preload()
@@ -119,7 +117,6 @@ export const artistRoutes: AppRouteConfig[] = [
       },
       {
         path: "works-for-sale",
-        theme: "v3",
         getComponent: () => WorksForSaleRoute,
         prepare: () => {
           WorksForSaleRoute.preload()
@@ -140,7 +137,6 @@ export const artistRoutes: AppRouteConfig[] = [
       },
       {
         path: "auction-results",
-        theme: "v3",
         getComponent: () => AuctionResultsRoute,
         prepare: () => {
           AuctionResultsRoute.preload()
@@ -185,7 +181,6 @@ export const artistRoutes: AppRouteConfig[] = [
 
       {
         path: "articles",
-        theme: "v3",
         hideNavigationTabs: true,
         getComponent: () => ArticlesRoute,
         prepare: () => {
@@ -237,7 +232,6 @@ export const artistRoutes: AppRouteConfig[] = [
       },
       {
         path: "cv",
-        theme: "v3",
         hideNavigationTabs: true,
         getComponent: () => CVRoute,
         prepare: () => {
@@ -253,7 +247,6 @@ export const artistRoutes: AppRouteConfig[] = [
       },
       {
         path: "shows",
-        theme: "v3",
         hideNavigationTabs: true,
         getComponent: () => ShowsRoute,
         prepare: () => {

--- a/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
+++ b/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
@@ -13,7 +13,6 @@ const ArtistSeriesApp = loadable(
 
 export const artistSeriesRoutes: AppRouteConfig[] = [
   {
-    theme: "v3",
     path: "/artist-series/:slug",
     getComponent: () => ArtistSeriesApp,
     prepare: () => {

--- a/src/v2/Apps/Artists/artistsRoutes.tsx
+++ b/src/v2/Apps/Artists/artistsRoutes.tsx
@@ -33,7 +33,6 @@ export const artistsRoutes: AppRouteConfig[] = [
     },
     children: [
       {
-        theme: "v3",
         path: "",
         getComponent: () => ArtistsIndexRoute,
         prepare: () => {
@@ -51,7 +50,6 @@ export const artistsRoutes: AppRouteConfig[] = [
         `,
       },
       {
-        theme: "v3",
         path: "artists-starting-with-:letter([a-zA-Z])",
         getComponent: () => ArtistsByLetterRoute,
         prepare: () => {

--- a/src/v2/Apps/Artwork/artworkRoutes.tsx
+++ b/src/v2/Apps/Artwork/artworkRoutes.tsx
@@ -11,7 +11,6 @@ const ArtworkApp = loadable(
 
 export const artworkRoutes: AppRouteConfig[] = [
   {
-    theme: "v3",
     path: "/artwork/:artworkID/:optional?", // There's a `confirm-bid` nested route.
     getComponent: () => ArtworkApp,
     prepare: () => {

--- a/src/v2/Apps/Auction/auctionRoutes.tsx
+++ b/src/v2/Apps/Auction/auctionRoutes.tsx
@@ -31,6 +31,7 @@ const RegisterRoute = loadable(
 export const auctionRoutes: AppRouteConfig[] = [
   {
     path: "/auction-faq",
+    theme: "v2",
     getComponent: () => AuctionFAQRoute,
     prepare: () => {
       AuctionFAQRoute.preload()
@@ -46,6 +47,7 @@ export const auctionRoutes: AppRouteConfig[] = [
   },
   {
     path: "/auction/:saleID/bid(2)?/:artworkID",
+    theme: "v2",
     getComponent: () => ConfirmBidRoute,
     prepare: () => {
       ConfirmBidRoute.preload()
@@ -101,6 +103,7 @@ export const auctionRoutes: AppRouteConfig[] = [
   },
   {
     path: "/auction-registration(2)?/:saleID",
+    theme: "v2",
     getComponent: () => RegisterRoute,
     prepare: () => {
       RegisterRoute.preload()

--- a/src/v2/Apps/Auctions/auctionsRoutes.tsx
+++ b/src/v2/Apps/Auctions/auctionsRoutes.tsx
@@ -51,7 +51,6 @@ const ArtworksRoute = loadable(
 export const auctionsRoutes: AppRouteConfig[] = [
   {
     path: "/auctions",
-    theme: "v3",
     ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => AuctionsApp,
     prepare: () => {
@@ -68,7 +67,6 @@ export const auctionsRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "", // represents current auctions aka /auctions/current
-        theme: "v3",
         Component: CurrentAuctionsPaginationContainer,
         query: graphql`
           query auctionsRoutes_Current_AuctionsQuery {
@@ -80,7 +78,6 @@ export const auctionsRoutes: AppRouteConfig[] = [
       },
       {
         path: "upcoming",
-        theme: "v3",
         Component: UpcomingAuctionsPaginationContainer,
         query: graphql`
           query auctionsRoutes_Upcoming_AuctionsQuery {
@@ -92,7 +89,6 @@ export const auctionsRoutes: AppRouteConfig[] = [
       },
       {
         path: "past",
-        theme: "v3",
         Component: PastAuctionsPaginationContainer,
         query: graphql`
           query auctionsRoutes_Past_AuctionsQuery {
@@ -104,7 +100,6 @@ export const auctionsRoutes: AppRouteConfig[] = [
       },
       {
         path: "auctions",
-        theme: "v3",
         getComponent: () => AuctionsRoute,
         query: graphql`
           query auctionsRoutes_Auctions_AuctionsQuery {
@@ -116,7 +111,6 @@ export const auctionsRoutes: AppRouteConfig[] = [
       },
       {
         path: "artworks",
-        theme: "v3",
         getComponent: () => ArtworksRoute,
         query: graphql`
           query auctionsRoutes_Artworks_AuctionsQuery {

--- a/src/v2/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/v2/Apps/Authentication/authenticationRoutes.tsx
@@ -13,7 +13,6 @@ export const authenticationRoutes: AppRouteConfig[] = [
   {
     hideNav: true,
     hideFooter: true,
-    theme: "v3",
     path: "/reset_password2",
     getComponent: () => ResetPasswordRoute,
     prepare: () => {

--- a/src/v2/Apps/BuyerGuarantee/buyerGuaranteeRoutes.tsx
+++ b/src/v2/Apps/BuyerGuarantee/buyerGuaranteeRoutes.tsx
@@ -21,7 +21,6 @@ const BuyerGuaranteeIndexRoute = loadable(
 export const buyerGuaranteeRoutes: AppRouteConfig[] = [
   {
     path: "/buyer-guarantee",
-    theme: "v3",
     getComponent: () => BuyerGuaranteeApp,
     prepare: () => {
       BuyerGuaranteeApp.preload()
@@ -29,7 +28,6 @@ export const buyerGuaranteeRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "",
-        theme: "v3",
         getComponent: () => BuyerGuaranteeIndexRoute,
         prepare: () => {
           return BuyerGuaranteeIndexRoute.preload()

--- a/src/v2/Apps/Categories/categoriesRoutes.tsx
+++ b/src/v2/Apps/Categories/categoriesRoutes.tsx
@@ -12,7 +12,6 @@ const CategoriesApp = loadable(
 export const categoriesRoutes: AppRouteConfig[] = [
   {
     path: "/categories",
-    theme: "v3",
     getComponent: () => CategoriesApp,
     prepare: () => {
       CategoriesApp.preload()

--- a/src/v2/Apps/Collect/collectRoutes.tsx
+++ b/src/v2/Apps/Collect/collectRoutes.tsx
@@ -27,7 +27,6 @@ const CollectionApp = loadable(
 export const collectRoutes: AppRouteConfig[] = [
   {
     path: "/collect/:medium?",
-    theme: "v3",
     getComponent: () => CollectApp,
     prepare: () => {
       CollectApp.preload()
@@ -37,7 +36,6 @@ export const collectRoutes: AppRouteConfig[] = [
   },
   {
     path: "/collect/color/:color?",
-    theme: "v3",
     getComponent: () => CollectApp,
     prepare: () => {
       CollectApp.preload()
@@ -47,7 +45,6 @@ export const collectRoutes: AppRouteConfig[] = [
   },
   {
     path: "/collections",
-    theme: "v3",
     getComponent: () => CollectionsApp,
     prepare: () => {
       CollectionsApp.preload()
@@ -61,7 +58,6 @@ export const collectRoutes: AppRouteConfig[] = [
     `,
   },
   {
-    theme: "v3",
     path: "/collection/:slug",
     getComponent: () => CollectionApp,
     prepare: () => {

--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -6,8 +6,8 @@ import { NavBar } from "v2/Components/NavBar"
 import { Match } from "found"
 import { isFunction } from "lodash"
 import { Footer } from "v2/Components/Footer"
-import { useEffect, useState } from "react";
-import * as React from "react";
+import { useEffect, useState } from "react"
+import * as React from "react"
 import createLogger from "v2/Utils/logger"
 import { useSystemContext } from "v2/System"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
@@ -63,7 +63,7 @@ export const AppShell: React.FC<AppShellProps> = props => {
    * will cause the styles to update out of sync with the page change. Here we
    * wait for the route to finish rendering before setting the next theme.
    */
-  const nextTheme = routeConfig.theme ?? "v2"
+  const nextTheme = routeConfig.theme ?? "v3"
   const [theme, setTheme] = useState<"v2" | "v3">(nextTheme)
   useRouteComplete({ onComplete: () => setTheme(nextTheme) })
 

--- a/src/v2/Apps/Consign/consignRoutes.tsx
+++ b/src/v2/Apps/Consign/consignRoutes.tsx
@@ -75,7 +75,6 @@ const ThankYou = loadable(
 
 export const consignRoutes: AppRouteConfig[] = [
   {
-    theme: "v3",
     path: "/consign",
     getComponent: () => MarketingLandingApp,
     prepare: () => {
@@ -83,7 +82,6 @@ export const consignRoutes: AppRouteConfig[] = [
     },
   },
   {
-    theme: "v3",
     path: "/consign/submission2",
     getComponent: () => SubmissionLayout,
     children: [
@@ -92,7 +90,6 @@ export const consignRoutes: AppRouteConfig[] = [
         to: "/consign/submission2/artwork-details",
       }) as any,
       {
-        theme: "v3",
         path: "artwork-details",
         hideFooter: true,
         getComponent: () => ArtworkDetails,
@@ -101,7 +98,6 @@ export const consignRoutes: AppRouteConfig[] = [
         },
       },
       {
-        theme: "v3",
         path: ":id/artwork-details",
         hideFooter: true,
         getComponent: () => ArtworkDetails,
@@ -110,7 +106,6 @@ export const consignRoutes: AppRouteConfig[] = [
         },
       },
       {
-        theme: "v3",
         path: ":id/upload-photos",
         hideFooter: true,
         getComponent: () => UploadPhotos,
@@ -119,7 +114,6 @@ export const consignRoutes: AppRouteConfig[] = [
         },
       },
       {
-        theme: "v3",
         path: ":id/contact-information",
         hideFooter: true,
         getComponent: () => ContactInformation,
@@ -135,7 +129,6 @@ export const consignRoutes: AppRouteConfig[] = [
         `,
       },
       {
-        theme: "v3",
         path: ":id/thank-you",
         hideFooter: true,
         getComponent: () => ThankYou,
@@ -147,6 +140,7 @@ export const consignRoutes: AppRouteConfig[] = [
   },
   {
     path: "/consign/offer/:offerID",
+    theme: "v2",
     getComponent: () => OfferDetailApp,
     prepare: () => {
       OfferDetailApp.preload()

--- a/src/v2/Apps/Conversation/conversationRoutes.tsx
+++ b/src/v2/Apps/Conversation/conversationRoutes.tsx
@@ -4,7 +4,6 @@ import { graphql } from "react-relay"
 
 export const conversationRoutes: AppRouteConfig[] = [
   {
-    theme: "v3",
     path: "/user/conversations",
     displayFullPage: true,
     hideFooter: true,
@@ -36,7 +35,6 @@ export const conversationRoutes: AppRouteConfig[] = [
     },
   },
   {
-    theme: "v3",
     path: "/user/conversations/:conversationID",
     displayFullPage: true,
     hideFooter: true,

--- a/src/v2/Apps/Debug/debugRoutes.tsx
+++ b/src/v2/Apps/Debug/debugRoutes.tsx
@@ -20,13 +20,11 @@ export const debugRoutes: AppRouteConfig[] = [
     Component: ({ children }) => children,
     children: [
       {
-        theme: "v3",
         path: "baseline",
         Component: DebugApp,
       },
       // TODO: Remove once inquiry is complete
       {
-        theme: "v3",
         path: "inquiry",
         Component: DebugInquiryApp,
       },

--- a/src/v2/Apps/Example/exampleRoutes.tsx
+++ b/src/v2/Apps/Example/exampleRoutes.tsx
@@ -51,6 +51,9 @@ const WelcomeRoute = loadable(
 export const exampleRoutes: AppRouteConfig[] = [
   {
     path: "/example",
+
+    // FIXME: V2 theme is deprecated. Still need to refactor example app to use latest
+    theme: "v2",
     getComponent: () => ExampleApp,
     prepare: () => {
       ExampleApp.preload()
@@ -65,10 +68,12 @@ export const exampleRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "",
+        theme: "v2",
         Component: WelcomeRoute,
       },
       {
         path: "artist/:slug",
+        theme: "v2",
         getComponent: () => ArtistRoute,
         prepare: () => {
           ArtistRoute.preload()
@@ -84,6 +89,7 @@ export const exampleRoutes: AppRouteConfig[] = [
       },
       {
         path: "artwork/:slug",
+        theme: "v2",
         getComponent: () => ArtworkRoute,
         prepare: () => {
           ArtworkRoute.preload()
@@ -99,6 +105,7 @@ export const exampleRoutes: AppRouteConfig[] = [
       },
       {
         path: "artwork-filter/:slug",
+        theme: "v2",
         getComponent: () => ArtworkFilterRoute,
         prepare: () => {
           ArtworkRoute.preload()

--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -56,7 +56,6 @@ const FairArticlesRoute = loadable(
 export const fairRoutes: AppRouteConfig[] = [
   {
     path: "/fair/:slug",
-    theme: "v3",
     ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => FairApp,
     prepare: () => {
@@ -72,7 +71,6 @@ export const fairRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "",
-        theme: "v3",
         getComponent: () => FairOverviewRoute,
         prepare: () => {
           FairOverviewRoute.preload()
@@ -87,7 +85,6 @@ export const fairRoutes: AppRouteConfig[] = [
       },
       {
         path: "exhibitors(.*)?",
-        theme: "v3",
         getComponent: () => FairExhibitorsRoute,
         prepare: () => {
           FairExhibitorsRoute.preload()
@@ -102,7 +99,6 @@ export const fairRoutes: AppRouteConfig[] = [
       },
       {
         path: "booths(.*)?",
-        theme: "v3",
         getComponent: () => FairBoothsRoute,
         prepare: () => {
           FairBoothsRoute.preload()
@@ -152,7 +148,6 @@ export const fairRoutes: AppRouteConfig[] = [
       },
       {
         path: "artworks(.*)?",
-        theme: "v3",
         getComponent: () => FairArtworksRoute,
         prepare: () => {
           FairArtworksRoute.preload()
@@ -182,7 +177,6 @@ export const fairRoutes: AppRouteConfig[] = [
   // The root `path: ""` matches the `FairExhibitorsRoute`.
   {
     path: "/fair/:slug",
-    theme: "v3",
     getComponent: () => FairSubApp,
     prepare: () => {
       FairSubApp.preload()
@@ -197,7 +191,6 @@ export const fairRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "articles",
-        theme: "v3",
         getComponent: () => FairArticlesRoute,
         prepare: () => {
           FairArticlesRoute.preload()

--- a/src/v2/Apps/FairOrginizer/fairOrganizerRoutes.tsx
+++ b/src/v2/Apps/FairOrginizer/fairOrganizerRoutes.tsx
@@ -32,7 +32,6 @@ const FairOrganizerDedicatedArticles = loadable(
 export const fairOrganizerRoutes: AppRouteConfig[] = [
   {
     path: "/fair-organizer/:slug",
-    theme: "v3",
     getComponent: () => FairOrganizerApp,
     prepare: () => {
       FairOrganizerApp.preload()
@@ -80,7 +79,6 @@ export const fairOrganizerRoutes: AppRouteConfig[] = [
   },
   {
     path: "/fair-organizer/:slug/articles",
-    theme: "v3",
     getComponent: () => FairOrganizerDedicatedArticles,
     prepare: () => {
       FairOrganizerDedicatedArticles.preload()

--- a/src/v2/Apps/Fairs/fairsRoutes.tsx
+++ b/src/v2/Apps/Fairs/fairsRoutes.tsx
@@ -32,7 +32,6 @@ export const fairsRoutes: AppRouteConfig[] = [
     },
     children: [
       {
-        theme: "v3",
         path: "",
         getComponent: () => FairsIndexRoute,
         prepare: () => {

--- a/src/v2/Apps/Feature/featureRoutes.tsx
+++ b/src/v2/Apps/Feature/featureRoutes.tsx
@@ -12,7 +12,6 @@ const FeatureApp = loadable(
 export const featureRoutes: AppRouteConfig[] = [
   {
     path: "/feature/:slug",
-    theme: "v3",
     getComponent: () => FeatureApp,
     prepare: () => {
       FeatureApp.preload()

--- a/src/v2/Apps/FeatureAKG/featureAKGRoutes.tsx
+++ b/src/v2/Apps/FeatureAKG/featureAKGRoutes.tsx
@@ -12,6 +12,7 @@ const FeatureAKGApp = loadable(
 export const featureAKGRoutes: AppRouteConfig[] = [
   {
     path: "/campaign/art-keeps-going",
+    theme: "v2",
     getComponent: () => FeatureAKGApp,
     prepare: () => {
       FeatureAKGApp.preload()

--- a/src/v2/Apps/Gene/geneRoutes.tsx
+++ b/src/v2/Apps/Gene/geneRoutes.tsx
@@ -39,7 +39,6 @@ export const geneRoutes: AppRouteConfig[] = [
         },
       },
       {
-        theme: "v3",
         path: "",
         getComponent: () => GeneShowRoute,
         prepare: () => {

--- a/src/v2/Apps/Home/homeRoutes.tsx
+++ b/src/v2/Apps/Home/homeRoutes.tsx
@@ -9,7 +9,6 @@ const HomeApp = loadable(
 
 export const homeRoutes: AppRouteConfig[] = [
   {
-    theme: "v3",
     path: "/",
     getComponent: () => HomeApp,
     prepare: () => {

--- a/src/v2/Apps/IdentityVerification/identityVerificationRoutes.tsx
+++ b/src/v2/Apps/IdentityVerification/identityVerificationRoutes.tsx
@@ -29,6 +29,7 @@ const Error = loadable(
 export const identityVerificationRoutes: AppRouteConfig[] = [
   {
     path: "/identity-verification/processing",
+    theme: "v2",
     getComponent: () => Processing,
     prepare: () => {
       Processing.preload()
@@ -36,6 +37,7 @@ export const identityVerificationRoutes: AppRouteConfig[] = [
   },
   {
     path: "/identity-verification/error",
+    theme: "v2",
     getComponent: () => Error,
     prepare: () => {
       Error.preload()
@@ -43,6 +45,7 @@ export const identityVerificationRoutes: AppRouteConfig[] = [
   },
   {
     path: "/identity-verification/:id",
+    theme: "v2",
     getComponent: () => IdentityVerificationApp,
     prepare: () => {
       IdentityVerificationApp.preload()

--- a/src/v2/Apps/Order/orderRoutes.tsx
+++ b/src/v2/Apps/Order/orderRoutes.tsx
@@ -88,7 +88,6 @@ const OrderApp = loadable(
 export const orderRoutes: AppRouteConfig[] = [
   {
     // TODO: Still need order2?
-    theme: "v3",
     path: "/order(2|s)/:orderID",
     hideFooter: true,
     Component: OrderApp,
@@ -142,7 +141,6 @@ export const orderRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "respond",
-        theme: "v3",
         Component: RespondRoute,
         shouldWarnBeforeLeaving: true,
         hideFooter: true,
@@ -159,7 +157,6 @@ export const orderRoutes: AppRouteConfig[] = [
       },
       {
         path: "offer",
-        theme: "v3",
         Component: OfferRoute,
         shouldWarnBeforeLeaving: true,
         hideFooter: true,
@@ -176,7 +173,6 @@ export const orderRoutes: AppRouteConfig[] = [
       },
       {
         path: "shipping",
-        theme: "v3",
         Component: ShippingRoute,
         shouldWarnBeforeLeaving: true,
         hideFooter: true,
@@ -196,7 +192,6 @@ export const orderRoutes: AppRouteConfig[] = [
       },
       {
         path: "payment",
-        theme: "v3",
         Component: PaymentRoute,
         shouldWarnBeforeLeaving: true,
         hideFooter: true,
@@ -216,7 +211,6 @@ export const orderRoutes: AppRouteConfig[] = [
       },
       {
         path: "payment/new",
-        theme: "v3",
         Component: NewPaymentRoute,
         shouldWarnBeforeLeaving: true,
         hideFooter: true,
@@ -236,7 +230,6 @@ export const orderRoutes: AppRouteConfig[] = [
       },
       {
         path: "review/counter",
-        theme: "v3",
         Component: CounterRoute,
         shouldWarnBeforeLeaving: true,
         hideFooter: true,
@@ -253,7 +246,6 @@ export const orderRoutes: AppRouteConfig[] = [
       },
       {
         path: "review",
-        theme: "v3",
         Component: ReviewRoute,
         shouldWarnBeforeLeaving: true,
         hideFooter: true,
@@ -270,7 +262,6 @@ export const orderRoutes: AppRouteConfig[] = [
       },
       {
         path: "review/accept",
-        theme: "v3",
         Component: AcceptRoute,
         hideFooter: true,
         query: graphql`
@@ -286,7 +277,6 @@ export const orderRoutes: AppRouteConfig[] = [
       },
       {
         path: "review/decline",
-        theme: "v3",
         Component: DeclineRoute,
         hideFooter: true,
         query: graphql`
@@ -299,7 +289,6 @@ export const orderRoutes: AppRouteConfig[] = [
       },
       {
         path: "status",
-        theme: "v3",
         Component: StatusRoute,
         hideFooter: true,
         query: graphql`

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -65,6 +65,7 @@ const ContactRoute = loadable(
 export const partnerRoutes: AppRouteConfig[] = [
   {
     path: "/partner/:partnerId",
+    theme: "v2",
     ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => PartnerApp,
     prepare: () => {
@@ -105,6 +106,7 @@ export const partnerRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "",
+        theme: "v2",
         getComponent: () => OverviewRoute,
         prepare: () => {
           OverviewRoute.preload()
@@ -119,6 +121,7 @@ export const partnerRoutes: AppRouteConfig[] = [
       },
       {
         path: "overview",
+        theme: "v2",
         render: props => {
           throw new RedirectException(
             `/partner/${props.match.params.partnerId}`,
@@ -128,6 +131,7 @@ export const partnerRoutes: AppRouteConfig[] = [
       },
       {
         path: "shows",
+        theme: "v2",
         getComponent: () => ShowsRoute,
         prepare: () => {
           ShowsRoute.preload()
@@ -169,6 +173,7 @@ export const partnerRoutes: AppRouteConfig[] = [
       },
       {
         path: "viewing-rooms",
+        theme: "v2",
         getComponent: () => ViewinRoomsRoute,
         prepare: () => {
           ViewinRoomsRoute.preload()
@@ -196,6 +201,7 @@ export const partnerRoutes: AppRouteConfig[] = [
       },
       {
         path: "works",
+        theme: "v2",
         getComponent: () => WorksRoute,
         prepare: () => {
           WorksRoute.preload()
@@ -275,6 +281,7 @@ export const partnerRoutes: AppRouteConfig[] = [
       },
       {
         path: "artists/:artistId?",
+        theme: "v2",
         getComponent: () => ArtistsRoute,
         prepare: () => {
           ArtistsRoute.preload()
@@ -316,6 +323,7 @@ export const partnerRoutes: AppRouteConfig[] = [
       },
       {
         path: "articles",
+        theme: "v2",
         getComponent: () => ArticlesRoute,
         prepare: () => {
           ArticlesRoute.preload()
@@ -363,6 +371,7 @@ export const partnerRoutes: AppRouteConfig[] = [
       },
       {
         path: "contact",
+        theme: "v2",
         getComponent: () => ContactRoute,
         prepare: () => {
           ContactRoute.preload()

--- a/src/v2/Apps/Partners/partnersRoutes.ts
+++ b/src/v2/Apps/Partners/partnersRoutes.ts
@@ -20,7 +20,6 @@ const InstitutionsRoute = loadable(
 
 export const partnersRoutes: AppRouteConfig[] = [
   {
-    theme: "v3",
     path: "/galleries2",
     getComponent: () => GalleriesRoute,
     prepare: () => {
@@ -35,7 +34,6 @@ export const partnersRoutes: AppRouteConfig[] = [
     `,
   },
   {
-    theme: "v3",
     path: "/institutions2",
     getComponent: () => InstitutionsRoute,
     prepare: () => {

--- a/src/v2/Apps/Payment/paymentRoutes.tsx
+++ b/src/v2/Apps/Payment/paymentRoutes.tsx
@@ -15,7 +15,6 @@ const PaymentApp = loadable(
 export const paymentRoutes: AppRouteConfig[] = [
   {
     // TODO: update route to /user/payments and remove stitched route to launch
-    theme: "v3",
     path: "/user/payments",
     getComponent: () => PaymentApp,
     prepare: () => {

--- a/src/v2/Apps/PriceDatabase/priceDatabaseRoutes.tsx
+++ b/src/v2/Apps/PriceDatabase/priceDatabaseRoutes.tsx
@@ -12,7 +12,6 @@ const PriceDatabaseApp = loadable(
 export const priceDatabaseRoutes: AppRouteConfig[] = [
   {
     path: "/price-database",
-    theme: "v3",
     getComponent: () => PriceDatabase,
     prepare: () => {
       PriceDatabaseApp.preload()

--- a/src/v2/Apps/Purchase/purchaseRoutes.tsx
+++ b/src/v2/Apps/Purchase/purchaseRoutes.tsx
@@ -11,7 +11,6 @@ const PurchasesApp = loadable(
 
 export const purchaseRoutes: AppRouteConfig[] = [
   {
-    theme: "v3",
     path: "/user/purchases",
     getComponent: () => PurchasesApp,
     prepare: () => {

--- a/src/v2/Apps/Search/searchRoutes.tsx
+++ b/src/v2/Apps/Search/searchRoutes.tsx
@@ -74,7 +74,6 @@ const tabsToEntitiesMap = {
 const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
   return {
     path: key,
-    theme: "v3",
     getComponent: () => SearchResultsEntity,
     prepare: () => {
       SearchResultsEntity.preload()
@@ -103,7 +102,6 @@ const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
 export const searchRoutes: AppRouteConfig[] = [
   {
     path: "/search",
-    theme: "v3",
     getComponent: () => SearchApp,
     prepare: () => {
       SearchApp.preload()
@@ -119,7 +117,6 @@ export const searchRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "/",
-        theme: "v3",
         getComponent: () => SearchResultsArtworks,
         prepare: () => {
           SearchResultsArtworks.preload()
@@ -169,7 +166,6 @@ export const searchRoutes: AppRouteConfig[] = [
       },
       {
         path: "artists",
-        theme: "v3",
         getComponent: () => SearchResultsArtists,
         prepare: () => {
           SearchResultsArtists.preload()

--- a/src/v2/Apps/Settings/settingsRoutes.tsx
+++ b/src/v2/Apps/Settings/settingsRoutes.tsx
@@ -106,7 +106,6 @@ export const settingsRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "/",
-        theme: "v3",
         getComponent: () => OverviewRoute,
         prepare: () => {
           OverviewRoute.preload()
@@ -114,7 +113,6 @@ export const settingsRoutes: AppRouteConfig[] = [
       },
       {
         path: "auctions",
-        theme: "v3",
         getComponent: () => AuctionsRoute,
         prepare: () => {
           AuctionsRoute.preload()
@@ -122,7 +120,6 @@ export const settingsRoutes: AppRouteConfig[] = [
       },
       {
         path: "edit-profile",
-        theme: "v3",
         getComponent: () => EditProfileRoute,
         prepare: () => {
           EditProfileRoute.preload()
@@ -130,7 +127,6 @@ export const settingsRoutes: AppRouteConfig[] = [
       },
       {
         path: "payments",
-        theme: "v3",
         getComponent: () => PaymentsRoute,
         prepare: () => {
           PaymentsRoute.preload()
@@ -138,7 +134,6 @@ export const settingsRoutes: AppRouteConfig[] = [
       },
       {
         path: "purchases",
-        theme: "v3",
         getComponent: () => PurchasesRoute,
         prepare: () => {
           PurchasesRoute.preload()
@@ -146,7 +141,6 @@ export const settingsRoutes: AppRouteConfig[] = [
       },
       {
         path: "saves",
-        theme: "v3",
         getComponent: () => SavesRoute,
         prepare: () => {
           SavesRoute.preload()
@@ -155,7 +149,6 @@ export const settingsRoutes: AppRouteConfig[] = [
 
       {
         path: "edit-settings",
-        theme: "v3",
         getComponent: () => SettingsRoute,
         prepare: () => {
           SettingsRoute.preload()
@@ -164,7 +157,6 @@ export const settingsRoutes: AppRouteConfig[] = [
 
       {
         path: "shipping",
-        theme: "v3",
         getComponent: () => ShippingRoute,
         prepare: () => {
           ShippingRoute.preload()

--- a/src/v2/Apps/Shipping/shippingRoutes.tsx
+++ b/src/v2/Apps/Shipping/shippingRoutes.tsx
@@ -14,7 +14,6 @@ const ShippingApp = loadable(
 
 export const shippingRoutes: AppRouteConfig[] = [
   {
-    theme: "v3",
     // TODO: update route to /user/shipping and remove stitched route to launch
     path: "/user/shipping",
     getComponent: () => ShippingApp,

--- a/src/v2/Apps/Show/showRoutes.tsx
+++ b/src/v2/Apps/Show/showRoutes.tsx
@@ -28,7 +28,6 @@ export const showRoutes: AppRouteConfig[] = [
   {
     getComponent: () => ShowApp,
     path: "/show/:slug",
-    theme: "v3",
     prepare: () => {
       ShowApp.preload()
     },
@@ -58,7 +57,6 @@ export const showRoutes: AppRouteConfig[] = [
       {
         getComponent: () => ShowInfoRoute,
         path: "info",
-        theme: "v3",
         prepare: () => {
           ShowInfoRoute.preload()
         },
@@ -79,7 +77,6 @@ export const showRoutes: AppRouteConfig[] = [
     ],
     getComponent: () => ShowSubApp,
     path: "/show/:slug",
-    theme: "v3",
     prepare: () => {
       ShowSubApp.preload()
     },

--- a/src/v2/Apps/Shows/showsRoutes.tsx
+++ b/src/v2/Apps/Shows/showsRoutes.tsx
@@ -40,7 +40,6 @@ export const showsRoutes: RouteConfig[] = [
     },
     children: [
       {
-        theme: "v3",
         path: "",
         getComponent: () => ShowsIndexRoute,
         prepare: () => {
@@ -58,7 +57,6 @@ export const showsRoutes: RouteConfig[] = [
         `,
       },
       {
-        theme: "v3",
         path: "all-cities",
         getComponent: () => ShowsAllCities,
         prepare: () => {
@@ -73,7 +71,6 @@ export const showsRoutes: RouteConfig[] = [
         `,
       },
       {
-        theme: "v3",
         path: ":slug",
         getComponent: () => ShowsCityRoute,
         prepare: () => {

--- a/src/v2/Apps/Tag/tagRoutes.tsx
+++ b/src/v2/Apps/Tag/tagRoutes.tsx
@@ -16,7 +16,6 @@ export const tagRoutes: AppRouteConfig[] = [
   {
     path: "/tag/:slug",
     getComponent: () => TagApp,
-    theme: "v3",
     prepare: () => {
       TagApp.preload()
     },

--- a/src/v2/Apps/Unsubscribe/unsubscribeRoutes.tsx
+++ b/src/v2/Apps/Unsubscribe/unsubscribeRoutes.tsx
@@ -9,7 +9,6 @@ const UnsubscribeApp = loadable(
 
 export const unsubscribeRoutes: AppRouteConfig[] = [
   {
-    theme: "v3",
     path: "/unsubscribe",
     getComponent: () => UnsubscribeApp,
     prepare: () => {

--- a/src/v2/Apps/ViewingRoom/viewingRoomRoutes.tsx
+++ b/src/v2/Apps/ViewingRoom/viewingRoomRoutes.tsx
@@ -38,7 +38,6 @@ const ViewingRoomsApp = loadable(
 
 export const viewingRoomRoutes: AppRouteConfig[] = [
   {
-    theme: "v3",
     path: "/viewing-rooms",
     getComponent: () => ViewingRoomsApp,
     prepare: () => {
@@ -83,7 +82,6 @@ export const viewingRoomRoutes: AppRouteConfig[] = [
     `,
     children: [
       {
-        theme: "v3",
         path: "/",
         Component: StatementRoute,
         query: graphql`
@@ -105,7 +103,6 @@ export const viewingRoomRoutes: AppRouteConfig[] = [
         },
       },
       {
-        theme: "v3",
         path: "artworks",
         Component: WorksRoute,
         query: graphql`


### PR DESCRIPTION
This sets the default theme to v3 in our routes. Now we don't have to specify. And routes that are still on v2 have been set as such. 