### PR TITLE
Add small check to staging branch, to confirm that status is reflected on release PRs (PLATFORM-3684)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,9 +340,13 @@ workflows:
 
       # Release
       - horizon/block:
-          <<: *only_release
           context: horizon
           project_id: 11
+          filters:
+            branches:
+              only:
+                - release
+                - staging
 
       - validate_production_schema:
           <<: *only_release


### PR DESCRIPTION
[This ticket](https://artsyproduct.atlassian.net/browse/PLATFORM-3684) asks for integration tests to be incorporated into Force's release pipeline. The hope is that a _few_, _reliable_ tests can be trustworthy and informative day-to-day, despite the fact that the full Integrity suite _has not_ been.

We hoped to use regular Github "checks" for this, on the `staging` branch. That way, an engineer (or bot) considering a release would see the ❌ from an integration test failure right on the PR and be warned about (or in the case of a bot, prevented from) merging. In a pinch, a human with the necessary permission could still bypass the check and merge the PR.

This PR adds a single CI step for the `staging` branch, just to confirm how it affects release PRs. I'll probably undo it afterwards (unless people like the deploy block step to be visible in the same way).