### PR TITLE
feat(SWA-102): Prepopulate contact information step with information from the session storage

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/Components/ContactInformationForm.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/Components/ContactInformationForm.tsx
@@ -5,13 +5,6 @@ import { useRouter } from "v2/System/Router/useRouter"
 import { ContactInformation_me } from "v2/__generated__/ContactInformation_me.graphql"
 import { useSubmission } from "../../Utils/useSubmission"
 
-export const getContactInformationFormInitialValues = (
-  me: ContactInformation_me
-) => ({
-  name: me?.name || "",
-  email: me?.email || "",
-  phone: me?.phone || "",
-})
 export interface ContactInformationFormModel {
   name: string
   email: string
@@ -32,7 +25,6 @@ export const ContactInformationForm: React.FC<ContactInformationFormProps> = ({
     handleBlur,
     resetForm,
     validateForm,
-    setErrors,
   } = useFormikContext<ContactInformationFormModel>()
 
   const {
@@ -45,13 +37,7 @@ export const ContactInformationForm: React.FC<ContactInformationFormProps> = ({
   useEffect(() => {
     if (submission) {
       resetForm({ values: submission.contactInformationForm })
-      validateForm(submission.contactInformationForm).then(e => {
-        setErrors(e)
-      })
-    } else {
-      resetForm({
-        values: getContactInformationFormInitialValues(me),
-      })
+      validateForm(submission.contactInformationForm)
     }
   }, [submission])
 

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/Components/ContactInformationForm.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/Components/ContactInformationForm.tsx
@@ -1,20 +1,59 @@
 import { Box, BoxProps, Input } from "@artsy/palette"
 import { useFormikContext } from "formik"
+import { useEffect } from "react"
+import { useRouter } from "v2/System/Router/useRouter"
+import { ContactInformation_me } from "v2/__generated__/ContactInformation_me.graphql"
+import { useSubmission } from "../../Utils/useSubmission"
 
+export const getContactInformationFormInitialValues = (
+  me: ContactInformation_me
+) => ({
+  name: me?.name || "",
+  email: me?.email || "",
+  phone: me?.phone || "",
+})
 export interface ContactInformationFormModel {
   name: string
   email: string
   phone: string
 }
 
-export interface ContactInformationFormProps extends BoxProps {}
+export interface ContactInformationFormProps extends BoxProps {
+  me: ContactInformation_me
+}
 
 export const ContactInformationForm: React.FC<ContactInformationFormProps> = ({
+  me,
   ...rest
 }) => {
-  const { values, handleChange, handleBlur } = useFormikContext<
-    ContactInformationFormModel
-  >()
+  const {
+    values,
+    handleChange,
+    handleBlur,
+    resetForm,
+    validateForm,
+    setErrors,
+  } = useFormikContext<ContactInformationFormModel>()
+
+  const {
+    match: {
+      params: { id },
+    },
+  } = useRouter()
+  const { submission } = useSubmission(id)
+
+  useEffect(() => {
+    if (submission) {
+      resetForm({ values: submission.contactInformationForm })
+      validateForm(submission.contactInformationForm).then(e => {
+        setErrors(e)
+      })
+    } else {
+      resetForm({
+        values: getContactInformationFormInitialValues(me),
+      })
+    }
+  }, [submission])
 
   return (
     <Box {...rest}>

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
@@ -10,6 +10,7 @@ import { Form, Formik } from "formik"
 import {
   ContactInformationForm,
   ContactInformationFormModel,
+  getContactInformationFormInitialValues,
 } from "./Components/ContactInformationForm"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ContactInformation_me } from "v2/__generated__/ContactInformation_me.graphql"
@@ -110,11 +111,7 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
       />
 
       <Formik<ContactInformationFormModel>
-        initialValues={{
-          name: me?.name || "",
-          email: me?.email || "",
-          phone: me?.phone || "",
-        }}
+        initialValues={getContactInformationFormInitialValues(me)}
         validateOnMount
         onSubmit={handleSubmit}
         validationSchema={contactInformationValidationSchema}
@@ -122,7 +119,7 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
         {({ isValid, isSubmitting }) => {
           return (
             <Form>
-              <ContactInformationForm my={6} />
+              <ContactInformationForm my={6} me={me} />
 
               <Button
                 data-test-id="save-button"

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
@@ -10,7 +10,6 @@ import { Form, Formik } from "formik"
 import {
   ContactInformationForm,
   ContactInformationFormModel,
-  getContactInformationFormInitialValues,
 } from "./Components/ContactInformationForm"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ContactInformation_me } from "v2/__generated__/ContactInformation_me.graphql"
@@ -19,6 +18,12 @@ import { contactInformationValidationSchema } from "../Utils/validation"
 import { BackLink } from "v2/Components/Links/BackLink"
 import { ErrorModal } from "v2/Components/Modal/ErrorModal"
 import { useState } from "react"
+
+const getContactInformationFormInitialValues = (me: ContactInformation_me) => ({
+  name: me?.name || "",
+  email: me?.email || "",
+  phone: me?.phone || "",
+})
 
 export interface ContactInformationProps {
   me: ContactInformation_me

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/__tests__/ContactInformation.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/__tests__/ContactInformation.jest.tsx
@@ -37,7 +37,12 @@ const previousStepsData = {
     ],
   },
 }
-const mockMe = { name: "Serge", email: "test@test.test", phone: "123456789" }
+const contactInformationForm = {
+  name: "Andy",
+  email: "andy@test.test",
+  phone: "111",
+}
+const mockMe = { name: "Serge", email: "serge@test.test", phone: "222" }
 const openAuthModalSpy = jest.spyOn(openAuthModal, "openAuthModal")
 const mockRouterPush = jest.fn()
 
@@ -139,15 +144,15 @@ describe("Contact Information step", () => {
 
       expect(wrapper.find(saveButtonSelector).prop("disabled")).toBe(true)
 
-      await simulateTyping(wrapper, "name", "Andy")
+      await simulateTyping(wrapper, "name", "Banksy")
 
       expect(wrapper.find(saveButtonSelector).prop("disabled")).toBe(true)
 
-      await simulateTyping(wrapper, "email", "test@test.test")
+      await simulateTyping(wrapper, "email", "banksy@test.test")
 
       expect(wrapper.find(saveButtonSelector).prop("disabled")).toBe(true)
 
-      await simulateTyping(wrapper, "phone", "123456789")
+      await simulateTyping(wrapper, "phone", "333")
 
       expect(wrapper.find(saveButtonSelector).prop("disabled")).toBe(false)
     })
@@ -173,15 +178,36 @@ describe("Contact Information step", () => {
       expect(wrapper.find("input[name='phone']").prop("value")).toBe("")
     })
 
+    it("fields are pre-populating from session storage", async () => {
+      sessionStore = {
+        "submission-1": JSON.stringify({
+          ...previousStepsData,
+          contactInformationForm,
+        }),
+      }
+      const { getWrapper } = getWrapperWithProps()
+      const wrapper = getWrapper({
+        Me: () => ({ name: null, email: null, phone: null }),
+      })
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(wrapper.find("input[name='name']").prop("value")).toBe("Andy")
+      expect(wrapper.find("input[name='email']").prop("value")).toBe(
+        "andy@test.test"
+      )
+      expect(wrapper.find("input[name='phone']").prop("value")).toBe("111")
+    })
+
     it("submiting a valid form", async () => {
       const { getWrapper } = getWrapperWithProps()
       const wrapper = getWrapper()
       await flushPromiseQueue()
       wrapper.update()
 
-      await simulateTyping(wrapper, "name", "Andy")
-      await simulateTyping(wrapper, "email", "test@test.test")
-      await simulateTyping(wrapper, "phone", "123456789")
+      await simulateTyping(wrapper, "name", "Banksy")
+      await simulateTyping(wrapper, "email", "banksy@test.test")
+      await simulateTyping(wrapper, "phone", "333")
 
       wrapper.find("Form").simulate("submit")
       await flushPromiseQueue()
@@ -192,11 +218,15 @@ describe("Contact Information step", () => {
   })
 
   describe("If logged in", () => {
-    it("fields are pre-populating from user profile", async () => {
+    it("fields are pre-populating from user profile if session storage is clear", async () => {
+      sessionStore = {
+        "submission-1": JSON.stringify({ ...previousStepsData }),
+      }
       const { getWrapper } = getWrapperWithProps(mockMe)
       const wrapper = getWrapper({ Me: () => mockMe })
       await flushPromiseQueue()
       wrapper.update()
+
       expect(wrapper.find("input[name='name']").prop("value")).toBe(mockMe.name)
       expect(wrapper.find("input[name='email']").prop("value")).toBe(
         mockMe.email
@@ -204,6 +234,25 @@ describe("Contact Information step", () => {
       expect(wrapper.find("input[name='phone']").prop("value")).toBe(
         mockMe.phone
       )
+    })
+
+    it("data from session storage overrides data from user profile", async () => {
+      sessionStore = {
+        "submission-1": JSON.stringify({
+          ...previousStepsData,
+          contactInformationForm,
+        }),
+      }
+      const { getWrapper } = getWrapperWithProps(mockMe)
+      const wrapper = getWrapper({ Me: () => mockMe })
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(wrapper.find("input[name='name']").prop("value")).toBe("Andy")
+      expect(wrapper.find("input[name='email']").prop("value")).toBe(
+        "andy@test.test"
+      )
+      expect(wrapper.find("input[name='phone']").prop("value")).toBe("111")
     })
 
     it("submiting a valid form", async () => {
@@ -230,9 +279,9 @@ describe("Contact Information step", () => {
     await flushPromiseQueue()
     wrapper.update()
 
-    await simulateTyping(wrapper, "name", " Andy  ")
-    await simulateTyping(wrapper, "email", "  test@test.test  ")
-    await simulateTyping(wrapper, "phone", "  123456789  ")
+    await simulateTyping(wrapper, "name", " Banksy  ")
+    await simulateTyping(wrapper, "email", "  banksy@test.test  ")
+    await simulateTyping(wrapper, "phone", "  333  ")
 
     wrapper.find("Form").simulate("submit")
     await flushPromiseQueue()
@@ -243,9 +292,9 @@ describe("Contact Information step", () => {
       JSON.stringify({
         ...previousStepsData,
         contactInformationForm: {
-          name: "Andy",
-          email: "test@test.test",
-          phone: "123456789",
+          name: "Banksy",
+          email: "banksy@test.test",
+          phone: "333",
         },
       })
     )
@@ -256,9 +305,9 @@ describe("Contact Information step", () => {
     expect(createConsignSubmissionData).toEqual({
       ...previousStepsData,
       contactInformationForm: {
-        name: "Andy",
-        email: "test@test.test",
-        phone: "123456789",
+        name: "Banksy",
+        email: "banksy@test.test",
+        phone: "333",
       },
     })
   })


### PR DESCRIPTION
Jira Ticket:ticket: : [SWA-102](https://artsyproduct.atlassian.net/browse/SWA-102)

This PR adds the ability to pre-populate `ContactInformationForm` fields from `session storage`. Fields from session storage override values that had been taken from the user profile. It is really helpful for example when the user  lost connection after he clicked `Submit Artwork`

**VIDEO:clapper: :**

https://user-images.githubusercontent.com/55637696/140531705-4b00799f-c7b8-437e-9e33-afb37f3afec4.mov


