### PR TITLE
fix(FX-2928): Track only allowed filter keys in commercial_filter_params_changed

### DIFF
--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -199,6 +199,8 @@ export const BaseArtworkFilter: React.FC<
 
             tracking.trackEvent(pageTrackingParams)
           } else {
+            const onlyAllowedFilters = allowedFilters(filterContext.filters)
+
             tracking.trackEvent(
               commercialFilterParamsChanged({
                 changed: JSON.stringify({
@@ -207,7 +209,7 @@ export const BaseArtworkFilter: React.FC<
                 contextOwnerId: contextPageOwnerId,
                 contextOwnerSlug: contextPageOwnerSlug,
                 contextOwnerType: contextPageOwnerType!,
-                current: JSON.stringify(filterContext.filters),
+                current: JSON.stringify(onlyAllowedFilters),
               })
             )
           }


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR resolves [FX-2928]

### Description
We should send in `commercial_filter_params_changed` only allowed filter keys

### Demo
|Before|After|
|-|-|
|<img width="1748" alt="before" src="https://user-images.githubusercontent.com/3513494/141476321-d78c2fd9-fbcb-427c-aa76-72a7d5a901c9.png">|<img width="1748" alt="after" src="https://user-images.githubusercontent.com/3513494/141476371-74855de8-41d9-46e2-a4d5-58eb095b0d84.png">|

[FX-2928]: https://artsyproduct.atlassian.net/browse/FX-2928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ