### PR TITLE
refactor: remove successfullyLoggedIn and createdAccount helpers

### DIFF
--- a/src/desktop/apps/authentication/components/ModalContainer.tsx
+++ b/src/desktop/apps/authentication/components/ModalContainer.tsx
@@ -1,12 +1,8 @@
 import Cookies from "cookies-js"
-import { Component } from "react";
+import { Component } from "react"
 import { data as sd } from "sharify"
 
-import {
-  AuthService,
-  createdAccount,
-  successfullyLoggedIn,
-} from "@artsy/cohesion"
+import { ActionType, AuthModalType, AuthService } from "@artsy/cohesion"
 import { handleSubmit, setCookies } from "../helpers"
 import { ModalManager } from "v2/Components/Authentication/ModalManager"
 import { ModalOptions, ModalType } from "v2/Components/Authentication/Types"
@@ -58,25 +54,30 @@ export class ModalContainer extends Component<any> {
     triggerSeconds,
   }: SocialAuthArgs) => {
     const options = {
-      authRedirect: redirectTo || destination,
-      contextModule,
-      copy,
+      auth_redirect: redirectTo || destination,
+      context_module: contextModule,
+      modal_copy: copy,
       intent,
       service,
-      triggerSeconds,
-      userId: sd.CURRENT_USER && sd.CURRENT_USER.id,
+      trigger: "timed",
+      trigger_seconds: triggerSeconds,
+      user_id: sd.CURRENT_USER && sd.CURRENT_USER.id,
     }
 
     let analyticsOptions
     if (mode === "signup") {
-      // @ts-expect-error STRICT_NULL_CHECK
-      analyticsOptions = createdAccount({
-        onboarding: !redirectTo,
+      analyticsOptions = {
+        action: ActionType.createdAccount,
         ...options,
-      })
+        type: AuthModalType.signup,
+        onboarding: !redirectTo,
+      }
     } else {
-      // @ts-expect-error STRICT_NULL_CHECK
-      analyticsOptions = successfullyLoggedIn(options)
+      analyticsOptions = {
+        action: ActionType.successfullyLoggedIn,
+        ...options,
+        type: AuthModalType.login,
+      }
     }
 
     Cookies.set(`analytics-${mode}`, JSON.stringify(analyticsOptions), {

--- a/src/desktop/apps/authentication/components/__tests__/ModalContainer.jest.tsx
+++ b/src/desktop/apps/authentication/components/__tests__/ModalContainer.jest.tsx
@@ -78,7 +78,7 @@ describe("ModalContainer", () => {
 
     expect(cookieSet).toBeCalledWith(
       "analytics-signup",
-      '{"action":"createdAccount","auth_redirect":"/artist/andy-warhol","context_module":"popUpModal","intent":"viewArtist","onboarding":false,"service":"facebook","trigger":"timed","trigger_seconds":2,"type":"signup"}',
+      '{"action":"createdAccount","auth_redirect":"/artist/andy-warhol","context_module":"popUpModal","intent":"viewArtist","service":"facebook","trigger":"timed","trigger_seconds":2,"type":"signup","onboarding":false}',
       { expires: 86400 }
     )
   })

--- a/src/desktop/components/inquiry_questionnaire/analytics/events.ts
+++ b/src/desktop/components/inquiry_questionnaire/analytics/events.ts
@@ -1,8 +1,8 @@
 import {
   ContextModule,
   Intent,
-  createdAccount,
-  successfullyLoggedIn,
+  ActionType,
+  AuthModalType,
 } from "@artsy/cohesion"
 import { omit } from "lodash"
 import { analyticsHooks } from "desktop/components/inquiry_questionnaire/analytics/analyticsHooks"
@@ -130,13 +130,16 @@ import { setAnalyticsClientReferrerOptions } from "lib/analytics/setAnalyticsCli
   // Non-namespaced events
   bind("user:login", function (context) {
     const userId = context.user.get("id")
-    const analyticsOptions = successfullyLoggedIn({
-      authRedirect: location.href,
-      contextModule: ContextModule.artworkSidebar,
+    const analyticsOptions = {
+      action: ActionType.successfullyLoggedIn,
+      type: AuthModalType.login,
+      user_id: userId,
+      auth_redirect: location.href,
+      context_module: ContextModule.artworkSidebar,
       intent: Intent.inquire,
       service: "email",
-      userId,
-    })
+      trigger: "click",
+    }
     trackWithoutNamespace(
       analyticsOptions.action,
       omit(analyticsOptions, "action")
@@ -145,13 +148,17 @@ import { setAnalyticsClientReferrerOptions } from "lib/analytics/setAnalyticsCli
 
   bind("user:signup", function (context) {
     const userId = context.user.get("id")
-    const analyticsOptions = createdAccount({
-      authRedirect: location.href,
-      contextModule: ContextModule.artworkSidebar,
+    const analyticsOptions = {
+      action: ActionType.createdAccount,
+      type: AuthModalType.signup,
+      user_id: userId,
+      onboarding: false,
+      auth_redirect: location.href,
+      context_module: ContextModule.artworkSidebar,
       intent: Intent.inquire,
       service: "email",
-      userId,
-    })
+      trigger: "click",
+    }
     trackWithoutNamespace(
       analyticsOptions.action,
       omit(analyticsOptions, "action")


### PR DESCRIPTION
This PR removes `successfullyLoggedIn` and `createdAccount` helpers to unblock https://github.com/artsy/force/pull/8598.