### PR TITLE
Revert "chore(analytics): Replace manual list with dynamic paths"

### DIFF
--- a/src/desktop/assets/analytics.ts
+++ b/src/desktop/assets/analytics.ts
@@ -1,14 +1,35 @@
 import { beforeAnalyticsReady, onAnalyticsReady } from "lib/analytics/helpers"
 import { trackPageView } from "lib/analytics/trackPageView"
-import { getRouteConfig } from "v2/System/Router/getRouteConfig"
-
 window.Cookies = require("cookies-js")
-
-const { routePaths } = getRouteConfig()
 
 // We exclude these routes from analytics.page calls because
 // they're already tracked in v2/System/Analytics/trackingMiddleware
-const excludedRoutes = routePaths
+const excludedRoutes = [
+  "/art-fairs",
+  "/artist(.*)",
+  "/artists",
+  "/artwork(.*)",
+  "/auctions(.*)",
+  "/auction-faq",
+  "/auction-registration(2)?/:saleID",
+  "/auction/:saleID/bid(2)?/:artworkID",
+  "/campaign(.*)",
+  "/collect(.*)",
+  "/collection(.*)",
+  "/collections(.*)",
+  "/consign(.*)",
+  "/fair(.*)",
+  "/feature(.*)",
+  "/identity-verification(.*)",
+  "/orders(.*)",
+  "/search(.*)",
+  "/show/(.*)",
+  "/shows",
+  "/user/conversations(.*)",
+  "/user/purchases(.*)",
+  "/viewing-room(.*)",
+  "/user/payments(.*)",
+]
 
 beforeAnalyticsReady()
 trackPageView(excludedRoutes)

--- a/src/lib/analytics/trackPageView.ts
+++ b/src/lib/analytics/trackPageView.ts
@@ -4,13 +4,12 @@ import { OwnerType } from "@artsy/cohesion"
 import { data as sd } from "sharify"
 
 const foundExcludedPath = excludedRoutes => {
-  const isFound = excludedRoutes.some(excludedPath => {
+  return excludedRoutes.some(excludedPath => {
     const { path } = getContextPageFromClient()
     const matcher = match(excludedPath, { decode: decodeURIComponent })
     const foundMatch = !!matcher(path)
     return foundMatch
   })
-  return isFound
 }
 
 export const trackPageView = (excludedRoutes: string[] = []) => {


### PR DESCRIPTION
Reverts artsy/force#8645

https://artsy.slack.com/archives/CP9P4KR35/p1634908945015100

OneTrust somehow is associating our javascripts with 3rd party cookies related to analytics. @damassi and I suspect it's related to artsy/force#8645 and would like to revert it to see.