### PR TITLE
chore(buttons): use "Show More" / primary variant for pagination buttons

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
@@ -15,8 +15,8 @@ import { hideGrid } from "v2/Apps/Artwork/Components/OtherWorks"
 import { track, useTracking } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
 import { ArtistCardFragmentContainer as ArtistCard } from "v2/Components/ArtistCard"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import {
   RelayPaginationProp,
   createPaginationContainer,
@@ -112,13 +112,8 @@ const ShowMoreButton: React.FC<{ onClick: () => void; loading: boolean }> = ({
 }) => {
   return (
     <Flex justifyContent="center">
-      <Button
-        variant="secondaryOutline"
-        size="small"
-        onClick={onClick}
-        loading={loading}
-      >
-        Show more
+      <Button onClick={onClick} loading={loading}>
+        Show More
       </Button>
     </Flex>
   )

--- a/src/v2/Apps/Auctions/Routes/CurrentAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/CurrentAuctions.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Box, Button, GridColumns, Column } from "@artsy/palette"
 import {
   createPaginationContainer,
@@ -65,12 +65,11 @@ const CurrentAuctions: React.FC<CurrentAuctionsProps> = ({ viewer, relay }) => {
         <Column span={12} mx="auto">
           <Button
             width="100%"
-            variant="secondaryGray"
             onClick={handleClick}
             loading={isLoading}
             disabled={!relay.hasMore()}
           >
-            Show more
+            Show More
           </Button>
         </Column>
       </GridColumns>

--- a/src/v2/Apps/Auctions/Routes/PastAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/PastAuctions.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Box, Button, GridColumns, Column } from "@artsy/palette"
 import {
   createPaginationContainer,
@@ -62,12 +62,11 @@ const PastAuctions: React.FC<PastAuctionsProps> = ({ viewer, relay }) => {
         <Column span={12} mx="auto">
           <Button
             width="100%"
-            variant="secondaryGray"
             onClick={handleClick}
             loading={isLoading}
             disabled={!relay.hasMore()}
           >
-            Show more
+            Show More
           </Button>
         </Column>
       </GridColumns>

--- a/src/v2/Apps/Auctions/Routes/UpcomingAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/UpcomingAuctions.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Box, Button, GridColumns, Column } from "@artsy/palette"
 import {
   createPaginationContainer,
@@ -68,12 +68,11 @@ const UpcomingAuctions: React.FC<UpcomingAuctionsProps> = ({
         <Column span={12} mx="auto">
           <Button
             width="100%"
-            variant="secondaryGray"
             onClick={handleClick}
             loading={isLoading}
             disabled={!relay.hasMore()}
           >
-            Show more
+            Show More
           </Button>
         </Column>
       </GridColumns>

--- a/src/v2/Apps/Auctions/Routes/__tests__/CurrentAuctions.jest.tsx
+++ b/src/v2/Apps/Auctions/Routes/__tests__/CurrentAuctions.jest.tsx
@@ -68,6 +68,6 @@ describe("CurrentAuctions", () => {
     })
     expect(wrapper.find("AuctionArtworksRailFragmentContainer")).toBeDefined()
     expect(wrapper.find("Button")).toBeDefined()
-    expect(wrapper.text()).toContain("Show more")
+    expect(wrapper.text()).toContain("Show More")
   })
 })

--- a/src/v2/Apps/Auctions/Routes/__tests__/PastAuctions.jest.tsx
+++ b/src/v2/Apps/Auctions/Routes/__tests__/PastAuctions.jest.tsx
@@ -68,6 +68,6 @@ describe("PastAuctions", () => {
     })
     expect(wrapper.find("AuctionArtworksRailFragmentContainer")).toBeDefined()
     expect(wrapper.find("Button")).toBeDefined()
-    expect(wrapper.text()).toContain("Show more")
+    expect(wrapper.text()).toContain("Show More")
   })
 })

--- a/src/v2/Apps/Auctions/Routes/__tests__/UpcomingAuctions.jest.tsx
+++ b/src/v2/Apps/Auctions/Routes/__tests__/UpcomingAuctions.jest.tsx
@@ -68,6 +68,6 @@ describe("UpcomingAuctions", () => {
     })
     expect(wrapper.find("AuctionArtworksRailFragmentContainer")).toBeDefined()
     expect(wrapper.find("Button")).toBeDefined()
-    expect(wrapper.text()).toContain("Show more")
+    expect(wrapper.text()).toContain("Show More")
   })
 })

--- a/src/v2/Apps/Fair/Routes/FairArticles.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArticles.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import {
   ResponsiveBox,
   Text,
@@ -172,12 +172,11 @@ const FairArticles: React.FC<FairArticlesProps> = ({ fair, relay }) => {
           <Column span={6} start={4}>
             <Button
               width="100%"
-              variant="secondaryGray"
               onClick={handleClick}
               loading={isLoading}
               disabled={!relay.hasMore()}
             >
-              Show more
+              Show More
             </Button>
           </Column>
         )}

--- a/src/v2/Apps/Fairs/Components/FairsPastFairs.tsx
+++ b/src/v2/Apps/Fairs/Components/FairsPastFairs.tsx
@@ -1,6 +1,6 @@
 import { Box, Button } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import {
   createPaginationContainer,
   graphql,
@@ -50,13 +50,12 @@ export const FairsPastFairs: React.FC<FairsPastFairsProps> = ({
       </Box>
 
       <Button
-        variant="secondaryOutline"
         display="block"
         mx="auto"
         loading={isLoading}
         onClick={handleClick}
       >
-        View more
+        Show More
       </Button>
     </>
   )

--- a/src/v2/Apps/Shows/Components/ShowsCurrentShows.tsx
+++ b/src/v2/Apps/Shows/Components/ShowsCurrentShows.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Join, Separator } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import {
   createPaginationContainer,
   graphql,
@@ -60,7 +60,7 @@ const ShowsCurrentShows: React.FC<ShowsCurrentShowsProps> = ({
               loading={loading}
               disabled={!relay.hasMore()}
             >
-              Show more
+              Show More
             </Button>
           </Box>
         )}


### PR DESCRIPTION
No ticket here; just noticed we didn't have a consistent label/variant for these and after consulting with Jonathan we are settling on `"Show More"` with the `primaryBlack` (default) button variant.