### PR TITLE
Issue with Buyer’s Premium modal display

### DIFF
--- a/src/v2/Components/AuctionBuyersPremiumDialog.tsx
+++ b/src/v2/Components/AuctionBuyersPremiumDialog.tsx
@@ -9,7 +9,7 @@ import {
   Text,
 } from "@artsy/palette"
 import { compact } from "lodash"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
@@ -79,12 +79,16 @@ const AuctionBuyersPremiumDialog: React.FC<AuctionBuyersPremiumDialogProps> = ({
             </Text>
           ) : (
             schedule.map((premium, i) => {
+              const percent = (premium.percent ?? 0) * 100
+              const hasDecimal = percent - Math.floor(percent) !== 0
+              const fixed = percent.toFixed(1)
+              const displayPercentage = hasDecimal ? fixed : percent
               // First
               if (i === 0) {
                 return (
                   <Text key={i} variant="sm" mb={0.5}>
                     On the hammer price up to and including{" "}
-                    {schedule[i + 1]?.amount}: {(premium.percent ?? 0) * 100}%
+                    {schedule[i + 1]?.amount}: {displayPercentage}%
                   </Text>
                 )
               }
@@ -94,7 +98,7 @@ const AuctionBuyersPremiumDialog: React.FC<AuctionBuyersPremiumDialogProps> = ({
                 return (
                   <Text key={i} variant="sm">
                     On the portion of the hammer price in excess of{" "}
-                    {premium?.amount}: {(premium.percent ?? 0) * 100}%
+                    {premium?.amount}: {displayPercentage}%
                   </Text>
                 )
               }
@@ -102,8 +106,7 @@ const AuctionBuyersPremiumDialog: React.FC<AuctionBuyersPremiumDialogProps> = ({
               return (
                 <Text key={i} variant="sm" mb={0.5}>
                   On the hammer price in excess of {premium.amount} up to and
-                  including {schedule[i + 1].amount}:{" "}
-                  {(premium.percent ?? 0) * 100}%
+                  including {schedule[i + 1].amount}: {displayPercentage}%
                 </Text>
               )
             })

--- a/src/v2/Components/__tests__/AuctionBuyersPremiumDialog.jest.tsx
+++ b/src/v2/Components/__tests__/AuctionBuyersPremiumDialog.jest.tsx
@@ -76,5 +76,19 @@ describe("AuctionBuyersPremiumDialog", () => {
         "On the portion of the hammer price in excess of $2,500,000: 12%"
       )
     })
+
+    describe("with a percentage that isn't a whole number", () => {
+      it("rounds to a single decimal place", () => {
+        const wrapper = getWrapper({
+          Sale: () => ({
+            buyersPremium: [{ amount: "$0", cents: 0, percent: 0.225 }],
+          }),
+        })
+
+        const text = wrapper.text()
+
+        expect(text).toContain("22.5% on the hammer price")
+      })
+    })
   })
 })

--- a/src/v2/Components/__tests__/AuctionBuyersPremiumDialog.jest.tsx
+++ b/src/v2/Components/__tests__/AuctionBuyersPremiumDialog.jest.tsx
@@ -1,10 +1,14 @@
 import { graphql } from "react-relay"
-import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
 import { AuctionBuyersPremiumDialogFragmentContainer } from "../AuctionBuyersPremiumDialog"
+import { AuctionBuyersPremiumDialog_Test_Query } from "v2/__generated__/AuctionBuyersPremiumDialog_Test_Query.graphql"
+import { screen } from "@testing-library/react"
 
 jest.unmock("react-relay")
 
-const { getWrapper } = setupTestWrapper({
+const { renderWithRelay } = setupTestWrapperTL<
+  AuctionBuyersPremiumDialog_Test_Query
+>({
   Component: AuctionBuyersPremiumDialogFragmentContainer,
   query: graphql`
     query AuctionBuyersPremiumDialog_Test_Query @relay_test_operation {
@@ -18,21 +22,19 @@ const { getWrapper } = setupTestWrapper({
 describe("AuctionBuyersPremiumDialog", () => {
   describe("one point", () => {
     it("renders the schedule correctly", () => {
-      const wrapper = getWrapper({
+      renderWithRelay({
         Sale: () => ({
           buyersPremium: [{ amount: "$0", cents: 0, percent: 0.2 }],
         }),
       })
 
-      const text = wrapper.text()
-
-      expect(text).toContain("20% on the hammer price")
+      expect(screen.getByText("20% on the hammer price")).toBeInTheDocument()
     })
   })
 
   describe("two points", () => {
     it("renders the schedule correctly", () => {
-      const wrapper = getWrapper({
+      renderWithRelay({
         Sale: () => ({
           buyersPremium: [
             { amount: "$0", cents: 0, percent: 0.25 },
@@ -41,20 +43,22 @@ describe("AuctionBuyersPremiumDialog", () => {
         }),
       })
 
-      const text = wrapper.text()
-
-      expect(text).toContain(
-        "On the hammer price up to and including $500,000: 25%"
-      )
-      expect(text).toContain(
-        "On the portion of the hammer price in excess of $500,000: 20%"
-      )
+      expect(
+        screen.getByText(
+          "On the hammer price up to and including $500,000: 25%"
+        )
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          "On the portion of the hammer price in excess of $500,000: 20%"
+        )
+      ).toBeInTheDocument()
     })
   })
 
   describe("three or more points", () => {
     it("renders the schedule correctly", () => {
-      const wrapper = getWrapper({
+      renderWithRelay({
         Sale: () => ({
           buyersPremium: [
             { amount: "$0", cents: 0, percent: 0.25 },
@@ -64,30 +68,36 @@ describe("AuctionBuyersPremiumDialog", () => {
         }),
       })
 
-      const text = wrapper.text()
+      expect(
+        screen.getByText(
+          "On the hammer price up to and including $250,000: 25%"
+        )
+      ).toBeInTheDocument()
 
-      expect(text).toContain(
-        "On the hammer price up to and including $250,000: 25%"
-      )
-      expect(text).toContain(
-        "On the hammer price in excess of $250,000 up to and including $2,500,000: 20%"
-      )
-      expect(text).toContain(
-        "On the portion of the hammer price in excess of $2,500,000: 12%"
-      )
+      expect(
+        screen.getByText(
+          "On the hammer price in excess of $250,000 up to and including $2,500,000: 20%"
+        )
+      ).toBeInTheDocument()
+
+      expect(
+        screen.getByText(
+          "On the portion of the hammer price in excess of $2,500,000: 12%"
+        )
+      ).toBeInTheDocument()
     })
 
     describe("with a percentage that isn't a whole number", () => {
       it("rounds to a single decimal place", () => {
-        const wrapper = getWrapper({
+        renderWithRelay({
           Sale: () => ({
             buyersPremium: [{ amount: "$0", cents: 0, percent: 0.225 }],
           }),
         })
 
-        const text = wrapper.text()
-
-        expect(text).toContain("22.5% on the hammer price")
+        expect(
+          screen.getByText("22.5% on the hammer price")
+        ).toBeInTheDocument()
       })
     })
   })


### PR DESCRIPTION
# [NX-3004]
cc @negotiate-devs

Context:
https://artsy.slack.com/archives/CCS8TMQ0K/p1636044522073500

Example: 
https://www.artsy.net/artwork/sam-francis-blue-green-lembark-l-dot-56-sf-318

Before:
<img width="592" alt="Screen Shot 2021-11-17 at 1 31 17 PM" src="https://user-images.githubusercontent.com/5643895/142266749-5d474fe6-ca77-40bb-8cef-3a85f4e2fb0b.png">

After:
<img width="583" alt="Screen Shot 2021-11-17 at 1 31 24 PM" src="https://user-images.githubusercontent.com/5643895/142266774-985f1387-90aa-4c48-80f0-c514706b0447.png">




[NX-3004]: https://artsyproduct.atlassian.net/browse/NX-3004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ