### PR TITLE
fix(RecentlyViewed): Don't cache response

### DIFF
--- a/src/v2/Components/RecentlyViewed/RecentlyViewed.tsx
+++ b/src/v2/Components/RecentlyViewed/RecentlyViewed.tsx
@@ -5,8 +5,8 @@ import { SystemContext } from "v2/System"
 import { useTracking } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
-import { useContext } from "react";
-import * as React from "react";
+import { useContext } from "react"
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { extractNodes } from "v2/Utils/extractNodes"
 import { ShelfArtworkFragmentContainer } from "../Artwork/ShelfArtwork"
@@ -100,6 +100,9 @@ export const RecentlyViewedQueryRenderer = () => {
         }
 
         return <RecentlyViewedFragmentContainer me={props.me!} />
+      }}
+      cacheConfig={{
+        force: true,
       }}
     />
   )


### PR DESCRIPTION
Noticed [this thread](https://artsy.slack.com/archives/C9SATFLUU/p1634935537133600) about the recently viewed rail no longer updating. This is due to recent fixes we made with [logged-in user caching](https://github.com/artsy/force/pull/8565). 

Easy fix, though: force a refetch by disabling caching. Now that we have queryrenderer lazyloading in place scrolling into view triggers a render / network request which updating the view, even though we're in a single page app context. (Confirmed that this fixes it.)