### PR TITLE
feat(FX-3515): styled back links

### DIFF
--- a/src/v2/Apps/Artist/Components/BackLink.tsx
+++ b/src/v2/Apps/Artist/Components/BackLink.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { AnalyticsSchema } from "v2/System"

--- a/src/v2/Components/Links/StyledLink.tsx
+++ b/src/v2/Components/Links/StyledLink.tsx
@@ -1,13 +1,13 @@
 import styled from "styled-components"
 import { RouterLink } from "v2/System/Router/RouterLink"
-import { color } from "@artsy/palette"
+import { themeGet } from "@styled-system/theme-get"
 
 export const StyledLink = styled(RouterLink)`
-  text-decoration: none;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  text-decoration: underline;
+  color: ${themeGet("colors.black100")};
 
   &:hover {
-    text-decoration: none;
-    color: ${color("black60")};
+    color: ${themeGet("colors.brand")};
   }
 `


### PR DESCRIPTION
Jira: [FX-3515](https://artsyproduct.atlassian.net/browse/FX-3515)

### Description
All back links should be Black100 with an underline. On hover, the link color changes to Blue100 (text and underline).

### Changes
- Updated styles for link component used in `<BackLink />`

### Demo

https://user-images.githubusercontent.com/56556580/139239098-043337f9-d808-4871-9fbc-96363611c4a7.mov

