### PR TITLE
feat(FX-3517): Added fair logo to sticky menu

### DIFF
--- a/src/v2/Apps/Fair/Components/FairHeader/FairHeader.tsx
+++ b/src/v2/Apps/Fair/Components/FairHeader/FairHeader.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Box, BoxProps, Flex, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairHeaderIconFragmentContainer } from "./FairHeaderIcon"
@@ -12,7 +12,7 @@ const FairHeader: React.FC<FairHeaderProps> = ({ fair }) => {
   const { name, exhibitionPeriod } = fair
 
   return (
-    <Flex my={[2, 4]}>
+    <Flex mt={[2, 4]}>
       <FairHeaderIconFragmentContainer fair={fair} mr={2} />
       <Box display="flex" flexDirection="column" justifyContent="center">
         <Text as="h1" variant={["lg", "xl"]}>

--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -2,7 +2,15 @@ import { useRef } from "react"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairApp_fair } from "v2/__generated__/FairApp_fair.graphql"
-import { Box, DROP_SHADOW, Flex, FullBleed, Text, Image } from "@artsy/palette"
+import {
+  Box,
+  DROP_SHADOW,
+  Flex,
+  FullBleed,
+  Text,
+  Image,
+  Spacer,
+} from "@artsy/palette"
 import { RouteTab, RouteTabs } from "v2/Components/RouteTabs"
 import { FairMetaFragmentContainer } from "./Components/FairMeta"
 import { useSystemContext } from "v2/System"
@@ -82,77 +90,84 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
             >
               <AppContainer>
                 <HorizontalPadding>
-                  <Flex>
-                    <Box
-                      width={60}
-                      height={60}
-                      border="1px solid transparent"
-                      borderBottomColor="black10"
-                    >
-                      {stuck && fair.profile?.icon?.cropped && (
-                        <Image
-                          src={fair.profile.icon.cropped.src}
-                          srcSet={fair.profile.icon.cropped.srcSet}
-                          width="100%"
-                          height="100%"
-                        />
-                      )}
-                    </Box>
-                    <RouteTabs textAlign="center" flexGrow={1} fill>
-                      <FairRouteTab
-                        to={fairHref}
-                        exact
-                        onClick={trackTabData(
-                          fairHref,
-                          "Overview",
-                          ContextModule.fairInfo
-                        )}
-                      >
-                        Overview
-                      </FairRouteTab>
-
-                      <FairRouteTab
-                        to={`${fairHref}/artworks`}
-                        exact
-                        onClick={trackTabData(
-                          `${fairHref}/artworks`,
-                          "Artworks",
-                          ContextModule.artworksTab
-                        )}
-                      >
-                        Artworks
-                        <Text display="inline">&nbsp;({artworkCount})</Text>
-                      </FairRouteTab>
-
-                      {enableFairPageExhibitorsTab && (
-                        <FairRouteTab
-                          to={`${fairHref}/exhibitors`}
-                          exact
-                          onClick={trackTabData(
-                            `${fairHref}/exhibitors`,
-                            "Exhibitors",
-                            ContextModule.exhibitorsTab
-                          )}
+                  <Flex
+                    height={70}
+                    py={1}
+                    border="1px solid transparent"
+                    borderBottomColor={stuck && "black10"}
+                  >
+                    {stuck && fair.profile?.icon?.cropped && (
+                      <>
+                        <Box
+                          width={fair.profile.icon.cropped.width}
+                          height={fair.profile.icon.cropped.height}
                         >
-                          Exhibitors A-Z
-                        </FairRouteTab>
-                      )}
-
-                      {!enableFairPageExhibitorsTab && (
-                        <FairRouteTab
-                          to={`${fairHref}/booths`}
-                          exact
-                          onClick={trackTabData(
-                            `${fairHref}/booths`,
-                            "Booths",
-                            ContextModule.boothsTab
-                          )}
-                        >
-                          Booths
-                        </FairRouteTab>
-                      )}
-                    </RouteTabs>
+                          <Image
+                            src={fair.profile.icon.cropped.src}
+                            srcSet={fair.profile.icon.cropped.srcSet}
+                            width="100%"
+                            height="100%"
+                          />
+                        </Box>
+                        <Spacer ml={1} />
+                        <Text variant="lg">{fair.name}</Text>
+                      </>
+                    )}
                   </Flex>
+                  <RouteTabs textAlign="center" flexGrow={1} fill>
+                    <FairRouteTab
+                      to={fairHref}
+                      exact
+                      onClick={trackTabData(
+                        fairHref,
+                        "Overview",
+                        ContextModule.fairInfo
+                      )}
+                    >
+                      Overview
+                    </FairRouteTab>
+
+                    <FairRouteTab
+                      to={`${fairHref}/artworks`}
+                      exact
+                      onClick={trackTabData(
+                        `${fairHref}/artworks`,
+                        "Artworks",
+                        ContextModule.artworksTab
+                      )}
+                    >
+                      Artworks
+                      <Text display="inline">&nbsp;({artworkCount})</Text>
+                    </FairRouteTab>
+
+                    {enableFairPageExhibitorsTab && (
+                      <FairRouteTab
+                        to={`${fairHref}/exhibitors`}
+                        exact
+                        onClick={trackTabData(
+                          `${fairHref}/exhibitors`,
+                          "Exhibitors",
+                          ContextModule.exhibitorsTab
+                        )}
+                      >
+                        Exhibitors A-Z
+                      </FairRouteTab>
+                    )}
+
+                    {!enableFairPageExhibitorsTab && (
+                      <FairRouteTab
+                        to={`${fairHref}/booths`}
+                        exact
+                        onClick={trackTabData(
+                          `${fairHref}/booths`,
+                          "Booths",
+                          ContextModule.boothsTab
+                        )}
+                      >
+                        Booths
+                      </FairRouteTab>
+                    )}
+                  </RouteTabs>
                 </HorizontalPadding>
               </AppContainer>
             </FullBleed>
@@ -208,11 +223,14 @@ export const FairAppFragmentContainer = createFragmentContainer(
         internalID
         href
         slug
+        name
         profile {
           icon {
-            cropped(width: 60, height: 60, version: "square140") {
+            cropped(width: 50, height: 50, version: "square140") {
               src
               srcSet
+              width
+              height
             }
           }
         }

--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -1,8 +1,8 @@
-import { useRef } from "react";
-import * as React from "react";
+import { useRef } from "react"
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairApp_fair } from "v2/__generated__/FairApp_fair.graphql"
-import { DROP_SHADOW, FullBleed, Text } from "@artsy/palette"
+import { Box, DROP_SHADOW, Flex, FullBleed, Text, Image } from "@artsy/palette"
 import { RouteTab, RouteTabs } from "v2/Components/RouteTabs"
 import { FairMetaFragmentContainer } from "./Components/FairMeta"
 import { useSystemContext } from "v2/System"
@@ -82,60 +82,77 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
             >
               <AppContainer>
                 <HorizontalPadding>
-                  <RouteTabs textAlign="center" fill>
-                    <FairRouteTab
-                      to={fairHref}
-                      exact
-                      onClick={trackTabData(
-                        fairHref,
-                        "Overview",
-                        ContextModule.fairInfo
-                      )}
+                  <Flex>
+                    <Box
+                      width={60}
+                      height={60}
+                      border="1px solid transparent"
+                      borderBottomColor="black10"
                     >
-                      Overview
-                    </FairRouteTab>
-
-                    <FairRouteTab
-                      to={`${fairHref}/artworks`}
-                      exact
-                      onClick={trackTabData(
-                        `${fairHref}/artworks`,
-                        "Artworks",
-                        ContextModule.artworksTab
+                      {stuck && fair.profile?.icon?.cropped && (
+                        <Image
+                          src={fair.profile.icon.cropped.src}
+                          srcSet={fair.profile.icon.cropped.srcSet}
+                          width="100%"
+                          height="100%"
+                        />
                       )}
-                    >
-                      Artworks
-                      <Text display="inline">&nbsp;({artworkCount})</Text>
-                    </FairRouteTab>
-
-                    {enableFairPageExhibitorsTab && (
+                    </Box>
+                    <RouteTabs textAlign="center" flexGrow={1} fill>
                       <FairRouteTab
-                        to={`${fairHref}/exhibitors`}
+                        to={fairHref}
                         exact
                         onClick={trackTabData(
-                          `${fairHref}/exhibitors`,
-                          "Exhibitors",
-                          ContextModule.exhibitorsTab
+                          fairHref,
+                          "Overview",
+                          ContextModule.fairInfo
                         )}
                       >
-                        Exhibitors A-Z
+                        Overview
                       </FairRouteTab>
-                    )}
 
-                    {!enableFairPageExhibitorsTab && (
                       <FairRouteTab
-                        to={`${fairHref}/booths`}
+                        to={`${fairHref}/artworks`}
                         exact
                         onClick={trackTabData(
-                          `${fairHref}/booths`,
-                          "Booths",
-                          ContextModule.boothsTab
+                          `${fairHref}/artworks`,
+                          "Artworks",
+                          ContextModule.artworksTab
                         )}
                       >
-                        Booths
+                        Artworks
+                        <Text display="inline">&nbsp;({artworkCount})</Text>
                       </FairRouteTab>
-                    )}
-                  </RouteTabs>
+
+                      {enableFairPageExhibitorsTab && (
+                        <FairRouteTab
+                          to={`${fairHref}/exhibitors`}
+                          exact
+                          onClick={trackTabData(
+                            `${fairHref}/exhibitors`,
+                            "Exhibitors",
+                            ContextModule.exhibitorsTab
+                          )}
+                        >
+                          Exhibitors A-Z
+                        </FairRouteTab>
+                      )}
+
+                      {!enableFairPageExhibitorsTab && (
+                        <FairRouteTab
+                          to={`${fairHref}/booths`}
+                          exact
+                          onClick={trackTabData(
+                            `${fairHref}/booths`,
+                            "Booths",
+                            ContextModule.boothsTab
+                          )}
+                        >
+                          Booths
+                        </FairRouteTab>
+                      )}
+                    </RouteTabs>
+                  </Flex>
                 </HorizontalPadding>
               </AppContainer>
             </FullBleed>
@@ -191,6 +208,14 @@ export const FairAppFragmentContainer = createFragmentContainer(
         internalID
         href
         slug
+        profile {
+          icon {
+            cropped(width: 60, height: 60, version: "square140") {
+              src
+              srcSet
+            }
+          }
+        }
         ...FairMeta_fair
         ...FairHeader_fair
         ...FairHeaderImage_fair

--- a/src/v2/__generated__/FairApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairApp_Test_Query.graphql.ts
@@ -28,11 +28,14 @@ fragment FairApp_fair on Fair {
   internalID
   href
   slug
+  name
   profile {
     icon {
-      cropped(width: 60, height: 60, version: "square140") {
+      cropped(width: 50, height: 50, version: "square140") {
         src
         srcSet
+        width
+        height
       }
     }
     id
@@ -97,36 +100,25 @@ v1 = {
   "name": "version",
   "value": "square140"
 },
-v2 = [
-  {
-    "kind": "Literal",
-    "name": "height",
-    "value": 60
-  },
-  (v1/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "width",
-    "value": 60
-  }
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "src",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "srcSet",
+  "storageKey": null
+},
+v4 = [
+  (v2/*: any*/),
+  (v3/*: any*/)
 ],
-v3 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "src",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
-  }
-],
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -197,6 +189,13 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "Profile",
             "kind": "LinkedField",
             "name": "profile",
@@ -212,13 +211,42 @@ return {
                 "selections": [
                   {
                     "alias": null,
-                    "args": (v2/*: any*/),
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 50
+                      },
+                      (v1/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 50
+                      }
+                    ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v3/*: any*/),
-                    "storageKey": "cropped(height:60,version:\"square140\",width:60)"
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "cropped(height:50,version:\"square140\",width:50)"
                   },
                   {
                     "alias": "desktop",
@@ -239,31 +267,36 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v3/*: any*/),
+                    "selections": (v4/*: any*/),
                     "storageKey": "cropped(height:100,version:\"square140\",width:100)"
                   },
                   {
                     "alias": "mobile",
-                    "args": (v2/*: any*/),
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 60
+                      },
+                      (v1/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 60
+                      }
+                    ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v3/*: any*/),
+                    "selections": (v4/*: any*/),
                     "storageKey": "cropped(height:60,version:\"square140\",width:60)"
                   }
                 ],
                 "storageKey": null
               },
-              (v4/*: any*/)
+              (v5/*: any*/)
             ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
             "storageKey": null
           },
           {
@@ -346,7 +379,7 @@ return {
             ],
             "storageKey": null
           },
-          (v4/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "fair(id:\"example\")"
       }
@@ -357,7 +390,7 @@ return {
     "metadata": {},
     "name": "FairApp_Test_Query",
     "operationKind": "query",
-    "text": "query FairApp_Test_Query {\n  fair(id: \"example\") {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  href\n  slug\n  profile {\n    icon {\n      cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  counts {\n    artworks\n  }\n}\n\nfragment FairHeaderIcon_fair on Fair {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 100, height: 100, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  ...FairHeaderIcon_fair\n  name\n  exhibitionPeriod\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
+    "text": "query FairApp_Test_Query {\n  fair(id: \"example\") {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  href\n  slug\n  name\n  profile {\n    icon {\n      cropped(width: 50, height: 50, version: \"square140\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  counts {\n    artworks\n  }\n}\n\nfragment FairHeaderIcon_fair on Fair {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 100, height: 100, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  ...FairHeaderIcon_fair\n  name\n  exhibitionPeriod\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairApp_Test_Query.graphql.ts
@@ -28,14 +28,20 @@ fragment FairApp_fair on Fair {
   internalID
   href
   slug
+  profile {
+    icon {
+      cropped(width: 60, height: 60, version: "square140") {
+        src
+        srcSet
+      }
+    }
+    id
+  }
   ...FairMeta_fair
   ...FairHeader_fair
   ...FairHeaderImage_fair
   counts {
     artworks
-  }
-  profile {
-    id
   }
 }
 
@@ -93,6 +99,19 @@ v1 = {
 },
 v2 = [
   {
+    "kind": "Literal",
+    "name": "height",
+    "value": 60
+  },
+  (v1/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 60
+  }
+],
+v3 = [
+  {
     "alias": null,
     "args": null,
     "kind": "ScalarField",
@@ -107,7 +126,7 @@ v2 = [
     "storageKey": null
   }
 ],
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -178,6 +197,71 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "Profile",
+            "kind": "LinkedField",
+            "name": "profile",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "icon",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": (v2/*: any*/),
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v3/*: any*/),
+                    "storageKey": "cropped(height:60,version:\"square140\",width:60)"
+                  },
+                  {
+                    "alias": "desktop",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 100
+                      },
+                      (v1/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 100
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v3/*: any*/),
+                    "storageKey": "cropped(height:100,version:\"square140\",width:100)"
+                  },
+                  {
+                    "alias": "mobile",
+                    "args": (v2/*: any*/),
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v3/*: any*/),
+                    "storageKey": "cropped(height:60,version:\"square140\",width:60)"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "kind": "ScalarField",
             "name": "name",
             "storageKey": null
@@ -210,73 +294,6 @@ return {
                 "name": "url",
                 "storageKey": "url(version:\"large_rectangle\")"
               }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Profile",
-            "kind": "LinkedField",
-            "name": "profile",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Image",
-                "kind": "LinkedField",
-                "name": "icon",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": "desktop",
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "height",
-                        "value": 100
-                      },
-                      (v1/*: any*/),
-                      {
-                        "kind": "Literal",
-                        "name": "width",
-                        "value": 100
-                      }
-                    ],
-                    "concreteType": "CroppedImageUrl",
-                    "kind": "LinkedField",
-                    "name": "cropped",
-                    "plural": false,
-                    "selections": (v2/*: any*/),
-                    "storageKey": "cropped(height:100,version:\"square140\",width:100)"
-                  },
-                  {
-                    "alias": "mobile",
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "height",
-                        "value": 60
-                      },
-                      (v1/*: any*/),
-                      {
-                        "kind": "Literal",
-                        "name": "width",
-                        "value": 60
-                      }
-                    ],
-                    "concreteType": "CroppedImageUrl",
-                    "kind": "LinkedField",
-                    "name": "cropped",
-                    "plural": false,
-                    "selections": (v2/*: any*/),
-                    "storageKey": "cropped(height:60,version:\"square140\",width:60)"
-                  }
-                ],
-                "storageKey": null
-              },
-              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -329,7 +346,7 @@ return {
             ],
             "storageKey": null
           },
-          (v3/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": "fair(id:\"example\")"
       }
@@ -340,7 +357,7 @@ return {
     "metadata": {},
     "name": "FairApp_Test_Query",
     "operationKind": "query",
-    "text": "query FairApp_Test_Query {\n  fair(id: \"example\") {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  href\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  counts {\n    artworks\n  }\n  profile {\n    id\n  }\n}\n\nfragment FairHeaderIcon_fair on Fair {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 100, height: 100, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  ...FairHeaderIcon_fair\n  name\n  exhibitionPeriod\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
+    "text": "query FairApp_Test_Query {\n  fair(id: \"example\") {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  href\n  slug\n  profile {\n    icon {\n      cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  counts {\n    artworks\n  }\n}\n\nfragment FairHeaderIcon_fair on Fair {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 100, height: 100, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  ...FairHeaderIcon_fair\n  name\n  exhibitionPeriod\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairApp_fair.graphql.ts
+++ b/src/v2/__generated__/FairApp_fair.graphql.ts
@@ -7,11 +7,14 @@ export type FairApp_fair = {
     readonly internalID: string;
     readonly href: string | null;
     readonly slug: string;
+    readonly name: string | null;
     readonly profile: {
         readonly icon: {
             readonly cropped: {
                 readonly src: string;
                 readonly srcSet: string;
+                readonly width: number;
+                readonly height: number;
             } | null;
         } | null;
         readonly id: string;
@@ -60,6 +63,13 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "Profile",
       "kind": "LinkedField",
       "name": "profile",
@@ -79,7 +89,7 @@ const node: ReaderFragment = {
                 {
                   "kind": "Literal",
                   "name": "height",
-                  "value": 60
+                  "value": 50
                 },
                 {
                   "kind": "Literal",
@@ -89,7 +99,7 @@ const node: ReaderFragment = {
                 {
                   "kind": "Literal",
                   "name": "width",
-                  "value": 60
+                  "value": 50
                 }
               ],
               "concreteType": "CroppedImageUrl",
@@ -110,9 +120,23 @@ const node: ReaderFragment = {
                   "kind": "ScalarField",
                   "name": "srcSet",
                   "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "width",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "height",
+                  "storageKey": null
                 }
               ],
-              "storageKey": "cropped(height:60,version:\"square140\",width:60)"
+              "storageKey": "cropped(height:50,version:\"square140\",width:50)"
             }
           ],
           "storageKey": null
@@ -163,5 +187,5 @@ const node: ReaderFragment = {
   ],
   "type": "Fair"
 };
-(node as any).hash = '6abe986e4e78ab1ae4b7687e47e09ba0';
+(node as any).hash = '8865f4a231bde5450215990c7c05d9fe';
 export default node;

--- a/src/v2/__generated__/FairApp_fair.graphql.ts
+++ b/src/v2/__generated__/FairApp_fair.graphql.ts
@@ -7,11 +7,17 @@ export type FairApp_fair = {
     readonly internalID: string;
     readonly href: string | null;
     readonly slug: string;
+    readonly profile: {
+        readonly icon: {
+            readonly cropped: {
+                readonly src: string;
+                readonly srcSet: string;
+            } | null;
+        } | null;
+        readonly id: string;
+    } | null;
     readonly counts: {
         readonly artworks: number | null;
-    } | null;
-    readonly profile: {
-        readonly id: string;
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"FairMeta_fair" | "FairHeader_fair" | "FairHeaderImage_fair">;
     readonly " $refType": "FairApp_fair";
@@ -54,6 +60,76 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
+      "concreteType": "Profile",
+      "kind": "LinkedField",
+      "name": "profile",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Image",
+          "kind": "LinkedField",
+          "name": "icon",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "height",
+                  "value": 60
+                },
+                {
+                  "kind": "Literal",
+                  "name": "version",
+                  "value": "square140"
+                },
+                {
+                  "kind": "Literal",
+                  "name": "width",
+                  "value": 60
+                }
+              ],
+              "concreteType": "CroppedImageUrl",
+              "kind": "LinkedField",
+              "name": "cropped",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "src",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "srcSet",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": "cropped(height:60,version:\"square140\",width:60)"
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "FairCounts",
       "kind": "LinkedField",
       "name": "counts",
@@ -64,24 +140,6 @@ const node: ReaderFragment = {
           "args": null,
           "kind": "ScalarField",
           "name": "artworks",
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Profile",
-      "kind": "LinkedField",
-      "name": "profile",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "id",
           "storageKey": null
         }
       ],
@@ -105,5 +163,5 @@ const node: ReaderFragment = {
   ],
   "type": "Fair"
 };
-(node as any).hash = 'ea55e447dd97a5b0350728baebef7444';
+(node as any).hash = '6abe986e4e78ab1ae4b7687e47e09ba0';
 export default node;

--- a/src/v2/__generated__/fairRoutes_FairQuery.graphql.ts
+++ b/src/v2/__generated__/fairRoutes_FairQuery.graphql.ts
@@ -32,11 +32,14 @@ fragment FairApp_fair on Fair {
   internalID
   href
   slug
+  name
   profile {
     icon {
-      cropped(width: 60, height: 60, version: "square140") {
+      cropped(width: 50, height: 50, version: "square140") {
         src
         srcSet
+        width
+        height
       }
     }
     id
@@ -109,36 +112,25 @@ v2 = {
   "name": "version",
   "value": "square140"
 },
-v3 = [
-  {
-    "kind": "Literal",
-    "name": "height",
-    "value": 60
-  },
-  (v2/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "width",
-    "value": 60
-  }
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "src",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "srcSet",
+  "storageKey": null
+},
+v5 = [
+  (v3/*: any*/),
+  (v4/*: any*/)
 ],
-v4 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "src",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
-  }
-],
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -209,6 +201,13 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "Profile",
             "kind": "LinkedField",
             "name": "profile",
@@ -224,13 +223,42 @@ return {
                 "selections": [
                   {
                     "alias": null,
-                    "args": (v3/*: any*/),
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 50
+                      },
+                      (v2/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 50
+                      }
+                    ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v4/*: any*/),
-                    "storageKey": "cropped(height:60,version:\"square140\",width:60)"
+                    "selections": [
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "cropped(height:50,version:\"square140\",width:50)"
                   },
                   {
                     "alias": "desktop",
@@ -251,31 +279,36 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v4/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": "cropped(height:100,version:\"square140\",width:100)"
                   },
                   {
                     "alias": "mobile",
-                    "args": (v3/*: any*/),
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 60
+                      },
+                      (v2/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 60
+                      }
+                    ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v4/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": "cropped(height:60,version:\"square140\",width:60)"
                   }
                 ],
                 "storageKey": null
               },
-              (v5/*: any*/)
+              (v6/*: any*/)
             ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
             "storageKey": null
           },
           {
@@ -358,7 +391,7 @@ return {
             ],
             "storageKey": null
           },
-          (v5/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
@@ -369,7 +402,7 @@ return {
     "metadata": {},
     "name": "fairRoutes_FairQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  href\n  slug\n  profile {\n    icon {\n      cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  counts {\n    artworks\n  }\n}\n\nfragment FairHeaderIcon_fair on Fair {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 100, height: 100, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  ...FairHeaderIcon_fair\n  name\n  exhibitionPeriod\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
+    "text": "query fairRoutes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  href\n  slug\n  name\n  profile {\n    icon {\n      cropped(width: 50, height: 50, version: \"square140\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  counts {\n    artworks\n  }\n}\n\nfragment FairHeaderIcon_fair on Fair {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 100, height: 100, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  ...FairHeaderIcon_fair\n  name\n  exhibitionPeriod\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/fairRoutes_FairQuery.graphql.ts
+++ b/src/v2/__generated__/fairRoutes_FairQuery.graphql.ts
@@ -32,14 +32,20 @@ fragment FairApp_fair on Fair {
   internalID
   href
   slug
+  profile {
+    icon {
+      cropped(width: 60, height: 60, version: "square140") {
+        src
+        srcSet
+      }
+    }
+    id
+  }
   ...FairMeta_fair
   ...FairHeader_fair
   ...FairHeaderImage_fair
   counts {
     artworks
-  }
-  profile {
-    id
   }
 }
 
@@ -105,6 +111,19 @@ v2 = {
 },
 v3 = [
   {
+    "kind": "Literal",
+    "name": "height",
+    "value": 60
+  },
+  (v2/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 60
+  }
+],
+v4 = [
+  {
     "alias": null,
     "args": null,
     "kind": "ScalarField",
@@ -119,7 +138,7 @@ v3 = [
     "storageKey": null
   }
 ],
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -190,6 +209,71 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "Profile",
+            "kind": "LinkedField",
+            "name": "profile",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "icon",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": (v3/*: any*/),
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": "cropped(height:60,version:\"square140\",width:60)"
+                  },
+                  {
+                    "alias": "desktop",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 100
+                      },
+                      (v2/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 100
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": "cropped(height:100,version:\"square140\",width:100)"
+                  },
+                  {
+                    "alias": "mobile",
+                    "args": (v3/*: any*/),
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": "cropped(height:60,version:\"square140\",width:60)"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "kind": "ScalarField",
             "name": "name",
             "storageKey": null
@@ -222,73 +306,6 @@ return {
                 "name": "url",
                 "storageKey": "url(version:\"large_rectangle\")"
               }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Profile",
-            "kind": "LinkedField",
-            "name": "profile",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Image",
-                "kind": "LinkedField",
-                "name": "icon",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": "desktop",
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "height",
-                        "value": 100
-                      },
-                      (v2/*: any*/),
-                      {
-                        "kind": "Literal",
-                        "name": "width",
-                        "value": 100
-                      }
-                    ],
-                    "concreteType": "CroppedImageUrl",
-                    "kind": "LinkedField",
-                    "name": "cropped",
-                    "plural": false,
-                    "selections": (v3/*: any*/),
-                    "storageKey": "cropped(height:100,version:\"square140\",width:100)"
-                  },
-                  {
-                    "alias": "mobile",
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "height",
-                        "value": 60
-                      },
-                      (v2/*: any*/),
-                      {
-                        "kind": "Literal",
-                        "name": "width",
-                        "value": 60
-                      }
-                    ],
-                    "concreteType": "CroppedImageUrl",
-                    "kind": "LinkedField",
-                    "name": "cropped",
-                    "plural": false,
-                    "selections": (v3/*: any*/),
-                    "storageKey": "cropped(height:60,version:\"square140\",width:60)"
-                  }
-                ],
-                "storageKey": null
-              },
-              (v4/*: any*/)
             ],
             "storageKey": null
           },
@@ -341,7 +358,7 @@ return {
             ],
             "storageKey": null
           },
-          (v4/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
@@ -352,7 +369,7 @@ return {
     "metadata": {},
     "name": "fairRoutes_FairQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  href\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  counts {\n    artworks\n  }\n  profile {\n    id\n  }\n}\n\nfragment FairHeaderIcon_fair on Fair {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 100, height: 100, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  ...FairHeaderIcon_fair\n  name\n  exhibitionPeriod\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
+    "text": "query fairRoutes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  href\n  slug\n  profile {\n    icon {\n      cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  counts {\n    artworks\n  }\n}\n\nfragment FairHeaderIcon_fair on Fair {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 100, height: 100, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  ...FairHeaderIcon_fair\n  name\n  exhibitionPeriod\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
[FX-3517]

This PR adds fair logo to tabs menu on fair page when this menu becomes sticky

We have received feedback that it needs to be clearer that users are still in the Fair area once they have gone past the banner on the Fair page.

**Why this is important**

Fair branding is still of utmost importance to our partners / they want the Artsy fair experience to feel more branded. Currently once users scroll past the main fair banner it's no longer clear that they are still in the fair microsite.

### Demo

#### Before

https://user-images.githubusercontent.com/44819355/141301986-63cbde13-4f43-4a29-9252-89298ac669e1.mp4


#### After

https://user-images.githubusercontent.com/44819355/141301739-48ee07d9-4cc0-483d-92ec-c28b49c71473.mp4



[FX-3517]: https://artsyproduct.atlassian.net/browse/FX-3517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ