### PR TITLE
refactor(type-checking): Update strict null check migration flag to be less ambiguous 

### DIFF
--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -15,7 +15,7 @@ Links should point to specific commits, and not a branch (in case the branch or 
 - [When writing UI, use Palette](#when-writing-ui-use-palette)
 - [For routing, use our framework](#for-routing-use-our-framework)
 - [Leverage TypeScript to prevent runtime bugs](#leverage-typescript-to-prevent-runtime-bugs)
-- [Avoid copying and try to fix `// @ts-expect-error STRICT_NULL_CHECK` flags](#avoid-copying-and-try-to-fix--ts-expect-error-strict_null_check-flags)
+- [Avoid copying and try to fix `// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION` flags](#avoid-copying-and-try-to-fix--ts-expect-error-strict_null_check-flags)
 - [Use Relay for network requests](#use-relay-for-network-requests)
 - [Prefer Relay containers (higher order components) over relay-hooks](#prefer-relay-containers-higher-order-components-over-relay-hooks)
 - [Keep file structure organized](#keep-file-structure-organized)
@@ -45,9 +45,9 @@ To learn how to create a new sub-app, see [the docs](https://github.com/artsy/fo
 
 We use [TypeScript](https://www.typescriptlang.org/docs) to maximize runtime code safety.
 
-### Avoid copying and try to fix `// @ts-expect-error STRICT_NULL_CHECK` flags 
+### Avoid copying and try to fix `// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION` flags
 
-Around mid-2021 we migrated to strict type checking for **all new code**. What this meant in practice was that all _old code_ that failed strict type checking was silenced via a special flag inserted by a script (`// @ts-expect-error STRICT_NULL_CHECK`) with all _new code_ expected to adhere to best practices. Going forward, this flag should never be used, and if encounted while working on old code it should be removed and the type error fixed.
+Around mid-2021 we migrated to strict type checking for **all new code**. What this meant in practice was that all _old code_ that failed strict type checking was silenced via a special flag inserted by a script (`// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION`) with all _new code_ expected to adhere to best practices. Going forward, this flag should never be used, and if encounted while working on old code it should be removed and the type error fixed.
 
 ### Use Relay for network requests
 

--- a/scripts/better.js
+++ b/scripts/better.js
@@ -9,8 +9,10 @@ const path = require("path")
 
 const files = JSON.parse(results.value)
 
-const JS_COMMENT = "// @ts-expect-error STRICT_NULL_CHECK"
-const JSX_COMMENT = "{/* @ts-expect-error STRICT_NULL_CHECK */}"
+const JS_COMMENT =
+  "// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION"
+const JSX_COMMENT =
+  "{/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}"
 
 for (let [label, warnings] of Object.entries(files)) {
   let offset = 0

--- a/src/desktop/apps/art_keeps_going/routes.tsx
+++ b/src/desktop/apps/art_keeps_going/routes.tsx
@@ -41,7 +41,7 @@ export const landingPage = async (
     const layout = await stitch({
       basePath: __dirname,
       blocks: {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         body: bodyHTML,
         head: () => <Fragment>{headTags}</Fragment>,
       },
@@ -55,7 +55,7 @@ export const landingPage = async (
       },
     })
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     res.status(status).send(layout)
   } catch (error) {
     next(error)

--- a/src/desktop/apps/article/__tests__/helpers.jest.tsx
+++ b/src/desktop/apps/article/__tests__/helpers.jest.tsx
@@ -66,7 +66,7 @@ describe("ad display logic in Feature and Standard Articles", () => {
 
   it("checks the shouldAdRender prop is passed to Feature articles", () => {
     const articleType = FeatureArticle.layout
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const shouldRender = shouldAdRender(null, null, null, articleType)
 
     expect(shouldRender).toBe(true)
@@ -74,7 +74,7 @@ describe("ad display logic in Feature and Standard Articles", () => {
 
   it("checks the shouldAdRender prop is passed to Standard articles", () => {
     const articleType = StandardArticle.layout
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const shouldRender = shouldAdRender(null, null, null, articleType)
 
     expect(shouldRender).toBe(true)

--- a/src/desktop/apps/article/components/App.tsx
+++ b/src/desktop/apps/article/components/App.tsx
@@ -1,4 +1,4 @@
-import { Component, Fragment } from "react";
+import { Component, Fragment } from "react"
 import ReactDOM from "react-dom"
 import { Article } from "@artsy/reaction/dist/Components/Publishing"
 import { Mediator, SystemContextProvider } from "@artsy/reaction/dist/Artsy"
@@ -82,10 +82,10 @@ class EditPortal extends Component<ArticleProps> {
         <EditButton
           channelId={article.channel_id}
           slug={article.slug}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           positionTop={positionTop}
         />,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         document.getElementById("react-portal")
       )
     } catch (e) {

--- a/src/desktop/apps/article/components/InfiniteScrollArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollArticle.tsx
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import { Component } from "react"
 import { flatten } from "underscore"
 import Waypoint from "react-waypoint"
 import styled from "styled-components"
@@ -139,7 +139,7 @@ export class InfiniteScrollArticle extends Component<
       articles.map((article, i) => {
         const articleType = article.layout
         // Feature articles and Standard articles should return true
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const renderAd = shouldAdRender(null, null, null, articleType, isEigen)
 
         return (

--- a/src/desktop/apps/article/components/__tests__/EditButton.jest.tsx
+++ b/src/desktop/apps/article/components/__tests__/EditButton.jest.tsx
@@ -38,7 +38,7 @@ describe("EditButton", () => {
     mockPositronql.mockReturnValue(Promise.resolve(data))
     const component = getWrapper()
     const instance = component.find(EditButton).instance()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     await instance.componentDidMount()
 
     component.update()
@@ -57,7 +57,7 @@ describe("EditButton", () => {
     mockPositronql.mockReturnValue(Promise.resolve(data))
     const component = getWrapper()
     const instance = component.find(EditButton).instance()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     await instance.componentDidMount()
 
     expect(component.children().length).toBe(1)
@@ -71,7 +71,7 @@ describe("EditButton", () => {
     delete sd.CURRENT_USER
     const component = getWrapper()
     const instance = component.find(EditButton).instance()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     await instance.componentDidMount()
 
     expect(mockPositronql).not.toBeCalled()

--- a/src/desktop/apps/article/components/layouts/Article.tsx
+++ b/src/desktop/apps/article/components/layouts/Article.tsx
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import { Component } from "react"
 import { Article } from "@artsy/reaction/dist/Components/Publishing/Article"
 import { AppProps } from "../App"
 import { InfiniteScrollArticle } from "../InfiniteScrollArticle"
@@ -64,7 +64,7 @@ export class ArticleLayout extends Component<AppProps> {
 
     const isStatic = isSuper || article.seriesArticle || customEditorial
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const renderAd = shouldAdRender(null, null, null, article.layout, isEigen)
 
     return (

--- a/src/desktop/apps/articles/components/__tests__/AuthWrapper.jest.tsx
+++ b/src/desktop/apps/articles/components/__tests__/AuthWrapper.jest.tsx
@@ -27,7 +27,7 @@ jest.useFakeTimers()
 describe("AuthWrapper", () => {
   beforeEach(() => {
     jest.spyOn(mediator, "on")
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     delete sd.IS_MOBILE
     delete sd.CURRENT_USER
     window.addEventListener = jest.fn()

--- a/src/desktop/apps/auction/components/layout/__tests__/ConfirmRegistrationModal.jest.tsx
+++ b/src/desktop/apps/auction/components/layout/__tests__/ConfirmRegistrationModal.jest.tsx
@@ -13,12 +13,12 @@ describe("Confirm Registration Modal", () => {
   })
 
   describe("sanitizing the URL", () => {
-    xit("removes /confirm-registration from the url", () => {
+    it.skip("removes /confirm-registration from the url", () => {
       document.title = "big time"
       window.location.pathname = "/auction/auction-one/confirm-registration"
 
       act(() =>
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         renderTestComponent({
           Component: ConfirmRegistrationModal,
           options: { renderMode: "mount" },

--- a/src/desktop/apps/auction/components/layout/auction_info/Registration.tsx
+++ b/src/desktop/apps/auction/components/layout/auction_info/Registration.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import block from "bem-cn-lite"
 import { connect } from "react-redux"
 import { Button, Sans } from "@artsy/palette"
@@ -62,7 +62,7 @@ const Registration: React.FC<RegistrationProps> = props => {
 
   const b = block("auction-Registration")
   const trackClick = desc => e => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     window.analytics.track(desc, {
       context_type: "auctions landing",
       auction_slug: auction.id,
@@ -110,7 +110,7 @@ const Registration: React.FC<RegistrationProps> = props => {
                 <div className={b("wrapper")}>
                   <a
                     className={b("idv-link")}
-                    // @ts-expect-error STRICT_NULL_CHECK
+                    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                     href={`/identity-verification/${pendingIdentityVerification.internalID}`}
                   >
                     <Button

--- a/src/desktop/apps/auction/utils/__tests__/analyticsMiddleware.jest.ts
+++ b/src/desktop/apps/auction/utils/__tests__/analyticsMiddleware.jest.ts
@@ -27,7 +27,7 @@ describe("analytics middleware", () => {
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
     store.dispatch(action)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith(
       "Commercial filter params changed",
       {
@@ -53,7 +53,7 @@ describe("analytics middleware", () => {
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
     store.dispatch(action)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith(
       "Commercial filter params changed",
       {
@@ -79,7 +79,7 @@ describe("analytics middleware", () => {
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
     store.dispatch(action)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith(
       "Commercial filter params changed",
       {
@@ -105,7 +105,7 @@ describe("analytics middleware", () => {
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
     store.dispatch(action)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith(
       "Commercial filter params changed",
       {
@@ -128,7 +128,7 @@ describe("analytics middleware", () => {
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
     store.dispatch(action)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith(
       "Commercial filter params changed",
       {
@@ -150,7 +150,7 @@ describe("analytics middleware", () => {
     const action = { type: "TOGGLE_LIST_VIEW", payload: { isListView: true } }
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
     store.dispatch(action)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).not.toBeCalled()
   })
 })

--- a/src/desktop/apps/auction/utils/analyticsMiddleware.ts
+++ b/src/desktop/apps/auction/utils/analyticsMiddleware.ts
@@ -54,7 +54,7 @@ function trackParamChange(changed, newState) {
     { price: filterParams.estimate_range },
   ]
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   window.analytics.track("Commercial filter params changed", {
     sale_id: _id,
     auction_slug: id,

--- a/src/desktop/apps/auction_reaction/routes.tsx
+++ b/src/desktop/apps/auction_reaction/routes.tsx
@@ -27,7 +27,7 @@ const renderPage = async ({ layoutTemplate }, req, res, next) => {
     const layout = await stitch({
       basePath: __dirname,
       blocks: {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         body: bodyHTML,
         head: () => headTags,
       },

--- a/src/desktop/apps/authentication/routeHelpers.ts
+++ b/src/desktop/apps/authentication/routeHelpers.ts
@@ -55,7 +55,7 @@ export const computeStitchOptions = ({
 
   const copy = computeCopy({ intent, pageTitle, req, res, type })
   const redirectTo = getRedirectTo(req)
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const destination = req.query.destination || (isStaticAuthRoute && "/")
   const signupReferer = req.header("Referer") || req.hostname
 

--- a/src/desktop/apps/consign/client/__tests__/analyticsMiddleware.jest.ts
+++ b/src/desktop/apps/consign/client/__tests__/analyticsMiddleware.jest.ts
@@ -25,9 +25,9 @@ describe("analyticsMiddleware", () => {
     })
     store.dispatch({ type: "SUBMIT_ARTIST" })
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toHaveBeenCalledTimes(1)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith(
       "consignment_artist_confirmed",
       {
@@ -43,9 +43,9 @@ describe("analyticsMiddleware", () => {
       payload: { errorType: "convection_create" },
     })
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toHaveBeenCalledTimes(1)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith(
       "consignment_failed_to_submit",
       {
@@ -62,9 +62,9 @@ describe("analyticsMiddleware", () => {
       payload: { errorType: "convection_complete_submission" },
     })
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toHaveBeenCalledTimes(1)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith(
       "consignment_failed_to_submit",
       {
@@ -81,9 +81,9 @@ describe("analyticsMiddleware", () => {
       payload: { submissionId: 123 },
     })
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toHaveBeenCalledTimes(1)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith("consignment_submitted", {
       contextPath: undefined,
       submissionId: 123,
@@ -101,9 +101,9 @@ describe("analyticsMiddleware", () => {
     })
     store.dispatch({ type: "SUBMISSION_COMPLETED" })
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toHaveBeenCalledTimes(1)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith(
       "consignment_asset_uploaded",
       {

--- a/src/desktop/apps/consign/client/analytics_middleware.ts
+++ b/src/desktop/apps/consign/client/analytics_middleware.ts
@@ -25,7 +25,7 @@ const analyticsMiddleware = store => next => action => {
     case actions.SUBMISSION_COMPLETED: {
       const submissionId = nextState.submissionFlow.submission.id
       const assetIds = nextState.submissionFlow.assetIds
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       window.analytics.track("consignment_asset_uploaded", {
         submissionId,
         assetIds,
@@ -44,7 +44,7 @@ const analyticsMiddleware = store => next => action => {
         errors = "Error completing submission"
       }
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       window.analytics.track("consignment_failed_to_submit", {
         type: errorType,
         errors,
@@ -53,7 +53,7 @@ const analyticsMiddleware = store => next => action => {
     }
     case actions.SUBMIT_ARTIST: {
       const artistId = nextState.submissionFlow.inputs.artist_id
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       window.analytics.track("consignment_artist_confirmed", {
         artist_id: artistId,
       })

--- a/src/desktop/apps/consign/client/index.ts
+++ b/src/desktop/apps/consign/client/index.ts
@@ -19,7 +19,7 @@ export const init = () => {
     ".consignments-header .consignments-header__consign-button",
     function (e) {
       const buttonText = $(e.target).text()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       window.analytics.track("click", {
         type: "button",
         label: buttonText,
@@ -36,7 +36,7 @@ export const init = () => {
     ".consignments-how-consignments-work .consignments-section__consign-button",
     function (e) {
       const buttonText = $(e.target).text()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       window.analytics.track("click", {
         type: "button",
         label: buttonText,
@@ -53,7 +53,7 @@ export const init = () => {
     ".consignments-top-sales .consignments-section__consign-button",
     function (e) {
       const buttonText = $(e.target).text()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       window.analytics.track("click", {
         type: "button",
         label: buttonText,
@@ -70,7 +70,7 @@ export const init = () => {
     ".consignments-upcoming-sales .consignments-section__consign-button",
     function (e) {
       const buttonText = $(e.target).text()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       window.analytics.track("click", {
         type: "button",
         label: buttonText,
@@ -87,7 +87,7 @@ export const init = () => {
     ".consignments-footer .consignments-header__consign-button",
     function (e) {
       const buttonText = $(e.target).text()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       window.analytics.track("click", {
         type: "button",
         label: buttonText,

--- a/src/desktop/apps/consign/client/reducers.ts
+++ b/src/desktop/apps/consign/client/reducers.ts
@@ -109,7 +109,7 @@ function submissionFlow(state = initialState, action) {
       }
       return u(
         {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           uploadedImages: state.uploadedImages.concat(newImage),
         },
         state

--- a/src/desktop/apps/consign/client/submission.tsx
+++ b/src/desktop/apps/consign/client/submission.tsx
@@ -34,16 +34,16 @@ function setupSubmissionFlow() {
 
   const middleware = []
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   middleware.push(thunkMiddleware) // lets us dispatch() functions
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   middleware.push(routerMiddleware(history))
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   middleware.push(analyticsMiddleware) // middleware to help us track previous and future states
 
   if (sd.NODE_ENV === "development" || sd.NODE_ENV === "staging") {
     middleware.push(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       createLogger({
         // middleware that logs actions
         collapsed: true,
@@ -63,7 +63,7 @@ function setupSubmissionFlow() {
 
   // track pageviews when react-router updates the url
   history.listen(ev => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     window.analytics.page(
       { path: ev.pathname },
       { integrations: { Marketo: false } }

--- a/src/desktop/apps/consign/client/validate.ts
+++ b/src/desktop/apps/consign/client/validate.ts
@@ -14,7 +14,7 @@ export const scrollToError = errors => {
   const firstErrorElement = document.getElementsByName(firstError)[0]
   if (firstErrorElement) {
     window.scrollTo(0, firstErrorElement.offsetTop - scrollBuffer)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     firstErrorElement.querySelector("input").focus()
   }
 }

--- a/src/desktop/apps/consign/components/create_account/index.tsx
+++ b/src/desktop/apps/consign/components/create_account/index.tsx
@@ -24,11 +24,11 @@ export class CreateAccount extends Component<CreateAccountProps> {
 
     let analyticsParams = []
     if (artistId && artistName) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       analyticsParams.push(`artistId=${artistId}`, `artistName=${artistName}`)
     }
     if (contextPath && subject) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       analyticsParams.push(`contextPath=${contextPath}`, `subject=${subject}`)
     }
 

--- a/src/desktop/apps/editorial_features/components/gucci/components/App.tsx
+++ b/src/desktop/apps/editorial_features/components/gucci/components/App.tsx
@@ -1,5 +1,5 @@
 import { Box, Theme } from "@artsy/palette"
-import { Component } from "react";
+import { Component } from "react"
 import { debounce } from "lodash"
 import { FixedHeader } from "./nav/fixed_header"
 import { SeriesHeader } from "./series/series_header"
@@ -56,7 +56,7 @@ export class App extends Component<GucciProps, GucciState> {
   onChangeSection = index => {
     const section = this.props.curation.sections[index]
     this.setState({ activeSection: index })
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     document.getElementById(section.slug).scrollIntoView()
   }
 

--- a/src/desktop/apps/editorial_features/components/gucci/components/nav/header.tsx
+++ b/src/desktop/apps/editorial_features/components/gucci/components/nav/header.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components"
-import * as React from "react";
+import * as React from "react"
 import { PartnerInline } from "@artsy/reaction/dist/Components/Publishing/Partner/PartnerInline"
 import {
   Clickable,
@@ -25,7 +25,7 @@ export const Header: React.SFC<HeaderProps> = props => {
 
   return (
     <HeaderMain justifyContent="space-between" alignItems="center">
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <PartnerInline
         url={partner_url}
         logo={partner_logo}

--- a/src/desktop/apps/editorial_features/components/gucci/components/nav/sections_nav.tsx
+++ b/src/desktop/apps/editorial_features/components/gucci/components/nav/sections_nav.tsx
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from "styled-components"
-import * as React from "react";
+import * as React from "react"
 import { Flex, Sans, color } from "@artsy/palette"
 
 interface SectionsNavProps {
@@ -14,7 +14,7 @@ export const SectionsNav: React.SFC<SectionsNavProps> = props => {
 
   return (
     <SectionsNavContainer
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       isAnimated={animated}
       mx="auto"
       mt={[4, 6]}
@@ -27,12 +27,12 @@ export const SectionsNav: React.SFC<SectionsNavProps> = props => {
       {sections.map((section, index) => (
         <SectionItem onClick={() => onClick(index)} key={"nav-" + index}>
           <Title
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             mt={animated && [4, 6]}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             mb={animated && [2, 5]}
             size={["10", "10", "10", "14"]}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             mx={animated && [3]}
             color={activeSection === index ? "black" : color("black10")}
           >

--- a/src/desktop/apps/editorial_features/components/gucci/components/series/series_footer.tsx
+++ b/src/desktop/apps/editorial_features/components/gucci/components/series/series_footer.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { PartnerBlock, Text } from "@artsy/reaction/dist/Components/Publishing"
 import { Box, Flex, Sans } from "@artsy/palette"
 import { Media } from "@artsy/reaction/dist/Utils/Responsive"
@@ -33,7 +33,7 @@ export const SeriesFooter: React.SFC<SeriesFooterProps> = props => {
         </Sans>
         <Media greaterThanOrEqual="lg">
           <Box pb={10}>
-            {/* @ts-expect-error STRICT_NULL_CHECK */}
+            {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             <PartnerBlock
               logo={logoSrc}
               url={logoUrl}
@@ -50,7 +50,7 @@ export const SeriesFooter: React.SFC<SeriesFooterProps> = props => {
         <Text html={curation.about} layout="standard" />
         <Media lessThan="md">
           <Box pt={80}>
-            {/* @ts-expect-error STRICT_NULL_CHECK */}
+            {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             <PartnerBlock
               logo={logoSrc}
               url={logoUrl}

--- a/src/desktop/apps/editorial_features/components/gucci/components/series/series_header.tsx
+++ b/src/desktop/apps/editorial_features/components/gucci/components/series/series_header.tsx
@@ -1,6 +1,6 @@
 import { Box, media } from "@artsy/palette"
 import styled from "styled-components"
-import * as React from "react";
+import * as React from "react"
 import Waypoint from "react-waypoint"
 import { Header } from "../nav/header"
 import { SectionsNav } from "../nav/sections_nav"
@@ -28,7 +28,7 @@ export const SeriesHeader: React.SFC<SeriesHeaderProps> = props => {
       </Box>
       <Waypoint onEnter={() => inBody(false)} onLeave={() => inBody(true)} />
       <SectionsNav
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         activeSection={null}
         sections={curation.sections}
         onClick={onChangeSection}

--- a/src/desktop/apps/personalize/client/onboarding.tsx
+++ b/src/desktop/apps/personalize/client/onboarding.tsx
@@ -22,7 +22,7 @@ const BrowserRouter = createBrowserRouter({
   ),
 })
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 const Onboarding = track(null, {
   dispatch: Events.postEvent,
 })(() => {

--- a/src/desktop/apps/personalize/test/routes.jest.ts
+++ b/src/desktop/apps/personalize/test/routes.jest.ts
@@ -80,7 +80,7 @@ describe("Personalize routes", () => {
     })
 
     it("calls next when there is a user", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       response.locals.sd.CURRENT_USER = {}
 
       ensureLoggedInUser(request, response, mockNext)

--- a/src/desktop/assets/analytics.ts
+++ b/src/desktop/assets/analytics.ts
@@ -14,7 +14,7 @@ beforeAnalyticsReady()
 trackPageView(excludedRoutes)
 
 document.addEventListener("DOMContentLoaded", () => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   window.analytics.ready(() => {
     onAnalyticsReady()
   })

--- a/src/desktop/components/inquiry_questionnaire/analytics/events.ts
+++ b/src/desktop/components/inquiry_questionnaire/analytics/events.ts
@@ -18,12 +18,12 @@ import { setAnalyticsClientReferrerOptions } from "lib/analytics/setAnalyticsCli
 
   track = function (event, props = {}) {
     event = namespace(" " + event)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     window.analytics.track(event, props, setAnalyticsClientReferrerOptions())
   }
 
   trackWithoutNamespace = function (event, props = {}) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     window.analytics.track(event, props, setAnalyticsClientReferrerOptions())
   }
 

--- a/src/desktop/components/inquiry_questionnaire/analytics/index.ts
+++ b/src/desktop/components/inquiry_questionnaire/analytics/index.ts
@@ -21,7 +21,7 @@ export function attachInquiryAnalyticsHooks(context) {
   const hooks = []
   const pendingHooks = pick(context, proxy)
   for (let event in pendingHooks) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     hooks.push(context[event].on("all", trigger(underscored(event))))
   }
   return hooks
@@ -33,7 +33,7 @@ export function teardownInquiryAnalyticsHooks(context) {
 
   for (let hook in pendingHooks) {
     const event = pendingHooks[hook]
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     hooks.push(event.off(null, null, this))
   }
   return hooks

--- a/src/desktop/components/react/stitch_components/ReactionTooltipQuestion.tsx
+++ b/src/desktop/components/react/stitch_components/ReactionTooltipQuestion.tsx
@@ -3,7 +3,7 @@ import { Tooltip } from "v2/Components/Tooltip"
 
 export const ReactionTooltipQuestion = props => {
   return (
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     <Tooltip {...props}>
       <HelpIcon />
     </Tooltip>

--- a/src/desktop/lib/__tests__/global_client_setup.jest.ts
+++ b/src/desktop/lib/__tests__/global_client_setup.jest.ts
@@ -25,7 +25,7 @@ describe("deprecatedGlobalClientSetup", () => {
         { expires: 86400 }
       )
       trackAuthenticationEvents()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(window.analytics.track).toBeCalledWith("createdAccount", {
         auth_redirect: "/artist/andy-warhol",
         context_module: "popUpModal",
@@ -37,7 +37,7 @@ describe("deprecatedGlobalClientSetup", () => {
         type: "signup",
         user_id: "123",
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(window.analytics.identify).toBeCalledWith(
         "123",
         "user@email.com",
@@ -55,7 +55,7 @@ describe("deprecatedGlobalClientSetup", () => {
         { expires: 86400 }
       )
       trackAuthenticationEvents()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(window.analytics.track).toBeCalledWith("successfullyLoggedIn", {
         auth_redirect: "/artist/andy-warhol",
         context_module: "popUpModal",
@@ -66,7 +66,7 @@ describe("deprecatedGlobalClientSetup", () => {
         type: "login",
         user_id: "123",
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(window.analytics.identify).toBeCalledWith(
         "123",
         "user@email.com",

--- a/src/desktop/lib/deprecated_global_client_setup.tsx
+++ b/src/desktop/lib/deprecated_global_client_setup.tsx
@@ -150,7 +150,7 @@ export function trackAuthenticationEvents() {
       if (user) {
         const { action } = data
         const analyticsOptions = omit(data, "action")
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         window.analytics.track(action, {
           ...analyticsOptions,
           user_id: user && user.id,
@@ -163,7 +163,7 @@ export function trackAuthenticationEvents() {
 
 function analyticsIdentify(user) {
   // FIXME: add typings for user
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   window.analytics.identify(user.id, user.email, {
     integrations: {
       All: false,

--- a/src/desktop/test/models/fair.jest.ts
+++ b/src/desktop/test/models/fair.jest.ts
@@ -91,12 +91,12 @@ describe("Fair", () => {
   describe("#fetchOverviewData", () => {
     it("fetches a ton of data in parallel for the fair page", () => {
       testContext.fair.fetchOverviewData({})
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       _.last(Backbone.sync.args)[2].success(
         new Backbone.Model(fabricate("profile"))
       )
       const urls = Array.from(Backbone.sync.args).map(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         call => _.result(call[1], "url") || call[2].url
       )
       urls[0].should.match(new RegExp(`api/v1/fair/.*`))

--- a/src/desktop/test/models/sale_artwork.jest.ts
+++ b/src/desktop/test/models/sale_artwork.jest.ts
@@ -173,13 +173,13 @@ describe("SaleArtwork", () => {
           done()
         },
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       _.last(Backone.sync.args)[2].success()
       testContext.saleArtwork.set({ highest_bid_amount_cents: 100 })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       _.last(Backone.sync.args)[2].success()
       testContext.saleArtwork.set({ highest_bid_amount_cents: 200 })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       _.last(Backone.sync.args)[2].success()
       // @ts-ignore
       setInterval.restore()

--- a/src/lib/__tests__/current_user.jest.ts
+++ b/src/lib/__tests__/current_user.jest.ts
@@ -265,7 +265,7 @@ describe("CurrentUser", () => {
   describe("#followArtist", () => {
     it("follows an artist", () => {
       user.followArtist("andy-foobar", {})
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       last(Backbone.sync.mock.calls)[1]
         .url()
         .should.containEql("me/follow/artist")
@@ -274,7 +274,7 @@ describe("CurrentUser", () => {
     it("injects the access token", () => {
       user.set({ accessToken: "xfoobar" })
       user.followArtist("andy-foobar", {})
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       last(Backbone.sync.mock.calls)[2].access_token.should.equal("xfoobar")
     })
   })

--- a/src/lib/__tests__/getContextPage.jest.ts
+++ b/src/lib/__tests__/getContextPage.jest.ts
@@ -44,7 +44,7 @@ describe("getContextPageFromReq", () => {
 
 describe("getContextPageFromClient", () => {
   it("returns correct props", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     delete window.location
     // @ts-ignore
     window.location = new URL("https://artsy.net/artist/test-artist")
@@ -60,7 +60,7 @@ describe("getContextPageFromClient", () => {
   })
 
   it("handles camelcasing", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     delete window.location
     // @ts-ignore
     window.location = new URL(

--- a/src/lib/analytics/__tests__/helpers.jest.ts
+++ b/src/lib/analytics/__tests__/helpers.jest.ts
@@ -20,7 +20,7 @@ describe("#trackEvent", () => {
       context_page_owner_slug: "andy-warhol",
       context_page_owner_type: OwnerType.artist,
     })
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith(
       "Time on page",
       {
@@ -41,7 +41,7 @@ describe("#trackEvent", () => {
         contextPageOwnerType: OwnerType.artist,
       })
     )
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).toBeCalledWith(
       "timeOnPage",
       {
@@ -61,9 +61,9 @@ describe("#trackEvent", () => {
       context_page_owner_slug: "andy-warhol",
       context_page_owner_type: OwnerType.artist,
     })
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.track).not.toBeCalled()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(window.analytics.page).toBeCalledWith(
       { path: "/" },
       { integrations: { Marketo: false } }

--- a/src/lib/analytics/helpers.ts
+++ b/src/lib/analytics/helpers.ts
@@ -23,7 +23,7 @@ export const trackEvent = (data: any, options: object = {}) => {
     const trackingOptions = setAnalyticsClientReferrerOptions(options)
 
     // Send event to segment
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     window.analytics.track(actionName, trackingData, trackingOptions)
   } else {
     console.error(
@@ -63,7 +63,7 @@ export const onAnalyticsReady = () => {
 const onClickedReadMore = data => {
   const pathname = data.pathname || location.pathname
   const href = window.sd.APP_URL + "/" + pathname
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   window.analytics.page(
     { path: pathname },
     { integrations: { Marketo: false } }
@@ -91,7 +91,7 @@ const logAnalyticsCalls = () => {
   const mobileText = sd.IS_MOBILE ? "MOBILE " : ""
 
   // Log all pageviews
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   window.analytics.on("page", function () {
     console.info(
       `${mobileText}ANALYTICS PAGEVIEW: `,
@@ -100,12 +100,12 @@ const logAnalyticsCalls = () => {
     )
   })
   // Log all track calls
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   window.analytics.on("track", (actionName: string, data?: any) => {
     console.info(`${mobileText}ANALYTICS TRACK:`, actionName, data)
   })
   // Log all identify calls
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   window.analytics.on(
     "identify",
     (userId: string, data: object, context: any) => {
@@ -131,7 +131,7 @@ const identify = () => {
     const traits = extend(pick(sd.CURRENT_USER, allowedlist), {
       session_id: sd.SESSION_ID,
     })
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     window.analytics.identify(sd.CURRENT_USER.id, traits, {
       integrations: { Marketo: false },
     })

--- a/src/lib/analytics/setAnalyticsClientReferrerOptions.ts
+++ b/src/lib/analytics/setAnalyticsClientReferrerOptions.ts
@@ -5,7 +5,7 @@
  * @param options page/referrer properties object, NOT event data
  */
 export const setAnalyticsClientReferrerOptions = (options: object = {}) => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const referrer = window.analytics.__artsyClientSideRoutingReferrer
   let trackingOptions = options
 

--- a/src/lib/analytics/trackPageView.ts
+++ b/src/lib/analytics/trackPageView.ts
@@ -32,7 +32,7 @@ export const trackPageView = (excludedRoutes: string[] = []) => {
       window.PARSELY = { autotrack: false }
     }
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     window.analytics.page(properties, { integrations: { Marketo: false } })
   }
 }
@@ -49,7 +49,7 @@ const maybeTrackAuctionPageView = () => {
     if (!matchedBidRoute) {
       window.addEventListener("load", function () {
         // distinct event required for marketing integrations (Criteo)
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         window.analytics.track("Auction Pageview", { auction_slug: pageSlug })
       })
     }

--- a/src/lib/cacheClient.tsx
+++ b/src/lib/cacheClient.tsx
@@ -25,7 +25,7 @@ const safeCacheCommand = async (func, ...args) => {
       // Will reject promise after configured timeout if the
       // cache command has not completed yet.
       let timeoutId = setTimeout(() => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         timeoutId = null
         const error = new Error(
           `Timeout of ${cacheAccessTimeoutMs}ms, skipping...`

--- a/src/lib/getContextPage.ts
+++ b/src/lib/getContextPage.ts
@@ -26,7 +26,7 @@ export function getContextPageFromReq({
   }
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 export function getContextPageFromClient(): {
   canonicalUrl: string
   pageParts: string[]

--- a/src/lib/metaphysics.ts
+++ b/src/lib/metaphysics.ts
@@ -55,7 +55,7 @@ export const metaphysics = function (
 
     if (token) {
       post.set({ "X-ACCESS-TOKEN": token })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       post.set({ "X-USER-ID": req.user.id })
     }
 

--- a/src/lib/middleware/__tests__/sameOrigin.jest.ts
+++ b/src/lib/middleware/__tests__/sameOrigin.jest.ts
@@ -13,7 +13,7 @@ describe("Same origin middleware", () => {
     res = {
       headers,
       set(name, value) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         return (headers[name] = value)
       },
     }

--- a/src/lib/middleware/morgan.ts
+++ b/src/lib/middleware/morgan.ts
@@ -55,13 +55,13 @@ type Options = {
 
 export function morganMiddleware(options: Options): RequestHandler {
   if (options.development) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     return morgan("dev", {
       skip: options.logAssets ? null : skipAssets,
     })
   }
   return morgan(logFormat, {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     skip: options.logAssets ? null : skipAssets,
   })
 }

--- a/src/lib/userPerformanceMetrics.ts
+++ b/src/lib/userPerformanceMetrics.ts
@@ -60,7 +60,7 @@ export function measure(
  */
 export function getUserTiming() {
   if (typeof PerformanceMark === "undefined") return null
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const marks = perf.getEntriesByType("mark").map(mark => {
     return {
       type: "mark",
@@ -68,7 +68,7 @@ export function getUserTiming() {
       startTime: Math.round(mark.startTime),
     }
   })
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const measures = perf.getEntriesByType("measure").map(measure => {
     return {
       type: "measure",
@@ -86,7 +86,7 @@ export function getUserTiming() {
  */
 export function getFirstPaint() {
   if (typeof PerformancePaintTiming === "undefined") return null
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const firstPaint = perf
     .getEntriesByType("paint")
     .find(({ name }) => name === "first-paint")
@@ -98,7 +98,7 @@ export function getFirstPaint() {
  */
 export function getFirstContentfulPaint() {
   if (typeof PerformancePaintTiming === "undefined") return null
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const firstContentfulPaint = perf
     .getEntriesByType("paint")
     .find(({ name }) => name === "first-contentful-paint")
@@ -112,7 +112,7 @@ export function getFirstContentfulPaint() {
  */
 export function getLoadEventEnd() {
   if (!timingAvailable) return null
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   return sanitizedMetrics(perf.timing.requestStart, perf.timing.loadEventEnd)
 }
 
@@ -124,7 +124,7 @@ export function getLoadEventEnd() {
  */
 export function getDomInteractive() {
   if (!timingAvailable) return null
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   return sanitizedMetrics(perf.timing.requestStart, perf.timing.domInteractive)
 }
 
@@ -138,9 +138,9 @@ export function getDomInteractive() {
 export function getDomContentLoadedStart() {
   if (!timingAvailable) return null
   return sanitizedMetrics(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     perf.timing.requestStart,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     perf.timing.domContentLoadedEventStart
   )
 }
@@ -154,9 +154,9 @@ export function getDomContentLoadedStart() {
 export function getDomContentLoadedEnd() {
   if (!timingAvailable) return null
   return sanitizedMetrics(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     perf.timing.requestStart,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     perf.timing.domContentLoadedEventEnd
   )
 }
@@ -169,7 +169,7 @@ export function getDomContentLoadedEnd() {
  */
 export function getDomComplete() {
   if (!timingAvailable) return null
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   return sanitizedMetrics(perf.timing.requestStart, perf.timing.domComplete)
 }
 

--- a/src/lib/volley.ts
+++ b/src/lib/volley.ts
@@ -21,7 +21,7 @@ const defaultMetrics: MetricMap = {
   "load-event-end": getLoadEventEnd,
   "first-paint": getFirstPaint,
   "first-contentful-paint": getFirstContentfulPaint,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   "time-to-interactive": getTTI,
 }
 

--- a/src/mobile/apps/partner_profile/client/contact.ts
+++ b/src/mobile/apps/partner_profile/client/contact.ts
@@ -3,7 +3,7 @@ import $ from "jquery"
   "use strict"
 
   $(".partner-profile-contact-email a").click(function (e) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     window.analytics.track("Click", {
       partner_id: $(e.currentTarget).data("partner-id"),
       label: "Contact gallery by email",
@@ -11,7 +11,7 @@ import $ from "jquery"
   })
 
   $(".partner-profile-contact-website a").click(function (e) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     window.analytics.track("Click", {
       partner_id: $(e.currentTarget).data("partner-id"),
       label: "External partner site",

--- a/src/mobile/assets/mobile_analytics.ts
+++ b/src/mobile/assets/mobile_analytics.ts
@@ -6,7 +6,7 @@ beforeAnalyticsReady()
 trackPageView()
 
 document.addEventListener("DOMContentLoaded", () => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   window.analytics.ready(() => {
     onAnalyticsReady()
   })

--- a/src/mobile/components/layout/test/layout.jest.ts
+++ b/src/mobile/components/layout/test/layout.jest.ts
@@ -9,7 +9,7 @@ jest.mock("desktop/lib/deprecated_global_client_setup", () => ({
 
 describe("bootstrap", () => {
   beforeAll(() => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     mediator.on = jest.fn((_e, cb) => cb())
   })
 

--- a/src/v2/Apps/Artist/Components/ArtistMeta.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistMeta.tsx
@@ -1,7 +1,7 @@
 import { ArtistMeta_artist } from "v2/__generated__/ArtistMeta_artist.graphql"
 import { Person as SeoDataForArtist } from "v2/Components/Seo/Person"
 import { identity, pickBy } from "lodash"
-import { Component } from "react";
+import { Component } from "react"
 import { Meta } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
@@ -12,7 +12,7 @@ interface Props {
   artist: ArtistMeta_artist
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 type ArtworkNode = ArtistMeta_artist["artworks_connection"]["edges"][0]["node"]
 
 export const sellerFromPartner = (partner: ArtworkNode["partner"]) => {
@@ -55,7 +55,7 @@ export const imageObjectAttributes = (item: ItemWithImage) => {
 }
 
 export const offersAttributes = (artist: ArtistMeta_artist) => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const { edges } = artist.artworks_connection
 
   const offers =
@@ -159,16 +159,16 @@ export const structuredDataAttributes = (artist: ArtistMeta_artist) => {
 export class ArtistMeta extends Component<Props> {
   renderImageMetaTags() {
     const { artist } = this.props
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const hasImage = artist.image && artist.image.versions.length
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     if (hasImage && artist.image.versions.indexOf("large") !== -1) {
       return (
         <>
           <Meta property="twitter:card" content="summary_large_image" />
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <Meta property="og:image" content={artist.image.large} />
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <Meta name="thumbnail" content={artist.image.square} />
         </>
       )
@@ -183,7 +183,7 @@ export class ArtistMeta extends Component<Props> {
 
   maybeRenderNoIndex() {
     const { artist } = this.props
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     if (artist.counts.artworks === 0 && !artist.blurb) {
       return (
         <>
@@ -205,13 +205,13 @@ export class ArtistMeta extends Component<Props> {
       <>
         <ArtistMetaCanonicalLink artist={artist} />
 
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <Meta name="description" content={artist.meta.description} />
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <Meta property="og:description" content={artist.meta.description} />
         <Meta
           property="twitter:description"
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           content={artist.meta.description}
         />
         <Meta property="og:url" href={`${sd.APP_URL}/artist/${artist.slug}`} />

--- a/src/v2/Apps/Artist/Components/ArtistMetaCanonicalLink.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistMetaCanonicalLink.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Link } from "react-head"
 import { data as sd } from "sharify"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -39,10 +39,10 @@ export const ArtistMetaCanonicalLink: React.FC<ArtistMetaCanonicalLinkProps> = (
 }) => {
   const { pathname } = useRouter().match.location
   const hasArtistInsights =
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     hasSections(artist) || (artist.insights && artist.insights.length > 0)
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const hasArtistContent = hasOverviewContent(artist)
   const canShowOverview = hasArtistInsights || hasArtistContent
 

--- a/src/v2/Apps/Artist/Components/__tests__/ArtistMeta.jest.tsx
+++ b/src/v2/Apps/Artist/Components/__tests__/ArtistMeta.jest.tsx
@@ -14,9 +14,9 @@ jest.mock("sharify", () => ({
 
 describe("Meta", () => {
   const artist: ArtistMeta_artist = {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     " $fragmentRefs": null,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     " $refType": null,
     alternate_names: null,
     birthday: "1929",
@@ -81,7 +81,7 @@ describe("Meta", () => {
     nationality: "Swedish",
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   type ArtworkMeta = ArtistMeta_artist["artworks_connection"]["edges"][number]["node"]
 
   const artistWithArtworkOverrides = (
@@ -93,7 +93,7 @@ describe("Meta", () => {
         edges: [
           {
             node: {
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               ...artist.artworks_connection.edges[0].node,
               ...artwork,
             },
@@ -227,7 +227,7 @@ describe("Meta", () => {
     })
 
     it("#productFromArtistArtwork construct product object from artist/artwork", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const artwork = artist.artworks_connection.edges[0].node
       const json = productAttributes(artist, artwork)
 
@@ -263,7 +263,7 @@ describe("Meta", () => {
       const modifiedArtist = artistWithArtworkOverrides({
         listPrice: null,
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const artwork = modifiedArtist.artworks_connection.edges[0].node
       const json = productAttributes(modifiedArtist, artwork)
       expect(json).toBeFalsy()
@@ -282,7 +282,7 @@ describe("Meta", () => {
           },
         } as const,
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const artwork = modifiedArtist.artworks_connection.edges[0].node
       const json = productAttributes(modifiedArtist, artwork)
       expect(json).toMatchObject({
@@ -304,7 +304,7 @@ describe("Meta", () => {
           minPrice: null,
         } as const,
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const artwork = modifiedArtist.artworks_connection.edges[0].node
       const json = productAttributes(modifiedArtist, artwork)
       expect(json).toBeFalsy()
@@ -321,7 +321,7 @@ describe("Meta", () => {
           },
         } as const,
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const artwork = modifiedArtist.artworks_connection.edges[0].node
       const json = productAttributes(modifiedArtist, artwork)
       expect(json).toMatchObject({
@@ -333,7 +333,7 @@ describe("Meta", () => {
     })
 
     it("#sellerFromPartner constructs seller object from partner", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const partner = artist.artworks_connection.edges[0].node.partner
       const json = sellerFromPartner(partner)
       expect(json).toEqual({

--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -142,7 +142,7 @@ const LargeAuctionItem: FC<Props> = props => {
     salePriceUSD,
   } = getProps(props)
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const imageUrl = get(images, i => i.thumbnail.url, "")
   const dateOfSale = getDisplaySaleDate(saleDate)
 
@@ -237,7 +237,7 @@ const ExtraSmallAuctionItem: FC<Props> = props => {
     salePrice,
     salePriceUSD,
   } = getProps(props)
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const imageUrl = get(images, i => i.thumbnail.url, "")
   const dateOfSale = getDisplaySaleDate(saleDate)
 
@@ -535,7 +535,7 @@ const renderLargeCollapse = (props, user, mediator, filtersAtDefault) => {
   const dateOfSale = getDisplaySaleDate(saleDate)
 
   return (
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     <Collapse open={expanded}>
       <Separator />
       <Box p={2}>
@@ -609,7 +609,7 @@ const renderSmallCollapse = (props, user, mediator, filtersAtDefault) => {
   const dateOfSale = getDisplaySaleDate(saleDate)
 
   return (
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     <Collapse open={expanded}>
       <Separator />
       <Box p={2}>

--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -10,8 +10,8 @@ import {
   themeProps,
 } from "@artsy/palette"
 import { isEqual } from "lodash"
-import { useContext, useState } from "react";
-import * as React from "react";
+import { useContext, useState } from "react"
+import * as React from "react"
 import { Title } from "react-head"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -146,7 +146,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
         // If user is not logged-in, show auth modal, but only if it was never shown before.
         if (!user && !authShownForFiltering) {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           openAuthModal(mediator, {
             contextModule: ContextModule.auctionResults,
             copy: `Sign up to see auction results for ${artistName}`,
@@ -269,7 +269,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
           {auctionResultsLength > 0 ? (
             <LoadingArea isLoading={isLoading}>
-              {/* @ts-expect-error STRICT_NULL_CHECK */}
+              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
               {artist.auctionResultsConnection.edges.map(({ node }, index) => {
                 return (
                   <React.Fragment key={index}>
@@ -293,7 +293,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
           <Pagination
             getHref={() => ""}
             hasNextPage={Boolean(pageInfo?.hasNextPage)}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             pageCursors={artist.auctionResultsConnection.pageCursors}
             onClick={(_cursor, page) => loadPage(_cursor, page)}
             onNext={() => loadNext()}

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignFAQ.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignFAQ.tsx
@@ -1,7 +1,7 @@
 import { Box, Sans, Serif, Spacer } from "@artsy/palette"
 import { ArtistConsignFAQ_artist } from "v2/__generated__/ArtistConsignFAQ_artist.graphql"
 import { AnalyticsSchema, useTracking } from "v2/System"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SectionContainer } from "./SectionContainer"
 import { Subheader } from "./Subheader"
@@ -52,7 +52,7 @@ const ArtistConsignFAQ: React.FC<ArtistConsignFAQProps> = props => {
                     })
                   }}
                   href={getConsignSubmissionUrl({
-                    // @ts-expect-error STRICT_NULL_CHECK
+                    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                     contextPath: props.artist.href,
                     subject: AnalyticsSchema.Subject.Here,
                   })}

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHeader/ArtistConsignHeaderImages.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHeader/ArtistConsignHeaderImages.tsx
@@ -1,11 +1,11 @@
 import { Box, Flex } from "@artsy/palette"
 import { ArtistConsignHeaderImages_artist } from "v2/__generated__/ArtistConsignHeaderImages_artist.graphql"
 import { last } from "lodash"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 type Artworks = ArtistConsignHeaderImages_artist["targetSupply"]["microfunnel"]["artworksConnection"]["edges"]
 
 interface HeaderImageProps {
@@ -14,10 +14,10 @@ interface HeaderImageProps {
 
 export const ArtistConsignHeaderImages: React.FC<HeaderImageProps> = props => {
   const leftImage =
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     props.artist.targetSupply.microfunnel?.artworksConnection?.edges?.[0]?.node
   const rightImage = last(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     props.artist.targetSupply.microfunnel?.artworksConnection?.edges
   )?.node
   const error = !(leftImage && rightImage)
@@ -28,11 +28,11 @@ export const ArtistConsignHeaderImages: React.FC<HeaderImageProps> = props => {
     <HeaderImageContainer>
       <Flex width="100%" justifyContent="space-between" m="auto">
         <LeftImage>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <LeftImagePhoto {...leftImage} />
         </LeftImage>
         <RightImage>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <RightImagePhoto {...rightImage} />
         </RightImage>
       </Flex>

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHeader/index.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHeader/index.tsx
@@ -6,7 +6,7 @@ import {
 } from "v2/Apps/Artist/Routes/Consign/Components/SectionContainer"
 import { AnalyticsSchema, useTracking } from "v2/System"
 import { RouterLink } from "v2/System/Router/RouterLink"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "v2/Utils/Responsive"
 import { getConsignSubmissionUrl } from "../Utils/getConsignSubmissionUrl"
@@ -56,7 +56,7 @@ export const ArtistConsignHeader: React.FC<ArtistConsignHeaderProps> = ({
         <Box>
           <RouterLink
             to={getConsignSubmissionUrl({
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               contextPath: artist.href,
               subject: AnalyticsSchema.Subject.RequestPriceEstimate,
             })}

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHowToSell.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHowToSell.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 
 import {
   AuctionIcon,
@@ -67,7 +67,7 @@ const ArtistConsignHowtoSell: React.FC<ArtistConsignHowtoSellProps> = ({
         <Box>
           <RouterLink
             to={getConsignSubmissionUrl({
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               contextPath: artist.href,
               subject: AnalyticsSchema.Subject.RequestPriceEstimate,
             })}

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignMarketTrends.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignMarketTrends.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Flex, Sans, Serif, color } from "@artsy/palette"
 import { AnalyticsSchema, useTracking } from "v2/System"
 import { RouterLink } from "v2/System/Router/RouterLink"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SectionContainer } from "./SectionContainer"
 import { Subheader } from "./Subheader"
@@ -19,7 +19,7 @@ export const ArtistConsignMarketTrends: React.FC<ArtistConsignMarketTrendsProps>
     artist: {
       href,
       targetSupply: {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         microfunnel: {
           metadata: { highestRealized, str, realized },
         },

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignMeta.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignMeta.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { getENV } from "v2/Utils/getENV"
@@ -17,7 +17,7 @@ export const ArtistConsignMeta: React.FC<ArtistConsignMetaProps> = props => {
 
   const imageURL = get(
     targetSupply,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     p => p.microfunnel.artworksConnection.edges[0].node.image.imageURL
   )
 

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignPageViews.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignPageViews.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 
 import { Box, Sans, Spacer } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -16,7 +16,7 @@ export const ArtistConsignPageViews: React.FC<ArtistConsignPageViewsProps> = pro
     artist: {
       name,
       targetSupply: {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         microfunnel: {
           metadata: { roundedViews, roundedUniqueVisitors },
         },

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Sans, Spacer } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 
 import { ArtistConsignRecentlySold_artist } from "v2/__generated__/ArtistConsignRecentlySold_artist.graphql"
 
@@ -16,7 +16,7 @@ interface ArtistConsignRecentlySoldProps {
 export const ArtistConsignRecentlySold: React.FC<ArtistConsignRecentlySoldProps> = ({
   artist,
 }) => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   if (artist.targetSupply.microfunnel.artworksConnection.edges.length === 0) {
     return null
   }
@@ -30,9 +30,9 @@ export const ArtistConsignRecentlySold: React.FC<ArtistConsignRecentlySoldProps>
           <Spacer my={4} />
 
           <Flex justifyContent={["center", "center"]} flexWrap="wrap">
-            {/* @ts-expect-error STRICT_NULL_CHECK */}
+            {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             {artist.targetSupply.microfunnel.artworksConnection.edges.map(
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               ({ node }, key) => {
                 return (
                   <Flex

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignSellArt.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignSellArt.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { ArtistConsignSellArt_artist } from "v2/__generated__/ArtistConsignSellArt_artist.graphql"
@@ -35,7 +35,7 @@ const ArtistConsignSellArt: React.FC<ArtistConsignSellArtProps> = ({
         <Box>
           <RouterLink
             to={getConsignSubmissionUrl({
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               contextPath: artist.href,
               subject: AnalyticsSchema.Subject.RequestPriceEstimate,
             })}

--- a/src/v2/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
@@ -1,5 +1,5 @@
 import { clickedEntityGroup, ContextModule, OwnerType } from "@artsy/cohesion"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { useAnalyticsContext, useSystemContext } from "v2/System"
@@ -71,7 +71,7 @@ const ArtistWorksForSaleRail: React.FC<ArtistWorksForSaleRailProps> = ({
                       contextModule: ContextModule.worksForSaleRail,
                       contextPageOwnerId,
                       contextPageOwnerSlug,
-                      // @ts-expect-error STRICT_NULL_CHECK
+                      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                       contextPageOwnerType,
                       destinationPageOwnerType: OwnerType.artwork,
                       destinationPageOwnerId: node.internalID,

--- a/src/v2/Apps/Artist/Routes/Overview/Components/__tests__/ArtistConsignButton.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/__tests__/ArtistConsignButton.jest.tsx
@@ -127,7 +127,7 @@ describe("ArtistConsignButton", () => {
 
       it("guards against missing imageURL", () => {
         const responseWithoutImage = cloneDeep(response)
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         responseWithoutImage.image = null
         const wrapper = getWrapper({
           breakpoint: "md",
@@ -176,7 +176,7 @@ describe("ArtistConsignButton", () => {
 
       it("guards against missing imageURL", () => {
         const responseWithoutImage = cloneDeep(response)
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         responseWithoutImage.image = null
         const wrapper = getWrapper({
           breakpoint: "md",

--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
@@ -6,7 +6,7 @@ import {
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { Match, RouterState, withRouter } from "found"
-import * as React from "react";
+import * as React from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 
 interface ArtistSeriesArtworksFilterProps {
@@ -55,7 +55,7 @@ const ArtistSeriesArtworksFilter: React.FC<ArtistSeriesArtworksFilterProps> = pr
 
 export const ArtistSeriesArtworksFilterRefetchContainer = createRefetchContainer(
   withRouter<ArtistSeriesArtworksFilterProps & RouterState>(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     ArtistSeriesArtworksFilter
   ),
   {

--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesMeta.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesMeta.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistSeriesMeta_artistSeries } from "v2/__generated__/ArtistSeriesMeta_artistSeries.graphql"
 import { truncate } from "lodash"
@@ -10,7 +10,7 @@ interface ArtistSeriesMetaProps {
 
 export const ArtistSeriesMeta: React.FC<ArtistSeriesMetaProps> = props => {
   const { artistSeries } = props
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const artist = artistSeries.artists[0]
   const artistName = artist?.name ? `${artist.name}’s ` : ""
   const title = `${artistName}${artistSeries.title} - For Sale on Artsy`

--- a/src/v2/Apps/Artists/Components/ArtistsArtistCard.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsArtistCard.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Box, Flex, Image, ResponsiveBox, Text } from "@artsy/palette"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { ContextModule } from "@artsy/cohesion"
@@ -27,18 +27,18 @@ export const ArtistsArtistCard: React.FC<ArtistsArtistCardProps> = ({
         tabIndex={-1}
       >
         <ResponsiveBox
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           aspectWidth={image.thumb.width}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           aspectHeight={image.thumb.height}
           maxWidth="100%"
         >
           <Image
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             src={image.thumb.src}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             srcSet={image.thumb.srcSet}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             alt={artist.name}
             width="100%"
             height="100%"
@@ -58,12 +58,12 @@ export const ArtistsArtistCard: React.FC<ArtistsArtistCardProps> = ({
               </Text>
             )}
 
-            {/* @ts-expect-error STRICT_NULL_CHECK */}
+            {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             {counts && counts.artworks > 0 && (
               <Text variant="xs" fontWeight="bold">
                 {counts.artworks} work
                 {counts.artworks === 1 ? "" : "s"}
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 {counts.forSaleArtworks > 0 &&
                   counts.forSaleArtworks !== counts.artworks && (
                     <>, {counts.forSaleArtworks} for sale</>

--- a/src/v2/Apps/Artists/Components/ArtistsCarouselCell.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsCarouselCell.tsx
@@ -1,6 +1,6 @@
 import { ContextModule } from "@artsy/cohesion"
 import { Box, Image, Text } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { FollowArtistButtonQueryRenderer } from "v2/Components/FollowButton/FollowArtistButton"
@@ -18,34 +18,33 @@ interface ArtistsCarouselCellProps {
 
 const ArtistsCarouselCell: React.FC<ArtistsCarouselCellProps> = ({
   featuredLink,
-
 }) => {
   const { image } = featuredLink
 
   if (!image) return null
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const slug = getSlug(featuredLink.href)
 
   return (
     <>
       <RouterLink
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         key={featuredLink.internalID}
         to={featuredLink.href}
         display="block"
         textDecoration="none"
       >
         <Image
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           src={image.thumb.src}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           srcSet={image.thumb.srcSet}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           width={image.thumb.width}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           height={image.thumb.height}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           alt={featuredLink.title}
           lazyLoad
         />
@@ -61,12 +60,12 @@ const ArtistsCarouselCell: React.FC<ArtistsCarouselCellProps> = ({
         height={50}
       >
         <RouterLink
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           key={featuredLink.internalID}
           to={featuredLink.href}
           dispaly="block"
           textDecoration="none"
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           aria-label={featuredLink.title}
         >
           <Text variant="lg">{featuredLink.title}</Text>

--- a/src/v2/Apps/Artists/Routes/ArtistsByLetter.tsx
+++ b/src/v2/Apps/Artists/Routes/ArtistsByLetter.tsx
@@ -8,8 +8,8 @@ import {
   Spacer,
   Column,
 } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { graphql, createRefetchContainer, RelayRefetchProp } from "react-relay"
 import styled, { css } from "styled-components"
 import { RouterLink } from "v2/System/Router/RouterLink"
@@ -66,7 +66,7 @@ export const ArtistsByLetter: React.FC<ArtistsByLetterProps> = ({
   } = viewer
 
   const handleNext = (page: number) => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     handleClick(endCursor, page)
   }
 
@@ -115,7 +115,7 @@ export const ArtistsByLetter: React.FC<ArtistsByLetterProps> = ({
       <Spacer mt={6} />
 
       <Columns isLoading={isLoading}>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {artists.map(({ artist }) => {
           return (
             <Text key={artist.internalID}>

--- a/src/v2/Apps/Artists/Routes/ArtistsIndex.tsx
+++ b/src/v2/Apps/Artists/Routes/ArtistsIndex.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import {
   Box,
@@ -56,16 +56,16 @@ export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
 
         {artists && (
           <Shelf my={2}>
-            {/*  @ts-expect-error STRICT_NULL_CHECK */}
+            {/*  @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             {artists.map((featuredLink, index) => {
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               if (!featuredLink.internalID) return null
 
               return (
                 <ArtistsCarouselCellFragmentContainer
-                  // @ts-expect-error STRICT_NULL_CHECK
+                  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                   key={featuredLink.internalID}
-                  // @ts-expect-error STRICT_NULL_CHECK
+                  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                   featuredLink={featuredLink}
                   index={index}
                 />
@@ -80,21 +80,21 @@ export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
       {genes && (
         <Join separator={<Spacer mt={6} />}>
           {genes?.map(gene => {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             if (gene.trendingArtists?.length === 0) return null
 
             return (
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               <React.Fragment key={gene.name}>
                 <Box display="flex" justifyContent="space-between" mb={2}>
-                  {/* @ts-expect-error STRICT_NULL_CHECK */}
+                  {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                   <RouterLink to={gene.href} noUnderline>
                     <Text variant="lg" as="h2">
-                      {/* @ts-expect-error STRICT_NULL_CHECK */}
+                      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                       {gene.name}
                     </Text>
                   </RouterLink>
-                  {/* @ts-expect-error STRICT_NULL_CHECK */}
+                  {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                   <RouterLink to={gene.href} noUnderline>
                     <Text variant="md" color="black60">
                       View
@@ -103,12 +103,12 @@ export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
                 </Box>
 
                 <GridColumns gridRowGap={[2, 0]}>
-                  {/* @ts-expect-error STRICT_NULL_CHECK */}
+                  {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                   {gene.trendingArtists.map(artist => {
                     return (
-                      // @ts-expect-error STRICT_NULL_CHECK
+                      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                       <Column key={artist.internalID} span={[12, 6, 3, 3]}>
-                        {/* @ts-expect-error STRICT_NULL_CHECK */}
+                        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                         <ArtistsArtistCardFragmentContainer artist={artist} />
                       </Column>
                     )

--- a/src/v2/Apps/Artists/__tests__/ArtistsByLetter.jest.tsx
+++ b/src/v2/Apps/Artists/__tests__/ArtistsByLetter.jest.tsx
@@ -17,7 +17,7 @@ const { getWrapper } = setupTestWrapper<ArtistsByLetterQuery>({
   Component: props => {
     return (
       <MockBoot>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <ArtistsByLetterFragmentContainer {...props} />
       </MockBoot>
     )

--- a/src/v2/Apps/Artists/__tests__/ArtistsIndex.jest.tsx
+++ b/src/v2/Apps/Artists/__tests__/ArtistsIndex.jest.tsx
@@ -11,7 +11,7 @@ const { getWrapper } = setupTestWrapper<
 >({
   Component: props => (
     <MockBoot>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <ArtistsIndexFragmentContainer {...props} />
     </MockBoot>
   ),

--- a/src/v2/Apps/Artwork/ArtworkApp.tsx
+++ b/src/v2/Apps/Artwork/ArtworkApp.tsx
@@ -1,6 +1,6 @@
 import { Column, GridColumns, Join, Spacer } from "@artsy/palette"
-import { useContext } from "react";
-import * as React from "react";
+import { useContext } from "react"
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { ArtworkApp_artwork } from "v2/__generated__/ArtworkApp_artwork.graphql"
@@ -131,9 +131,9 @@ export class ArtworkApp extends React.Component<Props> {
         action_type: Schema.ActionType.ViewedLot,
         artwork_id: internalID,
         artwork_slug: slug,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         auction_slug: sale.slug,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         sale_id: sale.internalID,
       }
       tracking.trackEvent(trackingData)

--- a/src/v2/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtistInfo.tsx
@@ -14,8 +14,8 @@ import { ArtistBioFragmentContainer as ArtistBio } from "v2/Components/ArtistBio
 import { ArtistMarketInsightsFragmentContainer as ArtistMarketInsights } from "v2/Components/ArtistMarketInsights"
 import { SelectedExhibitionFragmentContainer as SelectedExhibitions } from "v2/Components/SelectedExhibitions"
 import { ContextModule } from "@artsy/cohesion"
-import { Component } from "react";
-import * as React from "react";
+import { Component } from "react"
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import Events from "v2/Utils/Events"
@@ -89,9 +89,9 @@ export class ArtistInfo extends Component<ArtistInfoProps> {
         <SelectedExhibitions
           artistID={artist.internalID}
           border={false}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           totalExhibitions={artist.counts?.partner_shows}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           exhibitions={artist.exhibition_highlights}
           ViewAllLink={
             <a href={`${sd.APP_URL}/artist/${artist.slug}/cv`}>View all</a>

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromArtsy.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromArtsy.tsx
@@ -1,5 +1,5 @@
 import { HTML, ReadMore, Spacer } from "@artsy/palette"
-import { Component } from "react";
+import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "v2/Utils/Responsive"
 import { ArtworkDetailsAboutTheWorkFromArtsy_artwork } from "v2/__generated__/ArtworkDetailsAboutTheWorkFromArtsy_artwork.graphql"
@@ -40,7 +40,7 @@ export class ArtworkDetailsAboutTheWorkFromArtsy extends Component<
       <HTML variant="sm">
         <ReadMore
           maxChars={maxChars}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           content={description}
           onReadMoreClicked={this.trackReadMoreClick.bind(this)}
         />

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
@@ -2,7 +2,7 @@ import { filterLocations } from "v2/Apps/Artwork/Utils/filterLocations"
 import { limitWithCount } from "v2/Apps/Artwork/Utils/limitWithCount"
 import { SystemContextConsumer } from "v2/System"
 import { FollowProfileButtonFragmentContainer as FollowProfileButton } from "v2/Components/FollowButton/FollowProfileButton"
-import { Component } from "react";
+import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "v2/Utils/get"
 import { Media } from "v2/Utils/Responsive"
@@ -73,10 +73,10 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends Component<
   render() {
     const { artwork } = this.props
     const { additional_information, partner } = artwork
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const locationNames = get(
       partner,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       p => limitWithCount(filterLocations(p.locations), 2),
       []
     ).join(", ")

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
@@ -1,6 +1,6 @@
 import { Button, Link, Modal, Text } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { commitMutation, createFragmentContainer, graphql } from "react-relay"
 import {
   AnalyticsSchema as Schema,
@@ -46,7 +46,7 @@ export const RequestConditionReport: React.FC<RequestConditionReportProps> = pro
   const requestConditionReport = () => {
     return new Promise<RequestConditionReportMutationResponse>(
       async (resolve, reject) => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         commitMutation<RequestConditionReportMutation>(relayEnvironment, {
           onCompleted: data => {
             resolve(data)
@@ -66,7 +66,7 @@ export const RequestConditionReport: React.FC<RequestConditionReportProps> = pro
             }
           `,
           variables: {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             input: { saleArtworkID: artwork.saleArtwork.internalID },
           },
         })
@@ -93,10 +93,10 @@ export const RequestConditionReport: React.FC<RequestConditionReportProps> = pro
     trackEvent({
       action_type: Schema.ActionType.Click,
       subject: Schema.Subject.Login,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       sale_artwork_id: artwork.saleArtwork.internalID,
     })
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     openAuthModal(mediator, {
       mode: ModalType.login,
       redirectTo: location.href,
@@ -194,7 +194,7 @@ const TrackingWrappedRequestConditionReport: React.FC<RequestConditionReportProp
     context_page_owner_id: props.artwork.internalID,
     context_page_owner_slug: props.artwork.slug,
     context_page_owner_type: "Artwork",
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     sale_artwork_id: props.artwork.saleArtwork.internalID,
   }
 })(RequestConditionReport)

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/__tests__/ArtworkDetailsAdditionalInfo.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/__tests__/ArtworkDetailsAdditionalInfo.jest.tsx
@@ -24,7 +24,7 @@ const { getWrapper } = setupTestWrapper<
             contextPageOwnerType: OwnerType.artwork,
           }}
         >
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <ArtworkDetailsAdditionalInfoFragmentContainer {...props} />
         </AnalyticsContext.Provider>
       </MockBoot>

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/__tests__/RequestConditionReport.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/__tests__/RequestConditionReport.jest.tsx
@@ -19,7 +19,7 @@ const setupTestEnv = () => {
   return createTestEnv({
     TestPage: RequestConditionReportTestPage,
     Component: (props: RequestConditionReportQueryResponse) => (
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       <RequestConditionReportFragmentContainer {...props} />
     ),
     query: graphql`

--- a/src/v2/Apps/Artwork/Components/ArtworkDetailsMediumModal.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetailsMediumModal.tsx
@@ -1,5 +1,5 @@
 import { Button, Modal, Text } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkDetailsMediumModal_artwork } from "v2/__generated__/ArtworkDetailsMediumModal_artwork.graphql"
 
@@ -18,7 +18,7 @@ export const ArtworkDetailsMediumModal: React.FC<ArtworkDetailsMediumModalProps>
     <Modal
       show={show}
       onClose={onClose}
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       title={artwork.mediumType.name}
       FixedButton={
         <Button onClick={onClose} width="100%">
@@ -26,7 +26,7 @@ export const ArtworkDetailsMediumModal: React.FC<ArtworkDetailsMediumModalProps>
         </Button>
       }
     >
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <Text color="black100">{artwork.mediumType.longDescription}</Text>
     </Modal>
   )

--- a/src/v2/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
@@ -48,7 +48,7 @@ export const ArtworkRelatedArtists: React.FC<ArtworkRelatedArtistsProps> = track
       relay,
     } = props
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     if (hideGrid(artist.related.artistsConnection)) {
       return null
     }
@@ -151,7 +151,7 @@ export const ArtworkRelatedArtistsPaginationContainer = createPaginationContaine
   {
     direction: "forward",
     getConnectionFromProps(props) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       return props.artwork.artist.related.artistsConnection
     },
     getFragmentVariables(prevVars, count) {

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBidAction.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBidAction.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   Tooltip,
 } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkSidebarBidAction_artwork } from "v2/__generated__/ArtworkSidebarBidAction_artwork.graphql"
 import { ArtworkSidebarBidAction_me } from "v2/__generated__/ArtworkSidebarBidAction_me.graphql"
@@ -62,7 +62,7 @@ export class ArtworkSidebarBidAction extends React.Component<
   ArtworkSidebarBidActionState
 > {
   state: ArtworkSidebarBidActionState = {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     selectedMaxBidCents: null,
   }
 
@@ -141,7 +141,7 @@ export class ArtworkSidebarBidAction extends React.Component<
       pendingIdentityVerification,
       shouldPromptIdVerification,
     } = bidderQualifications(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       sale,
       me,
       sale.registrationStatus && {
@@ -161,7 +161,7 @@ export class ArtworkSidebarBidAction extends React.Component<
           )
         } else if (shouldPromptIdVerification) {
           PreviewAction = () => (
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             <VerifyIdentityButton id={pendingIdentityVerification.internalID} />
           )
         } else {
@@ -234,7 +234,7 @@ export class ArtworkSidebarBidAction extends React.Component<
           <>
             {shouldPromptIdVerification ? (
               <VerifyIdentityButton
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 id={pendingIdentityVerification.internalID}
               />
             ) : (
@@ -315,7 +315,7 @@ export class ArtworkSidebarBidAction extends React.Component<
 
             <Select
               variant="default"
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               options={selectOptions}
               onSelect={this.setMaxBid}
             />
@@ -326,7 +326,7 @@ export class ArtworkSidebarBidAction extends React.Component<
               width="100%"
               size="medium"
               data-test="bid"
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               onClick={() => this.redirectToBid(firstIncrement.cents)}
             >
               {hasMyBids ? "Increase max bid" : "Bid"}

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -20,8 +20,8 @@ import { ModalType } from "v2/Components/Authentication/Types"
 import { ErrorModal } from "v2/Components/Modal/ErrorModal"
 import currency from "currency.js"
 import { Router } from "found"
-import { FC, useContext } from "react";
-import * as React from "react";
+import { FC, useContext } from "react"
+import * as React from "react"
 import {
   RelayProp,
   commitMutation,
@@ -80,9 +80,9 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
   firstAvailableEcommerceEditionSet(): EditionSet {
     const editionSets = this.props.artwork.edition_sets
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     return editionSets.find(editionSet => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       return editionSet.is_acquireable || editionSet.is_offerable
     })
   }
@@ -179,7 +179,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
       {
         product_id: props.artwork.internalID,
         quantity: 1,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         price: currency(props.artwork.listPrice.display).value,
       },
     ],
@@ -188,10 +188,10 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
     const { user, mediator } = this.props
     if (user && user.id) {
       this.setState({ isCommittingCreateOrderMutation: true }, () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         if (get(this.props, props => props.relay.environment)) {
           commitMutation<ArtworkSidebarCommercialOrderMutation>(
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             this.props.relay.environment,
             {
               // TODO: Inputs to the mutation might have changed case of the keys!
@@ -233,7 +233,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
                   { isCommittingCreateOrderMutation: false },
                   () => {
                     const {
-                      // @ts-expect-error STRICT_NULL_CHECK
+                      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                       commerceCreateOrderWithArtwork: { orderOrError },
                     } = data
                     if (orderOrError.error) {
@@ -245,7 +245,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
                       )
                     } else {
                       const url = `/orders/${orderOrError.order.internalID}`
-                      // @ts-expect-error STRICT_NULL_CHECK
+                      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                       this.props.router.push(url)
                     }
                   }
@@ -277,10 +277,10 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
     const { user, mediator } = this.props
     if (user && user.id) {
       this.setState({ isCommittingCreateOfferOrderMutation: true }, () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         if (get(this.props, props => props.relay.environment)) {
           commitMutation<ArtworkSidebarCommercialOfferOrderMutation>(
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             this.props.relay.environment,
             {
               // TODO: Inputs to the mutation might have changed case of the keys!
@@ -322,7 +322,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
                   { isCommittingCreateOfferOrderMutation: false },
                   () => {
                     const {
-                      // @ts-expect-error STRICT_NULL_CHECK
+                      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                       commerceCreateOfferOrderWithArtwork: { orderOrError },
                     } = data
                     if (orderOrError.error) {
@@ -334,7 +334,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
                       )
                     } else {
                       const url = `/orders/${orderOrError.order.internalID}/offer`
-                      // @ts-expect-error STRICT_NULL_CHECK
+                      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                       this.props.router.push(url)
                     }
                   }

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarExtraLinks.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarExtraLinks.tsx
@@ -1,7 +1,7 @@
 import { Clickable, Link, Separator, Spacer, Text } from "@artsy/palette"
 import { track } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkSidebarExtraLinks_artwork } from "v2/__generated__/ArtworkSidebarExtraLinks_artwork.graphql"
 import { useInquiry, WithInquiryProps } from "v2/Components/Inquiry/useInquiry"
@@ -99,14 +99,14 @@ class ArtworkSidebarExtraLinksContainer extends React.Component<
   conditionsOfSaleText() {
     const first = "By placing your bid you agree to Artsy's "
     if (
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       !this.props.artwork.sale.isBenefit &&
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       !!this.props.artwork.sale.partner
     ) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const partnerName = this.props.artwork.sale.partner.name
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const possessivePartnerName = partnerName.endsWith("'s")
         ? partnerName
         : partnerName + "'s"

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPartnerInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPartnerInfo.tsx
@@ -1,6 +1,6 @@
 import { Flex, LocationIcon, Spacer, Text } from "@artsy/palette"
 import { filterLocations } from "v2/Apps/Artwork/Utils/filterLocations"
-import { Component } from "react";
+import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkSidebarPartnerInfo_artwork } from "v2/__generated__/ArtworkSidebarPartnerInfo_artwork.graphql"
 import { RouterLink } from "v2/System/Router/RouterLink"
@@ -52,7 +52,7 @@ export class ArtworkSidebarPartnerInfo extends Component<
       artwork.partner &&
       artwork.partner.locations &&
       artwork.partner.locations.length > 0 &&
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       filterLocations(artwork.partner.locations)
 
     return (

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarAuctionPartnerInfo.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarAuctionPartnerInfo.jest.tsx
@@ -35,12 +35,12 @@ describe("ArtworkSidebarAuctionPartnerInfo", () => {
       )
     })
 
-    xit("displays artwork without premium", async () => {
+    it.skip("displays artwork without premium", async () => {
       const wrapper = await getWrapper({
         ...ArtworkWithEstimateAndPremium,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         sale: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...ArtworkWithEstimateAndPremium.sale,
           // FIXME: This selection doesn't seem to exist, is this test obsolete?
           // is_with_buyers_premium: null,
@@ -53,9 +53,9 @@ describe("ArtworkSidebarAuctionPartnerInfo", () => {
     it("displays artwork without estimate", async () => {
       const wrapper = await getWrapper({
         ...ArtworkWithEstimateAndPremium,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         sale_artwork: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...ArtworkWithEstimateAndPremium.sale_artwork,
           estimate: null,
         },
@@ -67,9 +67,9 @@ describe("ArtworkSidebarAuctionPartnerInfo", () => {
     it("does not display anything for closed auctions", async () => {
       const wrapper = await getWrapper({
         ...ArtworkWithEstimateAndPremium,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         sale: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...ArtworkWithEstimateAndPremium.sale,
           is_closed: true,
         },

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarBidAction.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarBidAction.jest.tsx
@@ -178,7 +178,7 @@ describe("ArtworkSidebarBidAction", () => {
 
               const wrapper = await getWrapper({
                 artwork,
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 me: {
                   ...NotIDVedUser,
                   pendingIdentityVerification: {
@@ -206,7 +206,7 @@ describe("ArtworkSidebarBidAction", () => {
 
               const wrapper = await getWrapper({
                 artwork,
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 me: {
                   ...NotIDVedUser,
                   pendingIdentityVerification: null,

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCurrentBidInfo.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCurrentBidInfo.jest.tsx
@@ -48,7 +48,7 @@ describe("ArtworkSidebarCurrentBidInfo", () => {
     it("tracks a click on the buyers premium link", async () => {
       const component = await getWrapper(OpenAuctionReserveMetWithMyWinningBid)
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       component
         .find("button")
         .filterWhere(l => l.text() === "buyer’s premium")

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarExtraLinks.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarExtraLinks.jest.tsx
@@ -37,19 +37,19 @@ describe("ArtworkSidebarExtraLinks", () => {
 
   describe("for work in a benefit auction", () => {
     beforeAll(async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(BenefitAuctionArtwork)
     })
     it("displays proper conditions of sale text", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "By placing your bid you agree to Artsy's Conditions of Sale."
       )
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "Have a question? Read our auction FAQs or ask a specialist."
       )
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "Want to sell a work by this artist? Consign with Artsy."
       )
@@ -58,11 +58,11 @@ describe("ArtworkSidebarExtraLinks", () => {
 
   describe("for work in an auction by Van Ham", () => {
     beforeAll(async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(VanHamLiveAuctionArtwork)
     })
     it("displays proper conditions of sale text", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "By placing your bid you agree to Artsy's and Van Ham's Conditions of Sale."
       )
@@ -71,11 +71,11 @@ describe("ArtworkSidebarExtraLinks", () => {
 
   describe("for work in an auction without a partner", () => {
     beforeAll(async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(LiveAuctionArtworkWithoutPartner)
     })
     it("displays proper conditions of sale text", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "By placing your bid you agree to Artsy's Conditions of Sale."
       )
@@ -84,114 +84,114 @@ describe("ArtworkSidebarExtraLinks", () => {
 
   describe("for work in an auction", () => {
     beforeAll(async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(LiveAuctionArtwork)
     })
     it("displays proper conditions of sale text", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "By placing your bid you agree to Artsy's and Christie's Conditions of Sale."
       )
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "Have a question? Read our auction FAQs or ask a specialist."
       )
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "Want to sell a work by this artist? Consign with Artsy."
       )
     })
     it("displays conditions of sale link that opens conditions of sale page", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find('a[children="Conditions of Sale"]').length).toBe(1)
     })
     it("displays FAQ link that brings auction FAQ modal", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find('button[children="auction FAQs"]').length).toBe(1)
     })
     it("displays ask a specialist link that brings ask an auction specialist modal", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find('button[children="ask a specialist"]').length).toBe(1)
     })
     it("displays consign link that opens consign page", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find('a[children="Consign with Artsy"]').length).toBe(1)
     })
   })
 
   describe("for Buy now work", () => {
     beforeAll(async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(AcquireableArtworkWithOneConsignableArtist)
     })
     it("displays proper text", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "Have a question? Visit our help center or ask a specialist."
       )
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "Want to sell a work by this artist? Consign with Artsy."
       )
     })
 
     it("displays help center link that opens help center page", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find('a[children="Visit our help center"]').length).toBe(1)
     })
     it("displays ask a specialist link that brings ask sale specialist modal", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find('button[children="ask a specialist"]').length).toBe(1)
     })
     it("displays consign link that opens consign page", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find('a[children="Consign with Artsy"]').length).toBe(1)
     })
   })
 
   describe("for inquireable work", () => {
     beforeAll(async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(
         InquireableArtworkWithMultipleConsignableArtists
       )
     })
 
     it("displays proper text", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "Have a question? Visit our help center."
       )
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "Want to sell a work by these artists? Consign with Artsy."
       )
     })
     it("displays help center link that opens help center page", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find('a[children="Visit our help center"]').length).toBe(1)
     })
     it("displays consign link that opens consign page", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find('a[children="Consign with Artsy"]').length).toBe(1)
     })
   })
 
   describe("for not for sale work", () => {
     beforeAll(async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(NotForSaleArtworkWithOneConsignableArtist)
     })
     it("displays proper text", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).not.toContain("Have a question? Read our FAQ")
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.text()).toContain(
         "Want to sell a work by this artist? Consign with Artsy."
       )
     })
     it("displays consign link that opens consign page", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find('a[children="Consign with Artsy"]').length).toBe(1)
     })
   })

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarMetadata.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarMetadata.jest.tsx
@@ -37,24 +37,24 @@ describe("ArtworkSidebarMetadata", () => {
 
   describe("for non editioned artwork", () => {
     beforeAll(async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper()
     })
 
     it("displays title and year", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("<i>Easel (Vydock)</i>, 1995")
     })
 
     it("displays medium", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain(
         "Acrylic and graphite on bonded aluminium"
       )
     })
 
     it("displays dimentions", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const html = wrapper.html()
 
       expect(html).toContain("97 × 15 in")
@@ -62,65 +62,65 @@ describe("ArtworkSidebarMetadata", () => {
     })
 
     it("displays classification", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("This is a unique work")
     })
   })
 
   describe("for artwork with one edition", () => {
     beforeAll(async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(FilledOutMetadataOneEditionSet)
     })
 
     it("displays title and year", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("<i>Sun Keyed</i>, 1972")
     })
 
     it("displays medium", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("Serigraph")
     })
 
     it("displays edition dimentions", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const html = wrapper.html()
       expect(html).toContain("14 × 18 in")
       expect(html).toContain("35.6 × 45.7 cm")
     })
 
     it("displays edition details", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("Edition of 3000")
     })
 
     it("displays classification", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("This is part of a limited edition set")
     })
   })
 
   describe("for artwork with multiple editions", () => {
     beforeAll(async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(FilledOutMetadataMultipleEditionSets)
     })
 
     it("displays title and year", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("<i>Abstract 36742</i>, 2018")
     })
 
     it("displays medium", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("Premium high gloss archival print")
     })
 
     it("does not render edition dimentions or details", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find(ArtworkSidebarSizeInfo).length).toBe(0)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const html = wrapper.html()
       expect(html).not.toContain("40 × 42 in")
       expect(html).not.toContain("101.6 × 106.7 cm")
@@ -128,34 +128,34 @@ describe("ArtworkSidebarMetadata", () => {
     })
 
     it("displays classification", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("This is part of a limited edition set")
     })
   })
 
   describe("for artwork with minimal metadata", () => {
     it("only displays title info", async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(EmptyMetadataNoEditions)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const html = wrapper.html()
       expect(html).toContain("<i>Empty metadata / No editions</i>")
       expect(html).not.toContain("<i>Empty metadata / No editions<i>,")
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find(ArtworkSidebarSizeInfo).html()).toBe(null)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find(ArtworkSidebarClassification).html()).toBe(null)
     })
   })
 
   describe("for artwork in an auction", () => {
     beforeAll(async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(MetadataForAuctionWork)
     })
 
     it("displays lot number when present for biddable works", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("Lot 210")
     })
 
@@ -164,26 +164,26 @@ describe("ArtworkSidebarMetadata", () => {
         ...MetadataForAuctionWork,
         is_biddable: false,
       }
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper = await getWrapper(closedAuctionArtwork)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).not.toContain("Lot 210")
     })
 
     it("displays title and year", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain(
         '<i>Then the boy displayed to the Dervish his bosom, saying: "Look at my breasts which be goodlier than the breasts of maidens and my lipdews are sweeter than sugar candy...", from Four Tales from the Arabian Nights</i>, 1948'
       )
     })
 
     it("displays medium", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("Lithograph in colors, on laid paper")
     })
 
     it("displays edition dimentions", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const html = wrapper.html()
 
       expect(html).toContain("17 × 13 in")
@@ -191,7 +191,7 @@ describe("ArtworkSidebarMetadata", () => {
     })
 
     it("displays classification", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.html()).toContain("This is part of a limited edition set")
     })
   })

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebarClassificationsModal.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebarClassificationsModal.tsx
@@ -47,7 +47,7 @@ const ArtworkSidebarClassificationsModal: React.FC<ArtworkSidebarClassifications
     >
       <Join separator={<Spacer my={1} />}>
         {viewer
-          ? // @ts-expect-error STRICT_NULL_CHECK
+          ? // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             viewer.artworkAttributionClasses.map(classification => {
               if (!classification) return null
 
@@ -114,7 +114,7 @@ export const ArtworkSidebarClassificationsModalQueryRenderer: React.FC<Omit<
           return (
             <ArtworkSidebarClassificationsModalFragmentContainer
               {...rest}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               viewer={null}
             />
           )

--- a/src/v2/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
+++ b/src/v2/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
@@ -7,7 +7,7 @@ import { track } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
 import ArtworkGrid from "v2/Components/ArtworkGrid"
 import { take } from "lodash"
-import { Component } from "react";
+import { Component } from "react"
 import styled from "styled-components"
 import createLogger from "v2/Utils/logger"
 import { ContextModule } from "@artsy/cohesion"
@@ -76,7 +76,7 @@ class RelatedWorksArtworkGrid extends Component<
 
     // The layer might have failed to fetch, so we use the `get` helper
     // instead of ordinary destructuring.
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const artworksConnection = get(layer, l => l.artworksConnection)
 
     if (hideGrid(artworksConnection)) {
@@ -85,7 +85,7 @@ class RelatedWorksArtworkGrid extends Component<
 
     // For sale artworks are already rendered on the page so we filter them from related works
     const names = take(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       layers.filter(l => l.name !== "For Sale"),
       MAX_TAB_ITEMS
     )
@@ -100,9 +100,9 @@ class RelatedWorksArtworkGrid extends Component<
 
         <Spacer mt={4} />
 
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <Tabs onChange={this.handleTabClick}>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           {names.map(({ name, internalID }, key) => {
             return (
               <Tab name={name} key={key} data={{ layerId: internalID }}>
@@ -112,7 +112,7 @@ class RelatedWorksArtworkGrid extends Component<
                   ) : (
                     <ArtworkGrid
                       contextModule={ContextModule.relatedWorksRail}
-                      // @ts-expect-error STRICT_NULL_CHECK
+                      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                       artworks={artworksConnection}
                       columnCount={[2, 3, 4, 4]}
                       mediator={mediator}

--- a/src/v2/Apps/Artwork/Components/OtherWorks/index.tsx
+++ b/src/v2/Apps/Artwork/Components/OtherWorks/index.tsx
@@ -15,7 +15,7 @@ import { SystemContextProps, withSystemContext } from "v2/System"
 import { track, useTracking } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
 import ArtworkGrid from "v2/Components/ArtworkGrid"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "v2/Utils/get"
 import { Mediator } from "lib/mediator"
@@ -41,13 +41,13 @@ const populatedGrids = (grids: OtherWorks_artwork["contextGrids"]) => {
   if (grids && grids.length > 0) {
     return grids.filter(grid => {
       return (
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         grid.artworksConnection &&
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         grid.artworksConnection.edges &&
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         grid.artworksConnection.edges.length > 0 &&
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         grid.__typename !== "RelatedArtworkGrid"
       )
     })
@@ -100,19 +100,19 @@ export const OtherWorks = track()(
           <Join separator={<Spacer mt={6} />}>
             {gridsToShow.map((grid, index) => {
               const contextModule = contextGridTypeToV2ContextModule(
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 grid.__typename
               )
 
               return (
                 <Box key={`Grid-${index}`} data-test={contextModule}>
-                  {/* @ts-expect-error STRICT_NULL_CHECK */}
+                  {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                   <Header title={grid.title} buttonHref={grid.ctaHref} />
 
                   <Spacer mt={4} />
 
                   <ArtworkGrid
-                    // @ts-expect-error STRICT_NULL_CHECK
+                    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                     artworks={grid.artworksConnection}
                     columnCount={[2, 3, 4, 4]}
                     mediator={props.mediator}
@@ -122,7 +122,7 @@ export const OtherWorks = track()(
                         type: Schema.Type.ArtworkBrick,
                         action_type: Schema.ActionType.Click,
                         context_module: contextGridTypeToContextModule(
-                          // @ts-expect-error STRICT_NULL_CHECK
+                          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                           grid.__typename
                         ),
                       })

--- a/src/v2/Apps/Artwork/Components/PricingContext.tsx
+++ b/src/v2/Apps/Artwork/Components/PricingContext.tsx
@@ -14,7 +14,7 @@ import { PricingContext_artwork } from "v2/__generated__/PricingContext_artwork.
 import { track } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
 import { once } from "lodash"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import Waypoint from "react-waypoint"
 import Events from "v2/Utils/Events"
@@ -134,7 +134,7 @@ export class PricingContext extends React.Component<PricingContextProps> {
           bars={artwork.pricingContext.bins.map(
             (bin, index): BarDescriptor => {
               const isFirstBin = index === 0
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               const isLastBin = index === artwork.pricingContext.bins.length - 1
               const title = isLastBin
                 ? `${bin.minPrice}+`

--- a/src/v2/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
+++ b/src/v2/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
@@ -1,5 +1,5 @@
 import { trim } from "lodash"
-import * as React from "react";
+import * as React from "react"
 
 import { SeoDataForArtwork_artwork } from "v2/__generated__/SeoDataForArtwork_artwork.graphql"
 import { CreativeWork } from "v2/Components/Seo/CreativeWork"
@@ -24,15 +24,15 @@ export const SeoDataForArtwork: React.FC<SeoDataForArtworkProps> = ({
 }) => {
   const artistsName = artwork.artistNames
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const dimensions = parseDimensions(get(artwork, a => a.dimensions.in, ""))
 
   const artworkMetaData = {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     name: artwork.meta.title,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     image: get(artwork, a => a.meta_image.resized.url),
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     description: get(artwork, a => a.meta.description),
     url: `${APP_URL}${artwork.href}`,
     ...dimensions,
@@ -42,7 +42,7 @@ export const SeoDataForArtwork: React.FC<SeoDataForArtworkProps> = ({
     },
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const partnerType = get(artwork, a => a.partner.type)
   const offers = offerAttributes(artwork)
 
@@ -132,16 +132,16 @@ export const offerAttributes = (artwork: SeoDataForArtwork_artwork) => {
   if (!artwork.listPrice || artwork.is_price_hidden) return null
   const galleryProfileImage = get(
     artwork,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     a => a.partner.profile.image.resized.url
   )
   const seller = galleryProfileImage && {
     "@type": "ArtGallery",
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     name: get(artwork, a => a.partner.name),
     image: galleryProfileImage,
   }
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const availability = AVAILABILITY[artwork.availability]
   switch (artwork.listPrice.__typename) {
     case "PriceRange":
@@ -149,7 +149,7 @@ export const offerAttributes = (artwork: SeoDataForArtwork_artwork) => {
       if (!artwork.listPrice.minPrice) {
         return null
       }
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const highPrice = get(artwork.listPrice, price => price.maxPrice.major)
       return {
         "@type": "AggregateOffer",

--- a/src/v2/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.jest.tsx
@@ -39,7 +39,7 @@ describe("SeoDataForArtwork", () => {
 
   describe("SeoDataForArtworkFragmentContainer", () => {
     it("Renders without a partner", async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const wrapper = await getWrapper({
         ...SeoDataForArtworkFixture,
         partner: null,
@@ -50,9 +50,9 @@ describe("SeoDataForArtwork", () => {
     it("Renders a CreativeWork for an institution", async () => {
       const wrapper = await getWrapper({
         ...SeoDataForArtworkFixture,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         partner: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...SeoDataForArtworkFixture.partner,
           type: "Institution",
         },
@@ -76,7 +76,7 @@ describe("SeoDataForArtwork", () => {
     })
 
     it("Renders a Product for a non-institution", async () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const wrapper = await getWrapper({
         ...SeoDataForArtworkFixture,
         listPrice: {
@@ -115,7 +115,7 @@ describe("SeoDataForArtwork", () => {
 
     describe("Artwork availability", () => {
       it("Renders InStock when 'for sale'", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           listPrice: {
@@ -132,7 +132,7 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("Renders OutOfStock when not 'for sale'", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           listPrice: {
@@ -151,7 +151,7 @@ describe("SeoDataForArtwork", () => {
 
     describe("Artwork price", () => {
       it("renders CreativeWork when price is hidden", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           is_price_range: true,
@@ -163,7 +163,7 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("Renders AggregateOffer when price range", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           is_price_range: false,
@@ -195,7 +195,7 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("Renders AggregateOffer when price range with low and high bounds", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           is_price_range: false,
@@ -227,7 +227,7 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("Renders AggregateOffer when price range only with low bound", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           is_price_range: false,
@@ -256,7 +256,7 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("renders CreativeWork when price range and no low bound", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           is_price_range: false,
@@ -275,7 +275,7 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("Does not render seller within offer when profile image (required) is not present", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           partner: {
@@ -315,7 +315,7 @@ describe("SeoDataForArtwork", () => {
       }
 
       it("renders no dimensions when dimensions aren't parseable", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           listPrice,
@@ -330,7 +330,7 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("renders width and height when given two dimensions", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           listPrice,
@@ -345,7 +345,7 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("renders width, height, and depth when given three dimensions", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           listPrice,
@@ -360,7 +360,7 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("parses dimensions missing spaces", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           listPrice,
@@ -375,7 +375,7 @@ describe("SeoDataForArtwork", () => {
       })
 
       it("assumes inches when no unit is included", async () => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper({
           ...SeoDataForArtworkFixture,
           listPrice,
@@ -391,7 +391,7 @@ describe("SeoDataForArtwork", () => {
 
       it("successfully handles case when no dimensions are present", async () => {
         expect(() =>
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           getWrapper({ ...SeoDataForArtworkFixture, dimensions: undefined })
         ).not.toThrow()
       })

--- a/src/v2/Apps/Artwork/Components/TrustSignals/BuyerGuarantee.tsx
+++ b/src/v2/Apps/Artwork/Components/TrustSignals/BuyerGuarantee.tsx
@@ -1,5 +1,5 @@
 import { CheckCircleIcon, Link } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { BuyerGuarantee_artwork } from "v2/__generated__/BuyerGuarantee_artwork.graphql"
 
 import { createFragmentContainer, graphql } from "react-relay"
@@ -10,7 +10,7 @@ interface Props {
   artwork: BuyerGuarantee_artwork
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 const BuyerGuarantee: React.FC<Props> = props => {
   const { artwork } = props
   return (

--- a/src/v2/Apps/Artwork/Components/TrustSignals/SecurePayment.tsx
+++ b/src/v2/Apps/Artwork/Components/TrustSignals/SecurePayment.tsx
@@ -1,6 +1,6 @@
 import { Link, LockIcon } from "@artsy/palette"
 import { SecurePayment_artwork } from "v2/__generated__/SecurePayment_artwork.graphql"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "react-relay"
 import { TrustSignal, TrustSignalProps } from "./TrustSignal"
@@ -10,7 +10,7 @@ interface SecurePaymentProps
   artwork: SecurePayment_artwork
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 export const SecurePayment: React.FC<SecurePaymentProps> = ({
   artwork,
   ...other

--- a/src/v2/Apps/Artwork/Components/TrustSignals/VerifiedSeller.tsx
+++ b/src/v2/Apps/Artwork/Components/TrustSignals/VerifiedSeller.tsx
@@ -1,6 +1,6 @@
 import { VerifiedIcon } from "@artsy/palette"
 import { VerifiedSeller_artwork } from "v2/__generated__/VerifiedSeller_artwork.graphql"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "react-relay"
 import { TrustSignal, TrustSignalProps } from "./TrustSignal"
@@ -10,7 +10,7 @@ interface VerifiedSellerProps
   artwork: VerifiedSeller_artwork
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 export const VerifiedSeller: React.FC<VerifiedSellerProps> = ({
   artwork,
   ...other

--- a/src/v2/Apps/Artwork/Components/__tests__/ArtistInfo.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/__tests__/ArtistInfo.jest.tsx
@@ -51,14 +51,14 @@ describe("ArtistInfo", () => {
       const artist = {
         ...ArtistInfoFixture,
         highlights: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...ArtistInfoFixture.highlights,
           partnersConnection: null,
         },
         collections: null,
         auctionResultsConnection: null,
         exhibition_highlights: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...ArtistInfoFixture.exhibition_highlights,
           length: 1,
         },
@@ -71,7 +71,7 @@ describe("ArtistInfo", () => {
       const artist = {
         ...ArtistInfoFixture,
         biographyBlurb: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...ArtistInfoFixture.biographyBlurb,
           text: null,
         },
@@ -84,7 +84,7 @@ describe("ArtistInfo", () => {
       const artist = {
         ...ArtistInfoFixture,
         highlights: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...ArtistInfoFixture.highlights,
           partnersConnection: null,
         },

--- a/src/v2/Apps/Artwork/Components/__tests__/ArtworkArtistSeries.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/__tests__/ArtworkArtistSeries.jest.tsx
@@ -53,7 +53,7 @@ describe("ArtworkArtistSeries", () => {
 
   it("includes just the series rail if there are no artworks", async () => {
     const noArtworksData: ArtworkArtistSeries_QueryRawResponse = {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       artwork: {
         ...ArtworkArtistSeriesFixture.artwork,
         seriesForCounts: {
@@ -74,7 +74,7 @@ describe("ArtworkArtistSeries", () => {
 
   it("includes just series if the artist has any", async () => {
     const noSeriesData: ArtworkArtistSeries_QueryRawResponse = {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       artwork: {
         ...ArtworkArtistSeriesFixture.artwork,
         artistSeriesConnection: null,
@@ -88,7 +88,7 @@ describe("ArtworkArtistSeries", () => {
 
   it("is null if there is no series or artworks", async () => {
     const noSeriesData: ArtworkArtistSeries_QueryRawResponse = {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       artwork: {
         ...ArtworkArtistSeriesFixture.artwork,
         artistSeriesConnection: null,

--- a/src/v2/Apps/Artwork/Components/__tests__/PricingContext.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/__tests__/PricingContext.jest.tsx
@@ -18,7 +18,7 @@ import { flushPromiseQueue } from "v2/DevTools"
 jest.unmock("react-tracking")
 jest.unmock("react-relay")
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 const mockPricingContext: PricingContextTestQueryRawResponse["artwork"]["pricingContext"] = {
   appliedFiltersDisplay: "Price ranges of small mocks by David Sheldrick",
   appliedFilters: {
@@ -71,7 +71,7 @@ const mockArtwork: PricingContextTestQueryRawResponse["artwork"] = {
 describe("PricingContext", () => {
   function getWrapper(
     mockData: PricingContextTestQueryRawResponse = {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       artwork: {
         ...mockArtwork,
       },
@@ -80,7 +80,7 @@ describe("PricingContext", () => {
     return renderRelayTree({
       Component: (props: PricingContextTestQueryResponse) => (
         <div>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <PricingContextFragmentContainer {...props} />
         </div>
       ),
@@ -176,7 +176,7 @@ describe("PricingContext", () => {
     const wrapper = await getWrapper({
       artwork: {
         ...mockArtwork,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         pricingContext: {
           ...mockArtwork.pricingContext,
           bins: [
@@ -220,7 +220,7 @@ Object {
     const wrapper = await getWrapper({
       artwork: {
         ...mockArtwork,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         pricingContext: {
           ...mockArtwork.pricingContext,
           bins: [

--- a/src/v2/Apps/Artwork/Utils/__tests__/filterLocations.jest.tsx
+++ b/src/v2/Apps/Artwork/Utils/__tests__/filterLocations.jest.tsx
@@ -2,7 +2,7 @@ import { filterLocations } from "../filterLocations"
 
 describe("filterLocations", () => {
   it("returns null if no array of locations is given", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const filtered = filterLocations(null)
     expect(filtered).toBeNull()
   })

--- a/src/v2/Apps/Artwork/Utils/__tests__/limitWithCount.jest.tsx
+++ b/src/v2/Apps/Artwork/Utils/__tests__/limitWithCount.jest.tsx
@@ -2,7 +2,7 @@ import { limitWithCount } from "../limitWithCount"
 
 describe("limitWithCount", () => {
   it("returns empty array if no array of strings is given", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const limited = limitWithCount(null, 3)
     expect(limited).toEqual([])
   })

--- a/src/v2/Apps/Auction/Components/BidForm.tsx
+++ b/src/v2/Apps/Auction/Components/BidForm.tsx
@@ -68,17 +68,17 @@ export const BidForm: React.FC<Props> = ({
 }) => {
   const displayIncrements = dropWhile(
     saleArtwork.increments,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     increment => increment.cents < saleArtwork.minimumNextBid.cents
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   ).map(inc => ({ value: inc.cents.toString(), text: inc.display }))
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const selectedBid = getSelectedBid({ initialSelectedBid, displayIncrements })
   const {
     requiresCheckbox,
     requiresPaymentInformation,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   } = determineDisplayRequirements(saleArtwork.sale.registrationStatus, me)
   const validationSchema = requiresCheckbox
     ? requiresPaymentInformation
@@ -129,14 +129,14 @@ export const BidForm: React.FC<Props> = ({
               setFieldValue("selectedBid", value)
               setFieldTouched("selectedBid")
             }}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             options={displayIncrements}
             error={touched.selectedBid && errors.selectedBid}
           />
 
           <PricingTransparencyQueryRenderer
             relayEnvironment={relay.environment}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             saleId={saleArtwork.sale.slug}
             artworkId={artworkSlug}
             bidAmountMinor={parseInt(values.selectedBid)}
@@ -162,7 +162,7 @@ export const BidForm: React.FC<Props> = ({
 
               <Spacer mt={2} />
 
-              {/* @ts-expect-error STRICT_NULL_CHECK */}
+              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
               <AddressForm
                 value={values.address}
                 onChange={address => setFieldValue("address", address)}

--- a/src/v2/Apps/Auction/Components/Form/initialValues.ts
+++ b/src/v2/Apps/Auction/Components/Form/initialValues.ts
@@ -29,6 +29,6 @@ export const initialValuesForRegistration: FormValuesForRegistration = {
 
 export const initialValuesForBidding: FormValuesForBidding = {
   ...initialValuesForRegistration,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   selectedBid: undefined,
 }

--- a/src/v2/Apps/Auction/Components/LotInfo.tsx
+++ b/src/v2/Apps/Auction/Components/LotInfo.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Sans, Serif } from "@artsy/palette"
 import { LotInfo_artwork } from "v2/__generated__/LotInfo_artwork.graphql"
 import { LotInfo_saleArtwork } from "v2/__generated__/LotInfo_saleArtwork.graphql"
-import * as React from "react";
+import * as React from "react"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 
 interface Props {
@@ -12,7 +12,7 @@ interface Props {
 
 export const LotInfo: React.FC<Props> = ({ artwork, saleArtwork }) => {
   const {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     counts: { bidderPositions: bidCount },
   } = saleArtwork
   return (
@@ -40,7 +40,7 @@ export const LotInfo: React.FC<Props> = ({ artwork, saleArtwork }) => {
         </Serif>
         <br />
         <Serif size="3">
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           Current Bid: {saleArtwork.minimumNextBid.display}
         </Serif>
         {bidCount > 0 && (

--- a/src/v2/Apps/Auction/Components/OnSubmitValidationError.tsx
+++ b/src/v2/Apps/Auction/Components/OnSubmitValidationError.tsx
@@ -1,5 +1,5 @@
 import { FormikProps } from "formik"
-import * as React from "react";
+import * as React from "react"
 
 import { FormValuesForRegistration } from "v2/Apps/Auction/Components/Form"
 
@@ -26,7 +26,7 @@ export const OnSubmitValidationError: React.FC<{
 
   const effect = () => {
     if (
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       formikProps.submitCount > 0 &&
       !formikProps.isSubmitting &&
       !formikProps.isValid
@@ -37,9 +37,9 @@ export const OnSubmitValidationError: React.FC<{
 
       const errors = Object.assign({}, clonedErrors, addressErrors)
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       cb(Object.values(errors as string[]))
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       formikProps.setSubmitting(false)
     }
   }

--- a/src/v2/Apps/Auction/Components/PricingTransparency.tsx
+++ b/src/v2/Apps/Auction/Components/PricingTransparency.tsx
@@ -1,5 +1,5 @@
 import { Flex, Sans, Serif, Spinner } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { graphql } from "react-relay"
 
 import {
@@ -16,7 +16,7 @@ const Row = props => (
 )
 
 export const PricingTransparency: React.FC<PricingTransparencyQueryResponse> = props => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const { calculatedCost } = props.artwork.saleArtwork
 
   return (

--- a/src/v2/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/v2/Apps/Auction/Components/RegistrationForm.tsx
@@ -70,7 +70,7 @@ export const RegistrationForm: React.FC<RegistrationFormProps> = props => (
 
         <Spacer mt={4} />
 
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <AddressForm
           value={values.address}
           onChange={(address, _key) => setFieldValue("address", address)}

--- a/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -70,14 +70,14 @@ export const ConfirmBidRoute: React.FC<
   let registrationTracked = false
 
   const { artwork, me, relay, stripe, elements } = props
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const { saleArtwork } = artwork
   const { sale } = saleArtwork
   const { environment } = relay
   const { trackEvent } = useTracking()
   const { requiresPaymentInformation } = determineDisplayRequirements(
     sale.registrationStatus,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     me
   )
 
@@ -114,7 +114,7 @@ export const ConfirmBidRoute: React.FC<
           onError: reject,
           variables: {
             input: {
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               artworkID: artwork.internalID,
               maxBidAmountCents,
               saleID: sale.internalID,
@@ -190,16 +190,16 @@ export const ConfirmBidRoute: React.FC<
     const selectedBid = Number(values.selectedBid)
 
     if (requiresPaymentInformation) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const stripeAddress = toStripeAddress(values.address)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const { phoneNumber } = values.address
       const { setFieldError, setSubmitting } = actions
 
       try {
         const element = elements.getElement(CardElement)
         const { error, token } = await stripe.createToken(
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           element,
           stripeAddress
         )
@@ -210,10 +210,10 @@ export const ConfirmBidRoute: React.FC<
           return
         }
 
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const { id } = token
         const {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           createCreditCard: { creditCardOrError },
         } = await createCreditCardAndUpdatePhone(environment, phoneNumber, id)
 
@@ -246,7 +246,7 @@ export const ConfirmBidRoute: React.FC<
     data: ConfirmBidCreateBidderPositionMutationResponse
     selectedBid: number
   }) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const { result } = data.createBidderPosition
     const { position } = result
 
@@ -284,7 +284,7 @@ export const ConfirmBidRoute: React.FC<
     data: BidderPositionQueryResponse
     selectedBid: number
   }) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const { bidderPosition } = data.me
     const { status, position } = bidderPosition
 
@@ -306,7 +306,7 @@ export const ConfirmBidRoute: React.FC<
       pollCount += 1
     } else if (status === "WINNING") {
       trackConfirmBidSuccess(position.internalID)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       window.location.assign(`/artwork/${artwork.slug}`)
     } else {
       handleMutationError(actions, bidderPosition)
@@ -326,11 +326,11 @@ export const ConfirmBidRoute: React.FC<
       <Box maxWidth={550} px={[2, 0]} mx="auto" mt={[1, 0]} mb={[1, 100]}>
         <Serif size="8">Confirm your bid</Serif>
         <Separator />
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <LotInfo artwork={artwork} saleArtwork={artwork.saleArtwork} />
         <Separator />
         <BidForm
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           artworkSlug={artwork.slug}
           initialSelectedBid={props.match?.location?.query?.bid}
           saleArtwork={saleArtwork}
@@ -350,12 +350,12 @@ export const ConfirmBidRoute: React.FC<
 const StripeWrappedConfirmBidRoute = createStripeWrapper(ConfirmBidRoute)
 
 const TrackingWrappedConfirmBidRoute = track<ConfirmBidProps>(props => ({
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   artwork_slug: props.artwork.slug,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   auction_slug: props.artwork.saleArtwork.sale.slug,
   context_page: Schema.PageName.AuctionConfirmBidPage,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   sale_id: props.artwork.saleArtwork.sale.internalID,
   user_id: props.me.internalID,
 }))(StripeWrappedConfirmBidRoute)

--- a/src/v2/Apps/Auction/Routes/Register/index.tsx
+++ b/src/v2/Apps/Auction/Routes/Register/index.tsx
@@ -119,7 +119,7 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
       errorMessages = [error.message]
     }
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     trackRegistrationFailed(errorMessages)
     helpers.setStatus("submissionFailed")
   }
@@ -129,15 +129,15 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
     //  `onSubmit` function does not block.
     setTimeout(() => helpers.setSubmitting(true), 0)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const address = toStripeAddress(values.address)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const { phoneNumber } = values.address
     const { setFieldError, setSubmitting } = helpers
     const element = elements.getElement(CardElement)
 
     try {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const { error, token } = await stripe.createToken(element, address)
 
       if (error) {
@@ -145,10 +145,10 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
         return
       }
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const { id } = token
       const {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         createCreditCard: { creditCardOrError },
       } = await createCreditCardAndUpdatePhone(environment, phoneNumber, id)
 
@@ -163,7 +163,7 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
 
       const data = await createBidder(environment, sale.internalID)
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       trackRegistrationSuccess(data.createBidder.bidder.internalID)
       window.location.assign(saleConfirmRegistrationPath(sale.slug))
     } catch (error) {
@@ -184,9 +184,9 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
           onSubmit={createTokenAndSubmit}
           trackSubmissionErrors={trackRegistrationFailed}
           needsIdentityVerification={bidderNeedsIdentityVerification({
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             sale,
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             user: me,
           })}
         />

--- a/src/v2/Apps/Auction/Routes/__tests__/ConfirmBid.jest.tsx
+++ b/src/v2/Apps/Auction/Routes/__tests__/ConfirmBid.jest.tsx
@@ -51,13 +51,13 @@ jest.mock("@stripe/stripe-js", () => {
   return {
     loadStripe: () => {
       if (mock === null) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         mock = mockStripe()
       }
       return mock
     },
     _mockStripe: () => mock,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     _mockReset: () => (mock = mockStripe()),
   }
 })
@@ -70,7 +70,7 @@ const mockEnablePriceTransparency = jest.fn()
 
 const mockedLocation: Partial<Location> = {
   query: {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     bid: null,
   },
 }
@@ -85,7 +85,7 @@ const setupTestEnv = ({
     Component: (
       props: auctionRoutes_ConfirmBidQueryResponse & { tracking: TrackingProp }
     ) => (
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       <ConfirmBidRouteFragmentContainer
         match={{ location } as Match}
         {...props}

--- a/src/v2/Apps/Auction/Routes/__tests__/Register.jest.tsx
+++ b/src/v2/Apps/Auction/Routes/__tests__/Register.jest.tsx
@@ -32,13 +32,13 @@ jest.mock("@stripe/stripe-js", () => {
   return {
     loadStripe: () => {
       if (mock === null) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         mock = mockStripe()
       }
       return mock
     },
     _mockStripe: () => mock,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     _mockReset: () => (mock = mockStripe()),
   }
 })

--- a/src/v2/Apps/Auction/__tests__/routes.jest.ts
+++ b/src/v2/Apps/Auction/__tests__/routes.jest.ts
@@ -57,7 +57,7 @@ describe("Auction/routes", () => {
     it("does not redirect if the user is qualified to bid in the sale, the sale is open, and the artwork is biddable", async () => {
       const fixture = mockConfirmBidResolver()
       const { redirect, status } = await render(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${fixture.artwork.saleArtwork.sale.slug}/bid/${fixture.artwork.slug}`,
         fixture
       )
@@ -75,14 +75,14 @@ describe("Auction/routes", () => {
         },
       })
       const { redirect } = await render(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${fixture.artwork.saleArtwork.sale.slug}/bid/${fixture.artwork.slug}`,
         fixture
       )
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(redirect.url).toBe(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${fixture.artwork.saleArtwork.sale.slug}/confirm-registration`
       )
     })
@@ -98,13 +98,13 @@ describe("Auction/routes", () => {
         },
       })
       const { redirect } = await render(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${fixture.artwork.saleArtwork.sale.slug}/bid/${fixture.artwork.slug}`,
         fixture
       )
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(redirect.url).toBe(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${fixture.artwork.saleArtwork.sale.slug}/artwork/${fixture.artwork.slug}`
       )
     })
@@ -115,11 +115,11 @@ describe("Auction/routes", () => {
       })
 
       const { redirect } = await render(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${fixture.artwork.saleArtwork.sale.slug}/bid/${fixture.artwork.slug}`,
         fixture
       )
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(redirect.url).toBe(
         "/login?redirectTo=%2Fauction%2Fsaleslug%2Fbid%2Fartworkslug"
       )
@@ -137,13 +137,13 @@ describe("Auction/routes", () => {
         },
       })
       const { redirect } = await render(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${fixture.artwork.saleArtwork.sale.slug}/bid/${fixture.artwork.slug}`,
         fixture
       )
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(redirect.url).toBe(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${fixture.artwork.saleArtwork.sale.slug}/artwork/${fixture.artwork.slug}`
       )
     })
@@ -160,7 +160,7 @@ describe("Auction/routes", () => {
         },
       })
       const { redirect, status } = await render(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${fixture.artwork.saleArtwork.sale.slug}/bid/${fixture.artwork.slug}`,
         fixture
       )
@@ -173,7 +173,7 @@ describe("Auction/routes", () => {
   describe("Register: /auction-registration/:saleId", () => {
     it("does not redirect if a sale is found", async () => {
       const { redirect, status } = await render(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction-registration/${RegisterQueryResponseFixture.sale.slug}`,
         mockRegisterResolver(RegisterQueryResponseFixture)
       )
@@ -184,7 +184,7 @@ describe("Auction/routes", () => {
 
     it("also responds to auction-registration2 route", async () => {
       const { status } = await render(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction-registration2/${RegisterQueryResponseFixture.sale.slug}`,
         mockRegisterResolver(RegisterQueryResponseFixture)
       )
@@ -194,11 +194,11 @@ describe("Auction/routes", () => {
 
     it("redirects to the auction registration modal if the user has a qualified credit card", async () => {
       const { redirect } = await render(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction-registration/${RegisterQueryResponseFixture.sale.slug}`,
         mockRegisterResolver({
           ...RegisterQueryResponseFixture,
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           me: {
             ...RegisterQueryResponseFixture.me,
             hasQualifiedCreditCards: true,
@@ -206,20 +206,20 @@ describe("Auction/routes", () => {
         })
       )
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(redirect.url).toBe(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${RegisterQueryResponseFixture.sale.slug}/registration-flow`
       )
     })
 
     it("redirects back to the auction if the registration window has closed", async () => {
       const { redirect } = await render(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction-registration/${RegisterQueryResponseFixture.sale.slug}`,
         mockRegisterResolver({
           ...RegisterQueryResponseFixture,
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           sale: {
             ...RegisterQueryResponseFixture.sale,
             isRegistrationClosed: true,
@@ -227,24 +227,24 @@ describe("Auction/routes", () => {
         })
       )
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(redirect.url).toBe(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${RegisterQueryResponseFixture.sale.slug}`
       )
     })
 
     it("redirects to the auction confirm registration route if bidder has already registered", async () => {
       const { redirect } = await render(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction-registration/${RegisterQueryResponseFixture.sale.slug}`,
         mockRegisterResolver({
           ...RegisterQueryResponseFixture,
           sale: {
             ...RegisterQueryResponseFixture.sale,
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             registrationStatus: {
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               ...RegisterQueryResponseFixture.sale.registrationStatus,
               qualifiedForBidding: true,
             },
@@ -252,9 +252,9 @@ describe("Auction/routes", () => {
         })
       )
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(redirect.url).toBe(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         `/auction/${RegisterQueryResponseFixture.sale.slug}/confirm-registration`
       )
     })

--- a/src/v2/Apps/Auction/auctionRoutes.tsx
+++ b/src/v2/Apps/Auction/auctionRoutes.tsx
@@ -59,7 +59,7 @@ export const auctionRoutes: AppRouteConfig[] = [
           return <ErrorPage code={404} />
         }
         handleRedirect(
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           confirmBidRedirect({ artwork, me }, match.location),
           match.location
         )
@@ -116,7 +116,7 @@ export const auctionRoutes: AppRouteConfig[] = [
           return <ErrorPage code={404} />
         }
 
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         handleRedirect(registerRedirect({ sale, me }), match.location)
 
         return <Component {...props} />

--- a/src/v2/Apps/Auction/getRedirect.ts
+++ b/src/v2/Apps/Auction/getRedirect.ts
@@ -10,31 +10,31 @@ export function registerRedirect({
   me,
   sale,
 }: auctionRoutes_RegisterQueryResponse): Redirect | null {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   if (me.hasQualifiedCreditCards) {
     return {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       path: registrationFlowPath(sale),
       reason: "user already has a qualified credit card",
     }
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   } else if (!sale.isAuction) {
     return {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       path: `/sale/${sale.slug}`,
       reason: "sale must be an auction",
     }
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   } else if (!isRegisterable(sale)) {
     return {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       path: auctionPath(sale),
       reason: "auction must be registerable",
     }
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   } else if (userRegisteredToBid(sale)) {
     return {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       path: confirmRegistrationPath(sale),
       reason: "user is already registered to bid",
     }
@@ -48,7 +48,7 @@ export function confirmBidRedirect(
   location: Location
 ): Redirect | null {
   const { artwork, me } = data
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const { saleArtwork } = artwork
 
   const { sale } = saleArtwork
@@ -63,7 +63,7 @@ export function confirmBidRedirect(
 
   if (!registrationStatus && sale.isRegistrationClosed) {
     return {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       path: artworkPath(sale, artwork),
       reason: "user is not registered, registration closed",
     }
@@ -76,7 +76,7 @@ export function confirmBidRedirect(
   }
   if (sale.isClosed) {
     return {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       path: artworkPath(sale, artwork),
       reason: "sale is closed",
     }

--- a/src/v2/Apps/Auctions/Components/MyBids/MyBids.tsx
+++ b/src/v2/Apps/Auctions/Components/MyBids/MyBids.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { MyBids_me } from "v2/__generated__/MyBids_me.graphql"
 import { MyBidsBidHeaderFragmentContainer } from "./MyBidsBidHeader"
@@ -89,7 +89,7 @@ const MyBids: React.FC<MyBidsProps> = props => {
                           trackEvent(
                             clickedEntityGroup({
                               contextModule: ContextModule.yourActiveBids,
-                              // @ts-expect-error STRICT_NULL_CHECK
+                              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                               contextPageOwnerType,
                               destinationPageOwnerType: OwnerType.sale,
                               type: "thumbnail",

--- a/src/v2/Apps/Auctions/Components/MyBids/MyBidsBidHeader.tsx
+++ b/src/v2/Apps/Auctions/Components/MyBids/MyBidsBidHeader.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { MyBidsBidHeader_sale } from "v2/__generated__/MyBidsBidHeader_sale.graphql"
 import { Box, Image, Text, Spacer } from "@artsy/palette"
@@ -25,7 +25,7 @@ export const MyBidsBidHeader: React.FC<MyBidsBidHeaderProps> = ({ sale }) => {
         trackEvent(
           clickedEntityGroup({
             contextModule: ContextModule.yourActiveBids,
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             contextPageOwnerType,
             destinationPageOwnerType: OwnerType.sale,
             type: "thumbnail",

--- a/src/v2/Apps/Authentication/Components/ModalContainer.tsx
+++ b/src/v2/Apps/Authentication/Components/ModalContainer.tsx
@@ -87,7 +87,7 @@ export class ModalContainer extends Component<any> {
 
   render() {
     return (
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       <ModalManager
         ref={ref => (this.manager = ref)}
         // FIXME: reaction migration

--- a/src/v2/Apps/Collect/Components/SeoProductsForArtworks.tsx
+++ b/src/v2/Apps/Collect/Components/SeoProductsForArtworks.tsx
@@ -1,5 +1,5 @@
 import currency from "currency.js"
-import { Component } from "react";
+import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { toSentence } from "underscore.string"
 
@@ -27,7 +27,7 @@ export class SeoProducts extends Component<SeoProductsProps> {
     // here the filtering is necessary so we can re-use the artwork list shown in the page (could include
     // non-acquireable artworks) without making an extra request. Also, seller image is a required field
     // so excluding those that don't have `partner.profile.icon.url`.
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const artworksForSeoProduct = artworks.edges.filter(edge => {
       return get(edge, e => {
         return e!.node!.is_acquireable && e!.node!.partner!.profile!.icon!.url
@@ -43,7 +43,7 @@ export class SeoProducts extends Component<SeoProductsProps> {
           image,
           is_price_range,
           partner,
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           listPrice: { display },
         } = node
         const location = partner && partner.locations && partner.locations[0]
@@ -52,7 +52,7 @@ export class SeoProducts extends Component<SeoProductsProps> {
           : null
         const isInstitution = partner && partner.type === "Institution"
         const partnerImg = get(partner, p => {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           return p.profile.icon.url
         })
 

--- a/src/v2/Apps/Collect/Components/SeoProductsForCollections.tsx
+++ b/src/v2/Apps/Collect/Components/SeoProductsForCollections.tsx
@@ -1,7 +1,7 @@
 import { SeoProductsForCollections_ascending_artworks } from "v2/__generated__/SeoProductsForCollections_ascending_artworks.graphql"
 import { SeoProductsForCollections_descending_artworks } from "v2/__generated__/SeoProductsForCollections_descending_artworks.graphql"
 import { Product } from "v2/Components/Seo/Product"
-import { Component } from "react";
+import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "v2/Utils/get"
 
@@ -18,24 +18,24 @@ export const getMaxMinPrice = (
   ascending_artworks: SeoProductsForCollections_ascending_artworks
 ) => {
   const leastExpensive = getPriceRange(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     ascending_artworks.edges[0]?.node?.listPrice
   )
   const mostExpensive = getPriceRange(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     descending_artworks.edges[0]?.node?.listPrice
   )
 
   return {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     min: leastExpensive.min || mostExpensive.min,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     max: mostExpensive.max || leastExpensive.max,
   }
 }
 
 const getPriceRange = (
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   listPrice: SeoProductsForCollections_ascending_artworks["edges"][0]["node"]["listPrice"]
 ) => {
   if (!listPrice) {

--- a/src/v2/Apps/Collect/Components/__tests__/SeoProductsForCollections.jest.tsx
+++ b/src/v2/Apps/Collect/Components/__tests__/SeoProductsForCollections.jest.tsx
@@ -47,7 +47,7 @@ describe("Seo Products for Collection Page", () => {
     listPrice
   ): SeoProductsForCollections_descending_artworks {
     return {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       " $refType": null,
       edges: [
         {
@@ -65,7 +65,7 @@ describe("Seo Products for Collection Page", () => {
     listPrice
   ): SeoProductsForCollections_ascending_artworks {
     return {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       " $refType": null,
       edges: [
         {
@@ -210,7 +210,7 @@ describe("Seo Products for Collection Page", () => {
   })
 
   describe("when both a Money and a PriceRange are present", () => {
-    it("it uses the maxPrice when the descending is a PriceRange", () => {
+    it("uses the maxPrice when the descending is a PriceRange", () => {
       props.ascending_artworks = buildAscendingArtworks(
         buildIndividualPrice(42)
       )
@@ -225,7 +225,7 @@ describe("Seo Products for Collection Page", () => {
       expect(html).toContain('"highPrice": 420')
     })
 
-    it("it uses the minPrice when the ascending is a PriceRange", () => {
+    it("uses the minPrice when the ascending is a PriceRange", () => {
       props.ascending_artworks = buildAscendingArtworks(
         buildPriceRange(42, 100)
       )

--- a/src/v2/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
+++ b/src/v2/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
@@ -5,7 +5,7 @@ describe("getMetadata", () => {
     it("formats medium types", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
         medium: "painting",
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         color: null,
       })
       expect(title).toBe("Paintings - For Sale on Artsy")
@@ -18,7 +18,7 @@ describe("getMetadata", () => {
     it("falls back to fallback meta if medium is invalid", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
         medium: "foo" as any,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         color: null,
       })
       expect(title).toBe("Collect | Artsy")
@@ -32,7 +32,7 @@ describe("getMetadata", () => {
   describe("color", () => {
     it("formats color types", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         medium: null,
         color: "red",
       })
@@ -46,7 +46,7 @@ describe("getMetadata", () => {
 
     it("falls back to fallback meta if medium is invalid", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         medium: null,
         color: "foo" as any,
       })
@@ -60,9 +60,9 @@ describe("getMetadata", () => {
 
   it("formats default types", () => {
     const { title, breadcrumbTitle, description } = getMetadata({
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       medium: null,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       color: null,
     })
 

--- a/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
@@ -3,7 +3,7 @@ import { ArtistSeriesEntity_member } from "v2/__generated__/ArtistSeriesEntity_m
 import { useTracking } from "v2/System/Analytics/useTracking"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import currency from "currency.js"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ContextModule, clickedArtistSeriesGroup } from "@artsy/cohesion"
 import { useAnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
@@ -44,7 +44,7 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
         contextModule: ContextModule.artistSeriesRail,
         contextPageOwnerId,
         contextPageOwnerSlug,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         contextPageOwnerType,
         destinationPageOwnerId: id,
         destinationPageOwnerSlug: slug,
@@ -70,15 +70,15 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
               return (
                 <Box key={index} ml={index === 0 ? 0 : -2}>
                   <Image
-                    // @ts-expect-error STRICT_NULL_CHECK
+                    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                     src={resized.src}
-                    // @ts-expect-error STRICT_NULL_CHECK
+                    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                     srcSet={resized.srcSet}
-                    // @ts-expect-error STRICT_NULL_CHECK
+                    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                     width={resized.width}
-                    // @ts-expect-error STRICT_NULL_CHECK
+                    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                     height={resized.height}
-                    // @ts-expect-error STRICT_NULL_CHECK
+                    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                     alt={artwork.title}
                     lazyLoad
                   />
@@ -87,7 +87,7 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
             })
           ) : (
             <Image
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               {...cropped(headerImage, { width: 325, height: 150 })}
               width={325}
               height={150}

--- a/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -3,7 +3,7 @@ import { FeaturedCollectionsRails_collectionGroup } from "v2/__generated__/Featu
 import { useTracking } from "v2/System/Analytics/useTracking"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import currency from "currency.js"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ContextModule, clickedCollectionGroup } from "@artsy/cohesion"
 import { useAnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
@@ -65,7 +65,7 @@ export const FeaturedCollectionEntity: React.FC<FeaturedCollectionEntityProps> =
         contextModule: ContextModule.featuredCollectionsRail,
         contextPageOwnerId,
         contextPageOwnerSlug,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         contextPageOwnerType,
         destinationPageOwnerId: id,
         destinationPageOwnerSlug: slug,

--- a/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
@@ -2,7 +2,7 @@ import { Text, Image } from "@artsy/palette"
 import { OtherCollectionEntity_member } from "v2/__generated__/OtherCollectionEntity_member.graphql"
 import { useTracking } from "v2/System/Analytics/useTracking"
 import { RouterLink } from "v2/System/Router/RouterLink"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ContextModule, clickedCollectionGroup } from "@artsy/cohesion"
 import { useAnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
@@ -30,7 +30,7 @@ export const OtherCollectionEntity: React.FC<CollectionProps> = ({
         contextModule: ContextModule.otherCollectionsRail,
         contextPageOwnerId,
         contextPageOwnerSlug,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         contextPageOwnerType,
         destinationPageOwnerId: id,
         destinationPageOwnerSlug: slug,

--- a/src/v2/Apps/Collect/Routes/Collection/Components/Header/DefaultHeaderArtwork.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/Header/DefaultHeaderArtwork.tsx
@@ -3,7 +3,7 @@ import { DefaultHeaderArtwork_artwork } from "v2/__generated__/DefaultHeaderArtw
 import { AnalyticsSchema } from "v2/System/Analytics"
 import { useTracking } from "v2/System/Analytics/useTracking"
 import { RouterLink } from "v2/System/Router/RouterLink"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 export interface DefaultHeaderArtworkProps {
@@ -24,14 +24,14 @@ export const DefaultHeaderArtwork: React.FC<DefaultHeaderArtworkProps> = ({
   const handleClick = () => {
     trackEvent({
       action_type: AnalyticsSchema.ActionType.Click,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       context_module: AnalyticsSchema.ContextModule.ArtworkBanner,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       context_page_owner_type: AnalyticsSchema.OwnerType.Collection,
       context_page: AnalyticsSchema.PageName.CollectionPage,
       context_page_owner_id: collectionId,
       context_page_owner_slug: collectionSlug,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       destination_path: artwork.href,
     })
   }

--- a/src/v2/Apps/Collect/Routes/Collection/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/index.tsx
@@ -7,7 +7,7 @@ import { SystemContextProps, withSystemContext } from "v2/System/SystemContext"
 import { FrameWithRecentlyViewed } from "v2/Components/FrameWithRecentlyViewed"
 import { RelatedCollectionsRailFragmentContainer as RelatedCollectionsRail } from "v2/Components/RelatedCollectionsRail/RelatedCollectionsRail"
 import { BreadCrumbList } from "v2/Components/Seo"
-import * as React from "react";
+import * as React from "react"
 import { Title } from "react-head"
 import { RelayRefetchProp, graphql, createFragmentContainer } from "react-relay"
 import { data as sd } from "sharify"
@@ -87,18 +87,18 @@ export const CollectionApp: React.FC<CollectionAppProps> = props => {
 
       {artworksConnection && (
         <SeoProductsForCollections
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           descending_artworks={descending_artworks}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ascending_artworks={ascending_artworks}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           collectionDescription={description}
           collectionURL={collectionHref}
           collectionName={title}
         />
       )}
 
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <CollectionHeader collection={collection} artworks={artworksConnection} />
 
       <FrameWithRecentlyViewed>

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/GetPriceEstimate/ArtistInsightResult.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/GetPriceEstimate/ArtistInsightResult.tsx
@@ -35,7 +35,7 @@ export const ArtistInsightResult: React.FC = () => {
     return <ZeroState />
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const mediumSelectOptions = mediums.map(medium => ({
     text: medium,
     value: medium,

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/GetPriceEstimate/ConsignArtistAutosuggest.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/GetPriceEstimate/ConsignArtistAutosuggest.tsx
@@ -1,6 +1,6 @@
 import Autosuggest from "react-autosuggest"
-import { useEffect } from "react";
-import * as React from "react";
+import { useEffect } from "react"
+import * as React from "react"
 import {
   MagnifyingGlassIcon,
   Text,
@@ -49,7 +49,7 @@ export const ConsignArtistAutosuggest: React.FC = () => {
         owner_id: suggestion.internalID,
         owner_slug: suggestion.slug,
         owner_type: OwnerType.artist,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         query: searchQuery,
       })
     )
@@ -60,7 +60,7 @@ export const ConsignArtistAutosuggest: React.FC = () => {
       searchedWithNoResults({
         context_module: ContextModule.priceEstimate,
         context_owner_type: OwnerType.consign,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         query: searchQuery,
       })
     )
@@ -83,11 +83,11 @@ export const ConsignArtistAutosuggest: React.FC = () => {
     <Autosuggest
       suggestions={suggestions ?? []}
       onSuggestionsClearRequested={x => x}
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       onSuggestionsFetchRequested={() => fetchSuggestions(searchQuery)}
       onSuggestionSelected={(_, { suggestion }) => {
         trackSelectedItemFromSearch(suggestion)
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         selectSuggestion(suggestion)
       }}
       getSuggestionValue={suggestion => suggestion.node.displayLabel}
@@ -95,7 +95,7 @@ export const ConsignArtistAutosuggest: React.FC = () => {
       renderSuggestion={Suggestion}
       inputProps={{
         onChange: (_, { newValue }) => {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           setSearchQuery(newValue)
         },
         onFocus: trackFocusedOnSearchInput,

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/GetPriceEstimate/ConsignPriceEstimateContext.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/GetPriceEstimate/ConsignPriceEstimateContext.tsx
@@ -1,5 +1,5 @@
-import { Dispatch, useContext, useReducer } from "react";
-import * as React from "react";
+import { Dispatch, useContext, useReducer } from "react"
+import * as React from "react"
 import { createContext } from "react"
 import { Environment, fetchQuery, graphql } from "react-relay"
 import { useSystemContext } from "v2/System"
@@ -24,9 +24,9 @@ interface PriceEstimateContextProps {
   suggestions?: Suggestions
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 type ArtistInsights = ConsignPriceEstimateContext_ArtistInsights_Query["response"]["priceInsights"]["edges"]
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 type Suggestions = ConsignPriceEstimateContext_SearchConnection_Query["response"]["searchConnection"]["edges"]
 export type Suggestion = Suggestions[0]
 
@@ -62,7 +62,7 @@ type Action = {
 const initialState: State = {
   artistInsights: null,
   isFetching: false,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   medium: null,
   mediums: [],
   searchQuery: "",
@@ -80,7 +80,7 @@ function getActions(dispatch: Dispatch<Action>, relayEnvironment: Environment) {
      * Fetch artist insights based on artist's internalID.
      */
     fetchArtistInsights: async artistInternalID => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       actions.setFetching(true)
 
       const response = await fetchQuery<
@@ -116,14 +116,14 @@ function getActions(dispatch: Dispatch<Action>, relayEnvironment: Environment) {
       const artistInsights = response?.priceInsights?.edges || []
 
       if (artistInsights.length) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const mediums = artistInsights.map(({ node }) => node.medium)
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const medium = artistInsights[0].node.medium
 
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         actions.setMediums(mediums)
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         actions.setMedium(medium)
       }
 
@@ -132,7 +132,7 @@ function getActions(dispatch: Dispatch<Action>, relayEnvironment: Environment) {
         type: "artistInsights",
       })
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       actions.setFetching(false)
     },
 
@@ -170,7 +170,7 @@ function getActions(dispatch: Dispatch<Action>, relayEnvironment: Environment) {
         { searchQuery }
       )
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const suggestions = response.searchConnection.edges
 
       dispatch({
@@ -188,7 +188,7 @@ function getActions(dispatch: Dispatch<Action>, relayEnvironment: Environment) {
         type: "selectedSuggestion",
       })
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       await actions.fetchArtistInsights(selectedSuggestion.node.internalID)
     },
 
@@ -237,7 +237,7 @@ function reducer(state: State, action: Action): State {
 export const PriceEstimateContextProvider: React.FC = ({ children }) => {
   const { relayEnvironment } = useSystemContext()
   const [state, dispatch] = useReducer(reducer, initialState)
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const actions = getActions(dispatch, relayEnvironment)
   const values = {
     ...state,

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/GetPriceEstimate/__tests__/ConsignPriceEstimateContext.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/GetPriceEstimate/__tests__/ConsignPriceEstimateContext.jest.tsx
@@ -56,7 +56,7 @@ describe("ConsignPriceEstimateContext", () => {
         return { priceInsights: { edges: [{ node: { medium } }] } }
       })
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       await actions.fetchArtistInsights("some-id")
 
       expect(mockFetchQuery).toHaveBeenCalledWith(
@@ -116,7 +116,7 @@ describe("ConsignPriceEstimateContext", () => {
         return suggestions
       })
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       await actions.fetchSuggestions(searchQuery)
 
       expect(mockFetchQuery).toHaveBeenCalledWith(
@@ -142,7 +142,7 @@ describe("ConsignPriceEstimateContext", () => {
         },
       }
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       actions.selectSuggestion(someSuggestion)
       expect(actions.fetchArtistInsights).toHaveBeenCalledWith(
         someSuggestion.node.internalID
@@ -152,7 +152,7 @@ describe("ConsignPriceEstimateContext", () => {
     it("#setFetching", () => {
       const actions = getActions(mockDispatch, mockEnvironment)
       const isFetching = true
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       actions.setFetching(isFetching)
       expect(mockDispatch).toHaveBeenCalledWith({
         payload: {
@@ -165,7 +165,7 @@ describe("ConsignPriceEstimateContext", () => {
     it("#setMedium", async () => {
       const actions = getActions(mockDispatch, mockEnvironment)
       const medium = "some-medium"
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       actions.setMedium(medium)
       expect(mockDispatch).toHaveBeenCalledWith({
         payload: { medium },
@@ -176,7 +176,7 @@ describe("ConsignPriceEstimateContext", () => {
     it("#setMediums", async () => {
       const actions = getActions(mockDispatch, mockEnvironment)
       const mediums = ["foo", "bar", "baz"]
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       actions.setMediums(mediums)
       expect(mockDispatch).toHaveBeenCalledWith({
         payload: { mediums },
@@ -187,7 +187,7 @@ describe("ConsignPriceEstimateContext", () => {
     it("#setSearchQuery", () => {
       const actions = getActions(mockDispatch, mockEnvironment)
       const searchQuery = "foo"
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       actions.setSearchQuery(searchQuery)
       expect(mockDispatch).toHaveBeenCalledWith({
         payload: {

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/InDemandNow/ConsignTopArtists.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/InDemandNow/ConsignTopArtists.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { useSystemContext } from "v2/System"
 import { graphql } from "react-relay"
@@ -7,7 +7,7 @@ import { ConsignTopArtistsQuery } from "v2/__generated__/ConsignTopArtistsQuery.
 import { Text, EntityHeader, GridColumns, Column } from "@artsy/palette"
 import { formatCentsToDollars } from "v2/Apps/Consign/Routes/MarketingLanding/Utils/formatCentsToDollars"
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 type ArtworkProps = ConsignTopArtistsQuery["response"]["targetSupply"]["microfunnel"][0]["artworksConnection"]["edges"][0]["node"] & {
   realizedPriceAverage: string
 }
@@ -90,7 +90,7 @@ const TopArtists: React.FC<ConsignTopArtistsQuery["response"]> = props => {
           return null
         }
 
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const { edges } = artwork.artworksConnection
 
         const realizedPriceAverage = formatCentsToDollars(

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/SoldRecently.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/SoldRecently.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Box, Flex, Spacer, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System"
@@ -29,7 +29,7 @@ const SoldRecently: React.FC<SoldRecentlyProps> = ({ targetSupply }) => {
   const recentlySoldArtworks = shuffle(
     flatten(
       targetSupply.microfunnel.map(microfunnel => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const artworks = extractNodes(microfunnel.artworksConnection)
         return artworks.filter(
           artwork => artwork.realizedPrice && artwork.realizedToEstimate

--- a/src/v2/Apps/Consign/Routes/Offer/Components/ResponseForm.tsx
+++ b/src/v2/Apps/Consign/Routes/Offer/Components/ResponseForm.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Form, Formik } from "formik"
 import { BorderedRadio, Button, RadioGroup, Text } from "@artsy/palette"
 import { useSystemContext } from "v2/System"
@@ -31,7 +31,7 @@ const ResponseForm: React.FC<ResponseFormProps> = ({ offer }) => {
         intendedState: "ACCEPTED",
       }}
       onSubmit={async (values: ResponseFormValues, actions) => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         await CreateOfferResponse(relayEnvironment, offer.id, values)
         setResponded(true)
         actions.setSubmitting(false)

--- a/src/v2/Apps/Consign/Routes/Offer/Components/SubmissionSummary.tsx
+++ b/src/v2/Apps/Consign/Routes/Offer/Components/SubmissionSummary.tsx
@@ -1,5 +1,5 @@
 import { Box, Image, StackableBorderBox, Text } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 
@@ -17,7 +17,7 @@ const SubmissionSummary: React.FC<SubmissionSummaryProps> = ({ offer }) => {
       <Box height="auto">{renderImage(submission)}</Box>
       <Box>
         <TruncatedLine>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <Text variant="mediumText">{submission.artist.name}</Text>
           {renderTitleLine(submission)}
         </TruncatedLine>
@@ -59,7 +59,7 @@ function renderImage(submission: SubmissionSummary_offer["submission"]) {
     return null
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   return <Image src={imageURL} alt={submission.title} width={55} mr={1} />
 }
 

--- a/src/v2/Apps/Conversation/Components/Message.tsx
+++ b/src/v2/Apps/Conversation/Components/Message.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "relay-runtime"
 import Linkify from "react-linkify"
@@ -53,7 +53,7 @@ const MessageText = styled(Text)`
 `
 
 interface AttachmentProps {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   attachment: Message_message["attachments"][0]
   alignSelf: string
   bgColor: Color

--- a/src/v2/Apps/Conversation/Components/__tests__/Item.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/Item.jest.tsx
@@ -4,7 +4,7 @@ import { Conversation_conversation } from "v2/__generated__/Conversation_convers
 
 describe("Item", () => {
   describe("when inquiry item is an artwork", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const artworkItemProps: Conversation_conversation["items"][0]["item"] = {
       __typename: "Artwork",
       id: "12345",
@@ -40,7 +40,7 @@ describe("Item", () => {
   })
 
   describe("when inquiry item is a show", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const showItemProps: Conversation_conversation["items"][0]["item"] = {
       __typename: "Show",
       id: "12345",
@@ -73,7 +73,7 @@ describe("Item", () => {
   })
 
   describe("when inquiry item is %other", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const otherItemProps: Conversation_conversation["items"][0]["item"] = {
       __typename: "%other",
     }

--- a/src/v2/Apps/Conversation/Components/__tests__/Message.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/Message.jest.tsx
@@ -3,7 +3,7 @@ import { Message_message } from "v2/__generated__/Message_message.graphql"
 import { Message as messageFixture } from "v2/Apps/__tests__/Fixtures/Conversation"
 import { Message } from "../Message"
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 const message: Message_message = { " $refType": null, ...messageFixture }
 
 describe("Message", () => {

--- a/src/v2/Apps/Conversation/ConversationApp.tsx
+++ b/src/v2/Apps/Conversation/ConversationApp.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import * as React from "react";
+import { useEffect, useState } from "react"
+import * as React from "react"
 import { Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Match, Router } from "found"
@@ -19,7 +19,7 @@ interface ConversationAppProps {
 
 interface InboxProps {
   me: ConversationApp_me
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   selectedConversation: ConversationApp_me["conversationsConnection"]["edges"][0]["node"]
 }
 

--- a/src/v2/Apps/Conversation/Mutation/SendConversationMessage.ts
+++ b/src/v2/Apps/Conversation/Mutation/SendConversationMessage.ts
@@ -18,15 +18,15 @@ export const SendConversationMessage = (
 ) => {
   const storeUpdater = (store: RecordSourceSelectorProxy) => {
     const mutationPayload = store.getRootField("sendConversationMessage")
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const newMessageEdge = mutationPayload.getLinkedRecord("messageEdge")
     const conversationStore = store.get(conversation.id)
     const connection = ConnectionHandler.getConnection(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       conversationStore,
       "Messages_messagesConnection"
     )
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     ConnectionHandler.insertEdgeBefore(connection, newMessageEdge)
   }
   return commitMutation<SendConversationMessageMutation>(environment, {

--- a/src/v2/Apps/Conversation/Utils/groupMessages.tsx
+++ b/src/v2/Apps/Conversation/Utils/groupMessages.tsx
@@ -2,7 +2,7 @@ import { ConversationMessages_messages } from "v2/__generated__/ConversationMess
 import { DateTime } from "luxon"
 import { fromToday } from "../Components/TimeSince"
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 export type Message = ConversationMessages_messages["edges"][number]["node"]
 /**
  * Combines messages into groups of messages sent by the same party and

--- a/src/v2/Apps/Conversation/__tests__/ConversationApp.jest.tsx
+++ b/src/v2/Apps/Conversation/__tests__/ConversationApp.jest.tsx
@@ -12,7 +12,7 @@ import { ConversationAppFragmentContainer } from "../ConversationApp"
 
 jest.unmock("react-relay")
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 const pageInfo: ConversationAppTestQueryRawResponse["me"]["conversationsConnection"]["pageInfo"] = {
   startCursor: "NQ",
   endCursor: "MQ",
@@ -24,7 +24,7 @@ const render = (me: ConversationAppTestQueryRawResponse["me"], user: User) =>
   renderRelayTree({
     Component: (props: ConversationAppTestQueryResponse) => (
       <ConversationAppFragmentContainer
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         me={{
           ...me,
         }}

--- a/src/v2/Apps/Example/ExampleApp.tsx
+++ b/src/v2/Apps/Example/ExampleApp.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ExampleApp_system } from "v2/__generated__/ExampleApp_system.graphql"
 import {
@@ -22,7 +22,7 @@ export interface ExampleAppProps {
 }
 
 const ExampleApp: React.FC<ExampleAppProps> = ({ system, children }) => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const { month, day, year } = system.time
 
   return (

--- a/src/v2/Apps/Example/Routes/Artwork/ExampleArtworkRoute.tsx
+++ b/src/v2/Apps/Example/Routes/Artwork/ExampleArtworkRoute.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Image, Text, Title } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { AnalyticsContext, useAnalyticsContext } from "v2/System"
 import { ExampleArtworkRoute_artwork } from "v2/__generated__/ExampleArtworkRoute_artwork.graphql"
@@ -20,7 +20,7 @@ const ExampleArtworkRoute: React.FC<ExampleArtworkRouteProps> = ({
         <Text variant="lg" mb={2}>
           {artwork.title}
         </Text>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <Image src={artwork.imageUrl} alt={artwork.title} />
         <Text fontWeight="bold">{artwork.artistNames}</Text>
         <Text>{artwork.date}</Text>
@@ -29,7 +29,7 @@ const ExampleArtworkRoute: React.FC<ExampleArtworkRouteProps> = ({
       <Box>
         <Text variant="md">Related Artists</Text>
         <Flex my={2}>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           {artwork.artist.related.artistsConnection.edges.map(({ node }) => (
             <Box width={["100%", "25%"]} pr={[0, "20px"]}>
               <ArtistCard

--- a/src/v2/Apps/Example/Routes/Welcome/WelcomeRoute.tsx
+++ b/src/v2/Apps/Example/Routes/Welcome/WelcomeRoute.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Box, Button, Dialog, Text } from "@artsy/palette"
 import { useAnalyticsContext, useTracking } from "v2/System"
 import { ContextModule, clickedShowMore } from "@artsy/cohesion"
@@ -20,7 +20,7 @@ export const WelcomeRoute: React.FC = () => {
     trackEvent(
       clickedShowMore({
         context_module: ContextModule.promoSpace,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         context_page_owner_type: contextPageOwnerType,
         context_page_owner_slug: contextPageOwnerSlug,
         context_page_owner_id: contextPageOwnerId,

--- a/src/v2/Apps/Fair/Components/FairCollections/FairCollection.tsx
+++ b/src/v2/Apps/Fair/Components/FairCollections/FairCollection.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairCollection_collection } from "v2/__generated__/FairCollection_collection.graphql"
 import { TriptychCard } from "@artsy/palette"
@@ -43,7 +43,7 @@ export const FairCollection: React.FC<FairCollectionProps> = ({
 
   const collectionTrackingData: ClickedCollectionGroup = {
     context_module: ContextModule.curatedHighlightsRail,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     context_page_owner_type: contextPageOwnerType,
     context_page_owner_id: contextPageOwnerId,
     context_page_owner_slug: contextPageOwnerSlug,
@@ -56,7 +56,7 @@ export const FairCollection: React.FC<FairCollectionProps> = ({
   }
 
   const imageUrls = compact(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     collection.artworks.edges.map(({ node }) => node?.image?.url)
   )
 
@@ -77,7 +77,7 @@ export const FairCollection: React.FC<FairCollectionProps> = ({
     }
   })
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const count = collection.artworks.counts.total
 
   return (

--- a/src/v2/Apps/Fair/Components/FairCollections/FairCollections.tsx
+++ b/src/v2/Apps/Fair/Components/FairCollections/FairCollections.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairCollections_fair } from "v2/__generated__/FairCollections_fair.graphql"
 import { Box, BoxProps } from "@artsy/palette"
@@ -19,9 +19,9 @@ export const FairCollections: React.FC<FairCollectionsProps> = ({
         {fair.marketingCollections.map((collection, index) => {
           return (
             <FairCollection
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               key={collection.id}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               collection={collection}
               carouselIndex={index}
             />

--- a/src/v2/Apps/Fair/Components/FairOverview/FairFollowedArtists.tsx
+++ b/src/v2/Apps/Fair/Components/FairOverview/FairFollowedArtists.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairFollowedArtists_fair } from "v2/__generated__/FairFollowedArtists_fair.graphql"
 import { Carousel } from "v2/Components/Carousel"
@@ -34,7 +34,7 @@ export const FairFollowedArtists: React.FC<FairFollowedArtistsProps> = ({
 
   const tappedViewTrackingData: ClickedArtworkGroup = {
     context_module: ContextModule.worksByArtistsYouFollowRail,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     context_page_owner_type: contextPageOwnerType,
     context_page_owner_id: contextPageOwnerId,
     context_page_owner_slug: contextPageOwnerSlug,
@@ -52,7 +52,7 @@ export const FairFollowedArtists: React.FC<FairFollowedArtistsProps> = ({
   }): ClickedArtworkGroup => {
     return {
       context_module: ContextModule.worksByArtistsYouFollowRail,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       context_page_owner_type: contextPageOwnerType,
       context_page_owner_id: contextPageOwnerId,
       context_page_owner_slug: contextPageOwnerSlug,
@@ -87,7 +87,7 @@ export const FairFollowedArtists: React.FC<FairFollowedArtistsProps> = ({
       </Box>
 
       <Carousel arrowHeight={IMAGE_HEIGHT}>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {fair.followedArtistArtworks.edges.map(({ artwork }, index) => {
           return (
             <FillwidthItem

--- a/src/v2/Apps/Fair/Routes/FairArticles.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArticles.tsx
@@ -26,7 +26,7 @@ interface FairArticlesProps {
 
 const FairArticles: React.FC<FairArticlesProps> = ({ fair, relay }) => {
   const {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     articlesConnection: { edges: articles, totalCount },
   } = fair
 

--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -5,7 +5,7 @@ import {
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
-import * as React from "react";
+import * as React from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { MediumFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter"
 import { PriceRangeFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter"
@@ -39,7 +39,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   // we still want to render the rest of the page.
   if (!hasFilter) return null
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const { counts } = filtered_artworks
 
   // TODO: You shouldn't have to pass `relayEnvironment` and `user` through below.
@@ -82,7 +82,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
       ]}
       onChange={updateUrl}
       aggregations={
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         sidebarAggregations.aggregations as SharedArtworkFilterContextProps["aggregations"]
       }
     >

--- a/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
+++ b/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
@@ -23,7 +23,7 @@ const { getWrapper } = setupTestWrapper<FairApp_Test_Query>({
           },
         }}
       >
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <FairAppFragmentContainer {...props} />
       </MockBoot>
     )

--- a/src/v2/Apps/Fairs/Components/FairsFairRow.tsx
+++ b/src/v2/Apps/Fairs/Components/FairsFairRow.tsx
@@ -28,7 +28,7 @@ const FairsFairRow: React.FC<FairsFairRowProps> = ({ fair, ...rest }) => {
   const href =
     // If fair status is upcoming — link to the organizer profile
     // TODO: Extract this logic to Metaphysics `href`
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     DateTime.local() < DateTime.fromISO(fair.isoStartAt)
       ? fair?.organizer?.profile?.href // possibly null
       : fair.href

--- a/src/v2/Apps/Fairs/Routes/__tests__/FairsIndex.jest.tsx
+++ b/src/v2/Apps/Fairs/Routes/__tests__/FairsIndex.jest.tsx
@@ -10,7 +10,7 @@ const { getWrapper } = setupTestWrapper<FairsIndex_Test_Query>({
   Component: props => {
     return (
       <MockBoot>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <FairsIndexFragmentContainer {...props} />
       </MockBoot>
     )

--- a/src/v2/Apps/Feature/Components/FeatureSet/FeatureSet.tsx
+++ b/src/v2/Apps/Feature/Components/FeatureSet/FeatureSet.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Box, BoxProps, Spacer } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FeatureSet_set } from "v2/__generated__/FeatureSet_set.graphql"
@@ -13,12 +13,12 @@ export interface FeatureSetProps extends Omit<BoxProps, "color"> {
 const SUPPORTED_ITEM_TYPES = ["FeaturedLink", "Artwork"]
 
 export const FeatureSet: React.FC<FeatureSetProps> = ({ set, ...rest }) => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const count = set.orderedItems.edges.length
   const size =
     set.layout === "FULL"
       ? "full"
-      : // @ts-expect-error STRICT_NULL_CHECK
+      : // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         ({ 1: "large", 2: "medium" }[set.orderedItems.edges.length] as
           | "medium"
           | "large"
@@ -28,7 +28,7 @@ export const FeatureSet: React.FC<FeatureSetProps> = ({ set, ...rest }) => {
     // Nothing to render: it's possible to have a completely empty yet valid set
     (!set.name && !set.description && count === 0) ||
     // Or the set isn't a supported type (Sale, etc.)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     !SUPPORTED_ITEM_TYPES.includes(set.itemType)
   ) {
     return null
@@ -42,7 +42,7 @@ export const FeatureSet: React.FC<FeatureSetProps> = ({ set, ...rest }) => {
         <Spacer my={4} />
       )}
       <FeatureSetContainer set={set}>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {set.orderedItems.edges.map(({ node: setItem }) => {
           return (
             <FeatureSetItem key={setItem.id} setItem={setItem} size={size} />

--- a/src/v2/Apps/Feature/__tests__/FeatureApp.jest.tsx
+++ b/src/v2/Apps/Feature/__tests__/FeatureApp.jest.tsx
@@ -10,7 +10,7 @@ const { getWrapper } = setupTestWrapper<FeatureApp_Test_Query>({
   Component: props => {
     return (
       <MockBoot>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <FeatureAppFragmentContainer {...props} />
       </MockBoot>
     )

--- a/src/v2/Apps/FeatureAKG/Components/Feature.tsx
+++ b/src/v2/Apps/FeatureAKG/Components/Feature.tsx
@@ -9,7 +9,7 @@ import { AnalyticsSchema, ContextModule } from "v2/System"
 import { useTracking } from "v2/System/Analytics/useTracking"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { useSystemContext } from "v2/System/SystemContext"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { crop, resize } from "v2/Utils/resizer"
@@ -57,7 +57,7 @@ const Feature: React.FC<FeatureProps> = props => {
           <Box textAlign="center" mb={-1}>
             <Video
               src={heroVideo.large_src}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               placeholder={resizedLargePlaceholder}
             />
           </Box>
@@ -68,7 +68,7 @@ const Feature: React.FC<FeatureProps> = props => {
           <Box textAlign="center" mb={-1}>
             <Video
               src={heroVideo.small_src}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               placeholder={resizedSmallPlaceholder}
             />
           </Box>

--- a/src/v2/Apps/FeatureAKG/Components/FeaturedArticles.tsx
+++ b/src/v2/Apps/FeatureAKG/Components/FeaturedArticles.tsx
@@ -4,7 +4,7 @@ import { StyledLink } from "./StyledLink"
 import { AnalyticsSchema } from "v2/System"
 import { useTracking } from "v2/System/Analytics/useTracking"
 import { RouterLink } from "v2/System/Router/RouterLink"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "relay-runtime"
 import styled from "styled-components"
@@ -45,9 +45,9 @@ const FeaturedArticles: React.FC<FeaturedArticlesProps> = props => {
         <Col md={6}>
           <Box pr={[0, 0, 1]}>
             <StyledLink
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               to={firstArticle.href}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               onClick={() => trackClick(firstArticle.href)}
             >
               {firstArticleImage && (
@@ -63,11 +63,11 @@ const FeaturedArticles: React.FC<FeaturedArticlesProps> = props => {
                 />
               )}
               <Sans size={["4t", "4t", "6"]} my={1}>
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 {firstArticle.thumbnailTitle}
               </Sans>
               <Sans size="2" color="black60">
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 {firstArticle.publishedAt}
               </Sans>
             </StyledLink>
@@ -82,7 +82,7 @@ const FeaturedArticles: React.FC<FeaturedArticlesProps> = props => {
               <Box ml={[0, 0, 1]} key={`article-${index}`}>
                 <StyledLink
                   to={article.href}
-                  // @ts-expect-error STRICT_NULL_CHECK
+                  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                   onClick={() => trackClick(article.href)}
                 >
                   <Flex width="100%" justifyContent="space-between">
@@ -96,11 +96,11 @@ const FeaturedArticles: React.FC<FeaturedArticlesProps> = props => {
                     </Box>
                     <Box maxWidth={["90px", "120px"]}>
                       <Image
-                        // @ts-expect-error STRICT_NULL_CHECK
+                        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                         src={article.tinyImage.cropped.url}
                         width="60px"
                         height={60}
-                        // @ts-expect-error STRICT_NULL_CHECK
+                        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                         alt={article.thumbnailTitle}
                       />
                     </Box>

--- a/src/v2/Apps/FeatureAKG/Components/FeaturedArtists.tsx
+++ b/src/v2/Apps/FeatureAKG/Components/FeaturedArtists.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex } from "@artsy/palette"
 import { AnalyticsSchema } from "v2/System"
-import * as React from "react";
+import * as React from "react"
 import { FeaturedContentLink, FeaturedLinkType } from "./Feature"
 
 interface FeaturedArtistsProps {
@@ -26,7 +26,7 @@ export const FeaturedArtists: React.FC<FeaturedArtistsProps> = props => {
           >
             <FeaturedContentLink
               size="medium"
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               contextModule={AnalyticsSchema.ContextModule.FeaturedArtists}
               {...artist}
             />

--- a/src/v2/Apps/FeatureAKG/Components/FeaturedRails/FeaturedAuctions.tsx
+++ b/src/v2/Apps/FeatureAKG/Components/FeaturedRails/FeaturedAuctions.tsx
@@ -6,7 +6,7 @@ import {
 } from "v2/Apps/FeatureAKG/Components/FeaturedRails"
 import { AnalyticsSchema } from "v2/System"
 import { compact } from "lodash"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "relay-runtime"
 
@@ -25,7 +25,7 @@ const FeaturedAuctionsRail: React.FC<FeaturedAuctionsRailProps> = props => {
 
   const itemsForCarousel = auctions.edges.map(auction => {
     const matchingAuctionFromSpreadsheet = items.find(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       item => item.id === auction.node.slug
     )
 
@@ -34,9 +34,9 @@ const FeaturedAuctionsRail: React.FC<FeaturedAuctionsRailProps> = props => {
         ...auction,
         imageSrc: matchingAuctionFromSpreadsheet.image_src,
         subtitle: "Auction",
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         title: auction.node.name,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         href: auction.node.href,
       }
     } else {
@@ -48,7 +48,7 @@ const FeaturedAuctionsRail: React.FC<FeaturedAuctionsRailProps> = props => {
     return (
       <FeaturedRail title={title} subtitle={subtitle}>
         <FeaturedRailCarousel
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           itemsForCarousel={compact(itemsForCarousel)}
           contextModule={AnalyticsSchema.ContextModule.BrowseAuctions}
         />

--- a/src/v2/Apps/FeatureAKG/Components/FeaturedRails/FeaturedFairs.tsx
+++ b/src/v2/Apps/FeatureAKG/Components/FeaturedRails/FeaturedFairs.tsx
@@ -6,7 +6,7 @@ import {
 } from "v2/Apps/FeatureAKG/Components/FeaturedRails"
 import { AnalyticsSchema } from "v2/System"
 import { compact } from "lodash"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "relay-runtime"
 
@@ -40,7 +40,7 @@ const FeaturedFairsRail: React.FC<FeaturedFairsRailProps> = props => {
     return (
       <FeaturedRail title={title} subtitle={subtitle}>
         <FeaturedRailCarousel
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           itemsForCarousel={compact(itemsForCarousel)}
           contextModule={AnalyticsSchema.ContextModule.BrowseFairs}
         />

--- a/src/v2/Apps/FeatureAKG/Components/FeaturedRails/index.tsx
+++ b/src/v2/Apps/FeatureAKG/Components/FeaturedRails/index.tsx
@@ -7,7 +7,7 @@ import { FeaturedFairsRailFragmentContainer as FeaturedFairs } from "v2/Apps/Fea
 import { AnalyticsSchema, ContextModule } from "v2/System"
 import { useTracking } from "v2/System/Analytics/useTracking"
 import { Carousel } from "v2/Components/Carousel"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { crop } from "v2/Utils/resizer"
 
@@ -28,7 +28,7 @@ const FeaturedRails: React.FC<FeaturedRailsProps> = props => {
       {hasCollectionsRail && (
         <>
           <FeaturedCollections
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             collections={props.viewer.collections}
             railMetadata={props.collections_rail}
           />
@@ -39,7 +39,7 @@ const FeaturedRails: React.FC<FeaturedRailsProps> = props => {
       {hasAuctionsRail && (
         <>
           <FeaturedAuctions
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             auctions={props.viewer.auctions}
             railMetadata={props.auctions_rail}
           />
@@ -50,7 +50,7 @@ const FeaturedRails: React.FC<FeaturedRailsProps> = props => {
       {hasFairsRail && (
         <>
           <FeaturedFairs
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             fairs={props.viewer.fairs}
             railMetadata={props.fairs_rail}
           />
@@ -160,7 +160,7 @@ export const FeaturedRailCarousel: React.FC<FeaturedRailCarouselProps> = props =
             >
               <Image
                 lazyLoad
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 src={croppedImageUrl}
                 width={imgWidth}
                 height={imgHeight}

--- a/src/v2/Apps/FeatureAKG/Components/FeaturedThisWeek.tsx
+++ b/src/v2/Apps/FeatureAKG/Components/FeaturedThisWeek.tsx
@@ -1,6 +1,6 @@
 import { Box, Col, Grid, Row } from "@artsy/palette"
 import { AnalyticsSchema } from "v2/System"
-import * as React from "react";
+import * as React from "react"
 import { FeaturedContentLink, FeaturedLinkType } from "./Feature"
 
 interface FeaturedThisWeekProps {
@@ -25,7 +25,7 @@ export const FeaturedThisWeek: React.FC<FeaturedThisWeekProps> = props => {
             <FeaturedContentLink
               key={`featured-content-link-1`}
               size="large"
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               contextModule={AnalyticsSchema.ContextModule.FeaturedThisWeek}
               {...featured_item_1}
             />
@@ -36,7 +36,7 @@ export const FeaturedThisWeek: React.FC<FeaturedThisWeekProps> = props => {
             <FeaturedContentLink
               key={`featured-content-link-2`}
               size="large"
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               contextModule={AnalyticsSchema.ContextModule.FeaturedThisWeek}
               {...featured_item_2}
             />

--- a/src/v2/Apps/FeatureAKG/__tests__/FeatureAKGRoute.jest.tsx
+++ b/src/v2/Apps/FeatureAKG/__tests__/FeatureAKGRoute.jest.tsx
@@ -144,7 +144,7 @@ describe("FeatureAKG", () => {
         const largeWrapper = await getWrapper(
           ArtKeepsGoingFixture,
           defaultVariables,
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           largeWrapperData
         )
         expect(largeWrapper.html()).not.toContain("video_1_large")
@@ -177,7 +177,7 @@ describe("FeatureAKG", () => {
         const smallWrapper = await getWrapper(
           ArtKeepsGoingFixture,
           defaultVariables,
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           smallWrapperData,
           "xs"
         )
@@ -288,7 +288,7 @@ describe("FeatureAKG", () => {
         const wrapper = await getWrapper(
           ArtKeepsGoingFixture,
           defaultVariables,
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           injectedData
         )
 
@@ -324,7 +324,7 @@ describe("FeatureAKG", () => {
           },
         }
 
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper(noArticlesData, defaultVariables)
 
         // In this case we'll still render the section, but it should just be
@@ -356,7 +356,7 @@ describe("FeatureAKG", () => {
           },
         }
 
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper(noSelectedWorksData, defaultVariables)
 
         // In this case we'll still render the section, but it should just be
@@ -377,7 +377,7 @@ describe("FeatureAKG", () => {
         const wrapper = await getWrapper(
           ArtKeepsGoingFixture,
           defaultVariables,
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           injectedData
         )
 
@@ -454,7 +454,7 @@ describe("FeatureAKG", () => {
           },
         }
 
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper(noCollectionsData, defaultVariables)
         expect(wrapper.find("FeaturedRailCarousel").length).toEqual(2)
         expect(wrapper.find("FeaturedRails").text()).not.toContain(
@@ -473,7 +473,7 @@ describe("FeatureAKG", () => {
           },
         }
 
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper(noAuctionsData, defaultVariables)
         expect(wrapper.find("FeaturedRailCarousel").length).toEqual(2)
         expect(wrapper.find("FeaturedRails").text()).not.toContain(
@@ -489,7 +489,7 @@ describe("FeatureAKG", () => {
           },
         }
 
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const wrapper = await getWrapper(noFairsData, defaultVariables)
         expect(wrapper.find("FeaturedRailCarousel").length).toEqual(2)
         expect(wrapper.find("FeaturedRails").text()).not.toContain("Fairs")

--- a/src/v2/Apps/Gene/Routes/GeneShow.tsx
+++ b/src/v2/Apps/Gene/Routes/GeneShow.tsx
@@ -1,5 +1,5 @@
 import { Column, GridColumns, HTML, Spacer, Text } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { FollowGeneButtonFragmentContainer } from "v2/Components/FollowButton/FollowGeneButton"
@@ -32,9 +32,9 @@ export const GeneShow: React.FC<GeneShowProps> = ({ gene }) => {
           <Text as="h2" variant="xs" textTransform="uppercase" mb={1}>
             About
           </Text>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <HTML variant="sm" mb={2} html={gene.formattedDescription} />
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           {gene.similar?.edges.length > 0 && (
             <>
               <Text as="h2" variant="xs" textTransform="uppercase" mb={1}>
@@ -42,12 +42,12 @@ export const GeneShow: React.FC<GeneShowProps> = ({ gene }) => {
               </Text>
 
               <Text variant="sm" mb={2}>
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 {gene.similar.edges.map(({ node }, i) => {
                   return (
                     <React.Fragment key={node.internalID}>
                       <RouterLink to={node.href}>{node.name}</RouterLink>
-                      {/* @ts-expect-error STRICT_NULL_CHECK */}
+                      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                       {i !== gene.similar.edges.length - 1 && ", "}
                     </React.Fragment>
                   )
@@ -55,7 +55,7 @@ export const GeneShow: React.FC<GeneShowProps> = ({ gene }) => {
               </Text>
             </>
           )}
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           {gene.artistsConnection?.edges.length > 0 && (
             <>
               <Text as="h2" variant="xs" textTransform="uppercase" mb={1}>
@@ -63,12 +63,12 @@ export const GeneShow: React.FC<GeneShowProps> = ({ gene }) => {
               </Text>
 
               <Text variant="sm">
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 {gene.artistsConnection.edges.map(({ node }, i) => {
                   return (
                     <React.Fragment key={node.internalID}>
                       <RouterLink to={node.href}>{node.name}</RouterLink>
-                      {/* @ts-expect-error STRICT_NULL_CHECK */}
+                      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                       {i !== gene.artistsConnection.edges.length - 1 && ", "}
                     </React.Fragment>
                   )

--- a/src/v2/Apps/Gene/Routes/__tests__/GeneShow.jest.tsx
+++ b/src/v2/Apps/Gene/Routes/__tests__/GeneShow.jest.tsx
@@ -13,7 +13,7 @@ const { getWrapper } = setupTestWrapper<GeneShow_Test_Query>({
   Component: props => {
     return (
       <MockBoot>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <GeneShowFragmentContainer {...props} />
       </MockBoot>
     )

--- a/src/v2/Apps/IdentityVerification/IdentityVerificationApp/index.tsx
+++ b/src/v2/Apps/IdentityVerification/IdentityVerificationApp/index.tsx
@@ -3,8 +3,8 @@ import { IdentityVerificationApp_me } from "v2/__generated__/IdentityVerificatio
 import { IdentityVerificationAppStartMutation } from "v2/__generated__/IdentityVerificationAppStartMutation.graphql"
 import * as Schema from "v2/System/Analytics/Schema"
 import { ErrorModal } from "v2/Components/Modal/ErrorModal"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Title as HeadTitle } from "react-head"
 import {
   RelayProp,
@@ -31,11 +31,11 @@ const IdentityVerificationApp: React.FC<Props> = ({ me, relay }) => {
   const [showErrorModal, setShowErrorModal] = useState(false)
   const { trackEvent } = useTracking()
   if (!identityVerification || identityVerification.userID !== me.internalID) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     return <WrongOwner email={me.email} />
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   let AlternateComponent: React.FC = null
 
   if (identityVerification.state === "failed") {
@@ -82,7 +82,7 @@ const IdentityVerificationApp: React.FC<Props> = ({ me, relay }) => {
           } else {
             const {
               startIdentityVerification: {
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 startIdentityVerificationResponseOrError: {
                   identityVerificationFlowUrl,
                   mutationError,
@@ -98,7 +98,7 @@ const IdentityVerificationApp: React.FC<Props> = ({ me, relay }) => {
         },
         onError: reject,
         variables: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           input: { identityVerificationId: identityVerification.internalID },
         },
       })

--- a/src/v2/Apps/IdentityVerification/__tests__/routes.jest.tsx
+++ b/src/v2/Apps/IdentityVerification/__tests__/routes.jest.tsx
@@ -15,7 +15,7 @@ import { createRender } from "found"
 
 describe("IdentityVerification/routes", () => {
   const idvID =
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     IdentityVerificationAppQueryResponseFixture.me.identityVerification
       .internalID
   async function render(

--- a/src/v2/Apps/Order/Components/ArtworkSummaryItem.tsx
+++ b/src/v2/Apps/Order/Components/ArtworkSummaryItem.tsx
@@ -1,6 +1,6 @@
 import { ArtworkSummaryItem_order } from "v2/__generated__/ArtworkSummaryItem_order.graphql"
 import { Omit } from "lodash"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "v2/Utils/get"
 
@@ -21,7 +21,7 @@ export interface ArtworkSummaryItemProps extends Omit<FlexProps, "order"> {
 const ArtworkSummaryItem: React.FC<ArtworkSummaryItemProps> = ({
   order: {
     lineItems,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     sellerDetails: { name },
   },
   ...others

--- a/src/v2/Apps/Order/Components/CreditCardSummaryItem.tsx
+++ b/src/v2/Apps/Order/Components/CreditCardSummaryItem.tsx
@@ -14,7 +14,7 @@ const CreditCardSummaryItem = ({
 } & StepSummaryItemProps) => {
   return (
     <StepSummaryItem {...others}>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <CreditCardDetails {...creditCard} />
     </StepSummaryItem>
   )

--- a/src/v2/Apps/Order/Components/ItemReview.tsx
+++ b/src/v2/Apps/Order/Components/ItemReview.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 
 import { BorderBox, Flex, Text, Image } from "@artsy/palette"
 import { ItemReview_lineItem } from "v2/__generated__/ItemReview_lineItem.graphql"
@@ -17,23 +17,23 @@ const dimensionsDisplay = dimensions => (
 export const ItemReview: React.FC<ItemReviewProps> = ({
   lineItem: {
     artwork: {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       artistNames,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       title,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       date,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       medium,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       dimensions: artworkDimensions,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       attribution_class,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       image: {
         resized: { url },
       },
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       edition_sets,
     },
     editionSetId,

--- a/src/v2/Apps/Order/Components/OfferHistoryItem.tsx
+++ b/src/v2/Apps/Order/Components/OfferHistoryItem.tsx
@@ -4,7 +4,7 @@ import {
   StepSummaryItem,
   StepSummaryItemProps,
 } from "v2/Components/StepSummaryItem"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { RevealButton } from "./RevealButton"
 import { getOfferItemFromOrder } from "v2/Apps/Order/Utils/offerItemExtractor"
@@ -16,7 +16,7 @@ const OfferHistoryItem: React.FC<
 > = ({ order: { lastOffer, lineItems, offers }, ...others }) => {
   const offerItem = getOfferItemFromOrder(lineItems)
   const previousOffers = offers?.edges?.filter(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     ({ node: { internalID } }) => internalID !== lastOffer.internalID
   )
 
@@ -66,7 +66,7 @@ const OfferHistoryItem: React.FC<
               >
                 Offer history
               </Text>
-              {/* @ts-expect-error STRICT_NULL_CHECK */}
+              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
               {previousOffers.map(({ node: offer }) => (
                 <Row key={offer.internalID}>
                   <Text variant={["xs", "sm"]} color="black60">

--- a/src/v2/Apps/Order/Components/PaymentPicker.tsx
+++ b/src/v2/Apps/Order/Components/PaymentPicker.tsx
@@ -14,7 +14,7 @@ import { CreditCardInput } from "v2/Apps/Order/Components/CreditCardInput"
 import { validateAddress } from "v2/Apps/Order/Utils/formValidators"
 import { track } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import type {
   StripeError,
@@ -70,7 +70,7 @@ export class PaymentPicker extends React.Component<
   PaymentPickerProps & SystemContextProps & StripeProps,
   PaymentPickerState
 > {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   state = {
     hideBillingAddress: true,
     stripeError: null,
@@ -144,7 +144,7 @@ export class PaymentPicker extends React.Component<
       const { errors, hasErrors } = validateAddress(this.state.address)
       if (hasErrors) {
         this.setState({
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           addressErrors: errors,
           addressTouched: this.touchedAddress,
         })
@@ -192,7 +192,7 @@ export class PaymentPicker extends React.Component<
       }
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   @track((props: PaymentPickerProps, state, args) => {
     const showBillingAddress = !args[0]
     if (showBillingAddress && props.order.state === "PENDING") {
@@ -282,7 +282,7 @@ export class PaymentPicker extends React.Component<
             >
               {creditCardsArray
                 .map(e => {
-                  // @ts-expect-error STRICT_NULL_CHECK
+                  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                   const { internalID, ...creditCardProps } = e
                   return (
                     <BorderedRadio value={internalID} key={internalID}>

--- a/src/v2/Apps/Order/Components/__tests__/AddressModal.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/AddressModal.jest.tsx
@@ -178,7 +178,7 @@ describe("AddressModal", () => {
       })
 
       const formik = wrapper.find("Formik").first()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       formik.props().onSubmit(validAddress as any)
 
       await wrapper.update()
@@ -209,7 +209,7 @@ describe("AddressModal", () => {
       )
 
       const formik = wrapper.find("Formik").first()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       formik.props().onSubmit(validAddress as any)
 
       await wrapper.update()
@@ -238,7 +238,7 @@ describe("AddressModal", () => {
       )
 
       const formik = wrapper.find("Formik").first()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       formik.props().onSubmit(validAddress as any)
 
       await wrapper.update()

--- a/src/v2/Apps/Order/Components/__tests__/OfferHistoryItem.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/OfferHistoryItem.jest.tsx
@@ -26,7 +26,7 @@ const render = (
 ) =>
   renderRelayTree({
     Component: (props: OfferHistoryItemTestQueryResponse) => (
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       <OfferHistoryItem {...extraComponentProps} {...props} />
     ),
     mockData: {

--- a/src/v2/Apps/Order/Components/__tests__/PaymentPicker.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PaymentPicker.jest.tsx
@@ -41,13 +41,13 @@ jest.mock("@stripe/stripe-js", () => {
   return {
     loadStripe: () => {
       if (mock === null) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         mock = mockStripe()
       }
       return mock
     },
     _mockStripe: () => mock,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     _mockReset: () => (mock = mockStripe()),
   }
 })
@@ -355,16 +355,16 @@ describe("PaymentPickerFragmentContainer", () => {
     const stripeToken: { token: Token } = {
       token: {
         id: "tokenId",
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         object: null,
         client_ip: null,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         created: null,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         livemode: null,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         type: null,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         used: null,
       },
     }
@@ -384,16 +384,16 @@ describe("PaymentPickerFragmentContainer", () => {
   it("shows an error message when CreateToken passes in an error", async () => {
     const stripeError: { error: StripeError } = {
       error: {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         type: null,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         charge: null,
         message: "Your card number is invalid.",
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         code: null,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         decline_code: null,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         param: null,
       },
     }
@@ -410,7 +410,7 @@ describe("PaymentPickerFragmentContainer", () => {
   })
 
   describe("when the user has existing credit cards", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const cards: Array<PaymentPicker_me["creditCards"]["edges"][0]["node"]> = [
       {
         internalID: "card-id-1",

--- a/src/v2/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
@@ -54,7 +54,7 @@ describe("Saved Addresses", () => {
       const editButton = page
         .find(`[data-test="editAddressInProfileClick"]`)
         .first()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       editButton
         .props()
         .onClick(userAddressMutation.me.addressConnection.edges[0].node as any)

--- a/src/v2/Apps/Order/Components/__tests__/TransactionDetailsSummary.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/TransactionDetailsSummary.jest.tsx
@@ -62,7 +62,7 @@ const render = (
 ) =>
   renderRelayTree({
     Component: (props: TransactionDetailsSummaryItemTestQueryResponse) => (
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       <TransactionDetailsSummaryItemFragmentContainer
         {...props}
         {...extraProps}

--- a/src/v2/Apps/Order/Routes/Counter/index.tsx
+++ b/src/v2/Apps/Order/Routes/Counter/index.tsx
@@ -20,7 +20,7 @@ import { track } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
 import { CountdownTimer } from "v2/Components/CountdownTimer"
 import { Router } from "found"
-import { Component } from "react";
+import { Component } from "react"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 import createLogger from "v2/Utils/logger"
 import { Media } from "v2/Utils/Responsive"
@@ -81,7 +81,7 @@ export class CounterRoute extends Component<CounterProps> {
   onSubmitButtonPressed = async () => {
     try {
       const {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         commerceSubmitPendingOffer: { orderOrError },
       } = await this.submitPendingOffer({
         input: {

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -46,7 +46,7 @@ import {
   AddressTouched,
 } from "v2/Components/AddressForm"
 import { Router } from "found"
-import { Component } from "react";
+import { Component } from "react"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 import createLogger from "v2/Utils/logger"
 import { Media } from "v2/Utils/Responsive"
@@ -116,7 +116,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
     shippingOption: getShippingOption(
       this.props.order.requestedFulfillment?.__typename
     ),
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     address: startingAddress(this.props.me, this.props.order),
     addressErrors: {},
     addressTouched: {},

--- a/src/v2/Apps/Order/Routes/__tests__/Accept.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Accept.jest.tsx
@@ -35,13 +35,13 @@ jest.mock("@stripe/stripe-js", () => {
   return {
     loadStripe: () => {
       if (mock === null) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         mock = mockStripe()
       }
       return mock
     },
     _mockStripe: () => mock,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     _mockReset: () => (mock = mockStripe()),
   }
 })

--- a/src/v2/Apps/Order/Routes/__tests__/NewPayment.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/NewPayment.jest.tsx
@@ -31,13 +31,13 @@ jest.mock("@stripe/stripe-js", () => {
   return {
     loadStripe: () => {
       if (mock === null) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         mock = mockStripe()
       }
       return mock
     },
     _mockStripe: () => mock,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     _mockReset: () => (mock = mockStripe()),
   }
 })
@@ -175,7 +175,7 @@ describe("Payment", () => {
       "Not available",
       "Sorry, the work is no longer available."
     )
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const artistId = testOrder.lineItems.edges[0].node.artwork.artists[0].slug
     expect(window.location.assign).toHaveBeenCalledWith(`/artist/${artistId}`)
   })

--- a/src/v2/Apps/Order/Routes/__tests__/Respond.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Respond.jest.tsx
@@ -68,21 +68,21 @@ class RespondTestPage extends OrderAppTestPage {
 
   async selectAcceptRadio() {
     const radio = this.findRadioWithText("Accept seller's offer")
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     radio.props().onSelect({ selected: true, value: "ACCEPT" })
     await this.update()
   }
 
   async selectDeclineRadio() {
     const radio = this.findRadioWithText("Decline seller's offer")
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     radio.props().onSelect({ selected: true, value: "DECLINE" })
     await this.update()
   }
 
   async selectCounterRadio() {
     const radio = this.findRadioWithText("Send counteroffer")
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     radio.props().onSelect({ selected: true, value: "COUNTER" })
     await this.update()
   }

--- a/src/v2/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -43,13 +43,13 @@ jest.mock("@stripe/stripe-js", () => {
   return {
     loadStripe: () => {
       if (mock === null) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         mock = mockStripe()
       }
       return mock
     },
     _mockStripe: () => mock,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     _mockReset: () => (mock = mockStripe()),
   }
 })

--- a/src/v2/Apps/Order/Routes/__tests__/Status.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Status.jest.tsx
@@ -88,7 +88,7 @@ describe("Status", () => {
       it("should not show a note section if none exists", async () => {
         const page = await buildPageWithOrder(
           produce(testOrder, order => {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             order.lastOffer.note = null
           })
         )

--- a/src/v2/Apps/Order/Utils/__tests__/formValidators.jest.tsx
+++ b/src/v2/Apps/Order/Utils/__tests__/formValidators.jest.tsx
@@ -3,11 +3,11 @@ import { validateAddress, validatePresence } from "../formValidators"
 
 describe("formValidators/validatePresence", () => {
   it("returns error when field is null", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(validatePresence(null)).toBe("This field is required")
   })
   it("returns error when field is undefined", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(validatePresence(undefined)).toBe("This field is required")
   })
   it("returns error when field is empty", () => {
@@ -40,7 +40,7 @@ describe("formValidators/validateAddress", () => {
   describe("name", () => {
     it("returns an error for an undefined name", () => {
       const address: Address = buildAddress()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       address.name = undefined
 
       const result = validateAddress(address)
@@ -63,7 +63,7 @@ describe("formValidators/validateAddress", () => {
   describe("addressLine1", () => {
     it("returns an error for an undefined addressLine1", () => {
       const address: Address = buildAddress()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       address.addressLine1 = undefined
 
       const result = validateAddress(address)
@@ -86,7 +86,7 @@ describe("formValidators/validateAddress", () => {
   describe("city", () => {
     it("returns an error for an undefined city", () => {
       const address: Address = buildAddress()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       address.city = undefined
 
       const result = validateAddress(address)
@@ -109,7 +109,7 @@ describe("formValidators/validateAddress", () => {
   describe("region", () => {
     it("returns no error for an undefined region if it's not US/CA", () => {
       const address: Address = buildAddress()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       address.region = undefined
 
       const result = validateAddress(address)
@@ -119,7 +119,7 @@ describe("formValidators/validateAddress", () => {
 
     it("returns an error for an undefined region if it's US", () => {
       const address: Address = buildAddress()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       address.region = undefined
       address.country = "US"
 
@@ -144,7 +144,7 @@ describe("formValidators/validateAddress", () => {
   describe("country", () => {
     it("returns an error for an undefined country", () => {
       const address: Address = buildAddress()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       address.country = undefined
 
       const result = validateAddress(address)
@@ -167,7 +167,7 @@ describe("formValidators/validateAddress", () => {
   describe("postalCode", () => {
     it("returns no error for an undefined postalCode if it's not US/CA", () => {
       const address: Address = buildAddress()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       address.postalCode = undefined
 
       const result = validateAddress(address)
@@ -177,7 +177,7 @@ describe("formValidators/validateAddress", () => {
 
     it("returns an error for an undefined postalCode if it's US", () => {
       const address: Address = buildAddress()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       address.postalCode = undefined
       address.country = "US"
 

--- a/src/v2/Apps/Order/Utils/commitMutation.tsx
+++ b/src/v2/Apps/Order/Utils/commitMutation.tsx
@@ -1,6 +1,6 @@
 import { SystemContext } from "v2/System"
-import { useContext } from "react";
-import * as React from "react";
+import { useContext } from "react"
+import * as React from "react"
 import { commitMutation as relayCommitMutation } from "react-relay"
 import { Environment, MutationConfig, MutationParameters } from "relay-runtime"
 
@@ -95,9 +95,9 @@ export function injectCommitMutation<Props extends CommitMutationProps>(
         <MutationContext.Consumer>
           {({ isCommittingMutation, commitMutation }) => (
             <Component
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               isCommittingMutation={isCommittingMutation}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               commitMutation={commitMutation}
               {...(props as Props)}
             />

--- a/src/v2/Apps/Order/__tests__/OrderApp.jest.tsx
+++ b/src/v2/Apps/Order/__tests__/OrderApp.jest.tsx
@@ -30,13 +30,13 @@ jest.mock("@stripe/stripe-js", () => {
   return {
     loadStripe: () => {
       if (mock === null) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         mock = mockStripe()
       }
       return mock
     },
     _mockStripe: () => mock,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     _mockReset: () => (mock = mockStripe()),
   }
 })
@@ -426,7 +426,7 @@ describe("OrderApp routing redirects", () => {
         "/orders/2939023/review/counter",
         mockResolver({
           ...counterOfferOrder,
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           myLastOffer: {
             ...counterOfferOrder.myLastOffer,
             createdAt: DateTime.local().minus({ days: 2 }).toString(),

--- a/src/v2/Apps/Order/__tests__/getRedirect.jest.ts
+++ b/src/v2/Apps/Order/__tests__/getRedirect.jest.ts
@@ -10,7 +10,7 @@ describe("getRedirect", () => {
   ): RedirectRecord<{}> {
     return {
       path: "",
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       rules: [aNonMatchingPredicate],
       children: [...children],
     }
@@ -19,7 +19,7 @@ describe("getRedirect", () => {
   it("returns null when the root rule doesn`t match", () => {
     const rule: RedirectRecord<{}> = {
       path: "",
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       rules: [aNonMatchingPredicate],
     }
     const result = getRedirect(rule, "some-path", {})
@@ -34,7 +34,7 @@ describe("getRedirect", () => {
     }
     const result = getRedirect(rule, "some-path", {})
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(result.path).toEqual("the-root")
   })
 
@@ -46,12 +46,12 @@ describe("getRedirect", () => {
     }
     const rule: RedirectRecord<{}> = {
       path: "",
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       rules: [isData],
       children: [
         {
           path: "hello",
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           rules: [isData],
         },
       ],
@@ -66,11 +66,11 @@ describe("getRedirect", () => {
     const rule: RedirectRecord<number> = {
       path: "",
       rules: [
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         n => (n === 1 ? { path: "/one", reason: "first" } : null),
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         n => (n === 2 ? { path: "/two", reason: "second" } : null),
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         n => (n === 3 ? { path: "/three", reason: "third" } : null),
       ],
     }
@@ -114,7 +114,7 @@ describe("getRedirect", () => {
 
       const result = getRedirect(rule, "this-section", {})
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(result.path).toEqual("this-section-route")
     })
 
@@ -128,7 +128,7 @@ describe("getRedirect", () => {
 
       const result = getRedirect(rule, "this-section/and/this/page", {})
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(result.path).toEqual("this-section-route")
     })
 
@@ -146,7 +146,7 @@ describe("getRedirect", () => {
 
       const result = getRedirect(rule, "this-section/and/this/page", {})
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(result.path).toEqual("winning-route")
     })
 
@@ -164,7 +164,7 @@ describe("getRedirect", () => {
         {}
       )
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(result.path).toEqual("this-section-route")
     })
   })

--- a/src/v2/Apps/Partner/Components/Carousel/DesktopCarousel.tsx
+++ b/src/v2/Apps/Partner/Components/Carousel/DesktopCarousel.tsx
@@ -1,5 +1,5 @@
-import { useRef } from "react";
-import * as React from "react";
+import { useRef } from "react"
+import * as React from "react"
 import {
   Carousel,
   CarouselCell,
@@ -38,7 +38,7 @@ export const DesktopCarousel: React.FC<CarouselProps> = ({
 }) => {
   const railRef = useRef<HTMLDivElement | null>(null)
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   useRailOverflow(railRef, showMore => {
     onRailOverflowChange && onRailOverflowChange(showMore)
   })

--- a/src/v2/Apps/Partner/Components/Carousel/MobileCarousel.tsx
+++ b/src/v2/Apps/Partner/Components/Carousel/MobileCarousel.tsx
@@ -1,5 +1,5 @@
-import { Children, useRef } from "react";
-import * as React from "react";
+import { Children, useRef } from "react"
+import * as React from "react"
 import { Box, Swiper, SwiperRail } from "@artsy/palette"
 import { CarouselProps } from "./Carousel"
 import { useRailOverflow } from "./useRailOverflow"
@@ -14,7 +14,7 @@ export const MobileCarousel: React.FC<CarouselProps> = ({
   const cells = Children.toArray(children)
   const railRef = useRef<HTMLDivElement | null>(null)
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   useRailOverflow(railRef, showMore => {
     onRailOverflowChange && onRailOverflowChange(showMore)
   })

--- a/src/v2/Apps/Partner/Components/Carousel/useRailOverflow.ts
+++ b/src/v2/Apps/Partner/Components/Carousel/useRailOverflow.ts
@@ -6,7 +6,7 @@ export const useRailOverflow = (
   callback: (val: boolean) => void
 ) => {
   const { width: viewportWidth } = useWindowSize()
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const [showMore, setShowMore] = useState<boolean>(undefined)
 
   useEffect(() => {

--- a/src/v2/Apps/Partner/Components/Overview/ArticlesRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ArticlesRail.tsx
@@ -19,7 +19,7 @@ const ArticlesRail: React.FC<ArticlesRailProps> = ({
   articles,
   partnerSlug,
 }) => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const [isSeeAllAvaliable, setIsSeeAllAvaliable] = useState<boolean>(undefined)
   return (
     <>
@@ -38,13 +38,13 @@ const ArticlesRail: React.FC<ArticlesRailProps> = ({
         itemsPerViewport={[2, 2, 3]}
         onRailOverflowChange={setIsSeeAllAvaliable}
       >
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {flatten([
           articles.map(({ node: article }) => {
             return (
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               <Box width={["280px", "100%"]} key={article.internalID}>
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 <ArticleCard article={article} />
               </Box>
             )

--- a/src/v2/Apps/Partner/Components/Overview/ArtworksRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ArtworksRail.tsx
@@ -21,7 +21,7 @@ interface ArtworksRailProps extends BoxProps {
 export const ARTWORK_CAROUSEL_ITEM_HEIGHT = 300
 
 const ArtworksRail: React.FC<ArtworksRailProps> = ({ partner, ...rest }) => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const [isSeeAllAvaliable, setIsSeeAllAvaliable] = useState<boolean>(undefined)
 
   if (
@@ -50,14 +50,14 @@ const ArtworksRail: React.FC<ArtworksRailProps> = ({ partner, ...rest }) => {
       </Flex>
 
       <Carousel onRailOverflowChange={setIsSeeAllAvaliable}>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {flatten([
           artworks.map(artwork => {
             return (
               <FillwidthItem
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 key={artwork.node.id}
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 artwork={artwork.node}
                 imageHeight={ARTWORK_CAROUSEL_ITEM_HEIGHT}
                 hidePartnerName

--- a/src/v2/Apps/Partner/Components/Overview/ShowsRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ShowsRail.tsx
@@ -15,7 +15,7 @@ interface ShowsRailProps extends BoxProps {
 }
 
 const ShowsRail: React.FC<ShowsRailProps> = ({ partner, ...rest }) => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const [isSeeAllAvaliable, setIsSeeAllAvaliable] = useState<boolean>(undefined)
   if (
     !partner?.showsConnection?.edges ||
@@ -53,12 +53,12 @@ const ShowsRail: React.FC<ShowsRailProps> = ({ partner, ...rest }) => {
         onRailOverflowChange={setIsSeeAllAvaliable}
         itemsPerViewport={[2, 2, 3, 4]}
       >
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {flatten([
           shows.map(edge => {
             return (
               <Box key={edge?.node?.id} width={[300, "100%"]}>
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 <ShowCardFragmentContainer show={edge.node} />
               </Box>
             )

--- a/src/v2/Apps/Partner/Components/PartnerArticles/ArticleCard.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArticles/ArticleCard.tsx
@@ -1,6 +1,6 @@
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { Image, ResponsiveBox, Text } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { getAuthors } from "./helpers"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArticleCard_article } from "v2/__generated__/ArticleCard_article.graphql"
@@ -19,7 +19,7 @@ const ArticleCard: React.FC<ArticleCardProps> = ({ article }): JSX.Element => {
     contributingAuthors,
   } = article
   const { authorName, editorialName } = getAuthors(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     channelID,
     author,
     contributingAuthors
@@ -31,9 +31,9 @@ const ArticleCard: React.FC<ArticleCardProps> = ({ article }): JSX.Element => {
         {thumbnailImage && (
           <ResponsiveBox aspectWidth={4} aspectHeight={3} maxWidth="100%">
             <Image
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               src={thumbnailImage.medium.src}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               srcSet={thumbnailImage.medium.srcSet}
               alt=""
               width="100%"

--- a/src/v2/Apps/Partner/Components/PartnerArticles/helpers/articlesCard.ts
+++ b/src/v2/Apps/Partner/Components/PartnerArticles/helpers/articlesCard.ts
@@ -17,22 +17,22 @@ export const getAuthors = (
   const isIDsMatched = getENV("ARTSY_EDITORIAL_CHANNEL") === channelID
 
   if (!isIDsMatched) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     authorNameObj.editorialName = null
   }
 
   if (contributingAuthors.length) {
     const authorName = contributingAuthors.map(author => author.name)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     authorNameObj.authorName = toHumanSentence(authorName)
   }
 
   if (!contributingAuthors.length && author) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     authorNameObj.authorName = author.name
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   return authorNameObj
 }

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsList.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsList.tsx
@@ -1,6 +1,6 @@
 import { Box } from "@artsy/palette"
-import { useEffect, useRef, useState } from "react";
-import * as React from "react";
+import { useEffect, useRef, useState } from "react"
+import * as React from "react"
 import { useSystemContext } from "v2/System"
 import {
   createPaginationContainer,
@@ -39,7 +39,7 @@ export const PartnerArtistDetailsList: React.FC<PartnerArtistDetailsListProps> =
   }, [])
 
   const maybeLoadMore = () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const el = containerRef.current.getBoundingClientRect()
 
     if (window.innerHeight >= el.bottom && el.bottom > 0) {

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtistList.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtistList.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { PartnerArtistList_artists } from "v2/__generated__/PartnerArtistList_artists.graphql"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Box, Column, GridColumns, Text } from "@artsy/palette"
@@ -54,14 +54,14 @@ export const PartnerArtistList: React.FC<PartnerArtistListProps> = ({
                 </Text>
               )}
               <Box style={{ columnCount: group.columnSize }}>
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 {group.artists.map(({ node, counts: { artworks } }) => {
                   return (
                     <PartnerArtistItem
                       scrollTo={scrollTo}
-                      // @ts-expect-error STRICT_NULL_CHECK
+                      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                       key={node.internalID}
-                      // @ts-expect-error STRICT_NULL_CHECK
+                      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                       artist={node}
                       partnerSlug={partnerSlug}
                       hasPublishedArtworks={artworks > 0}

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtists.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtists.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import * as React from "react";
+import { useEffect } from "react"
+import * as React from "react"
 import { Box } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { PartnerArtists_partner } from "v2/__generated__/PartnerArtists_partner.graphql"
@@ -40,9 +40,9 @@ export const PartnerArtists: React.FC<PartnerArtistsProps> = ({
     <Box mt={4}>
       <PartnerArtistListFragmentContainer
         partnerSlug={slug}
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         scrollTo={scrollTo}
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         artists={artists}
         distinguishRepresentedArtists={!!distinguishRepresentedArtists}
         displayFullPartnerPage={!!displayFullPartnerPage}

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Box, Text, Flex } from "@artsy/palette"
 import { compact, flatten } from "lodash"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -25,7 +25,7 @@ export interface PartnerArtistsCarouselProps {
 export const PartnerArtistsCarousel: React.FC<PartnerArtistsCarouselProps> = ({
   partner,
 }) => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const [isSeeAllAvaliable, setIsSeeAllAvaliable] = useState<boolean>(undefined)
 
   if (!partner || !partner.artists || !partner.artists.edges) {

--- a/src/v2/Apps/Partner/Components/PartnerContacts/PartnerContacts.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerContacts/PartnerContacts.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { PartnerContacts_edges } from "v2/__generated__/PartnerContacts_edges.graphql"
 import { Column, GridColumns } from "@artsy/palette"
 import { PartnerContactCardFragmentContainer as PartnerContactCard } from "./PartnerContactCard"
@@ -17,9 +17,9 @@ export const PartnerContacts: React.FC<ContactRouteProps> = ({ edges }) => {
         .filter(edge => !!edge && !!edge.node)
         .map(edge => {
           return (
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             <Column key={edge.node.id} span={12}>
-              {/* @ts-expect-error STRICT_NULL_CHECK */}
+              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
               <PartnerContactCard location={edge.node} />
             </Column>
           )

--- a/src/v2/Apps/Partner/Components/PartnerHeader/index.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerHeader/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import styled from "styled-components"
 import {
   Box,
@@ -28,7 +28,7 @@ export const HeaderImage = styled(Image)`
 
 export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
   const { user } = useSystemContext()
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const hasLocations = partner.locations?.totalCount > 0
   // TODO: Remove after page migration.
   const partnerUrl = `/partner/${partner.slug}`
@@ -46,11 +46,11 @@ export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
                 style={{ display: "flex", textDecoration: "none" }}
               >
                 <HeaderImage
-                  // @ts-expect-error STRICT_NULL_CHECK
+                  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                   src={partner.profile.icon.resized.src}
-                  // @ts-expect-error STRICT_NULL_CHECK
+                  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                   srcSet={partner.profile.icon.resized.srcSet}
-                  // @ts-expect-error STRICT_NULL_CHECK
+                  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                   alt={partner.name}
                   width={[60, 80]}
                   height={[60, 80]}
@@ -71,7 +71,7 @@ export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
             </Text>
             {hasLocations && (
               <Text color="black60" variant="text">
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 <PartnerHeaderAddress {...partner.locations} />
               </Text>
             )}
@@ -81,7 +81,7 @@ export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
       <Column span={[12, 2]}>
         {canFollow && (
           <FollowProfileButton
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             profile={partner.profile}
             user={user}
             contextModule={ContextModule.partnerHeader}

--- a/src/v2/Apps/Partner/Components/PartnerShows/ShowBanner.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerShows/ShowBanner.tsx
@@ -9,8 +9,8 @@ import {
   ReadMore,
   Text,
 } from "@artsy/palette"
-import { useEffect, useState } from "react";
-import * as React from "react";
+import { useEffect, useState } from "react"
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { RouterLink } from "v2/System/Router/RouterLink"
@@ -62,7 +62,7 @@ const ShowBanner: React.FC<ShowBannerProps> = ({
     description,
     href,
   } = show
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const showType = `${statusLabelsMap[status]} ${
     isFairBooth ? "fair booth" : "show"
   }`
@@ -70,7 +70,7 @@ const ShowBanner: React.FC<ShowBannerProps> = ({
 
   useEffect(() => {
     if (withAnimation && selected !== active) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       setActive(selected)
     }
   }, [withAnimation, selected])
@@ -125,7 +125,7 @@ const ShowBanner: React.FC<ShowBannerProps> = ({
               <Image
                 src={coverImage.medium.src}
                 srcSet={coverImage.medium.srcSet}
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 alt={name}
                 width="100%"
                 height={[280, 480]}

--- a/src/v2/Apps/Partner/Components/PartnerShows/ShowCard.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerShows/ShowCard.tsx
@@ -1,6 +1,6 @@
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { Image, ResponsiveBox, Text } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShowCard_show } from "v2/__generated__/ShowCard_show.graphql"
 
@@ -16,18 +16,18 @@ const ShowCard: React.FC<ShowCardProps> = ({ show }): JSX.Element => {
     <RouterLink to={href} textDecoration="none">
       {coverImage && (
         <ResponsiveBox
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           aspectWidth={coverImage.medium.width}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           aspectHeight={coverImage.medium.height}
           maxWidth="100%"
         >
           <Image
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             src={coverImage.medium.src}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             srcSet={coverImage.medium.srcSet}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             alt={name}
             width="100%"
             height="100%"

--- a/src/v2/Apps/Partner/Components/PartnerShows/ShowEvents.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerShows/ShowEvents.tsx
@@ -1,5 +1,5 @@
 import { Column, GridColumns, Text } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShowCardFragmentContainer } from "./ShowCard"
 import { ShowEvents_edges } from "v2/__generated__/ShowEvents_edges.graphql"
@@ -22,9 +22,9 @@ const ShowEvents: React.FC<ShowEventsProps> = ({
       <GridColumns mb={6} gridRowGap={[2, 4]}>
         {edges.map(({ node: show }) => {
           return (
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             <Column key={show.internalID} span={[6, 6, 3, 3]}>
-              {/* @ts-expect-error STRICT_NULL_CHECK */}
+              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
               <ShowCardFragmentContainer show={show} />
             </Column>
           )

--- a/src/v2/Apps/Partner/Components/PartnerShows/ShowPaginatedEvents.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerShows/ShowPaginatedEvents.tsx
@@ -1,6 +1,6 @@
 import { Box } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { PaginationFragmentContainer } from "v2/Components/Pagination"
 import { LoadingArea } from "v2/Components/LoadingArea"
@@ -36,7 +36,7 @@ const ShowPaginatedEvents: React.FC<ShowEventsProps> = ({
   const [isLoading, setIsLoading] = useState(false)
 
   if (!partner.showsList) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     return null
   }
 
@@ -82,14 +82,14 @@ const ShowPaginatedEvents: React.FC<ShowEventsProps> = ({
   }
 
   const handleNext = (page: number) => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     handleClick(endCursor, page)
   }
 
   return (
     <Box id={scrollTo.substring(1)}>
       <LoadingArea isLoading={isLoading}>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <ShowEventsFragmentContainer edges={shows} eventTitle={eventTitle} />
       </LoadingArea>
 

--- a/src/v2/Apps/Partner/Components/__tests__/PartnerArtists/partnerArtistsUtils.jest.ts
+++ b/src/v2/Apps/Partner/Components/__tests__/PartnerArtists/partnerArtistsUtils.jest.ts
@@ -112,12 +112,12 @@ function generateArtistItem(
     },
     representedBy: representedBy,
     node: {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       internalID: null,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       " $fragmentRefs": null,
     },
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     " $refType": null,
   }
 }

--- a/src/v2/Apps/Partner/Routes/Articles/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Articles/index.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Column, GridColumns, Box } from "@artsy/palette"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { useRouter } from "v2/System/Router/useRouter"
@@ -68,7 +68,7 @@ const Articles: React.FC<ArticlesProps> = ({ partner, relay }) => {
   }
 
   const handleNext = (page: number) => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     handleClick(endCursor, page)
   }
 
@@ -76,7 +76,7 @@ const Articles: React.FC<ArticlesProps> = ({ partner, relay }) => {
     <Box id="jumpto--articlesGrid">
       <LoadingArea isLoading={isLoading}>
         <GridColumns mt={6} gridRowGap={[2, 4]}>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           {articles.map(({ node: article }) => {
             return (
               <Column key={article.internalID} span={4}>

--- a/src/v2/Apps/Partner/Routes/Contact/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Contact/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Contact_partner } from "v2/__generated__/Contact_partner.graphql"
 import { Box, Text } from "@artsy/palette"
@@ -12,7 +12,7 @@ export const ContactRoute: React.FC<ContactRouteProps> = ({ partner }) => {
   return (
     <Box mt={[4, 6]}>
       <Text variant="title">Locations</Text>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <PartnerContacts edges={partner.locations.edges} />
     </Box>
   )

--- a/src/v2/Apps/Partner/Routes/Works/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Works/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createRefetchContainer, RelayRefetchProp } from "react-relay"
 import { graphql } from "relay-runtime"
 import { Works_partner } from "v2/__generated__/Works_partner.graphql"
@@ -48,7 +48,7 @@ export const Artworks: React.FC<PartnerArtworkFilterProps> = ({
 }
 
 export const ArtworksRefetchContainer = createRefetchContainer(
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   withRouter<PartnerArtworkFilterProps & RouterState>(Artworks),
   {
     partner: graphql`

--- a/src/v2/Apps/Partner/__tests__/PartnerApp.jest.tsx
+++ b/src/v2/Apps/Partner/__tests__/PartnerApp.jest.tsx
@@ -25,7 +25,7 @@ const { getWrapper } = setupTestWrapper<PartnerApp_Test_Query>({
   Component: props => {
     return (
       <HeadProvider>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <PartnerAppFragmentContainer {...props} />
       </HeadProvider>
     )

--- a/src/v2/Apps/Payment/Components/PaymentSection.tsx
+++ b/src/v2/Apps/Payment/Components/PaymentSection.tsx
@@ -1,8 +1,8 @@
 import { Box, Button, Text } from "@artsy/palette"
 import { SystemContextProps } from "v2/System"
 
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 import { SavedCreditCards } from "v2/Components/Payment/SavedCreditCards"
 import { PaymentSectionCreditCard } from "v2/__generated__/PaymentSectionCreditCard.graphql"
@@ -19,7 +19,7 @@ interface PaymentSectionProps extends SystemContextProps {
 
 export const PaymentSection: React.FC<PaymentSectionProps> = props => {
   const creditCardEdges = props.me?.creditCards?.edges ?? []
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const creditCards = creditCardEdges.map(({ node: creditCard }) => {
     return creditCard
   })

--- a/src/v2/Apps/Payment/__tests__/PaymentSection.jest.tsx
+++ b/src/v2/Apps/Payment/__tests__/PaymentSection.jest.tsx
@@ -11,20 +11,20 @@ jest.mock("@stripe/stripe-js", () => {
   return {
     loadStripe: () => {
       if (mock === null) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         mock = mockStripe()
       }
       return mock
     },
     _mockStripe: () => mock,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     _mockReset: () => (mock = mockStripe()),
   }
 })
 
 const { getWrapper } = setupTestWrapper<PaymentSection_Test_Query>({
   Component: props => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     return <PaymentSectionFragmentContainer {...props} />
   },
   query: graphql`

--- a/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
+++ b/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
@@ -8,8 +8,8 @@ import {
 } from "@artsy/palette"
 import { data as sd } from "sharify"
 import { PurchaseHistory_me } from "v2/__generated__/PurchaseHistory_me.graphql"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { Media } from "v2/Utils/Responsive"
@@ -77,17 +77,17 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
 ) => {
   const [loading, setLoading] = useState(false)
   const { me } = props
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const pageInfo = me.orders.pageInfo
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const myOrders = me.orders.edges && me.orders.edges.map(x => x.node)
 
   const paginationProps = {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     hasNextPage: props.me.orders.pageInfo.hasNextPage,
     onClick: cursor => loadAfter(cursor, props.relay, setLoading),
     onNext: () => loadNext(pageInfo, props.relay, setLoading),
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     pageCursors: props.me.orders.pageCursors,
   }
 
@@ -96,16 +96,16 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
       <Box mx={["0px", "40px", "40px", "40px"]} mt="-5px">
         <UserSettingsTabs route={sd.CURRENT_PATH} username={me.name} />
       </Box>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       {myOrders.length ? (
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         myOrders.map((order, i) => (
           <OrderRow
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             key={order.code}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             order={order}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             hasDivider={i != myOrders.length - 1}
           />
         ))
@@ -116,7 +116,7 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
       )}
       <StyledBox>
         <Media at="xs">
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           {props.me.orders.pageCursors && (
             <SmallPagination
               {...paginationProps}
@@ -131,7 +131,7 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
         <Media greaterThan="xs">
           <Box>
             <Separator mb={3} pr={2} />
-            {/* @ts-expect-error STRICT_NULL_CHECK */}
+            {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             {props.me.orders.pageCursors && (
               <LargePagination
                 {...paginationProps}

--- a/src/v2/Apps/Purchase/__tests__/PurchaseApp.jest.tsx
+++ b/src/v2/Apps/Purchase/__tests__/PurchaseApp.jest.tsx
@@ -14,7 +14,7 @@ import { Pagination } from "@artsy/palette"
 jest.unmock("react-relay")
 jest.mock("v2/Components/Pagination/useComputeHref")
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 const pageInfo: PurchaseAppTestQueryRawResponse["me"]["orders"]["pageInfo"] = {
   endCursor: "MQ",
   hasNextPage: true,
@@ -22,7 +22,7 @@ const pageInfo: PurchaseAppTestQueryRawResponse["me"]["orders"]["pageInfo"] = {
   startCursor: "NQ",
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 const pageCursors: PurchaseAppTestQueryRawResponse["me"]["orders"]["pageCursors"] = {
   around: [
     { cursor: "", isCurrent: true, page: 1 },

--- a/src/v2/Apps/Search/Components/SendFeedback.tsx
+++ b/src/v2/Apps/Search/Components/SendFeedback.tsx
@@ -11,7 +11,7 @@ import {
 import { SendFeedbackSearchResultsMutation } from "v2/__generated__/SendFeedbackSearchResultsMutation.graphql"
 import { SystemContextProps } from "v2/System"
 import { withSystemContext } from "v2/System"
-import { Component } from "react";
+import { Component } from "react"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
 import { ErrorWithMetadata } from "v2/Utils/errors"
@@ -45,7 +45,7 @@ class SendFeedbackForm extends Component<SystemContextProps, State> {
     const { relayEnvironment } = this.props
     const { message, name, email } = this.state
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     commitMutation<SendFeedbackSearchResultsMutation>(relayEnvironment, {
       // TODO: Inputs to the mutation might have changed case of the keys!
       mutation: graphql`
@@ -85,7 +85,7 @@ class SendFeedbackForm extends Component<SystemContextProps, State> {
       },
       onCompleted: data => {
         const {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           sendFeedback: { feedbackOrError },
         } = data
         if (feedbackOrError.mutationError) {

--- a/src/v2/Apps/Search/Components/ZeroState.tsx
+++ b/src/v2/Apps/Search/Components/ZeroState.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Text } from "@artsy/palette"
 import { SendFeedback } from "v2/Apps/Search/Components/SendFeedback"
 import { useArtworkFilterContext } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
-import { FC } from "react";
+import { FC } from "react"
 
 interface ZeroStateProps {
   term: string
@@ -10,7 +10,7 @@ interface ZeroStateProps {
 export const ZeroState: FC<ZeroStateProps> = props => {
   const {
     hasFilters,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     filters: { term = props.term },
   } = useArtworkFilterContext()
 

--- a/src/v2/Apps/Search/Components/__tests__/NavigationTabs.jest.tsx
+++ b/src/v2/Apps/Search/Components/__tests__/NavigationTabs.jest.tsx
@@ -4,7 +4,7 @@ const props: NavigationTabsProps = {
   artworkCount: 601,
   term: "whitney",
   searchableConnection: {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     " $refType": null,
     aggregations: [
       {

--- a/src/v2/Apps/Search/Components/__tests__/SendFeedback.jest.tsx
+++ b/src/v2/Apps/Search/Components/__tests__/SendFeedback.jest.tsx
@@ -62,7 +62,7 @@ describe("SendFeedback", () => {
 
   describe("logged out", () => {
     it("does not call the mutation without a valid email", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const component = getWrapper({ user: null })
       simulateTypingNameAndEmail(component, {
         name: "Percy Z",
@@ -76,7 +76,7 @@ describe("SendFeedback", () => {
     })
 
     it("calls the mutation with a valid email and name", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const component = getWrapper({ user: null })
       commitMutation.mockImplementationOnce((_environment, { onCompleted }) => {
         onCompleted(successResponse)

--- a/src/v2/Apps/Search/Routes/SearchResultsArtists.tsx
+++ b/src/v2/Apps/Search/Routes/SearchResultsArtists.tsx
@@ -94,7 +94,7 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
         })
         // TODO: Look into using router push w/ query params.
         // this.props.router.replace(`/search/artists?${urlParams}`)
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         window.history.pushState({}, null, `/search/artists?${urlParams}`)
       }
     )

--- a/src/v2/Apps/Search/Routes/SearchResultsEntity.tsx
+++ b/src/v2/Apps/Search/Routes/SearchResultsEntity.tsx
@@ -96,7 +96,7 @@ export class SearchResultsEntityRoute extends React.Component<Props, State> {
         })
         // TODO: Look into using router push w/ query params.
         // this.props.router.replace(`/search/${tab}?${urlParams}`)
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         window.history.pushState({}, null, `/search/${tab}?${urlParams}`)
       }
     )

--- a/src/v2/Apps/Show/Components/ShowContextCard.tsx
+++ b/src/v2/Apps/Show/Components/ShowContextCard.tsx
@@ -6,7 +6,7 @@ import {
   Spacer,
   Text,
 } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShowContextCard_show } from "v2/__generated__/ShowContextCard_show.graphql"
 import { FairTimingFragmentContainer as FairTiming } from "v2/Apps/Fair/Components/FairHeader/FairTiming"
@@ -55,14 +55,14 @@ export const ShowContextCard: React.FC<Props> = ({ show }) => {
       const payload: ClickedFairCard = {
         action: ActionType.clickedFairCard,
         context_module: ContextModule.presentingFair,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         context_page_owner_type: contextPageOwnerType,
         context_page_owner_id: contextPageOwnerId,
         context_page_owner_slug: contextPageOwnerSlug,
         destination_page_owner_type: OwnerType.fair,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         destination_page_owner_id: fair.internalID,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         destination_page_owner_slug: fair.slug,
         type: "thumbnail",
       }
@@ -72,25 +72,25 @@ export const ShowContextCard: React.FC<Props> = ({ show }) => {
 
     return (
       <GridColumns>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {fair.isActive && (
           <Column span={6}>
-            {/* @ts-expect-error STRICT_NULL_CHECK */}
+            {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             <Text variant="lg">Part of {fair.name}</Text>
           </Column>
         )}
         <Column span={6}>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <StyledLink noUnderline to={fair.href} onClick={handleClick}>
-            {/* @ts-expect-error STRICT_NULL_CHECK */}
+            {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             <FairCard fair={fair} />
 
             <Spacer mb={2} />
             <Box>
-              {/* @ts-expect-error STRICT_NULL_CHECK */}
+              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
               <Text variant="xl">{fair.name}</Text>
 
-              {/* @ts-expect-error STRICT_NULL_CHECK */}
+              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
               <FairTiming fair={fair} />
             </Box>
           </StyledLink>
@@ -103,7 +103,7 @@ export const ShowContextCard: React.FC<Props> = ({ show }) => {
     const partnerHref = partner?.href
     const partnerName = partner?.name
     const imageUrls = compact(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       partner?.artworksConnection?.edges?.map(({ node }) => node?.image?.url)
     )
 
@@ -113,7 +113,7 @@ export const ShowContextCard: React.FC<Props> = ({ show }) => {
     })
 
     const locationNames = limitWithCount(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       filterLocations(partner.locations),
       2
     ).join(", ")
@@ -122,14 +122,14 @@ export const ShowContextCard: React.FC<Props> = ({ show }) => {
       const payload: ClickedPartnerCard = {
         action: ActionType.clickedPartnerCard,
         context_module: ContextModule.presentingPartner,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         context_page_owner_type: contextPageOwnerType,
         context_page_owner_id: contextPageOwnerId,
         context_page_owner_slug: contextPageOwnerSlug,
         destination_page_owner_type: OwnerType.partner,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         destination_page_owner_id: partner.internalID,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         destination_page_owner_slug: partner.slug,
         type: "thumbnail",
       }
@@ -143,7 +143,7 @@ export const ShowContextCard: React.FC<Props> = ({ show }) => {
           <Text variant="lg">Presented by {partnerName}</Text>
         </Column>
         <Column span={6}>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <StyledLink to={partnerHref} noUnderline onClick={handleClick}>
             <TriptychCard
               title={partnerName}

--- a/src/v2/Apps/Show/Components/ShowContextualLink.tsx
+++ b/src/v2/Apps/Show/Components/ShowContextualLink.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "v2/Utils/Responsive"
 import { ShowContextualLink_show } from "v2/__generated__/ShowContextualLink_show.graphql"
@@ -37,11 +37,11 @@ export const ContextualLink: React.FC<Props> = ({ show }) => {
   if (isFairBooth) {
     return (
       <>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {fair.isActive && (
           <Box>
             <Text variant="sm">
-              {/* @ts-expect-error STRICT_NULL_CHECK */}
+              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
               Part of <RouterLink to={fairHref}>{fairName}</RouterLink>
             </Text>
           </Box>

--- a/src/v2/Apps/Show/Components/ShowHeader.tsx
+++ b/src/v2/Apps/Show/Components/ShowHeader.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Box, BoxProps, Join, Spacer, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShowHeader_show } from "v2/__generated__/ShowHeader_show.graphql"
@@ -13,7 +13,7 @@ export const ShowHeader: React.FC<ShowHeaderProps> = ({ show, ...rest }) => {
   const { name, startAt, endAt, formattedStartAt, formattedEndAt } = show
 
   const currentTime = useCurrentTime({ syncWithServer: true })
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const { formattedTime } = useEventTiming({ currentTime, startAt, endAt })
 
   return (

--- a/src/v2/Apps/Show/Components/ShowMeta.tsx
+++ b/src/v2/Apps/Show/Components/ShowMeta.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Link, Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShowMeta_show } from "v2/__generated__/ShowMeta_show.graphql"
@@ -22,7 +22,7 @@ const ShowMeta: React.FC<ShowMetaProps> = ({
   const title = `${name} | Artsy`
   const href = `${getENV("APP_URL")}/show/${slug}`
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const fallbackDescription = `Explore ${name} from ${partner.name} on Artsy. ${formattedStartAt} - ${formattedEndAt}.`
   const description = metaDescription || fallbackDescription
   return (

--- a/src/v2/Apps/Show/Components/ShowPartnerEntityHeader.tsx
+++ b/src/v2/Apps/Show/Components/ShowPartnerEntityHeader.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { ContextModule } from "@artsy/cohesion"
 import { createFragmentContainer, graphql } from "react-relay"
 import { EntityHeader } from "@artsy/palette"
@@ -26,7 +26,7 @@ const ShowPartnerEntityHeader: React.FC<ShowPartnerEntityHeaderProps> = ({
   const canFollow =
     partner && partner.type !== "Auction House" && !!partner.profile
   const locationNames = limitWithCount(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     filterLocations(partner.locations),
     2
   ).join(", ")

--- a/src/v2/Apps/Show/Components/ShowViewingRoom.tsx
+++ b/src/v2/Apps/Show/Components/ShowViewingRoom.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Box, BoxProps, Card, ResponsiveBox, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShowViewingRoom_show } from "v2/__generated__/ShowViewingRoom_show.graphql"
@@ -41,7 +41,7 @@ export const ShowViewingRoom: React.FC<ShowViewingRoomProps> = ({
     const payload: ClickedViewingRoomCard = {
       action: ActionType.clickedViewingRoomCard,
       context_module: ContextModule.associatedViewingRoom,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       context_page_owner_type: contextPageOwnerType,
       context_page_owner_id: contextPageOwnerId,
       context_page_owner_slug: contextPageOwnerSlug,

--- a/src/v2/Apps/Show/__tests__/ShowContextCard.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowContextCard.jest.tsx
@@ -18,7 +18,7 @@ const { getWrapper } = setupTestWrapper<ShowContextCard_Test_Query>({
         contextPageOwnerType: OwnerType.show,
       }}
     >
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <ShowContextCardFragmentContainer {...props} />
     </AnalyticsContext.Provider>
   ),

--- a/src/v2/Apps/Show/__tests__/ShowContextualLink.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowContextualLink.jest.tsx
@@ -9,7 +9,7 @@ jest.unmock("react-relay")
 const { getWrapper } = setupTestWrapper<ShowContextualLink_Test_Query>({
   Component: props => (
     <MockBoot breakpoint="lg">
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <ShowContextualLinkFragmentContainer {...props} />
     </MockBoot>
   ),

--- a/src/v2/Apps/Show/__tests__/ShowViewingRoom.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowViewingRoom.jest.tsx
@@ -19,7 +19,7 @@ const { getWrapper } = setupTestWrapper<ShowViewingRoom_Test_Query>({
           contextPageOwnerType: OwnerType.show,
         }}
       >
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <ShowViewingRoom {...props} />
       </AnalyticsContext.Provider>
     )

--- a/src/v2/Apps/Tag/__tests__/TagApp.jest.tsx
+++ b/src/v2/Apps/Tag/__tests__/TagApp.jest.tsx
@@ -15,7 +15,7 @@ const { renderWithRelay } = setupTestWrapperTL<TagApp_Test_Query>({
   Component: props => {
     return (
       <MockBoot>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <TagAppFragmentContainer {...props} />
       </MockBoot>
     )

--- a/src/v2/Apps/WorksForYou/WorksForYouArtistFeed.tsx
+++ b/src/v2/Apps/WorksForYou/WorksForYouArtistFeed.tsx
@@ -2,7 +2,7 @@ import { EntityHeader, Spacer, Spinner } from "@artsy/palette"
 import { WorksForYouArtistFeed_viewer } from "v2/__generated__/WorksForYouArtistFeed_viewer.graphql"
 import { SystemContextProps } from "v2/System"
 import ArtworkGrid from "v2/Components/ArtworkGrid"
-import { Component } from "react";
+import { Component } from "react"
 import styled from "styled-components"
 import { get } from "v2/Utils/get"
 
@@ -31,7 +31,7 @@ export class WorksForYouArtistFeed extends Component<Props, State> {
   }
 
   loadMoreArtworks() {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const hasMore = this.props.viewer.artist.artworks_connection.pageInfo
       .hasNextPage
 
@@ -54,21 +54,21 @@ export class WorksForYouArtistFeed extends Component<Props, State> {
       viewer: { artist },
     } = this.props
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const avatarImageUrl = get(artist, p => p.image.resized.url)
     const meta =
       (forSale
-        ? // @ts-expect-error STRICT_NULL_CHECK
+        ? // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           get(artist, p => p.counts.for_sale_artworks.toLocaleString(), "")
-        : // @ts-expect-error STRICT_NULL_CHECK
+        : // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           get(artist, p => p.counts.artworks.toLocaleString(), "")) + " Works"
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const worksForSaleHref = artist.href + "/works-for-sale"
 
     return (
       <>
         <EntityHeader
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           name={artist.name}
           meta={meta}
           imageUrl={avatarImageUrl}
@@ -78,7 +78,7 @@ export class WorksForYouArtistFeed extends Component<Props, State> {
         <Spacer mb={3} />
 
         <ArtworkGrid
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           artworks={artist.artworks_connection}
           columnCount={3}
           itemMargin={40}
@@ -146,7 +146,7 @@ export const WorksForYouArtistFeedPaginationContainer = createPaginationContaine
   {
     direction: "forward",
     getConnectionFromProps(props) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       return props.viewer.artist.artworks_connection
     },
     getFragmentVariables(prevVars, totalCount) {

--- a/src/v2/Apps/WorksForYou/WorksForYouFeed.tsx
+++ b/src/v2/Apps/WorksForYou/WorksForYouFeed.tsx
@@ -2,7 +2,7 @@ import { Box, EntityHeader, Separator, Spacer, Spinner } from "@artsy/palette"
 import { WorksForYouFeed_viewer } from "v2/__generated__/WorksForYouFeed_viewer.graphql"
 import { SystemContextProps } from "v2/System"
 import ArtworkGrid from "v2/Components/ArtworkGrid"
-import { Component } from "react";
+import { Component } from "react"
 import ReactDOM from "react-dom"
 import styled from "styled-components"
 import { get } from "v2/Utils/get"
@@ -45,14 +45,14 @@ export class WorksForYouFeed extends Component<Props, State> {
 
   componentWillUnmount() {
     if (this.state.interval) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       clearInterval(this.state.interval)
     }
   }
 
   maybeLoadMore() {
     const threshold = window.innerHeight + window.scrollY
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const el = ReactDOM.findDOMNode(this).parentElement as Element
     if (threshold >= el.clientHeight + el.scrollTop) {
       this.loadMoreArtworks()
@@ -60,12 +60,12 @@ export class WorksForYouFeed extends Component<Props, State> {
   }
 
   loadMoreArtworks() {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const hasMore = this.props.viewer.me.followsAndSaves.notifications.pageInfo
       .hasNextPage
 
     if (!hasMore && this.state.interval) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       clearInterval(this.state.interval)
     }
     if (hasMore && !this.state.loading) {
@@ -84,9 +84,9 @@ export class WorksForYouFeed extends Component<Props, State> {
   render() {
     return (
       <>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {this.props.viewer.me.followsAndSaves.notifications.edges.map(
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ({ node }, index) => {
             const avatarImageUrl = get(node, p => p.image.resized.url)
             const meta = `${node.summary}, ${node.published_at}`
@@ -174,7 +174,7 @@ export const WorksForYouFeedPaginationContainer = createPaginationContainer(
   {
     direction: "forward",
     getConnectionFromProps(props) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       return props.viewer.me.followsAndSaves.notifications
     },
     getFragmentVariables(prevVars, totalCount) {

--- a/src/v2/Apps/WorksForYou/index.tsx
+++ b/src/v2/Apps/WorksForYou/index.tsx
@@ -5,7 +5,7 @@ import { MarketingHeader } from "v2/Apps/WorksForYou/MarketingHeader"
 import { SystemContextConsumer, SystemContextProps } from "v2/System"
 import { track } from "v2/System/Analytics"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
-import { Component } from "react";
+import { Component } from "react"
 import { graphql } from "react-relay"
 import styled from "styled-components"
 import Events from "v2/Utils/Events"
@@ -17,7 +17,7 @@ export interface Props extends SystemContextProps {
   forSale?: boolean
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 @track(null, {
   dispatch: data => Events.postEvent(data),
 })
@@ -30,7 +30,7 @@ export class WorksForYou extends Component<Props> {
   render() {
     const { artistID, forSale } = this.props
     const includeSelectedArtist = !!artistID
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const filter: ArtistArtworksFilters[] = forSale ? ["IS_FOR_SALE"] : null
 
     return (
@@ -72,7 +72,7 @@ export class WorksForYou extends Component<Props> {
                         <Box pt={3} pb={3}>
                           {includeSelectedArtist ? (
                             <WorksForYouArtistFeed
-                              // @ts-expect-error STRICT_NULL_CHECK
+                              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                               artistID={this.props.artistID}
                               viewer={props.viewer!}
                               forSale={forSale}

--- a/src/v2/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarBidAction.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarBidAction.ts
@@ -82,7 +82,7 @@ export const ArtworkFromTimedAuctionRegistrationClosed: ArtworkSidebarBidAction_
 }
 
 export const SaleRequiringIDV: Partial<
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   ArtworkSidebarBidAction_Test_QueryRawResponse["artwork"]["sale"]
 > = {
   requireIdentityVerification: true,
@@ -91,7 +91,7 @@ export const SaleRequiringIDV: Partial<
 export const NotIDVedUser: ArtworkSidebarBidAction_Test_QueryRawResponse["me"] = {
   id: "user-id",
   identityVerified: false,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   pendingIdentityVerification: undefined,
 }
 
@@ -104,7 +104,7 @@ export const UserPendingIDV: ArtworkSidebarBidAction_Test_QueryRawResponse["me"]
 export const IDVedUser: ArtworkSidebarBidAction_Test_QueryRawResponse["me"] = {
   id: "user-id",
   identityVerified: true,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   pendingIdentityVerification: undefined,
 }
 

--- a/src/v2/Apps/__tests__/Fixtures/Pagination.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Pagination.ts
@@ -1,7 +1,7 @@
 import { Pagination_pageCursors } from "v2/__generated__/Pagination_pageCursors.graphql"
 
 export const paginationProps = {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   cursor: {
     first: { page: 1, cursor: "Y3Vyc29yMg==", isCurrent: false },
     last: { page: 20, cursor: "Y3Vyc29yMw==", isCurrent: false },

--- a/src/v2/Components/AddToCalendar/AddToCalendar.tsx
+++ b/src/v2/Components/AddToCalendar/AddToCalendar.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Box, Clickable, Menu, MenuItem, Text } from "@artsy/palette"
 import {
   generateGoogleCalendarUrl,
@@ -41,7 +41,7 @@ export const AddToCalendar: React.FC<CalendarEventProps> = props => {
         context_module: props.contextModule,
         context_owner_id: contextPageOwnerId,
         context_owner_slug: contextPageOwnerSlug,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         context_owner_type: contextPageOwnerType,
         subject,
       })

--- a/src/v2/Components/ArtistMarketInsights.tsx
+++ b/src/v2/Components/ArtistMarketInsights.tsx
@@ -1,6 +1,6 @@
 import { BorderBox, Box, Join, Spacer } from "@artsy/palette"
 import { ArtistMarketInsights_artist } from "v2/__generated__/ArtistMarketInsights_artist.graphql"
-import { Component } from "react";
+import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkDefinitionList } from "v2/Apps/Artwork/Components/ArtworkDefinitionList"
 import { groupBy } from "lodash"
@@ -88,7 +88,7 @@ export class MarketInsights extends Component<MarketInsightsProps> {
   }
 
   render() {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     if (!hasSections(this.props.artist)) {
       return null
     }

--- a/src/v2/Components/ArtistSeriesRail/ArtistSeriesItem.tsx
+++ b/src/v2/Components/ArtistSeriesRail/ArtistSeriesItem.tsx
@@ -1,6 +1,6 @@
 import { Box, Image, Text } from "@artsy/palette"
 import { ArtistSeriesItem_artistSeries } from "v2/__generated__/ArtistSeriesItem_artistSeries.graphql"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ContextModule, clickedArtistSeriesGroup } from "@artsy/cohesion"
 import { useTracking } from "v2/System/Analytics/useTracking"
@@ -40,7 +40,7 @@ export const ArtistSeriesItem: React.FC<ArtistSeriesItemProps> = ({
     trackEvent(
       clickedArtistSeriesGroup({
         contextModule,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         contextPageOwnerType,
         destinationPageOwnerId: internalID,
         destinationPageOwnerSlug: slug,

--- a/src/v2/Components/ArtistSeriesRail/__tests__/ArtistSeriesItem.jest.tsx
+++ b/src/v2/Components/ArtistSeriesRail/__tests__/ArtistSeriesItem.jest.tsx
@@ -77,7 +77,7 @@ const itemContent: ArtistSeriesItem_artistSeries = {
   slug: "slug",
   title: "title",
   featured: true,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   " $refType": null,
   image: {
     cropped: {

--- a/src/v2/Components/Artwork/Badge.tsx
+++ b/src/v2/Components/Artwork/Badge.tsx
@@ -1,6 +1,6 @@
 import { Flex, Text } from "@artsy/palette"
 import { Badge_artwork } from "v2/__generated__/Badge_artwork.graphql"
-import { Component } from "react";
+import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { get } from "v2/Utils/get"
@@ -22,7 +22,7 @@ class Badge extends Component<BadgeProps> {
 
     return get(
       this.props,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       p => p.width / devicePixelRatio < MIN_IMAGE_SIZE,
       false
     )

--- a/src/v2/Components/Artwork/Contact.tsx
+++ b/src/v2/Components/Artwork/Contact.tsx
@@ -1,5 +1,5 @@
 import { Contact_artwork } from "v2/__generated__/Contact_artwork.graphql"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "v2/Utils/get"
 import TextLink from "../TextLink"
@@ -20,27 +20,27 @@ export class Contact extends React.Component<ContactProps, null> {
 
   auctionLine() {
     const { artwork } = this.props
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const isLiveOpen = get(artwork, p => p.sale.is_live_open)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const isOpen = get(artwork, p => p.sale.is_open)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const isClosed = get(artwork, p => p.sale.is_closed)
 
     if (isLiveOpen) {
       return (
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         <TextLink href={artwork.href} underline>
           Enter Live Auction
         </TextLink>
       )
     } else if (isOpen) {
       const sa = get(artwork, p => p.sale_artwork)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const bidderPositions = get(sa, p => p.counts.bidder_positions)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const highestBidDisplay = get(sa, p => p.highest_bid.display)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const openingBidDisplay = get(sa, p => p.opening_bid.display)
 
       if (bidderPositions && bidderPositions > 0) {
@@ -63,13 +63,13 @@ export class Contact extends React.Component<ContactProps, null> {
 
   contactPartnerLine() {
     const partner = get(this.props, p =>
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       p.artwork.partner.type.toLocaleLowerCase()
     )
 
     if (partner) {
       return (
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         <TextLink href={this.props.artwork.href} underline>
           Contact {partner}
         </TextLink>
@@ -84,7 +84,7 @@ export class Contact extends React.Component<ContactProps, null> {
   }
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 export default createFragmentContainer(Contact, {
   artwork: graphql`
     fragment Contact_artwork on Artwork {

--- a/src/v2/Components/Artwork/Details.tsx
+++ b/src/v2/Components/Artwork/Details.tsx
@@ -6,7 +6,7 @@ import {
   TextVariant,
 } from "@artsy/palette"
 import { Details_artwork } from "v2/__generated__/Details_artwork.graphql"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface DetailsProps {
@@ -84,7 +84,7 @@ const TitleLine: React.FC<DetailsProps> = ({
   })
 
   return (
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     <ConditionalLink includeLinks={includeLinks} href={href}>
       <Text variant={tokens.variant} color="black60" overflowEllipsis>
         <i>{title}</i>
@@ -117,7 +117,7 @@ const PartnerLine: React.FC<DetailsProps> = ({
 
   if (partner) {
     return (
-      //  @ts-expect-error STRICT_NULL_CHECK
+      //  @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       <ConditionalLink includeLinks={includeLinks} href={partner.href}>
         <Text variant={tokens.variant} color="black60" overflowEllipsis>
           {partner.name}
@@ -185,7 +185,7 @@ const BidInfo: React.FC<DetailsProps> = ({
     return null
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const bidderPositionCounts = sale_artwork?.counts.bidder_positions ?? 0
 
   if (bidderPositionCounts === 0) {

--- a/src/v2/Components/Artwork/__tests__/Details.jest.tsx
+++ b/src/v2/Components/Artwork/__tests__/Details.jest.tsx
@@ -73,10 +73,10 @@ describe("Details", () => {
     it("shows 'bidding closed' message if in closed auction", async () => {
       const data = {
         ...artworkInAuction,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         sale: { ...artworkInAuction.sale, is_closed: true },
       }
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const wrapper = await getWrapper(data)
       expect(wrapper.html()).toContain("Bidding closed")
     })
@@ -85,16 +85,16 @@ describe("Details", () => {
       const data = {
         ...artworkInAuction,
         sale_artwork: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...artworkInAuction.sale_artwork,
           highest_bid: {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             ...artworkInAuction.sale_artwork.highest_bid,
             display: null,
           },
         },
       }
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const wrapper = await getWrapper(data)
       const html = wrapper.html()
       expect(html).toContain("$2,400")
@@ -105,12 +105,12 @@ describe("Details", () => {
         ...artworkInAuction,
         sale_message: "Contact For Price",
         sale: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...artworkInAuction.sale,
           is_auction: false,
         },
       }
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const wrapper = await getWrapper(data)
       const html = wrapper.html()
       expect(html).toContain("Contact for Price")
@@ -120,26 +120,26 @@ describe("Details", () => {
       const data = {
         ...artworkInAuction,
         sale: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...artworkInAuction.sale,
           is_auction: false,
         },
         sale_artwork: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...artworkInAuction.sale_artwork,
           highest_bid: {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             ...artworkInAuction.sale_artwork.highest_bid,
             display: null,
           },
           opening_bid: {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             ...artworkInAuction.sale_artwork.highest_bid,
             display: null,
           },
         },
       }
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const wrapper = await getWrapper(data)
       const html = wrapper.html()
       expect(html).toContain("$450")
@@ -149,16 +149,16 @@ describe("Details", () => {
       const data = {
         ...artworkInAuction,
         sale_artwork: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...artworkInAuction.sale_artwork,
           counts: {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             ...artworkInAuction.sale_artwork.counts,
             bidder_positions: 2,
           },
         },
       }
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const wrapper = await getWrapper(data)
       const html = wrapper.html()
       expect(html).toContain("$2,600")
@@ -169,21 +169,21 @@ describe("Details", () => {
       const data = {
         ...artworkInAuction,
         sale: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...artworkInAuction.sale,
           is_closed: true,
         },
         sale_artwork: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...artworkInAuction.sale_artwork,
           counts: {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             ...artworkInAuction.sale_artwork.counts,
             bidder_positions: 2,
           },
         },
       }
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const wrapper = await getWrapper(data)
       const html = wrapper.html()
       expect(html).not.toContain("(2 bids)")
@@ -193,16 +193,16 @@ describe("Details", () => {
       const data = {
         ...artworkInAuction,
         sale_artwork: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           ...artworkInAuction.sale_artwork,
           counts: {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             ...artworkInAuction.sale_artwork.counts,
             bidder_positions: 0,
           },
         },
       }
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const wrapper = await getWrapper(data)
       const html = wrapper.html()
       expect(html).not.toContain("bid")

--- a/src/v2/Components/Artwork/index.tsx
+++ b/src/v2/Components/Artwork/index.tsx
@@ -1,5 +1,5 @@
 import { Artwork_artwork } from "v2/__generated__/Artwork_artwork.graphql"
-import * as React from "react";
+import * as React from "react"
 // @ts-ignore
 import { ComponentRef, createFragmentContainer, graphql } from "react-relay"
 import styled, { css } from "styled-components"
@@ -109,7 +109,7 @@ export class Artwork extends React.Component<ArtworkProps, ArtworkState> {
     return (
       <Container onClick={this.onSelected}>
         <ImageContainer>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <Image src={artwork.image.url} />
           <div className={overlayClasses}>
             {Overlay && <Overlay selected={this.state.isSelected} />}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -1,5 +1,5 @@
 import { Spacer, useThemeConfig } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 import { ArtworkFilterArtworkGrid_filtered_artworks } from "v2/__generated__/ArtworkFilterArtworkGrid_filtered_artworks.graphql"
 import { useSystemContext, useTracking } from "v2/System"
@@ -47,7 +47,7 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
    */
   function loadNext() {
     if (hasNextPage) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       loadPage(context.filters.page + 1)
     }
   }
@@ -61,7 +61,7 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
 
   return (
     <>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <LoadingArea isLoading={props.isLoading}>
         <ArtworkGrid
           artworks={props.filtered_artworks}
@@ -74,14 +74,14 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
           onBrickClick={(artwork, artworkIndex) => {
             trackEvent(
               clickedMainArtworkGrid({
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 contextPageOwnerType,
                 contextPageOwnerSlug,
                 contextPageOwnerId,
                 destinationPageOwnerId: artwork.internalID,
                 destinationPageOwnerSlug: artwork.slug,
                 position: artworkIndex,
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 sort: context.filters.sort,
               })
             )

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -1,6 +1,6 @@
 import { omit } from "lodash"
-import { useContext, useReducer, useState } from "react";
-import * as React from "react";
+import { useContext, useReducer, useState } from "react"
+import * as React from "react"
 import useDeepCompareEffect from "use-deep-compare-effect"
 import { SortOptions } from "../SortFilter"
 import { hasFilters } from "./Utils/hasFilters"
@@ -166,18 +166,18 @@ export const ArtworkFilterContext = React.createContext<
 >({
   filters: initialArtworkFilterState,
   hasFilters: false,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   isDefaultValue: null,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   rangeToTuple: null,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   resetFilters: null,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   setFilter: null,
   sortOptions: [],
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   unsetFilter: null,
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   ZeroState: null,
   mountedContext: false,
 })
@@ -302,7 +302,7 @@ export const ArtworkFilterContextProvider: React.FC<
     resetFilters: () => {
       const action: ArtworkFiltersAction = {
         type: "RESET",
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         payload: null,
       }
       dispatchOrStage(action)

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterMobileActionSheet.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterMobileActionSheet.tsx
@@ -7,8 +7,8 @@ import {
   Sans,
   color,
 } from "@artsy/palette"
-import { useEffect, useRef } from "react";
-import * as React from "react";
+import { useEffect, useRef } from "react"
+import * as React from "react"
 import styled from "styled-components"
 import {
   initialArtworkFilterState,
@@ -43,21 +43,21 @@ export const ArtworkFilterMobileActionSheet: React.FC<{
     //
     // On mount, enter staged mode, and initialize a set of staged filter
     // changes from the current filter choices.
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     filterContext.setShouldStageFilterChanges(true)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     filterContext.setStagedFilters(filterContext.filters)
 
     // On unmount, exit staged mode.
     return () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       filterContext.setShouldStageFilterChanges(false)
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // enumerate the difference between prior and currently selected filters
   const changedFilterCount = countChangedFilters(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     filterContext.filters,
     filterContext.stagedFilters
   )
@@ -65,7 +65,7 @@ export const ArtworkFilterMobileActionSheet: React.FC<{
   const applyFilters = () => {
     // On apply, replace the actual filter state with the
     // hitherto staged filters
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     filterContext.setFilters(filterContext.stagedFilters)
     onClose()
   }
@@ -86,7 +86,7 @@ export const ArtworkFilterMobileActionSheet: React.FC<{
           size="small"
           onClick={() => {
             // On close, abandon any staged filter changes
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             filterContext.setStagedFilters({})
             onClose()
           }}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -1,5 +1,5 @@
-import { FC, useEffect, useState } from "react";
-import * as React from "react";
+import { FC, useEffect, useState } from "react"
+import * as React from "react"
 import { sortBy } from "lodash"
 import { Checkbox, CheckboxProps, Flex, useThemeConfig } from "@artsy/palette"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
@@ -33,7 +33,7 @@ const ArtistItem: React.FC<
 }) => {
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
   const toggleArtistSelection = (selected, slug) => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     let artistIDs = currentlySelectedFilters().artistIDs.slice()
     if (selected) {
       artistIDs.push(slug)
@@ -62,7 +62,7 @@ const ArtistItem: React.FC<
     <Checkbox
       {...checkboxProps}
       selected={
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         currentlySelectedFilters().artistIDs.includes(slug) ||
         (isFollowedArtistCheckboxSelected && isFollowedArtist)
       }
@@ -83,7 +83,7 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({
   user,
 }) => {
   const { aggregations, ...filterContext } = useArtworkFilterContext()
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const artists = aggregations.find(agg => agg.slice === "ARTIST")
 
   const [followedArtists, setFollowedArtists] = useState<FollowedArtistList>([])
@@ -112,11 +112,11 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({
 
   const isFollowedArtistCheckboxSelected =
     !!user &&
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     filterContext.currentlySelectedFilters()["includeArtworksByFollowedArtists"]
   const followedArtistArtworkCount = filterContext?.counts?.followedArtists ?? 0
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const selection = filterContext.currentlySelectedFilters().artistIDs
   const hasSelection =
     (selection && selection.length > 0) || isFollowedArtistCheckboxSelected
@@ -143,7 +143,7 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({
                 slug={slug}
                 name={name}
                 followedArtistSlugs={followedArtistSlugs}
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 isFollowedArtistCheckboxSelected={
                   isFollowedArtistCheckboxSelected
                 }

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Checkbox, Flex, useThemeConfig } from "@artsy/palette"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { FilterExpandable } from "./FilterExpandable"
@@ -32,7 +32,7 @@ export const AttributionClassFilter: React.FC<AttributionClassFilterProps> = ({
   const filterContext = useArtworkFilterContext()
 
   const toggleSelection = (selected, name) => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     let attributions = filterContext
       .currentlySelectedFilters()
       .attributionClass.slice()
@@ -58,7 +58,7 @@ export const AttributionClassFilter: React.FC<AttributionClassFilterProps> = ({
               key={index}
               my={tokens.my}
               onSelect={selected => toggleSelection(selected, value)}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               selected={filterContext
                 .currentlySelectedFilters()
                 .attributionClass.includes(value)}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -8,7 +8,7 @@ import {
   useThemeConfig,
 } from "@artsy/palette"
 import { intersection } from "lodash"
-import * as React from "react";
+import * as React from "react"
 import styled from "styled-components"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { sortResults } from "./ResultsFilter"
@@ -64,19 +64,19 @@ const ColorFilterOption: React.FC<{ colorOption: ColorOption }> = ({
   const { name, value, hex } = colorOption
 
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const { colors: selectedColorOptions } = currentlySelectedFilters()
 
   const toggleColor = (color: string) => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     if (selectedColorOptions.includes(color)) {
       setFilter(
         "colors",
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         selectedColorOptions.filter(selectedColor => color !== selectedColor)
       )
     } else {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       setFilter("colors", [...selectedColorOptions, color])
     }
   }
@@ -90,7 +90,7 @@ const ColorFilterOption: React.FC<{ colorOption: ColorOption }> = ({
     <Checkbox
       key={name}
       onSelect={() => toggleColor(value)}
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       selected={selectedColorOptions.includes(value)}
       my={tokens.my}
     >
@@ -121,14 +121,14 @@ export const ColorFilter: React.FC<ColorFilterProps> = ({ expanded }) => {
   const { currentlySelectedFilters } = useArtworkFilterContext()
   const hasBelowTheFoldColorFilter =
     intersection(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       currentlySelectedFilters().colors,
       COLOR_OPTIONS.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
     ).length > 0
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const hasColorFilter = currentlySelectedFilters().colors.length > 0
   const resultsSorted = sortResults(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     currentlySelectedFilters().colors,
     COLOR_OPTIONS
   )

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, Flex, useThemeConfig } from "@artsy/palette"
-import { FC } from "react";
+import { FC } from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { ShowMore, INITIAL_ITEMS_TO_SHOW } from "./ShowMore"
 import { intersection } from "lodash"
@@ -12,7 +12,7 @@ export interface MediumFilterProps {
 
 export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
   const { aggregations, counts, ...filterContext } = useArtworkFilterContext()
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const mediums = aggregations.find(agg => agg.slice === "MEDIUM") || {
     slice: "",
     counts: [],
@@ -21,7 +21,7 @@ export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
     mediums && mediums.counts.length ? mediums.counts : hardcodedMediums
 
   const toggleMediumSelection = (selected, slug) => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     let geneIDs = filterContext
       .currentlySelectedFilters()
       .additionalGeneIDs.slice()
@@ -33,11 +33,11 @@ export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
     filterContext.setFilter("additionalGeneIDs", geneIDs)
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const currentFilters = filterContext.currentlySelectedFilters()
   const hasBelowTheFoldMediumFilter =
     intersection(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       currentFilters.additionalGeneIDs,
       allowedMediums.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
     ).length > 0
@@ -47,7 +47,7 @@ export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
     v3: { my: 1 },
   })
   const resultsSorted = sortResults(
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     currentFilters.additionalGeneIDs,
     allowedMediums
   )
@@ -55,7 +55,7 @@ export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
   return (
     <FilterExpandable
       label="Medium"
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expanded={(!counts.artworks || counts.artworks > 0) && expanded}
     >
       <Flex flexDirection="column" alignItems="left">
@@ -64,7 +64,7 @@ export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
             return (
               <Checkbox
                 selected={
-                  // @ts-expect-error STRICT_NULL_CHECK
+                  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                   currentFilters.additionalGeneIDs.includes(slug) ||
                   currentFilters.medium === slug
                 }

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import * as React from "react";
+import { useEffect, useState } from "react"
+import * as React from "react"
 import {
   Button,
   Flex,
@@ -73,7 +73,7 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
   const [mode, setMode] = useState<"resting" | "done">("resting")
 
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const { priceRange: initialRange, reset } = currentlySelectedFilters()
 
   const numericInitialRange = parseRange(initialRange)
@@ -118,7 +118,7 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
     }
 
     if (selectedOption !== null) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       setCustomRange(parseRange(selectedOption))
     }
 
@@ -131,7 +131,7 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
     v3: { my: 1 },
   })
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const selection = currentlySelectedFilters().priceRange
   const hasSelection = selection && selection.length > 0
 

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ResultOption.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ResultOption.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, useThemeConfig } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import {
   MultiSelectArtworkFilters,
   useArtworkFilterContext,
@@ -20,7 +20,7 @@ export const ResultOption: React.FC<ResultOptionProps> = ({
   value,
 }) => {
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const results = currentlySelectedFilters()[facetName] || []
 
   const handleSelect = (value: string) => (selected: boolean) => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ResultsFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ResultsFilter.tsx
@@ -1,7 +1,7 @@
 import { intersection, orderBy } from "lodash"
 import { Flex } from "@artsy/palette"
 import { toTitleCase } from "@artsy/to-title-case"
-import * as React from "react";
+import * as React from "react"
 import {
   MultiSelectArtworkFilters,
   Slice,
@@ -45,9 +45,9 @@ export const ResultsFilter: React.FC<ResultsFilterProps> = ({
   const { aggregations, currentlySelectedFilters } = useArtworkFilterContext()
   const { isFiltered, handleFilterChange } = useFacetFilter()
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const selectedValues = currentlySelectedFilters()[facetName]
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const results = aggregations.find(aggregation => aggregation.slice === slice)
     ?.counts
 
@@ -56,12 +56,12 @@ export const ResultsFilter: React.FC<ResultsFilterProps> = ({
   }
 
   const resultsOrdered = orderBy(results, ["count", "name"], ["desc", "asc"])
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const resultsSorted = sortResults(selectedValues, resultsOrdered)
 
   const isBelowTheFoldFilterSelected =
     intersection(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       selectedValues,
       resultsSorted.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
     ).length > 0

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, Flex, useThemeConfig } from "@artsy/palette"
-import { FC } from "react";
+import { FC } from "react"
 import { intersection } from "lodash"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { FilterExpandable } from "./FilterExpandable"
@@ -12,7 +12,7 @@ export interface TimePeriodFilterProps {
 
 export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({ expanded }) => {
   const { aggregations, ...filterContext } = useArtworkFilterContext()
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const timePeriods = aggregations.find(agg => agg.slice === "MAJOR_PERIOD")
 
   let periods
@@ -32,7 +32,7 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({ expanded }) => {
   if (!periods.length) return null
 
   const togglePeriodSelection = (selected, period) => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     let majorPeriods = filterContext
       .currentlySelectedFilters()
       .majorPeriods.slice()
@@ -44,18 +44,18 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({ expanded }) => {
     filterContext.setFilter("majorPeriods", majorPeriods)
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const currentFilters = filterContext.currentlySelectedFilters()
   const hasBelowTheFoldMajorPeriodFilter =
     intersection(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       currentFilters.majorPeriods,
       periods.slice(INITIAL_ITEMS_TO_SHOW).map(({ name }) => name)
     ).length > 0
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const hasMajorPeriodFilter = currentFilters.majorPeriods.length > 0
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const resultsSorted = sortResults(currentFilters.majorPeriods, periods)
 
   return (
@@ -68,7 +68,7 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({ expanded }) => {
           {resultsSorted.map(({ name }, index) => {
             return (
               <Checkbox
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 selected={currentFilters.majorPeriods.includes(name)}
                 key={index}
                 onSelect={selected => togglePeriodSelection(selected, name)}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
@@ -1,6 +1,6 @@
 import { Checkbox, Flex, useThemeConfig } from "@artsy/palette"
 import { isEmpty } from "lodash"
-import { FC } from "react";
+import { FC } from "react"
 import {
   ArtworkFilters,
   useArtworkFilterContext,
@@ -33,25 +33,25 @@ export const WaysToBuyFilter: FC<WaysToBuyFilterProps> = ({ expanded }) => {
 
   const checkboxes: WayToBuy[] = [
     {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       disabled: isDisabled(filterContext.counts.ecommerce_artworks),
       name: "Buy Now",
       state: "acquireable",
     },
     {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       disabled: isDisabled(filterContext.counts.has_make_offer_artworks),
       name: "Make Offer",
       state: "offerable",
     },
     {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       disabled: isDisabled(filterContext.counts.auction_artworks),
       name: "Bid",
       state: "atAuction",
     },
     {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       disabled: isDisabled(filterContext.counts.for_sale_artworks),
       name: "Inquire",
       state: "inquireableOnly",
@@ -63,7 +63,7 @@ export const WaysToBuyFilter: FC<WaysToBuyFilterProps> = ({ expanded }) => {
     v3: { my: 1 },
   })
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const selection = filterContext.currentlySelectedFilters()
   const hasSelection =
     !!selection.acquireable ||
@@ -81,7 +81,7 @@ export const WaysToBuyFilter: FC<WaysToBuyFilterProps> = ({ expanded }) => {
               disabled={checkbox.disabled}
               onSelect={value => filterContext.setFilter(checkbox.state, value)}
               selected={Boolean(
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 filterContext.currentlySelectedFilters()[checkbox.state]
               )}
               my={tokens.my}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/AttributionClassFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/AttributionClassFilter.jest.tsx
@@ -35,11 +35,11 @@ describe("AttributionClassFilter", () => {
     const wrapper = getWrapper() as any
 
     await wrapper.find("Checkbox").at(0).simulate("click")
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(context.filters.attributionClass).toEqual(["unique"])
 
     await wrapper.find("Checkbox").at(2).simulate("click")
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(context.filters.attributionClass).toEqual(["unique", "open edition"])
   })
 

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
@@ -57,17 +57,17 @@ describe("MaterialsTermFilter", () => {
     it("acts on material term values", async () => {
       const wrapper = getWrapper({ aggregations })
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(context.filters.materialsTerms).toHaveLength(0)
 
       await wrapper.find("Checkbox").first().simulate("click")
       await wrapper.find("Checkbox").last().simulate("click")
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(context.filters.materialsTerms).toHaveLength(2)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(context.filters.materialsTerms).toContain("acrylic")
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(context.filters.materialsTerms).toContain("enamel")
     })
 

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
@@ -44,7 +44,7 @@ describe("PriceRangeFilter", () => {
     option.simulate("click")
     await flushPromiseQueue()
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(context.filters.priceRange).toEqual("25000-50000")
   })
 
@@ -96,12 +96,12 @@ describe("PriceRangeFilter", () => {
     await flushPromiseQueue()
     wrapper.update()
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper.find(Input).first().find("input").prop("onChange")({
       currentTarget: { value: "400" },
     } as any)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper.find(Input).last().find("input").prop("onChange")({
       currentTarget: { value: "7500" },
     } as any)
@@ -109,7 +109,7 @@ describe("PriceRangeFilter", () => {
     wrapper.update()
     wrapper.find("Button").last().simulate("click")
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(context.filters.priceRange).toEqual("400-7500")
   })
 
@@ -120,28 +120,28 @@ describe("PriceRangeFilter", () => {
     await flushPromiseQueue()
     wrapper.update()
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper.find(Input).first().find("input").prop("onChange")({
       currentTarget: { value: "400" },
     } as any)
 
     wrapper.update()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper.find("Button").last().prop("onClick")({} as any)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(context.filters.priceRange).toEqual("400-*")
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper.find(Input).first().find("input").prop("onChange")({
       currentTarget: { value: "" },
     } as any)
 
     wrapper.update()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper.find("Button").last().prop("onClick")({} as any)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(context.filters.priceRange).toEqual("*-*")
   })
 

--- a/src/v2/Components/ArtworkFilter/Utils/countChangedFilters.ts
+++ b/src/v2/Components/ArtworkFilter/Utils/countChangedFilters.ts
@@ -6,7 +6,7 @@ const difference = (initial: {}, next: {}) => {
     if (!isEqual(value, initial[key])) {
       result[key] =
         isObject(value) && isObject(initial[key])
-          ? // @ts-expect-error STRICT_NULL_CHECK
+          ? // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             difference(value, initial[key])
           : value
     }

--- a/src/v2/Components/ArtworkFilter/Utils/rangeToTuple.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/rangeToTuple.tsx
@@ -34,6 +34,6 @@ export const rangeToTuple: (
     ;[minStr, maxStr] = ["*", "*"]
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   return [min, max]
 }

--- a/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
@@ -53,7 +53,7 @@ export const buildUrl = (
 
   const url = queryString ? `${pathname}?${queryString}` : pathname
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   return url
 }
 

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterContext.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterContext.jest.tsx
@@ -37,7 +37,7 @@ describe("ArtworkFilterContext", () => {
     it("#onFilterClick", () => {
       const spy = jest.fn()
       getWrapper({ onFilterClick: spy })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       context.onFilterClick("color", "purple", initialArtworkFilterState)
       expect(spy).toHaveBeenCalledWith(
         "color",
@@ -72,11 +72,11 @@ describe("ArtworkFilterContext", () => {
         },
       })
       act(() => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         expect(context.filters.page).toEqual(10)
         context.setFilter("sort", "relevant")
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(context.filters.page).toEqual(1)
     })
 
@@ -88,11 +88,11 @@ describe("ArtworkFilterContext", () => {
         },
       })
       act(() => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         expect(context.filters.page).toEqual(10)
         context.unsetFilter("sort")
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(context.filters.page).toEqual(1)
     })
 
@@ -108,7 +108,7 @@ describe("ArtworkFilterContext", () => {
 
         // copy that to a 'staged' filter state
         act(() => {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           context.setStagedFilters(filters)
         })
       })
@@ -116,7 +116,7 @@ describe("ArtworkFilterContext", () => {
       describe("when not in staged mode", () => {
         beforeEach(() => {
           act(() => {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             context.setShouldStageFilterChanges(false)
           })
         })
@@ -125,9 +125,9 @@ describe("ArtworkFilterContext", () => {
           act(() => {
             context.setFilter("medium", "jewelry")
           })
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.filters.medium).toEqual("jewelry")
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.stagedFilters.medium).not.toEqual("jewelry")
         })
 
@@ -135,9 +135,9 @@ describe("ArtworkFilterContext", () => {
           act(() => {
             context.unsetFilter("medium")
           })
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.filters.medium).not.toEqual("painting")
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.stagedFilters.medium).toEqual("painting")
         })
 
@@ -159,7 +159,7 @@ describe("ArtworkFilterContext", () => {
           act(() => {
             context.setFilter("medium", "design")
           })
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.currentlySelectedFilters()).toEqual(context.filters)
         })
       })
@@ -167,7 +167,7 @@ describe("ArtworkFilterContext", () => {
       describe("when in staged mode", () => {
         beforeEach(() => {
           act(() => {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             context.setShouldStageFilterChanges(true)
           })
         })
@@ -176,9 +176,9 @@ describe("ArtworkFilterContext", () => {
           act(() => {
             context.setFilter("medium", "jewelry")
           })
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.filters.medium).not.toEqual("jewelry")
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.stagedFilters.medium).toEqual("jewelry")
         })
 
@@ -186,9 +186,9 @@ describe("ArtworkFilterContext", () => {
           act(() => {
             context.unsetFilter("medium")
           })
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.filters.medium).toEqual("painting")
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.stagedFilters.medium).not.toEqual("painting")
         })
 
@@ -210,7 +210,7 @@ describe("ArtworkFilterContext", () => {
           act(() => {
             context.setFilter("medium", "design")
           })
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.currentlySelectedFilters()).toEqual(
             context.stagedFilters
           )
@@ -220,31 +220,31 @@ describe("ArtworkFilterContext", () => {
       describe("regardless of mode", () => {
         test("#setFilters replaces only the 'real' filters", () => {
           act(() => {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             context.setFilters({
               ...initialArtworkFilterState,
               medium: "jewelry",
             })
           })
 
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.filters.medium).toEqual("jewelry")
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.stagedFilters.medium).not.toEqual("jewelry")
         })
 
         test("#setStagedFilters replaces only the staged filters", () => {
           act(() => {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             context.setStagedFilters({
               ...initialArtworkFilterState,
               medium: "jewelry",
             })
           })
 
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.filters.medium).not.toEqual("jewelry")
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           expect(context.stagedFilters.medium).toEqual("jewelry")
         })
       })

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -310,7 +310,7 @@ export const BaseArtworkFilter: React.FC<
           <Spacer mb={2} />
 
           <ArtworkFilterArtworkGrid
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             filtered_artworks={viewer.filtered_artworks}
             isLoading={isFetching}
             offset={offset}
@@ -359,7 +359,7 @@ export const BaseArtworkFilter: React.FC<
 
             {children || (
               <ArtworkFilterArtworkGrid
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 filtered_artworks={viewer.filtered_artworks}
                 isLoading={isFetching}
                 offset={offset}

--- a/src/v2/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/v2/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -4,8 +4,8 @@ import { ArtworkGrid_artworks } from "v2/__generated__/ArtworkGrid_artworks.grap
 import { ArtworkGridEmptyState } from "v2/Components/ArtworkGrid/ArtworkGridEmptyState"
 import { isEqual } from "lodash"
 import memoizeOnce from "memoize-one"
-import { ReactNode } from "react";
-import * as React from "react";
+import { ReactNode } from "react"
+import * as React from "react"
 import ReactDOM from "react-dom"
 // @ts-ignore
 import { ComponentRef, createFragmentContainer, graphql } from "react-relay"
@@ -13,10 +13,10 @@ import styled from "styled-components"
 import { Media, valuesWithBreakpointProps } from "v2/Utils/Responsive"
 import GridItem from "../Artwork/GridItem"
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 type SectionedArtworks = Array<Array<ArtworkGrid_artworks["edges"][0]["node"]>>
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 type Artwork = ArtworkGrid_artworks["edges"][0]["node"]
 
 export interface ArtworkGridProps
@@ -57,7 +57,7 @@ export class ArtworkGridContainer extends React.Component<
 
   private get _columnCount(): number[] {
     const columnCount = this.props.columnCount
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     return typeof columnCount === "number" ? [columnCount] : columnCount
   }
 
@@ -72,7 +72,7 @@ export class ArtworkGridContainer extends React.Component<
 
   componentWillUnmount() {
     if (this.state.interval) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       clearInterval(this.state.interval)
     }
   }
@@ -98,7 +98,7 @@ export class ArtworkGridContainer extends React.Component<
     const threshold = window.innerHeight + window.scrollY
     const el = ReactDOM.findDOMNode(this) as Element
     if (threshold >= el.clientHeight + el.scrollTop) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       this.props.onLoadMore()
     }
   }
@@ -126,12 +126,12 @@ export class ArtworkGridContainer extends React.Component<
         const artwork = sectionedArtworks[column][row]
 
         artworkComponents.push(
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           <GridItem
             contextModule={contextModule}
             artwork={artwork}
             key={artwork.id}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             lazyLoad={artworkIndex >= preloadImageCount}
             onClick={() => {
               if (this.props.onBrickClick) {
@@ -143,7 +143,7 @@ export class ArtworkGridContainer extends React.Component<
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.
         if (row < sectionedArtworks[column].length - 1) {
           artworkComponents.push(
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             <div style={spacerStyle} key={"spacer-" + row + "-" + artwork.id} />
           )
         }
@@ -156,7 +156,7 @@ export class ArtworkGridContainer extends React.Component<
       }
 
       sections.push(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         <div style={sectionSpecificStyle} key={column}>
           {artworkComponents}
         </div>
@@ -262,9 +262,9 @@ function areSectionedArtworksEqual(current: any, previous: any) {
     const currentEdges = (current as ArtworkGrid_artworks).edges
     const previousEdges = (previous as ArtworkGrid_artworks).edges
     return (
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       currentEdges.length === previousEdges.length &&
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       currentEdges.every((e, i) => e.node.id === previousEdges[i].node.id)
     )
   }
@@ -280,18 +280,18 @@ export function createSectionedArtworks(
 
   for (let i = 0; i < columnCount; i++) {
     sectionedArtworks.push([])
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     sectionRatioSums.push(0)
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   artworks.forEach(artworkEdge => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const artwork = artworkEdge.node
 
     // There are artworks without images and other ‘issues’. Like Force we’re just going to reject those for now.
     // See: https://github.com/artsy/eigen/issues/1667
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     if (artwork.image) {
       // Find section with lowest *inverted* aspect ratio sum, which is the shortest column.
       let lowestRatioSum = Number.MAX_VALUE
@@ -299,7 +299,7 @@ export function createSectionedArtworks(
       for (let j = 0; j < sectionRatioSums.length; j++) {
         const ratioSum = sectionRatioSums[j]
         if (ratioSum < lowestRatioSum) {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           sectionIndex = j
           lowestRatioSum = ratioSum
         }
@@ -310,10 +310,10 @@ export function createSectionedArtworks(
         section.push(artwork)
 
         // Keep track of total section aspect ratio
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const aspectRatio = artwork.image.aspect_ratio || 1 // Ensure we never divide by null/0
         // Invert the aspect ratio so that a lower value means a shorter section.
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         sectionRatioSums[sectionIndex] += 1 / aspectRatio
       }
     }

--- a/src/v2/Components/ArtworkGrid/__tests__/ArtworkGrid.jest.tsx
+++ b/src/v2/Components/ArtworkGrid/__tests__/ArtworkGrid.jest.tsx
@@ -26,7 +26,7 @@ const TestContainer = createFragmentContainer(
     artist,
     ...props
   }: ExtractProps<typeof ArtworkGrid> & { artist: ArtworkGrid_artist }) => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     return <ArtworkGrid {...props} artworks={artist.artworks_connection} />
   },
   {
@@ -70,7 +70,7 @@ describe("ArtworkGrid", () => {
         1.36,
       ]
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const artworks = {
         " $refType": null,
         edges: aspectRatios.reduce(
@@ -113,7 +113,7 @@ describe("ArtworkGrid", () => {
       artworks,
       ...componentProps
     }: Omit<ArtworkGridProps, "artworks"> & {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       artworks: ArtworkGrid_Test_QueryRawResponse["artist"]["artworks_connection"]
     }) => {
       return await renderRelayTree({
@@ -171,7 +171,7 @@ describe("ArtworkGrid", () => {
     it("#componentWillUnmount calls #clearInterval if state.interval exists", async () => {
       props.onLoadMore = jest.fn()
       const wrapper = (await getRelayWrapper(props)).find(ArtworkGridContainer)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       wrapper.instance().componentWillUnmount()
       expect(global.clearInterval).toBeCalled()
     })

--- a/src/v2/Components/ArtworkGrid/__tests__/ArtworkGridFixture.ts
+++ b/src/v2/Components/ArtworkGrid/__tests__/ArtworkGridFixture.ts
@@ -1,6 +1,6 @@
 import { ArtworkGrid_Test_QueryRawResponse } from "v2/__generated__/ArtworkGrid_Test_Query.graphql"
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 export const ArtworksGridEdges: ArtworkGrid_Test_QueryRawResponse["artist"]["artworks_connection"]["edges"] = [
   {
     __typename: "ArtworkEdge",
@@ -163,7 +163,7 @@ export const ArtworksGridEdges: ArtworkGrid_Test_QueryRawResponse["artist"]["art
   },
 ]
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 export const ArtworkGridFixture: ArtworkGrid_Test_QueryRawResponse["artist"]["artworks_connection"] = {
   // pageInfo: {
   //   hasNextPage: true,

--- a/src/v2/Components/Authentication/FormSwitcher.tsx
+++ b/src/v2/Components/Authentication/FormSwitcher.tsx
@@ -108,7 +108,7 @@ export class FormSwitcher extends Component<FormSwitcherProps, State> {
 
   getAfterSignupAction = (options: ModalOptions): AfterSignUpAction => {
     const { afterSignUpAction, action, kind, objectId } = options
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     return (
       afterSignUpAction || {
         action,
@@ -128,7 +128,7 @@ export class FormSwitcher extends Component<FormSwitcherProps, State> {
       email = qs.parse(searchQuery).email as string
     }
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     return email || values.email || ""
   }
 
@@ -176,12 +176,12 @@ export class FormSwitcher extends Component<FormSwitcherProps, State> {
     const { handleSubmit, onBackButtonClicked, values } = this.props
 
     const defaultValues = {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       accepted_terms_of_service: values.accepted_terms_of_service || false,
       email: this.getEmailValue(),
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       name: values.name || "",
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       password: values.password || "",
     }
 

--- a/src/v2/Components/Authentication/ModalManager.tsx
+++ b/src/v2/Components/Authentication/ModalManager.tsx
@@ -50,7 +50,7 @@ export class ModalManager extends Component<
   ModalManagerState
 > {
   state: ModalManagerState = {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     currentType: null,
     options: {} as ModalOptions,
     recaptchaLoaded: false,
@@ -74,7 +74,7 @@ export class ModalManager extends Component<
     let afterClose = this.state.options?.afterClose
 
     this.setState({
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       currentType: null,
       options: {} as ModalOptions,
     })
@@ -124,7 +124,7 @@ export class ModalManager extends Component<
 
     const handleSubmit: SubmitHandler = !!this.props.handleSubmit
       ? this.props.handleSubmit.bind(this, currentType, options)
-      : // @ts-expect-error STRICT_NULL_CHECK
+      : // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         defaultHandleSubmit(submitUrls[currentType], csrf, redirectTo)
 
     return (

--- a/src/v2/Components/Authentication/Views/ForgotPasswordForm.tsx
+++ b/src/v2/Components/Authentication/Views/ForgotPasswordForm.tsx
@@ -27,7 +27,7 @@ export class ForgotPasswordForm extends Component<
   render() {
     return (
       <Formik
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         initialValues={this.props.values}
         onSubmit={this.onSubmit}
         validationSchema={ForgotPasswordValidator}

--- a/src/v2/Components/Authentication/__tests__/ModalManager.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/ModalManager.jest.tsx
@@ -86,7 +86,7 @@ describe("ModalManager", () => {
 
     expect(manager.state.currentType).toEqual("signup")
     expect(manager.state.switchedForms).toEqual(true)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(manager.state.options.mode).toEqual("signup")
   })
 

--- a/src/v2/Components/BorderedPulldown.tsx
+++ b/src/v2/Components/BorderedPulldown.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 
 import styled from "styled-components"
 import colors from "../Assets/Colors"
@@ -53,7 +53,7 @@ export class BorderedPulldown extends React.Component<
     })
 
     const displayValue =
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       (this.state.selected && this.state.selected.name) ||
       selectedName ||
       defaultValue

--- a/src/v2/Components/CCPARequest.tsx
+++ b/src/v2/Components/CCPARequest.tsx
@@ -13,8 +13,8 @@ import {
 } from "@artsy/palette"
 import { CCPARequestMutation } from "v2/__generated__/CCPARequestMutation.graphql"
 import { useSystemContext } from "v2/System"
-import { useEffect, useState } from "react";
-import * as React from "react";
+import { useEffect, useState } from "react"
+import * as React from "react"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
 import { ErrorWithMetadata } from "v2/Utils/errors"
@@ -208,7 +208,7 @@ const sendDataRequest = ({
     },
     onCompleted: data => {
       const {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         createAccountRequest: { accountRequestOrError },
       } = data
       if (accountRequestOrError.mutationError) {
@@ -237,7 +237,7 @@ export const CCPARequest: React.SFC<Props> = props => {
   const [clickedSubmit, setClickedSubmit] = useState(false)
   const [submitted, setSubmitted] = useState(false)
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const userEmail = get(props, p => p.user.email)
 
   const modalContents = submitted ? (

--- a/src/v2/Components/CollectionsHubsHomepageNav.tsx
+++ b/src/v2/Components/CollectionsHubsHomepageNav.tsx
@@ -33,7 +33,7 @@ export const CollectionsHubsHomepageNav = track(
       {props.marketingHubCollections.slice(0, 6).map(hub => (
         <ImageLink
           to={`/collection/${hub.slug}`}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           src={resize(hub.thumbnail, { width: 357, height: 175 })}
           ratio={[0.49]}
           title={<Text variant="text">{hub.title}</Text>}

--- a/src/v2/Components/CollectionsHubsNav.tsx
+++ b/src/v2/Components/CollectionsHubsNav.tsx
@@ -2,7 +2,7 @@ import { CSSGrid, Text } from "@artsy/palette"
 import { CollectionsHubsNav_marketingHubCollections } from "v2/__generated__/CollectionsHubsNav_marketingHubCollections.graphql"
 import { useTracking } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
-import { FC } from "react";
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { resize } from "v2/Utils/resizer"
 import { ImageLink } from "./ImageLink"
@@ -27,7 +27,7 @@ export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
       {props.marketingHubCollections.slice(0, 6).map(hub => (
         <ImageLink
           to={`/collection/${hub.slug}`}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           src={resize(hub.thumbnail, { width: 357, height: 175 })}
           ratio={[0.49]}
           title={

--- a/src/v2/Components/CollectionsRail/CollectionEntity.tsx
+++ b/src/v2/Components/CollectionsRail/CollectionEntity.tsx
@@ -3,7 +3,7 @@ import { CollectionEntity_collection } from "v2/__generated__/CollectionEntity_c
 import { track } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
 import currency from "currency.js"
-import { Component } from "react";
+import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
@@ -57,7 +57,7 @@ export class CollectionEntity extends Component<CollectionProps> {
           onClick={this.onLinkClick.bind(this)}
         >
           <Background
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             collectionImage={resize(collection.headerImage, {
               width: 645,
               height: 275,
@@ -66,7 +66,8 @@ export class CollectionEntity extends Component<CollectionProps> {
           />
           <CollectionTitle size="4">{collection.title}</CollectionTitle>
           <Sans size="2">
-            Works from ${/* @ts-expect-error STRICT_NULL_CHECK */}
+            Works from $
+            {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             {currency(collection.price_guidance, {
               separator: ",",
               precision: 0,

--- a/src/v2/Components/CollectionsRail/CollectionsRail.tsx
+++ b/src/v2/Components/CollectionsRail/CollectionsRail.tsx
@@ -4,7 +4,7 @@ import { track } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
 import { pMedia } from "v2/Components/Helpers"
 import { once } from "lodash"
-import { Component } from "react";
+import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import Waypoint from "react-waypoint"
 import styled from "styled-components"
@@ -34,7 +34,7 @@ const RailsWrapper = styled(Flex)`
   `};
 `
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 @track(null, {
   dispatch: data => Events.postEvent(data),
 })

--- a/src/v2/Components/ConfirmPasswordModal/__tests__/ConfirmPasswordModal.jest.tsx
+++ b/src/v2/Components/ConfirmPasswordModal/__tests__/ConfirmPasswordModal.jest.tsx
@@ -55,7 +55,7 @@ describe("ConfirmPasswordModal", () => {
 
   it("calls ConfirmPassword and onConfirm on submit", async () => {
     const wrapper = getWrapper()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper
       .find("input[type='password']")
       .props()
@@ -72,7 +72,7 @@ describe("ConfirmPasswordModal", () => {
   it("displays errors", async () => {
     ConfirmPassword.mockRejectedValue({ error: "Invalid password." })
     const wrapper = getWrapper()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper
       .find("input[type='password']")
       .props()

--- a/src/v2/Components/ConfirmPasswordModal/index.tsx
+++ b/src/v2/Components/ConfirmPasswordModal/index.tsx
@@ -1,5 +1,5 @@
 import { Banner, Button, Flex, Modal, space, Text } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { useSystemContext } from "v2/System"
 import { PasswordInput } from "v2/Components/PasswordInput"
 import { Form, Formik, FormikProps } from "formik"
@@ -25,7 +25,7 @@ export const ConfirmPasswordModal: React.FC<ConfirmPasswordModalProps> = props =
   ) => {
     formikBag.setStatus({ error: undefined })
     try {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       await ConfirmPassword(relayEnvironment, {
         password,
       })

--- a/src/v2/Components/DownloadAppBadge.tsx
+++ b/src/v2/Components/DownloadAppBadge.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import track, { useTracking } from "react-tracking"
 import { clickedAppDownload, ContextModule } from "@artsy/cohesion"
 import { useAnalyticsContext } from "v2/System"
@@ -24,7 +24,7 @@ interface DownloadAppBadgeProps extends LinkProps {
   downloadAppUrl: string
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 export const DownloadAppBadge: React.FC<DownloadAppBadgeProps> = track(null, {
   dispatch: data => Events.postEvent(data),
 })(({ contextModule, device, downloadAppUrl, ...rest }) => {

--- a/src/v2/Components/FairCard.tsx
+++ b/src/v2/Components/FairCard.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Image, ResponsiveBox } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairCard_fair } from "v2/__generated__/FairCard_fair.graphql"
@@ -20,11 +20,11 @@ export const FairCard: React.FC<FairHeaderImageProps> = ({
     >
       {image && (
         <Image
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           src={image.cropped.src}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           srcSet={image.cropped.srcSet}
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           alt={name}
           lazyLoad
           borderRadius={4}

--- a/src/v2/Components/FilterInput/FilterInput.tsx
+++ b/src/v2/Components/FilterInput/FilterInput.tsx
@@ -5,8 +5,8 @@ import {
   LabeledInput,
   MagnifyingGlassIcon,
 } from "@artsy/palette"
-import { useRef, useState } from "react";
-import * as React from "react";
+import { useRef, useState } from "react"
+import * as React from "react"
 
 export type FilterInputProps = InputProps
 
@@ -30,7 +30,7 @@ export const FilterInput: React.FC<InputProps> = ({
   const handleClick = () => {
     setValue("")
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     ref.current.focus()
 
     // HACK: simulate an onChange event

--- a/src/v2/Components/FlashBanner/__tests__/FlashBanner.jest.tsx
+++ b/src/v2/Components/FlashBanner/__tests__/FlashBanner.jest.tsx
@@ -23,7 +23,7 @@ const getRelayWrapper = async ({
   queryString: search = "",
   props: passedProps = {},
 }) => {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   delete window.location
   window.location = { search } as any
 

--- a/src/v2/Components/FollowArtistPopover/FollowArtistPopoverRow.tsx
+++ b/src/v2/Components/FollowArtistPopover/FollowArtistPopoverRow.tsx
@@ -8,7 +8,7 @@ import {
 import { FollowArtistPopoverRow_artist } from "v2/__generated__/FollowArtistPopoverRow_artist.graphql"
 import { FollowArtistPopoverRowMutation } from "v2/__generated__/FollowArtistPopoverRowMutation.graphql"
 import { SystemContextProps } from "v2/System"
-import { Component } from "react";
+import { Component } from "react"
 import {
   RelayProp,
   commitMutation,
@@ -32,7 +32,7 @@ interface State {
 
 class FollowArtistPopoverRow extends Component<Props, State> {
   state: State = {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     swappedArtist: null,
     followed: false,
   }
@@ -40,7 +40,7 @@ class FollowArtistPopoverRow extends Component<Props, State> {
   handleClick(artistID: string) {
     const { user, relay, excludeArtistIdsState } = this.props
     const {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       state: { excludeArtistIds },
     } = excludeArtistIdsState
     if (user && user.id) {
@@ -84,9 +84,9 @@ class FollowArtistPopoverRow extends Component<Props, State> {
         },
         updater: (_store, data) => {
           const {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             node,
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           } = data.followArtist.artist.related.suggestedConnection.edges[0]
 
           // Add slight delay to make UX seem a bit nicer
@@ -104,7 +104,7 @@ class FollowArtistPopoverRow extends Component<Props, State> {
             }
           )
 
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           excludeArtistIdsState.addArtist(node.internalID)
         },
       })

--- a/src/v2/Components/FollowArtistPopover/state.ts
+++ b/src/v2/Components/FollowArtistPopover/state.ts
@@ -11,14 +11,14 @@ export class FollowArtistPopoverState extends Container<State> {
     super()
 
     if (props && props.excludeArtistIds) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       this.state.excludeArtistIds = props.excludeArtistIds
     }
   }
 
   addArtist = (artistId: string) => {
     const { excludeArtistIds } = this.state
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     this.setState({ excludeArtistIds: excludeArtistIds.concat(artistId) })
   }
 }

--- a/src/v2/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/v2/Components/FollowButton/FollowArtistButton.tsx
@@ -77,7 +77,7 @@ export class FollowArtistButton extends React.Component<Props> {
       contextModule,
       contextOwnerId: contextPageOwnerId,
       contextOwnerSlug: contextPageOwnerSlug,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       contextOwnerType: contextPageOwnerType,
       ownerId: artist.internalID,
       ownerSlug: artist.slug,
@@ -87,7 +87,7 @@ export class FollowArtistButton extends React.Component<Props> {
       ? unfollowedArtist(args)
       : followedArtist(args)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     tracking.trackEvent(analyticsData)
   }
 
@@ -102,7 +102,7 @@ export class FollowArtistButton extends React.Component<Props> {
     if (user && user.id) {
       this.followArtistForUser()
     } else {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       openAuthToFollowSave(mediator, {
         contextModule,
         entity: artist,
@@ -120,7 +120,7 @@ export class FollowArtistButton extends React.Component<Props> {
       ? (artist.counts?.follows ?? 0) - 1
       : (artist.counts?.follows ?? 0) + 1
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     commitMutation<FollowArtistButtonMutation>(relay.environment, {
       mutation: graphql`
         mutation FollowArtistButtonMutation($input: FollowArtistInput!) {
@@ -147,10 +147,10 @@ export class FollowArtistButton extends React.Component<Props> {
         },
       },
       updater: (store, data) => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const artistProxy = store.get(data.followArtist.artist.id)
 
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         artistProxy
           .getLinkedRecord("counts")
           .setValue(newFollowCount, "follows")
@@ -203,7 +203,7 @@ export class FollowArtistButton extends React.Component<Props> {
                 }}
               >
                 {" "}
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 {render(artist)}
               </Container>
             ) : (
@@ -268,7 +268,7 @@ export const FollowArtistButtonQueryRenderer: React.FC<
       variables={{ id }}
       render={({ error, props }) => {
         if (error || !props) {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           return <FollowArtistButtonFragmentContainer {...rest} artist={null} />
         }
 

--- a/src/v2/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/v2/Components/FollowButton/FollowGeneButton.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { commitMutation, createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System"
 import { FollowButton } from "./Button"
@@ -20,7 +20,7 @@ const FollowGeneButton: React.FC<FollowGeneButtonProps> = ({
 
   const handleClick = () => {
     if (!user) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       openAuthToFollowSave(mediator, {
         entity: gene,
         contextModule: ContextModule.geneHeader,
@@ -30,7 +30,7 @@ const FollowGeneButton: React.FC<FollowGeneButtonProps> = ({
       return
     }
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     commitMutation<FollowGeneButtonMutation>(relayEnvironment, {
       mutation: graphql`
         mutation FollowGeneButtonMutation($input: FollowGeneInput!) {
@@ -61,7 +61,7 @@ const FollowGeneButton: React.FC<FollowGeneButtonProps> = ({
 
   return (
     <FollowButton
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       isFollowed={gene.isFollowed}
       handleFollow={handleClick}
       buttonProps={rest}

--- a/src/v2/Components/FollowButton/FollowProfileButton.tsx
+++ b/src/v2/Components/FollowButton/FollowProfileButton.tsx
@@ -1,6 +1,6 @@
 import { FollowProfileButtonMutation } from "v2/__generated__/FollowProfileButtonMutation.graphql"
 import * as Artsy from "v2/System"
-import * as React from "react";
+import * as React from "react"
 import track, { TrackingProp } from "react-tracking"
 import { FollowProfileButton_profile } from "../../__generated__/FollowProfileButton_profile.graphql"
 import { FollowButton } from "./Button"
@@ -58,23 +58,23 @@ export class FollowProfileButton extends React.Component<Props> {
     } = this.props
 
     const args: FollowedArgs = {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       ownerId: profile.internalID,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       ownerSlug: profile.slug,
       contextModule,
       contextOwnerId: contextPageOwnerId,
       contextOwnerSlug: contextPageOwnerSlug,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       contextOwnerType: contextPageOwnerType,
     }
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const analyticsData = profile.is_followed
       ? unfollowedPartner(args)
       : followedPartner(args)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     tracking.trackEvent(analyticsData)
   }
 
@@ -83,7 +83,7 @@ export class FollowProfileButton extends React.Component<Props> {
     const { contextModule, profile, user, relay, mediator } = this.props
 
     if (user && user.id) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       commitMutation<FollowProfileButtonMutation>(relay.environment, {
         // TODO: Inputs to the mutation might have changed case of the keys!
         mutation: graphql`
@@ -98,18 +98,18 @@ export class FollowProfileButton extends React.Component<Props> {
         `,
         variables: {
           input: {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             profileID: profile.internalID,
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             unfollow: profile.is_followed,
           },
         },
         optimisticResponse: {
           followProfile: {
             profile: {
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               id: profile.id,
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               is_followed: !profile.is_followed,
             },
           },
@@ -117,12 +117,12 @@ export class FollowProfileButton extends React.Component<Props> {
       })
       this.trackFollow()
     } else {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       openAuthToFollowSave(mediator, {
         entity: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           name: profile.name,
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           slug: profile.slug,
         },
         contextModule,
@@ -138,14 +138,14 @@ export class FollowProfileButton extends React.Component<Props> {
     if (render) {
       return (
         <Clickable onClick={this.handleFollow} data-test="followButton">
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           {render(profile)}
         </Clickable>
       )
     } else {
       return (
         <FollowButton
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           isFollowed={profile && profile.is_followed}
           handleFollow={this.handleFollow}
           buttonProps={buttonProps}

--- a/src/v2/Components/FollowButton/__tests__/FollowGeneButton.jest.tsx
+++ b/src/v2/Components/FollowButton/__tests__/FollowGeneButton.jest.tsx
@@ -20,7 +20,7 @@ const { getWrapper } = setupTestWrapper<FollowGeneButton_Test_Query>({
   Component: props => {
     return (
       <SystemContextProvider user={user}>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <FollowGeneButtonFragmentContainer {...props} />
       </SystemContextProvider>
     )
@@ -72,7 +72,7 @@ describe("FollowGeneButton", () => {
   })
 
   describe("logged out", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     user = null
 
     it("pops up the auth model when clicked", () => {

--- a/src/v2/Components/Links/ForwardLink.tsx
+++ b/src/v2/Components/Links/ForwardLink.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { BoxProps, ChevronIcon, Text, boxMixin } from "@artsy/palette"
 import { StyledLink } from "./StyledLink"
 import styled from "styled-components"
@@ -39,7 +39,7 @@ export const ForwardLink: React.FC<ForwardLinkProps> = ({
       </Text>
 
       <ChevronIcon
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         title={null}
         direction="right"
         color="black"

--- a/src/v2/Components/Menu/MenuItem.tsx
+++ b/src/v2/Components/Menu/MenuItem.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import styled from "styled-components"
 import {
   Box,
@@ -60,9 +60,9 @@ export const MenuItem: React.FC<MenuItemProps> = ({
 }) => {
   return (
     <Container
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       to={href}
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       hasLighterTextColor={hasLighterTextColor}
       px={2}
       py={1}

--- a/src/v2/Components/Modal/ErrorModal.tsx
+++ b/src/v2/Components/Modal/ErrorModal.tsx
@@ -1,5 +1,5 @@
 import { Box, Link } from "@artsy/palette"
-import { Component } from "react";
+import { Component } from "react"
 import { getENV } from "v2/Utils/getENV"
 import { ModalDialog } from "./ModalDialog"
 import { ModalWidth } from "./ModalWrapper"
@@ -64,7 +64,7 @@ export class ErrorModal extends Component<ErrorModalProps> {
           </>
         }
         primaryCta={{
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           action: ctaAction || onClose,
           text: closeText,
         }}

--- a/src/v2/Components/Modal/FlashModal.tsx
+++ b/src/v2/Components/Modal/FlashModal.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import * as React from "react";
+import { useEffect, useState } from "react"
+import * as React from "react"
 import { useSystemContext } from "v2/System/useSystemContext"
 import { ErrorModal, ErrorModalProps } from "./ErrorModal"
 
@@ -15,17 +15,17 @@ export const FlashMessage: React.FC = () => {
   const [message, setMessage] = useState(null)
 
   useEffect(() => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     mediator.on("modal:error:show", (options: FlashMessageProps) => {
       setShow(true)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       setMessage(options.message)
     })
   })
 
   return show ? (
     <ErrorModal
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       detailText={message}
       onClose={() => {
         setShow(false)

--- a/src/v2/Components/Modal/ModalCta.tsx
+++ b/src/v2/Components/Modal/ModalCta.tsx
@@ -1,5 +1,5 @@
 import { Button, color, space } from "@artsy/palette"
-import { SFC } from "react";
+import { SFC } from "react"
 import styled from "styled-components"
 import { media } from "../Helpers"
 
@@ -15,7 +15,7 @@ export const ModalCta: SFC<{
   onClose: () => void
 }> = props => {
   const {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     cta: { isFixed, onClick, text },
     hasImage,
     onClose,

--- a/src/v2/Components/Modal/ModalWrapper.tsx
+++ b/src/v2/Components/Modal/ModalWrapper.tsx
@@ -1,5 +1,5 @@
 import { Theme } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import styled, { createGlobalStyle, keyframes } from "styled-components"
 import { getViewportDimensions } from "v2/Utils/viewport"
 import FadeTransition from "../Animation/FadeTransition"
@@ -86,7 +86,7 @@ export class ModalWrapper extends React.Component<
   }
 
   close = () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     this.props.onClose()
     this.removeBlurToContainers()
   }
@@ -148,7 +148,7 @@ export class ModalWrapper extends React.Component<
           <GlobalStyle suppressMultiMountWarning />
           {isShown && (
             <ModalOverlay
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               onClick={
                 this.props.disableCloseOnBackgroundClick ? null : this.close
               }
@@ -228,7 +228,7 @@ export const ModalContainer = styled.div<{
   background: #fff;
   width: ${props => {
     if (props.image) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       return props.viewportWidth > 900 ? ModalWidth.Wide : ModalWidth.Medium
     } else {
       return props.width ? props.width : ModalWidth.Normal

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -98,7 +98,7 @@ export const NavBar: React.FC = track(
         toggleMobileNav(false)
         return
       }
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       target = target.parentElement
     }
   }
@@ -221,7 +221,7 @@ export const NavBar: React.FC = track(
                       variant="secondaryOutline"
                       size="small"
                       onClick={() => {
-                        // @ts-expect-error STRICT_NULL_CHECK
+                        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                         openAuthModal(mediator, {
                           mode: ModalType.login,
                           intent: Intent.login,
@@ -235,7 +235,7 @@ export const NavBar: React.FC = track(
                     <Button
                       size="small"
                       onClick={() => {
-                        // @ts-expect-error STRICT_NULL_CHECK
+                        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                         openAuthModal(mediator, {
                           mode: ModalType.signup,
                           intent: Intent.signup,

--- a/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -69,7 +69,7 @@ describe("NavBar", () => {
     })
 
     it("renders logged in items", () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const wrapper = getWrapper({ user: true })
       expect(wrapper.html()).not.toContain("Log In")
       expect(wrapper.html()).not.toContain("Sign Up")
@@ -80,7 +80,7 @@ describe("NavBar", () => {
     describe("lab features", () => {
       it("shows inquiries icon if lab feature enabled", () => {
         const wrapper = getWrapper({
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           user: { type: "NotAdmin", lab_features: ["User Conversations View"] },
         })
         expect(wrapper.find(EnvelopeIcon).length).toEqual(1)
@@ -145,7 +145,7 @@ describe("NavBar", () => {
 
     it("shows the inbox notifications count  when there are conversations", () => {
       const wrapper = getWrapper({
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         user: { type: "NotAdmin", lab_features: ["User Conversations View"] },
       })
       expect(wrapper.find(NavBarMobileMenuInboxNotificationCount).length).toBe(

--- a/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
@@ -107,7 +107,7 @@ describe("NavBarTracking", () => {
   describe("Mobile", () => {
     it("tracks show mobile menu hamburger button clicks", () => {
       const wrapper = mount(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         <Wrapper user={null}>
           <NavBar />
         </Wrapper>

--- a/src/v2/Components/Onboarding/ArtistsStep/ArtistSearchResults.tsx
+++ b/src/v2/Components/Onboarding/ArtistsStep/ArtistSearchResults.tsx
@@ -6,7 +6,7 @@ import {
 import { ArtistSearchResultsQuery } from "v2/__generated__/ArtistSearchResultsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "v2/System"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
-import * as React from "react";
+import * as React from "react"
 import {
   RelayProp,
   commitMutation,
@@ -17,7 +17,7 @@ import { RecordSourceSelectorProxy } from "relay-runtime"
 import ReplaceTransition from "../../Animation/ReplaceTransition"
 import ItemLink, { LinkContainer } from "../ItemLink"
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 type Artist = ArtistSearchResults_viewer["searchConnection"]["edges"][number]["node"]
 
 export interface ContainerProps {
@@ -37,9 +37,9 @@ class ArtistSearchResultsContent extends React.Component<Props, null> {
   constructor(props: Props, context: any) {
     super(props, context)
     this.excludedArtistIds = new Set(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       this.props.viewer.searchConnection.edges.map(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         ({ node }) => node.internalID
       )
     )
@@ -54,20 +54,20 @@ class ArtistSearchResultsContent extends React.Component<Props, null> {
     this.props.onArtistFollow(follow, artist)
 
     const suggestedArtistEdge =
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       data.followArtist.artist.related.suggestedConnection.edges[0]
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const popularArtist = data.followArtist.popular_artists[0]
     const artistToSuggest = store.get(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       ((suggestedArtistEdge && suggestedArtistEdge.node) || popularArtist).id
     )
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     this.excludedArtistIds.add(artistToSuggest.getValue("internalID") as string)
 
     const popularArtistsRootField = store.get("client:root:viewer")
     const popularArtists =
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       popularArtistsRootField.getLinkedRecords("match_artist", {
         term: this.props.term,
       }) || []
@@ -75,9 +75,9 @@ class ArtistSearchResultsContent extends React.Component<Props, null> {
       artistItem.getDataID() === artist.id ? artistToSuggest : artistItem
     )
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     popularArtistsRootField.setLinkedRecords(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       updatedPopularArtists,
       "match_artist",
       { term: this.props.term }
@@ -86,7 +86,7 @@ class ArtistSearchResultsContent extends React.Component<Props, null> {
 
   onFollowedArtist(artist: Artist, follow: boolean) {
     commitMutation<ArtistSearchResultsArtistMutation>(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       this.props.relay.environment,
       {
         // TODO: Inputs to the mutation might have changed case of the keys!
@@ -150,9 +150,9 @@ class ArtistSearchResultsContent extends React.Component<Props, null> {
   }
 
   render() {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const artistItems = this.props.viewer.searchConnection.edges.map(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       ({ node: artist }, index) => {
         return (
           <LinkContainer key={`artist-search-results-${index}`}>
@@ -184,7 +184,7 @@ class ArtistSearchResultsContent extends React.Component<Props, null> {
 }
 
 export const ArtistSearchResultsContentContainer = createFragmentContainer(
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   ArtistSearchResultsContent,
   {
     viewer: graphql`

--- a/src/v2/Components/Onboarding/ArtistsStep/ArtistsStep.tsx
+++ b/src/v2/Components/Onboarding/ArtistsStep/ArtistsStep.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { throttle } from "lodash"
 import styled from "styled-components"
 import { ProgressIndicator } from "v2/Components/ProgressIndicator"
@@ -83,9 +83,9 @@ export const ArtistsStep: React.FC<Props> = props => {
 
   return (
     <>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <ProgressIndicator percentComplete={0.25} />
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <Layout
         buttonState={buttonState}
         onNextButtonPressed={handleNextButtonPress}

--- a/src/v2/Components/Onboarding/ArtistsStep/PopularArtists.tsx
+++ b/src/v2/Components/Onboarding/ArtistsStep/PopularArtists.tsx
@@ -6,7 +6,7 @@ import {
 import { PopularArtistsQuery } from "v2/__generated__/PopularArtistsQuery.graphql"
 import { SystemContextProps, withSystemContext } from "v2/System"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
-import * as React from "react";
+import * as React from "react"
 import {
   RelayProp,
   commitMutation,
@@ -48,20 +48,20 @@ class PopularArtistsContent extends React.Component<Props, null> {
     this.props.onArtistFollow(follow, artist)
 
     const suggestedArtistEdge =
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       data.followArtist.artist.related.suggestedConnection.edges[0]
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const popularArtist = data.followArtist.popular_artists[0]
     const artistToSuggest = store.get(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       ((suggestedArtistEdge && suggestedArtistEdge.node) || popularArtist).id
     )
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     this.excludedArtistIds.add(artistToSuggest.getValue("internalID") as string)
 
     const popularArtistsRootField = store.get("client:root")
     const popularArtists =
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       popularArtistsRootField.getLinkedRecords("popular_artists", {
         exclude_followed_artists: true,
       }) || []
@@ -72,16 +72,16 @@ class PopularArtistsContent extends React.Component<Props, null> {
         artistItem.getDataID() === artist.id ? artistToSuggest : artistItem
       )
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     store
       .get("client:root")
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       .setLinkedRecords(updatedPopularArtists, "popular_artists")
   }
 
   onFollowedArtist(artist: Artist, follow: boolean) {
     commitMutation<PopularArtistsFollowArtistMutation>(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       this.props.relay.environment,
       {
         // TODO: Inputs to the mutation might have changed case of the keys!
@@ -150,7 +150,7 @@ class PopularArtistsContent extends React.Component<Props, null> {
     const artistItems = this.props.popular_artists
       .filter(Boolean)
       .map((artist, index) => {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const imageUrl = get(artist, a => a.image.cropped.url)
         return (
           <LinkContainer key={`popular-artists-${index}`}>
@@ -163,9 +163,9 @@ class PopularArtistsContent extends React.Component<Props, null> {
                 item={artist}
                 key={artist.id}
                 id={artist.id}
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 name={artist.name}
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 image_url={imageUrl}
                 onFollow={selected => this.onFollowedArtist(artist, selected)}
               />
@@ -179,7 +179,7 @@ class PopularArtistsContent extends React.Component<Props, null> {
 }
 
 export const PopularArtistContentContainer = createFragmentContainer(
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   PopularArtistsContent,
   {
     popular_artists: graphql`

--- a/src/v2/Components/Onboarding/ArtistsStep/__tests__/ArtistSearchResults.jest.tsx
+++ b/src/v2/Components/Onboarding/ArtistsStep/__tests__/ArtistSearchResults.jest.tsx
@@ -42,11 +42,11 @@ describe("ArtistSearchResults", () => {
 
     const mutationCalls = (commitMutation as any).mock.calls
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     onClick({} as any)
     expect(mutationCalls[0][1].variables.input.unfollow).toBe(false)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     onClick({} as any)
     expect(mutationCalls[1][1].variables.input.unfollow).toBe(true)
   })

--- a/src/v2/Components/Onboarding/ArtistsStep/__tests__/ArtistsStep.jest.tsx
+++ b/src/v2/Components/Onboarding/ArtistsStep/__tests__/ArtistsStep.jest.tsx
@@ -16,7 +16,7 @@ describe("ArtistsStep", () => {
 
     const onInput = wrapper.find("input").prop("onInput")
     const event: any = { target: { value: "andy" } }
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     onInput(event)
     wrapper.update()
 

--- a/src/v2/Components/Onboarding/ArtistsStep/__tests__/PopularArtists.jest.tsx
+++ b/src/v2/Components/Onboarding/ArtistsStep/__tests__/PopularArtists.jest.tsx
@@ -38,11 +38,11 @@ describe("PopularArtists", () => {
 
     const mutationCalls = (commitMutation as any).mock.calls
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     onClick({} as any)
     expect(mutationCalls[0][1].variables.input.unfollow).toBe(false)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     onClick({} as any)
     expect(mutationCalls[1][1].variables.input.unfollow).toBe(true)
   })

--- a/src/v2/Components/Onboarding/GenesStep/GeneSearchResults.tsx
+++ b/src/v2/Components/Onboarding/GenesStep/GeneSearchResults.tsx
@@ -7,7 +7,7 @@ import { GeneSearchResultsQuery } from "v2/__generated__/GeneSearchResultsQuery.
 import { SystemContextProps, withSystemContext } from "v2/System"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { garamond } from "v2/Assets/Fonts"
-import * as React from "react";
+import * as React from "react"
 import {
   RelayProp,
   commitMutation,
@@ -20,7 +20,7 @@ import { get } from "v2/Utils/get"
 import ReplaceTransition from "../../Animation/ReplaceTransition"
 import ItemLink, { LinkContainer } from "../ItemLink"
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 type Gene = GeneSearchResults_viewer["match_gene"]["edges"][number]["node"]
 
 interface ContainerProps {
@@ -48,7 +48,7 @@ class GeneSearchResultsContent extends React.Component<Props, null> {
   constructor(props: Props, context: any) {
     super(props, context)
     this.excludedGeneIds = new Set(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       this.props.viewer.match_gene.edges.map(({ node }) => node.internalID)
     )
   }
@@ -62,15 +62,15 @@ class GeneSearchResultsContent extends React.Component<Props, null> {
     this.props.onGeneFollow(follow, gene)
 
     const suggestedGene = store.get(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       data.followGene.gene.similar.edges[0].node.id
     )
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     this.excludedGeneIds.add(suggestedGene.getValue("internalID") as string)
 
     const suggestedGenesRootField = store.get("client:root:viewer")
     const suggestedGenes =
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       suggestedGenesRootField.getLinkedRecords("match_gene", {
         term: this.props.term,
       }) || []
@@ -78,9 +78,9 @@ class GeneSearchResultsContent extends React.Component<Props, null> {
       geneItem.getValue("id") === gene.id ? suggestedGene : geneItem
     )
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     suggestedGenesRootField.setLinkedRecords(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       updatedSuggestedGenes,
       "match_gene",
       { term: this.props.term }
@@ -91,7 +91,7 @@ class GeneSearchResultsContent extends React.Component<Props, null> {
     this.excludedGeneIds.add(gene.internalID)
 
     commitMutation<GeneSearchResultsFollowGeneMutation>(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       this.props.relay.environment,
       {
         // TODO: Inputs to the mutation might have changed case of the keys!
@@ -135,9 +135,9 @@ class GeneSearchResultsContent extends React.Component<Props, null> {
   }
 
   render() {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const items = this.props.viewer.match_gene.edges.map(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       ({ node: item }, index) => {
         const imageUrl = get(item, i => i.image.cropped.url)
         return (
@@ -171,7 +171,7 @@ class GeneSearchResultsContent extends React.Component<Props, null> {
 }
 
 export const GeneSearchResultsContentContainer = createFragmentContainer(
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   GeneSearchResultsContent,
   {
     viewer: graphql`

--- a/src/v2/Components/Onboarding/GenesStep/GenesStep.tsx
+++ b/src/v2/Components/Onboarding/GenesStep/GenesStep.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { throttle } from "lodash"
 import styled from "styled-components"
 import { ProgressIndicator } from "v2/Components/ProgressIndicator"
@@ -80,9 +80,9 @@ export const GenesStep: React.FC<Props> = props => {
 
   return (
     <>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <ProgressIndicator percentComplete={0.5} />
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <Layout
         buttonState={buttonState}
         onNextButtonPressed={handleNextButtonPress}

--- a/src/v2/Components/Onboarding/GenesStep/SuggestedGenes.tsx
+++ b/src/v2/Components/Onboarding/GenesStep/SuggestedGenes.tsx
@@ -6,7 +6,7 @@ import {
 import { SuggestedGenesQuery } from "v2/__generated__/SuggestedGenesQuery.graphql"
 import { SystemContextProps, withSystemContext } from "v2/System"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
-import * as React from "react";
+import * as React from "react"
 import {
   RelayProp,
   commitMutation,
@@ -48,23 +48,23 @@ class SuggestedGenesContent extends React.Component<Props> {
     this.props.onGeneFollow(follow, gene)
 
     const suggestedGene = store.get(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       data.followGene.gene.similar.edges[0].node.id
     )
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     this.excludedGeneIds.add(suggestedGene.getValue("internalID") as string)
 
     const suggestedGenesRootField = store.get("client:root")
     const suggestedGenes =
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       suggestedGenesRootField.getLinkedRecords("suggested_genes") || []
     const updatedSuggestedGenes = suggestedGenes.map(geneItem =>
       geneItem.getValue("id") === gene.id ? suggestedGene : geneItem
     )
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     suggestedGenesRootField.setLinkedRecords(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       updatedSuggestedGenes,
       "suggested_genes"
     )
@@ -74,7 +74,7 @@ class SuggestedGenesContent extends React.Component<Props> {
     this.excludedGeneIds.add(gene.internalID)
 
     commitMutation<SuggestedGenesFollowGeneMutation>(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       this.props.relay.environment,
       {
         // TODO: Inputs to the mutation might have changed case of the keys!
@@ -119,7 +119,7 @@ class SuggestedGenesContent extends React.Component<Props> {
 
   render() {
     const items = this.props.suggested_genes.map((item, index) => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const imageUrl = get(item, i => i.image.cropped.url)
       return (
         <LinkContainer key={`suggested-genes-${index}`}>
@@ -132,9 +132,9 @@ class SuggestedGenesContent extends React.Component<Props> {
               item={item}
               key={item.id}
               id={item.slug}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               name={item.name}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               image_url={imageUrl}
               onFollow={selected => this.followedGene(item, selected)}
             />

--- a/src/v2/Components/Onboarding/GenesStep/__tests__/GeneSearchResults.jest.tsx
+++ b/src/v2/Components/Onboarding/GenesStep/__tests__/GeneSearchResults.jest.tsx
@@ -39,11 +39,11 @@ describe("GeneSearchResults", () => {
 
     const mutationCalls = (commitMutation as any).mock.calls
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     onClick({} as any)
     expect(mutationCalls[0][1].variables.input.unfollow).toBe(false)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     onClick({} as any)
     expect(mutationCalls[1][1].variables.input.unfollow).toBe(true)
   })

--- a/src/v2/Components/Onboarding/GenesStep/__tests__/GenesStep.jest.tsx
+++ b/src/v2/Components/Onboarding/GenesStep/__tests__/GenesStep.jest.tsx
@@ -15,7 +15,7 @@ describe("GenesStep", () => {
 
     const onInput = wrapper.find("input").prop("onInput")
     const event: any = { target: { value: "photo" } }
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     onInput(event)
     wrapper.update()
 

--- a/src/v2/Components/Onboarding/GenesStep/__tests__/SuggestedGenes.jest.tsx
+++ b/src/v2/Components/Onboarding/GenesStep/__tests__/SuggestedGenes.jest.tsx
@@ -38,11 +38,11 @@ describe("SuggestedGenes", () => {
 
     const mutationCalls = (commitMutation as any).mock.calls
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     onClick({} as any)
     expect(mutationCalls[0][1].variables.input.unfollow).toBe(false)
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     onClick({} as any)
     expect(mutationCalls[1][1].variables.input.unfollow).toBe(true)
   })

--- a/src/v2/Components/Onboarding/Steps/Budget.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
@@ -84,23 +84,23 @@ export const BudgetComponent: React.FC<Props> = props => {
 
   const onOptionSelected = (index: number) => {
     const selection = { selection: Object.values(budgetOptions)[index] }
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     setSelectedOption(selection)
   }
 
   const options = Object.keys(budgetOptions).map((text, index) => (
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     <SelectableToggle
       key={index}
       text={text}
       onSelect={() => onOptionSelected(index)}
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       selected={selectedOption?.selection === budgetOptions[text]}
     />
   ))
 
   const submit = () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const priceRangeMax = selectedOption?.selection
     if (!priceRangeMax) return
 
@@ -124,9 +124,9 @@ export const BudgetComponent: React.FC<Props> = props => {
 
   return (
     <>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <ProgressIndicator percentComplete={0.75} />
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <Layout
         title="What’s your maximum artwork budget?"
         subtitle="Select one"

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
@@ -100,7 +100,7 @@ export const CollectorIntentComponent: React.FC<Props> = props => {
   }
 
   const optionTags = Object.keys(intentEnum).map((text, index) => (
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     <SelectableToggle
       key={index}
       text={text}
@@ -124,9 +124,9 @@ export const CollectorIntentComponent: React.FC<Props> = props => {
 
   return (
     <>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <ProgressIndicator />
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <Layout
         buttonState={buttonState}
         onNextButtonPressed={submit}

--- a/src/v2/Components/Onboarding/Steps/Layout.tsx
+++ b/src/v2/Components/Onboarding/Steps/Layout.tsx
@@ -1,6 +1,6 @@
 import Colors from "v2/Assets/Colors"
 import { avantgarde } from "v2/Assets/Fonts"
-import { Component } from "react";
+import { Component } from "react"
 import styled from "styled-components"
 import MultiStateButton, {
   MultiButtonState,
@@ -106,7 +106,7 @@ export class Layout extends Component<Props, null> {
             <NextButton
               disabled={disabled}
               onClick={this.props.onNextButtonPressed}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               state={this.props.buttonState}
             >
               {buttonText}

--- a/src/v2/Components/Onboarding/__tests__/ItemLink.jest.tsx
+++ b/src/v2/Components/Onboarding/__tests__/ItemLink.jest.tsx
@@ -27,7 +27,7 @@ describe("ArtistSearchResults", () => {
 
     const onClick = wrapper.find("Link").prop("onClick")
     const event: any = {}
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     onClick(event)
     wrapper.update()
 

--- a/src/v2/Components/Pagination/index.tsx
+++ b/src/v2/Components/Pagination/index.tsx
@@ -51,7 +51,7 @@ export const Pagination: React.FC<Props> = ({
     if (userIsForcingNavigation(event)) return
     event.preventDefault()
     onClick(cursor, page)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     scrollIntoView({ selector: scrollTo, offset })
   }
 
@@ -59,7 +59,7 @@ export const Pagination: React.FC<Props> = ({
     if (userIsForcingNavigation(event)) return
     event.preventDefault()
     onNext(page)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     scrollIntoView({ selector: scrollTo, offset })
   }
 
@@ -69,7 +69,7 @@ export const Pagination: React.FC<Props> = ({
     onClick: handleClick,
     onNext: handleNext,
     pageCursors: pageCursors as any,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     scrollTo,
   }
 

--- a/src/v2/Components/Pagination/useComputeHref.ts
+++ b/src/v2/Components/Pagination/useComputeHref.ts
@@ -17,7 +17,7 @@ export function useComputeHref() {
 
   // Artwork filter-specific
   // (location doesn't update in the case of artwork filter)
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const currentlySelectedFilters = artworkFilterContext.currentlySelectedFilters()
 
   const computeHref = page => {

--- a/src/v2/Components/PasswordInput.tsx
+++ b/src/v2/Components/PasswordInput.tsx
@@ -1,6 +1,6 @@
 import { ClosedEyeIcon, OpenEyeIcon, space } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import styled from "styled-components"
 import QuickInput, { QuickInputProps } from "./QuickInput"
 
@@ -41,7 +41,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = ({
       error={error}
       type={type}
       rightAddOn={eyeIcon()}
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       note={note}
     />
   )

--- a/src/v2/Components/Payment/PaymentModal.tsx
+++ b/src/v2/Components/Payment/PaymentModal.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { Button, Modal, Spacer, Text } from "@artsy/palette"
 import { Formik, FormikHelpers, FormikProps } from "formik"
 import {
@@ -29,7 +29,7 @@ const onCreditCardAdded = (
   data: PaymentModalCreateCreditCardMutation["response"]
 ): void => {
   const {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     createCreditCard: { creditCardOrError },
   } = data
 
@@ -37,7 +37,7 @@ const onCreditCardAdded = (
   if (creditCardOrError.creditCardEdge) {
     const meStore = store.get(me.id)
     const connection = ConnectionHandler.getConnection(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       meStore,
       "PaymentSection_creditCards"
     )
@@ -48,7 +48,7 @@ const onCreditCardAdded = (
     const creditCardEdge = creditCardOrErrorEdge.getLinkedRecord(
       "creditCardEdge"
     )
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     ConnectionHandler.insertEdgeAfter(connection, creditCardEdge)
   }
 }
@@ -110,19 +110,19 @@ export const PaymentModal: React.FC<PaymentModalProps> = props => {
       address_country: values.country,
     }
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const cardElement = elements.getElement(CardElement)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const stripeResults = await stripe.createToken(cardElement, billingAddress)
     const { token, error } = stripeResults
     if (error) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       setCreateError(error.message)
     } else {
       commitMutation<PaymentModalCreateCreditCardMutation>(relay.environment, {
         onCompleted: (data, errors) => {
           const {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             createCreditCard: { creditCardOrError },
           } = data
           actions?.setSubmitting(false)
@@ -132,14 +132,14 @@ export const PaymentModal: React.FC<PaymentModalProps> = props => {
             if (errors) {
               // TODO: user freindly message?
               setCreateError(
-                // @ts-expect-error STRICT_NULL_CHECK
+                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 `Failed. ${errors
                   .map((e: PayloadError) => e.message)
                   .join(", ")}`
               )
             } else {
               const mutationError = creditCardOrError.mutationError
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               setCreateError(`Failed. ${mutationError.message}`)
             }
           }
@@ -147,12 +147,12 @@ export const PaymentModal: React.FC<PaymentModalProps> = props => {
         onError: error => {
           actions?.setSubmitting(false)
           logger.error(error)
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           setCreateError("Failed.")
         },
         mutation,
         variables: {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           input: { token: token.id },
         },
         updater: (store, data) => {

--- a/src/v2/Components/Payment/SavedCreditCards.tsx
+++ b/src/v2/Components/Payment/SavedCreditCards.tsx
@@ -5,7 +5,7 @@ import {
 } from "v2/__generated__/SavedCreditCardsDeleteCreditCardMutation.graphql"
 import { CreditCardDetails } from "v2/Apps/Order/Components/CreditCardDetails"
 import { ErrorModal } from "v2/Components/Modal/ErrorModal"
-import * as React from "react";
+import * as React from "react"
 import { RelayProp, commitMutation, graphql } from "react-relay"
 import { ConnectionHandler, RecordSourceSelectorProxy } from "relay-runtime"
 import styled from "styled-components"
@@ -69,12 +69,12 @@ export class CreditCard extends React.Component<
   private deleteCreditCard() {
     this.setState({ isCommittingMutation: true }, () => {
       commitMutation<SavedCreditCardsDeleteCreditCardMutation>(
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         this.props.relay.environment,
         {
           onCompleted: (data, errors) => {
             const {
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               deleteCreditCard: { creditCardOrError },
             } = data
 
@@ -109,7 +109,7 @@ export class CreditCard extends React.Component<
             }
           `,
           variables: {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             input: { id: this.props.creditCard.internalID },
           },
           updater: (store, data) => this.onCreditCardDeleted(store, data),
@@ -125,7 +125,7 @@ export class CreditCard extends React.Component<
     data: SavedCreditCardsDeleteCreditCardMutationResponse
   ) {
     const {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       deleteCreditCard: { creditCardOrError },
     } = data
 
@@ -139,13 +139,13 @@ export class CreditCard extends React.Component<
       const creditCardId = creditCardEdge.getValue("id")
       const meStore = store.get(this.props.me.id)
       let connection = null
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       connection = ConnectionHandler.getConnection(
         meStore!,
         "UserSettingsPayments_creditCards"
       )
       if (!connection) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         connection = ConnectionHandler.getConnection(
           meStore!,
           "PaymentSection_creditCards"

--- a/src/v2/Components/Payment/__tests__/PaymentModal.jest.tsx
+++ b/src/v2/Components/Payment/__tests__/PaymentModal.jest.tsx
@@ -19,13 +19,13 @@ jest.mock("@stripe/stripe-js", () => {
   return {
     loadStripe: () => {
       if (mock === null) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         mock = mockStripe()
       }
       return mock
     },
     _mockStripe: () => mock,
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     _mockReset: () => (mock = mockStripe()),
   }
 })
@@ -88,7 +88,7 @@ describe("PaymentModal", () => {
     })
 
     const formik = wrapper.find("Formik").first()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     formik.props().onSubmit(validAddress as any)
 
     const stripeCall = await _mockStripe().createToken
@@ -114,7 +114,7 @@ describe("PaymentModal", () => {
     })
 
     const formik = wrapper.find("Formik").first()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     formik.props().onSubmit(validAddress as any)
 
     const stripeCall = await _mockStripe().createToken
@@ -142,7 +142,7 @@ describe("PaymentModal", () => {
     )
 
     const formik = wrapper.find("Formik").first()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     formik.props().onSubmit(validAddress as any)
 
     const stripeCall = await _mockStripe().createToken
@@ -174,7 +174,7 @@ describe("PaymentModal", () => {
     )
 
     const formik = wrapper.find("Formik").first()
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     formik.props().onSubmit(validAddress as any)
 
     const stripeCall = await _mockStripe().createToken

--- a/src/v2/Components/QuickInput.tsx
+++ b/src/v2/Components/QuickInput.tsx
@@ -2,7 +2,7 @@ import { space } from "@artsy/palette"
 import { fadeIn, fadeOut } from "v2/Assets/Animations"
 import Colors from "v2/Assets/Colors"
 import { garamond, unica } from "v2/Assets/Fonts"
-import { Component } from "react";
+import { Component } from "react"
 import styled from "styled-components"
 import { borderedInputMixin } from "./Mixins"
 
@@ -28,10 +28,7 @@ export interface QuickInputState {
  * Quick input. Renders the label inside of the textbox.
  * @deprecated
  */
-export class QuickInput extends Component<
-  QuickInputProps,
-  QuickInputState
-> {
+export class QuickInput extends Component<QuickInputProps, QuickInputState> {
   state = {
     focused: false,
     value: (this.props.value as string) || "",
@@ -58,7 +55,7 @@ export class QuickInput extends Component<
 
   onBlur = e => {
     if (this.props.setTouched) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       this.props.setTouched({ [this.props.name]: true })
     }
     this.setState({
@@ -72,7 +69,7 @@ export class QuickInput extends Component<
 
   onChange = e => {
     if (this.props.touchedOnChange && this.props.setTouched) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       this.props.setTouched({ [this.props.name]: true })
     }
     this.setState({

--- a/src/v2/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
+++ b/src/v2/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Image, Text } from "@artsy/palette"
 import { RelatedCollectionEntity_collection } from "v2/__generated__/RelatedCollectionEntity_collection.graphql"
 import { useTracking } from "v2/System/Analytics"
 import currency from "currency.js"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ContextModule, clickedCollectionGroup } from "@artsy/cohesion"
 import { useAnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
@@ -28,7 +28,7 @@ export const RelatedCollectionEntity: React.FC<RelatedCollectionEntityProps> = (
     slug,
     title,
   } = collection
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const artworks = artworksConnection.edges.map(({ node }) => node)
 
   const { trackEvent } = useTracking()
@@ -44,7 +44,7 @@ export const RelatedCollectionEntity: React.FC<RelatedCollectionEntityProps> = (
         contextModule: ContextModule.relatedCollectionsRail,
         contextPageOwnerId,
         contextPageOwnerSlug,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         contextPageOwnerType,
         destinationPageOwnerId: id,
         destinationPageOwnerSlug: slug,
@@ -78,7 +78,7 @@ export const RelatedCollectionEntity: React.FC<RelatedCollectionEntityProps> = (
             })
           ) : (
             <Image
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               {...cropped(headerImage, { width: 325, height: 150 })}
               width={325}
               height={150}

--- a/src/v2/Components/Search/SearchBar.tsx
+++ b/src/v2/Components/Search/SearchBar.tsx
@@ -1,5 +1,5 @@
-import { Component, useContext } from "react";
-import * as React from "react";
+import { Component, useContext } from "react"
+import * as React from "react"
 import { Box, BoxProps } from "@artsy/palette"
 import { SearchBar_viewer } from "v2/__generated__/SearchBar_viewer.graphql"
 import { SearchBarSuggestQuery } from "v2/__generated__/SearchBarSuggestQuery.graphql"
@@ -78,7 +78,7 @@ const Form = styled.form`
   width: 100%;
 `
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 @track(null, {
   dispatch: data => Events.postEvent(data),
 })
@@ -92,7 +92,7 @@ export class SearchBar extends Component<Props, State> {
 
   private removeNavigationListener: () => void
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   state = {
     entityID: null,
     entityType: null,
@@ -145,9 +145,9 @@ export class SearchBar extends Component<Props, State> {
           this.reportPerformanceMeasurement(performanceStart)
         }
         const { viewer } = this.props
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const edges = get(viewer, v => v.searchConnection.edges, [])
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         this.trackSearch(term, edges.length > 0)
       }
     )
@@ -234,9 +234,9 @@ export class SearchBar extends Component<Props, State> {
     //  to follow it.
     if (!this.userClickedOnDescendant) {
       this.setState({
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         entityID: null,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         entityType: null,
       })
     }
@@ -298,7 +298,7 @@ export class SearchBar extends Component<Props, State> {
   renderSuggestionsContainer = ({ containerProps, children, query }) => {
     const noResults = get(
       this.props,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       p => p.viewer.searchConnection.edges.length === 0
     )
     const { focused } = this.state
@@ -403,9 +403,9 @@ export class SearchBar extends Component<Props, State> {
       },
     }
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const edges = get(viewer, v => v.searchConnection.edges, [])
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const suggestions = [firstSuggestionPlaceholder, ...edges]
 
     return (

--- a/src/v2/Components/Search/SearchInputContainer.tsx
+++ b/src/v2/Components/Search/SearchInputContainer.tsx
@@ -6,7 +6,7 @@ import {
 } from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
 import { isEmpty } from "lodash"
-import * as React from "react";
+import * as React from "react"
 import styled from "styled-components"
 
 const SearchButton = styled(Clickable)`
@@ -39,7 +39,7 @@ export const SearchInputContainer: React.ForwardRefExoticComponent<
         <SearchButton
           type="submit"
           onClick={event => {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             ;(event.target as HTMLElement).parentElement.blur()
 
             if (isEmpty(props.value)) {

--- a/src/v2/Components/Search/__tests__/SearchBar.jest.tsx
+++ b/src/v2/Components/Search/__tests__/SearchBar.jest.tsx
@@ -176,36 +176,36 @@ describe("SearchBar", () => {
 describe("getSearchTerm", () => {
   function buildLocationWithQueryString(queryString: string): Location {
     return {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       ancestorOrigins: undefined,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       host: undefined,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       hostname: undefined,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       href: undefined,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       origin: undefined,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       port: undefined,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       protocol: undefined,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       assign: undefined,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       hash: undefined,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       pathname: undefined,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       reload: undefined,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       replace: undefined,
       search: queryString,
     }
   }
 
   it("returns empty string if there is no term", () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const location = buildLocationWithQueryString(undefined)
 
     const result = getSearchTerm(location)

--- a/src/v2/Components/SelectedCareerAchievements.tsx
+++ b/src/v2/Components/SelectedCareerAchievements.tsx
@@ -10,7 +10,7 @@ import { SelectedCareerAchievements_artist } from "v2/__generated__/SelectedCare
 
 import { ArtistInsight } from "v2/Components/ArtistInsight"
 import { ArtistInsightsModal } from "v2/Components/ArtistInsightsModal"
-import { Component } from "react";
+import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SpaceProps } from "styled-system"
 import { RouterLink } from "v2/System/Router/RouterLink"
@@ -48,15 +48,15 @@ export class SelectedCareerAchievements extends Component<
   renderAuctionHighlight() {
     if (
       !this.props.artist.auctionResultsConnection ||
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       this.props.artist.auctionResultsConnection.edges.length < 1
     ) {
       return null
     }
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const topAuctionResult = this.props.artist.auctionResultsConnection.edges[0]
       .node
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const display = `${topAuctionResult.price_realized.display}, ${topAuctionResult.organization}, ${topAuctionResult.sale_date}`
 
     return (
@@ -71,7 +71,7 @@ export class SelectedCareerAchievements extends Component<
   }
   renderGalleryRepresentation() {
     const { highlights } = this.props.artist
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const { partnersConnection } = highlights
     if (
       partnersConnection &&
@@ -108,7 +108,7 @@ export class SelectedCareerAchievements extends Component<
 
   render() {
     if (
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       !hasSections(this.props.artist) &&
       (!this.props.artist.insights || this.props.artist.insights.length === 0)
     ) {
@@ -138,7 +138,7 @@ export class SelectedCareerAchievements extends Component<
                 {this.renderGalleryRepresentation()}
                 {this.renderAuctionHighlight()}
 
-                {/*  @ts-expect-error STRICT_NULL_CHECK */}
+                {/*  @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 {this.props.artist.insights.map(insight => {
                   return this.renderInsight(insight)
                 })}

--- a/src/v2/Components/SelectedExhibitions.tsx
+++ b/src/v2/Components/SelectedExhibitions.tsx
@@ -10,7 +10,7 @@ import {
 import { SelectedExhibitions_exhibitions } from "v2/__generated__/SelectedExhibitions_exhibitions.graphql"
 import { Link } from "found"
 import { groupBy, toPairs } from "lodash"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "v2/Utils/Responsive"
 import { ArtworkDefinitionList } from "v2/Apps/Artwork/Components/ArtworkDefinitionList"
@@ -181,10 +181,10 @@ export class SelectedExhibitionsContainer extends React.Component<
 
           {!isCollapsed({ expanded: this.state.expanded, ...this.props }) && (
             <FullExhibitionList
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               artistID={this.props.artistID}
               exhibitions={this.props.exhibitions}
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               totalExhibitions={this.props.totalExhibitions}
               ViewAllLink={this.props.ViewAllLink}
             />

--- a/src/v2/Components/Text.tsx
+++ b/src/v2/Components/Text.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import styled from "styled-components"
 import * as fonts from "../Assets/Fonts"
 
@@ -51,10 +51,10 @@ const RawText: React.SFC<TextProps> = (props: TextProps) => {
  */
 const Text = styled(RawText)`
   ${props =>
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     textStyleNameToCss[props.textStyle]};
   font-size: ${props =>
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     TextStyleToTextSize[props.textStyle][props.textSize]};
   text-align: ${props => props.align};
   color: ${props => props.color};

--- a/src/v2/Components/TextLink.tsx
+++ b/src/v2/Components/TextLink.tsx
@@ -1,5 +1,5 @@
 import { garamond } from "v2/Assets/Fonts"
-import * as React from "react";
+import * as React from "react"
 import styled from "styled-components"
 import colors from "../Assets/Colors"
 
@@ -34,19 +34,19 @@ export class TextLink extends React.Component<LinkProps, null> {
   }
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 const StyledTextLink = styled(TextLink)`
   ${garamond("s15")};
   color: ${props =>
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     props.color};
   text-decoration: ${props =>
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     props.underline ? "underline" : "none"};
 `
 
 StyledTextLink.defaultProps = {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   underline: false,
   color: colors.grayBold,
 }

--- a/src/v2/Components/Title.tsx
+++ b/src/v2/Components/Title.tsx
@@ -33,7 +33,7 @@ const StyledTitle = styled(Title)`
   color: ${props => props.color};
   margin: 20px 0;
   ${p =>
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     garamond(titleSizes[p.titleSize] as any)};
   ${media.sm`
     font-size: ${titleSizes.small};

--- a/src/v2/Components/Truncator.tsx
+++ b/src/v2/Components/Truncator.tsx
@@ -1,5 +1,5 @@
 import { ErrorBoundary } from "v2/System/Router/ErrorBoundary"
-import * as React from "react";
+import * as React from "react"
 import ReactDOM from "react-dom/server"
 
 interface Props {
@@ -22,7 +22,7 @@ export const Truncator: React.SFC<Props> = ({
   let readMoreHTML = null
 
   if (ReadMoreLink) {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     readMoreHTML = ReactDOM.renderToStaticMarkup(ReadMoreLink())
   }
 

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -3,8 +3,8 @@ import { CreateAppSecondFactorMutationResponse } from "v2/__generated__/CreateAp
 import { useSystemContext } from "v2/System"
 import { Formik, FormikHelpers as FormikActions, FormikProps } from "formik"
 import QRCode from "qrcode.react"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import * as Yup from "yup"
 import { ApiError } from "../../ApiError"
 import { EnableSecondFactor } from "../Mutation/EnableSecondFactor"
@@ -32,7 +32,7 @@ interface AppSecondFactorModalProps {
   onClose: () => void
   show?: boolean
   onComplete: () => void
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   secondFactor: CreateAppSecondFactorMutationResponse["createAppSecondFactor"]["secondFactorOrErrors"]
 }
 
@@ -76,7 +76,7 @@ export const AppSecondFactorModal: React.FC<AppSecondFactorModalProps> = props =
     actions: FormikActions<FormValues>
   ) => {
     try {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       await UpdateAppSecondFactor(relayEnvironment, {
         secondFactorID: secondFactor.internalID,
         attributes: {
@@ -84,13 +84,13 @@ export const AppSecondFactorModal: React.FC<AppSecondFactorModalProps> = props =
         },
       })
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const response = await EnableSecondFactor(relayEnvironment, {
         secondFactorID: secondFactor.internalID,
         code: values.code,
       })
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       setRecoveryCodes(response.enableSecondFactor.recoveryCodes)
 
       actions.setSubmitting(false)
@@ -137,7 +137,7 @@ export const AppSecondFactorModal: React.FC<AppSecondFactorModalProps> = props =
         }
       >
         <BackupSecondFactorReminder
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           backupSecondFactors={recoveryCodes}
           factorTypeName={secondFactor.__typename}
         />
@@ -147,7 +147,7 @@ export const AppSecondFactorModal: React.FC<AppSecondFactorModalProps> = props =
 }
 
 interface InnerFormProps extends FormikProps<FormValues> {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   secondFactor: CreateAppSecondFactorMutationResponse["createAppSecondFactor"]["secondFactorOrErrors"]
 }
 

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Mutation/CreateAppSecondFactor.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Mutation/CreateAppSecondFactor.ts
@@ -13,7 +13,7 @@ export const CreateAppSecondFactor = (
     async (resolve, reject) => {
       commitMutation<CreateAppSecondFactorMutation>(environment, {
         onCompleted: data => {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           const response = data.createAppSecondFactor.secondFactorOrErrors
 
           switch (response.__typename) {

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Mutation/UpdateAppSecondFactor.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Mutation/UpdateAppSecondFactor.ts
@@ -13,7 +13,7 @@ export const UpdateAppSecondFactor = (
     async (resolve, reject) => {
       commitMutation<UpdateAppSecondFactorMutation>(environment, {
         onCompleted: data => {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           const response = data.updateAppSecondFactor.secondFactorOrErrors
 
           switch (response.__typename) {

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -8,8 +8,8 @@ import {
   Sans,
   Serif,
 } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { RelayRefetchProp, createFragmentContainer, graphql } from "react-relay"
 import request from "superagent"
 
@@ -60,7 +60,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
     }
 
     if (props.me.hasSecondFactorEnabled) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       relayRefetch.refetch({}, {}, showCompleteModalCallback)
     } else {
       if (redirectTo) {
@@ -105,12 +105,12 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
     setCreating(true)
 
     try {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const response = await CreateAppSecondFactor(relayEnvironment, {
         attributes: {},
         password,
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       setStagedSecondFactor(response.createAppSecondFactor.secondFactorOrErrors)
       setShowConfirmPassword(false)
       setShowSetupModal(true)
@@ -122,7 +122,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
   }
 
   function onDisableSecondFactor() {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     relayRefetch.refetch({}, {}, () => {
       setShowConfirmDisable(false)
     })
@@ -171,13 +171,13 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
           </Serif>
         </Flex>
         <Flex mt={[3, 0]} flexDirection={["column", "row"]} alignItems="center">
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           {me.appSecondFactors.length &&
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           me.appSecondFactors[0].__typename === "AppSecondFactor" ? (
             <>
               <Sans color="black60" size="3" weight="medium">
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 {me.appSecondFactors[0].name || "Unnamed"}
               </Sans>
               <DisableButton width={["100%", "auto"]} ml={[0, 1]} mt={[1, 0]} />
@@ -215,15 +215,15 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
         show={!!apiErrors.length}
         errors={apiErrors}
       />
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       {me.appSecondFactors.length > 0 &&
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         me.appSecondFactors[0].__typename === "AppSecondFactor" && (
           <DisableFactorConfirmation
             show={showConfirmDisable}
             onConfirm={onDisableSecondFactor}
             onCancel={() => setShowConfirmDisable(false)}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             secondFactorID={me.appSecondFactors[0].internalID}
           />
         )}

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorModalContent.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorModalContent.tsx
@@ -1,6 +1,6 @@
 import { BorderBoxProps, Box, Flex, Sans } from "@artsy/palette"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { BackupSecondFactorModalContent_me } from "v2/__generated__/BackupSecondFactorModalContent_me.graphql"
@@ -23,11 +23,11 @@ export const BackupSecondFactorModalContent: React.FC<BackupSecondFactorModalCon
         one-time codes to access your account.
       </Sans>
       <Flex mt={3} flexDirection="row" flexWrap="wrap">
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {me.backupSecondFactors.map((factor, index) => (
           <Box width="50%" key={index}>
             <Sans size="6" color="black60" textAlign="center" py={0.5}>
-              {/* @ts-expect-error STRICT_NULL_CHECK */}
+              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
               {factor.code}
             </Sans>
           </Box>

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/Mutation/CreateBackupSecondFactors.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/Mutation/CreateBackupSecondFactors.ts
@@ -10,7 +10,7 @@ export const CreateBackupSecondFactors = (environment: Environment) => {
     async (resolve, reject) => {
       commitMutation<CreateBackupSecondFactorsMutation>(environment, {
         onCompleted: data => {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           const response = data.createBackupSecondFactors.secondFactorsOrErrors
 
           switch (response.__typename) {

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/index.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/index.tsx
@@ -7,8 +7,8 @@ import {
   Sans,
   Serif,
 } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { useSystemContext } from "v2/System"
@@ -32,7 +32,7 @@ export const BackupSecondFactor: React.FC<BackupSecondFactorProps> = props => {
     setCreating(true)
 
     try {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       await CreateBackupSecondFactors(relayEnvironment)
       setShowModal(true)
     } catch (e) {
@@ -78,11 +78,11 @@ export const BackupSecondFactor: React.FC<BackupSecondFactorProps> = props => {
           </Serif>
         </Flex>
         <Flex mt={[3, 0]} flexDirection={["column", "row"]} alignItems="center">
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           {me.backupSecondFactors.length ? (
             <>
               <Sans color="black60" size="3" weight="medium">
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 {me.backupSecondFactors.length} remaining
               </Sans>
               <ShowButton width={["100%", "auto"]} ml={[0, 1]} mt={[1, 0]} />

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/DisableFactorConfirmation.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/DisableFactorConfirmation.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { useSystemContext } from "v2/System"
 import { DisableSecondFactor } from "./Mutation/DisableSecondFactor"
 import { FormikProps } from "formik"
@@ -28,7 +28,7 @@ export const DisableFactorConfirmation: React.FC<DisableFactorConfirmationProps>
     }
 
     try {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       await DisableSecondFactor(relayEnvironment, {
         password,
         secondFactorID,

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/Mutation/EnableSecondFactor.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/Mutation/EnableSecondFactor.ts
@@ -13,7 +13,7 @@ export const EnableSecondFactor = (
     async (resolve, reject) => {
       commitMutation<EnableSecondFactorMutation>(environment, {
         onCompleted: data => {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           const response = data.enableSecondFactor.secondFactorOrErrors
 
           switch (response.__typename) {

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -9,8 +9,8 @@ import {
   Spacer,
 } from "@artsy/palette"
 import { FormikHelpers as FormikActions } from "formik"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import styled from "styled-components"
 
 import * as Yup from "yup"
@@ -33,7 +33,7 @@ interface SmsSecondFactorModalProps {
   onClose: () => void
   show?: boolean
   onComplete: () => void
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   secondFactor: CreateSmsSecondFactorMutationResponse["createSmsSecondFactor"]["secondFactorOrErrors"]
 }
 
@@ -62,14 +62,14 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
     setSubmitting(true)
 
     try {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const response = await EnableSecondFactor(relayEnvironment, {
         secondFactorID: secondFactor.internalID,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         code: values.code,
       })
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       setRecoveryCodes(response.enableSecondFactor.recoveryCodes)
 
       setShowRecoveryCodes(true)
@@ -117,22 +117,22 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
       setDelivering(true)
 
       try {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         await UpdateSmsSecondFactor(relayEnvironment, {
           secondFactorID: secondFactor.internalID,
           attributes: {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             phoneNumber: values.phoneNumber,
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             countryCode: values.countryCode,
           },
         })
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const response = await DeliverSecondFactor(relayEnvironment, {
           secondFactorID: secondFactor.internalID,
         })
 
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const factor = response.deliverSecondFactor.secondFactorOrErrors
 
         if (factor.__typename === "SmsSecondFactor") {
@@ -294,7 +294,7 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
         }
       >
         <BackupSecondFactorReminder
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           backupSecondFactors={recoveryCodes}
           factorTypeName={secondFactor.__typename}
         />

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Mutation/CreateSmsSecondFactor.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Mutation/CreateSmsSecondFactor.ts
@@ -13,7 +13,7 @@ export const CreateSmsSecondFactor = (
     async (resolve, reject) => {
       commitMutation<CreateSmsSecondFactorMutation>(environment, {
         onCompleted: data => {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           const response = data.createSmsSecondFactor.secondFactorOrErrors
 
           switch (response.__typename) {

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Mutation/DeliverSecondFactor.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Mutation/DeliverSecondFactor.ts
@@ -13,7 +13,7 @@ export const DeliverSecondFactor = (
     async (resolve, reject) => {
       commitMutation<DeliverSecondFactorMutation>(environment, {
         onCompleted: data => {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           const response = data.deliverSecondFactor.secondFactorOrErrors
 
           switch (response.__typename) {

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Mutation/UpdateSmsSecondFactor.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Mutation/UpdateSmsSecondFactor.ts
@@ -13,7 +13,7 @@ export const UpdateSmsSecondFactor = (
     async (resolve, reject) => {
       commitMutation<UpdateSmsSecondFactorMutation>(environment, {
         onCompleted: data => {
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           const response = data.updateSmsSecondFactor.secondFactorOrErrors
 
           switch (response.__typename) {

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -7,8 +7,8 @@ import {
   Sans,
   Serif,
 } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { RelayRefetchProp, createFragmentContainer, graphql } from "react-relay"
 import request from "superagent"
 
@@ -60,7 +60,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     }
 
     if (props.me.hasSecondFactorEnabled) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       relayRefetch.refetch({}, {}, showCompleteModalCallback)
     } else {
       showCompleteModalCallback()
@@ -106,14 +106,14 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     setCreating(true)
 
     try {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const response = await CreateSmsSecondFactor(relayEnvironment, {
         attributes: {},
         password,
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const factor = response.createSmsSecondFactor.secondFactorOrErrors
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       setStagedSecondFactor(factor)
       setShowConfirmPassword(false)
       setShowSetupModal(true)
@@ -125,7 +125,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
   }
 
   async function onDisableSecondFactor() {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     relayRefetch.refetch({}, {}, () => {
       setShowConfirmDisable(false)
     })
@@ -168,13 +168,13 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
           </Serif>
         </Flex>
         <Flex mt={[3, 0]} flexDirection={["column", "row"]} alignItems="center">
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           {me.smsSecondFactors.length &&
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           me.smsSecondFactors[0].__typename === "SmsSecondFactor" ? (
             <>
               <Sans color="black60" size="3" weight="medium">
-                {/* @ts-expect-error STRICT_NULL_CHECK */}
+                {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                 {me.smsSecondFactors[0].formattedPhoneNumber}
               </Sans>
               <DisableButton width={["100%", "auto"]} ml={[0, 1]} mt={[1, 0]} />
@@ -212,15 +212,15 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
         show={!!apiErrors.length}
         errors={apiErrors}
       />
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       {me.smsSecondFactors.length > 0 &&
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         me.smsSecondFactors[0].__typename === "SmsSecondFactor" && (
           <DisableFactorConfirmation
             show={showConfirmDisable}
             onConfirm={onDisableSecondFactor}
             onCancel={() => setShowConfirmDisable(false)}
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             secondFactorID={me.smsSecondFactors[0].internalID}
           />
         )}

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/__tests__/TwoFactorAuthentication.jest.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/__tests__/TwoFactorAuthentication.jest.tsx
@@ -27,7 +27,7 @@ const setupTestEnv = () => {
   return createTestEnv({
     TestPage: TwoFactorAuthenticationTestPage,
     Component: (props: TwoFactorAuthenticationQueryResponse) => (
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       <TwoFactorAuthenticationRefetchContainer {...props} />
     ),
     query: graphql`
@@ -58,7 +58,7 @@ const setupTestEnv = () => {
   })
 }
 
-describe("TwoFactorAuthentication ", () => {
+describe("TwoFactorAuthentication", () => {
   it("shows current 2FA enrollment status", async () => {
     const env = setupTestEnv()
     const page = await env.buildPage()

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/__tests__/helpers.jest.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/__tests__/helpers.jest.ts
@@ -4,7 +4,7 @@ const { location: originalLocation } = window
 
 describe("afterUpdateRedirect", () => {
   beforeEach(() => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     delete window.location
   })
   afterEach(() => {

--- a/src/v2/Components/UserSettings/UserEmailPreferences/UserEmailPreferencesMutation.tsx
+++ b/src/v2/Components/UserSettings/UserEmailPreferences/UserEmailPreferencesMutation.tsx
@@ -29,7 +29,7 @@ export const UpdateUserEmailPreferencesMutation = (
           updateMyUserProfile: {
             me: {
               id,
-              // @ts-expect-error STRICT_NULL_CHECK
+              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
               emailFrequency: input.emailFrequency,
             },
           },

--- a/src/v2/Components/UserSettings/UserEmailPreferences/index.tsx
+++ b/src/v2/Components/UserSettings/UserEmailPreferences/index.tsx
@@ -22,7 +22,7 @@ const options = [
 
 export const UserEmailPreferences: React.FC<UserEmailPreferencesQueryResponse> = props => {
   const { relayEnvironment } = useSystemContext()
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const emailFrequency = props.me.emailFrequency || fallbackFrequency
   const [updated, setUpdated] = useState(false)
 
@@ -30,10 +30,10 @@ export const UserEmailPreferences: React.FC<UserEmailPreferencesQueryResponse> =
     setUpdated(false)
     const variables = { emailFrequency: newEmailFrequency }
     await UpdateUserEmailPreferencesMutation(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       relayEnvironment,
       variables,
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       props.me.id
     )
     setUpdated(true)

--- a/src/v2/Components/UserSettings/UserInformation/__tests__/UserInformation.jest.tsx
+++ b/src/v2/Components/UserSettings/UserInformation/__tests__/UserInformation.jest.tsx
@@ -19,7 +19,7 @@ const defaultData = {
 const setupTestEnv = () => {
   return createTestEnv({
     Component: (props: UserInformationQueryResponse) => (
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       <UserInformationRefetchContainer {...props} />
     ),
     TestPage: UserInformationTestPage,

--- a/src/v2/Components/UserSettings/UserInformation/__tests__/UserInformationTestPage.tsx
+++ b/src/v2/Components/UserSettings/UserInformation/__tests__/UserInformationTestPage.tsx
@@ -8,7 +8,7 @@ export class UserInformationTestPage extends RootTestPage {
 
   async changeEmailInput() {
     const input = this.find("QuickInput input[name='email']")
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     input.props().onChange({
       // @ts-ignore
       currentTarget: { id: "email", value: "new-email@email.com" },
@@ -19,7 +19,7 @@ export class UserInformationTestPage extends RootTestPage {
 
   async changeNameInput(value = "New name") {
     const input = this.find("QuickInput input[name='name']")
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     input.props().onChange({
       // @ts-ignore
       currentTarget: { id: "name", value },

--- a/src/v2/Components/UserSettings/UserInformation/index.tsx
+++ b/src/v2/Components/UserSettings/UserInformation/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import QuickInput from "v2/Components/QuickInput"
 import {
   QueryRenderer,
@@ -45,18 +45,18 @@ export const UserInformation: React.FC<UserInformationProps> = ({
         phone,
       }
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const response = await UpdateUserInformation(relayEnvironment, variables)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const userOrError = response.updateMyUserProfile.userOrError
 
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       if (userOrError.mutationError) {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const { message, fieldErrors } = userOrError.mutationError
         if (fieldErrors) {
           // display errors for a specified form field
-          // @ts-expect-error STRICT_NULL_CHECK
+          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           const formattedErrors = formatGravityErrors(userOrError.mutationError)
           formikBag.setErrors(formattedErrors)
         } else if (message) {
@@ -142,7 +142,7 @@ export const UserInformation: React.FC<UserInformationProps> = ({
                 <PasswordInput
                   autoFocus
                   block
-                  // @ts-expect-error STRICT_NULL_CHECK
+                  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                   error={
                     !values.password && "Password is required to change email."
                   }
@@ -205,7 +205,7 @@ export const UserInformationQueryRenderer = () => {
 
   return (
     <QueryRenderer<UserInformationQuery>
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       environment={relayEnvironment}
       variables={{}}
       query={graphql`
@@ -220,7 +220,7 @@ export const UserInformationQueryRenderer = () => {
   )
 }
 
-// @ts-expect-error STRICT_NULL_CHECK
+// @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 type GravityFieldErrors = UpdateUserInformationMutationResponse["updateMyUserProfile"]["userOrError"]["mutationError"]
 
 const formatGravityErrors = ({ fieldErrors }: GravityFieldErrors) => {

--- a/src/v2/Components/Wizard/Wizard.tsx
+++ b/src/v2/Components/Wizard/Wizard.tsx
@@ -1,8 +1,8 @@
 import { Form, Formik, FormikHelpers as FormikActions } from "formik"
 import { isEmpty } from "lodash"
 import PropTypes from "prop-types"
-import { Component } from "react";
-import * as React from "react";
+import { Component } from "react"
+import * as React from "react"
 import { StepElement, StepProps, WizardRenderProps } from "./types"
 import { FormValues, WizardContext } from "./types"
 
@@ -157,7 +157,7 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
     return (
       <Formik
         initialValues={initialValues}
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         validate={validate}
         validationSchema={validationSchema}
         validateOnChange={false}

--- a/src/v2/Components/__tests__/ArtistBio.jest.tsx
+++ b/src/v2/Components/__tests__/ArtistBio.jest.tsx
@@ -20,7 +20,7 @@ describe("ArtistBio", () => {
     return renderRelayTree({
       Component: ({ bio }: ArtistBioTestQueryResponse) => (
         <MockBoot breakpoint="xl">
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
+          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <ArtistBio bio={bio} />
         </MockBoot>
       ),

--- a/src/v2/Components/__tests__/ArtistCard.jest.tsx
+++ b/src/v2/Components/__tests__/ArtistCard.jest.tsx
@@ -38,13 +38,13 @@ describe("ArtistCard", () => {
         name: "Francesca DiMattio",
         formatted_nationality_and_birthday: "American, b. 1979",
         slug: "percy",
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         " $fragmentRefs": null,
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         " $refType": null,
       },
     }
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     window.matchMedia = undefined // Immediately set matching media query in MockBoot
   })
 

--- a/src/v2/Components/__tests__/AuctionCard.jest.tsx
+++ b/src/v2/Components/__tests__/AuctionCard.jest.tsx
@@ -32,7 +32,7 @@ describe("relativeTime", () => {
 
 describe("upcomingLabel", () => {
   const sale: AuctionCard_sale = {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     " $refType": null,
     cover_image: {
       cropped: {

--- a/src/v2/Components/__tests__/DownloadAppBadge.jest.tsx
+++ b/src/v2/Components/__tests__/DownloadAppBadge.jest.tsx
@@ -36,7 +36,7 @@ describe("DownloadAppBadge", () => {
   it("tracks clicks on the app download badge", () => {
     const badge = mount(<DownloadAppBadge {...props} />)
     const downloadLink = badge.find(Link)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     downloadLink.props().onClick({} as any)
     expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining(event))
   })

--- a/src/v2/Components/__tests__/RouteTabs.jest.tsx
+++ b/src/v2/Components/__tests__/RouteTabs.jest.tsx
@@ -42,7 +42,7 @@ describe("RouteTabs", () => {
   it("renders nav items", async () => {
     const wrapper = getWrapper()
 
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     await wrapper.find("MockRouter").instance().componentDidMount()
 
     const html = wrapper.html()

--- a/src/v2/Components/__tests__/SelectedCareerAchievements.jest.tsx
+++ b/src/v2/Components/__tests__/SelectedCareerAchievements.jest.tsx
@@ -49,12 +49,12 @@ describe("SelectedCareerAchievements", () => {
   })
 
   it("renders selected career achievements if no auction results or partner highlights", async () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper = await getWrapper({
       ...artistResponse,
       auctionResultsConnection: null,
       highlights: {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         ...artistResponse.highlights,
         partnersConnection: null,
       },
@@ -71,12 +71,12 @@ describe("SelectedCareerAchievements", () => {
 
   // TODO https://artsyproduct.atlassian.net/browse/GRO-393
   it("doesn't render selected career achievements if no auction results, partner highlights, or insights", async () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper = await getWrapper({
       ...artistResponse,
       auctionResultsConnection: null,
       highlights: {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         ...artistResponse.highlights,
         partnersConnection: null,
       },
@@ -89,12 +89,12 @@ describe("SelectedCareerAchievements", () => {
 
   // TODO https://artsyproduct.atlassian.net/browse/GRO-393
   it("doesn't render selected career achievements if no auction results or partner highlights and insights is null", async () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper = await getWrapper({
       ...artistResponse,
       auctionResultsConnection: null,
       highlights: {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         ...artistResponse.highlights,
         partnersConnection: null,
       },
@@ -107,12 +107,12 @@ describe("SelectedCareerAchievements", () => {
 
   // TODO https://artsyproduct.atlassian.net/browse/GRO-393
   it("renders the Artists CV link regardless of career achievements", async () => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     wrapper = await getWrapper({
       ...artistResponse,
       auctionResultsConnection: null,
       highlights: {
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         ...artistResponse.highlights,
         partnersConnection: null,
       },

--- a/src/v2/Components/__tests__/SelectedExhibitions.jest.tsx
+++ b/src/v2/Components/__tests__/SelectedExhibitions.jest.tsx
@@ -13,7 +13,7 @@ describe("SelectedExhibitions", () => {
   }
 
   beforeAll(() => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     window.matchMedia = undefined // Immediately set matching media query in Boot
   })
 

--- a/src/v2/DevTools/MockRelayRenderer.tsx
+++ b/src/v2/DevTools/MockRelayRenderer.tsx
@@ -3,7 +3,7 @@ import { SystemContextConsumer } from "v2/System"
 import { renderWithLoadProgress } from "v2/System/Relay/renderWithLoadProgress"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { IMocks } from "graphql-tools/dist/Interfaces"
-import * as React from "react";
+import * as React from "react"
 /* tslint:disable-next-line:no-query-renderer-import */
 import { QueryRenderer } from "react-relay"
 import {
@@ -136,7 +136,7 @@ export class MockRelayRenderer<T extends OperationType> extends React.Component<
   MockRelayRendererProps<T>,
   MockRelayRendererState
 > {
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   state = {
     caughtError: undefined,
   }
@@ -198,7 +198,7 @@ export class MockRelayRenderer<T extends OperationType> extends React.Component<
     }
 
     if (this.state.caughtError) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const { error, errorInfo } = this.state.caughtError
       console.error({ error, errorInfo })
       return `Error occurred while rendering Relay component: ${error}`

--- a/src/v2/DevTools/MockRouter.tsx
+++ b/src/v2/DevTools/MockRouter.tsx
@@ -6,7 +6,7 @@ import {
 } from "v2/DevTools/createMockNetworkLayer"
 import { FarceCreateRouterArgs, RouteConfig } from "found"
 import { IMocks } from "graphql-tools/dist/Interfaces"
-import { Component, Fragment } from "react";
+import { Component, Fragment } from "react"
 import { getUser } from "v2/Utils/user"
 
 interface Props {
@@ -76,9 +76,9 @@ export class MockRouter extends Component<Props> {
 
     return (
       <Fragment>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {ClientApp && <ClientApp {...this.props.initialState} />}
       </Fragment>
-    );
+    )
   }
 }

--- a/src/v2/DevTools/__tests__/MockRelayRenderer.mocked.jest.tsx
+++ b/src/v2/DevTools/__tests__/MockRelayRenderer.mocked.jest.tsx
@@ -14,7 +14,7 @@ describe("MockRelayRenderer", () => {
 
   it("throws when react-relay is mocked", () => {
     expect(() => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       mount(<MockRelayRenderer Component={null} query={null} />)
     }).toThrowError('jest.unmock("react-relay")')
   })

--- a/src/v2/DevTools/__tests__/MockRelayRendererFixtures.tsx
+++ b/src/v2/DevTools/__tests__/MockRelayRendererFixtures.tsx
@@ -26,7 +26,7 @@ const Metadata = createFragmentContainer(
 export const Artwork = createFragmentContainer(
   (props: { artwork: MockRelayRendererFixtures_artwork }) => (
     <div>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
+      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <img src={props.artwork.image.url} />
       <Metadata artworkMetadata={props.artwork} />
       {props.artwork.artist && (

--- a/src/v2/DevTools/__tests__/createMockNetworkLayer.jest.ts
+++ b/src/v2/DevTools/__tests__/createMockNetworkLayer.jest.ts
@@ -86,7 +86,7 @@ describe("createMockNetworkLayer", () => {
           artwork: { title: "Untitled", id: "untitled" },
         },
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(data.artwork.title).toEqual("Untitled")
     })
 
@@ -96,7 +96,7 @@ describe("createMockNetworkLayer", () => {
           artwork: { title: null, id: "null" },
         },
       })
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(data.artwork.title).toEqual(null)
     })
   })
@@ -204,11 +204,11 @@ describe("createMockNetworkLayer", () => {
         }
       `
     )
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(data.artist.forSaleArtworks.edges[0].node).toEqual({
       id: "for-sale-work",
     })
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(data.artist.notForSaleArtworks.edges[0].node).toEqual({
       id: "no-for-sale-work",
     })
@@ -241,7 +241,7 @@ describe("createMockNetworkLayer", () => {
         }
       `
     )
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     expect(data.artist.forSaleArtworks.edges[0].node).toEqual({
       id: "for-sale-work",
     })

--- a/src/v2/DevTools/__tests__/createTestEnv.jest.tsx
+++ b/src/v2/DevTools/__tests__/createTestEnv.jest.tsx
@@ -116,7 +116,7 @@ const Component = createFragmentContainer(
     <div>
       <h1>This is the main heading</h1>
       <p>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
+        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         The artwork is {artwork.title} by {artwork.artist.name}
       </p>
       <button

--- a/src/v2/DevTools/__tests__/renderUntil.jest.tsx
+++ b/src/v2/DevTools/__tests__/renderUntil.jest.tsx
@@ -1,5 +1,5 @@
 import { mount } from "enzyme"
-import * as React from "react";
+import * as React from "react"
 import { Responsive } from "v2/Utils/Responsive"
 import { MockBoot } from "../MockBoot"
 import { renderUntil } from "../renderUntil"
@@ -37,7 +37,7 @@ describe("renderUntil", () => {
       const states = []
       await mount(<Component />).renderUntil(tree => {
         const text = tree.find("div").text()
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         states.push(text)
         return text !== "Loading"
       })
@@ -57,7 +57,7 @@ describe("renderUntil", () => {
       const states = []
       await renderUntil(wrapper => {
         const text = wrapper.find("div").text()
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         states.push(text)
         return text !== "Loading"
       }, <Component />)

--- a/src/v2/DevTools/createMockNetworkLayer/index.ts
+++ b/src/v2/DevTools/createMockNetworkLayer/index.ts
@@ -72,7 +72,7 @@ export const createMockFetchQuery = ({
       // whether to resolve fields in a given value
       if (typeof source !== "object") {
         const parentPath = pathAsArray.slice(0, -1).join("/")
-        // @ts-expect-error STRICT_NULL_CHECK
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         const operationName = get(info, i => i.operation.name.value)
         throw new Error(
           `The value at path '${parentPath}' for operation '${operationName}' should be an object but is a ${typeof source}.`
@@ -217,7 +217,7 @@ function error(
     renderMessage({
       path: responsePathAsArray(info.path).join("/"),
       type: info.returnType.inspect(),
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       operationName: get(info, i => i.operation.name.value, "(unknown)"),
     })
   )

--- a/src/v2/DevTools/setupTestWrapper.tsx
+++ b/src/v2/DevTools/setupTestWrapper.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { mount } from "enzyme"
 import { render } from "@testing-library/react"
 import { QueryRenderer } from "react-relay"
@@ -74,7 +74,7 @@ export const setupTestWrapper = <T extends OperationType>({
         query={query}
         render={({ props, error }) => {
           if (props) {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             return <Component {...props} />
           } else if (error) {
             console.error(error)
@@ -120,7 +120,7 @@ export const setupTestWrapperTL = <T extends OperationType>({
         query={query}
         render={({ props, error }) => {
           if (props) {
-            // @ts-expect-error STRICT_NULL_CHECK
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             return <Component {...props} />
           } else if (error) {
             console.error(error)

--- a/src/v2/Utils/Hooks/useAuthIntent/index.ts
+++ b/src/v2/Utils/Hooks/useAuthIntent/index.ts
@@ -102,7 +102,7 @@ export const useAuthIntent = () => {
   const { user, relayEnvironment } = useSystemContext()
 
   useEffect(() => {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     runAuthIntent(user, relayEnvironment)
   }, [relayEnvironment, user])
 }

--- a/src/v2/Utils/Hooks/useCurrentTime.tsx
+++ b/src/v2/Utils/Hooks/useCurrentTime.tsx
@@ -35,7 +35,7 @@ export const useCurrentTime = ({
 
   useEffect(() => {
     if (syncWithServer) {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       getOffsetBetweenGravityClock(relayEnvironment).then(offset => {
         setTimeOffsetInMilliseconds(offset)
       })
@@ -46,7 +46,7 @@ export const useCurrentTime = ({
     }, interval)
 
     return () => {
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       clearInterval(intervalId.current)
     }
   }, [interval, relayEnvironment, syncWithServer])

--- a/src/v2/Utils/Hooks/useMatchMedia.ts
+++ b/src/v2/Utils/Hooks/useMatchMedia.ts
@@ -34,7 +34,7 @@ export function __internal__useMatchMedia(
 
   useEffect(() => {
     const mediaQueryList = window.matchMedia(mediaQueryString)
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     setMatches(mediaQueryList.matches)
     const handleChange = event => setMatches(event.matches)
 

--- a/src/v2/Utils/__tests__/time.jest.ts
+++ b/src/v2/Utils/__tests__/time.jest.ts
@@ -26,6 +26,6 @@ it("returns an offset between current time and system time", async () => {
 
   jest.runAllTicks()
 
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   expect(await getOffsetBetweenGravityClock(null)).toEqual(10 * MINUTES)
 })

--- a/src/v2/Utils/identityVerificationRequirements.ts
+++ b/src/v2/Utils/identityVerificationRequirements.ts
@@ -51,7 +51,7 @@ export const bidderQualifications = (
 ) => {
   const registrationAttempted = Boolean(registration)
   const qualifiedForBidding =
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     registrationAttempted && registration.qualifiedForBidding
 
   const userLacksIdentityVerification =

--- a/src/v2/Utils/openAuthModal.ts
+++ b/src/v2/Utils/openAuthModal.ts
@@ -105,7 +105,7 @@ function getDesktopIntent(options: AuthModalOptions): ModalOptions {
     case Intent.saveArtwork:
       return getDesktopIntentToSaveArtwork(options)
     default:
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       return undefined
   }
 }

--- a/src/v2/Utils/resized.ts
+++ b/src/v2/Utils/resized.ts
@@ -52,7 +52,7 @@ export const resized = (
   })
 
   return {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     src: _1x,
     srcSet: `${_1x} 1x, ${_2x} 2x`,
   }
@@ -89,7 +89,7 @@ export const cropped = (
   })
 
   return {
-    // @ts-expect-error STRICT_NULL_CHECK
+    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     src: _1x,
     srcSet: `${_1x} 1x, ${_2x} 2x`,
   }

--- a/src/v2/Utils/time.ts
+++ b/src/v2/Utils/time.ts
@@ -39,7 +39,7 @@ export async function getOffsetBetweenGravityClock(
     const possibleNetworkLatencyInMilliSeconds =
       (getLocalTimestampInMilliSeconds() - startTime) / 2
     const serverTimestampInMilliSeconds =
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       data.system.time.unix * 1e3 + possibleNetworkLatencyInMilliSeconds
 
     return serverTimestampInMilliSeconds

--- a/src/v2/Utils/user.ts
+++ b/src/v2/Utils/user.ts
@@ -28,7 +28,7 @@ export function getUser(user: User | null | undefined): User | null {
 
 export function userHasLabFeature(user: User, featureName: string): boolean {
   const lab_features = get(user, u => u?.lab_features, [])
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const hasLabFeature = lab_features.includes(featureName)
   return hasLabFeature
 }

--- a/src/v2/client.tsx
+++ b/src/v2/client.tsx
@@ -28,7 +28,7 @@ async function setupClient() {
     // Attach analytics
     if (getClientParam("disableAnalytics") !== "true") {
       beforeAnalyticsReady()
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       window.analytics.ready(() => {
         onAnalyticsReady()
       })

--- a/src/v2/jest.envSetup.ts
+++ b/src/v2/jest.envSetup.ts
@@ -46,7 +46,7 @@ afterAll(() => {
 if (typeof window !== "undefined") {
   window.open = jest.fn()
   // Needed for new tests
-  // @ts-expect-error STRICT_NULL_CHECK
+  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   window.matchMedia = undefined
 
   window.grecaptcha = {
@@ -71,7 +71,7 @@ if (process.env.ALLOW_CONSOLE_LOGS !== "true") {
     if (args[0] instanceof Error) {
       const msg = explanation + chalk.red(args[0].message)
       const err = new Error(msg)
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       err.stack = args[0].stack.replace(`Error: ${args[0].message}`, msg)
       return err
     } else {

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -128,7 +128,7 @@ function getProductionWebpackConfig() {
   // Support configuration dumps for a basic insights into the webpack configuration.
   if (env.enableWebpackDumpConfig) {
     fs.writeFileSync(
-      // @ts-expect-error STRICT_NULL_CHECK
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       process.env.WEBPACK_DUMP_CONFIG,
       JSON.stringify(config, null, 2)
     )


### PR DESCRIPTION
I'm not sure if `PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION` is too far over the top, but since the questions around `STRICT_NULL_CHECK` and copy-pasta nature of these flags keep propagating we should just... update em. 