### PR TITLE
fix: Attachment display on conversation sidebar

### DIFF
--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -101,11 +101,6 @@ export const Details: FC<DetailsProps> = ({
     ?.map(edge => edge?.node?.attachments)
     ?.filter(attachments => attachments?.length)
     ?.flat()
-  // ?.filter(attachment => !attachment?.contentType.includes("image"))
-
-  useEffect(() => {
-    console.log("Hey HEy", attachments)
-  }, [])
 
   const attachmentItems = attachments
     ?.filter(attachment => attachment?.id && attachment?.downloadURL)

--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from "react";
+import { FC, useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import {
   Box,
@@ -55,6 +55,12 @@ const DetailsContainer = styled(Flex)<{ transform?: string }>`
   `}
 `
 
+const TruncatedLine = styled(Text)`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+`
+
 interface DetailsProps extends FlexProps {
   conversation: Details_conversation
   showDetails: boolean
@@ -94,8 +100,12 @@ export const Details: FC<DetailsProps> = ({
   const attachments = conversation?.messagesConnection?.edges
     ?.map(edge => edge?.node?.attachments)
     ?.filter(attachments => attachments?.length)
-    ?.reduce((previous, current) => previous?.concat(current!), [])
-    ?.filter(attachment => !attachment?.contentType.includes("image"))
+    ?.flat()
+  // ?.filter(attachment => !attachment?.contentType.includes("image"))
+
+  useEffect(() => {
+    console.log("Hey HEy", attachments)
+  }, [])
 
   const attachmentItems = attachments
     ?.filter(attachment => attachment?.id && attachment?.downloadURL)
@@ -109,7 +119,7 @@ export const Details: FC<DetailsProps> = ({
         >
           <Flex alignItems="center">
             <DocumentIcon mr={0.5} />
-            <Text variant="xs">{attachment?.fileName}</Text>
+            <TruncatedLine variant="xs">{attachment?.fileName}</TruncatedLine>
           </Flex>
         </Link>
       )
@@ -195,7 +205,7 @@ export const Details: FC<DetailsProps> = ({
           </Flex>
         </>
       )}
-      {attachments?.length && (
+      {!!attachments?.length && (
         <>
           <Separator my={2} />
           <Box px={2}>


### PR DESCRIPTION
[NX-3027]

Fixed an issue causing the length of the attachments to display on the conversation sidebar if there was none, and no attachments if any were present.
Also included is an ellipsis for long file names while at it, but this area's design is set to be revisited soon.

Before (displaying the actual `attachments.length`):
![image](https://user-images.githubusercontent.com/7117670/143254732-62404e8b-aad1-4902-85c9-72c26226108c.png)

After (with and without attachments):
<img width="378" alt="Screenshot 2021-11-24 at 15 09 44" src="https://user-images.githubusercontent.com/7117670/143255152-3c3627db-aa80-4e98-ac89-042f9acc4b56.png">
<img width="375" alt="Screenshot 2021-11-24 at 12 18 58" src="https://user-images.githubusercontent.com/7117670/143255186-983266f9-af7c-41ea-a8d5-741a49009fcf.png">

cc: @artsy/negotiate-devs 



[NX-3027]: https://artsyproduct.atlassian.net/browse/NX-3027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ