### PR TITLE
feature: Dockerfile Tuning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:experimental
+# syntax=docker/dockerfile:1.3
 #              +------------------+
 #              |                  |
 #              |  builder-base    |
@@ -82,8 +82,8 @@ COPY patches ./patches
 # ---------------------------------------------------------
 FROM yarn-base as yarn-deps
 
-RUN --mount=type=cache,target=/usr/local/share/.cache \
-  --mount=type=cache,target=/root/.cache/Cypress \
+RUN --mount=type=cache,id=yarndev,target=/usr/local/share/.cache \
+  --mount=type=cache,id=cypress,sharing=locked,target=/root/.cache/Cypress \
   yarn install --frozen-lockfile --quiet
 
 # ---------------------------------------------------------
@@ -91,8 +91,8 @@ RUN --mount=type=cache,target=/usr/local/share/.cache \
 # ---------------------------------------------------------
 FROM yarn-base as yarn-deps-prod
 
-RUN --mount=type=cache,target=/usr/local/share/.cache \
-  --mount=type=cache,target=/root/.cache/Cypress \
+RUN --mount=type=cache,id=yarnprod,target=/usr/local/share/.cache \
+  --mount=type=cache,id=cypress,sharing=locked,target=/root/.cache/Cypress \
   yarn install --production --frozen-lockfile --quiet
 
 # ---------------------------------------------------------


### PR DESCRIPTION
Tuns the way that caches are used in the Dockerfile.

The first change separates the dev and prod caches this fixes a rare
issues caused when the cache is empty and both instances of yarn attempt
to write the same files at the same time. This will increase total disk
space in CI by about 2 GB.

The second change limits a single writer to the cypress directory at a
time.