### PR TITLE
[PLATFORM-3280] Copy/Download recovery codes

### DIFF
--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorActions.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorActions.tsx
@@ -1,0 +1,58 @@
+import { Button, BorderBoxProps, Flex } from "@artsy/palette"
+import React, { useEffect, useState } from "react"
+
+interface BackupSecondFactorActionsProps extends BorderBoxProps {
+  backupSecondFactors: string[]
+}
+
+export const BackupSecondFactorActions: React.FC<BackupSecondFactorActionsProps> = props => {
+  const { backupSecondFactors } = props
+
+  const [supportsClipboard, setSupportsClipboard] = useState(false)
+
+  useEffect(() => {
+    // Only render the copy button if browser supports the Clipboard API
+    // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
+    if ("clipboard" in navigator) setSupportsClipboard(true)
+  }, [])
+
+  function copyCodesToClipboard() {
+    navigator.clipboard.writeText(backupSecondFactors.join("\n"))
+  }
+
+  function downloadCodes() {
+    const codes = backupSecondFactors.join("\n")
+    const element = document.createElement("a");
+    const file = new Blob([codes], {type: 'text/plain'});
+    element.href = URL.createObjectURL(file);
+    element.download = "recovery_codes.txt";
+    document.body.appendChild(element); // Required for this to work in FireFox
+    element.click();
+  }
+
+  return (
+    <Flex justifyContent="center">
+      {supportsClipboard && (
+        <Button
+          onClick={copyCodesToClipboard}
+          variant="secondaryOutline"
+          size="small"
+          m={1}
+          data-test="copyButton"
+        >
+          Copy
+        </Button>
+      )}
+
+      <Button
+        onClick={downloadCodes}
+        variant="secondaryOutline"
+        size="small"
+        m={1}
+        data-test="downloadButton"
+      >
+        Download
+      </Button>
+    </Flex>
+  )
+}

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorActions.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorActions.tsx
@@ -22,12 +22,13 @@ export const BackupSecondFactorActions: React.FC<BackupSecondFactorActionsProps>
 
   function downloadCodes() {
     const codes = backupSecondFactors.join("\n")
-    const element = document.createElement("a");
-    const file = new Blob([codes], {type: 'text/plain'});
-    element.href = URL.createObjectURL(file);
-    element.download = "recovery_codes.txt";
-    document.body.appendChild(element); // Required for this to work in FireFox
-    element.click();
+    const element = document.createElement("a")
+    const file = new Blob([codes], { type: "text/plain" })
+    element.href = URL.createObjectURL(file)
+    element.download = "recovery_codes.txt"
+    document.body.appendChild(element) // Required for this to work in FireFox
+    element.click()
+    URL.revokeObjectURL(element.href)
   }
 
   return (

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorModalContent.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorModalContent.tsx
@@ -29,6 +29,16 @@ export const BackupSecondFactorModalContent: React.FC<BackupSecondFactorModalCon
     navigator.clipboard.writeText(codes)
   }
 
+  function downloadCodes() {
+    const codes = me.backupSecondFactors!.map(item => item!.code).join("\n")
+    const element = document.createElement("a")
+    const file = new Blob([codes], { type: "text/plain" })
+    element.href = URL.createObjectURL(file)
+    element.download = "recovery_codes.txt"
+    document.body.appendChild(element) // Required for this to work in FireFox
+    element.click()
+  }
+
   return (
     <Box minHeight="280px">
       <Sans size="3" color="black60">
@@ -47,20 +57,29 @@ export const BackupSecondFactorModalContent: React.FC<BackupSecondFactorModalCon
         ))}
       </Flex>
 
-      {supportsClipboard && (
-        <Flex justifyContent="center">
+      <Flex justifyContent="center">
+        {supportsClipboard && (
           <Button
             onClick={copyCodesToClipboard}
             variant="secondaryOutline"
             size="small"
-            mt={1}
-            mb={1}
+            m={1}
             data-test="copyButton"
           >
             Copy
           </Button>
-        </Flex>
-      )}
+        )}
+
+        <Button
+          onClick={downloadCodes}
+          variant="secondaryOutline"
+          size="small"
+          m={1}
+          data-test="downloadButton"
+        >
+          Download
+        </Button>
+      </Flex>
     </Box>
   )
 }

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorModalContent.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorModalContent.tsx
@@ -1,6 +1,6 @@
-import { BorderBoxProps, Box, Flex, Sans } from "@artsy/palette"
+import { Button, BorderBoxProps, Box, Flex, Sans } from "@artsy/palette"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
-import * as React from "react"
+import React, { useEffect, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { BackupSecondFactorModalContent_me } from "v2/__generated__/BackupSecondFactorModalContent_me.graphql"
@@ -15,6 +15,19 @@ interface BackupSecondFactorModalContentProps extends BorderBoxProps {
 
 export const BackupSecondFactorModalContent: React.FC<BackupSecondFactorModalContentProps> = props => {
   const { me } = props
+
+  const [supportsClipboard, setSupportsClipboard] = useState(false)
+
+  useEffect(() => {
+    // Only render the copy button if browser supports the Clipboard API
+    // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
+    if ("clipboard" in navigator) setSupportsClipboard(true)
+  }, [])
+
+  function copyCodesToClipboard() {
+    const codes = me.backupSecondFactors!.map(item => item!.code).join("\n")
+    navigator.clipboard.writeText(codes)
+  }
 
   return (
     <Box minHeight="280px">
@@ -33,6 +46,21 @@ export const BackupSecondFactorModalContent: React.FC<BackupSecondFactorModalCon
           </Box>
         ))}
       </Flex>
+
+      {supportsClipboard && (
+        <Flex justifyContent="center">
+          <Button
+            onClick={copyCodesToClipboard}
+            variant="secondaryOutline"
+            size="small"
+            mt={1}
+            mb={1}
+            data-test="copyButton"
+          >
+            Copy
+          </Button>
+        </Flex>
+      )}
     </Box>
   )
 }

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorModalContent.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/BackupSecondFactorModalContent.tsx
@@ -1,8 +1,9 @@
-import { Button, BorderBoxProps, Box, Flex, Sans } from "@artsy/palette"
+import { BorderBoxProps, Box, Flex, Sans } from "@artsy/palette"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
-import React, { useEffect, useState } from "react"
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
+import { BackupSecondFactorActions } from "./BackupSecondFactorActions"
 import { BackupSecondFactorModalContent_me } from "v2/__generated__/BackupSecondFactorModalContent_me.graphql"
 import { BackupSecondFactorModalContentQuery } from "v2/__generated__/BackupSecondFactorModalContentQuery.graphql"
 
@@ -15,29 +16,6 @@ interface BackupSecondFactorModalContentProps extends BorderBoxProps {
 
 export const BackupSecondFactorModalContent: React.FC<BackupSecondFactorModalContentProps> = props => {
   const { me } = props
-
-  const [supportsClipboard, setSupportsClipboard] = useState(false)
-
-  useEffect(() => {
-    // Only render the copy button if browser supports the Clipboard API
-    // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
-    if ("clipboard" in navigator) setSupportsClipboard(true)
-  }, [])
-
-  function copyCodesToClipboard() {
-    const codes = me.backupSecondFactors!.map(item => item!.code).join("\n")
-    navigator.clipboard.writeText(codes)
-  }
-
-  function downloadCodes() {
-    const codes = me.backupSecondFactors!.map(item => item!.code).join("\n")
-    const element = document.createElement("a")
-    const file = new Blob([codes], { type: "text/plain" })
-    element.href = URL.createObjectURL(file)
-    element.download = "recovery_codes.txt"
-    document.body.appendChild(element) // Required for this to work in FireFox
-    element.click()
-  }
 
   return (
     <Box minHeight="280px">
@@ -57,29 +35,8 @@ export const BackupSecondFactorModalContent: React.FC<BackupSecondFactorModalCon
         ))}
       </Flex>
 
-      <Flex justifyContent="center">
-        {supportsClipboard && (
-          <Button
-            onClick={copyCodesToClipboard}
-            variant="secondaryOutline"
-            size="small"
-            m={1}
-            data-test="copyButton"
-          >
-            Copy
-          </Button>
-        )}
-
-        <Button
-          onClick={downloadCodes}
-          variant="secondaryOutline"
-          size="small"
-          m={1}
-          data-test="downloadButton"
-        >
-          Download
-        </Button>
-      </Flex>
+      <BackupSecondFactorActions
+        backupSecondFactors={me.backupSecondFactors!.map(item => item!.code!.toString())} />
     </Box>
   )
 }

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/__tests__/BackupSecondFactorActions.jest.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/__tests__/BackupSecondFactorActions.jest.tsx
@@ -1,0 +1,73 @@
+import { mount } from "enzyme"
+import { BackupSecondFactorActions } from "../BackupSecondFactorActions"
+
+describe("Two factor authentication enrollment", () => {
+  const props = {
+    backupSecondFactors: ["d3bd78d468", "7aa4c5922c"],
+  }
+  const getWrapper = (passedProps = props) => {
+    return mount(<BackupSecondFactorActions {...passedProps} />)
+  }
+
+  const getCopyButton = () => {
+    return getWrapper().find('[data-test="copyButton"]').first()
+  }
+
+  describe("when the browser does not support clipboard", () => {
+    it("displays a copy button based on browser support", () => {
+      expect(getCopyButton()).toHaveLength(0)
+    })
+  })
+
+  describe("when the browser supports clipboard", () => {
+    const mockClipboard = { writeText: jest.fn() }
+    beforeEach(() => {
+      Object.assign(navigator, {
+        clipboard: mockClipboard,
+      })
+    })
+
+    it("displays a copy button", () => {
+      const copyButton = getCopyButton()
+
+      expect(copyButton).toHaveLength(1)
+      expect(copyButton.text()).toBe("Copy")
+    })
+
+    it("enables user to copy the recovery codes", () => {
+      const copyButtonProps = getCopyButton().props()
+
+      if (copyButtonProps.onClick) copyButtonProps.onClick({} as any)
+
+      expect(navigator.clipboard.writeText).toBeCalledTimes(1)
+    })
+  })
+
+  describe("txt file download", () => {
+    const downloadButton = getWrapper()
+      .find('[data-test="downloadButton"]')
+      .first()
+
+    it("displays a download button", () => {
+      expect(downloadButton).toHaveLength(1)
+      expect(downloadButton.text()).toBe("Download")
+    })
+
+    it("enables user to download the recovery codes", () => {
+      global.URL.createObjectURL = jest.fn()
+
+      // @ts-ignore: Type
+      global.Blob = function (content, options) {
+        return { content, options }
+      }
+
+      const downloadButtonProps = downloadButton.props()
+      if (downloadButtonProps.onClick) downloadButtonProps.onClick({} as any)
+
+      expect(URL.createObjectURL).toBeCalledWith({
+        content: ["d3bd78d468\n7aa4c5922c"],
+        options: { type: "text/plain" },
+      })
+    })
+  })
+})

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
@@ -1,5 +1,11 @@
-import { BorderBoxProps, Box, Flex, Text } from "@artsy/palette"
-import * as React from "react";
+import {
+  BorderBoxProps,
+  Box,
+  Button,
+  Flex,
+  Text,
+} from "@artsy/palette"
+import React, { useEffect, useState } from "react"
 
 interface BackupSecondFactorReminderProps extends BorderBoxProps {
   backupSecondFactors: string[]
@@ -8,6 +14,17 @@ interface BackupSecondFactorReminderProps extends BorderBoxProps {
 
 export const BackupSecondFactorReminder: React.FC<BackupSecondFactorReminderProps> = props => {
   const { backupSecondFactors, factorTypeName } = props
+  const [supportsClipboard, setSupportsClipboard] = useState(false)
+
+  useEffect(() => {
+    // Only render the copy button if browser supports the Clipboard API
+    // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
+    if ("clipboard" in navigator) setSupportsClipboard(true)
+  }, [])
+
+  function copyCodesToClipboard() {
+    navigator.clipboard.writeText(props.backupSecondFactors.join("\n"))
+  }
 
   return (
     <Box minHeight="280px">
@@ -36,6 +53,21 @@ export const BackupSecondFactorReminder: React.FC<BackupSecondFactorReminderProp
           </Box>
         ))}
       </Flex>
+
+      {supportsClipboard && (
+        <Flex justifyContent="center">
+          <Button
+            onClick={copyCodesToClipboard}
+            variant="secondaryOutline"
+            size="small"
+            mt={1}
+            mb={1}
+            data-test="copyButton"
+          >
+            Copy
+          </Button>
+        </Flex>
+      )}
     </Box>
   )
 }

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
@@ -1,10 +1,4 @@
-import {
-  BorderBoxProps,
-  Box,
-  Button,
-  Flex,
-  Text,
-} from "@artsy/palette"
+import { BorderBoxProps, Box, Button, Flex, Text } from "@artsy/palette"
 import React, { useEffect, useState } from "react"
 
 interface BackupSecondFactorReminderProps extends BorderBoxProps {
@@ -24,6 +18,16 @@ export const BackupSecondFactorReminder: React.FC<BackupSecondFactorReminderProp
 
   function copyCodesToClipboard() {
     navigator.clipboard.writeText(props.backupSecondFactors.join("\n"))
+  }
+
+  function downloadCodes() {
+    const codes = props.backupSecondFactors.join("\n")
+    const element = document.createElement("a")
+    const file = new Blob([codes], { type: "text/plain" })
+    element.href = URL.createObjectURL(file)
+    element.download = "recovery_codes.txt"
+    document.body.appendChild(element) // Required for this to work in FireFox
+    element.click()
   }
 
   return (
@@ -54,8 +58,8 @@ export const BackupSecondFactorReminder: React.FC<BackupSecondFactorReminderProp
         ))}
       </Flex>
 
-      {supportsClipboard && (
-        <Flex justifyContent="center">
+      <Flex justifyContent="center">
+        {supportsClipboard && (
           <Button
             onClick={copyCodesToClipboard}
             variant="secondaryOutline"
@@ -66,8 +70,18 @@ export const BackupSecondFactorReminder: React.FC<BackupSecondFactorReminderProp
           >
             Copy
           </Button>
-        </Flex>
-      )}
+        )}
+
+        <Button
+          onClick={downloadCodes}
+          variant="secondaryOutline"
+          size="small"
+          m={1}
+          data-test="downloadButton"
+        >
+          Download
+        </Button>
+      </Flex>
     </Box>
   )
 }

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
@@ -1,5 +1,6 @@
-import { BorderBoxProps, Box, Button, Flex, Text } from "@artsy/palette"
-import React, { useEffect, useState } from "react"
+import { BorderBoxProps, Box, Flex, Text } from "@artsy/palette"
+import { BackupSecondFactorActions } from "./BackupSecondFactor/BackupSecondFactorActions"
+import * as React from "react"
 
 interface BackupSecondFactorReminderProps extends BorderBoxProps {
   backupSecondFactors: string[]
@@ -8,27 +9,6 @@ interface BackupSecondFactorReminderProps extends BorderBoxProps {
 
 export const BackupSecondFactorReminder: React.FC<BackupSecondFactorReminderProps> = props => {
   const { backupSecondFactors, factorTypeName } = props
-  const [supportsClipboard, setSupportsClipboard] = useState(false)
-
-  useEffect(() => {
-    // Only render the copy button if browser supports the Clipboard API
-    // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
-    if ("clipboard" in navigator) setSupportsClipboard(true)
-  }, [])
-
-  function copyCodesToClipboard() {
-    navigator.clipboard.writeText(props.backupSecondFactors.join("\n"))
-  }
-
-  function downloadCodes() {
-    const codes = props.backupSecondFactors.join("\n")
-    const element = document.createElement("a")
-    const file = new Blob([codes], { type: "text/plain" })
-    element.href = URL.createObjectURL(file)
-    element.download = "recovery_codes.txt"
-    document.body.appendChild(element) // Required for this to work in FireFox
-    element.click()
-  }
 
   return (
     <Box minHeight="280px">
@@ -58,30 +38,7 @@ export const BackupSecondFactorReminder: React.FC<BackupSecondFactorReminderProp
         ))}
       </Flex>
 
-      <Flex justifyContent="center">
-        {supportsClipboard && (
-          <Button
-            onClick={copyCodesToClipboard}
-            variant="secondaryOutline"
-            size="small"
-            mt={1}
-            mb={1}
-            data-test="copyButton"
-          >
-            Copy
-          </Button>
-        )}
-
-        <Button
-          onClick={downloadCodes}
-          variant="secondaryOutline"
-          size="small"
-          m={1}
-          data-test="downloadButton"
-        >
-          Download
-        </Button>
-      </Flex>
+      <BackupSecondFactorActions backupSecondFactors={backupSecondFactors} />
     </Box>
   )
 }

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/__tests__/TwoFactorAuthentication.jest.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/__tests__/TwoFactorAuthentication.jest.tsx
@@ -19,6 +19,8 @@ import {
   UpdateSmsSecondFactorMutationSuccessResponse,
 } from "./fixtures"
 import { TwoFactorAuthenticationTestPage } from "./Utils/TwoFactorAuthenticationTestPage"
+import { mount } from "enzyme"
+import { BackupSecondFactorReminder } from "../Components/BackupSecondFactorReminder"
 
 jest.unmock("react-relay")
 HTMLCanvasElement.prototype.getContext = jest.fn()
@@ -194,6 +196,50 @@ describe("TwoFactorAuthentication", () => {
 
         done()
       })
+    })
+  })
+})
+
+describe("Two factor authentication enrollment", () => {
+  const props = {
+    backupSecondFactors: ['d3bd78d468', '7aa4c5922c'],
+    factorTypeName: 'AppSecondFactor'
+  }
+  const getWrapper = (passedProps = props) => {
+    return mount(<BackupSecondFactorReminder {...passedProps} />)
+  }
+
+  const getCopyButton = () => {
+    return getWrapper().find('[data-test="copyButton"]').first()
+  }
+
+  describe("when the browser does not support clipboard", () => {
+    it("displays a copy button based on browser support", () => {
+      expect(getCopyButton()).toHaveLength(0)
+    })
+  })
+
+  describe("when the browser supports clipboard", () => {
+    const mockClipboard = { writeText: jest.fn() };
+    beforeEach(() => {
+      Object.assign(navigator, {
+        clipboard: mockClipboard
+      });
+    })
+
+    it("displays a copy button", () => {
+      const copyButton = getCopyButton()
+
+      expect(copyButton).toHaveLength(1)
+      expect(copyButton.text()).toBe("Copy")
+    })
+
+    it("enables user to copy the recovery codes", () => {
+      const copyButtonProps = getCopyButton().props()
+
+      if (copyButtonProps.onClick) copyButtonProps.onClick({} as any);
+
+      expect(navigator.clipboard.writeText).toBeCalledTimes(1)
     })
   })
 })

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/__tests__/TwoFactorAuthentication.jest.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/__tests__/TwoFactorAuthentication.jest.tsx
@@ -19,8 +19,6 @@ import {
   UpdateSmsSecondFactorMutationSuccessResponse,
 } from "./fixtures"
 import { TwoFactorAuthenticationTestPage } from "./Utils/TwoFactorAuthenticationTestPage"
-import { mount } from "enzyme"
-import { BackupSecondFactorReminder } from "../Components/BackupSecondFactorReminder"
 
 jest.unmock("react-relay")
 HTMLCanvasElement.prototype.getContext = jest.fn()
@@ -196,50 +194,6 @@ describe("TwoFactorAuthentication", () => {
 
         done()
       })
-    })
-  })
-})
-
-describe("Two factor authentication enrollment", () => {
-  const props = {
-    backupSecondFactors: ['d3bd78d468', '7aa4c5922c'],
-    factorTypeName: 'AppSecondFactor'
-  }
-  const getWrapper = (passedProps = props) => {
-    return mount(<BackupSecondFactorReminder {...passedProps} />)
-  }
-
-  const getCopyButton = () => {
-    return getWrapper().find('[data-test="copyButton"]').first()
-  }
-
-  describe("when the browser does not support clipboard", () => {
-    it("displays a copy button based on browser support", () => {
-      expect(getCopyButton()).toHaveLength(0)
-    })
-  })
-
-  describe("when the browser supports clipboard", () => {
-    const mockClipboard = { writeText: jest.fn() };
-    beforeEach(() => {
-      Object.assign(navigator, {
-        clipboard: mockClipboard
-      });
-    })
-
-    it("displays a copy button", () => {
-      const copyButton = getCopyButton()
-
-      expect(copyButton).toHaveLength(1)
-      expect(copyButton.text()).toBe("Copy")
-    })
-
-    it("enables user to copy the recovery codes", () => {
-      const copyButtonProps = getCopyButton().props()
-
-      if (copyButtonProps.onClick) copyButtonProps.onClick({} as any);
-
-      expect(navigator.clipboard.writeText).toBeCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
[PLATFORM-3280]

- [x] Add a `copy` button to the modal that is displayed by the time a user enables 2FA
- [x] Add a `copy` button to the modal that is displayed by the time a user clicks on `show` or `regenerate` backup codes
- [x] Add a `download` button to the modal that is displayed by the time a user enables 2FA
- [x] Add a `download` button to the modal that is displayed by the time a user clicks on `show` or `regenerate` backup codes
- [x] Refactor

<img width="434" alt="Screenshot 2021-11-23 at 18 23 07" src="https://user-images.githubusercontent.com/8002618/143074122-e9706d2e-d93b-40f2-a97d-6f4fb574b1c0.png">


[PLATFORM-3280]: https://artsyproduct.atlassian.net/browse/PLATFORM-3280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ