### PR TITLE
fix(auth): manually validate on social sign up clicks

### DIFF
--- a/src/v2/Components/Authentication/Views/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Views/SignUpForm.tsx
@@ -102,6 +102,7 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
           setTouched,
           status,
           touched,
+          validateForm,
           values,
         }: FormikProps<InputValues>) => {
           const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -249,16 +250,18 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                   handleTypeChange={() =>
                     this.props.handleTypeChange?.(ModalType.login)
                   }
-                  onAppleLogin={e => {
+                  onAppleLogin={async e => {
                     if (!values.accepted_terms_of_service) {
                       setTouched({ accepted_terms_of_service: true })
+                      await validateForm()
                     } else {
                       this.props.onAppleLogin?.(e)
                     }
                   }}
-                  onFacebookLogin={e => {
+                  onFacebookLogin={async e => {
                     if (!values.accepted_terms_of_service) {
                       setTouched({ accepted_terms_of_service: true })
+                      await validateForm()
                     } else {
                       this.props.onFacebookLogin?.(e)
                     }


### PR DESCRIPTION
Closes [PX-4689](https://artsyproduct.atlassian.net/browse/PX-4689)

It seems we were relying on: the first input to autofocus, then blur, and validation run on blur, when the social sign up links were clicked. Since we changed validation to only run on change, we lost the validation. This PR just manually runs validation on click which will then highlight the checkbox in red.