### PR TITLE
fix(Auctions): Un-query-renderer mybids

### DIFF
--- a/src/v2/Apps/Auctions/Components/CuritorialRailsTabBar.tsx
+++ b/src/v2/Apps/Auctions/Components/CuritorialRailsTabBar.tsx
@@ -1,10 +1,10 @@
 import { Join, Spacer, Tab, Tabs } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System"
 import { CuritorialRailsTabBar_viewer } from "v2/__generated__/CuritorialRailsTabBar_viewer.graphql"
 import { AuctionsZeroState } from "./AuctionsZeroState"
-import { MyBidsQueryRenderer } from "./MyBids/MyBids"
+import { MyBidsFragmentContainer } from "./MyBids/MyBids"
 import { StandoutLotsRailFragmentContainer } from "./StandoutLotsRail"
 import { TrendingLotsRailFragmentContainer } from "./TrendingLotsRail"
 import { WorksByArtistsYouFollowRailFragmentContainer } from "./WorksByArtistsYouFollowRail"
@@ -23,7 +23,7 @@ export const CuritorialRailsTabBar: React.FC<CuritorialRailsTabBarProps> = ({
       {user && (
         <Tab name="Works For You">
           <Join separator={<Spacer mt={2} />}>
-            <MyBidsQueryRenderer />
+            <MyBidsFragmentContainer me={viewer.me!} />
             <WorksByArtistsYouFollowRailFragmentContainer viewer={viewer} />
           </Join>
         </Tab>


### PR DESCRIPTION
We had swapped out the fragment container for a query renderer a week or so back due to some concerns about performance, but those were only ephemeral. This fixes the UX placeholder loading flash and only displays my bids if the user has bids. 