### PR TITLE
feat(SWA-132): Add recaptcha for the submission creation

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
@@ -15,6 +15,7 @@ import { contactInformationValidationSchema } from "../Utils/validation"
 import { BackLink } from "v2/Components/Links/BackLink"
 import { useErrorModal } from "../Utils/useErrorModal"
 import { data as sd } from "sharify"
+import { recaptcha, RecaptchaAction } from "v2/Utils/recaptcha"
 
 const getContactInformationFormInitialValues = (me: ContactInformation_me) => ({
   name: me?.name || "",
@@ -47,11 +48,16 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
     removeSubmission,
   } = useSubmission(id)
 
+  const handleRecaptcha = (action: RecaptchaAction) =>
+    new Promise(resolve => recaptcha(action, resolve))
+
   const handleSubmit = async ({
     name,
     email,
     phone,
   }: ContactInformationFormModel) => {
+    if (!(await handleRecaptcha("submission_submit"))) return
+
     if (submission) {
       const contactInformationForm = {
         name: name.trim(),

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/__tests__/ContactInformation.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/__tests__/ContactInformation.jest.tsx
@@ -62,7 +62,9 @@ jest.mock("../../Utils/useErrorModal", () => ({
   useErrorModal: jest.fn(),
 }))
 
-jest.mock("sharify", () => ({ data: { SESSION_ID: "SessionID" } }))
+jest.mock("sharify", () => ({
+  data: { SESSION_ID: "SessionID", RECAPTCHA_KEY: "recaptcha-api-key" },
+}))
 
 jest.mock("../../Utils/createConsignSubmission", () => ({
   ...jest.requireActual("../../Utils/createConsignSubmission"),
@@ -246,6 +248,9 @@ describe("Contact Information step", () => {
       await flushPromiseQueue()
       wrapper.update()
 
+      expect(window.grecaptcha.execute).toBeCalledWith("recaptcha-api-key", {
+        action: "submission_submit",
+      })
       expect(sessionStorage.setItem).toHaveBeenCalled()
       expect(mockCreateConsignSubmission).toHaveBeenCalled()
       expect(mockCreateConsignSubmission.mock.calls[0][2]).toEqual(undefined)
@@ -304,6 +309,9 @@ describe("Contact Information step", () => {
       await flushPromiseQueue()
       wrapper.update()
 
+      expect(window.grecaptcha.execute).toBeCalledWith("recaptcha-api-key", {
+        action: "submission_submit",
+      })
       expect(sessionStorage.setItem).toHaveBeenCalled()
       expect(mockCreateConsignSubmission).toHaveBeenCalled()
       expect(mockCreateConsignSubmission.mock.calls[0][2]).toEqual("userId")

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/SubmissionLayout.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/SubmissionLayout.tsx
@@ -3,6 +3,7 @@ import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 import { MinimalNavBar } from "v2/Components/NavBar/MinimalNavBar"
 import { MetaTags } from "v2/Components/MetaTags"
 import { ErrorModalProvider } from "./Utils/useErrorModal"
+import { EnableRecaptcha } from "v2/Utils/EnableRecaptcha"
 
 export const SubmissionLayout: React.FC = ({ children }) => {
   return (
@@ -13,6 +14,7 @@ export const SubmissionLayout: React.FC = ({ children }) => {
         description="Get competitive offers from the world's top auction houses and galleries to sell art from your collection. Submit today at no cost."
       />
       <AppContainer overflowX="hidden">
+        <EnableRecaptcha />
         <HorizontalPadding mb={4}>
           <ErrorModalProvider>{children}</ErrorModalProvider>
         </HorizontalPadding>

--- a/src/v2/Utils/recaptcha.ts
+++ b/src/v2/Utils/recaptcha.ts
@@ -36,3 +36,4 @@ export type RecaptchaAction =
   | "inquiry_register_impression"
   | "login_submit"
   | "signup_submit"
+  | "submission_submit"


### PR DESCRIPTION
Jira Ticket:ticket: : [SWA-132](https://artsyproduct.atlassian.net/browse/SWA-132)

This PR adds `Recaptcha` usage to the `Contact Information` form submitting.

❓:
- Is it enough? Or we should use backend validation for our flow? @damassi, @mzikherman could you help, please? I noticed that in Force only `SignUpForm` has backend validation.
- Are those Recaptcha call's doing something? 
https://github.com/artsy/force/blob/0d76e5e579925c2027711ff725450001a6fc0882/src/v2/Components/Authentication/Views/ForgotPasswordForm.tsx#L23
https://github.com/artsy/force/blob/0d76e5e579925c2027711ff725450001a6fc0882/src/v2/Components/Authentication/Views/LoginForm.tsx#L46
