### PR TITLE
fix(home): utilize partner cell on featured rail

### DIFF
--- a/src/v2/Apps/Home/__tests__/HomeFeaturedGalleriesRail.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeFeaturedGalleriesRail.jest.tsx
@@ -17,7 +17,7 @@ const { getWrapper } = setupTestWrapper<HomeFeaturedGalleriesRail_Test_Query>({
   },
   query: graphql`
     query HomeFeaturedGalleriesRail_Test_Query {
-      orderedSet(id: "5638fdfb7261690296000031") {
+      orderedSet(id: "example") {
         ...HomeFeaturedGalleriesRail_orderedSet
       }
     }
@@ -37,17 +37,9 @@ afterEach(() => {
 describe("HomeFeaturedGalleriesRail", () => {
   it("renders correctly", () => {
     const wrapper = getWrapper({
-      OrderedSet: () => ({
-        orderedItemsConnection: {
-          edges: [
-            {
-              node: {
-                name: "Test Gallery",
-                href: "test-href",
-              },
-            },
-          ],
-        },
+      Partner: () => ({
+        name: "Test Gallery",
+        href: "/test-href",
       }),
     })
 
@@ -60,22 +52,14 @@ describe("HomeFeaturedGalleriesRail", () => {
 
   it("shows initials if no images", () => {
     const wrapper = getWrapper({
-      OrderedSet: () => ({
-        orderedItemsConnection: {
-          edges: [
-            {
-              node: {
-                name: "Test Gallery",
-                href: "test-href",
-                initials: "initials",
-                image: {
-                  cropped: {
-                    src: null,
-                  },
-                },
-              },
-            },
-          ],
+      Profile: () => ({
+        owner: {
+          initials: "initials",
+        },
+        image: {
+          cropped: {
+            src: null,
+          },
         },
       }),
     })

--- a/src/v2/__generated__/HomeFeaturedGalleriesRailQuery.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRailQuery.graphql.ts
@@ -38,20 +38,14 @@ fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
       node {
         __typename
         ... on Profile {
-          ...FollowProfileButton_profile
-          initials
-          internalID
-          isFollowed
-          name
-          slug
-          href
-          location
-          image {
-            cropped(width: 325, height: 230) {
-              src
-              srcSet
-              width
-              height
+          owner {
+            __typename
+            ...PartnerCell_partner
+            ... on Node {
+              id
+            }
+            ... on FairOrganizer {
+              id
             }
           }
           id
@@ -64,6 +58,33 @@ fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
         }
       }
     }
+  }
+}
+
+fragment PartnerCell_partner on Partner {
+  internalID
+  slug
+  name
+  href
+  initials
+  locationsConnection(first: 15) {
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
+  profile {
+    ...FollowProfileButton_profile
+    isFollowed
+    image {
+      cropped(width: 445, height: 334, version: ["wide", "large", "featured", "larger"]) {
+        src
+        srcSet
+      }
+    }
+    id
   }
 }
 */
@@ -80,7 +101,35 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
   "storageKey": null
 };
 return {
@@ -153,130 +202,176 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "__typename",
-                        "storageKey": null
-                      },
                       (v1/*: any*/),
+                      (v2/*: any*/),
                       {
                         "kind": "InlineFragment",
                         "selections": [
                           {
                             "alias": null,
                             "args": null,
-                            "kind": "ScalarField",
-                            "name": "slug",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "name",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "internalID",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_followed",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isFollowed",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "initials",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isFollowed",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "href",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "location",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Image",
+                            "concreteType": null,
                             "kind": "LinkedField",
-                            "name": "image",
+                            "name": "owner",
                             "plural": false,
                             "selections": [
+                              (v1/*: any*/),
+                              (v2/*: any*/),
                               {
-                                "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "height",
-                                    "value": 230
-                                  },
-                                  {
-                                    "kind": "Literal",
-                                    "name": "width",
-                                    "value": 325
-                                  }
-                                ],
-                                "concreteType": "CroppedImageUrl",
-                                "kind": "LinkedField",
-                                "name": "cropped",
-                                "plural": false,
+                                "kind": "InlineFragment",
                                 "selections": [
+                                  (v3/*: any*/),
+                                  (v4/*: any*/),
+                                  (v5/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
                                     "kind": "ScalarField",
-                                    "name": "src",
+                                    "name": "href",
                                     "storageKey": null
                                   },
                                   {
                                     "alias": null,
                                     "args": null,
                                     "kind": "ScalarField",
-                                    "name": "srcSet",
+                                    "name": "initials",
                                     "storageKey": null
                                   },
                                   {
                                     "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "width",
-                                    "storageKey": null
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "first",
+                                        "value": 15
+                                      }
+                                    ],
+                                    "concreteType": "LocationConnection",
+                                    "kind": "LinkedField",
+                                    "name": "locationsConnection",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "LocationEdge",
+                                        "kind": "LinkedField",
+                                        "name": "edges",
+                                        "plural": true,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Location",
+                                            "kind": "LinkedField",
+                                            "name": "node",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "city",
+                                                "storageKey": null
+                                              },
+                                              (v2/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "locationsConnection(first:15)"
                                   },
                                   {
                                     "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "height",
+                                    "concreteType": "Profile",
+                                    "kind": "LinkedField",
+                                    "name": "profile",
+                                    "plural": false,
+                                    "selections": [
+                                      (v2/*: any*/),
+                                      (v4/*: any*/),
+                                      (v5/*: any*/),
+                                      (v3/*: any*/),
+                                      {
+                                        "alias": "is_followed",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isFollowed",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isFollowed",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Image",
+                                        "kind": "LinkedField",
+                                        "name": "image",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": [
+                                              {
+                                                "kind": "Literal",
+                                                "name": "height",
+                                                "value": 334
+                                              },
+                                              {
+                                                "kind": "Literal",
+                                                "name": "version",
+                                                "value": [
+                                                  "wide",
+                                                  "large",
+                                                  "featured",
+                                                  "larger"
+                                                ]
+                                              },
+                                              {
+                                                "kind": "Literal",
+                                                "name": "width",
+                                                "value": 445
+                                              }
+                                            ],
+                                            "concreteType": "CroppedImageUrl",
+                                            "kind": "LinkedField",
+                                            "name": "cropped",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "src",
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "srcSet",
+                                                "storageKey": null
+                                              }
+                                            ],
+                                            "storageKey": "cropped(height:334,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:445)"
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
-                                "storageKey": "cropped(height:230,width:325)"
+                                "type": "Partner"
                               }
                             ],
                             "storageKey": null
@@ -293,7 +388,7 @@ return {
             ],
             "storageKey": "orderedItemsConnection(first:20)"
           },
-          (v1/*: any*/)
+          (v2/*: any*/)
         ],
         "storageKey": "orderedSet(id:\"5638fdfb7261690296000031\")"
       }
@@ -304,7 +399,7 @@ return {
     "metadata": {},
     "name": "HomeFeaturedGalleriesRailQuery",
     "operationKind": "query",
-    "text": "query HomeFeaturedGalleriesRailQuery {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          ...FollowProfileButton_profile\n          initials\n          internalID\n          isFollowed\n          name\n          slug\n          href\n          location\n          image {\n            cropped(width: 325, height: 230) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          id\n        }\n        ... on Node {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query HomeFeaturedGalleriesRailQuery {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          owner {\n            __typename\n            ...PartnerCell_partner\n            ... on Node {\n              id\n            }\n            ... on FairOrganizer {\n              id\n            }\n          }\n          id\n        }\n        ... on Node {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/HomeFeaturedGalleriesRail_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRail_Test_Query.graphql.ts
@@ -18,7 +18,7 @@ export type HomeFeaturedGalleriesRail_Test_Query = {
 
 /*
 query HomeFeaturedGalleriesRail_Test_Query {
-  orderedSet(id: "5638fdfb7261690296000031") {
+  orderedSet(id: "example") {
     ...HomeFeaturedGalleriesRail_orderedSet
     id
   }
@@ -38,20 +38,14 @@ fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
       node {
         __typename
         ... on Profile {
-          ...FollowProfileButton_profile
-          initials
-          internalID
-          isFollowed
-          name
-          slug
-          href
-          location
-          image {
-            cropped(width: 325, height: 230) {
-              src
-              srcSet
-              width
-              height
+          owner {
+            __typename
+            ...PartnerCell_partner
+            ... on Node {
+              id
+            }
+            ... on FairOrganizer {
+              id
             }
           }
           id
@@ -66,6 +60,33 @@ fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
     }
   }
 }
+
+fragment PartnerCell_partner on Partner {
+  internalID
+  slug
+  name
+  href
+  initials
+  locationsConnection(first: 15) {
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
+  profile {
+    ...FollowProfileButton_profile
+    isFollowed
+    image {
+      cropped(width: 445, height: 334, version: ["wide", "large", "featured", "larger"]) {
+        src
+        srcSet
+      }
+    }
+    id
+  }
+}
 */
 
 const node: ConcreteRequest = (function(){
@@ -73,14 +94,42 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "id",
-    "value": "5638fdfb7261690296000031"
+    "value": "example"
   }
 ],
 v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
   "storageKey": null
 };
 return {
@@ -104,7 +153,7 @@ return {
             "name": "HomeFeaturedGalleriesRail_orderedSet"
           }
         ],
-        "storageKey": "orderedSet(id:\"5638fdfb7261690296000031\")"
+        "storageKey": "orderedSet(id:\"example\")"
       }
     ],
     "type": "Query"
@@ -153,130 +202,176 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "__typename",
-                        "storageKey": null
-                      },
                       (v1/*: any*/),
+                      (v2/*: any*/),
                       {
                         "kind": "InlineFragment",
                         "selections": [
                           {
                             "alias": null,
                             "args": null,
-                            "kind": "ScalarField",
-                            "name": "slug",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "name",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "internalID",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_followed",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isFollowed",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "initials",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isFollowed",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "href",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "location",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Image",
+                            "concreteType": null,
                             "kind": "LinkedField",
-                            "name": "image",
+                            "name": "owner",
                             "plural": false,
                             "selections": [
+                              (v1/*: any*/),
+                              (v2/*: any*/),
                               {
-                                "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "height",
-                                    "value": 230
-                                  },
-                                  {
-                                    "kind": "Literal",
-                                    "name": "width",
-                                    "value": 325
-                                  }
-                                ],
-                                "concreteType": "CroppedImageUrl",
-                                "kind": "LinkedField",
-                                "name": "cropped",
-                                "plural": false,
+                                "kind": "InlineFragment",
                                 "selections": [
+                                  (v3/*: any*/),
+                                  (v4/*: any*/),
+                                  (v5/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
                                     "kind": "ScalarField",
-                                    "name": "src",
+                                    "name": "href",
                                     "storageKey": null
                                   },
                                   {
                                     "alias": null,
                                     "args": null,
                                     "kind": "ScalarField",
-                                    "name": "srcSet",
+                                    "name": "initials",
                                     "storageKey": null
                                   },
                                   {
                                     "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "width",
-                                    "storageKey": null
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "first",
+                                        "value": 15
+                                      }
+                                    ],
+                                    "concreteType": "LocationConnection",
+                                    "kind": "LinkedField",
+                                    "name": "locationsConnection",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "LocationEdge",
+                                        "kind": "LinkedField",
+                                        "name": "edges",
+                                        "plural": true,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Location",
+                                            "kind": "LinkedField",
+                                            "name": "node",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "city",
+                                                "storageKey": null
+                                              },
+                                              (v2/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "locationsConnection(first:15)"
                                   },
                                   {
                                     "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "height",
+                                    "concreteType": "Profile",
+                                    "kind": "LinkedField",
+                                    "name": "profile",
+                                    "plural": false,
+                                    "selections": [
+                                      (v2/*: any*/),
+                                      (v4/*: any*/),
+                                      (v5/*: any*/),
+                                      (v3/*: any*/),
+                                      {
+                                        "alias": "is_followed",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isFollowed",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isFollowed",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Image",
+                                        "kind": "LinkedField",
+                                        "name": "image",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": [
+                                              {
+                                                "kind": "Literal",
+                                                "name": "height",
+                                                "value": 334
+                                              },
+                                              {
+                                                "kind": "Literal",
+                                                "name": "version",
+                                                "value": [
+                                                  "wide",
+                                                  "large",
+                                                  "featured",
+                                                  "larger"
+                                                ]
+                                              },
+                                              {
+                                                "kind": "Literal",
+                                                "name": "width",
+                                                "value": 445
+                                              }
+                                            ],
+                                            "concreteType": "CroppedImageUrl",
+                                            "kind": "LinkedField",
+                                            "name": "cropped",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "src",
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "srcSet",
+                                                "storageKey": null
+                                              }
+                                            ],
+                                            "storageKey": "cropped(height:334,version:[\"wide\",\"large\",\"featured\",\"larger\"],width:445)"
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
-                                "storageKey": "cropped(height:230,width:325)"
+                                "type": "Partner"
                               }
                             ],
                             "storageKey": null
@@ -293,9 +388,9 @@ return {
             ],
             "storageKey": "orderedItemsConnection(first:20)"
           },
-          (v1/*: any*/)
+          (v2/*: any*/)
         ],
-        "storageKey": "orderedSet(id:\"5638fdfb7261690296000031\")"
+        "storageKey": "orderedSet(id:\"example\")"
       }
     ]
   },
@@ -304,9 +399,9 @@ return {
     "metadata": {},
     "name": "HomeFeaturedGalleriesRail_Test_Query",
     "operationKind": "query",
-    "text": "query HomeFeaturedGalleriesRail_Test_Query {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          ...FollowProfileButton_profile\n          initials\n          internalID\n          isFollowed\n          name\n          slug\n          href\n          location\n          image {\n            cropped(width: 325, height: 230) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          id\n        }\n        ... on Node {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query HomeFeaturedGalleriesRail_Test_Query {\n  orderedSet(id: \"example\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          owner {\n            __typename\n            ...PartnerCell_partner\n            ... on Node {\n              id\n            }\n            ... on FairOrganizer {\n              id\n            }\n          }\n          id\n        }\n        ... on Node {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment PartnerCell_partner on Partner {\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    isFollowed\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'c26bfa9b5a68842c47e367169ff48acc';
+(node as any).hash = 'aaaf3fbf53f774e436d7e7056aebab57';
 export default node;

--- a/src/v2/__generated__/HomeFeaturedGalleriesRail_orderedSet.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRail_orderedSet.graphql.ts
@@ -8,22 +8,9 @@ export type HomeFeaturedGalleriesRail_orderedSet = {
         readonly edges: ReadonlyArray<{
             readonly node: ({
                 readonly __typename: "Profile";
-                readonly initials: string | null;
-                readonly internalID: string;
-                readonly isFollowed: boolean | null;
-                readonly name: string | null;
-                readonly slug: string;
-                readonly href: string | null;
-                readonly location: string | null;
-                readonly image: {
-                    readonly cropped: {
-                        readonly src: string;
-                        readonly srcSet: string;
-                        readonly width: number;
-                        readonly height: number;
-                    } | null;
-                } | null;
-                readonly " $fragmentRefs": FragmentRefs<"FollowProfileButton_profile">;
+                readonly owner: {
+                    readonly " $fragmentRefs": FragmentRefs<"PartnerCell_partner">;
+                };
             } | {
                 /*This will never be '%other', but we need some
                 value in case none of the concrete values match.*/
@@ -90,117 +77,18 @@ const node: ReaderFragment = {
                     {
                       "alias": null,
                       "args": null,
-                      "kind": "ScalarField",
-                      "name": "initials",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "internalID",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "isFollowed",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "name",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "slug",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "href",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "location",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "concreteType": "Image",
+                      "concreteType": null,
                       "kind": "LinkedField",
-                      "name": "image",
+                      "name": "owner",
                       "plural": false,
                       "selections": [
                         {
-                          "alias": null,
-                          "args": [
-                            {
-                              "kind": "Literal",
-                              "name": "height",
-                              "value": 230
-                            },
-                            {
-                              "kind": "Literal",
-                              "name": "width",
-                              "value": 325
-                            }
-                          ],
-                          "concreteType": "CroppedImageUrl",
-                          "kind": "LinkedField",
-                          "name": "cropped",
-                          "plural": false,
-                          "selections": [
-                            {
-                              "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "src",
-                              "storageKey": null
-                            },
-                            {
-                              "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "srcSet",
-                              "storageKey": null
-                            },
-                            {
-                              "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "width",
-                              "storageKey": null
-                            },
-                            {
-                              "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "height",
-                              "storageKey": null
-                            }
-                          ],
-                          "storageKey": "cropped(height:230,width:325)"
+                          "args": null,
+                          "kind": "FragmentSpread",
+                          "name": "PartnerCell_partner"
                         }
                       ],
                       "storageKey": null
-                    },
-                    {
-                      "args": null,
-                      "kind": "FragmentSpread",
-                      "name": "FollowProfileButton_profile"
                     }
                   ],
                   "type": "Profile"
@@ -217,5 +105,5 @@ const node: ReaderFragment = {
   ],
   "type": "OrderedSet"
 };
-(node as any).hash = 'ad6d002279e9b40dd32d5e3f8c72602f';
+(node as any).hash = 'c1d656d65f824f2ce8b585cecd25cd2c';
 export default node;


### PR DESCRIPTION
Closes: [GRO-637](https://artsyproduct.atlassian.net/browse/GRO-637)

Not much too this — we now expose the `Profile#owner` in Metaphysics so we can use the `PartnerCell` component. This fixes the issue with mismatched slugs. As well as adding in locations and using higher quality images.

### New on top, old on bottom:

![](https://static.damonzucconi.com/_capture/eIWBqC5s.png)