### PR TITLE
fix(SWA-58): Artwork details: Update artwork classifications modal copy

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebarClassificationsModal.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebarClassificationsModal.tsx
@@ -1,5 +1,4 @@
 import { Box, SkeletonText, Modal, Button, Join, Spacer } from "@artsy/palette"
-import * as React from "react";
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
@@ -26,12 +25,14 @@ interface ArtworkSidebarClassificationsModalProps {
   viewer: ArtworkSidebarClassificationsModal_viewer
   show: boolean
   onClose(): void
+  showDisclaimer?: boolean
 }
 
 const ArtworkSidebarClassificationsModal: React.FC<ArtworkSidebarClassificationsModalProps> = ({
   viewer,
   show,
   onClose,
+  showDisclaimer = true,
 }) => {
   return (
     <Modal
@@ -64,10 +65,12 @@ const ArtworkSidebarClassificationsModal: React.FC<ArtworkSidebarClassifications
             })
           : ARTWORK_CLASSIFICATIONS_PLACEHOLDER}
 
-        <Text variant="xs" color="black60">
-          Our partners are responsible for providing accurate classification
-          information for all works.
-        </Text>
+        {showDisclaimer && (
+          <Text variant="xs" color="black60">
+            Our partners are responsible for providing accurate classification
+            information for all works.
+          </Text>
+        )}
       </Join>
     </Modal>
   )

--- a/src/v2/Apps/Artwork/Components/__tests__/ArtworkSidebarClassificationsModal.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/__tests__/ArtworkSidebarClassificationsModal.jest.tsx
@@ -13,13 +13,21 @@ jest.mock("@artsy/palette", () => {
 
 jest.unmock("react-relay")
 
-const { getWrapper } = setupTestWrapper({
-  Component: ArtworkSidebarClassificationsModalFragmentContainer,
-  query: ARTWORK_SIDEBAR_CLASSIFICATIONS_MODAL_QUERY,
-})
+const getWrapperWithResponsibilityMessage = (showDisclaimer?: boolean) =>
+  setupTestWrapper({
+    Component: (props: any) => {
+      return (
+        <ArtworkSidebarClassificationsModalFragmentContainer
+          {...{ ...props, showDisclaimer }}
+        />
+      )
+    },
+    query: ARTWORK_SIDEBAR_CLASSIFICATIONS_MODAL_QUERY,
+  })
 
 describe("ArtworkSidebarClassificationsModal", () => {
-  it("renders the classifications", () => {
+  it("renders the classifications with disclaimer", () => {
+    const { getWrapper } = getWrapperWithResponsibilityMessage(true)
     const wrapper = getWrapper({
       AttributionClass: () => ({
         name: "Unique",
@@ -32,6 +40,24 @@ describe("ArtworkSidebarClassificationsModal", () => {
     expect(html).toContain("Unique")
     expect(html).toContain("One of a kind piece, created by the artist.")
     expect(html).toContain(
+      "Our partners are responsible for providing accurate classification information for all works."
+    )
+  })
+
+  it("renders the classifications without disclaimer", () => {
+    const { getWrapper } = getWrapperWithResponsibilityMessage(false)
+    const wrapper = getWrapper({
+      AttributionClass: () => ({
+        name: "Unique",
+        longDescription: "One of a kind piece, created by the artist.",
+      }),
+    })
+
+    const html = wrapper.html()
+
+    expect(html).toContain("Unique")
+    expect(html).toContain("One of a kind piece, created by the artist.")
+    expect(html).not.toContain(
       "Our partners are responsible for providing accurate classification information for all works."
     )
   })

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtworkDetailsForm.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtworkDetailsForm.tsx
@@ -125,6 +125,7 @@ export const ArtworkDetailsForm: React.FC = () => {
       <ArtworkSidebarClassificationsModalQueryRenderer
         onClose={() => setIsRarityModalOpen(false)}
         show={isRarityModalOpen}
+        showDisclaimer={false}
       />
       <GridColumns>
         <Column span={6}>


### PR DESCRIPTION
Jira Ticket:ticket: : [SWA-58](https://artsyproduct.atlassian.net/browse/SWA-58)

This PR adds the ability to `turn off `the `responsibility message` for the `ArtworkSidebarClassificationsModal`

**VIDEO:clapper: :**

https://user-images.githubusercontent.com/55637696/138482759-6281f505-9145-439a-8889-339bf260afdc.mov


