### PR TITLE
chore(CX-2114): update copy on price-database

### DIFF
--- a/src/v2/Apps/PriceDatabase/Components/PriceDatabaseBenefits.tsx
+++ b/src/v2/Apps/PriceDatabase/Components/PriceDatabaseBenefits.tsx
@@ -9,8 +9,8 @@ import {
   Box,
   Spacer,
 } from "@artsy/palette"
-import { ReactElement } from "react";
-import * as React from "react";
+import { ReactElement } from "react"
+import * as React from "react"
 import { Media } from "v2/Utils/Responsive"
 
 export const PriceDatabaseBenefits: React.FC = () => {
@@ -28,7 +28,7 @@ export const PriceDatabaseBenefits: React.FC = () => {
 
       <Section
         title="The largest publicly available art market database"
-        text="With nearly 6.5 million auction records, our growing database encompasses 2,400 top auction houses with pricing that dates back to 1986. Get real-time records from history-making auction houses like Christie's, Sotheby's, Phillips, Bonhams, and more."
+        text="With nearly 6.5 million auction records, our growing database encompasses over 900 auction houses with pricing that dates back to 1986. Get real-time records from history-making auction houses like Christie's, Sotheby's, Phillips, Bonhams, and more."
         jsx={<PopularArtistsList />}
       />
 


### PR DESCRIPTION
This PR resolves [CX-2114]

**Description**
Change the copy in the landing page to “over 900 auction houses” replacing “from 2,400 top auction houses” as shown below

[CX-2114]: https://artsyproduct.atlassian.net/browse/CX-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ