### PR TITLE
fea: add smoke test  after deploy to staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,6 +359,8 @@ workflows:
 
       - smoketest-on-staging:
           context: hokusai
+          requires:
+            - builder-image-push
           filters:
             branches:
               only:
@@ -373,7 +375,6 @@ workflows:
           name: deploy-production
           requires:
             - horizon/block
-            - smoketest-on-staging
             - validate_production_schema
 
       # Other

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - checkout
       - run:
           name: Install Dependencies
-          command: npm ci
+          command: npm install
       - run: ./node_modules/.bin/cypress run --config baseUrl=https://staging.artsy.net
 
   run_deepcrawl_automator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,13 +25,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: npm ci
-      - save_cache:
-          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
-          # cache NPM modules and the folder with the Cypress binary
-          paths:
-            - ~/.npm
-            - ~/.cache
-      - run: $(npm bin)/cypress run --config baseUrl=https://staging.artsy.net
+      - run: ./node_modules/.bin/cypress run --config baseUrl=https://staging.artsy.net
 
   run_deepcrawl_automator:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,14 @@ workflows:
             branches:
               only:
                 - release
+
+      - smoketest_on_staging:
+          filters:
+            branches:
+              only:
                 - staging
+          steps:
+            - run: cypress run --config baseUrl=https://staging.artsy.net
 
       - validate_production_schema:
           <<: *only_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,11 @@ orbs:
   yarn: artsy/yarn@6.0.0
 
 jobs:
+  smoketest-on-staging:
+    executor: node/build
+    steps:
+      - run: cypress run --config baseUrl=https://staging.artsy.net
+
   run_deepcrawl_automator:
     docker:
       - image: cimg/base:2021.11
@@ -347,14 +352,12 @@ workflows:
               only:
                 - release
 
-      - smoketest_on_staging:
+      - smoketest-on-staging:
           filters:
             branches:
               only:
                 - staging
                 - sonecabr/add-smoketest-before-prod
-          steps:
-            - run: cypress run --config baseUrl=https://staging.artsy.net
 
       - validate_production_schema:
           <<: *only_release
@@ -364,6 +367,7 @@ workflows:
           name: deploy-production
           requires:
             - horizon/block
+            - smoketest-on-staging
             - validate_production_schema
 
       # Other

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,20 @@ jobs:
           TERM: xterm
     working_directory: /app
     steps:
+      - restore_cache:
+          keys:
+            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+            - v1-deps-{{ .Branch }}
+            - v1-deps
+      - run:
+          name: Install Dependencies
+          command: npm ci
+      - save_cache:
+          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+          # cache NPM modules and the folder with the Cypress binary
+          paths:
+            - ~/.npm
+            - ~/.cache
       - run: $(npm bin)/cypress run --config baseUrl=https://staging.artsy.net
 
   run_deepcrawl_automator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,8 @@ jobs:
       - image: cypress/base:14.16.0
         environment:
           TERM: xterm
-    working_directory: /app
+    working_directory: ~/app
     steps:
-      - restore_cache:
-          keys:
-            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
-            - v1-deps-{{ .Branch }}
-            - v1-deps
       - run:
           name: Install Dependencies
           command: npm ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,6 +352,7 @@ workflows:
           project-name: force
           requires:
             - production-image-push
+            - smoke-test-on-live-env
 
       # Release
       - horizon/block:
@@ -367,7 +368,6 @@ workflows:
             branches:
               only:
                 - staging
-                - release
 
       - validate_production_schema:
           <<: *only_release
@@ -378,7 +378,6 @@ workflows:
           requires:
             - horizon/block
             - validate_production_schema
-            - smoke-test-on-live-env
 
       # Other
       - run_deepcrawl_automator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,12 @@ orbs:
 
 jobs:
   smoketest-on-staging:
-    executor: node/build
+    docker:
+      - image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:$CIRCLE_SHA1-builder
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+    working_directory: /app
     steps:
       - run: cypress run --config baseUrl=https://staging.artsy.net
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,6 +358,7 @@ workflows:
                 - release
 
       - smoketest-on-staging:
+          context: hokusai
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,19 +10,6 @@ orbs:
   yarn: artsy/yarn@6.0.0
 
 jobs:
-  smoketest-on-staging:
-    docker:
-      - image: cypress/base:14.16.0
-        environment:
-          TERM: xterm
-    working_directory: ~/app
-    steps:
-      - checkout
-      - run:
-          name: Install Dependencies
-          command: npm install
-      - run: ./node_modules/.bin/cypress run --config baseUrl=https://staging.artsy.net
-
   run_deepcrawl_automator:
     docker:
       - image: cimg/base:2021.11
@@ -207,6 +194,19 @@ jobs:
             exit $code
           fi
 
+  smoke_test_on_running_env:
+    docker:
+      - image: cypress/base:14.16.0
+        environment:
+          TERM: xterm
+    working_directory: ~/app
+    steps:
+      - checkout
+      - run:
+          name: Install Dependencies
+          command: yarn install
+      - run: ./node_modules/.bin/cypress run --config baseUrl=$SMOKE_TEST_TARGET
+
 not_master_or_staging_or_release: &not_master_or_staging_or_release
   filters:
     branches:
@@ -360,12 +360,12 @@ workflows:
               only:
                 - release
 
-      - smoketest-on-staging:
+      - smoke_test_on_running_env:
           filters:
             branches:
               only:
                 - staging
-                - sonecabr/add-smoketest-before-prod
+                - sonecabr/add-smoketest-before-prod # temporary branch just to check schema without merge
 
       - validate_production_schema:
           <<: *only_release
@@ -376,6 +376,7 @@ workflows:
           requires:
             - horizon/block
             - validate_production_schema
+            - smoke_test_on_running_env
 
       # Other
       - run_deepcrawl_automator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,6 +367,7 @@ workflows:
             branches:
               only:
                 - staging
+                - release
 
       - validate_production_schema:
           <<: *only_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           TERM: xterm
     working_directory: ~/app
     steps:
+      - checkout
       - run:
           name: Install Dependencies
           command: npm ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
           name: Install Dependencies
           command: yarn install
       - run:
-          name: Run Smoke Tests on $SMOKE_TEST_TARGET
+          name: Run Smoke Tests on Staging
           command: ./node_modules/.bin/cypress run --config baseUrl=$SMOKE_TEST_TARGET
 
 not_master_or_staging_or_release: &not_master_or_staging_or_release
@@ -367,7 +367,6 @@ workflows:
             branches:
               only:
                 - staging
-                - sonecabr/add-smoketest-before-prod # temporary branch just to check schema without merge
 
       - validate_production_schema:
           <<: *only_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,6 +352,7 @@ workflows:
             branches:
               only:
                 - staging
+                - sonecabr/add-smoketest-before-prod
           steps:
             - run: cypress run --config baseUrl=https://staging.artsy.net
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,8 +367,6 @@ workflows:
             branches:
               only:
                 - staging
-          requires:
-            - hokusai/deploy-staging
 
       - validate_production_schema:
           <<: *only_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,6 @@ workflows:
           project-name: force
           requires:
             - production-image-push
-            - smoke-test-on-live-env
 
       # Release
       - horizon/block:
@@ -368,6 +367,8 @@ workflows:
             branches:
               only:
                 - staging
+          requires:
+            - hokusai/deploy-staging
 
       - validate_production_schema:
           <<: *only_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
             exit $code
           fi
 
-  smoke_test_on_running_env:
+  smoke-test-on-live-env:
     docker:
       - image: cypress/base:14.16.0
         environment:
@@ -362,7 +362,7 @@ workflows:
               only:
                 - release
 
-      - smoke_test_on_running_env:
+      - smoke-test-on-live-env:
           filters:
             branches:
               only:
@@ -378,7 +378,7 @@ workflows:
           requires:
             - horizon/block
             - validate_production_schema
-            - smoke_test_on_running_env
+            - smoke-test-on-live-env
 
       # Other
       - run_deepcrawl_automator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,12 @@ orbs:
 jobs:
   smoketest-on-staging:
     docker:
-      - image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:$CIRCLE_SHA1-builder
-        aws_auth:
-          aws_access_key_id: $AWS_ACCESS_KEY_ID
-          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+      - image: cypress/base:14.16.0
+        environment:
+          TERM: xterm
     working_directory: /app
     steps:
-      - run: cypress run --config baseUrl=https://staging.artsy.net
+      - run: $(npm bin)/cypress run --config baseUrl=https://staging.artsy.net
 
   run_deepcrawl_automator:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,9 +357,6 @@ workflows:
                 - release
 
       - smoketest-on-staging:
-          context: hokusai
-          requires:
-            - builder-image-push
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,9 @@ jobs:
       - run:
           name: Install Dependencies
           command: yarn install
-      - run: ./node_modules/.bin/cypress run --config baseUrl=$SMOKE_TEST_TARGET
+      - run:
+          name: Run Smoke Tests on $SMOKE_TEST_TARGET
+          command: ./node_modules/.bin/cypress run --config baseUrl=$SMOKE_TEST_TARGET
 
 not_master_or_staging_or_release: &not_master_or_staging_or_release
   filters:


### PR DESCRIPTION
As part of our effort to make force as automated as possible it's desired that we have automated approval gates which decides if current version is safe or not to step forward in the pipeline.
We are introducing an approval gate after deploy to staging which:
 - Run smoke tests using cypress definition on current running staging environment
 - In case tests are failing CircleCi will mark this execution as failed
 
Dependencies:
- CircleCI need an environment called $SMOKE_TEST_TARGET eg: https://staging.artsy.net
