### PR TITLE
fix(FX-3562): Unable to click the "view all" buttons on partner page in mobile browser

### DIFF
--- a/src/v2/Apps/Partner/Components/Overview/ArticlesRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ArticlesRail.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { ResponsiveBox, Box, Flex, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Carousel } from "../Carousel"
@@ -23,7 +23,12 @@ const ArticlesRail: React.FC<ArticlesRailProps> = ({
   const [isSeeAllAvaliable, setIsSeeAllAvaliable] = useState<boolean>(undefined)
   return (
     <>
-      <Flex justifyContent="space-between" alignItems="center" mb={4}>
+      <Flex
+        justifyContent="space-between"
+        alignItems="center"
+        mb={4}
+        position="relative"
+      >
         <Text variant="title">Articles</Text>
 
         <ViewAllButton to={`/partner/${partnerSlug}/articles`} />

--- a/src/v2/Apps/Partner/Components/Overview/ArtistsRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ArtistsRail.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Box, BoxProps, Flex, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistsRail_partner } from "v2/__generated__/ArtistsRail_partner.graphql"
@@ -44,7 +44,12 @@ const ArtistsRail: React.FC<ArtistsRailProps> = ({ partner, ...rest }) => {
 
   return (
     <Box {...rest}>
-      <Flex mb={6} justifyContent="space-between" alignItems="center">
+      <Flex
+        mb={6}
+        justifyContent="space-between"
+        alignItems="center"
+        position="relative"
+      >
         <Text variant="title">
           {profileArtistsLayout === "Grid" ? "Featured Artists" : "Artists"}
         </Text>

--- a/src/v2/Apps/Partner/Components/Overview/ArtworksRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ArtworksRail.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Box, BoxProps, Flex, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworksRail_partner } from "v2/__generated__/ArtworksRail_partner.graphql"
@@ -38,7 +38,12 @@ const ArtworksRail: React.FC<ArtworksRailProps> = ({ partner, ...rest }) => {
 
   return (
     <Box {...rest}>
-      <Flex mb={4} justifyContent="space-between" alignItems="center">
+      <Flex
+        mb={4}
+        justifyContent="space-between"
+        alignItems="center"
+        position="relative"
+      >
         <Text variant="title">Featured Artworks</Text>
 
         <ViewAllButton to={`/partner/${slug}/works`} />

--- a/src/v2/Apps/Partner/Components/Overview/ShowsRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ShowsRail.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Box, BoxProps, Flex, ResponsiveBox, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShowsRail_partner } from "v2/__generated__/ShowsRail_partner.graphql"
@@ -39,7 +39,12 @@ const ShowsRail: React.FC<ShowsRailProps> = ({ partner, ...rest }) => {
 
   return (
     <Box {...rest}>
-      <Flex mb={4} justifyContent="space-between" alignItems="center">
+      <Flex
+        mb={4}
+        justifyContent="space-between"
+        alignItems="center"
+        position="relative"
+      >
         <Text variant="title">All Events</Text>
 
         {canShowAll && <ViewAllButton to={`/partner/${slug}/shows`} />}


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR resolves [FX-3562]

### Description
* As a user
* When I navigate to the partner screen
* And tap on “view all” button (for example, in “all events” section)
* I navigate to “view all” screen

### Useful links
* [Slack thread](https://artsy.slack.com/archives/C9SATFLUU/p1636469153134500)
* [Demo partner link](https://www.artsy.net/partner/galerie-benjamin-eck)

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/140970840-4fe9ae6f-68ea-4c29-82be-acc755f28198.mp4

#### After
https://user-images.githubusercontent.com/3513494/140971419-409b8b86-d030-4022-b7e4-c117ab66590c.mp4

[FX-3562]: https://artsyproduct.atlassian.net/browse/FX-3562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ