### PR TITLE
feat(FX-3607): Upon email alert click scroll down to artwork grid immediately

### DIFF
--- a/src/v2/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
@@ -31,7 +31,9 @@ const ArtistWorksForSaleRoute: React.FC<ArtistWorksForSaleRouteProps> = ({
 
   useEffect(() => {
     if (isMatchMediaParsed && match?.location?.query?.search_criteria_id) {
-      scrollTo()
+      requestAnimationFrame(() => {
+        scrollTo()
+      })
     }
   }, [isMatchMediaParsed])
 

--- a/src/v2/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
@@ -29,6 +29,13 @@ const ArtistWorksForSaleRoute: React.FC<ArtistWorksForSaleRouteProps> = ({
     offset: 10,
   })
 
+  /**
+   * We should perform scroll only when isReadyForUse is true
+   * Otherwise the wrong offset will be used for mWeb
+   *
+   * scrollTo without requestAnimationFrame doesn't work in Safari
+   * when it is used in useEffect hook
+   */
   useEffect(() => {
     if (isReadyForUse && match?.location?.query?.search_criteria_id) {
       requestAnimationFrame(() => {

--- a/src/v2/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistArtworkFilterRefetchContainer } from "./Components/ArtistArtworkFilter"
 import { ArtistWorksForSaleRoute_artist } from "v2/__generated__/ArtistWorksForSaleRoute_artist.graphql"
@@ -7,6 +7,8 @@ import { ArtistSeriesRailFragmentContainer } from "v2/Components/ArtistSeriesRai
 import { ContextModule } from "@artsy/cohesion"
 import { computeTitle } from "v2/Apps/Artist/Utils/computeTitle"
 import { Title } from "react-head"
+import { useScrollTo } from "v2/Utils/Hooks/useScrollTo"
+import { useRouter } from "v2/System/Router/useRouter"
 
 interface ArtistWorksForSaleRouteProps {
   artist: ArtistWorksForSaleRoute_artist
@@ -20,6 +22,18 @@ const ArtistWorksForSaleRoute: React.FC<ArtistWorksForSaleRouteProps> = ({
     artist?.counts?.forSaleArtworks!,
     true
   )
+  const { match } = useRouter()
+  const { scrollTo, isMatchMediaParsed } = useScrollTo({
+    selectorOrRef: "#jump--artworkFilter",
+    behavior: "smooth",
+    offset: 10,
+  })
+
+  useEffect(() => {
+    if (isMatchMediaParsed && match?.location?.query?.search_criteria_id) {
+      scrollTo()
+    }
+  }, [isMatchMediaParsed])
 
   return (
     <>

--- a/src/v2/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
@@ -23,19 +23,19 @@ const ArtistWorksForSaleRoute: React.FC<ArtistWorksForSaleRouteProps> = ({
     true
   )
   const { match } = useRouter()
-  const { scrollTo, isMatchMediaParsed } = useScrollTo({
+  const { scrollTo, isReadyForUse } = useScrollTo({
     selectorOrRef: "#jump--artworkFilter",
     behavior: "smooth",
     offset: 10,
   })
 
   useEffect(() => {
-    if (isMatchMediaParsed && match?.location?.query?.search_criteria_id) {
+    if (isReadyForUse && match?.location?.query?.search_criteria_id) {
       requestAnimationFrame(() => {
         scrollTo()
       })
     }
-  }, [isMatchMediaParsed])
+  }, [isReadyForUse])
 
   return (
     <>

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -7,12 +7,13 @@ import {
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { Match } from "found"
-import * as React from "react"
+import React, { useEffect } from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { ZeroState } from "./ZeroState"
 import { useRouter } from "v2/System/Router/useRouter"
 import { SavedSearchAttributes } from "v2/Components/ArtworkFilter/SavedSearch/types"
+import { useScrollTo } from "v2/Utils/Hooks/useScrollTo"
 
 interface ArtistArtworkFilterProps {
   aggregations: SharedArtworkFilterContextProps["aggregations"]
@@ -26,6 +27,18 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
   const { relay, aggregations, artist } = props
   const { filtered_artworks } = artist
   const hasFilter = filtered_artworks && filtered_artworks.id
+
+  const { scrollTo, isMatchMediaParsed } = useScrollTo({
+    selectorOrRef: "#jump--artworkFilter",
+    behavior: "smooth",
+    offset: 10,
+  })
+
+  useEffect(() => {
+    if (isMatchMediaParsed && match?.location?.query?.search_criteria_id) {
+      scrollTo()
+    }
+  }, [isMatchMediaParsed])
 
   if (!hasFilter) {
     return null

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -7,13 +7,12 @@ import {
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { Match } from "found"
-import React, { useEffect } from "react"
+import * as React from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import { ZeroState } from "./ZeroState"
 import { useRouter } from "v2/System/Router/useRouter"
 import { SavedSearchAttributes } from "v2/Components/ArtworkFilter/SavedSearch/types"
-import { useScrollTo } from "v2/Utils/Hooks/useScrollTo"
 
 interface ArtistArtworkFilterProps {
   aggregations: SharedArtworkFilterContextProps["aggregations"]
@@ -27,18 +26,6 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
   const { relay, aggregations, artist } = props
   const { filtered_artworks } = artist
   const hasFilter = filtered_artworks && filtered_artworks.id
-
-  const { scrollTo, isMatchMediaParsed } = useScrollTo({
-    selectorOrRef: "#jump--artworkFilter",
-    behavior: "smooth",
-    offset: 10,
-  })
-
-  useEffect(() => {
-    if (isMatchMediaParsed && match?.location?.query?.search_criteria_id) {
-      scrollTo()
-    }
-  }, [isMatchMediaParsed])
 
   if (!hasFilter) {
     return null

--- a/src/v2/Utils/Hooks/useScrollTo.ts
+++ b/src/v2/Utils/Hooks/useScrollTo.ts
@@ -47,5 +47,5 @@ export const useScrollTo = ({
     window.scrollTo({ top: position, behavior })
   }
 
-  return { scrollTo, isMatchMediaParsed: isMobile !== null }
+  return { scrollTo, isReadyForUse: isMobile !== null }
 }

--- a/src/v2/Utils/Hooks/useScrollTo.ts
+++ b/src/v2/Utils/Hooks/useScrollTo.ts
@@ -47,5 +47,5 @@ export const useScrollTo = ({
     window.scrollTo({ top: position, behavior })
   }
 
-  return { scrollTo }
+  return { scrollTo, isMatchMediaParsed: isMobile !== null }
 }


### PR DESCRIPTION
Type: **Feature**
Jira ticket: [FX-3607]

### Description
* Clicking the CTA in the email alert should lead the user directly to the artworks they want to see on the Artist’s Works for Sale tab
* The effect should be that the screen “jumps” right to the artwork grid on the artist artwork tab, rather than land at the top of the mWeb page

### Demo
[Demo link](https://artist-artworks-scroll.artsy.net/artist/kaws/works-for-sale?attribution_class%5B0%5D=unique&additional_gene_ids%5B0%5D=sculpture&search_criteria_id=f5c5e83b-a53c-4461-a496-bba7ddc109ca)
#### Web
https://user-images.githubusercontent.com/3513494/143268199-14950fca-c7da-48b3-af4c-c797f658f7e4.mp4

#### mWeb
https://user-images.githubusercontent.com/3513494/143268226-118f2caf-e340-46c6-aa16-e42dce1c434e.mp4


[FX-3607]: https://artsyproduct.atlassian.net/browse/FX-3607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ