### PR TITLE
fix(auth): prevents validation on blur from shifting content

### DIFF
--- a/src/v2/Components/Authentication/Views/ForgotPasswordForm.tsx
+++ b/src/v2/Components/Authentication/Views/ForgotPasswordForm.tsx
@@ -1,7 +1,7 @@
 import { Banner, Box, Button, Input, Join, Spacer } from "@artsy/palette"
 import { Formik, FormikProps } from "formik"
-import { Component } from "react";
-import * as React from "react";
+import { Component } from "react"
+import * as React from "react"
 import { recaptcha } from "v2/Utils/recaptcha"
 import { AuthenticationFooter } from "../Components/AuthenticationFooter"
 import { FormProps, InputValues, ModalType } from "../Types"
@@ -31,6 +31,7 @@ export class ForgotPasswordForm extends Component<
         initialValues={this.props.values}
         onSubmit={this.onSubmit}
         validationSchema={ForgotPasswordValidator}
+        validateOnBlur={false}
       >
         {({
           values,

--- a/src/v2/Components/Authentication/Views/LoginForm.tsx
+++ b/src/v2/Components/Authentication/Views/LoginForm.tsx
@@ -15,8 +15,8 @@ import {
 } from "v2/Components/Authentication/Types"
 import { LoginValidator } from "v2/Components/Authentication/Validators"
 import { Formik, FormikProps } from "formik"
-import { Component, useEffect } from "react";
-import * as React from "react";
+import { Component, useEffect } from "react"
+import * as React from "react"
 import { recaptcha } from "v2/Utils/recaptcha"
 import { isOtpError } from "v2/Components/Authentication/helpers"
 import { AuthenticationPasswordInput } from "../Components/AuthenticationPasswordInput"
@@ -59,6 +59,7 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
         initialValues={this.props.values || {}}
         onSubmit={this.onSubmit}
         validationSchema={LoginValidator}
+        validateOnBlur={false}
       >
         {({
           values,

--- a/src/v2/Components/Authentication/Views/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Views/SignUpForm.tsx
@@ -8,8 +8,8 @@ import {
 } from "v2/Components/Authentication/Types"
 import { SignUpValidator } from "v2/Components/Authentication/Validators"
 import { Formik, FormikProps } from "formik"
-import { Component } from "react";
-import * as React from "react";
+import { Component } from "react"
+import * as React from "react"
 import { recaptcha } from "v2/Utils/recaptcha"
 import { data as sd } from "sharify"
 import { SignUpForm_requestLocation } from "v2/__generated__/SignUpForm_requestLocation.graphql"
@@ -89,6 +89,7 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
         initialValues={initialValues}
         onSubmit={this.onSubmit}
         validationSchema={SignUpValidator}
+        validateOnBlur={false}
       >
         {({
           errors,

--- a/src/v2/Components/Authentication/__tests__/Views/ForgotPasswordForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Views/ForgotPasswordForm.jest.tsx
@@ -2,6 +2,7 @@ import { ForgotPasswordForm } from "v2/Components/Authentication/Views/ForgotPas
 import { mount } from "enzyme"
 import { Clickable } from "@artsy/palette"
 import { AuthenticationFooter } from "v2/Components/Authentication/Components/AuthenticationFooter"
+import { flushPromiseQueue } from "v2/DevTools"
 
 jest.mock("sharify", () => ({ data: { RECAPTCHA_KEY: "recaptcha-api-key" } }))
 
@@ -56,18 +57,14 @@ describe("ForgotPasswordForm", () => {
     })
   })
 
-  // eslint-disable-next-line jest/no-done-callback
-  it("renders errors", done => {
-    props.values = {}
-    const wrapper = getWrapper()
-    const button = wrapper.find(`input[name="email"]`)
-    button.simulate("blur")
-    wrapper.update()
+  it("renders errors", async () => {
+    const wrapper = getWrapper({ values: { email: "" } })
 
-    setTimeout(() => {
-      expect(wrapper.html()).toMatch("Please enter a valid email.")
-      done()
-    })
+    wrapper.find("form").simulate("submit")
+
+    await flushPromiseQueue()
+
+    expect(wrapper.html()).toMatch("Please enter a valid email.")
   })
 
   // eslint-disable-next-line jest/no-done-callback

--- a/src/v2/Components/Authentication/__tests__/Views/LoginForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Views/LoginForm.jest.tsx
@@ -23,16 +23,14 @@ describe("LoginForm", () => {
     return mount(<LoginForm {...passedProps} />)
   }
 
-  it("renders errors", done => {
-    const wrapper = getWrapper()
-    const input = wrapper.find(`input[name="email"]`)
-    input.simulate("blur")
-    wrapper.update()
+  it("renders errors", async () => {
+    const wrapper = getWrapper({ values: { email: "" } })
 
-    setTimeout(() => {
-      expect(wrapper.html()).toMatch("Please enter a valid email.")
-      done()
-    })
+    wrapper.find("form").simulate("submit")
+
+    await flushPromiseQueue()
+
+    expect(wrapper.html()).toMatch("Please enter a valid email.")
   })
 
   it("clears error after input change", done => {

--- a/src/v2/Components/Authentication/__tests__/Views/SignUpForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Views/SignUpForm.jest.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable jest/no-done-callback */
-import { setupTestWrapper } from "v2/DevTools/setupTestWrapper";
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 import { tests } from "v2/Components/Authentication/Views/SignUpForm"
 import { SignupValues } from "../fixtures"
 import { ContextModule, Intent } from "@artsy/cohesion"
+import { flushPromiseQueue } from "v2/DevTools"
 
 jest.unmock("react-relay")
 
@@ -48,18 +49,15 @@ describe("SignUpForm", () => {
     }
   })
 
-  describe("general stuff", () => {
-    it("renders errors", done => {
-      passedProps.values.email = ""
-      const wrapper = getWrapper()
-      const button = wrapper.find(`input[name="email"]`)
-      button.simulate("blur")
+  it("renders errors", async () => {
+    passedProps.values.email = ""
+    const wrapper = getWrapper()
 
-      setTimeout(() => {
-        expect(wrapper.html()).toMatch("Please enter a valid email.")
-        done()
-      })
-    })
+    wrapper.find("form").simulate("submit")
+
+    await flushPromiseQueue()
+
+    expect(wrapper.html()).toMatch("Please enter a valid email.")
   })
 
   describe("with a GDPR country code", () => {


### PR DESCRIPTION
Previously: validation would run on blur > blur occurs on mousedown > clicks only get executed on the mouseup. So you'd go to click the link, the form would run validation even if you didn't fill it out, and then display an error which would shift the content down and your mouse would no longer be over the hit area of the button.

Thankfully Formik has a prop for disabling this behavior. Validations still run on change.

![](https://static.damonzucconi.com/_capture/BBhnSn1A.gif)