### PR TITLE
fix(router): Make onServerSideRender calls async

### DIFF
--- a/src/v2/Apps/Artwork/Server/__tests__/handleArtworkImageDownload.jest.ts
+++ b/src/v2/Apps/Artwork/Server/__tests__/handleArtworkImageDownload.jest.ts
@@ -27,12 +27,11 @@ describe("artworkMiddleware", () => {
         canDownload: true,
         get: jest.fn(),
       },
-      pipe: () => ({
-        pipe: spy,
-      }),
     }
 
-    const res = {}
+    const res = {
+      redirect: spy,
+    }
     await handleArtworkImageDownload({ req, res })
     expect(spy).toHaveBeenCalled()
   })
@@ -47,12 +46,11 @@ describe("artworkMiddleware", () => {
         canDownload: false,
         get: jest.fn(),
       },
-      pipe: () => ({
-        pipe: jest.fn(),
-      }),
     }
 
-    const res = {}
+    const res = {
+      redirect: spy,
+    }
     await handleArtworkImageDownload({ req, res })
     expect(spy).not.toHaveBeenCalled()
   })

--- a/src/v2/Apps/Artwork/Server/handleArtworkImageDownload.ts
+++ b/src/v2/Apps/Artwork/Server/handleArtworkImageDownload.ts
@@ -13,6 +13,6 @@ export const handleArtworkImageDownload = async ({ req, res }) => {
     if (req.user) {
       imageRequest.set("X-ACCESS-TOKEN", req.user.get("accessToken"))
     }
-    req.pipe(imageRequest, { end: false }).pipe(res)
+    res.redirect(302, imageRequest.url.replace("original", "normalized"))
   }
 }

--- a/src/v2/Apps/Artwork/artworkRoutes.tsx
+++ b/src/v2/Apps/Artwork/artworkRoutes.tsx
@@ -14,7 +14,6 @@ export const artworkRoutes: AppRouteConfig[] = [
   {
     path: "/artwork/:artworkID/:optional?", // There's a `confirm-bid` nested route.
     getComponent: () => ArtworkApp,
-    onServerSideRender: handleArtworkImageDownload,
     onClientSideRender: () => {
       ArtworkApp.preload()
     },
@@ -36,5 +35,10 @@ export const artworkRoutes: AppRouteConfig[] = [
     cacheConfig: {
       force: true,
     },
+  },
+  {
+    path: "/artwork/:artworkID/download/:filename",
+    Component: () => null,
+    onServerSideRender: handleArtworkImageDownload,
   },
 ]

--- a/src/v2/System/Router/buildServerApp.tsx
+++ b/src/v2/System/Router/buildServerApp.tsx
@@ -89,16 +89,16 @@ export function buildServerApp(
         path: req.path,
       })
 
-      matchedRoutes.forEach((route: AppRouteConfig) => {
+      for await (const route of matchedRoutes) {
         if (isFunction(route?.onServerSideRender)) {
-          route.onServerSideRender({
+          await route.onServerSideRender({
             req,
             res,
             next,
             route,
           })
         }
-      })
+      }
 
       const serverContext = buildServerAppContext(req, res, context)
       const userAgent = req.header("User-Agent")


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GRO-650 

We noticed that for logged in artsymail users sometimes the image would appear, rather than the page. This is due to the route being improperly mounted. 

Looking deeper, noticed that we weren't properly `await`ing our `onServerSideRender` calls, so this updates that. 