### PR TITLE
feat(FX-3581): analytics tracking for create alert button

### DIFF
--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -35,6 +35,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
     type: "artist",
     id: artist.internalID,
     name: artist.name ?? "",
+    slug: artist.slug,
   }
 
   return (

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react"
 import { BellIcon, Button } from "@artsy/palette"
 import { CreateSavedSearchAlert } from "v2/Components/SavedSearchAlert/CreateSavedSearchAlert"
 import { SavedSearchAttributes } from "../types"
+import { useTracking } from "v2/System"
+import { ActionType, PageOwnerType } from "@artsy/cohesion"
 
 interface CreateAlertButtonProps {
   savedSearchAttributes: SavedSearchAttributes
@@ -10,9 +12,19 @@ interface CreateAlertButtonProps {
 export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
   savedSearchAttributes,
 }) => {
+  const tracking = useTracking()
   const [visibleForm, setVisibleForm] = useState(false)
 
-  const handleOpenForm = () => setVisibleForm(true)
+  const handleOpenForm = () => {
+    setVisibleForm(true)
+
+    tracking.trackEvent({
+      action: ActionType.clickedCreateAlert,
+      context_page_owner_type: savedSearchAttributes.type as PageOwnerType,
+      context_page_owner_id: savedSearchAttributes.id,
+      context_page_owner_slug: savedSearchAttributes.slug,
+    })
+  }
   const handleCloseForm = () => setVisibleForm(false)
 
   return (

--- a/src/v2/Components/ArtworkFilter/SavedSearch/types.ts
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/types.ts
@@ -22,6 +22,7 @@ export interface SavedSearchAttributes {
   type: "artist"
   id: string
   name: string
+  slug: string
 }
 
 export type SearchCriteriaAttributeKeys = keyof SearchCriteriaAttributes

--- a/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertForm.jest.tsx
+++ b/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertForm.jest.tsx
@@ -19,6 +19,7 @@ const savedSearchProps: SavedSearchAttributes = {
   type: "artist",
   id: "test-artist-id",
   name: "test-artist-name",
+  slug: "test-artist-slug",
 }
 
 const savedSearchFilters = {


### PR DESCRIPTION
Jira: [FX-3581](https://artsyproduct.atlassian.net/browse/FX-3581)

### Description
Track `ClickedCreateAlert` event when user clicks "create alert" button 
More info [here](https://docs.google.com/spreadsheets/d/1_VDAmRJz2K87FXDq7oh_tQSgwBv4syuZjaaR3sfetcI/edit#gid=121201130)

### Changes
- add analytics tracking

### Demo
When user click the button this event is fired
![image](https://user-images.githubusercontent.com/56556580/143255462-30024a33-6efa-457b-8c1a-0bfb14710dfc.png)

