### PR TITLE
[Fix]: GRO-618 - Check against null in addition to empty arr in HomeCurrentFairs

### DIFF
--- a/src/v2/Apps/Home/Components/HomeCurrentFairs.tsx
+++ b/src/v2/Apps/Home/Components/HomeCurrentFairs.tsx
@@ -9,7 +9,7 @@ import {
   SkeletonBox,
   ResponsiveBox,
 } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext, useTracking } from "v2/System"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
@@ -31,7 +31,7 @@ interface HomeCurrentFairsProps {
 const HomeCurrentFairs: React.FC<HomeCurrentFairsProps> = ({ viewer }) => {
   const { trackEvent } = useTracking()
 
-  if (viewer.fairs?.length === 0) {
+  if (!viewer.fairs?.length) {
     return null
   }
 

--- a/src/v2/Apps/Home/__tests__/HomeCurrentFairs.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeCurrentFairs.jest.tsx
@@ -49,6 +49,16 @@ describe("HomeCurrentFairs", () => {
     expect(wrapper.html()).toContain("/fair/test-href")
   })
 
+  it("returns null when no data is received", () => {
+    const wrapper = getWrapper({
+      Viewer: () => ({
+        fairs: null,
+      }),
+    })
+
+    expect(wrapper.isEmptyRender()).toBe(true)
+  })
+
   describe("tracking", () => {
     it("tracks item clicks", () => {
       const wrapper = getWrapper()


### PR DESCRIPTION
### Description 

When we get null for fairs, the check for the length of fairs in HomeCurrentFairs component doesn’t work and we get an err that clashes the app. For details see the video in [GRO-618](https://artsyproduct.atlassian.net/browse/GRO-618).  