### PR TITLE
fix(AuctionRoutes): Hide new auction-faq behind 2

### DIFF
--- a/src/v2/Apps/Auction2/auction2Routes.tsx
+++ b/src/v2/Apps/Auction2/auction2Routes.tsx
@@ -105,7 +105,7 @@ export const auction2Routes: AppRouteConfig[] = [
     ],
   },
   {
-    path: "/auction-faq",
+    path: "/auction-faq2",
     getComponent: () => AuctionFAQRoute,
   },
 ]


### PR DESCRIPTION
It was [noticed](https://artsy.slack.com/archives/C01ADJNCS5D/p1635181629107900) that this route wasn't namespaced under the rebuild auctions2 namespace. This fixes that.