### PR TITLE
chore: update apple-app-association

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "@artsy/backbone-mixins": "2.0.0",
     "@artsy/cohesion": "4.19.0",
-    "@artsy/eigen-web-association": "1.2.0",
+    "@artsy/eigen-web-association": "^1.2.1",
     "@artsy/express-reloadable": "1.6.0",
     "@artsy/fresnel": "3.1.0",
     "@artsy/gemup": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/detect-responsive-traits/-/detect-responsive-traits-0.0.5.tgz#abf85959f8567816babec6f582b744f58c98b726"
   integrity sha512-axgW5YuqSpPzHb27yo2jmPHz/N9eN2hh2E+Mub5BKuu/jHZI+iDTdw0OZ3I+z7Z9WKBh+FPVx4gpza5w7slJNA==
 
-"@artsy/eigen-web-association@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@artsy/eigen-web-association/-/eigen-web-association-1.2.0.tgz#904cad018cd99da8ce30c4f6875a45a63abede65"
-  integrity sha512-VPOoecp1lgkYe9bH5/5BXosYPejHJLHlE4wJiezsILgW2zSM3p7MxjsPGio2YGpoGNt1NpM9XJhK9TObq5N9Qg==
+"@artsy/eigen-web-association@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@artsy/eigen-web-association/-/eigen-web-association-1.2.1.tgz#8b286b8fe15384dd53ad85dd90b7c7acf660115b"
+  integrity sha512-o9IWTgo595yKPDLCv3t7MqVsXgx1nLEnFjdBPZjZp2XgzQG7oJrLhi8EImn5rmjth/cR+3KOqgia5pTMQqCdWQ==
   dependencies:
     express "^4.15.0"
 
@@ -15694,7 +15694,6 @@ pascalcase@^0.1.1:
 
 "passport-apple@https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f":
   version "1.1.2"
-  uid f41adb7822c8344b72bc36a7d68312f6592cb14f
   resolved "https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f"
   dependencies:
     jsonwebtoken "^8.5.1"


### PR DESCRIPTION
**Description:**

This update is in order to ignore the price-database as a deep link.

This is a follow-up work from https://github.com/artsy/artsy-wwwify/pull/100 and https://github.com/artsy/artsy-eigen-web-association/pull/45