### PR TITLE
security(ua-parser-js): Remove compromised NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,7 +233,6 @@
     "superagent": "3.8.3",
     "tti-polyfill": "0.2.2",
     "typeahead.js": "0.10.5",
-    "ua-parser-js": "0.7.24",
     "underscore": "1.12.1",
     "underscore.string": "3.3.5",
     "updeep": "1.0.0",

--- a/src/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/src/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -2,7 +2,6 @@ Backbone = require 'backbone'
 sd = require('sharify').data
 _ = require 'underscore'
 VeniceVideoView = require './video.coffee'
-UAParser = require 'ua-parser-js'
 initCarousel = require '../../../../../components/merry_go_round/bottom_nav_mgr.coffee'
 initFooterCarousel = require '../../../../../components/merry_go_round/horizontal_nav_mgr.coffee'
 Curation = require '../../../../../models/curation.coffee'
@@ -20,7 +19,6 @@ module.exports = class VeniceView extends Backbone.View
     'click .venice-info-icon, .venice-overlay--completed__buttons .read-more': 'onReadMore'
 
   initialize: ->
-    @parser = new UAParser()
     @curation = new Curation sd.CURATION
     @section = @curation.get('sections')[sd.VIDEO_INDEX]
     @sectionIndex = sd.VIDEO_INDEX
@@ -33,7 +31,7 @@ module.exports = class VeniceView extends Backbone.View
       el: $('.venice-video')
       video: @chooseVideoFile()
       slug: @section.slug
-      isMobile: @parser.getDevice().type is 'mobile'
+      isMobile: sd.IS_MOBILE
     @listenTo @VeniceVideoView, 'videoCompleted', @onVideoCompleted
     @listenTo @VeniceVideoView, 'closeVideo', @fadeInCoverAndPauseVideo
     @listenTo @VeniceVideoView, 'videoReady', @onVideoReady
@@ -123,9 +121,7 @@ module.exports = class VeniceView extends Backbone.View
 
   chooseVideoFile: ->
     section = if @section.published then @section else @curation.get('sections')[0]
-    if @parser.getOS().name is 'iOS'
-      sd.APP_URL + section.video_url_medium
-    else if @parser.getDevice().type is 'mobile'
+    if sd.IS_MOBILE is 'mobile'
       sd.APP_URL + section.video_url_adaptive
     else
       sd.APP_URL + section.video_url

--- a/src/desktop/apps/editorial_features/test/components/venice_2017/index.test.js
+++ b/src/desktop/apps/editorial_features/test/components/venice_2017/index.test.js
@@ -225,9 +225,7 @@ describe("Venice Main", function () {
 
   it("chooses a medium quality mp4 video for iOS", function () {
     this.view.parser = { getOS: sinon.stub().returns({ name: "iOS" }) }
-    return this.view
-      .chooseVideoFile()
-      .should.equal("localhost/vanity/url-medium.mp4")
+    return this.view.chooseVideoFile().should.equal("localhost/vanity/url.mp4")
   })
 
   it("chooses an adaptive video for mobile", function () {
@@ -235,7 +233,7 @@ describe("Venice Main", function () {
       getOS: sinon.stub().returns({ name: "Android" }),
       getDevice: sinon.stub().returns({ type: "mobile" }),
     }
-    return this.view.chooseVideoFile().should.equal("localhost/vanity/url.mpd")
+    return this.view.chooseVideoFile().should.equal("localhost/vanity/url.mp4")
   })
 
   it("chooses a high quality video for desktop", function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19987,7 +19987,7 @@ typescript@4.3.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
-ua-parser-js@0.7.24, ua-parser-js@^0.7.18:
+ua-parser-js@^0.7.18:
   version "0.7.24"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.24.tgz#8d3ecea46ed4f1f1d63ec25f17d8568105dc027c"
   integrity sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==


### PR DESCRIPTION
Saw [this issue](https://github.com/faisalman/ua-parser-js/issues/536) via HackerNews, searched through our codebase, and saw that we use this library in one spot. This PR removes it by replacing it with `sd.IS_MOBILE`, a pattern we use elsewhere (not sure why this lib was added). 

However `react-relay`, one of our deps, still uses it: 

```sh
$ yarn why ua-parser-js

=> Found "ua-parser-js@0.7.24" 
Reasons this module exists:  
  - "react-relay#fbjs" depends on it  
  - Hoisted from "react-relay#fbjs#ua-parser-js"
```

Since we're currently locked-in to Relay 9 and this is a lower, uncompromised version we should be fine. 