### PR TITLE
[WIP] Convert shipping form to functional component

### DIFF
--- a/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -24,7 +24,7 @@ import {
   settingOrderShipmentMissingRegionFailure,
   settingOrderShipmentSuccess,
 } from "../__fixtures__/MutationResults"
-import { ShippingFragmentContainer, ShippingRoute } from "../Shipping"
+import { ShippingFragmentContainer } from "../Shipping"
 import { OrderAppTestPage } from "./Utils/OrderAppTestPage"
 import {
   deleteAddressSuccess,
@@ -213,7 +213,10 @@ describe("Shipping", () => {
 
       page.find(`[data-test="save-address-checkbox"]`).first().simulate("click")
 
-      expect(page.find(ShippingRoute).state().saveAddress).toEqual(false)
+      expect(
+        page.find(`[data-test="save-address-checkbox"]`).first().props()
+          .selected
+      ).toEqual(false)
 
       await page.clickSubmit()
 
@@ -801,9 +804,6 @@ describe("Shipping", () => {
       )
     })
 
-    it("saves the default address selection into state", async () => {
-      expect(page.find(ShippingRoute).state().selectedAddressID).toEqual("2")
-    })
     it("commits the mutation with selected address and phone number", async () => {
       await page.clickSubmit()
 
@@ -831,7 +831,6 @@ describe("Shipping", () => {
     it("when another saved address is selected commits mutation with selected address and phone number", async () => {
       page.find(`[data-test="savedAddress"]`).first().simulate("click")
       await page.update()
-      expect(page.find(ShippingRoute).state().selectedAddressID).toEqual("1")
       await page.clickSubmit()
 
       expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
@@ -923,8 +922,7 @@ describe("Shipping", () => {
         expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
           "SetShippingMutation"
         )
-
-        expect(page.find(ShippingRoute).state().shippingQuotes).toHaveLength(5)
+        expect(page.find(`[data-test="shipping-quotes"]`)).toHaveLength(5)
       })
 
       it("submit button disabled if shipping quote is not selected", async () => {
@@ -933,10 +931,6 @@ describe("Shipping", () => {
 
       it("submit button enabled if shipping quote is selected", async () => {
         page.find(`[data-test="shipping-quotes"]`).last().simulate("click")
-
-        expect(page.find(ShippingRoute).state().shippingQuoteId).toEqual(
-          "1eb3ba19-643b-4101-b113-2eb4ef7e30b6"
-        )
 
         expect(page.submitButton.props().disabled).toBeFalsy()
       })

--- a/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -13,7 +13,7 @@ import {
   validAddress,
 } from "v2/Components/__tests__/Utils/addressForm"
 import { CountrySelect } from "v2/Components/CountrySelect"
-import { Input } from "@artsy/palette"
+import { Input, BorderedRadio } from "@artsy/palette"
 import { createTestEnv } from "v2/DevTools/createTestEnv"
 import { graphql } from "react-relay"
 import {
@@ -922,7 +922,9 @@ describe("Shipping", () => {
         expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
           "SetShippingMutation"
         )
-        expect(page.find(`[data-test="shipping-quotes"]`)).toHaveLength(5)
+        expect(
+          page.find(`[data-test="shipping-quotes"]`).find(BorderedRadio)
+        ).toHaveLength(5)
       })
 
       it("submit button disabled if shipping quote is not selected", async () => {

--- a/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -804,6 +804,12 @@ describe("Shipping", () => {
       )
     })
 
+    it("the default address is selected", async () => {
+      const savedAddressButtons = page.find(`[data-test="savedAddress"]`)
+      expect(savedAddressButtons.first().props().selected).toEqual(false)
+      expect(savedAddressButtons.last().props().selected).toEqual(true)
+    })
+
     it("commits the mutation with selected address and phone number", async () => {
       await page.clickSubmit()
 
@@ -831,6 +837,11 @@ describe("Shipping", () => {
     it("when another saved address is selected commits mutation with selected address and phone number", async () => {
       page.find(`[data-test="savedAddress"]`).first().simulate("click")
       await page.update()
+
+      const savedAddressButtons = page.find(`[data-test="savedAddress"]`)
+      expect(savedAddressButtons.first().props().selected).toEqual(true)
+      expect(savedAddressButtons.last().props().selected).toEqual(false)
+
       await page.clickSubmit()
 
       expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
@@ -933,6 +944,10 @@ describe("Shipping", () => {
 
       it("submit button enabled if shipping quote is selected", async () => {
         page.find(`[data-test="shipping-quotes"]`).last().simulate("click")
+
+        expect(
+          page.find(`[data-test="shipping-quotes"]`).last().props().selected
+        ).toEqual(true)
 
         expect(page.submitButton.props().disabled).toBeFalsy()
       })


### PR DESCRIPTION
**[DO NOT MERGE YET]: Some use cases are being not covered after the latest commit**

As part of the [consolidation of the address forms into one component](https://artsyproduct.atlassian.net/browse/NX-2993), we need to convert the parent components (only Shipping and PaymentPicker) to functional components.

Ticket: [nx 2993/](https://artsyproduct.atlassian.net/browse/NX-3025)

Co-authored-by: @rquartararo @laurabeth 

Things to keep in mind when reviewing this PR:
- `state()` is not available anymore on a test level, so we are now testing the UI behaves as expected.
- when tracking user's selection of delivery method (ship, pickup) we were sending `flow: "buy now"` and `type: "button"` which is not part of our schema. Now we are using `flow: Schema.Flow.BuyNow, // Equals to "Buy now"` and `type: Schema.Type.Button, // Equals to "Button"` instead.
- `@track` class decorator was replaced for `useTracking` hook