### PR TITLE
[WIP]: [feat]: Replace meta title for /consign

### DIFF
--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHowToSell.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHowToSell.tsx
@@ -51,7 +51,7 @@ const ArtistConsignHowtoSell: React.FC<ArtistConsignHowtoSellProps> = ({
           <Section
             icon={<EnvelopeIcon width={30} height={30} />}
             text="Receive offers"
-            description="If your work is accepted, you’ll receive competitive consignment
+            description="If your work is accepted, you’ll receive competitive
             offers from auction houses, galleries, and collectors."
           />
           <Section

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ConsignMeta.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ConsignMeta.tsx
@@ -1,11 +1,11 @@
-import * as React from "react";
+import * as React from "react"
 import { MetaTags } from "v2/Components/MetaTags"
 
 export const ConsignMeta: React.FC = () => {
   return (
     <MetaTags
       pathname="/consign"
-      title="Sell Artwork with Artsy | Art Consignment | Artsy"
+      title="Sell Artwork with Artsy"
       description="Sell and consign your art with Artsy. Get competitive offers from the world’s top auction houses and galleries to sell art from your collection. Submit today at no cost."
     />
   )

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ConsignMeta.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ConsignMeta.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { MetaTags } from "v2/Components/MetaTags"
 
 export const ConsignMeta: React.FC = () => {

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/FAQ.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/FAQ.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Expandable, Join, Spacer, Text } from "@artsy/palette"
 
 export const FAQ: React.FC = () => {
@@ -70,15 +70,15 @@ export const FAQ: React.FC = () => {
               <a href="/consign" target="_blank">
                 Sell with Artsy program
               </a>{" "}
-              in which we currently accept consignments of works by artists that
-              are already in our database who have a resale market and
-              substantial collector demand. To learn more about our Sell with
-              Artsy program, please visit our Help Center article on{" "}
+              in which we currently accept works by artists that are already in
+              our database who have a resale market and substantial collector
+              demand. To learn more about our Sell with Artsy program, please
+              visit our Help Center article on{" "}
               <a
                 href="https://support.artsy.net/hc/en-us/articles/1500006366381"
                 target="_blank"
               >
-                what do we look for in consignment submissions
+                what do we look for works from your collection
               </a>
               ? Please note that not being accepted for our Sell with Artsy
               program is in no way a reflection or judgement of artistic

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/HowToSell.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/HowToSell.tsx
@@ -37,7 +37,7 @@ export const HowToSell: React.FC = () => {
           <Section
             icon={<MultipleOffersIcon width={50} height={50} />}
             text="Receive multiple offers"
-            description="If your work is accepted, you’ll receive competitive consignment offers from Artsy’s curated auctions, auction houses, and galleries."
+            description="If your work is accepted, you’ll receive competitive offers from Artsy’s curated auctions, auction houses, and galleries."
           />
         </Column>
 

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -74,8 +74,8 @@ export const ArtworkDetails: React.FC = () => {
         &#8226; All fields are required to submit a work.
       </Text>
       <Text mb={[2, 6]} variant="sm" color="black60">
-        &#8226; Unfortunately we are not accepting consignments directly from
-        artists at this time.
+        &#8226; We currently do not allow artists to sell their own work on
+        Artsy.
       </Text>
 
       <Formik<ArtworkDetailsFormModel>

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
@@ -103,7 +103,7 @@ describe("ArtworkDetails", () => {
       expect(text).toContain("Tell us about your artwork")
       expect(text).toContain("All fields are required to submit a work.")
       expect(text).toContain(
-        "Unfortunately we are not accepting consignments directly from artists at this time."
+        "We currently do not allow artists to sell their own work on Artsy."
       )
       expect(wrapper.find(ArtworkDetailsForm)).toBeTruthy()
       expect(wrapper.find("[data-test-id='save-button']")).toBeTruthy()


### PR DESCRIPTION
### Description 

This PR is replacing the references to the word 'consign' or 'consignment' under /consign. The replacements are provided in the ticket [SWA-80](https://artsyproduct.atlassian.net/browse/SWA-80). 