### PR TITLE
Avoid erroring when Marketo js fails to load

### DIFF
--- a/src/desktop/apps/partnerships/templates/auction_sections.jade
+++ b/src/desktop/apps/partnerships/templates/auction_sections.jade
@@ -22,7 +22,7 @@ mixin auction_apply(section)
       script(src='//app-ab14.marketo.com/js/forms2/js/forms2.min.js')
       form#mktoForm_1240
       script.
-        MktoForms2.loadForm("//app-ab14.marketo.com", "609-FDY-207", 1240);
+        typeof MktoForms2 !== "undefined" && MktoForms2.loadForm("//app-ab14.marketo.com", "609-FDY-207", 1240);
 
 mixin auction_audience(section)
   .partnerships-section-header.audience

--- a/src/desktop/components/article/templates/gi_signup.jade
+++ b/src/desktop/components/article/templates/gi_signup.jade
@@ -4,6 +4,6 @@ script(src='//app-ab14.marketo.com/js/forms2/js/forms2.min.js')
     .article-subscribe-mainheader Subscribe to the Gallery Insights newsletter
     .article-subscribe-subheader The latest market research, art buying trends & forecasts, and tools to help you excel.
     script.
-      MktoForms2.loadForm("//app-ab14.marketo.com", "609-FDY-207", 1230);
+      typeof MktoForms2 !== "undefined" && MktoForms2.loadForm("//app-ab14.marketo.com", "609-FDY-207", 1230);
     .articles-insights-marketo-form
       form#mktoForm_1230


### PR DESCRIPTION
Smoke tests (which are just the usual acceptance tests, but against staging) [fail](https://app.circleci.com/pipelines/github/artsy/force/21926/workflows/eb3679b8-cfbf-4d59-a2c7-869501cdc183/jobs/166537) surprisingly often on the `/auction-partnerships` page with `MktoForms2 is not defined`. I haven't been able to reproduce the issue myself, so I'm hoping it's limited to cypress tests. 🤞 

This PR adds a guard that prevents the Marketo reference from raising a client-side error. If there's a straightforward way to defer this call (possibly increasing its likelihood of succeeding) instead of skipping it, I'd be open to that.