### PR TITLE
fix(FX-3559): Dropdown filters on /galleries page

### DIFF
--- a/src/desktop/apps/galleries_institutions/components/primary_carousel/fetch.coffee
+++ b/src/desktop/apps/galleries_institutions/components/primary_carousel/fetch.coffee
@@ -1,8 +1,8 @@
 _ = require 'underscore'
 Profile = require '../../../../models/profile.coffee'
+FilterPartners = require './collections/filter_partners.coffee'
 { Profiles } = require '../../../../collections/profiles'
 { OrderedSets } = require '../../../../collections/ordered_sets'
-{ FilterPartners } = require './collections/filter_partners'
 
 key =
   gallery: 'galleries:carousel-galleries' # https://admin.artsy.net/set/5638fdfb7261690296000031


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR resolves [FX-3559]

### Description
* As a user
* When I go to the `/galleries` page
* And specify some filter
* I see that nothing is happening

### Some context
* [Slack thread](https://artsy.slack.com/archives/C9SATFLUU/p1636452319117100)
* PR after which the problem appeared artsy/force#8707


### Demo
#### Before
https://user-images.githubusercontent.com/3513494/140926689-1c6efbf9-b02a-412f-a6a6-f0eb2c9547c1.mp4

#### After
https://user-images.githubusercontent.com/3513494/140926751-f5ab5e7b-ee92-45f8-974b-24fd133be92f.mp4

[FX-3559]: https://artsyproduct.atlassian.net/browse/FX-3559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ