### PR TITLE
feat(FX-3514): remove exhibitors logo from list on Exhibitors A-Z tab

### DIFF
--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import { Box, Flex, Image, Text, BorderBox } from "@artsy/palette"
+import React from "react"
+import { Box, Flex, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useAnalyticsContext, useSystemContext, useTracking } from "v2/System"
 import {
@@ -60,25 +60,13 @@ export const FairExhibitorCard: React.FC<FairExhibitorCardProps> = ({
 
   return (
     <RouterLink
-      // use this param to display navigation banner on show
+      // use from_fair param to display navigation banner on show
       to={`/show/${exhibitor.profileID}?from_fair=true`}
       textDecoration="none"
       display="block"
       onClick={() => tracking.trackEvent(tappedPartnerTrackingData)}
     >
       <Flex id={`jump--${exhibitor.partner?.internalID}`}>
-        <BorderBox width={52} height={52} p={0} mr={1}>
-          {profile?.icon?.cropped && (
-            <Image
-              lazyLoad
-              src={profile?.icon?.cropped?.src}
-              srcSet={profile?.icon?.cropped?.srcSet}
-              alt={`Logo of ${name}`}
-              width={50}
-              height={50}
-            />
-          )}
-        </BorderBox>
         <Box>
           <Text variant="md" overflow="clip">
             {name}
@@ -123,12 +111,6 @@ export const FairExhibitorCardFragmentContainer = createFragmentContainer(
           cities
           profile {
             ...FollowProfileButton_profile
-            icon {
-              cropped(width: 50, height: 50) {
-                src
-                srcSet
-              }
-            }
           }
         }
       }

--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorsGroup.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorsGroup.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react"
 import { Column, GridColumns } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairExhibitorsGroup_exhibitorsGroup } from "v2/__generated__/FairExhibitorsGroup_exhibitorsGroup.graphql"
@@ -12,7 +12,7 @@ export const FairExhibitorsGroup: React.FC<FairExhibitorsGroupProps> = ({
   exhibitorsGroup: { exhibitors },
 }) => {
   return (
-    <GridColumns position="relative" gridRowGap={4}>
+    <GridColumns position="relative" gridRowGap={4} gridColumnGap={[0, 6]}>
       {exhibitors?.map(exhibitor => {
         if (!exhibitor?.partner) {
           return null

--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from "react";
-import * as React from "react";
+import React, { useEffect } from "react"
 import { Box, DROP_SHADOW, FullBleed, Spacer, Text } from "@artsy/palette"
 import { graphql, createFragmentContainer } from "react-relay"
 import { FairExhibitors_fair } from "v2/__generated__/FairExhibitors_fair.graphql"

--- a/src/v2/__generated__/FairExhibitorCard_exhibitor.graphql.ts
+++ b/src/v2/__generated__/FairExhibitorCard_exhibitor.graphql.ts
@@ -11,12 +11,6 @@ export type FairExhibitorCard_exhibitor = {
         readonly slug: string;
         readonly cities: ReadonlyArray<string | null> | null;
         readonly profile: {
-            readonly icon: {
-                readonly cropped: {
-                    readonly src: string;
-                    readonly srcSet: string;
-                } | null;
-            } | null;
             readonly " $fragmentRefs": FragmentRefs<"FollowProfileButton_profile">;
         } | null;
     } | null;
@@ -88,53 +82,6 @@ const node: ReaderFragment = {
           "plural": false,
           "selections": [
             {
-              "alias": null,
-              "args": null,
-              "concreteType": "Image",
-              "kind": "LinkedField",
-              "name": "icon",
-              "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "height",
-                      "value": 50
-                    },
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 50
-                    }
-                  ],
-                  "concreteType": "CroppedImageUrl",
-                  "kind": "LinkedField",
-                  "name": "cropped",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "src",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "srcSet",
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": "cropped(height:50,width:50)"
-                }
-              ],
-              "storageKey": null
-            },
-            {
               "args": null,
               "kind": "FragmentSpread",
               "name": "FollowProfileButton_profile"
@@ -148,5 +95,5 @@ const node: ReaderFragment = {
   ],
   "type": "FairExhibitor"
 };
-(node as any).hash = 'da98359cf26a7797eba752408b3f3f62';
+(node as any).hash = '05a4102e1727dc4949254af298a9e7ce';
 export default node;

--- a/src/v2/__generated__/FairExhibitors_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairExhibitors_Test_Query.graphql.ts
@@ -43,12 +43,6 @@ fragment FairExhibitorCard_exhibitor on FairExhibitor {
     cities
     profile {
       ...FollowProfileButton_profile
-      icon {
-        cropped(width: 50, height: 50) {
-          src
-          srcSet
-        }
-      }
       id
     }
     id
@@ -236,53 +230,6 @@ return {
                             "kind": "ScalarField",
                             "name": "isFollowed",
                             "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "kind": "LinkedField",
-                            "name": "icon",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "height",
-                                    "value": 50
-                                  },
-                                  {
-                                    "kind": "Literal",
-                                    "name": "width",
-                                    "value": 50
-                                  }
-                                ],
-                                "concreteType": "CroppedImageUrl",
-                                "kind": "LinkedField",
-                                "name": "cropped",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "src",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "srcSet",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": "cropped(height:50,width:50)"
-                              }
-                            ],
-                            "storageKey": null
                           }
                         ],
                         "storageKey": null
@@ -314,7 +261,7 @@ return {
     "metadata": {},
     "name": "FairExhibitors_Test_Query",
     "operationKind": "query",
-    "text": "query FairExhibitors_Test_Query(\n  $id: String!\n) {\n  fair(id: $id) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairExhibitorCard_exhibitor on FairExhibitor {\n  profileID\n  partner {\n    name\n    internalID\n    slug\n    cities\n    profile {\n      ...FollowProfileButton_profile\n      icon {\n        cropped(width: 50, height: 50) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      id\n    }\n    ...FairExhibitorCard_exhibitor\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n  ...ExhibitorsLetterNav_fair\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query FairExhibitors_Test_Query(\n  $id: String!\n) {\n  fair(id: $id) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairExhibitorCard_exhibitor on FairExhibitor {\n  profileID\n  partner {\n    name\n    internalID\n    slug\n    cities\n    profile {\n      ...FollowProfileButton_profile\n      id\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      id\n    }\n    ...FairExhibitorCard_exhibitor\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n  ...ExhibitorsLetterNav_fair\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/fairRoutes_FairExhibitorsQuery.graphql.ts
+++ b/src/v2/__generated__/fairRoutes_FairExhibitorsQuery.graphql.ts
@@ -43,12 +43,6 @@ fragment FairExhibitorCard_exhibitor on FairExhibitor {
     cities
     profile {
       ...FollowProfileButton_profile
-      icon {
-        cropped(width: 50, height: 50) {
-          src
-          srcSet
-        }
-      }
       id
     }
     id
@@ -236,53 +230,6 @@ return {
                             "kind": "ScalarField",
                             "name": "isFollowed",
                             "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "kind": "LinkedField",
-                            "name": "icon",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "height",
-                                    "value": 50
-                                  },
-                                  {
-                                    "kind": "Literal",
-                                    "name": "width",
-                                    "value": 50
-                                  }
-                                ],
-                                "concreteType": "CroppedImageUrl",
-                                "kind": "LinkedField",
-                                "name": "cropped",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "src",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "srcSet",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": "cropped(height:50,width:50)"
-                              }
-                            ],
-                            "storageKey": null
                           }
                         ],
                         "storageKey": null
@@ -314,7 +261,7 @@ return {
     "metadata": {},
     "name": "fairRoutes_FairExhibitorsQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairExhibitorCard_exhibitor on FairExhibitor {\n  profileID\n  partner {\n    name\n    internalID\n    slug\n    cities\n    profile {\n      ...FollowProfileButton_profile\n      icon {\n        cropped(width: 50, height: 50) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      id\n    }\n    ...FairExhibitorCard_exhibitor\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n  ...ExhibitorsLetterNav_fair\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query fairRoutes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairExhibitorCard_exhibitor on FairExhibitor {\n  profileID\n  partner {\n    name\n    internalID\n    slug\n    cities\n    profile {\n      ...FollowProfileButton_profile\n      id\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      id\n    }\n    ...FairExhibitorCard_exhibitor\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n  ...ExhibitorsLetterNav_fair\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Jira: [FX-3514](https://artsyproduct.atlassian.net/browse/FX-3514)

### Description
Remove the logo thumbnails from the AZ tab on the Fairs page.
Examples: https://www.artsy.net/fair/2021-art-taipei/exhibitors

Why? Too many exhibitors do not have a profile logo uploaded. When they do, it is too often getting cropped in a way that makes it illegible.
As a result, this page is looking buggy and unprofessional. We have already received complaints from fair organizers about it. Since many people view this page it also affects our brand.

It seems the easiest way around this would be to remove the thumbnails completely, just leave the gallery name and follow button.

### Changes
- updated graphql query
- removed logo component

### Demo

https://user-images.githubusercontent.com/56556580/141275756-94a957ee-2bbb-48f9-af18-8b7c96aec91f.mov


