### PR TITLE
feat(partners): implements filtered partners

### DIFF
--- a/src/v2/Apps/Partners/Components/PartnersFilteredCells.tsx
+++ b/src/v2/Apps/Partners/Components/PartnersFilteredCells.tsx
@@ -1,0 +1,172 @@
+import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import {
+  PartnerCellFragmentContainer,
+  PartnerCellPlaceholder,
+} from "v2/Components/Cells/PartnerCell"
+import { PartnersFilteredCells_viewer } from "v2/__generated__/PartnersFilteredCells_viewer.graphql"
+import { PartnersFilteredCellsQuery } from "v2/__generated__/PartnersFilteredCellsQuery.graphql"
+import { useSystemContext } from "v2/System"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import {
+  Box,
+  Button,
+  Column,
+  GridColumns,
+  Skeleton,
+  SkeletonText,
+  Text,
+} from "@artsy/palette"
+import { compact } from "lodash"
+
+interface PartnersFilteredCellsProps {
+  viewer: PartnersFilteredCells_viewer
+}
+
+const PartnersFilteredCells: FC<PartnersFilteredCellsProps> = ({ viewer }) => {
+  const response = viewer.filterPartners
+
+  const handleClick = () => {
+    // TODO
+  }
+
+  if (!response) return null
+
+  const partners = compact(response.hits)
+
+  return (
+    <>
+      <Text variant="lg" mb={4}>
+        {response.total ?? 0} Result{response.total === 1 ? "" : "s"}
+      </Text>
+
+      <GridColumns gridRowGap={4}>
+        {partners.map(partner => {
+          return (
+            <Column
+              key={partner.internalID}
+              span={[6, 4, 3]}
+              display="flex"
+              alignItems="flex-end"
+            >
+              <PartnerCellFragmentContainer partner={partner} mode="GRID" />
+            </Column>
+          )
+        })}
+      </GridColumns>
+
+      <Box textAlign="center" mt={4}>
+        <Button onClick={handleClick}>Show More</Button>
+      </Box>
+    </>
+  )
+}
+
+const PartnersFilteredCellsFragmentContainer = createFragmentContainer(
+  PartnersFilteredCells,
+  {
+    viewer: graphql`
+      fragment PartnersFilteredCells_viewer on Viewer
+        @argumentDefinitions(
+          category: { type: "[String]" }
+          near: { type: "String" }
+          page: { type: "Int", defaultValue: 1 }
+          type: { type: "[PartnerClassification]" }
+        ) {
+        filterPartners(
+          aggregations: [TOTAL]
+          defaultProfilePublic: true
+          eligibleForListing: true
+          near: $near
+          page: $page
+          partnerCategories: $category
+          size: 12
+          sort: RANDOM_SCORE_DESC
+          type: $type
+        ) {
+          total
+          aggregations {
+            counts {
+              name
+              value
+              count
+            }
+          }
+          hits {
+            internalID
+            ...PartnerCell_partner
+          }
+        }
+      }
+    `,
+  }
+)
+
+const PartnersFilteredCellsPlaceholder: FC = () => {
+  return (
+    <Skeleton>
+      <SkeletonText variant="lg" mb={4}>
+        0 Results
+      </SkeletonText>
+
+      <GridColumns gridRowGap={4}>
+        {[...new Array(12)].map((_, i) => {
+          return (
+            <Column key={i} span={[6, 4, 3]}>
+              <PartnerCellPlaceholder mode="GRID" />
+            </Column>
+          )
+        })}
+      </GridColumns>
+    </Skeleton>
+  )
+}
+
+const PARTNERS_FILTERED_CELLS_QUERY = graphql`
+  query PartnersFilteredCellsQuery(
+    $near: String
+    $category: [String]
+    $type: [PartnerClassification]
+  ) {
+    viewer {
+      ...PartnersFilteredCells_viewer
+        @arguments(type: $type, near: $near, category: $category)
+    }
+  }
+`
+
+interface PartnersFilteredCellsQueryRendererProps {
+  near?: string
+  category?: string
+  type: "INSTITUTION" | "GALLERY"
+}
+
+export const PartnersFilteredCellsQueryRenderer: FC<PartnersFilteredCellsQueryRendererProps> = ({
+  near,
+  category,
+  type,
+}) => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <SystemQueryRenderer<PartnersFilteredCellsQuery>
+      lazyLoad
+      environment={relayEnvironment}
+      placeholder={<PartnersFilteredCellsPlaceholder />}
+      variables={{ near, category, type }}
+      query={PARTNERS_FILTERED_CELLS_QUERY}
+      render={({ props, error }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props?.viewer) {
+          return <PartnersFilteredCellsPlaceholder />
+        }
+
+        return <PartnersFilteredCellsFragmentContainer viewer={props.viewer} />
+      }}
+    />
+  )
+}

--- a/src/v2/Apps/Partners/Components/PartnersRail.tsx
+++ b/src/v2/Apps/Partners/Components/PartnersRail.tsx
@@ -1,6 +1,6 @@
 import { compact, take } from "lodash"
-import { useMemo } from "react";
-import * as React from "react";
+import { useMemo } from "react"
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { PartnerCellFragmentContainer } from "v2/Components/Cells/PartnerCell"
 import { Rail } from "v2/Components/Rail"
@@ -40,14 +40,20 @@ export const PartnersRailFragmentContainer = createFragmentContainer(
   {
     partnerCategory: graphql`
       fragment PartnersRail_partnerCategory on PartnerCategory
-        @argumentDefinitions(type: { type: "[PartnerClassification!]!" }) {
+        @argumentDefinitions(
+          category: { type: "[String]" }
+          near: { type: "String" }
+          type: { type: "[PartnerClassification!]!" }
+        ) {
         name
         primary: partners(
+          defaultProfilePublic: true
           eligibleForListing: true
           eligibleForPrimaryBucket: true
-          type: $type
+          near: $near
+          partnerCategories: $category
           sort: RANDOM_SCORE_DESC
-          defaultProfilePublic: true
+          type: $type
         ) {
           internalID
           ...PartnerCell_partner
@@ -56,6 +62,8 @@ export const PartnersRailFragmentContainer = createFragmentContainer(
           eligibleForListing: true
           eligibleForSecondaryBucket: true
           type: $type
+          near: $near
+          partnerCategories: $category
           sort: RANDOM_SCORE_DESC
           defaultProfilePublic: true
         ) {

--- a/src/v2/Apps/Partners/Components/PartnersRails.tsx
+++ b/src/v2/Apps/Partners/Components/PartnersRails.tsx
@@ -1,0 +1,117 @@
+import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { PartnersRailFragmentContainer } from "./PartnersRail"
+import { PartnersRails_viewer } from "v2/__generated__/PartnersRails_viewer.graphql"
+import { PartnersRailsQuery } from "v2/__generated__/PartnersRailsQuery.graphql"
+import { compact, shuffle } from "lodash"
+import { useSystemContext } from "v2/System"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { Join, Skeleton, Spacer } from "@artsy/palette"
+import { Rail } from "v2/Components/Rail"
+import { PartnerCellPlaceholder } from "v2/Components/Cells/PartnerCell"
+
+interface PartnersRailsProps {
+  viewer: PartnersRails_viewer
+}
+
+const PartnersRails: FC<PartnersRailsProps> = ({ viewer }) => {
+  const categories = shuffle(compact(viewer.partnerCategories))
+
+  return (
+    <Join separator={<Spacer mt={4} />}>
+      {categories.map((partnerCategory, i) => {
+        return (
+          <PartnersRailFragmentContainer
+            key={i}
+            partnerCategory={partnerCategory}
+          />
+        )
+      })}
+    </Join>
+  )
+}
+
+const PartnersRailsFragmentContainer = createFragmentContainer(PartnersRails, {
+  viewer: graphql`
+    fragment PartnersRails_viewer on Viewer
+      @argumentDefinitions(
+        categoryType: { type: "PartnerCategoryType" }
+        type: { type: "[PartnerClassification]" }
+      ) {
+      partnerCategories(
+        categoryType: $categoryType
+        size: 50
+        internal: false
+      ) {
+        name
+        slug
+        ...PartnersRail_partnerCategory @arguments(type: $type)
+      }
+    }
+  `,
+})
+
+const PartnersRailsPlaceholder: FC = () => {
+  return (
+    <Skeleton>
+      <Join separator={<Spacer mt={4} />}>
+        {[...new Array(4)].map((_, i) => {
+          return (
+            <Rail
+              key={i}
+              title="Example"
+              isLoading
+              getItems={() => {
+                return [...new Array(9)].map((_, k) => {
+                  return <PartnerCellPlaceholder key={k} mode="RAIL" />
+                })
+              }}
+            />
+          )
+        })}
+      </Join>
+    </Skeleton>
+  )
+}
+
+interface PartnersRailsQueryRendererProps {
+  type: "INSTITUTION" | "GALLERY"
+}
+
+export const PartnersRailsQueryRenderer: FC<PartnersRailsQueryRendererProps> = ({
+  type,
+}) => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <SystemQueryRenderer<PartnersRailsQuery>
+      lazyLoad
+      environment={relayEnvironment}
+      placeholder={<PartnersRailsPlaceholder />}
+      variables={{ categoryType: type, type }}
+      query={graphql`
+        query PartnersRailsQuery(
+          $categoryType: PartnerCategoryType
+          $type: [PartnerClassification]
+        ) {
+          viewer {
+            ...PartnersRails_viewer
+              @arguments(categoryType: $categoryType, type: $type)
+          }
+        }
+      `}
+      render={({ props, error }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props?.viewer) {
+          return <PartnersRailsPlaceholder />
+        }
+
+        return <PartnersRailsFragmentContainer viewer={props.viewer} />
+      }}
+    />
+  )
+}

--- a/src/v2/Apps/Partners/Routes/InstitutionsRoute.tsx
+++ b/src/v2/Apps/Partners/Routes/InstitutionsRoute.tsx
@@ -7,23 +7,26 @@ import {
   Spacer,
   Text,
 } from "@artsy/palette"
-import { compact } from "lodash"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { MetaTags } from "v2/Components/MetaTags"
+import { useRouter } from "v2/System/Router/useRouter"
 import { InstitutionsRoute_viewer } from "v2/__generated__/InstitutionsRoute_viewer.graphql"
 import { PartnersFeaturedCarouselFragmentContainer } from "../Components/PartnersFeaturedCarousel"
+import { PartnersFilteredCellsQueryRenderer } from "../Components/PartnersFilteredCells"
 import { PartnersFilters } from "../Components/PartnersFilters"
-import { PartnersRailFragmentContainer } from "../Components/PartnersRail"
+import { PartnersRailsQueryRenderer } from "../Components/PartnersRails"
 
 interface InstitutionsRouteProps {
   viewer: InstitutionsRoute_viewer
 }
 
 const InstitutionsRoute: React.FC<InstitutionsRouteProps> = ({ viewer }) => {
-  // TODO: In the original implementation these categories are shuffled.
-  // We need a way to do SSR-stable shuffle.
-  const categories = compact(viewer.partnerCategories)
+  const {
+    match: {
+      location: { query },
+    },
+  } = useRouter()
 
   return (
     <>
@@ -37,14 +40,15 @@ const InstitutionsRoute: React.FC<InstitutionsRouteProps> = ({ viewer }) => {
 
         <PartnersFilters type="INSTITUTION" />
 
-        {categories.map((partnerCategory, i) => {
-          return (
-            <PartnersRailFragmentContainer
-              key={i}
-              partnerCategory={partnerCategory}
-            />
-          )
-        })}
+        {"category" in query || "near" in query ? (
+          <PartnersFilteredCellsQueryRenderer
+            type="INSTITUTION"
+            category={query.category}
+            near={query.near}
+          />
+        ) : (
+          <PartnersRailsQueryRenderer type="INSTITUTION" />
+        )}
 
         <Separator />
 
@@ -76,15 +80,6 @@ export const InstitutionsRouteFragmentContainer = createFragmentContainer(
       fragment InstitutionsRoute_viewer on Viewer {
         ...PartnersFeaturedCarousel_viewer
           @arguments(id: "564e181a258faf3d5c000080")
-        partnerCategories(
-          categoryType: INSTITUTION
-          size: 50
-          internal: false
-        ) {
-          name
-          slug
-          ...PartnersRail_partnerCategory @arguments(type: INSTITUTION)
-        }
       }
     `,
   }

--- a/src/v2/Apps/Partners/Routes/__tests__/GalleriesRoute.jest.tsx
+++ b/src/v2/Apps/Partners/Routes/__tests__/GalleriesRoute.jest.tsx
@@ -5,19 +5,25 @@ import { GalleriesRouteFragmentContainer_Test_Query } from "v2/__generated__/Gal
 import { MockBoot } from "v2/DevTools"
 import { screen } from "@testing-library/react"
 import { useTracking } from "react-tracking"
+import { useRouter } from "v2/System/Router/useRouter"
 
 jest.unmock("react-relay")
-
+jest.mock("v2/System/Router/useRouter")
 jest.mock("v2/Components/FollowButton/FollowProfileButton", () => ({
   FollowProfileButtonFragmentContainer: () => null,
 }))
-
 jest.mock("v2/System/Analytics/useTracking", () => ({
   useTracking: () => ({}),
 }))
-
 jest.mock("../../Components/PartnersFilters", () => ({
   PartnersFilters: () => null,
+}))
+jest.mock("../../Components/PartnersRails", () => ({
+  PartnersRailsQueryRenderer: () => "PartnersRailsQueryRenderer",
+}))
+jest.mock("../../Components/PartnersFilteredCells", () => ({
+  PartnersFilteredCellsQueryRenderer: () =>
+    "PartnersFilteredCellsQueryRenderer",
 }))
 
 const { renderWithRelay } = setupTestWrapperTL<
@@ -40,20 +46,48 @@ const { renderWithRelay } = setupTestWrapperTL<
 })
 
 describe("GalleriesRoute", () => {
-  const trackEvent = jest.fn()
+  const mockTracking = useTracking as jest.Mock
+  const mockUseRouter = useRouter as jest.Mock
+
   beforeEach(() => {
-    renderWithRelay()
-    ;(useTracking as jest.Mock).mockImplementation(() => ({ trackEvent }))
+    mockTracking.mockImplementation(() => ({ trackEvent: jest.fn() }))
+    mockUseRouter.mockImplementation(() => ({
+      match: { location: { query: {} } },
+    }))
   })
 
   afterEach(() => {
-    trackEvent.mockReset()
+    mockTracking.mockReset()
+    mockUseRouter.mockReset()
   })
 
   it("renders the page", () => {
-    //
+    renderWithRelay()
+
     expect(
       screen.getByText("Interested in Listing Your Gallery on Artsy?")
     ).toBeInTheDocument()
+
+    expect(screen.getByText("PartnersRailsQueryRenderer")).toBeInTheDocument()
+  })
+
+  describe("when querying", () => {
+    beforeEach(() => {
+      mockUseRouter.mockImplementation(() => ({
+        match: { location: { query: { near: "0,0" } } },
+      }))
+    })
+
+    it("renders the page with the filtered cells", () => {
+      renderWithRelay()
+
+      expect(
+        screen.getByText("Interested in Listing Your Gallery on Artsy?")
+      ).toBeInTheDocument()
+
+      expect(
+        screen.getByText("PartnersFilteredCellsQueryRenderer")
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/src/v2/Apps/Partners/Routes/__tests__/InstitutionsRoute.jest.tsx
+++ b/src/v2/Apps/Partners/Routes/__tests__/InstitutionsRoute.jest.tsx
@@ -5,19 +5,25 @@ import { InstitutionsRouteFragmentContainer_Test_Query } from "v2/__generated__/
 import { MockBoot } from "v2/DevTools"
 import { screen } from "@testing-library/react"
 import { useTracking } from "react-tracking"
+import { useRouter } from "v2/System/Router/useRouter"
 
 jest.unmock("react-relay")
-
+jest.mock("v2/System/Router/useRouter")
 jest.mock("v2/Components/FollowButton/FollowProfileButton", () => ({
   FollowProfileButtonFragmentContainer: () => null,
 }))
-
 jest.mock("v2/System/Analytics/useTracking", () => ({
   useTracking: () => ({}),
 }))
-
 jest.mock("../../Components/PartnersFilters", () => ({
   PartnersFilters: () => null,
+}))
+jest.mock("../../Components/PartnersRails", () => ({
+  PartnersRailsQueryRenderer: () => "PartnersRailsQueryRenderer",
+}))
+jest.mock("../../Components/PartnersFilteredCells", () => ({
+  PartnersFilteredCellsQueryRenderer: () =>
+    "PartnersFilteredCellsQueryRenderer",
 }))
 
 const { renderWithRelay } = setupTestWrapperTL<
@@ -40,19 +46,48 @@ const { renderWithRelay } = setupTestWrapperTL<
 })
 
 describe("InstitutionsRoute", () => {
-  const trackEvent = jest.fn()
+  const mockTracking = useTracking as jest.Mock
+  const mockUseRouter = useRouter as jest.Mock
+
   beforeEach(() => {
-    renderWithRelay()
-    ;(useTracking as jest.Mock).mockImplementation(() => ({ trackEvent }))
+    mockTracking.mockImplementation(() => ({ trackEvent: jest.fn() }))
+    mockUseRouter.mockImplementation(() => ({
+      match: { location: { query: {} } },
+    }))
   })
 
   afterEach(() => {
-    trackEvent.mockReset()
+    mockTracking.mockReset()
+    mockUseRouter.mockReset()
   })
 
   it("renders the page", () => {
+    renderWithRelay()
+
     expect(
       screen.getByText("Interested in Listing Your Museum on Artsy?")
     ).toBeInTheDocument()
+
+    expect(screen.getByText("PartnersRailsQueryRenderer")).toBeInTheDocument()
+  })
+
+  describe("when querying", () => {
+    beforeEach(() => {
+      mockUseRouter.mockImplementation(() => ({
+        match: { location: { query: { near: "0,0" } } },
+      }))
+    })
+
+    it("renders the page with the filtered cells", () => {
+      renderWithRelay()
+
+      expect(
+        screen.getByText("Interested in Listing Your Museum on Artsy?")
+      ).toBeInTheDocument()
+
+      expect(
+        screen.getByText("PartnersFilteredCellsQueryRenderer")
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/src/v2/Components/Cells/PartnerCell.tsx
+++ b/src/v2/Components/Cells/PartnerCell.tsx
@@ -8,12 +8,13 @@ import {
   Box,
   EntityHeader,
   Image,
+  ResponsiveBox,
   SkeletonBox,
   SkeletonText,
   Text,
 } from "@artsy/palette"
 import { uniq } from "lodash"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "v2/System/Analytics/useTracking"
 import { useSystemContext } from "v2/System"
@@ -24,12 +25,18 @@ import { FollowProfileButtonFragmentContainer } from "v2/Components/FollowButton
 
 interface PartnerCellProps {
   partner: PartnerCell_partner
+  /** Defaults to `"RAIL"` */
+  mode?: "GRID" | "RAIL"
 }
 
-const PartnerCell: React.FC<PartnerCellProps> = ({ partner }) => {
+const PartnerCell: React.FC<PartnerCellProps> = ({
+  partner,
+  mode = "RAIL",
+}) => {
   const { user } = useSystemContext()
   const { trackEvent } = useTracking()
 
+  const width = mode === "GRID" ? "100%" : 325
   const locations = extractNodes(partner.locationsConnection)
   const meta = uniq(locations.map(location => location.city?.trim())).join(", ")
   const image = partner.profile?.image?.cropped
@@ -43,7 +50,7 @@ const PartnerCell: React.FC<PartnerCellProps> = ({ partner }) => {
       to={`/partner${partner.href}`}
       display="block"
       textDecoration="none"
-      width={325}
+      width={width}
       onClick={() => {
         const trackingEvent: ClickedGalleryGroup = {
           action: ActionType.clickedGalleryGroup,
@@ -84,44 +91,56 @@ const PartnerCell: React.FC<PartnerCellProps> = ({ partner }) => {
         }
       />
 
-      {image?.src ? (
-        <Image
-          src={image.src}
-          srcSet={image.srcSet}
-          width={325}
-          height={244}
-          alt=""
-          lazyLoad
-          style={{ display: "block" }}
-        />
-      ) : (
-        <Text
-          variant="lg"
-          bg="black10"
-          width={325}
-          height={244}
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-        >
-          {partner.initials}
-        </Text>
-      )}
+      <ResponsiveBox aspectWidth={4} aspectHeight={3} maxWidth="100%">
+        {image?.src ? (
+          <Image
+            src={image.src}
+            srcSet={image.srcSet}
+            width="100%"
+            height="100%"
+            alt=""
+            lazyLoad
+            style={{ display: "block" }}
+          />
+        ) : (
+          <Text
+            variant="lg"
+            bg="black10"
+            width="100%"
+            height="100%"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+          >
+            {partner.initials}
+          </Text>
+        )}
+      </ResponsiveBox>
     </RouterLink>
   )
 }
 
-export const PARTNER_CELL_PLACEHOLDER = (
-  <Box width={325}>
-    <SkeletonText variant="lg">Example Gallery</SkeletonText>
+type PartnerCellPlaceholderProps = Pick<PartnerCellProps, "mode">
 
-    <SkeletonText variant="md" mb={1}>
-      Location
-    </SkeletonText>
+export const PartnerCellPlaceholder: React.FC<PartnerCellPlaceholderProps> = ({
+  mode = "RAIL",
+}) => {
+  const width = mode === "GRID" ? "100%" : 325
 
-    <SkeletonBox width={325} height={244} />
-  </Box>
-)
+  return (
+    <Box width={width}>
+      <SkeletonText variant="lg">Example Gallery</SkeletonText>
+
+      <SkeletonText variant="md" mb={1}>
+        Location
+      </SkeletonText>
+
+      <ResponsiveBox aspectWidth={4} aspectHeight={3} maxWidth="100%">
+        <SkeletonBox width="100%" height="100%" />
+      </ResponsiveBox>
+    </Box>
+  )
+}
 
 export const PartnerCellFragmentContainer = createFragmentContainer(
   PartnerCell,
@@ -145,8 +164,8 @@ export const PartnerCellFragmentContainer = createFragmentContainer(
           isFollowed
           image {
             cropped(
-              width: 325
-              height: 244
+              width: 445
+              height: 334
               version: ["wide", "large", "featured", "larger"]
             ) {
               src

--- a/src/v2/__generated__/GalleriesRouteFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/GalleriesRouteFragmentContainer_Test_Query.graphql.ts
@@ -33,39 +33,6 @@ fragment FollowProfileButton_profile on Profile {
 
 fragment GalleriesRoute_viewer on Viewer {
   ...PartnersFeaturedCarousel_viewer_4uWBz4
-  partnerCategories(categoryType: GALLERY, size: 50, internal: false) {
-    name
-    slug
-    ...PartnersRail_partnerCategory_uMgyM
-    id
-  }
-}
-
-fragment PartnerCell_partner on Partner {
-  internalID
-  slug
-  name
-  href
-  initials
-  locationsConnection(first: 15) {
-    edges {
-      node {
-        city
-        id
-      }
-    }
-  }
-  profile {
-    ...FollowProfileButton_profile
-    isFollowed
-    image {
-      cropped(width: 325, height: 244, version: ["wide", "large", "featured", "larger"]) {
-        src
-        srcSet
-      }
-    }
-    id
-  }
 }
 
 fragment PartnersFeaturedCarouselCell_profile on Profile {
@@ -123,20 +90,6 @@ fragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {
     id
   }
 }
-
-fragment PartnersRail_partnerCategory_uMgyM on PartnerCategory {
-  name
-  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
-    internalID
-    ...PartnerCell_partner
-    id
-  }
-  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
-    internalID
-    ...PartnerCell_partner
-    id
-  }
-}
 */
 
 const node: ConcreteRequest = (function(){
@@ -165,198 +118,15 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
-  "alias": "is_followed",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isFollowed",
-  "storageKey": null
-},
-v6 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MMM D"
   }
-],
-v7 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "city",
-    "storageKey": null
-  },
-  (v1/*: any*/)
-],
-v8 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "src",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
-  }
-],
-v9 = {
-  "kind": "Literal",
-  "name": "defaultProfilePublic",
-  "value": true
-},
-v10 = {
-  "kind": "Literal",
-  "name": "eligibleForListing",
-  "value": true
-},
-v11 = {
-  "kind": "Literal",
-  "name": "sort",
-  "value": "RANDOM_SCORE_DESC"
-},
-v12 = {
-  "kind": "Literal",
-  "name": "type",
-  "value": "GALLERY"
-},
-v13 = [
-  (v2/*: any*/),
-  (v3/*: any*/),
-  (v4/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "href",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "initials",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Literal",
-        "name": "first",
-        "value": 15
-      }
-    ],
-    "concreteType": "LocationConnection",
-    "kind": "LinkedField",
-    "name": "locationsConnection",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "LocationEdge",
-        "kind": "LinkedField",
-        "name": "edges",
-        "plural": true,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Location",
-            "kind": "LinkedField",
-            "name": "node",
-            "plural": false,
-            "selections": (v7/*: any*/),
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": "locationsConnection(first:15)"
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Profile",
-    "kind": "LinkedField",
-    "name": "profile",
-    "plural": false,
-    "selections": [
-      (v1/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v2/*: any*/),
-      (v5/*: any*/),
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "isFollowed",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Image",
-        "kind": "LinkedField",
-        "name": "image",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "height",
-                "value": 244
-              },
-              {
-                "kind": "Literal",
-                "name": "version",
-                "value": [
-                  "wide",
-                  "large",
-                  "featured",
-                  "larger"
-                ]
-              },
-              {
-                "kind": "Literal",
-                "name": "width",
-                "value": 325
-              }
-            ],
-            "concreteType": "CroppedImageUrl",
-            "kind": "LinkedField",
-            "name": "cropped",
-            "plural": false,
-            "selections": (v8/*: any*/),
-            "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  },
-  (v1/*: any*/)
 ];
 return {
   "fragment": {
@@ -426,9 +196,21 @@ return {
                     "kind": "InlineFragment",
                     "selections": [
                       (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
                       (v3/*: any*/),
-                      (v4/*: any*/),
-                      (v5/*: any*/),
+                      {
+                        "alias": "is_followed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFollowed",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -443,7 +225,7 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v2/*: any*/),
-                              (v4/*: any*/),
+                              (v3/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -452,7 +234,7 @@ return {
                                 "name": "featuredShow",
                                 "plural": false,
                                 "selections": [
-                                  (v4/*: any*/),
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -469,14 +251,14 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "kind": "ScalarField",
                                     "name": "startAt",
                                     "storageKey": "startAt(format:\"MMM D\")"
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "kind": "ScalarField",
                                     "name": "endAt",
                                     "storageKey": "endAt(format:\"MMM D\")"
@@ -495,7 +277,16 @@ return {
                                     "kind": "LinkedField",
                                     "name": "location",
                                     "plural": false,
-                                    "selections": (v7/*: any*/),
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "city",
+                                        "storageKey": null
+                                      },
+                                      (v1/*: any*/)
+                                    ],
                                     "storageKey": null
                                   },
                                   {
@@ -528,7 +319,22 @@ return {
                                         "kind": "LinkedField",
                                         "name": "resized",
                                         "plural": false,
-                                        "selections": (v8/*: any*/),
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "src",
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "srcSet",
+                                            "storageKey": null
+                                          }
+                                        ],
                                         "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
                                       }
                                     ],
@@ -553,76 +359,6 @@ return {
               (v1/*: any*/)
             ],
             "storageKey": "orderedSet(id:\"5638fdfb7261690296000031\")"
-          },
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "categoryType",
-                "value": "GALLERY"
-              },
-              {
-                "kind": "Literal",
-                "name": "internal",
-                "value": false
-              },
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 50
-              }
-            ],
-            "concreteType": "PartnerCategory",
-            "kind": "LinkedField",
-            "name": "partnerCategories",
-            "plural": true,
-            "selections": [
-              (v4/*: any*/),
-              (v3/*: any*/),
-              {
-                "alias": "primary",
-                "args": [
-                  (v9/*: any*/),
-                  (v10/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "eligibleForPrimaryBucket",
-                    "value": true
-                  },
-                  (v11/*: any*/),
-                  (v12/*: any*/)
-                ],
-                "concreteType": "Partner",
-                "kind": "LinkedField",
-                "name": "partners",
-                "plural": true,
-                "selections": (v13/*: any*/),
-                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForPrimaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"GALLERY\")"
-              },
-              {
-                "alias": "secondary",
-                "args": [
-                  (v9/*: any*/),
-                  (v10/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "eligibleForSecondaryBucket",
-                    "value": true
-                  },
-                  (v11/*: any*/),
-                  (v12/*: any*/)
-                ],
-                "concreteType": "Partner",
-                "kind": "LinkedField",
-                "name": "partners",
-                "plural": true,
-                "selections": (v13/*: any*/),
-                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForSecondaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"GALLERY\")"
-              },
-              (v1/*: any*/)
-            ],
-            "storageKey": "partnerCategories(categoryType:\"GALLERY\",internal:false,size:50)"
           }
         ],
         "storageKey": null
@@ -634,7 +370,7 @@ return {
     "metadata": {},
     "name": "GalleriesRouteFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query GalleriesRouteFragmentContainer_Test_Query {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n  partnerCategories(categoryType: GALLERY, size: 50, internal: false) {\n    name\n    slug\n    ...PartnersRail_partnerCategory_uMgyM\n    id\n  }\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 325, height: 244, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersRail_partnerCategory_uMgyM on PartnerCategory {\n  name\n  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n}\n"
+    "text": "query GalleriesRouteFragmentContainer_Test_Query {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/GalleriesRoute_viewer.graphql.ts
+++ b/src/v2/__generated__/GalleriesRoute_viewer.graphql.ts
@@ -4,11 +4,6 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type GalleriesRoute_viewer = {
-    readonly partnerCategories: ReadonlyArray<{
-        readonly name: string | null;
-        readonly slug: string;
-        readonly " $fragmentRefs": FragmentRefs<"PartnersRail_partnerCategory">;
-    } | null> | null;
     readonly " $fragmentRefs": FragmentRefs<"PartnersFeaturedCarousel_viewer">;
     readonly " $refType": "GalleriesRoute_viewer";
 };
@@ -27,58 +22,6 @@ const node: ReaderFragment = {
   "name": "GalleriesRoute_viewer",
   "selections": [
     {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "categoryType",
-          "value": "GALLERY"
-        },
-        {
-          "kind": "Literal",
-          "name": "internal",
-          "value": false
-        },
-        {
-          "kind": "Literal",
-          "name": "size",
-          "value": 50
-        }
-      ],
-      "concreteType": "PartnerCategory",
-      "kind": "LinkedField",
-      "name": "partnerCategories",
-      "plural": true,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "name",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "slug",
-          "storageKey": null
-        },
-        {
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "type",
-              "value": "GALLERY"
-            }
-          ],
-          "kind": "FragmentSpread",
-          "name": "PartnersRail_partnerCategory"
-        }
-      ],
-      "storageKey": "partnerCategories(categoryType:\"GALLERY\",internal:false,size:50)"
-    },
-    {
       "args": [
         {
           "kind": "Literal",
@@ -92,5 +35,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = 'e5c5a9b83ff147c0fadf2d43f013d0c5';
+(node as any).hash = 'ce6e81cc90204e38ed5a0a996d92e310';
 export default node;

--- a/src/v2/__generated__/InstitutionsRouteFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/InstitutionsRouteFragmentContainer_Test_Query.graphql.ts
@@ -33,39 +33,6 @@ fragment FollowProfileButton_profile on Profile {
 
 fragment InstitutionsRoute_viewer on Viewer {
   ...PartnersFeaturedCarousel_viewer_3Ao4DD
-  partnerCategories(categoryType: INSTITUTION, size: 50, internal: false) {
-    name
-    slug
-    ...PartnersRail_partnerCategory_q3ILp
-    id
-  }
-}
-
-fragment PartnerCell_partner on Partner {
-  internalID
-  slug
-  name
-  href
-  initials
-  locationsConnection(first: 15) {
-    edges {
-      node {
-        city
-        id
-      }
-    }
-  }
-  profile {
-    ...FollowProfileButton_profile
-    isFollowed
-    image {
-      cropped(width: 325, height: 244, version: ["wide", "large", "featured", "larger"]) {
-        src
-        srcSet
-      }
-    }
-    id
-  }
 }
 
 fragment PartnersFeaturedCarouselCell_profile on Profile {
@@ -123,20 +90,6 @@ fragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {
     id
   }
 }
-
-fragment PartnersRail_partnerCategory_q3ILp on PartnerCategory {
-  name
-  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
-    internalID
-    ...PartnerCell_partner
-    id
-  }
-  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
-    internalID
-    ...PartnerCell_partner
-    id
-  }
-}
 */
 
 const node: ConcreteRequest = (function(){
@@ -165,198 +118,15 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
-  "alias": "is_followed",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isFollowed",
-  "storageKey": null
-},
-v6 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MMM D"
   }
-],
-v7 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "city",
-    "storageKey": null
-  },
-  (v1/*: any*/)
-],
-v8 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "src",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
-  }
-],
-v9 = {
-  "kind": "Literal",
-  "name": "defaultProfilePublic",
-  "value": true
-},
-v10 = {
-  "kind": "Literal",
-  "name": "eligibleForListing",
-  "value": true
-},
-v11 = {
-  "kind": "Literal",
-  "name": "sort",
-  "value": "RANDOM_SCORE_DESC"
-},
-v12 = {
-  "kind": "Literal",
-  "name": "type",
-  "value": "INSTITUTION"
-},
-v13 = [
-  (v2/*: any*/),
-  (v3/*: any*/),
-  (v4/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "href",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "initials",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Literal",
-        "name": "first",
-        "value": 15
-      }
-    ],
-    "concreteType": "LocationConnection",
-    "kind": "LinkedField",
-    "name": "locationsConnection",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "LocationEdge",
-        "kind": "LinkedField",
-        "name": "edges",
-        "plural": true,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Location",
-            "kind": "LinkedField",
-            "name": "node",
-            "plural": false,
-            "selections": (v7/*: any*/),
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": "locationsConnection(first:15)"
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Profile",
-    "kind": "LinkedField",
-    "name": "profile",
-    "plural": false,
-    "selections": [
-      (v1/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v2/*: any*/),
-      (v5/*: any*/),
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "isFollowed",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Image",
-        "kind": "LinkedField",
-        "name": "image",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "height",
-                "value": 244
-              },
-              {
-                "kind": "Literal",
-                "name": "version",
-                "value": [
-                  "wide",
-                  "large",
-                  "featured",
-                  "larger"
-                ]
-              },
-              {
-                "kind": "Literal",
-                "name": "width",
-                "value": 325
-              }
-            ],
-            "concreteType": "CroppedImageUrl",
-            "kind": "LinkedField",
-            "name": "cropped",
-            "plural": false,
-            "selections": (v8/*: any*/),
-            "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  },
-  (v1/*: any*/)
 ];
 return {
   "fragment": {
@@ -426,9 +196,21 @@ return {
                     "kind": "InlineFragment",
                     "selections": [
                       (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
                       (v3/*: any*/),
-                      (v4/*: any*/),
-                      (v5/*: any*/),
+                      {
+                        "alias": "is_followed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFollowed",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -443,7 +225,7 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v2/*: any*/),
-                              (v4/*: any*/),
+                              (v3/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -452,7 +234,7 @@ return {
                                 "name": "featuredShow",
                                 "plural": false,
                                 "selections": [
-                                  (v4/*: any*/),
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -469,14 +251,14 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "kind": "ScalarField",
                                     "name": "startAt",
                                     "storageKey": "startAt(format:\"MMM D\")"
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "kind": "ScalarField",
                                     "name": "endAt",
                                     "storageKey": "endAt(format:\"MMM D\")"
@@ -495,7 +277,16 @@ return {
                                     "kind": "LinkedField",
                                     "name": "location",
                                     "plural": false,
-                                    "selections": (v7/*: any*/),
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "city",
+                                        "storageKey": null
+                                      },
+                                      (v1/*: any*/)
+                                    ],
                                     "storageKey": null
                                   },
                                   {
@@ -528,7 +319,22 @@ return {
                                         "kind": "LinkedField",
                                         "name": "resized",
                                         "plural": false,
-                                        "selections": (v8/*: any*/),
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "src",
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "srcSet",
+                                            "storageKey": null
+                                          }
+                                        ],
                                         "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
                                       }
                                     ],
@@ -553,76 +359,6 @@ return {
               (v1/*: any*/)
             ],
             "storageKey": "orderedSet(id:\"564e181a258faf3d5c000080\")"
-          },
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "categoryType",
-                "value": "INSTITUTION"
-              },
-              {
-                "kind": "Literal",
-                "name": "internal",
-                "value": false
-              },
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 50
-              }
-            ],
-            "concreteType": "PartnerCategory",
-            "kind": "LinkedField",
-            "name": "partnerCategories",
-            "plural": true,
-            "selections": [
-              (v4/*: any*/),
-              (v3/*: any*/),
-              {
-                "alias": "primary",
-                "args": [
-                  (v9/*: any*/),
-                  (v10/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "eligibleForPrimaryBucket",
-                    "value": true
-                  },
-                  (v11/*: any*/),
-                  (v12/*: any*/)
-                ],
-                "concreteType": "Partner",
-                "kind": "LinkedField",
-                "name": "partners",
-                "plural": true,
-                "selections": (v13/*: any*/),
-                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForPrimaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"INSTITUTION\")"
-              },
-              {
-                "alias": "secondary",
-                "args": [
-                  (v9/*: any*/),
-                  (v10/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "eligibleForSecondaryBucket",
-                    "value": true
-                  },
-                  (v11/*: any*/),
-                  (v12/*: any*/)
-                ],
-                "concreteType": "Partner",
-                "kind": "LinkedField",
-                "name": "partners",
-                "plural": true,
-                "selections": (v13/*: any*/),
-                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForSecondaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"INSTITUTION\")"
-              },
-              (v1/*: any*/)
-            ],
-            "storageKey": "partnerCategories(categoryType:\"INSTITUTION\",internal:false,size:50)"
           }
         ],
         "storageKey": null
@@ -634,7 +370,7 @@ return {
     "metadata": {},
     "name": "InstitutionsRouteFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query InstitutionsRouteFragmentContainer_Test_Query {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n  partnerCategories(categoryType: INSTITUTION, size: 50, internal: false) {\n    name\n    slug\n    ...PartnersRail_partnerCategory_q3ILp\n    id\n  }\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 325, height: 244, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersRail_partnerCategory_q3ILp on PartnerCategory {\n  name\n  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n}\n"
+    "text": "query InstitutionsRouteFragmentContainer_Test_Query {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/InstitutionsRoute_viewer.graphql.ts
+++ b/src/v2/__generated__/InstitutionsRoute_viewer.graphql.ts
@@ -4,11 +4,6 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type InstitutionsRoute_viewer = {
-    readonly partnerCategories: ReadonlyArray<{
-        readonly name: string | null;
-        readonly slug: string;
-        readonly " $fragmentRefs": FragmentRefs<"PartnersRail_partnerCategory">;
-    } | null> | null;
     readonly " $fragmentRefs": FragmentRefs<"PartnersFeaturedCarousel_viewer">;
     readonly " $refType": "InstitutionsRoute_viewer";
 };
@@ -27,58 +22,6 @@ const node: ReaderFragment = {
   "name": "InstitutionsRoute_viewer",
   "selections": [
     {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "categoryType",
-          "value": "INSTITUTION"
-        },
-        {
-          "kind": "Literal",
-          "name": "internal",
-          "value": false
-        },
-        {
-          "kind": "Literal",
-          "name": "size",
-          "value": 50
-        }
-      ],
-      "concreteType": "PartnerCategory",
-      "kind": "LinkedField",
-      "name": "partnerCategories",
-      "plural": true,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "name",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "slug",
-          "storageKey": null
-        },
-        {
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "type",
-              "value": "INSTITUTION"
-            }
-          ],
-          "kind": "FragmentSpread",
-          "name": "PartnersRail_partnerCategory"
-        }
-      ],
-      "storageKey": "partnerCategories(categoryType:\"INSTITUTION\",internal:false,size:50)"
-    },
-    {
       "args": [
         {
           "kind": "Literal",
@@ -92,5 +35,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = '4bbf1101a55a168cb787473f66e0d5d8';
+(node as any).hash = '8c395bc11a0178f10f342c07631bf2f2';
 export default node;

--- a/src/v2/__generated__/PartnerCellFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerCellFragmentContainer_Test_Query.graphql.ts
@@ -50,7 +50,7 @@ fragment PartnerCell_partner on Partner {
     ...FollowProfileButton_profile
     isFollowed
     image {
-      cropped(width: 325, height: 244, version: ["wide", "large", "featured", "larger"]) {
+      cropped(width: 445, height: 334, version: ["wide", "large", "featured", "larger"]) {
         src
         srcSet
       }
@@ -240,7 +240,7 @@ return {
                       {
                         "kind": "Literal",
                         "name": "height",
-                        "value": 244
+                        "value": 334
                       },
                       {
                         "kind": "Literal",
@@ -255,7 +255,7 @@ return {
                       {
                         "kind": "Literal",
                         "name": "width",
-                        "value": 325
+                        "value": 445
                       }
                     ],
                     "concreteType": "CroppedImageUrl",
@@ -278,7 +278,7 @@ return {
                         "storageKey": null
                       }
                     ],
-                    "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
+                    "storageKey": "cropped(height:334,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:445)"
                   }
                 ],
                 "storageKey": null
@@ -297,7 +297,7 @@ return {
     "metadata": {},
     "name": "PartnerCellFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerCellFragmentContainer_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerCell_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 325, height: 244, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query PartnerCellFragmentContainer_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerCell_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerCell_partner.graphql.ts
+++ b/src/v2/__generated__/PartnerCell_partner.graphql.ts
@@ -152,7 +152,7 @@ const node: ReaderFragment = {
                 {
                   "kind": "Literal",
                   "name": "height",
-                  "value": 244
+                  "value": 334
                 },
                 {
                   "kind": "Literal",
@@ -167,7 +167,7 @@ const node: ReaderFragment = {
                 {
                   "kind": "Literal",
                   "name": "width",
-                  "value": 325
+                  "value": 445
                 }
               ],
               "concreteType": "CroppedImageUrl",
@@ -190,7 +190,7 @@ const node: ReaderFragment = {
                   "storageKey": null
                 }
               ],
-              "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
+              "storageKey": "cropped(height:334,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:445)"
             }
           ],
           "storageKey": null
@@ -206,5 +206,5 @@ const node: ReaderFragment = {
   ],
   "type": "Partner"
 };
-(node as any).hash = '495d4620a9747f42d1cb6fb93b7365d0';
+(node as any).hash = '97216233ec62a0a1236c3735da900b08';
 export default node;

--- a/src/v2/__generated__/PartnersFilteredCellsQuery.graphql.ts
+++ b/src/v2/__generated__/PartnersFilteredCellsQuery.graphql.ts
@@ -1,0 +1,468 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PartnerClassification = "AUCTION" | "BRAND" | "DEMO" | "GALLERY" | "INSTITUTION" | "INSTITUTIONAL_SELLER" | "PRIVATE_COLLECTOR" | "PRIVATE_DEALER" | "%future added value";
+export type PartnersFilteredCellsQueryVariables = {
+    near?: string | null;
+    category?: Array<string | null> | null;
+    type?: Array<PartnerClassification | null> | null;
+};
+export type PartnersFilteredCellsQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"PartnersFilteredCells_viewer">;
+    } | null;
+};
+export type PartnersFilteredCellsQuery = {
+    readonly response: PartnersFilteredCellsQueryResponse;
+    readonly variables: PartnersFilteredCellsQueryVariables;
+};
+
+
+
+/*
+query PartnersFilteredCellsQuery(
+  $near: String
+  $category: [String]
+  $type: [PartnerClassification]
+) {
+  viewer {
+    ...PartnersFilteredCells_viewer_4vwjik
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  is_followed: isFollowed
+}
+
+fragment PartnerCell_partner on Partner {
+  internalID
+  slug
+  name
+  href
+  initials
+  locationsConnection(first: 15) {
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
+  profile {
+    ...FollowProfileButton_profile
+    isFollowed
+    image {
+      cropped(width: 445, height: 334, version: ["wide", "large", "featured", "larger"]) {
+        src
+        srcSet
+      }
+    }
+    id
+  }
+}
+
+fragment PartnersFilteredCells_viewer_4vwjik on Viewer {
+  filterPartners(aggregations: [TOTAL], defaultProfilePublic: true, eligibleForListing: true, near: $near, page: 1, partnerCategories: $category, size: 12, sort: RANDOM_SCORE_DESC, type: $type) {
+    total
+    aggregations {
+      counts {
+        name
+        value
+        count
+      }
+    }
+    hits {
+      internalID
+      ...PartnerCell_partner
+      id
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "near",
+    "type": "String"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "category",
+    "type": "[String]"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "type",
+    "type": "[PartnerClassification]"
+  }
+],
+v1 = {
+  "kind": "Variable",
+  "name": "near",
+  "variableName": "near"
+},
+v2 = {
+  "kind": "Variable",
+  "name": "type",
+  "variableName": "type"
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PartnersFilteredCellsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "category",
+                "variableName": "category"
+              },
+              (v1/*: any*/),
+              (v2/*: any*/)
+            ],
+            "kind": "FragmentSpread",
+            "name": "PartnersFilteredCells_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "PartnersFilteredCellsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "aggregations",
+                "value": [
+                  "TOTAL"
+                ]
+              },
+              {
+                "kind": "Literal",
+                "name": "defaultProfilePublic",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "eligibleForListing",
+                "value": true
+              },
+              (v1/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "page",
+                "value": 1
+              },
+              {
+                "kind": "Variable",
+                "name": "partnerCategories",
+                "variableName": "category"
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 12
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "RANDOM_SCORE_DESC"
+              },
+              (v2/*: any*/)
+            ],
+            "concreteType": "FilterPartners",
+            "kind": "LinkedField",
+            "name": "filterPartners",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "total",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PartnersAggregationResults",
+                "kind": "LinkedField",
+                "name": "aggregations",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "kind": "LinkedField",
+                    "name": "counts",
+                    "plural": true,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "value",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "count",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "hits",
+                "plural": true,
+                "selections": [
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "href",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "initials",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 15
+                      }
+                    ],
+                    "concreteType": "LocationConnection",
+                    "kind": "LinkedField",
+                    "name": "locationsConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "LocationEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Location",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "city",
+                                "storageKey": null
+                              },
+                              (v6/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "locationsConnection(first:15)"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Profile",
+                    "kind": "LinkedField",
+                    "name": "profile",
+                    "plural": false,
+                    "selections": [
+                      (v6/*: any*/),
+                      (v5/*: any*/),
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "alias": "is_followed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFollowed",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFollowed",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 334
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "wide",
+                                  "large",
+                                  "featured",
+                                  "larger"
+                                ]
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 445
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "cropped(height:334,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:445)"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v6/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "PartnersFilteredCellsQuery",
+    "operationKind": "query",
+    "text": "query PartnersFilteredCellsQuery(\n  $near: String\n  $category: [String]\n  $type: [PartnerClassification]\n) {\n  viewer {\n    ...PartnersFilteredCells_viewer_4vwjik\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersFilteredCells_viewer_4vwjik on Viewer {\n  filterPartners(aggregations: [TOTAL], defaultProfilePublic: true, eligibleForListing: true, near: $near, page: 1, partnerCategories: $category, size: 12, sort: RANDOM_SCORE_DESC, type: $type) {\n    total\n    aggregations {\n      counts {\n        name\n        value\n        count\n      }\n    }\n    hits {\n      internalID\n      ...PartnerCell_partner\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'c38d039654dfacc2a89d61db506f1073';
+export default node;

--- a/src/v2/__generated__/PartnersFilteredCells_viewer.graphql.ts
+++ b/src/v2/__generated__/PartnersFilteredCells_viewer.graphql.ts
@@ -1,0 +1,198 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PartnersFilteredCells_viewer = {
+    readonly filterPartners: {
+        readonly total: number | null;
+        readonly aggregations: ReadonlyArray<{
+            readonly counts: ReadonlyArray<{
+                readonly name: string;
+                readonly value: string;
+                readonly count: number;
+            } | null> | null;
+        } | null> | null;
+        readonly hits: ReadonlyArray<{
+            readonly internalID: string;
+            readonly " $fragmentRefs": FragmentRefs<"PartnerCell_partner">;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "PartnersFilteredCells_viewer";
+};
+export type PartnersFilteredCells_viewer$data = PartnersFilteredCells_viewer;
+export type PartnersFilteredCells_viewer$key = {
+    readonly " $data"?: PartnersFilteredCells_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"PartnersFilteredCells_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "category",
+      "type": "[String]"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "near",
+      "type": "String"
+    },
+    {
+      "defaultValue": 1,
+      "kind": "LocalArgument",
+      "name": "page",
+      "type": "Int"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "type",
+      "type": "[PartnerClassification]"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "PartnersFilteredCells_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "aggregations",
+          "value": [
+            "TOTAL"
+          ]
+        },
+        {
+          "kind": "Literal",
+          "name": "defaultProfilePublic",
+          "value": true
+        },
+        {
+          "kind": "Literal",
+          "name": "eligibleForListing",
+          "value": true
+        },
+        {
+          "kind": "Variable",
+          "name": "near",
+          "variableName": "near"
+        },
+        {
+          "kind": "Variable",
+          "name": "page",
+          "variableName": "page"
+        },
+        {
+          "kind": "Variable",
+          "name": "partnerCategories",
+          "variableName": "category"
+        },
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 12
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "RANDOM_SCORE_DESC"
+        },
+        {
+          "kind": "Variable",
+          "name": "type",
+          "variableName": "type"
+        }
+      ],
+      "concreteType": "FilterPartners",
+      "kind": "LinkedField",
+      "name": "filterPartners",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "total",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PartnersAggregationResults",
+          "kind": "LinkedField",
+          "name": "aggregations",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "AggregationCount",
+              "kind": "LinkedField",
+              "name": "counts",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "value",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "count",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Partner",
+          "kind": "LinkedField",
+          "name": "hits",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "internalID",
+              "storageKey": null
+            },
+            {
+              "args": null,
+              "kind": "FragmentSpread",
+              "name": "PartnerCell_partner"
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Viewer"
+};
+(node as any).hash = 'da136d97d7ef75805c0a24dbda576aae';
+export default node;

--- a/src/v2/__generated__/PartnersRail_partnerCategory.graphql.ts
+++ b/src/v2/__generated__/PartnersRail_partnerCategory.graphql.ts
@@ -35,16 +35,26 @@ v1 = {
   "value": true
 },
 v2 = {
+  "kind": "Variable",
+  "name": "near",
+  "variableName": "near"
+},
+v3 = {
+  "kind": "Variable",
+  "name": "partnerCategories",
+  "variableName": "category"
+},
+v4 = {
   "kind": "Literal",
   "name": "sort",
   "value": "RANDOM_SCORE_DESC"
 },
-v3 = {
+v5 = {
   "kind": "Variable",
   "name": "type",
   "variableName": "type"
 },
-v4 = [
+v6 = [
   {
     "alias": null,
     "args": null,
@@ -60,6 +70,18 @@ v4 = [
 ];
 return {
   "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "category",
+      "type": "[String]"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "near",
+      "type": "String"
+    },
     {
       "defaultValue": null,
       "kind": "LocalArgument",
@@ -89,13 +111,15 @@ return {
           "value": true
         },
         (v2/*: any*/),
-        (v3/*: any*/)
+        (v3/*: any*/),
+        (v4/*: any*/),
+        (v5/*: any*/)
       ],
       "concreteType": "Partner",
       "kind": "LinkedField",
       "name": "partners",
       "plural": true,
-      "selections": (v4/*: any*/),
+      "selections": (v6/*: any*/),
       "storageKey": null
     },
     {
@@ -109,18 +133,20 @@ return {
           "value": true
         },
         (v2/*: any*/),
-        (v3/*: any*/)
+        (v3/*: any*/),
+        (v4/*: any*/),
+        (v5/*: any*/)
       ],
       "concreteType": "Partner",
       "kind": "LinkedField",
       "name": "partners",
       "plural": true,
-      "selections": (v4/*: any*/),
+      "selections": (v6/*: any*/),
       "storageKey": null
     }
   ],
   "type": "PartnerCategory"
 };
 })();
-(node as any).hash = '32505a6b0834102961161984a8464b59';
+(node as any).hash = '11933362f3154c27961fbfbc6f0e45bd';
 export default node;

--- a/src/v2/__generated__/PartnersRailsQuery.graphql.ts
+++ b/src/v2/__generated__/PartnersRailsQuery.graphql.ts
@@ -1,0 +1,438 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PartnerCategoryType = "GALLERY" | "INSTITUTION" | "%future added value";
+export type PartnerClassification = "AUCTION" | "BRAND" | "DEMO" | "GALLERY" | "INSTITUTION" | "INSTITUTIONAL_SELLER" | "PRIVATE_COLLECTOR" | "PRIVATE_DEALER" | "%future added value";
+export type PartnersRailsQueryVariables = {
+    categoryType?: PartnerCategoryType | null;
+    type?: Array<PartnerClassification | null> | null;
+};
+export type PartnersRailsQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"PartnersRails_viewer">;
+    } | null;
+};
+export type PartnersRailsQuery = {
+    readonly response: PartnersRailsQueryResponse;
+    readonly variables: PartnersRailsQueryVariables;
+};
+
+
+
+/*
+query PartnersRailsQuery(
+  $categoryType: PartnerCategoryType
+  $type: [PartnerClassification]
+) {
+  viewer {
+    ...PartnersRails_viewer_1Wcb23
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  is_followed: isFollowed
+}
+
+fragment PartnerCell_partner on Partner {
+  internalID
+  slug
+  name
+  href
+  initials
+  locationsConnection(first: 15) {
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
+  profile {
+    ...FollowProfileButton_profile
+    isFollowed
+    image {
+      cropped(width: 445, height: 334, version: ["wide", "large", "featured", "larger"]) {
+        src
+        srcSet
+      }
+    }
+    id
+  }
+}
+
+fragment PartnersRail_partnerCategory_4ygNFC on PartnerCategory {
+  name
+  primary: partners(defaultProfilePublic: true, eligibleForListing: true, eligibleForPrimaryBucket: true, sort: RANDOM_SCORE_DESC, type: $type) {
+    internalID
+    ...PartnerCell_partner
+    id
+  }
+  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: $type, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
+    internalID
+    ...PartnerCell_partner
+    id
+  }
+}
+
+fragment PartnersRails_viewer_1Wcb23 on Viewer {
+  partnerCategories(categoryType: $categoryType, size: 50, internal: false) {
+    name
+    slug
+    ...PartnersRail_partnerCategory_4ygNFC
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "categoryType",
+    "type": "PartnerCategoryType"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "type",
+    "type": "[PartnerClassification]"
+  }
+],
+v1 = {
+  "kind": "Variable",
+  "name": "categoryType",
+  "variableName": "categoryType"
+},
+v2 = {
+  "kind": "Variable",
+  "name": "type",
+  "variableName": "type"
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v5 = {
+  "kind": "Literal",
+  "name": "defaultProfilePublic",
+  "value": true
+},
+v6 = {
+  "kind": "Literal",
+  "name": "eligibleForListing",
+  "value": true
+},
+v7 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "RANDOM_SCORE_DESC"
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v10 = [
+  (v8/*: any*/),
+  (v4/*: any*/),
+  (v3/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "href",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "initials",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Literal",
+        "name": "first",
+        "value": 15
+      }
+    ],
+    "concreteType": "LocationConnection",
+    "kind": "LinkedField",
+    "name": "locationsConnection",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "LocationEdge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "city",
+                "storageKey": null
+              },
+              (v9/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": "locationsConnection(first:15)"
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Profile",
+    "kind": "LinkedField",
+    "name": "profile",
+    "plural": false,
+    "selections": [
+      (v9/*: any*/),
+      (v4/*: any*/),
+      (v3/*: any*/),
+      (v8/*: any*/),
+      {
+        "alias": "is_followed",
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isFollowed",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isFollowed",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Image",
+        "kind": "LinkedField",
+        "name": "image",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "height",
+                "value": 334
+              },
+              {
+                "kind": "Literal",
+                "name": "version",
+                "value": [
+                  "wide",
+                  "large",
+                  "featured",
+                  "larger"
+                ]
+              },
+              {
+                "kind": "Literal",
+                "name": "width",
+                "value": 445
+              }
+            ],
+            "concreteType": "CroppedImageUrl",
+            "kind": "LinkedField",
+            "name": "cropped",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "src",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "srcSet",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "cropped(height:334,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:445)"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  (v9/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PartnersRailsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": [
+              (v1/*: any*/),
+              (v2/*: any*/)
+            ],
+            "kind": "FragmentSpread",
+            "name": "PartnersRails_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "PartnersRailsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              (v1/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "internal",
+                "value": false
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 50
+              }
+            ],
+            "concreteType": "PartnerCategory",
+            "kind": "LinkedField",
+            "name": "partnerCategories",
+            "plural": true,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              {
+                "alias": "primary",
+                "args": [
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "eligibleForPrimaryBucket",
+                    "value": true
+                  },
+                  (v7/*: any*/),
+                  (v2/*: any*/)
+                ],
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "partners",
+                "plural": true,
+                "selections": (v10/*: any*/),
+                "storageKey": null
+              },
+              {
+                "alias": "secondary",
+                "args": [
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "eligibleForSecondaryBucket",
+                    "value": true
+                  },
+                  (v7/*: any*/),
+                  (v2/*: any*/)
+                ],
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "partners",
+                "plural": true,
+                "selections": (v10/*: any*/),
+                "storageKey": null
+              },
+              (v9/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "PartnersRailsQuery",
+    "operationKind": "query",
+    "text": "query PartnersRailsQuery(\n  $categoryType: PartnerCategoryType\n  $type: [PartnerClassification]\n) {\n  viewer {\n    ...PartnersRails_viewer_1Wcb23\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersRail_partnerCategory_4ygNFC on PartnerCategory {\n  name\n  primary: partners(defaultProfilePublic: true, eligibleForListing: true, eligibleForPrimaryBucket: true, sort: RANDOM_SCORE_DESC, type: $type) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: $type, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n}\n\nfragment PartnersRails_viewer_1Wcb23 on Viewer {\n  partnerCategories(categoryType: $categoryType, size: 50, internal: false) {\n    name\n    slug\n    ...PartnersRail_partnerCategory_4ygNFC\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '52f4cc94a03d9e88e14d1600fee8a203';
+export default node;

--- a/src/v2/__generated__/PartnersRails_viewer.graphql.ts
+++ b/src/v2/__generated__/PartnersRails_viewer.graphql.ts
@@ -1,0 +1,97 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PartnersRails_viewer = {
+    readonly partnerCategories: ReadonlyArray<{
+        readonly name: string | null;
+        readonly slug: string;
+        readonly " $fragmentRefs": FragmentRefs<"PartnersRail_partnerCategory">;
+    } | null> | null;
+    readonly " $refType": "PartnersRails_viewer";
+};
+export type PartnersRails_viewer$data = PartnersRails_viewer;
+export type PartnersRails_viewer$key = {
+    readonly " $data"?: PartnersRails_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"PartnersRails_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "categoryType",
+      "type": "PartnerCategoryType"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "type",
+      "type": "[PartnerClassification]"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "PartnersRails_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "categoryType",
+          "variableName": "categoryType"
+        },
+        {
+          "kind": "Literal",
+          "name": "internal",
+          "value": false
+        },
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 50
+        }
+      ],
+      "concreteType": "PartnerCategory",
+      "kind": "LinkedField",
+      "name": "partnerCategories",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "slug",
+          "storageKey": null
+        },
+        {
+          "args": [
+            {
+              "kind": "Variable",
+              "name": "type",
+              "variableName": "type"
+            }
+          ],
+          "kind": "FragmentSpread",
+          "name": "PartnersRail_partnerCategory"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Viewer"
+};
+(node as any).hash = 'a33b2f28aa2428dbc99b19cdb5620187';
+export default node;

--- a/src/v2/__generated__/partnersRoutes_GalleriesRouteQuery.graphql.ts
+++ b/src/v2/__generated__/partnersRoutes_GalleriesRouteQuery.graphql.ts
@@ -33,39 +33,6 @@ fragment FollowProfileButton_profile on Profile {
 
 fragment GalleriesRoute_viewer on Viewer {
   ...PartnersFeaturedCarousel_viewer_4uWBz4
-  partnerCategories(categoryType: GALLERY, size: 50, internal: false) {
-    name
-    slug
-    ...PartnersRail_partnerCategory_uMgyM
-    id
-  }
-}
-
-fragment PartnerCell_partner on Partner {
-  internalID
-  slug
-  name
-  href
-  initials
-  locationsConnection(first: 15) {
-    edges {
-      node {
-        city
-        id
-      }
-    }
-  }
-  profile {
-    ...FollowProfileButton_profile
-    isFollowed
-    image {
-      cropped(width: 325, height: 244, version: ["wide", "large", "featured", "larger"]) {
-        src
-        srcSet
-      }
-    }
-    id
-  }
 }
 
 fragment PartnersFeaturedCarouselCell_profile on Profile {
@@ -123,20 +90,6 @@ fragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {
     id
   }
 }
-
-fragment PartnersRail_partnerCategory_uMgyM on PartnerCategory {
-  name
-  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
-    internalID
-    ...PartnerCell_partner
-    id
-  }
-  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
-    internalID
-    ...PartnerCell_partner
-    id
-  }
-}
 */
 
 const node: ConcreteRequest = (function(){
@@ -165,198 +118,15 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
-  "alias": "is_followed",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isFollowed",
-  "storageKey": null
-},
-v6 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MMM D"
   }
-],
-v7 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "city",
-    "storageKey": null
-  },
-  (v1/*: any*/)
-],
-v8 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "src",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
-  }
-],
-v9 = {
-  "kind": "Literal",
-  "name": "defaultProfilePublic",
-  "value": true
-},
-v10 = {
-  "kind": "Literal",
-  "name": "eligibleForListing",
-  "value": true
-},
-v11 = {
-  "kind": "Literal",
-  "name": "sort",
-  "value": "RANDOM_SCORE_DESC"
-},
-v12 = {
-  "kind": "Literal",
-  "name": "type",
-  "value": "GALLERY"
-},
-v13 = [
-  (v2/*: any*/),
-  (v3/*: any*/),
-  (v4/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "href",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "initials",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Literal",
-        "name": "first",
-        "value": 15
-      }
-    ],
-    "concreteType": "LocationConnection",
-    "kind": "LinkedField",
-    "name": "locationsConnection",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "LocationEdge",
-        "kind": "LinkedField",
-        "name": "edges",
-        "plural": true,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Location",
-            "kind": "LinkedField",
-            "name": "node",
-            "plural": false,
-            "selections": (v7/*: any*/),
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": "locationsConnection(first:15)"
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Profile",
-    "kind": "LinkedField",
-    "name": "profile",
-    "plural": false,
-    "selections": [
-      (v1/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v2/*: any*/),
-      (v5/*: any*/),
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "isFollowed",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Image",
-        "kind": "LinkedField",
-        "name": "image",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "height",
-                "value": 244
-              },
-              {
-                "kind": "Literal",
-                "name": "version",
-                "value": [
-                  "wide",
-                  "large",
-                  "featured",
-                  "larger"
-                ]
-              },
-              {
-                "kind": "Literal",
-                "name": "width",
-                "value": 325
-              }
-            ],
-            "concreteType": "CroppedImageUrl",
-            "kind": "LinkedField",
-            "name": "cropped",
-            "plural": false,
-            "selections": (v8/*: any*/),
-            "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  },
-  (v1/*: any*/)
 ];
 return {
   "fragment": {
@@ -426,9 +196,21 @@ return {
                     "kind": "InlineFragment",
                     "selections": [
                       (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
                       (v3/*: any*/),
-                      (v4/*: any*/),
-                      (v5/*: any*/),
+                      {
+                        "alias": "is_followed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFollowed",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -443,7 +225,7 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v2/*: any*/),
-                              (v4/*: any*/),
+                              (v3/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -452,7 +234,7 @@ return {
                                 "name": "featuredShow",
                                 "plural": false,
                                 "selections": [
-                                  (v4/*: any*/),
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -469,14 +251,14 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "kind": "ScalarField",
                                     "name": "startAt",
                                     "storageKey": "startAt(format:\"MMM D\")"
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "kind": "ScalarField",
                                     "name": "endAt",
                                     "storageKey": "endAt(format:\"MMM D\")"
@@ -495,7 +277,16 @@ return {
                                     "kind": "LinkedField",
                                     "name": "location",
                                     "plural": false,
-                                    "selections": (v7/*: any*/),
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "city",
+                                        "storageKey": null
+                                      },
+                                      (v1/*: any*/)
+                                    ],
                                     "storageKey": null
                                   },
                                   {
@@ -528,7 +319,22 @@ return {
                                         "kind": "LinkedField",
                                         "name": "resized",
                                         "plural": false,
-                                        "selections": (v8/*: any*/),
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "src",
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "srcSet",
+                                            "storageKey": null
+                                          }
+                                        ],
                                         "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
                                       }
                                     ],
@@ -553,76 +359,6 @@ return {
               (v1/*: any*/)
             ],
             "storageKey": "orderedSet(id:\"5638fdfb7261690296000031\")"
-          },
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "categoryType",
-                "value": "GALLERY"
-              },
-              {
-                "kind": "Literal",
-                "name": "internal",
-                "value": false
-              },
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 50
-              }
-            ],
-            "concreteType": "PartnerCategory",
-            "kind": "LinkedField",
-            "name": "partnerCategories",
-            "plural": true,
-            "selections": [
-              (v4/*: any*/),
-              (v3/*: any*/),
-              {
-                "alias": "primary",
-                "args": [
-                  (v9/*: any*/),
-                  (v10/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "eligibleForPrimaryBucket",
-                    "value": true
-                  },
-                  (v11/*: any*/),
-                  (v12/*: any*/)
-                ],
-                "concreteType": "Partner",
-                "kind": "LinkedField",
-                "name": "partners",
-                "plural": true,
-                "selections": (v13/*: any*/),
-                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForPrimaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"GALLERY\")"
-              },
-              {
-                "alias": "secondary",
-                "args": [
-                  (v9/*: any*/),
-                  (v10/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "eligibleForSecondaryBucket",
-                    "value": true
-                  },
-                  (v11/*: any*/),
-                  (v12/*: any*/)
-                ],
-                "concreteType": "Partner",
-                "kind": "LinkedField",
-                "name": "partners",
-                "plural": true,
-                "selections": (v13/*: any*/),
-                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForSecondaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"GALLERY\")"
-              },
-              (v1/*: any*/)
-            ],
-            "storageKey": "partnerCategories(categoryType:\"GALLERY\",internal:false,size:50)"
           }
         ],
         "storageKey": null
@@ -634,7 +370,7 @@ return {
     "metadata": {},
     "name": "partnersRoutes_GalleriesRouteQuery",
     "operationKind": "query",
-    "text": "query partnersRoutes_GalleriesRouteQuery {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n  partnerCategories(categoryType: GALLERY, size: 50, internal: false) {\n    name\n    slug\n    ...PartnersRail_partnerCategory_uMgyM\n    id\n  }\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 325, height: 244, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersRail_partnerCategory_uMgyM on PartnerCategory {\n  name\n  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: GALLERY, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n}\n"
+    "text": "query partnersRoutes_GalleriesRouteQuery {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/partnersRoutes_InstitutionsRouteQuery.graphql.ts
+++ b/src/v2/__generated__/partnersRoutes_InstitutionsRouteQuery.graphql.ts
@@ -33,39 +33,6 @@ fragment FollowProfileButton_profile on Profile {
 
 fragment InstitutionsRoute_viewer on Viewer {
   ...PartnersFeaturedCarousel_viewer_3Ao4DD
-  partnerCategories(categoryType: INSTITUTION, size: 50, internal: false) {
-    name
-    slug
-    ...PartnersRail_partnerCategory_q3ILp
-    id
-  }
-}
-
-fragment PartnerCell_partner on Partner {
-  internalID
-  slug
-  name
-  href
-  initials
-  locationsConnection(first: 15) {
-    edges {
-      node {
-        city
-        id
-      }
-    }
-  }
-  profile {
-    ...FollowProfileButton_profile
-    isFollowed
-    image {
-      cropped(width: 325, height: 244, version: ["wide", "large", "featured", "larger"]) {
-        src
-        srcSet
-      }
-    }
-    id
-  }
 }
 
 fragment PartnersFeaturedCarouselCell_profile on Profile {
@@ -123,20 +90,6 @@ fragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {
     id
   }
 }
-
-fragment PartnersRail_partnerCategory_q3ILp on PartnerCategory {
-  name
-  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
-    internalID
-    ...PartnerCell_partner
-    id
-  }
-  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {
-    internalID
-    ...PartnerCell_partner
-    id
-  }
-}
 */
 
 const node: ConcreteRequest = (function(){
@@ -165,198 +118,15 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
-  "alias": "is_followed",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isFollowed",
-  "storageKey": null
-},
-v6 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MMM D"
   }
-],
-v7 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "city",
-    "storageKey": null
-  },
-  (v1/*: any*/)
-],
-v8 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "src",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
-  }
-],
-v9 = {
-  "kind": "Literal",
-  "name": "defaultProfilePublic",
-  "value": true
-},
-v10 = {
-  "kind": "Literal",
-  "name": "eligibleForListing",
-  "value": true
-},
-v11 = {
-  "kind": "Literal",
-  "name": "sort",
-  "value": "RANDOM_SCORE_DESC"
-},
-v12 = {
-  "kind": "Literal",
-  "name": "type",
-  "value": "INSTITUTION"
-},
-v13 = [
-  (v2/*: any*/),
-  (v3/*: any*/),
-  (v4/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "href",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "initials",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Literal",
-        "name": "first",
-        "value": 15
-      }
-    ],
-    "concreteType": "LocationConnection",
-    "kind": "LinkedField",
-    "name": "locationsConnection",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "LocationEdge",
-        "kind": "LinkedField",
-        "name": "edges",
-        "plural": true,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Location",
-            "kind": "LinkedField",
-            "name": "node",
-            "plural": false,
-            "selections": (v7/*: any*/),
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": "locationsConnection(first:15)"
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Profile",
-    "kind": "LinkedField",
-    "name": "profile",
-    "plural": false,
-    "selections": [
-      (v1/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v2/*: any*/),
-      (v5/*: any*/),
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "isFollowed",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Image",
-        "kind": "LinkedField",
-        "name": "image",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "height",
-                "value": 244
-              },
-              {
-                "kind": "Literal",
-                "name": "version",
-                "value": [
-                  "wide",
-                  "large",
-                  "featured",
-                  "larger"
-                ]
-              },
-              {
-                "kind": "Literal",
-                "name": "width",
-                "value": 325
-              }
-            ],
-            "concreteType": "CroppedImageUrl",
-            "kind": "LinkedField",
-            "name": "cropped",
-            "plural": false,
-            "selections": (v8/*: any*/),
-            "storageKey": "cropped(height:244,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:325)"
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  },
-  (v1/*: any*/)
 ];
 return {
   "fragment": {
@@ -426,9 +196,21 @@ return {
                     "kind": "InlineFragment",
                     "selections": [
                       (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
                       (v3/*: any*/),
-                      (v4/*: any*/),
-                      (v5/*: any*/),
+                      {
+                        "alias": "is_followed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFollowed",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -443,7 +225,7 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v2/*: any*/),
-                              (v4/*: any*/),
+                              (v3/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -452,7 +234,7 @@ return {
                                 "name": "featuredShow",
                                 "plural": false,
                                 "selections": [
-                                  (v4/*: any*/),
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -469,14 +251,14 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "kind": "ScalarField",
                                     "name": "startAt",
                                     "storageKey": "startAt(format:\"MMM D\")"
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "kind": "ScalarField",
                                     "name": "endAt",
                                     "storageKey": "endAt(format:\"MMM D\")"
@@ -495,7 +277,16 @@ return {
                                     "kind": "LinkedField",
                                     "name": "location",
                                     "plural": false,
-                                    "selections": (v7/*: any*/),
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "city",
+                                        "storageKey": null
+                                      },
+                                      (v1/*: any*/)
+                                    ],
                                     "storageKey": null
                                   },
                                   {
@@ -528,7 +319,22 @@ return {
                                         "kind": "LinkedField",
                                         "name": "resized",
                                         "plural": false,
-                                        "selections": (v8/*: any*/),
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "src",
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "srcSet",
+                                            "storageKey": null
+                                          }
+                                        ],
                                         "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
                                       }
                                     ],
@@ -553,76 +359,6 @@ return {
               (v1/*: any*/)
             ],
             "storageKey": "orderedSet(id:\"564e181a258faf3d5c000080\")"
-          },
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "categoryType",
-                "value": "INSTITUTION"
-              },
-              {
-                "kind": "Literal",
-                "name": "internal",
-                "value": false
-              },
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 50
-              }
-            ],
-            "concreteType": "PartnerCategory",
-            "kind": "LinkedField",
-            "name": "partnerCategories",
-            "plural": true,
-            "selections": [
-              (v4/*: any*/),
-              (v3/*: any*/),
-              {
-                "alias": "primary",
-                "args": [
-                  (v9/*: any*/),
-                  (v10/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "eligibleForPrimaryBucket",
-                    "value": true
-                  },
-                  (v11/*: any*/),
-                  (v12/*: any*/)
-                ],
-                "concreteType": "Partner",
-                "kind": "LinkedField",
-                "name": "partners",
-                "plural": true,
-                "selections": (v13/*: any*/),
-                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForPrimaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"INSTITUTION\")"
-              },
-              {
-                "alias": "secondary",
-                "args": [
-                  (v9/*: any*/),
-                  (v10/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "eligibleForSecondaryBucket",
-                    "value": true
-                  },
-                  (v11/*: any*/),
-                  (v12/*: any*/)
-                ],
-                "concreteType": "Partner",
-                "kind": "LinkedField",
-                "name": "partners",
-                "plural": true,
-                "selections": (v13/*: any*/),
-                "storageKey": "partners(defaultProfilePublic:true,eligibleForListing:true,eligibleForSecondaryBucket:true,sort:\"RANDOM_SCORE_DESC\",type:\"INSTITUTION\")"
-              },
-              (v1/*: any*/)
-            ],
-            "storageKey": "partnerCategories(categoryType:\"INSTITUTION\",internal:false,size:50)"
           }
         ],
         "storageKey": null
@@ -634,7 +370,7 @@ return {
     "metadata": {},
     "name": "partnersRoutes_InstitutionsRouteQuery",
     "operationKind": "query",
-    "text": "query partnersRoutes_InstitutionsRouteQuery {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n  partnerCategories(categoryType: INSTITUTION, size: 50, internal: false) {\n    name\n    slug\n    ...PartnersRail_partnerCategory_q3ILp\n    id\n  }\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 325, height: 244, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment PartnersRail_partnerCategory_q3ILp on PartnerCategory {\n  name\n  primary: partners(eligibleForListing: true, eligibleForPrimaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: INSTITUTION, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...PartnerCell_partner\n    id\n  }\n}\n"
+    "text": "query partnersRoutes_InstitutionsRouteQuery {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Closes: [GRO-593](https://artsyproduct.atlassian.net/browse/GRO-593)

I'll need to open up a new ticket however for pagination as the `filteredPartners` field is implemented in a very unconventional manner. I'll have to re-implement it as a new field as a proper connection and restructure the schema for it.

This also winds up closing
* [GRO-603](https://artsyproduct.atlassian.net/browse/GRO-603) — Moved the set of rails to the client-side now that there's a banner up top which renders server-side.
* [GRO-590](https://artsyproduct.atlassian.net/browse/GRO-590) — Since this renders client-side now we can just use a traditional shuffle.

https://user-images.githubusercontent.com/112297/139942032-c601a6c9-7579-4f2b-b807-2a04184639d0.mov

