### PR TITLE
feat(SWA-105): Add logic to determine whether a submission should be created anonymously

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
@@ -15,6 +15,7 @@ import { contactInformationValidationSchema } from "../Utils/validation"
 import { BackLink } from "v2/Components/Links/BackLink"
 import { ErrorModal } from "v2/Components/Modal/ErrorModal"
 import { useState } from "react"
+import { data as sd } from "sharify"
 
 const getContactInformationFormInitialValues = (me: ContactInformation_me) => ({
   name: me?.name || "",
@@ -36,13 +37,14 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
     },
   } = useRouter()
   const [isSubmissionApiError, setIsSubmissionApiError] = useState(false)
-  const { relayEnvironment, user } = useSystemContext()
+  const { relayEnvironment, user, isLoggedIn } = useSystemContext()
   const {
     submission,
     saveSubmission,
     submissionId,
     removeSubmission,
   } = useSubmission(id)
+
   const handleSubmit = async ({
     name,
     email,
@@ -62,7 +64,12 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
 
     if (relayEnvironment && submission) {
       try {
-        await createConsignSubmission(relayEnvironment, submission, user?.id)
+        await createConsignSubmission(
+          relayEnvironment,
+          submission,
+          user?.id,
+          !isLoggedIn ? sd.SESSION_ID : undefined
+        )
         removeSubmission()
         router.push(`/consign/submission/${submissionId}/thank-you`)
       } catch (error) {

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/__tests__/createConsignSubmission.jest.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/__tests__/createConsignSubmission.jest.ts
@@ -107,9 +107,13 @@ describe("createConsignSubmission", () => {
     })
   })
 
-  it("creates submission", async () => {
-    const result = await createConsignSubmission(relayEnvironment, submission)
-
+  it("creates submission if logged-in", async () => {
+    const result = await createConsignSubmission(
+      relayEnvironment,
+      submission,
+      "userId",
+      undefined
+    )
     const input = {
       artistID: "artistId",
       year: "year",
@@ -127,6 +131,42 @@ describe("createConsignSubmission", () => {
       userName: "name",
       userPhone: "123456789",
       provenance: "provenance",
+      sessionID: undefined,
+    }
+
+    expect(createConsignSubmissionMutation).toHaveBeenCalled()
+    expect(createConsignSubmissionMutation).toHaveBeenCalledWith(
+      relayEnvironment,
+      input
+    )
+    expect(result).toEqual("123")
+  })
+
+  it("creates submission if not logged-in", async () => {
+    const result = await createConsignSubmission(
+      relayEnvironment,
+      submission,
+      undefined,
+      "sessionId"
+    )
+    const input = {
+      artistID: "artistId",
+      year: "year",
+      title: "title",
+      medium: "materials",
+      attributionClass: "RARITY",
+      editionNumber: "",
+      editionSizeFormatted: "",
+      height: "height",
+      width: "width",
+      depth: "",
+      dimensionsMetric: "units",
+      state: "SUBMITTED",
+      userEmail: "test@test.test",
+      userName: "name",
+      userPhone: "123456789",
+      provenance: "provenance",
+      sessionID: "sessionId",
     }
 
     expect(createConsignSubmissionMutation).toHaveBeenCalled()

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/createConsignSubmission.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/createConsignSubmission.ts
@@ -16,7 +16,8 @@ const logger = createLogger("createConsignSubmission.ts")
 export const createConsignSubmission = async (
   relayEnvironment: Environment,
   submission: SubmissionModel,
-  userId?: string
+  userId?: string,
+  sessionId?: string
 ) => {
   if (
     !submission ||
@@ -26,7 +27,7 @@ export const createConsignSubmission = async (
     return
   }
 
-  const input = createConsignSubmissionInput(submission)
+  const input = createConsignSubmissionInput(submission, sessionId)
 
   const submissionId = await createConsignSubmissionMutation(
     relayEnvironment,

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/createConsignSubmissionInput.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/createConsignSubmissionInput.ts
@@ -5,7 +5,8 @@ import {
 import { SubmissionModel } from "./useSubmission"
 
 export const createConsignSubmissionInput = (
-  submission: SubmissionModel
+  submission: SubmissionModel,
+  sessionId?: string
 ): CreateSubmissionMutationInput => {
   return {
     artistID: submission.artworkDetailsForm.artistId,
@@ -26,5 +27,6 @@ export const createConsignSubmissionInput = (
     userEmail: submission.contactInformationForm?.email,
     userName: submission.contactInformationForm?.name,
     userPhone: submission.contactInformationForm?.phone,
+    sessionID: sessionId,
   }
 }


### PR DESCRIPTION
Jira Ticket:ticket: : [SWA-105](https://artsyproduct.atlassian.net/browse/SWA-105)

~[WIP] because we should wait until [this ticket](https://github.com/artsy/convection/pull/1163) and [this](https://github.com/artsy/force/pull/8897) been merged.~

This PR adds sessionId usage to `createConsignSubmission`

**VIDEO:clapper: :**
<details>
  <summary>Anonymous submission</summary>

https://user-images.githubusercontent.com/55637696/142842393-c7707dd2-acac-49b8-9f0f-caed23494979.mov
</details>
<details>
  <summary>Submission from logged-in user</summary>

https://user-images.githubusercontent.com/55637696/142843001-e09e5d98-f2a2-44ad-a9a5-174038087354.mov
</details>
