### PR TITLE
feat(FX-3489): update nav bar categories and content

### DIFF
--- a/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -89,8 +89,8 @@ describe("NavBar", () => {
 
     it("includes the sub-menus when rendering", () => {
       const wrapper = getWrapper()
-      expect(wrapper.html()).toContain("View all artists")
-      expect(wrapper.html()).toContain("View all artworks")
+      expect(wrapper.html()).toContain("View All Artists")
+      expect(wrapper.html()).toContain("View All Artworks")
     })
   })
 

--- a/src/v2/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
@@ -37,25 +37,28 @@ describe("NavBarSubMenu", () => {
     // expect(linkMenuItems.length).toBe(5)
     expect(linkMenuItems.at(0).text()).toContain("Trove")
     expect(linkMenuItems.at(0).prop("href")).toEqual("/gene/trove")
-    expect(linkMenuItems.at(1).text()).toContain("New This Week")
+
+    expect(linkMenuItems.at(1).text()).toContain(
+      "Highlights at Auction This Week"
+    )
     expect(linkMenuItems.at(1).prop("href")).toEqual(
-      "/collection/new-this-week"
-    )
-    expect(linkMenuItems.at(2).text()).toContain("Trending on Artsy")
-    expect(linkMenuItems.at(2).prop("href")).toEqual(
-      "/collection/highlights-this-month"
-    )
-    expect(linkMenuItems.at(3).text()).toContain("Exclusively on Artsy")
-    expect(linkMenuItems.at(3).prop("href")).toEqual(
-      "/collection/exclusively-on-artsy"
-    )
-    expect(linkMenuItems.at(4).text()).toContain("Limited Editions")
-    expect(linkMenuItems.at(4).prop("href")).toEqual(
-      "/collection/limited-edition-works"
+      "/collection/auction-highlights"
     )
 
-    expect(linkMenuItems.at(5).text()).toContain("View all artworks")
-    expect(linkMenuItems.at(5).prop("href")).toEqual("/collect")
+    expect(linkMenuItems.at(2).text()).toContain(
+      "Highlights at Fairs This Week"
+    )
+    expect(linkMenuItems.at(2).prop("href")).toEqual(
+      "/collection/art-fair-highlights"
+    )
+
+    expect(linkMenuItems.at(3).text()).toContain("New in Figurative Painting")
+    expect(linkMenuItems.at(3).prop("href")).toEqual(
+      "/collection/emerging-figurative-painting"
+    )
+
+    expect(linkMenuItems.at(4).text()).toContain("View All Artworks")
+    expect(linkMenuItems.at(4).prop("href")).toEqual("/collect")
   })
 
   it("doesn't render artists letter nav inside artworks dropdown", () => {

--- a/src/v2/Components/NavBar/menuData.ts
+++ b/src/v2/Components/NavBar/menuData.ts
@@ -32,66 +32,34 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
     title: "Artists",
     links: [
       {
-        text: "In-Demand Artists",
-        href: "/collection/in-demand-artists",
+        text: "Trending on Artsy",
+        href: "/collection/highlights-this-month",
       },
       {
-        text: "Artists We're Eyeing",
-        href: "/collection/artists-we-are-eyeing",
-      },
-      {
-        text: "Artsy Vanguard Artists",
+        text: "The Artsy Vanguard Artists",
         href: "/collection/artsy-vanguard-artists",
+      },
+      {
+        text: "Limited-Edition Prints by Leading Artists",
+        href: "/collection/limited-edition-prints-trending-artists",
         dividerBelow: true,
       },
       {
-        text: "Career Stage",
+        text: "New From",
         menu: {
-          title: "Career Stage",
+          title: "New From",
           links: [
             {
-              text: "Blue-Chip Artists",
-              href: "/collection/blue-chip-artists",
-            },
-            {
-              text: "Critically Acclaimed Artists",
-              href: "/collection/critically-acclaimed-artists",
-            },
-            {
-              text: "Trending Emerging Artists",
-              href: "/collection/trending-emerging-artists",
-            },
-            {
-              text: "New & Noteworthy Artists",
-              href: "/collection/new-and-noteworthy-artists",
-            },
-          ],
-        },
-      },
-      {
-        text: "Popular Categories",
-        menu: {
-          title: "Popular Categories",
-          links: [
-            {
-              text: "New From Emerging Artists",
+              text: "Emerging Artists",
               href: "/collection/new-from-emerging-artists",
             },
             {
-              text: "Modern & Contemporary Masters",
-              href: "/collection/master-works",
+              text: "Established Artists",
+              href: "/collection/new-from-established-artists",
             },
             {
-              text: "Limited-Edition Prints by Leading Artists",
-              href: "/collection/limited-edition-prints-trending-artists",
-            },
-            {
-              text: "Black Figurative Painters",
-              href: "/collection/black-figurative-painters",
-            },
-            {
-              text: "Women Artists to Watch",
-              href: "/collection/women-painters-on-the-rise",
+              text: "Street Artists",
+              href: "/collection/street-art-highlights",
             },
           ],
         },
@@ -139,38 +107,38 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
           title: "Featured Artists",
           links: [
             {
-              text: "Derrick Adams",
-              href: "/artist/derrick-adams/works-for-sale",
+              text: "Barbara Kruger",
+              href: "/artist/barbara-kruger/works-for-sale",
             },
             {
-              text: "Bridget Riley",
-              href: "/artist/bridget-riley/works-for-sale",
+              text: "Carrie Mae Weems",
+              href: "/artist/carrie-mae-weems/works-for-sale",
             },
             {
-              text: "Frank Stella",
-              href: "/artist/frank-stella/works-for-sale",
+              text: "Daniel Arsham",
+              href: "/artist/daniel-arsham/works-for-sale",
             },
             {
-              text: "Julian Opie",
-              href: "/artist/julian-opie/works-for-sale",
+              text: "Sam Gilliam",
+              href: "/artist/sam-gilliam/works-for-sale",
             },
             {
-              text: "Judy Chicago",
-              href: "/artist/judy-chicago/works-for-sale",
+              text: "Takashi Murakami",
+              href: "/artist/takashi-murakami/works-for-sale",
             },
             {
-              text: "Etel Adnan",
-              href: "/artist/etel-adnan/works-for-sale",
+              text: "Tracey Emin",
+              href: "/artist/tracey-emin/works-for-sale",
             },
             {
-              text: "Mickalene Thomas",
-              href: "/artist/mickalene-thomas/works-for-sale",
+              text: "Yinka Shonibare",
+              href: "/artist/yinka-shonibare/works-for-sale",
             },
           ],
         },
       },
       {
-        text: "View all artists",
+        text: "View All Artists",
         href: "/artists",
       },
     ],
@@ -187,45 +155,16 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
         href: "/gene/trove",
       },
       {
-        text: "New This Week",
-        href: "/collection/new-this-week",
+        text: "Highlights at Auction This Week",
+        href: "/collection/auction-highlights",
       },
       {
-        text: "Trending on Artsy",
-        href: "/collection/highlights-this-month",
+        text: "Highlights at Fairs This Week",
+        href: "/collection/art-fair-highlights",
       },
       {
-        text: "Exclusively on Artsy",
-        href: "/collection/exclusively-on-artsy",
-      },
-      {
-        text: "Limited Editions",
-        href: "/collection/limited-edition-works",
-        dividerBelow: true,
-      },
-      {
-        text: "Highlights From",
-        menu: {
-          title: "Highlights From",
-          links: [
-            {
-              text: "Auction",
-              href: "/collection/auction-highlights",
-            },
-            {
-              text: "Art Fairs",
-              href: "/collection/art-fair-highlights",
-            },
-            {
-              text: "Gallery Shows",
-              href: "/collection/gallery-show-highlights",
-            },
-            {
-              text: "Non-profit Shops",
-              href: "/collection/nonprofit-shops",
-            },
-          ],
-        },
+        text: "New in Figurative Painting",
+        href: "/collection/emerging-figurative-painting",
       },
       {
         text: "Price",
@@ -256,42 +195,6 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
         },
       },
       {
-        text: "Medium",
-        menu: {
-          title: "Medium",
-          links: [
-            {
-              text: "Painting",
-              href: "/collection/painting",
-            },
-            {
-              text: "Prints",
-              href: "/collection/prints",
-            },
-            {
-              text: "Photography",
-              href: "/collection/photography",
-            },
-            {
-              text: "Sculpture",
-              href: "/collection/sculpture",
-            },
-            {
-              text: "Works on Paper",
-              href: "/collection/works-on-paper",
-            },
-            {
-              text: "Mixed Media",
-              href: "/collection/mixed-media",
-            },
-            {
-              text: "Design",
-              href: "/collection/design",
-            },
-          ],
-        },
-      },
-      {
         text: "Movements",
         menu: {
           title: "Movements",
@@ -317,7 +220,7 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
               href: "/collection/post-war",
             },
             {
-              text: "Impressionism & Modernism",
+              text: "Impressionism and Modernism",
               href: "/collection/impressionist-and-modern",
             },
             {
@@ -326,33 +229,45 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
             },
           ],
         },
-        dividerBelow: true,
       },
       {
-        text: "Subject Matter",
+        text: "Medium",
         menu: {
-          title: "Subject Matter",
+          title: "Medium",
           links: [
             {
-              text: "Abstract Art",
-              href: "/gene/abstract-art",
+              text: "Painting",
+              href: "/collection/painting",
             },
             {
-              text: "Figurative Art",
-              href: "/gene/figurative-art",
+              text: "Prints",
+              href: "/collection/prints",
             },
             {
-              text: "Landscapes",
-              href: "/gene/landscapes",
+              text: "Photography",
+              href: "/collection/photography",
             },
             {
-              text: "Still Life",
-              href: "/gene/still-life",
+              text: "Sculpture",
+              href: "/collection/sculpture",
+            },
+            {
+              text: "Work on Paper",
+              href: "/collection/works-on-paper",
+            },
+            {
+              text: "Mixed Media",
+              href: "/collection/mixed-media",
+            },
+            {
+              text: "Design",
+              href: "/collection/design",
             },
           ],
         },
+        dividerBelow: true,
       },
-      { text: "View all artworks", href: "/collect" },
+      { text: "View All Artworks", href: "/collect" },
     ],
   },
 }


### PR DESCRIPTION
Jira: [FX-3489](https://artsyproduct.atlassian.net/browse/FX-3489)

### Description
As part of our quarterly collaboration, Curatorial (now Merchandising) reviews the performance of the 'Artist' and 'Artwork' Navigation Bar categories and content, and provides an update. This quarter, we've worked with the Brand team to consolidate many of our "evergreen" collections, so we're presenting a much tighter version of the Nav Bar for this upcoming quarter. 

You can find the requested updates on tab 1 of this spreadsheet [here](https://docs.google.com/spreadsheets/d/1nmGK9_qhkmne3FCtX7OcJrQDadbcrKX5t7RQHDt4OjE/edit#gid=752290928)

### Changes
- Updated links in nav bar

### Demo
Artists submenu
![image](https://user-images.githubusercontent.com/56556580/139060974-cf47e1cf-4706-4f30-a637-984ea8d140a9.png)

Artworks submenu
![image](https://user-images.githubusercontent.com/56556580/139060986-25fa5300-1f6c-4e8f-b6e5-eb8d60fa2ef9.png)
