### PR TITLE
fix(settings): submits the password with mutation; improves validation and display

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,6 +309,7 @@
     "@types/underscore.string": "0.0.32",
     "@types/webpack": "4.4.24",
     "@types/webpack-env": "1.13.6",
+    "@types/yup": "^0.29.13",
     "@typescript-eslint/eslint-plugin": "2.30.0",
     "@typescript-eslint/parser": "4.18.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.0",

--- a/src/v2/Apps/Settings/Routes/EditSettings/SettingsEditSettingsInformation.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/SettingsEditSettingsInformation.tsx
@@ -1,18 +1,18 @@
 import * as React from "react"
+import * as Yup from "yup"
 import { createFragmentContainer, graphql } from "react-relay"
-import { Form, Formik, FormikProps } from "formik"
+import { Form, Formik } from "formik"
 import { SettingsEditSettingsInformation_me } from "v2/__generated__/SettingsEditSettingsInformation_me.graphql"
 import {
   Button,
   Text,
-  Banner,
   Input,
   Join,
   Spacer,
   useToasts,
   PasswordInput,
 } from "@artsy/palette"
-import { ChangeUserInformationValidator } from "v2/Components/Authentication/Validators"
+import { email, password, name } from "v2/Components/Authentication/Validators"
 import { useUpdateSettingsInformation } from "./useUpdateSettingsInformation"
 
 interface SettingsEditSettingsInformationProps {
@@ -25,57 +25,6 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
   const { sendToast } = useToasts()
   const { submitUpdateSettingsInformation } = useUpdateSettingsInformation()
 
-  const onSubmit = async (
-    { email, name, phone, password },
-    // TODO: Fix typing & type errors
-    formikBag: FormikProps<any>
-  ) => {
-    formikBag.setStatus({ error: undefined })
-
-    try {
-      const variables = {
-        email,
-        name,
-        password,
-        phone,
-      }
-
-      const response = await submitUpdateSettingsInformation(variables)
-
-      const userOrError = response.updateMyUserProfile!.userOrError
-
-      sendToast({
-        variant: "success",
-        message: "Information updated successfully",
-      })
-
-      // TODO: Simplify this mess
-      if (userOrError!.mutationError) {
-        const { message, fieldErrors } = userOrError!.mutationError
-        if (fieldErrors) {
-          // display errors for a specified form field
-          const formattedErrors = formatGravityErrors(
-            userOrError!.mutationError
-          )
-          formikBag.setErrors(formattedErrors)
-        } else if (message) {
-          // display generic gravity error
-          formikBag.setStatus({ error: message })
-        }
-      } else {
-        formikBag.resetForm()
-      }
-    } catch (err) {
-      formikBag.setErrors(err)
-
-      sendToast({
-        variant: "error",
-        message: "There was a problem",
-        description: err.message,
-      })
-    }
-  }
-
   return (
     <>
       <Text variant="lg" mb={4}>
@@ -83,91 +32,108 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
       </Text>
 
       <Formik
+        validateOnBlur
+        validateOnChange
         initialValues={{
-          name: me.name,
-          email: me.email,
-          phone: me.phone,
-          paddleNumber: me.paddleNumber,
-          internalID: me.internalID,
+          name: me.name ?? "",
+          email: me.email ?? "",
+          phone: me.phone ?? "",
+          password: "",
         }}
-        validationSchema={ChangeUserInformationValidator}
-        onSubmit={onSubmit}
-        validateOnBlur={false}
+        validationSchema={Yup.object().shape({
+          email,
+          name,
+          // Requires password when email is changed
+          password: password.when("email", {
+            is: email => email !== me.email,
+            otherwise: field => field.notRequired(),
+          }),
+        })}
+        onSubmit={async ({ email, name, password, phone }) => {
+          try {
+            await submitUpdateSettingsInformation({
+              email,
+              name,
+              password,
+              phone,
+            })
+
+            sendToast({
+              variant: "success",
+              message: "Information updated successfully",
+            })
+          } catch (err) {
+            console.error(err)
+
+            sendToast({
+              variant: "error",
+              message: "There was a problem",
+              description: err.message,
+            })
+          }
+        }}
       >
-        {({
-          errors,
-          handleBlur,
-          handleChange,
-          handleSubmit,
-          isSubmitting,
-          status,
-          touched,
-          values,
-        }) => (
-          <Form onSubmit={handleSubmit}>
+        {({ errors, handleBlur, handleChange, isSubmitting, values }) => (
+          <Form>
             <Join separator={<Spacer mt={2} />}>
               <Input
-                title="Full name"
+                title="Full Name"
                 name="name"
-                error={errors.name as any}
+                error={errors.name}
                 placeholder="Enter your full name"
                 value={values.name}
                 onChange={handleChange}
                 onBlur={handleBlur}
+                required
+                autoComplete="name"
               />
 
               <Input
                 title="Email"
                 name="email"
-                error={errors.email as any}
+                error={errors.email}
                 placeholder="Enter your email address"
                 value={values.email}
                 onChange={handleChange}
                 onBlur={handleBlur}
+                type="email"
+                required
+                autoComplete="email"
               />
 
               <Input
-                title="Mobile number"
+                title="Mobile Number"
                 name="phone"
                 placeholder="Enter your mobile phone number"
                 value={values.phone}
                 onChange={handleChange}
                 onBlur={handleBlur}
                 type="tel"
+                autoComplete="tel"
               />
 
               {me.paddleNumber && (
-                <>
-                  <Input
-                    name="paddleNumber"
-                    title="Bidder number"
-                    value={me.paddleNumber}
-                    readOnly
-                  />
-                </>
+                <Input
+                  name="paddleNumber"
+                  title="Bidder Number"
+                  value={me.paddleNumber}
+                  readOnly
+                  disabled
+                />
               )}
 
-              {touched.email && values.email !== me.email && (
-                <>
-                  <PasswordInput
-                    title="Password"
-                    autoFocus
-                    error={
-                      !values.password &&
-                      "Password is required to change email."
-                    }
-                    placeholder="Enter your password"
-                    value={values.password}
-                    onChange={handleChange}
-                    onBlur={handleBlur}
-                    required
-                  />
-                </>
-              )}
-
-              {/* TODO: Remove with toast usage */}
-              {status && status.error && (
-                <Banner variant="error">{status.error}</Banner>
+              {values.email !== me.email && (
+                <PasswordInput
+                  name="password"
+                  title="Password"
+                  error={errors.password}
+                  placeholder="Enter your password"
+                  value={values.password}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  required
+                  autoComplete="current-password"
+                />
               )}
 
               <Button mt={2} type="submit" loading={isSubmitting}>
@@ -190,17 +156,7 @@ export const SettingsEditSettingsInformationFragmentContainer = createFragmentCo
         name
         paddleNumber
         phone
-        internalID
       }
     `,
   }
 )
-
-// TODO: Clean up with error related refactoring
-const formatGravityErrors = ({ fieldErrors }: any) => {
-  const formatted = {}
-  fieldErrors.map(err => {
-    formatted[err["name"]] = err.message.split(", ")
-  })
-  return formatted
-}

--- a/src/v2/Apps/Settings/Routes/EditSettings/__tests__/SettingsEditSettingsInformation.jest.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/__tests__/SettingsEditSettingsInformation.jest.tsx
@@ -1,0 +1,43 @@
+import { screen, fireEvent } from "@testing-library/react"
+import { graphql } from "react-relay"
+import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
+import { SettingsEditSettingsInformationFragmentContainer } from "../SettingsEditSettingsInformation"
+
+jest.unmock("react-relay")
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: SettingsEditSettingsInformationFragmentContainer,
+  query: graphql`
+    query SettingsEditSettingsInformation_Test_Query {
+      me {
+        ...SettingsEditSettingsInformation_me
+      }
+    }
+  `,
+})
+
+describe("SettingsEditSettingsInformation", () => {
+  it("renders the form", () => {
+    renderWithRelay()
+
+    expect(screen.queryByText("Full Name")).toBeInTheDocument()
+    expect(screen.queryByText("Email")).toBeInTheDocument()
+    expect(screen.queryByText("Password")).not.toBeInTheDocument()
+  })
+
+  it("displays the password", async () => {
+    renderWithRelay({ Me: () => ({ email: "me@example.com" }) })
+
+    expect(screen.queryByText("Password")).not.toBeInTheDocument()
+
+    const emailInput = screen.getByPlaceholderText("Enter your email address")
+
+    fireEvent.change(emailInput, {
+      target: { name: "email", value: "changed@example.com" },
+    })
+
+    const passwordInput = screen.getByPlaceholderText("Enter your password")
+
+    expect(passwordInput).toBeInTheDocument()
+  })
+})

--- a/src/v2/Apps/Settings/Routes/EditSettings/useUpdateSettingsInformation.ts
+++ b/src/v2/Apps/Settings/Routes/EditSettings/useUpdateSettingsInformation.ts
@@ -28,6 +28,9 @@ export const useUpdateSettingsInformation = () => {
             $input: UpdateMyProfileInput!
           ) {
             updateMyUserProfile(input: $input) {
+              me {
+                ...SettingsEditSettingsInformation_me
+              }
               userOrError {
                 ... on UpdateMyProfileMutationSuccess {
                   user {

--- a/src/v2/Components/Authentication/Validators.tsx
+++ b/src/v2/Components/Authentication/Validators.tsx
@@ -4,9 +4,9 @@ export const email = Yup.string()
   .email("Please enter a valid email.")
   .required("Please enter a valid email.")
 
-const name = Yup.string().required("Name is required.")
+export const name = Yup.string().required("Name is required.")
 
-const password = Yup.string()
+export const password = Yup.string()
   .required("Password required")
   .min(8, "Your password must be at least 8 characters")
 

--- a/src/v2/__generated__/SettingsEditSettingsInformation_Test_Query.graphql.ts
+++ b/src/v2/__generated__/SettingsEditSettingsInformation_Test_Query.graphql.ts
@@ -3,23 +3,23 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type settingsRoutes_SettingsEditSettingsRouteQueryVariables = {};
-export type settingsRoutes_SettingsEditSettingsRouteQueryResponse = {
+export type SettingsEditSettingsInformation_Test_QueryVariables = {};
+export type SettingsEditSettingsInformation_Test_QueryResponse = {
     readonly me: {
-        readonly " $fragmentRefs": FragmentRefs<"SettingsEditSettingsRoute_me">;
+        readonly " $fragmentRefs": FragmentRefs<"SettingsEditSettingsInformation_me">;
     } | null;
 };
-export type settingsRoutes_SettingsEditSettingsRouteQuery = {
-    readonly response: settingsRoutes_SettingsEditSettingsRouteQueryResponse;
-    readonly variables: settingsRoutes_SettingsEditSettingsRouteQueryVariables;
+export type SettingsEditSettingsInformation_Test_Query = {
+    readonly response: SettingsEditSettingsInformation_Test_QueryResponse;
+    readonly variables: SettingsEditSettingsInformation_Test_QueryVariables;
 };
 
 
 
 /*
-query settingsRoutes_SettingsEditSettingsRouteQuery {
+query SettingsEditSettingsInformation_Test_Query {
   me {
-    ...SettingsEditSettingsRoute_me
+    ...SettingsEditSettingsInformation_me
     id
   }
 }
@@ -30,10 +30,6 @@ fragment SettingsEditSettingsInformation_me on Me {
   paddleNumber
   phone
 }
-
-fragment SettingsEditSettingsRoute_me on Me {
-  ...SettingsEditSettingsInformation_me
-}
 */
 
 const node: ConcreteRequest = {
@@ -41,7 +37,7 @@ const node: ConcreteRequest = {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "settingsRoutes_SettingsEditSettingsRouteQuery",
+    "name": "SettingsEditSettingsInformation_Test_Query",
     "selections": [
       {
         "alias": null,
@@ -54,7 +50,7 @@ const node: ConcreteRequest = {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "SettingsEditSettingsRoute_me"
+            "name": "SettingsEditSettingsInformation_me"
           }
         ],
         "storageKey": null
@@ -66,7 +62,7 @@ const node: ConcreteRequest = {
   "operation": {
     "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "settingsRoutes_SettingsEditSettingsRouteQuery",
+    "name": "SettingsEditSettingsInformation_Test_Query",
     "selections": [
       {
         "alias": null,
@@ -119,10 +115,10 @@ const node: ConcreteRequest = {
   "params": {
     "id": null,
     "metadata": {},
-    "name": "settingsRoutes_SettingsEditSettingsRouteQuery",
+    "name": "SettingsEditSettingsInformation_Test_Query",
     "operationKind": "query",
-    "text": "query settingsRoutes_SettingsEditSettingsRouteQuery {\n  me {\n    ...SettingsEditSettingsRoute_me\n    id\n  }\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phone\n}\n\nfragment SettingsEditSettingsRoute_me on Me {\n  ...SettingsEditSettingsInformation_me\n}\n"
+    "text": "query SettingsEditSettingsInformation_Test_Query {\n  me {\n    ...SettingsEditSettingsInformation_me\n    id\n  }\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phone\n}\n"
   }
 };
-(node as any).hash = '87f56be623fa0ca771be8d9298fd830e';
+(node as any).hash = 'bacba3a36985208c8d653b5bd00f81a7';
 export default node;

--- a/src/v2/__generated__/SettingsEditSettingsInformation_me.graphql.ts
+++ b/src/v2/__generated__/SettingsEditSettingsInformation_me.graphql.ts
@@ -8,7 +8,6 @@ export type SettingsEditSettingsInformation_me = {
     readonly name: string | null;
     readonly paddleNumber: string | null;
     readonly phone: string | null;
-    readonly internalID: string;
     readonly " $refType": "SettingsEditSettingsInformation_me";
 };
 export type SettingsEditSettingsInformation_me$data = SettingsEditSettingsInformation_me;
@@ -52,16 +51,9 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "phone",
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "internalID",
-      "storageKey": null
     }
   ],
   "type": "Me"
 };
-(node as any).hash = '9d46433d4e508aa5b9bb74d4f11991ea';
+(node as any).hash = '4b58a8c8a4bb4bcbc13fd9519056de2a';
 export default node;

--- a/src/v2/__generated__/useUpdateSettingsInformationMutation.graphql.ts
+++ b/src/v2/__generated__/useUpdateSettingsInformationMutation.graphql.ts
@@ -2,6 +2,7 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
 export type UpdateMyProfileInput = {
     artworksPerYear?: string | null;
     bio?: string | null;
@@ -46,6 +47,9 @@ export type useUpdateSettingsInformationMutationVariables = {
 };
 export type useUpdateSettingsInformationMutationResponse = {
     readonly updateMyUserProfile: {
+        readonly me: {
+            readonly " $fragmentRefs": FragmentRefs<"SettingsEditSettingsInformation_me">;
+        } | null;
         readonly userOrError: {
             readonly user?: {
                 readonly internalID: string;
@@ -75,6 +79,10 @@ mutation useUpdateSettingsInformationMutation(
   $input: UpdateMyProfileInput!
 ) {
   updateMyUserProfile(input: $input) {
+    me {
+      ...SettingsEditSettingsInformation_me
+      id
+    }
     userOrError {
       __typename
       ... on UpdateMyProfileMutationSuccess {
@@ -97,6 +105,13 @@ mutation useUpdateSettingsInformationMutation(
       }
     }
   }
+}
+
+fragment SettingsEditSettingsInformation_me on Me {
+  email
+  name
+  paddleNumber
+  phone
 }
 */
 
@@ -131,6 +146,13 @@ v3 = {
   "storageKey": null
 },
 v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -171,13 +193,7 @@ v4 = {
           "name": "fieldErrors",
           "plural": true,
           "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "name",
-              "storageKey": null
-            },
+            (v4/*: any*/),
             (v3/*: any*/)
           ],
           "storageKey": null
@@ -187,6 +203,13 @@ v4 = {
     }
   ],
   "type": "UpdateMyProfileMutationFailure"
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -203,6 +226,22 @@ return {
         "name": "updateMyUserProfile",
         "plural": false,
         "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Me",
+            "kind": "LinkedField",
+            "name": "me",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "SettingsEditSettingsInformation_me"
+              }
+            ],
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -229,7 +268,7 @@ return {
                 ],
                 "type": "UpdateMyProfileMutationSuccess"
               },
-              (v4/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": null
           }
@@ -253,6 +292,40 @@ return {
         "name": "updateMyUserProfile",
         "plural": false,
         "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Me",
+            "kind": "LinkedField",
+            "name": "me",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "email",
+                "storageKey": null
+              },
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "paddleNumber",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "phone",
+                "storageKey": null
+              },
+              (v6/*: any*/)
+            ],
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -280,20 +353,14 @@ return {
                     "plural": false,
                     "selections": [
                       (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "id",
-                        "storageKey": null
-                      }
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   }
                 ],
                 "type": "UpdateMyProfileMutationSuccess"
               },
-              (v4/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": null
           }
@@ -307,9 +374,9 @@ return {
     "metadata": {},
     "name": "useUpdateSettingsInformationMutation",
     "operationKind": "mutation",
-    "text": "mutation useUpdateSettingsInformationMutation(\n  $input: UpdateMyProfileInput!\n) {\n  updateMyUserProfile(input: $input) {\n    userOrError {\n      __typename\n      ... on UpdateMyProfileMutationSuccess {\n        user {\n          internalID\n          id\n        }\n      }\n      ... on UpdateMyProfileMutationFailure {\n        mutationError {\n          type\n          message\n          detail\n          error\n          fieldErrors {\n            name\n            message\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation useUpdateSettingsInformationMutation(\n  $input: UpdateMyProfileInput!\n) {\n  updateMyUserProfile(input: $input) {\n    me {\n      ...SettingsEditSettingsInformation_me\n      id\n    }\n    userOrError {\n      __typename\n      ... on UpdateMyProfileMutationSuccess {\n        user {\n          internalID\n          id\n        }\n      }\n      ... on UpdateMyProfileMutationFailure {\n        mutationError {\n          type\n          message\n          detail\n          error\n          fieldErrors {\n            name\n            message\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phone\n}\n"
   }
 };
 })();
-(node as any).hash = '23b440f4eb85495acfc488dcdbfc45cc';
+(node as any).hash = 'c3ddab7400b980cba872ea195359ca0a';
 export default node;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3877,6 +3877,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yup@^0.29.13":
+  version "0.29.13"
+  resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.29.13.tgz#21b137ba60841307a3c8a1050d3bf4e63ad561e9"
+  integrity sha512-qRyuv+P/1t1JK1rA+elmK1MmCL1BapEzKKfbEhDBV/LMMse4lmhZ/XbgETI39JveDJRpLjmToOI6uFtMW/WR2g==
+
 "@typescript-eslint/eslint-plugin@2.30.0":
   version "2.30.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.30.0.tgz#312a37e80542a764d96e8ad88a105316cdcd7b05"


### PR DESCRIPTION
So this PR primarily fixes the issue where we weren't sending the password through with the mutation and corrects the logic surrounding how it's displayed. 

So here you can see: as soon as you change the email the password input displays itself. If you type the correct password, it updates the email. If you type the wrong password, it prevents you from updating the email and errors.

https://user-images.githubusercontent.com/112297/142661528-4007db15-c7b6-4282-bc9f-42ec1e4ae922.mov

I'll leave a few comments below explaining what was going on and why.