### PR TITLE
chore: add a hook to the agree to terms checkbox for integrity

### DIFF
--- a/src/v2/Components/Authentication/Views/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Views/SignUpForm.tsx
@@ -179,6 +179,7 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                       setFieldValue("agreed_to_receive_emails", selected)
                       setFieldValue("accepted_terms_of_service", selected)
                     }}
+                    data-test="agreeToTerms"
                   >
                     {"I agree to the "}
                     <a href="https://www.artsy.net/terms" target="_blank">
@@ -204,6 +205,7 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                     onSelect={selected => {
                       setFieldValue("accepted_terms_of_service", selected)
                     }}
+                    data-test="agreeToTerms"
                   >
                     {"By checking this box, you consent to our "}
                     <a href="https://www.artsy.net/terms" target="_blank">


### PR DESCRIPTION
This PR adds a `data-test` attribute to the "I agree to the terms" checkbox of the registration modal. 

I've confirmed that integrity tests pass locally for me against this new attribute for both GDPR & non-GDPR requests.

## Why?

I noticed while running integrity locally that during registration specs, we target the "I agree to the terms" checkbox via the `[role=checkbox]` selector.

This works great in non-GDPR countries, but since I'm in Germany right now all these tests were failing because we split the checkboxes for GDPR. The `[role=checkbox]` selector wasn't granular enough, and cypress didn't like the fact that we were trying to click multiple checkboxes at once.

This isn't ever a problem in CI because the tests don't run in a GDPR country. This PR is for our friends in GDPR countries though, so that they get the same results as we do in the US when they run these tests. 