### PR TITLE
feat(FX-3582): add analytics tracking for alert save

### DIFF
--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -35,6 +35,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
     type: "artist",
     id: artist.internalID,
     name: artist.name ?? "",
+    slug: artist.slug,
   }
 
   return (

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react"
 import { BellIcon, Button } from "@artsy/palette"
 import { CreateSavedSearchAlert } from "v2/Components/SavedSearchAlert/CreateSavedSearchAlert"
 import { SavedSearchAttributes } from "../types"
+import { useTracking } from "v2/System"
+import { ActionType, PageOwnerType } from "@artsy/cohesion"
 
 interface CreateAlertButtonProps {
   savedSearchAttributes: SavedSearchAttributes
@@ -10,9 +12,19 @@ interface CreateAlertButtonProps {
 export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
   savedSearchAttributes,
 }) => {
+  const tracking = useTracking()
   const [visibleForm, setVisibleForm] = useState(false)
 
-  const handleOpenForm = () => setVisibleForm(true)
+  const handleOpenForm = () => {
+    setVisibleForm(true)
+
+    tracking.trackEvent({
+      action: ActionType.clickedCreateAlert,
+      context_page_owner_type: savedSearchAttributes.type as PageOwnerType,
+      context_page_owner_id: savedSearchAttributes.id,
+      context_page_owner_slug: savedSearchAttributes.slug,
+    })
+  }
   const handleCloseForm = () => setVisibleForm(false)
 
   return (

--- a/src/v2/Components/ArtworkFilter/SavedSearch/types.ts
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/types.ts
@@ -22,6 +22,7 @@ export interface SavedSearchAttributes {
   type: "artist"
   id: string
   name: string
+  slug: string
 }
 
 export type SearchCriteriaAttributeKeys = keyof SearchCriteriaAttributes

--- a/src/v2/Components/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/v2/Components/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -3,6 +3,8 @@ import { Modal, Text } from "@artsy/palette"
 import { SavedSearchAlertForm } from "./SavedSearchAlertForm"
 import { SavedSearchAlertMutationResult } from "./SavedSearchAlertModel"
 import { SavedSearchAttributes } from "../ArtworkFilter/SavedSearch/types"
+import { useTracking } from "v2/System"
+import { ActionType, PageOwnerType } from "@artsy/cohesion"
 
 interface CreateSavedSearchAlertProps {
   savedSearchAttributes: SavedSearchAttributes
@@ -17,8 +19,23 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = ({
   onComplete,
   visible,
 }) => {
+  const tracking = useTracking()
+
+  const trackAlertSave = (savedSearchId: string) => {
+    const trackInfo = {
+      action_type: ActionType.toggledSavedSearch,
+      context_page_owner_type: savedSearchAttributes.type as PageOwnerType,
+      context_page_owner_id: savedSearchAttributes.id,
+      context_page_owner_slug: savedSearchAttributes.slug,
+      saved_search_id: savedSearchId,
+    }
+
+    tracking.trackEvent(trackInfo)
+  }
+
   const handleComplete = async (result: SavedSearchAlertMutationResult) => {
     onComplete(result)
+    trackAlertSave(result.id)
   }
 
   return (

--- a/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertForm.jest.tsx
+++ b/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertForm.jest.tsx
@@ -19,6 +19,7 @@ const savedSearchProps: SavedSearchAttributes = {
   type: "artist",
   id: "test-artist-id",
   name: "test-artist-name",
+  slug: "test-artist-slug",
 }
 
 const savedSearchFilters = {


### PR DESCRIPTION
Jira: [FX-3582](https://artsyproduct.atlassian.net/browse/FX-3582)

### Description
Track analytics event toggled_saved_search when user saves an alert 
More info [here](https://docs.google.com/spreadsheets/d/1_VDAmRJz2K87FXDq7oh_tQSgwBv4syuZjaaR3sfetcI/edit#gid=121201130)

### Changes
- update saved search model
- add analytics tracking

### Demo
![image](https://user-images.githubusercontent.com/56556580/143236368-7f41e4b1-3b4a-4902-a2bb-e4dd35e38181.png)
