### PR TITLE
feat(FX-3513): Added alerts_only email frequency option

### DIFF
--- a/src/v2/Apps/Unsubscribe/Components/UnsubscribeLoggedIn.tsx
+++ b/src/v2/Apps/Unsubscribe/Components/UnsubscribeLoggedIn.tsx
@@ -1,6 +1,6 @@
 import { Spacer, Button, Select, useToasts } from "@artsy/palette"
-import { useRef, useState } from "react";
-import * as React from "react";
+import { useRef, useState } from "react"
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System"
 import { UpdateUserEmailPreferencesMutation } from "v2/Components/UserSettings/UserEmailPreferences/UserEmailPreferencesMutation"
@@ -72,6 +72,7 @@ export const UnsubscribeLoggedIn: React.FC<UnsubscribeLoggedInProps> = ({
           { text: "None", value: "none" },
           { text: "Weekly", value: "weekly" },
           { text: "Daily", value: "daily" },
+          { text: "Alerts Only", value: "alerts_only" },
         ]}
         onSelect={setEmailFrequency}
       />

--- a/src/v2/Components/UserSettings/UserEmailPreferences/index.tsx
+++ b/src/v2/Components/UserSettings/UserEmailPreferences/index.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Banner, Box, Flex, SelectSmall, Serif } from "@artsy/palette"
 import { useSystemContext } from "v2/System/SystemContext"
 import { graphql } from "react-relay"
@@ -17,6 +17,7 @@ const options = [
   { text: "None", value: "none" },
   { text: "Daily", value: "daily" },
   { text: "Weekly", value: "weekly" },
+  { text: "Alerts Only", value: "alerts_only" },
 ]
 
 export const UserEmailPreferences: React.FC<UserEmailPreferencesQueryResponse> = props => {


### PR DESCRIPTION
[FX-3513]

This adds _Alert Only_ option to email frequency dropdowns on `/unsubscribe` and `/user/edit` pages

![Screenshot 2021-11-01 at 16 02 11](https://user-images.githubusercontent.com/44819355/139675656-997a224e-b204-4896-8170-b4d43d318ff2.png)

![Screenshot 2021-11-01 at 16 04 24](https://user-images.githubusercontent.com/44819355/139675951-738c58d5-bdb2-4589-8285-f57c2dcebfff.png)



[FX-3513]: https://artsyproduct.atlassian.net/browse/FX-3513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ