### PR TITLE
[FX-3344] Remove clickedArticleGroup helper

### DIFF
--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ReadMore.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ReadMore.tsx
@@ -1,23 +1,30 @@
-import * as React from "react";
+import * as React from "react"
 import { Box, Column, GridColumns, Image, Text } from "@artsy/palette"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { useTracking } from "react-tracking"
-import { ContextModule, OwnerType, clickedArticleGroup } from "@artsy/cohesion"
+import {
+  ActionType,
+  ClickedArticleGroup,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
 import { cropped } from "v2/Utils/resized"
 
 export const ReadMore: React.FC = () => {
   const tracking = useTracking()
 
   const trackClick = ({ slug, internalID }) => {
-    tracking.trackEvent(
-      clickedArticleGroup({
-        context_module: ContextModule.relatedArticles,
-        context_page_owner_type: OwnerType.consign,
-        destination_page_owner_id: internalID,
-        destination_page_owner_slug: slug,
-        destination_page_owner_type: OwnerType.article,
-      })
-    )
+    const clickedArticleGroup: ClickedArticleGroup = {
+      action: ActionType.clickedArticleGroup,
+      context_module: ContextModule.relatedArticles,
+      context_page_owner_type: OwnerType.consign,
+      destination_page_owner_id: internalID,
+      destination_page_owner_slug: slug,
+      destination_page_owner_type: OwnerType.article,
+      type: "thumbnail",
+    }
+
+    tracking.trackEvent(clickedArticleGroup)
   }
 
   return (


### PR DESCRIPTION
[FX-3344]

Replace clickedArticleGroup helper usage on ReadMore component with [ClickedArticleGroup type](https://github.com/artsy/cohesion/blob/01b821a0f3ea5e67eaaca9876533998b86ac8eee/src/Schema/Events/Click.ts#L88) that is provided by cohesion.


[FX-3344]: https://artsyproduct.atlassian.net/browse/FX-3344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ