### PR TITLE
fix(FX-3506): update fairs exhibition period displaying

### DIFF
--- a/src/v2/Apps/Fairs/Components/FairsFairBanner.tsx
+++ b/src/v2/Apps/Fairs/Components/FairsFairBanner.tsx
@@ -1,5 +1,5 @@
+import * as React from "react"
 import { Box, BoxProps, Image, ResponsiveBox, Text } from "@artsy/palette"
-import * as React from "react";
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { RouterLink } from "v2/System/Router/RouterLink"
@@ -92,9 +92,7 @@ const FairsFairBanner: React.FC<FairsFairBannerProps> = ({ fair, ...rest }) => {
           <Box>
             <Text>{fair.name}</Text>
 
-            <Text>
-              {fair.startAt} – {fair.endAt}
-            </Text>
+            <Text>{fair.exhibitionPeriod}</Text>
           </Box>
         </Box>
       </RouterLink>
@@ -109,8 +107,7 @@ export const FairsFairBannerFragmentContainer = createFragmentContainer(
       fragment FairsFairBanner_fair on Fair {
         href
         name
-        startAt(format: "MMM Do")
-        endAt(format: "MMM Do YYYY")
+        exhibitionPeriod
         bannerSize
         image {
           large: cropped(width: 1840, height: 790, version: ["wide"]) {

--- a/src/v2/Apps/Fairs/Components/FairsFairRow.tsx
+++ b/src/v2/Apps/Fairs/Components/FairsFairRow.tsx
@@ -1,5 +1,5 @@
+import * as React from "react"
 import { Box, BoxProps, ChevronIcon, Flex, Image, Text } from "@artsy/palette"
-import * as React from "react";
 import { createFragmentContainer, graphql } from "react-relay"
 import styled, { css } from "styled-components"
 import { DateTime } from "luxon"
@@ -77,7 +77,7 @@ const FairsFairRow: React.FC<FairsFairRowProps> = ({ fair, ...rest }) => {
           </Text>
 
           <Text as="h4" variant="md" display="flex" flex={1}>
-            {fair.startAt} – {fair.endAt}
+            {fair.exhibitionPeriod}
           </Text>
         </Flex>
 
@@ -95,8 +95,7 @@ export const FairsFairRowFragmentContainer = createFragmentContainer(
         href
         name
         isoStartAt: startAt
-        startAt(format: "MMM Do")
-        endAt(format: "MMM Do YYYY")
+        exhibitionPeriod
         profile {
           icon {
             resized(width: 80, height: 80, version: "square140") {

--- a/src/v2/Apps/Fairs/Routes/FairsIndex.tsx
+++ b/src/v2/Apps/Fairs/Routes/FairsIndex.tsx
@@ -1,3 +1,4 @@
+import * as React from "react"
 import { ContextModule, Intent } from "@artsy/cohesion"
 import {
   Box,
@@ -12,7 +13,6 @@ import {
   Tabs,
   Text,
 } from "@artsy/palette"
-import * as React from "react";
 import { createFragmentContainer, graphql } from "react-relay"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { ModalType } from "v2/Components/Authentication/Types"
@@ -297,9 +297,7 @@ export const FairsIndex: React.FC<FairsIndexProps> = ({
                     fair.name
                   )}
 
-                  <Box>
-                    {fair.startAt} – {fair.endAt}
-                  </Box>
+                  <Box>{fair.exhibitionPeriod}</Box>
                   {fair.location && <Box>{fair.location.city}</Box>}
                 </Text>
               )
@@ -370,8 +368,7 @@ export const FairsIndexFragmentContainer = createFragmentContainer(FairsIndex, {
       ) {
         internalID
         name
-        startAt(format: "MMM Do")
-        endAt(format: "MMM Do YYYY")
+        exhibitionPeriod
         location {
           city
         }

--- a/src/v2/Apps/Home/Components/HomeCurrentFairs.tsx
+++ b/src/v2/Apps/Home/Components/HomeCurrentFairs.tsx
@@ -79,11 +79,11 @@ const HomeCurrentFairs: React.FC<HomeCurrentFairsProps> = ({ viewer }) => {
                 )}
 
                 <Text variant={["lg", "xl"]} mt={1}>
-                  {fair?.name}
+                  {fair.name}
                 </Text>
 
                 <Text variant={["md", "lg"]} color="black60">
-                  {fair.startAt} – {fair?.endAt}
+                  {fair.exhibitionPeriod}
                 </Text>
               </RouterLink>
             </Column>
@@ -177,6 +177,7 @@ export const HomeCurrentFairsFragmentContainer = createFragmentContainer(
           name
           startAt(format: "MMM Do")
           endAt(format: "MMM Do YYYY")
+          exhibitionPeriod
           bannerSize
           image {
             # 4:3 aspect ratio

--- a/src/v2/__generated__/FairsFairBanner_fair.graphql.ts
+++ b/src/v2/__generated__/FairsFairBanner_fair.graphql.ts
@@ -6,8 +6,7 @@ import { FragmentRefs } from "relay-runtime";
 export type FairsFairBanner_fair = {
     readonly href: string | null;
     readonly name: string | null;
-    readonly startAt: string | null;
-    readonly endAt: string | null;
+    readonly exhibitionPeriod: string | null;
     readonly bannerSize: string | null;
     readonly image: {
         readonly large: {
@@ -107,29 +106,10 @@ return {
     },
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "format",
-          "value": "MMM Do"
-        }
-      ],
+      "args": null,
       "kind": "ScalarField",
-      "name": "startAt",
-      "storageKey": "startAt(format:\"MMM Do\")"
-    },
-    {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "format",
-          "value": "MMM Do YYYY"
-        }
-      ],
-      "kind": "ScalarField",
-      "name": "endAt",
-      "storageKey": "endAt(format:\"MMM Do YYYY\")"
+      "name": "exhibitionPeriod",
+      "storageKey": null
     },
     {
       "alias": null,
@@ -250,5 +230,5 @@ return {
   "type": "Fair"
 };
 })();
-(node as any).hash = '58e8880a9280ec9cf910d1dff96f8d2f';
+(node as any).hash = '8b6356d6ed39457f9f42fa416367490e';
 export default node;

--- a/src/v2/__generated__/FairsFairRow_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairsFairRow_Test_Query.graphql.ts
@@ -28,8 +28,7 @@ fragment FairsFairRow_fair on Fair {
   href
   name
   isoStartAt: startAt
-  startAt(format: "MMM Do")
-  endAt(format: "MMM Do YYYY")
+  exhibitionPeriod
   profile {
     icon {
       resized(width: 80, height: 80, version: "square140") {
@@ -130,29 +129,10 @@ return {
           },
           {
             "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "format",
-                "value": "MMM Do"
-              }
-            ],
+            "args": null,
             "kind": "ScalarField",
-            "name": "startAt",
-            "storageKey": "startAt(format:\"MMM Do\")"
-          },
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "format",
-                "value": "MMM Do YYYY"
-              }
-            ],
-            "kind": "ScalarField",
-            "name": "endAt",
-            "storageKey": "endAt(format:\"MMM Do YYYY\")"
+            "name": "exhibitionPeriod",
+            "storageKey": null
           },
           {
             "alias": null,
@@ -268,7 +248,7 @@ return {
     "metadata": {},
     "name": "FairsFairRow_Test_Query",
     "operationKind": "query",
-    "text": "query FairsFairRow_Test_Query {\n  fair(id: \"example\") {\n    ...FairsFairRow_fair\n    id\n  }\n}\n\nfragment FairsFairRow_fair on Fair {\n  href\n  name\n  isoStartAt: startAt\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  organizer {\n    profile {\n      href\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query FairsFairRow_Test_Query {\n  fair(id: \"example\") {\n    ...FairsFairRow_fair\n    id\n  }\n}\n\nfragment FairsFairRow_fair on Fair {\n  href\n  name\n  isoStartAt: startAt\n  exhibitionPeriod\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  organizer {\n    profile {\n      href\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairsFairRow_fair.graphql.ts
+++ b/src/v2/__generated__/FairsFairRow_fair.graphql.ts
@@ -7,8 +7,7 @@ export type FairsFairRow_fair = {
     readonly href: string | null;
     readonly name: string | null;
     readonly isoStartAt: string | null;
-    readonly startAt: string | null;
-    readonly endAt: string | null;
+    readonly exhibitionPeriod: string | null;
     readonly profile: {
         readonly icon: {
             readonly resized: {
@@ -65,29 +64,10 @@ return {
     },
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "format",
-          "value": "MMM Do"
-        }
-      ],
+      "args": null,
       "kind": "ScalarField",
-      "name": "startAt",
-      "storageKey": "startAt(format:\"MMM Do\")"
-    },
-    {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "format",
-          "value": "MMM Do YYYY"
-        }
-      ],
-      "kind": "ScalarField",
-      "name": "endAt",
-      "storageKey": "endAt(format:\"MMM Do YYYY\")"
+      "name": "exhibitionPeriod",
+      "storageKey": null
     },
     {
       "alias": null,
@@ -193,5 +173,5 @@ return {
   "type": "Fair"
 };
 })();
-(node as any).hash = 'a0b427ff1b06ef97c38a1c080e99b12e';
+(node as any).hash = '18bcad7870e32664847bf5de2aa4b757';
 export default node;

--- a/src/v2/__generated__/FairsIndex_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairsIndex_Test_Query.graphql.ts
@@ -33,8 +33,7 @@ query FairsIndex_Test_Query {
 fragment FairsFairBanner_fair on Fair {
   href
   name
-  startAt(format: "MMM Do")
-  endAt(format: "MMM Do YYYY")
+  exhibitionPeriod
   bannerSize
   image {
     large: cropped(width: 1840, height: 790, version: ["wide"]) {
@@ -67,8 +66,7 @@ fragment FairsFairRow_fair on Fair {
   href
   name
   isoStartAt: startAt
-  startAt(format: "MMM Do")
-  endAt(format: "MMM Do YYYY")
+  exhibitionPeriod
   profile {
     icon {
       resized(width: 80, height: 80, version: "square140") {
@@ -140,8 +138,7 @@ fragment FairsIndex_viewer on Viewer {
   upcomingFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_ASC, size: 25, status: UPCOMING) {
     internalID
     name
-    startAt(format: "MMM Do")
-    endAt(format: "MMM Do YYYY")
+    exhibitionPeriod
     location {
       city
       id
@@ -344,51 +341,32 @@ v16 = {
 },
 v17 = {
   "alias": null,
-  "args": [
-    {
-      "kind": "Literal",
-      "name": "format",
-      "value": "MMM Do"
-    }
-  ],
+  "args": null,
   "kind": "ScalarField",
-  "name": "startAt",
-  "storageKey": "startAt(format:\"MMM Do\")"
+  "name": "exhibitionPeriod",
+  "storageKey": null
 },
 v18 = {
-  "alias": null,
-  "args": [
-    {
-      "kind": "Literal",
-      "name": "format",
-      "value": "MMM Do YYYY"
-    }
-  ],
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": "endAt(format:\"MMM Do YYYY\")"
-},
-v19 = {
   "kind": "Literal",
   "name": "version",
   "value": [
     "wide"
   ]
 },
-v20 = [
+v19 = [
   (v6/*: any*/),
   (v7/*: any*/),
   (v4/*: any*/),
   (v5/*: any*/)
 ],
-v21 = {
+v20 = {
   "alias": "isoStartAt",
   "args": null,
   "kind": "ScalarField",
   "name": "startAt",
   "storageKey": null
 },
-v22 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "FairOrganizer",
@@ -413,12 +391,12 @@ v22 = {
   ],
   "storageKey": null
 },
-v23 = {
+v22 = {
   "kind": "Literal",
   "name": "status",
   "value": "CLOSED"
 },
-v24 = [
+v23 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -427,7 +405,7 @@ v24 = [
   (v9/*: any*/),
   (v10/*: any*/),
   (v12/*: any*/),
-  (v23/*: any*/)
+  (v22/*: any*/)
 ];
 return {
   "fragment": {
@@ -587,7 +565,6 @@ return {
               (v15/*: any*/),
               (v16/*: any*/),
               (v17/*: any*/),
-              (v18/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -604,7 +581,7 @@ return {
                         "name": "height",
                         "value": 790
                       },
-                      (v19/*: any*/),
+                      (v18/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -615,7 +592,7 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v20/*: any*/),
+                    "selections": (v19/*: any*/),
                     "storageKey": "cropped(height:790,version:[\"wide\"],width:1840)"
                   },
                   {
@@ -626,7 +603,7 @@ return {
                         "name": "height",
                         "value": 512
                       },
-                      (v19/*: any*/),
+                      (v18/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -637,14 +614,14 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v20/*: any*/),
+                    "selections": (v19/*: any*/),
                     "storageKey": "cropped(height:512,version:[\"wide\"],width:910)"
                   }
                 ],
                 "storageKey": null
               },
+              (v20/*: any*/),
               (v21/*: any*/),
-              (v22/*: any*/),
               (v2/*: any*/)
             ],
             "storageKey": "fairs(hasFullFeature:true,hasListing:true,size:25,sort:\"START_AT_DESC\",status:\"RUNNING\")"
@@ -656,7 +633,7 @@ return {
               (v10/*: any*/),
               (v11/*: any*/),
               (v12/*: any*/),
-              (v23/*: any*/)
+              (v22/*: any*/)
             ],
             "concreteType": "Fair",
             "kind": "LinkedField",
@@ -668,10 +645,9 @@ return {
               (v14/*: any*/),
               (v15/*: any*/),
               (v16/*: any*/),
-              (v21/*: any*/),
+              (v20/*: any*/),
               (v17/*: any*/),
-              (v18/*: any*/),
-              (v22/*: any*/),
+              (v21/*: any*/),
               (v2/*: any*/)
             ],
             "storageKey": "fairs(hasFullFeature:true,hasListing:true,size:25,sort:\"START_AT_DESC\",status:\"CLOSED\")"
@@ -701,7 +677,6 @@ return {
               (v3/*: any*/),
               (v16/*: any*/),
               (v17/*: any*/),
-              (v18/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -723,16 +698,16 @@ return {
               },
               (v13/*: any*/),
               (v14/*: any*/),
-              (v22/*: any*/),
-              (v15/*: any*/),
               (v21/*: any*/),
+              (v15/*: any*/),
+              (v20/*: any*/),
               (v2/*: any*/)
             ],
             "storageKey": "fairs(hasFullFeature:true,hasListing:true,size:25,sort:\"START_AT_ASC\",status:\"UPCOMING\")"
           },
           {
             "alias": "pastFairs",
-            "args": (v24/*: any*/),
+            "args": (v23/*: any*/),
             "concreteType": "FairConnection",
             "kind": "LinkedField",
             "name": "fairsConnection",
@@ -759,10 +734,9 @@ return {
                       (v14/*: any*/),
                       (v15/*: any*/),
                       (v16/*: any*/),
-                      (v21/*: any*/),
+                      (v20/*: any*/),
                       (v17/*: any*/),
-                      (v18/*: any*/),
-                      (v22/*: any*/),
+                      (v21/*: any*/),
                       (v2/*: any*/),
                       (v1/*: any*/)
                     ],
@@ -808,7 +782,7 @@ return {
           },
           {
             "alias": "pastFairs",
-            "args": (v24/*: any*/),
+            "args": (v23/*: any*/),
             "filters": [
               "hasListing",
               "hasFullFeature",
@@ -830,7 +804,7 @@ return {
     "metadata": {},
     "name": "FairsIndex_Test_Query",
     "operationKind": "query",
-    "text": "query FairsIndex_Test_Query {\n  featuredFairs: orderedSets(key: \"art-fairs:featured\") {\n    ...FairsIndex_featuredFairs\n    id\n  }\n  viewer {\n    ...FairsIndex_viewer\n  }\n}\n\nfragment FairsFairBanner_fair on Fair {\n  href\n  name\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  bannerSize\n  image {\n    large: cropped(width: 1840, height: 790, version: [\"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    small: cropped(width: 910, height: 512, version: [\"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairsFairRow_fair on Fair {\n  href\n  name\n  isoStartAt: startAt\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  organizer {\n    profile {\n      href\n      id\n    }\n    id\n  }\n}\n\nfragment FairsIndex_featuredFairs on OrderedSet {\n  items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      title\n      image {\n        cropped(width: 547, height: 410) {\n          width\n          height\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    ... on Node {\n      id\n    }\n    ... on Profile {\n      id\n    }\n  }\n}\n\nfragment FairsIndex_viewer on Viewer {\n  runningFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: RUNNING) {\n    internalID\n    bannerSize\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    ...FairsFairBanner_fair\n    ...FairsFairRow_fair\n    id\n  }\n  closedFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: CLOSED) {\n    internalID\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    ...FairsFairRow_fair\n    id\n  }\n  upcomingFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_ASC, size: 25, status: UPCOMING) {\n    internalID\n    name\n    startAt(format: \"MMM Do\")\n    endAt(format: \"MMM Do YYYY\")\n    location {\n      city\n      id\n    }\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    organizer {\n      profile {\n        href\n        id\n      }\n      id\n    }\n    ...FairsFairRow_fair\n    id\n  }\n  ...FairsPastFairs_viewer\n}\n\nfragment FairsPastFairs_viewer on Viewer {\n  pastFairs: fairsConnection(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, status: CLOSED, first: 15) {\n    edges {\n      node {\n        internalID\n        isPublished\n        profile {\n          isPublished\n          id\n        }\n        ...FairsFairRow_fair\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query FairsIndex_Test_Query {\n  featuredFairs: orderedSets(key: \"art-fairs:featured\") {\n    ...FairsIndex_featuredFairs\n    id\n  }\n  viewer {\n    ...FairsIndex_viewer\n  }\n}\n\nfragment FairsFairBanner_fair on Fair {\n  href\n  name\n  exhibitionPeriod\n  bannerSize\n  image {\n    large: cropped(width: 1840, height: 790, version: [\"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    small: cropped(width: 910, height: 512, version: [\"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairsFairRow_fair on Fair {\n  href\n  name\n  isoStartAt: startAt\n  exhibitionPeriod\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  organizer {\n    profile {\n      href\n      id\n    }\n    id\n  }\n}\n\nfragment FairsIndex_featuredFairs on OrderedSet {\n  items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      title\n      image {\n        cropped(width: 547, height: 410) {\n          width\n          height\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    ... on Node {\n      id\n    }\n    ... on Profile {\n      id\n    }\n  }\n}\n\nfragment FairsIndex_viewer on Viewer {\n  runningFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: RUNNING) {\n    internalID\n    bannerSize\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    ...FairsFairBanner_fair\n    ...FairsFairRow_fair\n    id\n  }\n  closedFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: CLOSED) {\n    internalID\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    ...FairsFairRow_fair\n    id\n  }\n  upcomingFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_ASC, size: 25, status: UPCOMING) {\n    internalID\n    name\n    exhibitionPeriod\n    location {\n      city\n      id\n    }\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    organizer {\n      profile {\n        href\n        id\n      }\n      id\n    }\n    ...FairsFairRow_fair\n    id\n  }\n  ...FairsPastFairs_viewer\n}\n\nfragment FairsPastFairs_viewer on Viewer {\n  pastFairs: fairsConnection(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, status: CLOSED, first: 15) {\n    edges {\n      node {\n        internalID\n        isPublished\n        profile {\n          isPublished\n          id\n        }\n        ...FairsFairRow_fair\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairsIndex_viewer.graphql.ts
+++ b/src/v2/__generated__/FairsIndex_viewer.graphql.ts
@@ -24,8 +24,7 @@ export type FairsIndex_viewer = {
     readonly upcomingFairs: ReadonlyArray<{
         readonly internalID: string;
         readonly name: string | null;
-        readonly startAt: string | null;
-        readonly endAt: string | null;
+        readonly exhibitionPeriod: string | null;
         readonly location: {
             readonly city: string | null;
         } | null;
@@ -203,29 +202,10 @@ return {
         },
         {
           "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "format",
-              "value": "MMM Do"
-            }
-          ],
+          "args": null,
           "kind": "ScalarField",
-          "name": "startAt",
-          "storageKey": "startAt(format:\"MMM Do\")"
-        },
-        {
-          "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "format",
-              "value": "MMM Do YYYY"
-            }
-          ],
-          "kind": "ScalarField",
-          "name": "endAt",
-          "storageKey": "endAt(format:\"MMM Do YYYY\")"
+          "name": "exhibitionPeriod",
+          "storageKey": null
         },
         {
           "alias": null,
@@ -289,5 +269,5 @@ return {
   "type": "Viewer"
 };
 })();
-(node as any).hash = '4bf7c4475b0a6d845cc4543c6144b3ce';
+(node as any).hash = '863757b83cf4b9a2c9aab52c1fb95c00';
 export default node;

--- a/src/v2/__generated__/FairsPastFairsQuery.graphql.ts
+++ b/src/v2/__generated__/FairsPastFairsQuery.graphql.ts
@@ -33,8 +33,7 @@ fragment FairsFairRow_fair on Fair {
   href
   name
   isoStartAt: startAt
-  startAt(format: "MMM Do")
-  endAt(format: "MMM Do YYYY")
+  exhibitionPeriod
   profile {
     icon {
       resized(width: 80, height: 80, version: "square140") {
@@ -320,29 +319,10 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "format",
-                            "value": "MMM Do"
-                          }
-                        ],
+                        "args": null,
                         "kind": "ScalarField",
-                        "name": "startAt",
-                        "storageKey": "startAt(format:\"MMM Do\")"
-                      },
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "format",
-                            "value": "MMM Do YYYY"
-                          }
-                        ],
-                        "kind": "ScalarField",
-                        "name": "endAt",
-                        "storageKey": "endAt(format:\"MMM Do YYYY\")"
+                        "name": "exhibitionPeriod",
+                        "storageKey": null
                       },
                       {
                         "alias": null,
@@ -442,7 +422,7 @@ return {
     "metadata": {},
     "name": "FairsPastFairsQuery",
     "operationKind": "query",
-    "text": "query FairsPastFairsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...FairsPastFairs_viewer_2HEEH6\n  }\n}\n\nfragment FairsFairRow_fair on Fair {\n  href\n  name\n  isoStartAt: startAt\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  organizer {\n    profile {\n      href\n      id\n    }\n    id\n  }\n}\n\nfragment FairsPastFairs_viewer_2HEEH6 on Viewer {\n  pastFairs: fairsConnection(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, status: CLOSED, first: $first, after: $after) {\n    edges {\n      node {\n        internalID\n        isPublished\n        profile {\n          isPublished\n          id\n        }\n        ...FairsFairRow_fair\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query FairsPastFairsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...FairsPastFairs_viewer_2HEEH6\n  }\n}\n\nfragment FairsFairRow_fair on Fair {\n  href\n  name\n  isoStartAt: startAt\n  exhibitionPeriod\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  organizer {\n    profile {\n      href\n      id\n    }\n    id\n  }\n}\n\nfragment FairsPastFairs_viewer_2HEEH6 on Viewer {\n  pastFairs: fairsConnection(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, status: CLOSED, first: $first, after: $after) {\n    edges {\n      node {\n        internalID\n        isPublished\n        profile {\n          isPublished\n          id\n        }\n        ...FairsFairRow_fair\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/HomeCurrentFairsQuery.graphql.ts
+++ b/src/v2/__generated__/HomeCurrentFairsQuery.graphql.ts
@@ -37,6 +37,7 @@ fragment HomeCurrentFairs_viewer on Viewer {
     name
     startAt(format: "MMM Do")
     endAt(format: "MMM Do YYYY")
+    exhibitionPeriod
     image {
       cropped(width: 600, height: 450) {
         src
@@ -217,6 +218,13 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "kind": "ScalarField",
+                "name": "exhibitionPeriod",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "concreteType": "Image",
                 "kind": "LinkedField",
                 "name": "image",
@@ -289,7 +297,7 @@ return {
     "metadata": {},
     "name": "HomeCurrentFairsQuery",
     "operationKind": "query",
-    "text": "query HomeCurrentFairsQuery {\n  viewer {\n    ...HomeCurrentFairs_viewer\n  }\n}\n\nfragment HomeCurrentFairs_viewer on Viewer {\n  fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: RUNNING) {\n    internalID\n    slug\n    bannerSize\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    href\n    name\n    startAt(format: \"MMM Do\")\n    endAt(format: \"MMM Do YYYY\")\n    image {\n      cropped(width: 600, height: 450) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query HomeCurrentFairsQuery {\n  viewer {\n    ...HomeCurrentFairs_viewer\n  }\n}\n\nfragment HomeCurrentFairs_viewer on Viewer {\n  fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: RUNNING) {\n    internalID\n    slug\n    bannerSize\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    href\n    name\n    startAt(format: \"MMM Do\")\n    endAt(format: \"MMM Do YYYY\")\n    exhibitionPeriod\n    image {\n      cropped(width: 600, height: 450) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/HomeCurrentFairs_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeCurrentFairs_Test_Query.graphql.ts
@@ -37,6 +37,7 @@ fragment HomeCurrentFairs_viewer on Viewer {
     name
     startAt(format: "MMM Do")
     endAt(format: "MMM Do YYYY")
+    exhibitionPeriod
     image {
       cropped(width: 600, height: 450) {
         src
@@ -217,6 +218,13 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "kind": "ScalarField",
+                "name": "exhibitionPeriod",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "concreteType": "Image",
                 "kind": "LinkedField",
                 "name": "image",
@@ -289,7 +297,7 @@ return {
     "metadata": {},
     "name": "HomeCurrentFairs_Test_Query",
     "operationKind": "query",
-    "text": "query HomeCurrentFairs_Test_Query {\n  viewer {\n    ...HomeCurrentFairs_viewer\n  }\n}\n\nfragment HomeCurrentFairs_viewer on Viewer {\n  fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: RUNNING) {\n    internalID\n    slug\n    bannerSize\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    href\n    name\n    startAt(format: \"MMM Do\")\n    endAt(format: \"MMM Do YYYY\")\n    image {\n      cropped(width: 600, height: 450) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query HomeCurrentFairs_Test_Query {\n  viewer {\n    ...HomeCurrentFairs_viewer\n  }\n}\n\nfragment HomeCurrentFairs_viewer on Viewer {\n  fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: RUNNING) {\n    internalID\n    slug\n    bannerSize\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    href\n    name\n    startAt(format: \"MMM Do\")\n    endAt(format: \"MMM Do YYYY\")\n    exhibitionPeriod\n    image {\n      cropped(width: 600, height: 450) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/HomeCurrentFairs_viewer.graphql.ts
+++ b/src/v2/__generated__/HomeCurrentFairs_viewer.graphql.ts
@@ -16,6 +16,7 @@ export type HomeCurrentFairs_viewer = {
         readonly name: string | null;
         readonly startAt: string | null;
         readonly endAt: string | null;
+        readonly exhibitionPeriod: string | null;
         readonly image: {
             readonly cropped: {
                 readonly src: string;
@@ -160,6 +161,13 @@ return {
         {
           "alias": null,
           "args": null,
+          "kind": "ScalarField",
+          "name": "exhibitionPeriod",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
           "concreteType": "Image",
           "kind": "LinkedField",
           "name": "image",
@@ -225,5 +233,5 @@ return {
   "type": "Viewer"
 };
 })();
-(node as any).hash = '06d53aa66fea0db7f33c1f11a4a27b32';
+(node as any).hash = '772c24fda5e4c96fef072e0a03e6f8f4';
 export default node;

--- a/src/v2/__generated__/RegisterButton_Test_Query.graphql.ts
+++ b/src/v2/__generated__/RegisterButton_Test_Query.graphql.ts
@@ -40,22 +40,22 @@ fragment RegisterButton_me on Me {
 }
 
 fragment RegisterButton_sale on Sale {
-  slug
+  bidder {
+    qualifiedForBidding
+    id
+  }
   isAuction
   isClosed
   isLiveOpen
-  liveURLIfOpen
   isRegistrationClosed
+  liveURLIfOpen
   requireIdentityVerification
   registrationStatus {
     internalID
     id
   }
+  slug
   status
-  bidder {
-    qualifiedForBidding
-    id
-  }
 }
 */
 
@@ -143,8 +143,20 @@ return {
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "slug",
+            "concreteType": "Bidder",
+            "kind": "LinkedField",
+            "name": "bidder",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "qualifiedForBidding",
+                "storageKey": null
+              },
+              (v1/*: any*/)
+            ],
             "storageKey": null
           },
           {
@@ -172,14 +184,14 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "liveURLIfOpen",
+            "name": "isRegistrationClosed",
             "storageKey": null
           },
           {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "isRegistrationClosed",
+            "name": "liveURLIfOpen",
             "storageKey": null
           },
           {
@@ -203,26 +215,14 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "status",
+            "name": "slug",
             "storageKey": null
           },
           {
             "alias": null,
             "args": null,
-            "concreteType": "Bidder",
-            "kind": "LinkedField",
-            "name": "bidder",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "qualifiedForBidding",
-                "storageKey": null
-              },
-              (v1/*: any*/)
-            ],
+            "kind": "ScalarField",
+            "name": "status",
             "storageKey": null
           },
           (v1/*: any*/)
@@ -265,7 +265,7 @@ return {
     "metadata": {},
     "name": "RegisterButton_Test_Query",
     "operationKind": "query",
-    "text": "query RegisterButton_Test_Query {\n  sale(id: \"foo\") {\n    ...RegisterButton_sale\n    id\n  }\n  me {\n    ...RegisterButton_me\n    id\n  }\n}\n\nfragment RegisterButton_me on Me {\n  identityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment RegisterButton_sale on Sale {\n  slug\n  isAuction\n  isClosed\n  isLiveOpen\n  liveURLIfOpen\n  isRegistrationClosed\n  requireIdentityVerification\n  registrationStatus {\n    internalID\n    id\n  }\n  status\n  bidder {\n    qualifiedForBidding\n    id\n  }\n}\n"
+    "text": "query RegisterButton_Test_Query {\n  sale(id: \"foo\") {\n    ...RegisterButton_sale\n    id\n  }\n  me {\n    ...RegisterButton_me\n    id\n  }\n}\n\nfragment RegisterButton_me on Me {\n  identityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment RegisterButton_sale on Sale {\n  bidder {\n    qualifiedForBidding\n    id\n  }\n  isAuction\n  isClosed\n  isLiveOpen\n  isRegistrationClosed\n  liveURLIfOpen\n  requireIdentityVerification\n  registrationStatus {\n    internalID\n    id\n  }\n  slug\n  status\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/RegisterButton_sale.graphql.ts
+++ b/src/v2/__generated__/RegisterButton_sale.graphql.ts
@@ -4,20 +4,20 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type RegisterButton_sale = {
-    readonly slug: string;
+    readonly bidder: {
+        readonly qualifiedForBidding: boolean | null;
+    } | null;
     readonly isAuction: boolean | null;
     readonly isClosed: boolean | null;
     readonly isLiveOpen: boolean | null;
-    readonly liveURLIfOpen: string | null;
     readonly isRegistrationClosed: boolean | null;
+    readonly liveURLIfOpen: string | null;
     readonly requireIdentityVerification: boolean | null;
     readonly registrationStatus: {
         readonly internalID: string;
     } | null;
+    readonly slug: string;
     readonly status: string | null;
-    readonly bidder: {
-        readonly qualifiedForBidding: boolean | null;
-    } | null;
     readonly " $refType": "RegisterButton_sale";
 };
 export type RegisterButton_sale$data = RegisterButton_sale;
@@ -37,8 +37,19 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "slug",
+      "concreteType": "Bidder",
+      "kind": "LinkedField",
+      "name": "bidder",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "qualifiedForBidding",
+          "storageKey": null
+        }
+      ],
       "storageKey": null
     },
     {
@@ -66,14 +77,14 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "liveURLIfOpen",
+      "name": "isRegistrationClosed",
       "storageKey": null
     },
     {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "isRegistrationClosed",
+      "name": "liveURLIfOpen",
       "storageKey": null
     },
     {
@@ -105,29 +116,18 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "status",
+      "name": "slug",
       "storageKey": null
     },
     {
       "alias": null,
       "args": null,
-      "concreteType": "Bidder",
-      "kind": "LinkedField",
-      "name": "bidder",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "qualifiedForBidding",
-          "storageKey": null
-        }
-      ],
+      "kind": "ScalarField",
+      "name": "status",
       "storageKey": null
     }
   ],
   "type": "Sale"
 };
-(node as any).hash = 'd0028e512f8ab292d2bd9a2b5a0c1138';
+(node as any).hash = '70eb9020abfc06c5aa8350243fd5f520';
 export default node;

--- a/src/v2/__generated__/auction2Routes_TopLevelQuery.graphql.ts
+++ b/src/v2/__generated__/auction2Routes_TopLevelQuery.graphql.ts
@@ -209,22 +209,22 @@ fragment RegisterButton_me on Me {
 }
 
 fragment RegisterButton_sale on Sale {
-  slug
+  bidder {
+    qualifiedForBidding
+    id
+  }
   isAuction
   isClosed
   isLiveOpen
-  liveURLIfOpen
   isRegistrationClosed
+  liveURLIfOpen
   requireIdentityVerification
   registrationStatus {
     internalID
     id
   }
+  slug
   status
-  bidder {
-    qualifiedForBidding
-    id
-  }
 }
 */
 
@@ -262,35 +262,10 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isClosed",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isLiveOpen",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = [
-  (v6/*: any*/),
-  (v7/*: any*/)
-],
-v9 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -298,7 +273,32 @@ v9 = [
     "name": "qualifiedForBidding",
     "storageKey": null
   },
-  (v7/*: any*/)
+  (v4/*: any*/)
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isClosed",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isLiveOpen",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v9 = [
+  (v8/*: any*/),
+  (v4/*: any*/)
 ],
 v10 = {
   "alias": null,
@@ -351,7 +351,7 @@ v16 = {
 },
 v17 = [
   (v2/*: any*/),
-  (v7/*: any*/)
+  (v4/*: any*/)
 ],
 v18 = {
   "kind": "Variable",
@@ -432,24 +432,34 @@ return {
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "isAuction",
+            "concreteType": "Bidder",
+            "kind": "LinkedField",
+            "name": "bidder",
+            "plural": false,
+            "selections": (v5/*: any*/),
             "storageKey": null
           },
-          (v4/*: any*/),
-          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "liveURLIfOpen",
+            "name": "isAuction",
             "storageKey": null
           },
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
             "name": "isRegistrationClosed",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "liveURLIfOpen",
             "storageKey": null
           },
           {
@@ -466,7 +476,7 @@ return {
             "kind": "LinkedField",
             "name": "registrationStatus",
             "plural": false,
-            "selections": (v8/*: any*/),
+            "selections": (v9/*: any*/),
             "storageKey": null
           },
           {
@@ -474,16 +484,6 @@ return {
             "args": null,
             "kind": "ScalarField",
             "name": "status",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Bidder",
-            "kind": "LinkedField",
-            "name": "bidder",
-            "plural": false,
-            "selections": (v9/*: any*/),
             "storageKey": null
           },
           (v10/*: any*/),
@@ -543,7 +543,7 @@ return {
             ],
             "storageKey": null
           },
-          (v6/*: any*/),
+          (v8/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -589,8 +589,8 @@ return {
               (v12/*: any*/),
               (v13/*: any*/),
               (v3/*: any*/),
-              (v4/*: any*/),
-              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -601,7 +601,7 @@ return {
               (v10/*: any*/),
               (v2/*: any*/),
               (v11/*: any*/),
-              (v7/*: any*/)
+              (v4/*: any*/)
             ],
             "storageKey": null
           },
@@ -728,7 +728,7 @@ return {
                                   (v3/*: any*/),
                                   (v13/*: any*/),
                                   (v2/*: any*/),
-                                  (v7/*: any*/)
+                                  (v4/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -750,11 +750,11 @@ return {
                                 "name": "isAcquireable",
                                 "storageKey": null
                               },
-                              (v7/*: any*/)
+                              (v4/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v7/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -764,7 +764,7 @@ return {
                 ],
                 "storageKey": "saleArtworksConnection(first:25)"
               },
-              (v7/*: any*/)
+              (v4/*: any*/)
             ],
             "storageKey": null
           },
@@ -782,7 +782,7 @@ return {
             "name": "symbol",
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       },
@@ -808,10 +808,10 @@ return {
             "kind": "LinkedField",
             "name": "pendingIdentityVerification",
             "plural": false,
-            "selections": (v8/*: any*/),
+            "selections": (v9/*: any*/),
             "storageKey": null
           },
-          (v6/*: any*/),
+          (v8/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -828,7 +828,7 @@ return {
             "kind": "LinkedField",
             "name": "bidders",
             "plural": true,
-            "selections": (v9/*: any*/),
+            "selections": (v5/*: any*/),
             "storageKey": null
           },
           {
@@ -853,7 +853,7 @@ return {
                 "kind": "LinkedField",
                 "name": "activeBid",
                 "plural": false,
-                "selections": (v8/*: any*/),
+                "selections": (v9/*: any*/),
                 "storageKey": null
               },
               {
@@ -939,9 +939,9 @@ return {
                     "selections": [
                       (v10/*: any*/),
                       (v12/*: any*/),
-                      (v5/*: any*/),
-                      (v4/*: any*/),
-                      (v7/*: any*/)
+                      (v7/*: any*/),
+                      (v6/*: any*/),
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -990,18 +990,18 @@ return {
                         "selections": (v17/*: any*/),
                         "storageKey": null
                       },
-                      (v7/*: any*/)
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v7/*: any*/)
+                  (v4/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
@@ -1012,7 +1012,7 @@ return {
     "metadata": {},
     "name": "auction2Routes_TopLevelQuery",
     "operationKind": "query",
-    "text": "query auction2Routes_TopLevelQuery(\n  $slug: String!\n) {\n  sale(id: $slug) @principalField {\n    ...Auction2App_sale\n    id\n  }\n  me {\n    ...Auction2App_me\n    id\n  }\n}\n\nfragment Auction2App_me on Me {\n  ...AuctionDetails_me\n  internalID\n  hasCreditCards\n  identityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n  bidders(saleID: $slug) {\n    qualifiedForBidding\n    id\n  }\n  lotStandings(saleID: $slug, live: true) {\n    activeBid {\n      internalID\n      id\n    }\n    isLeadingBidder\n    saleArtwork {\n      slug\n      lotLabel\n      reserveStatus\n      counts {\n        bidderPositions\n      }\n      saleID\n      highestBid {\n        display\n      }\n      sale {\n        liveStartAt\n        endAt\n        isLiveOpen\n        isClosed\n        id\n      }\n      artwork {\n        href\n        title\n        date\n        image {\n          url(version: \"square\")\n        }\n        artist {\n          name\n          id\n        }\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Auction2App_sale on Sale {\n  ...Auction2Meta_sale\n  ...AuctionDetails_sale\n  formattedStartDateTime\n  href\n  coverImage {\n    cropped(width: 1800, height: 600, version: \"wide\") {\n      src\n      url\n    }\n  }\n  internalID\n  slug\n  associatedSale {\n    coverImage {\n      cropped(width: 260, height: 110) {\n        url\n      }\n    }\n    endAt\n    href\n    slug\n    isClosed\n    isLiveOpen\n    isPreview\n    liveStartAt\n    name\n    startAt\n    id\n  }\n  status\n  currency\n  eligibleSaleArtworksCount\n  endAt\n  isAuction\n  isClosed\n  isLiveOpen\n  isOpen\n  liveStartAt\n  name\n  promotedSale {\n    slug\n    name\n    saleArtworksConnection(first: 25) {\n      edges {\n        node {\n          artwork {\n            slug\n            title\n            date\n            saleMessage\n            isInAuction\n            image {\n              placeholder\n              url\n              aspectRatio\n            }\n            artists {\n              slug\n              href\n              name\n              id\n            }\n            partner {\n              name\n              id\n            }\n            href\n            isAcquireable\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n  registrationEndsAt\n  requireIdentityVerification\n  startAt\n  symbol\n}\n\nfragment Auction2Meta_sale on Sale {\n  name\n  description(format: HTML)\n  slug\n}\n\nfragment AuctionDetails_me on Me {\n  ...RegisterButton_me\n}\n\nfragment AuctionDetails_sale on Sale {\n  ...RegisterButton_sale\n  ...AuctionInfoSidebar_sale\n  name\n  slug\n  formattedStartDateTime\n  liveStartAt\n  startAt\n  endAt\n  description(format: HTML)\n  href\n}\n\nfragment AuctionInfoSidebar_sale on Sale {\n  liveStartAt\n}\n\nfragment RegisterButton_me on Me {\n  identityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment RegisterButton_sale on Sale {\n  slug\n  isAuction\n  isClosed\n  isLiveOpen\n  liveURLIfOpen\n  isRegistrationClosed\n  requireIdentityVerification\n  registrationStatus {\n    internalID\n    id\n  }\n  status\n  bidder {\n    qualifiedForBidding\n    id\n  }\n}\n"
+    "text": "query auction2Routes_TopLevelQuery(\n  $slug: String!\n) {\n  sale(id: $slug) @principalField {\n    ...Auction2App_sale\n    id\n  }\n  me {\n    ...Auction2App_me\n    id\n  }\n}\n\nfragment Auction2App_me on Me {\n  ...AuctionDetails_me\n  internalID\n  hasCreditCards\n  identityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n  bidders(saleID: $slug) {\n    qualifiedForBidding\n    id\n  }\n  lotStandings(saleID: $slug, live: true) {\n    activeBid {\n      internalID\n      id\n    }\n    isLeadingBidder\n    saleArtwork {\n      slug\n      lotLabel\n      reserveStatus\n      counts {\n        bidderPositions\n      }\n      saleID\n      highestBid {\n        display\n      }\n      sale {\n        liveStartAt\n        endAt\n        isLiveOpen\n        isClosed\n        id\n      }\n      artwork {\n        href\n        title\n        date\n        image {\n          url(version: \"square\")\n        }\n        artist {\n          name\n          id\n        }\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Auction2App_sale on Sale {\n  ...Auction2Meta_sale\n  ...AuctionDetails_sale\n  formattedStartDateTime\n  href\n  coverImage {\n    cropped(width: 1800, height: 600, version: \"wide\") {\n      src\n      url\n    }\n  }\n  internalID\n  slug\n  associatedSale {\n    coverImage {\n      cropped(width: 260, height: 110) {\n        url\n      }\n    }\n    endAt\n    href\n    slug\n    isClosed\n    isLiveOpen\n    isPreview\n    liveStartAt\n    name\n    startAt\n    id\n  }\n  status\n  currency\n  eligibleSaleArtworksCount\n  endAt\n  isAuction\n  isClosed\n  isLiveOpen\n  isOpen\n  liveStartAt\n  name\n  promotedSale {\n    slug\n    name\n    saleArtworksConnection(first: 25) {\n      edges {\n        node {\n          artwork {\n            slug\n            title\n            date\n            saleMessage\n            isInAuction\n            image {\n              placeholder\n              url\n              aspectRatio\n            }\n            artists {\n              slug\n              href\n              name\n              id\n            }\n            partner {\n              name\n              id\n            }\n            href\n            isAcquireable\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n  registrationEndsAt\n  requireIdentityVerification\n  startAt\n  symbol\n}\n\nfragment Auction2Meta_sale on Sale {\n  name\n  description(format: HTML)\n  slug\n}\n\nfragment AuctionDetails_me on Me {\n  ...RegisterButton_me\n}\n\nfragment AuctionDetails_sale on Sale {\n  ...RegisterButton_sale\n  ...AuctionInfoSidebar_sale\n  name\n  slug\n  formattedStartDateTime\n  liveStartAt\n  startAt\n  endAt\n  description(format: HTML)\n  href\n}\n\nfragment AuctionInfoSidebar_sale on Sale {\n  liveStartAt\n}\n\nfragment RegisterButton_me on Me {\n  identityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment RegisterButton_sale on Sale {\n  bidder {\n    qualifiedForBidding\n    id\n  }\n  isAuction\n  isClosed\n  isLiveOpen\n  isRegistrationClosed\n  liveURLIfOpen\n  requireIdentityVerification\n  registrationStatus {\n    internalID\n    id\n  }\n  slug\n  status\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/fairsRoutes_FairsQuery.graphql.ts
+++ b/src/v2/__generated__/fairsRoutes_FairsQuery.graphql.ts
@@ -33,8 +33,7 @@ query fairsRoutes_FairsQuery {
 fragment FairsFairBanner_fair on Fair {
   href
   name
-  startAt(format: "MMM Do")
-  endAt(format: "MMM Do YYYY")
+  exhibitionPeriod
   bannerSize
   image {
     large: cropped(width: 1840, height: 790, version: ["wide"]) {
@@ -67,8 +66,7 @@ fragment FairsFairRow_fair on Fair {
   href
   name
   isoStartAt: startAt
-  startAt(format: "MMM Do")
-  endAt(format: "MMM Do YYYY")
+  exhibitionPeriod
   profile {
     icon {
       resized(width: 80, height: 80, version: "square140") {
@@ -140,8 +138,7 @@ fragment FairsIndex_viewer on Viewer {
   upcomingFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_ASC, size: 25, status: UPCOMING) {
     internalID
     name
-    startAt(format: "MMM Do")
-    endAt(format: "MMM Do YYYY")
+    exhibitionPeriod
     location {
       city
       id
@@ -344,51 +341,32 @@ v16 = {
 },
 v17 = {
   "alias": null,
-  "args": [
-    {
-      "kind": "Literal",
-      "name": "format",
-      "value": "MMM Do"
-    }
-  ],
+  "args": null,
   "kind": "ScalarField",
-  "name": "startAt",
-  "storageKey": "startAt(format:\"MMM Do\")"
+  "name": "exhibitionPeriod",
+  "storageKey": null
 },
 v18 = {
-  "alias": null,
-  "args": [
-    {
-      "kind": "Literal",
-      "name": "format",
-      "value": "MMM Do YYYY"
-    }
-  ],
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": "endAt(format:\"MMM Do YYYY\")"
-},
-v19 = {
   "kind": "Literal",
   "name": "version",
   "value": [
     "wide"
   ]
 },
-v20 = [
+v19 = [
   (v6/*: any*/),
   (v7/*: any*/),
   (v4/*: any*/),
   (v5/*: any*/)
 ],
-v21 = {
+v20 = {
   "alias": "isoStartAt",
   "args": null,
   "kind": "ScalarField",
   "name": "startAt",
   "storageKey": null
 },
-v22 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "FairOrganizer",
@@ -413,12 +391,12 @@ v22 = {
   ],
   "storageKey": null
 },
-v23 = {
+v22 = {
   "kind": "Literal",
   "name": "status",
   "value": "CLOSED"
 },
-v24 = [
+v23 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -427,7 +405,7 @@ v24 = [
   (v9/*: any*/),
   (v10/*: any*/),
   (v12/*: any*/),
-  (v23/*: any*/)
+  (v22/*: any*/)
 ];
 return {
   "fragment": {
@@ -587,7 +565,6 @@ return {
               (v15/*: any*/),
               (v16/*: any*/),
               (v17/*: any*/),
-              (v18/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -604,7 +581,7 @@ return {
                         "name": "height",
                         "value": 790
                       },
-                      (v19/*: any*/),
+                      (v18/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -615,7 +592,7 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v20/*: any*/),
+                    "selections": (v19/*: any*/),
                     "storageKey": "cropped(height:790,version:[\"wide\"],width:1840)"
                   },
                   {
@@ -626,7 +603,7 @@ return {
                         "name": "height",
                         "value": 512
                       },
-                      (v19/*: any*/),
+                      (v18/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -637,14 +614,14 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v20/*: any*/),
+                    "selections": (v19/*: any*/),
                     "storageKey": "cropped(height:512,version:[\"wide\"],width:910)"
                   }
                 ],
                 "storageKey": null
               },
+              (v20/*: any*/),
               (v21/*: any*/),
-              (v22/*: any*/),
               (v2/*: any*/)
             ],
             "storageKey": "fairs(hasFullFeature:true,hasListing:true,size:25,sort:\"START_AT_DESC\",status:\"RUNNING\")"
@@ -656,7 +633,7 @@ return {
               (v10/*: any*/),
               (v11/*: any*/),
               (v12/*: any*/),
-              (v23/*: any*/)
+              (v22/*: any*/)
             ],
             "concreteType": "Fair",
             "kind": "LinkedField",
@@ -668,10 +645,9 @@ return {
               (v14/*: any*/),
               (v15/*: any*/),
               (v16/*: any*/),
-              (v21/*: any*/),
+              (v20/*: any*/),
               (v17/*: any*/),
-              (v18/*: any*/),
-              (v22/*: any*/),
+              (v21/*: any*/),
               (v2/*: any*/)
             ],
             "storageKey": "fairs(hasFullFeature:true,hasListing:true,size:25,sort:\"START_AT_DESC\",status:\"CLOSED\")"
@@ -701,7 +677,6 @@ return {
               (v3/*: any*/),
               (v16/*: any*/),
               (v17/*: any*/),
-              (v18/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -723,16 +698,16 @@ return {
               },
               (v13/*: any*/),
               (v14/*: any*/),
-              (v22/*: any*/),
-              (v15/*: any*/),
               (v21/*: any*/),
+              (v15/*: any*/),
+              (v20/*: any*/),
               (v2/*: any*/)
             ],
             "storageKey": "fairs(hasFullFeature:true,hasListing:true,size:25,sort:\"START_AT_ASC\",status:\"UPCOMING\")"
           },
           {
             "alias": "pastFairs",
-            "args": (v24/*: any*/),
+            "args": (v23/*: any*/),
             "concreteType": "FairConnection",
             "kind": "LinkedField",
             "name": "fairsConnection",
@@ -759,10 +734,9 @@ return {
                       (v14/*: any*/),
                       (v15/*: any*/),
                       (v16/*: any*/),
-                      (v21/*: any*/),
+                      (v20/*: any*/),
                       (v17/*: any*/),
-                      (v18/*: any*/),
-                      (v22/*: any*/),
+                      (v21/*: any*/),
                       (v2/*: any*/),
                       (v1/*: any*/)
                     ],
@@ -808,7 +782,7 @@ return {
           },
           {
             "alias": "pastFairs",
-            "args": (v24/*: any*/),
+            "args": (v23/*: any*/),
             "filters": [
               "hasListing",
               "hasFullFeature",
@@ -830,7 +804,7 @@ return {
     "metadata": {},
     "name": "fairsRoutes_FairsQuery",
     "operationKind": "query",
-    "text": "query fairsRoutes_FairsQuery {\n  featuredFairs: orderedSets(key: \"art-fairs:featured\") {\n    ...FairsIndex_featuredFairs\n    id\n  }\n  viewer {\n    ...FairsIndex_viewer\n  }\n}\n\nfragment FairsFairBanner_fair on Fair {\n  href\n  name\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  bannerSize\n  image {\n    large: cropped(width: 1840, height: 790, version: [\"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    small: cropped(width: 910, height: 512, version: [\"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairsFairRow_fair on Fair {\n  href\n  name\n  isoStartAt: startAt\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  organizer {\n    profile {\n      href\n      id\n    }\n    id\n  }\n}\n\nfragment FairsIndex_featuredFairs on OrderedSet {\n  items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      title\n      image {\n        cropped(width: 547, height: 410) {\n          width\n          height\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    ... on Node {\n      id\n    }\n    ... on Profile {\n      id\n    }\n  }\n}\n\nfragment FairsIndex_viewer on Viewer {\n  runningFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: RUNNING) {\n    internalID\n    bannerSize\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    ...FairsFairBanner_fair\n    ...FairsFairRow_fair\n    id\n  }\n  closedFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: CLOSED) {\n    internalID\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    ...FairsFairRow_fair\n    id\n  }\n  upcomingFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_ASC, size: 25, status: UPCOMING) {\n    internalID\n    name\n    startAt(format: \"MMM Do\")\n    endAt(format: \"MMM Do YYYY\")\n    location {\n      city\n      id\n    }\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    organizer {\n      profile {\n        href\n        id\n      }\n      id\n    }\n    ...FairsFairRow_fair\n    id\n  }\n  ...FairsPastFairs_viewer\n}\n\nfragment FairsPastFairs_viewer on Viewer {\n  pastFairs: fairsConnection(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, status: CLOSED, first: 15) {\n    edges {\n      node {\n        internalID\n        isPublished\n        profile {\n          isPublished\n          id\n        }\n        ...FairsFairRow_fair\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query fairsRoutes_FairsQuery {\n  featuredFairs: orderedSets(key: \"art-fairs:featured\") {\n    ...FairsIndex_featuredFairs\n    id\n  }\n  viewer {\n    ...FairsIndex_viewer\n  }\n}\n\nfragment FairsFairBanner_fair on Fair {\n  href\n  name\n  exhibitionPeriod\n  bannerSize\n  image {\n    large: cropped(width: 1840, height: 790, version: [\"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    small: cropped(width: 910, height: 512, version: [\"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairsFairRow_fair on Fair {\n  href\n  name\n  isoStartAt: startAt\n  exhibitionPeriod\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  organizer {\n    profile {\n      href\n      id\n    }\n    id\n  }\n}\n\nfragment FairsIndex_featuredFairs on OrderedSet {\n  items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      title\n      image {\n        cropped(width: 547, height: 410) {\n          width\n          height\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    ... on Node {\n      id\n    }\n    ... on Profile {\n      id\n    }\n  }\n}\n\nfragment FairsIndex_viewer on Viewer {\n  runningFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: RUNNING) {\n    internalID\n    bannerSize\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    ...FairsFairBanner_fair\n    ...FairsFairRow_fair\n    id\n  }\n  closedFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, size: 25, status: CLOSED) {\n    internalID\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    ...FairsFairRow_fair\n    id\n  }\n  upcomingFairs: fairs(hasListing: true, hasFullFeature: true, sort: START_AT_ASC, size: 25, status: UPCOMING) {\n    internalID\n    name\n    exhibitionPeriod\n    location {\n      city\n      id\n    }\n    isPublished\n    profile {\n      isPublished\n      id\n    }\n    organizer {\n      profile {\n        href\n        id\n      }\n      id\n    }\n    ...FairsFairRow_fair\n    id\n  }\n  ...FairsPastFairs_viewer\n}\n\nfragment FairsPastFairs_viewer on Viewer {\n  pastFairs: fairsConnection(hasListing: true, hasFullFeature: true, sort: START_AT_DESC, status: CLOSED, first: 15) {\n    edges {\n      node {\n        internalID\n        isPublished\n        profile {\n          isPublished\n          id\n        }\n        ...FairsFairRow_fair\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Jira: [FX-3506](https://artsyproduct.atlassian.net/browse/FX-3506)

### Description
Exhibition period of fair differs at fairs list (any page with fairs) and fair page

**Example**

_Home page_
![image](https://user-images.githubusercontent.com/56556580/139659688-131355cb-a35e-481b-914f-6e8ae8fec028.png)
_Fair page_
![image](https://user-images.githubusercontent.com/56556580/139659708-44f52c41-eef3-4f6a-a756-8ccf92e3475c.png)

Slack [discussion](https://artsy.slack.com/archives/C9SATFLUU/p1634911010101100) 

The solution: use `exhibitionPeriod` to display right date in "full months" format like `October 22 – November 5, 2021`

### Changes
- use `exhibitionPeriod` to display fair period instead of `{startAt} - {endAt}`

### Demo

https://user-images.githubusercontent.com/56556580/139660327-1dfba25d-38c8-48c7-bfc1-d0940c85b5b7.mov


