### PR TITLE
[FX-3343] Remove clickedAppDownload helper

### DIFF
--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/SellWithArtsy.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/SellWithArtsy.tsx
@@ -1,9 +1,15 @@
-import * as React from "react";
+import * as React from "react"
 import { Box, Button, Flex, Image, Link, Text, color } from "@artsy/palette"
 import { SectionContainer } from "./SectionContainer"
+import { useAnalyticsContext } from "v2/System"
 import { Media } from "v2/Utils/Responsive"
 import { useTracking } from "react-tracking"
-import { ContextModule, OwnerType, clickedAppDownload } from "@artsy/cohesion"
+import {
+  ActionType,
+  ContextModule,
+  OwnerType,
+  ClickedAppDownload,
+} from "@artsy/cohesion"
 
 const DOWNLOAD_URL =
   "https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080"
@@ -11,15 +17,20 @@ const DOWNLOAD_URL =
 export const SellWithArtsy: React.FC = () => {
   const tracking = useTracking()
 
+  const { contextPageOwnerId, contextPageOwnerSlug } = useAnalyticsContext()
+
+  const clickedAppDownload: ClickedAppDownload = {
+    action: ActionType.clickedAppDownload,
+    context_module: ContextModule.sellFooter,
+    context_page_owner_type: OwnerType.consign,
+    context_page_owner_slug: contextPageOwnerSlug,
+    context_page_owner_id: contextPageOwnerId,
+    destination_path: DOWNLOAD_URL,
+    subject: "Download the app",
+  }
+
   const trackDownloadAppClick = () => {
-    tracking.trackEvent(
-      clickedAppDownload({
-        context_module: ContextModule.sellFooter,
-        context_page_owner_type: OwnerType.consign,
-        destination_path: DOWNLOAD_URL,
-        subject: "Download the app",
-      })
-    )
+    tracking.trackEvent(clickedAppDownload)
   }
 
   return (

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/SellWithArtsy.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/SellWithArtsy.jest.tsx
@@ -1,11 +1,14 @@
 import { mount } from "enzyme"
+import { useTracking } from "react-tracking"
 import { MockBoot } from "v2/DevTools"
 import { Breakpoint } from "@artsy/palette"
 import { SellWithArtsy, tests } from "../SellWithArtsy"
+import { Link } from "@artsy/palette"
 
 jest.mock("react-tracking")
 
 describe("SellWithArtsy", () => {
+  const trackEvent = jest.fn()
   const getWrapper = (breakpoint = "lg") => {
     return mount(
       <MockBoot breakpoint={breakpoint as Breakpoint}>
@@ -14,8 +17,41 @@ describe("SellWithArtsy", () => {
     )
   }
 
+  beforeEach(() => {
+    const mockTracking = useTracking as jest.Mock
+    mockTracking.mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
   it("links out to submission flow", () => {
     const wrapper = getWrapper()
     expect(wrapper.find("Link").props().href).toBe(tests.DOWNLOAD_URL)
+  })
+
+  it("tracks clicks on the app download link", () => {
+    const wrapper = mount(<SellWithArtsy />)
+    const downloadLink = wrapper.find(Link)
+    // @ts-expect-error STRICT_NULL_CHECK
+    downloadLink.props().onClick({} as any)
+    expect(trackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "clickedAppDownload",
+          "context_module": "sellFooter",
+          "context_page_owner_id": undefined,
+          "context_page_owner_slug": undefined,
+          "context_page_owner_type": "consign",
+          "destination_path": "https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080",
+          "subject": "Download the app",
+        },
+      ]
+    `)
   })
 })

--- a/src/v2/Components/DownloadAppBadge.tsx
+++ b/src/v2/Components/DownloadAppBadge.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import * as React from "react"
 import track, { useTracking } from "react-tracking"
-import { clickedAppDownload, ContextModule } from "@artsy/cohesion"
+import { ActionType, ClickedAppDownload, ContextModule } from "@artsy/cohesion"
 import { useAnalyticsContext } from "v2/System"
 import Events from "v2/Utils/Events"
 import { Link, LinkProps } from "@artsy/palette"
@@ -37,16 +37,17 @@ export const DownloadAppBadge: React.FC<DownloadAppBadgeProps> = track(null, {
   } = useAnalyticsContext()
 
   const handleClick = () => {
-    tracking.trackEvent(
-      clickedAppDownload({
-        context_module: contextModule,
-        context_page_owner_type: contextPageOwnerType!,
-        context_page_owner_slug: contextPageOwnerSlug,
-        context_page_owner_id: contextPageOwnerId,
-        destination_path: downloadAppUrl,
-        subject: "Download on the App Store",
-      })
-    )
+    const clickedAppDownload: ClickedAppDownload = {
+      action: ActionType.clickedAppDownload,
+      context_module: contextModule,
+      context_page_owner_type: contextPageOwnerType!,
+      context_page_owner_slug: contextPageOwnerSlug,
+      context_page_owner_id: contextPageOwnerId,
+      destination_path: downloadAppUrl,
+      subject: "Download on the App Store",
+    }
+
+    tracking.trackEvent(clickedAppDownload)
   }
 
   if (device === Device.Unknown) {

--- a/src/v2/Components/__tests__/DownloadAppBadge.jest.tsx
+++ b/src/v2/Components/__tests__/DownloadAppBadge.jest.tsx
@@ -7,12 +7,6 @@ import { Device } from "v2/Utils/Hooks/useDeviceDetection"
 
 describe("DownloadAppBadge", () => {
   const trackEvent = jest.fn()
-  const event = {
-    context_module: "footer",
-    subject: "Download on the App Store",
-    destination_path:
-      "https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080",
-  }
   const props = {
     contextModule: ContextModule.footer,
     device: Device.iPhone,
@@ -38,6 +32,18 @@ describe("DownloadAppBadge", () => {
     const downloadLink = badge.find(Link)
     // @ts-expect-error STRICT_NULL_CHECK
     downloadLink.props().onClick({} as any)
-    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining(event))
+    expect(trackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "clickedAppDownload",
+          "context_module": "footer",
+          "context_page_owner_id": undefined,
+          "context_page_owner_slug": undefined,
+          "context_page_owner_type": undefined,
+          "destination_path": "https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080",
+          "subject": "Download on the App Store",
+        },
+      ]
+    `)
   })
 })


### PR DESCRIPTION
[FX-3343]

Remove deprecated `clickedAppDownload` helper from the two components that were using it (`DownloadAppBadge` and `SellWithArtsy`), replacing it with `ClickedAppDownload` type that is [provided by cohesion](https://github.com/artsy/eigen/pull/5492/files#diff-f9f35322e1193efeb953aaf472a8d911d497795c25d0dd3ceaf6313e4ced9a8eR113).

[FX-3343]: https://artsyproduct.atlassian.net/browse/FX-3343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ