### PR TITLE
fix(SWA-63): Confirmation page: Back to Artsy Homepage link missing

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
@@ -20,9 +20,16 @@ export const ThankYou: React.FC = () => {
         </Text>
       </Box>
 
-      <Flex py={[2, 4]} mt={4} alignItems="center">
+      <Flex
+        py={2}
+        my={4}
+        flexDirection={["column", "row"]}
+        alignItems={["stretch", "center"]}
+      >
         <RouterLink to="/consign/submission2/artwork-details">
           <Button
+            mr={[0, 150]}
+            width={["100%", "auto"]}
             data-test-id="submit-another-work"
             size="medium"
             variant="primaryBlack"
@@ -31,7 +38,13 @@ export const ThankYou: React.FC = () => {
           </Button>
         </RouterLink>
 
-        <RouterLink to="/" ml={150} data-test-id="go-to-artsy-homepage">
+        <RouterLink
+          to="/"
+          data-test-id="go-to-artsy-homepage"
+          display="flex"
+          justifyContent="center"
+          mt={[4, 0]}
+        >
           Back to Artsy Homepage
         </RouterLink>
       </Flex>


### PR DESCRIPTION
Jira Ticket:ticket: : [SWA-63](https://artsyproduct.atlassian.net/browse/SWA-63)

This PR adds full-width buttons on small screens in the `Thank you` step and fixes `Back to Artsy Homepage`  button

**VIDEO:clapper: :**

https://user-images.githubusercontent.com/55637696/138433985-a14c8253-1cc2-4926-aa40-75665b1d77e9.mov


