### PR TITLE
chore: Github Package Authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "dependencies": {
     "@artsy/backbone-mixins": "2.0.0",
     "@artsy/cohesion": "4.18.0",
+    "@artsy/eigen-web-association": "^1.1.1",
     "@artsy/express-reloadable": "1.6.0",
     "@artsy/fresnel": "3.0.2",
     "@artsy/gemup": "0.1.0",
@@ -102,7 +103,6 @@
     "@styled-system/theme-get": "5.1.2",
     "accounting": "0.4.1",
     "analytics-node": "2.4.1",
-    "artsy-eigen-web-association": "git://github.com/artsy/artsy-eigen-web-association.git",
     "artsy-ezel-components": "artsy/artsy-ezel-components",
     "autosuggest-highlight": "3.1.1",
     "backbone": "1.3.3",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,7 +16,7 @@ import glob from "glob"
 import helmet from "helmet"
 import path from "path"
 import sharify from "sharify"
-import siteAssociation from "artsy-eigen-web-association"
+import siteAssociation from "@artsy/eigen-web-association"
 import timeout from "connect-timeout"
 import bodyParser from "body-parser"
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,13 @@
   resolved "https://registry.yarnpkg.com/@artsy/detect-responsive-traits/-/detect-responsive-traits-0.0.5.tgz#abf85959f8567816babec6f582b744f58c98b726"
   integrity sha512-axgW5YuqSpPzHb27yo2jmPHz/N9eN2hh2E+Mub5BKuu/jHZI+iDTdw0OZ3I+z7Z9WKBh+FPVx4gpza5w7slJNA==
 
+"@artsy/eigen-web-association@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@artsy/eigen-web-association/-/eigen-web-association-1.1.1.tgz#9ea441a8445518a9b44913fd0cb11040ff806be0"
+  integrity sha512-+d9nVU3hgufaT+3WkYgYlQI8RBDRkTSijYL0PLDHlHAFEozxjXpHtEDkX9F1L/UJJxdrldxx1i+TdkL/msI8CQ==
+  dependencies:
+    express "^4.15.0"
+
 "@artsy/express-reloadable@1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@artsy/express-reloadable/-/express-reloadable-1.6.0.tgz#5660febfa07d4c7ea5a838878ae61b906fd10c0d"
@@ -4753,12 +4760,6 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-"artsy-eigen-web-association@git://github.com/artsy/artsy-eigen-web-association.git":
-  version "1.0.7"
-  resolved "git://github.com/artsy/artsy-eigen-web-association.git#300293aa524984efe82768b2cbbd70b15d8a4dd1"
-  dependencies:
-    express "*"
-
 artsy-ezel-components@artsy/artsy-ezel-components:
   version "0.0.6"
   resolved "https://codeload.github.com/artsy/artsy-ezel-components/tar.gz/61983f3758ecc4a0a057aa9c830e3552abcaa50e"
@@ -9082,42 +9083,6 @@ express-request-id@1.4.0:
   dependencies:
     uuid "^3.0.1"
 
-express@*, express@^4.14.0, express@^4.16.3, express@^4.17.1:
-  version "4.17.1"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
-  integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
-  dependencies:
-    accepts "~1.3.7"
-    array-flatten "1.1.1"
-    body-parser "1.19.0"
-    content-disposition "0.5.3"
-    content-type "~1.0.4"
-    cookie "0.4.0"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "~1.1.2"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "~1.1.2"
-    fresh "0.5.2"
-    merge-descriptors "1.0.1"
-    methods "~1.1.2"
-    on-finished "~2.3.0"
-    parseurl "~1.3.3"
-    path-to-regexp "0.1.7"
-    proxy-addr "~2.0.5"
-    qs "6.7.0"
-    range-parser "~1.2.1"
-    safe-buffer "5.1.2"
-    send "0.17.1"
-    serve-static "1.14.1"
-    setprototypeof "1.1.1"
-    statuses "~1.5.0"
-    type-is "~1.6.18"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
-
 express@4.16.4:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
@@ -9151,6 +9116,42 @@ express@4.16.4:
     setprototypeof "1.1.0"
     statuses "~1.4.0"
     type-is "~1.6.16"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
+express@^4.14.0, express@^4.15.0, express@^4.16.3, express@^4.17.1:
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
+  integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
+  dependencies:
+    accepts "~1.3.7"
+    array-flatten "1.1.1"
+    body-parser "1.19.0"
+    content-disposition "0.5.3"
+    content-type "~1.0.4"
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "~1.1.2"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.5"
+    qs "6.7.0"
+    range-parser "~1.2.1"
+    safe-buffer "5.1.2"
+    send "0.17.1"
+    serve-static "1.14.1"
+    setprototypeof "1.1.1"
+    statuses "~1.5.0"
+    type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
 


### PR DESCRIPTION
Github is removing unrestricted package authentication and this is a
great time to cleanup the last unpublished package that exists in force.

https://github.blog/2021-09-01-improving-git-protocol-security-github/