### PR TITLE
fix(partners): updates carousel to use connection

### DIFF
--- a/src/v2/Apps/Partners/Components/PartnersFeaturedCarousel.tsx
+++ b/src/v2/Apps/Partners/Components/PartnersFeaturedCarousel.tsx
@@ -1,7 +1,7 @@
-import { compact } from "lodash"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { HeroCarousel } from "v2/Components/HeroCarousel/HeroCarousel"
+import { extractNodes } from "v2/Utils/extractNodes"
 import { PartnersFeaturedCarousel_viewer } from "v2/__generated__/PartnersFeaturedCarousel_viewer.graphql"
 import { PartnersFeaturedCarouselCellFragmentContainer } from "./PartnersFeaturedCarouselCell"
 
@@ -12,7 +12,7 @@ interface PartnersFeaturedCarouselProps {
 const PartnersFeaturedCarousel: FC<PartnersFeaturedCarouselProps> = ({
   viewer,
 }) => {
-  const profiles = compact(viewer.orderedSet?.items)
+  const profiles = extractNodes(viewer.orderedSet?.orderedItemsConnection)
 
   return (
     <HeroCarousel fullBleed={false}>
@@ -35,10 +35,14 @@ export const PartnersFeaturedCarouselFragmentContainer = createFragmentContainer
       fragment PartnersFeaturedCarousel_viewer on Viewer
         @argumentDefinitions(id: { type: "String!" }) {
         orderedSet(id: $id) {
-          items {
-            ... on Profile {
-              internalID
-              ...PartnersFeaturedCarouselCell_profile
+          orderedItemsConnection(first: 50) {
+            edges {
+              node {
+                ... on Profile {
+                  internalID
+                  ...PartnersFeaturedCarouselCell_profile
+                }
+              }
             }
           }
         }

--- a/src/v2/__generated__/GalleriesRouteFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/GalleriesRouteFragmentContainer_Test_Query.graphql.ts
@@ -73,18 +73,22 @@ fragment PartnersFeaturedCarouselCell_profile on Profile {
 
 fragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {
   orderedSet(id: "5638fdfb7261690296000031") {
-    items {
-      __typename
-      ... on Profile {
-        internalID
-        ...PartnersFeaturedCarouselCell_profile
-        id
-      }
-      ... on Node {
-        id
-      }
-      ... on FeaturedLink {
-        id
+    orderedItemsConnection(first: 50) {
+      edges {
+        node {
+          __typename
+          ... on Profile {
+            internalID
+            ...PartnersFeaturedCarouselCell_profile
+            id
+          }
+          ... on Node {
+            id
+          }
+          ... on FeaturedLink {
+            id
+          }
+        }
       }
     }
     id
@@ -184,39 +188,32 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": null,
-                "concreteType": null,
-                "kind": "LinkedField",
-                "name": "items",
-                "plural": true,
-                "selections": [
-                  (v0/*: any*/),
-                  (v1/*: any*/),
+                "args": [
                   {
-                    "kind": "InlineFragment",
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 50
+                  }
+                ],
+                "concreteType": "OrderedSetItemConnection",
+                "kind": "LinkedField",
+                "name": "orderedItemsConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "OrderedSetItemEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
                     "selections": [
-                      (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
-                      (v3/*: any*/),
-                      {
-                        "alias": "is_followed",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isFollowed",
-                        "storageKey": null
-                      },
                       {
                         "alias": null,
                         "args": null,
                         "concreteType": null,
                         "kind": "LinkedField",
-                        "name": "owner",
+                        "name": "node",
                         "plural": false,
                         "selections": [
                           (v0/*: any*/),
@@ -225,136 +222,171 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v2/*: any*/),
-                              (v3/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
-                                "concreteType": "Show",
+                                "kind": "ScalarField",
+                                "name": "slug",
+                                "storageKey": null
+                              },
+                              (v3/*: any*/),
+                              {
+                                "alias": "is_followed",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isFollowed",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": null,
                                 "kind": "LinkedField",
-                                "name": "featuredShow",
+                                "name": "owner",
                                 "plural": false,
                                 "selections": [
-                                  (v3/*: any*/),
+                                  (v0/*: any*/),
+                                  (v1/*: any*/),
                                   {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "status",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "statusUpdate",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v4/*: any*/),
-                                    "kind": "ScalarField",
-                                    "name": "startAt",
-                                    "storageKey": "startAt(format:\"MMM D\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v4/*: any*/),
-                                    "kind": "ScalarField",
-                                    "name": "endAt",
-                                    "storageKey": "endAt(format:\"MMM D\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isOnlineExclusive",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Location",
-                                    "kind": "LinkedField",
-                                    "name": "location",
-                                    "plural": false,
+                                    "kind": "InlineFragment",
                                     "selections": [
+                                      (v2/*: any*/),
+                                      (v3/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "city",
-                                        "storageKey": null
-                                      },
-                                      (v1/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "coverImage",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "height",
-                                            "value": 500
-                                          },
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "normalized",
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
+                                        "concreteType": "Show",
                                         "kind": "LinkedField",
-                                        "name": "resized",
+                                        "name": "featuredShow",
                                         "plural": false,
                                         "selections": [
+                                          (v3/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
                                             "kind": "ScalarField",
-                                            "name": "src",
+                                            "name": "status",
                                             "storageKey": null
                                           },
                                           {
                                             "alias": null,
                                             "args": null,
                                             "kind": "ScalarField",
-                                            "name": "srcSet",
+                                            "name": "statusUpdate",
                                             "storageKey": null
-                                          }
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": (v4/*: any*/),
+                                            "kind": "ScalarField",
+                                            "name": "startAt",
+                                            "storageKey": "startAt(format:\"MMM D\")"
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": (v4/*: any*/),
+                                            "kind": "ScalarField",
+                                            "name": "endAt",
+                                            "storageKey": "endAt(format:\"MMM D\")"
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "isOnlineExclusive",
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Location",
+                                            "kind": "LinkedField",
+                                            "name": "location",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "city",
+                                                "storageKey": null
+                                              },
+                                              (v1/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Image",
+                                            "kind": "LinkedField",
+                                            "name": "coverImage",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "height",
+                                                    "value": 500
+                                                  },
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": [
+                                                      "normalized",
+                                                      "larger",
+                                                      "large"
+                                                    ]
+                                                  }
+                                                ],
+                                                "concreteType": "ResizedImageUrl",
+                                                "kind": "LinkedField",
+                                                "name": "resized",
+                                                "plural": false,
+                                                "selections": [
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "src",
+                                                    "storageKey": null
+                                                  },
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "srcSet",
+                                                    "storageKey": null
+                                                  }
+                                                ],
+                                                "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
+                                              }
+                                            ],
+                                            "storageKey": null
+                                          },
+                                          (v1/*: any*/)
                                         ],
-                                        "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
+                                        "storageKey": null
                                       }
                                     ],
-                                    "storageKey": null
-                                  },
-                                  (v1/*: any*/)
+                                    "type": "Partner"
+                                  }
                                 ],
                                 "storageKey": null
                               }
                             ],
-                            "type": "Partner"
+                            "type": "Profile"
                           }
                         ],
                         "storageKey": null
                       }
                     ],
-                    "type": "Profile"
+                    "storageKey": null
                   }
                 ],
-                "storageKey": null
+                "storageKey": "orderedItemsConnection(first:50)"
               },
               (v1/*: any*/)
             ],
@@ -370,7 +402,7 @@ return {
     "metadata": {},
     "name": "GalleriesRouteFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query GalleriesRouteFragmentContainer_Test_Query {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query GalleriesRouteFragmentContainer_Test_Query {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/InstitutionsRouteFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/InstitutionsRouteFragmentContainer_Test_Query.graphql.ts
@@ -73,18 +73,22 @@ fragment PartnersFeaturedCarouselCell_profile on Profile {
 
 fragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {
   orderedSet(id: "564e181a258faf3d5c000080") {
-    items {
-      __typename
-      ... on Profile {
-        internalID
-        ...PartnersFeaturedCarouselCell_profile
-        id
-      }
-      ... on Node {
-        id
-      }
-      ... on FeaturedLink {
-        id
+    orderedItemsConnection(first: 50) {
+      edges {
+        node {
+          __typename
+          ... on Profile {
+            internalID
+            ...PartnersFeaturedCarouselCell_profile
+            id
+          }
+          ... on Node {
+            id
+          }
+          ... on FeaturedLink {
+            id
+          }
+        }
       }
     }
     id
@@ -184,39 +188,32 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": null,
-                "concreteType": null,
-                "kind": "LinkedField",
-                "name": "items",
-                "plural": true,
-                "selections": [
-                  (v0/*: any*/),
-                  (v1/*: any*/),
+                "args": [
                   {
-                    "kind": "InlineFragment",
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 50
+                  }
+                ],
+                "concreteType": "OrderedSetItemConnection",
+                "kind": "LinkedField",
+                "name": "orderedItemsConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "OrderedSetItemEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
                     "selections": [
-                      (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
-                      (v3/*: any*/),
-                      {
-                        "alias": "is_followed",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isFollowed",
-                        "storageKey": null
-                      },
                       {
                         "alias": null,
                         "args": null,
                         "concreteType": null,
                         "kind": "LinkedField",
-                        "name": "owner",
+                        "name": "node",
                         "plural": false,
                         "selections": [
                           (v0/*: any*/),
@@ -225,136 +222,171 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v2/*: any*/),
-                              (v3/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
-                                "concreteType": "Show",
+                                "kind": "ScalarField",
+                                "name": "slug",
+                                "storageKey": null
+                              },
+                              (v3/*: any*/),
+                              {
+                                "alias": "is_followed",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isFollowed",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": null,
                                 "kind": "LinkedField",
-                                "name": "featuredShow",
+                                "name": "owner",
                                 "plural": false,
                                 "selections": [
-                                  (v3/*: any*/),
+                                  (v0/*: any*/),
+                                  (v1/*: any*/),
                                   {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "status",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "statusUpdate",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v4/*: any*/),
-                                    "kind": "ScalarField",
-                                    "name": "startAt",
-                                    "storageKey": "startAt(format:\"MMM D\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v4/*: any*/),
-                                    "kind": "ScalarField",
-                                    "name": "endAt",
-                                    "storageKey": "endAt(format:\"MMM D\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isOnlineExclusive",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Location",
-                                    "kind": "LinkedField",
-                                    "name": "location",
-                                    "plural": false,
+                                    "kind": "InlineFragment",
                                     "selections": [
+                                      (v2/*: any*/),
+                                      (v3/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "city",
-                                        "storageKey": null
-                                      },
-                                      (v1/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "coverImage",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "height",
-                                            "value": 500
-                                          },
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "normalized",
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
+                                        "concreteType": "Show",
                                         "kind": "LinkedField",
-                                        "name": "resized",
+                                        "name": "featuredShow",
                                         "plural": false,
                                         "selections": [
+                                          (v3/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
                                             "kind": "ScalarField",
-                                            "name": "src",
+                                            "name": "status",
                                             "storageKey": null
                                           },
                                           {
                                             "alias": null,
                                             "args": null,
                                             "kind": "ScalarField",
-                                            "name": "srcSet",
+                                            "name": "statusUpdate",
                                             "storageKey": null
-                                          }
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": (v4/*: any*/),
+                                            "kind": "ScalarField",
+                                            "name": "startAt",
+                                            "storageKey": "startAt(format:\"MMM D\")"
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": (v4/*: any*/),
+                                            "kind": "ScalarField",
+                                            "name": "endAt",
+                                            "storageKey": "endAt(format:\"MMM D\")"
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "isOnlineExclusive",
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Location",
+                                            "kind": "LinkedField",
+                                            "name": "location",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "city",
+                                                "storageKey": null
+                                              },
+                                              (v1/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Image",
+                                            "kind": "LinkedField",
+                                            "name": "coverImage",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "height",
+                                                    "value": 500
+                                                  },
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": [
+                                                      "normalized",
+                                                      "larger",
+                                                      "large"
+                                                    ]
+                                                  }
+                                                ],
+                                                "concreteType": "ResizedImageUrl",
+                                                "kind": "LinkedField",
+                                                "name": "resized",
+                                                "plural": false,
+                                                "selections": [
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "src",
+                                                    "storageKey": null
+                                                  },
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "srcSet",
+                                                    "storageKey": null
+                                                  }
+                                                ],
+                                                "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
+                                              }
+                                            ],
+                                            "storageKey": null
+                                          },
+                                          (v1/*: any*/)
                                         ],
-                                        "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
+                                        "storageKey": null
                                       }
                                     ],
-                                    "storageKey": null
-                                  },
-                                  (v1/*: any*/)
+                                    "type": "Partner"
+                                  }
                                 ],
                                 "storageKey": null
                               }
                             ],
-                            "type": "Partner"
+                            "type": "Profile"
                           }
                         ],
                         "storageKey": null
                       }
                     ],
-                    "type": "Profile"
+                    "storageKey": null
                   }
                 ],
-                "storageKey": null
+                "storageKey": "orderedItemsConnection(first:50)"
               },
               (v1/*: any*/)
             ],
@@ -370,7 +402,7 @@ return {
     "metadata": {},
     "name": "InstitutionsRouteFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query InstitutionsRouteFragmentContainer_Test_Query {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query InstitutionsRouteFragmentContainer_Test_Query {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnersFeaturedCarousel_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnersFeaturedCarousel_Test_Query.graphql.ts
@@ -69,18 +69,22 @@ fragment PartnersFeaturedCarouselCell_profile on Profile {
 
 fragment PartnersFeaturedCarousel_viewer_3GNcE2 on Viewer {
   orderedSet(id: "example") {
-    items {
-      __typename
-      ... on Profile {
-        internalID
-        ...PartnersFeaturedCarouselCell_profile
-        id
-      }
-      ... on Node {
-        id
-      }
-      ... on FeaturedLink {
-        id
+    orderedItemsConnection(first: 50) {
+      edges {
+        node {
+          __typename
+          ... on Profile {
+            internalID
+            ...PartnersFeaturedCarouselCell_profile
+            id
+          }
+          ... on Node {
+            id
+          }
+          ... on FeaturedLink {
+            id
+          }
+        }
       }
     }
     id
@@ -181,39 +185,32 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": null,
-                "concreteType": null,
-                "kind": "LinkedField",
-                "name": "items",
-                "plural": true,
-                "selections": [
-                  (v1/*: any*/),
-                  (v2/*: any*/),
+                "args": [
                   {
-                    "kind": "InlineFragment",
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 50
+                  }
+                ],
+                "concreteType": "OrderedSetItemConnection",
+                "kind": "LinkedField",
+                "name": "orderedItemsConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "OrderedSetItemEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
                     "selections": [
-                      (v3/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
-                      (v4/*: any*/),
-                      {
-                        "alias": "is_followed",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isFollowed",
-                        "storageKey": null
-                      },
                       {
                         "alias": null,
                         "args": null,
                         "concreteType": null,
                         "kind": "LinkedField",
-                        "name": "owner",
+                        "name": "node",
                         "plural": false,
                         "selections": [
                           (v1/*: any*/),
@@ -222,136 +219,171 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v3/*: any*/),
-                              (v4/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
-                                "concreteType": "Show",
+                                "kind": "ScalarField",
+                                "name": "slug",
+                                "storageKey": null
+                              },
+                              (v4/*: any*/),
+                              {
+                                "alias": "is_followed",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isFollowed",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": null,
                                 "kind": "LinkedField",
-                                "name": "featuredShow",
+                                "name": "owner",
                                 "plural": false,
                                 "selections": [
-                                  (v4/*: any*/),
+                                  (v1/*: any*/),
+                                  (v2/*: any*/),
                                   {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "status",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "statusUpdate",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v5/*: any*/),
-                                    "kind": "ScalarField",
-                                    "name": "startAt",
-                                    "storageKey": "startAt(format:\"MMM D\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v5/*: any*/),
-                                    "kind": "ScalarField",
-                                    "name": "endAt",
-                                    "storageKey": "endAt(format:\"MMM D\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isOnlineExclusive",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Location",
-                                    "kind": "LinkedField",
-                                    "name": "location",
-                                    "plural": false,
+                                    "kind": "InlineFragment",
                                     "selections": [
+                                      (v3/*: any*/),
+                                      (v4/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "city",
-                                        "storageKey": null
-                                      },
-                                      (v2/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "coverImage",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "height",
-                                            "value": 500
-                                          },
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "normalized",
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
+                                        "concreteType": "Show",
                                         "kind": "LinkedField",
-                                        "name": "resized",
+                                        "name": "featuredShow",
                                         "plural": false,
                                         "selections": [
+                                          (v4/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
                                             "kind": "ScalarField",
-                                            "name": "src",
+                                            "name": "status",
                                             "storageKey": null
                                           },
                                           {
                                             "alias": null,
                                             "args": null,
                                             "kind": "ScalarField",
-                                            "name": "srcSet",
+                                            "name": "statusUpdate",
                                             "storageKey": null
-                                          }
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": (v5/*: any*/),
+                                            "kind": "ScalarField",
+                                            "name": "startAt",
+                                            "storageKey": "startAt(format:\"MMM D\")"
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": (v5/*: any*/),
+                                            "kind": "ScalarField",
+                                            "name": "endAt",
+                                            "storageKey": "endAt(format:\"MMM D\")"
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "isOnlineExclusive",
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Location",
+                                            "kind": "LinkedField",
+                                            "name": "location",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "city",
+                                                "storageKey": null
+                                              },
+                                              (v2/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Image",
+                                            "kind": "LinkedField",
+                                            "name": "coverImage",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "height",
+                                                    "value": 500
+                                                  },
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": [
+                                                      "normalized",
+                                                      "larger",
+                                                      "large"
+                                                    ]
+                                                  }
+                                                ],
+                                                "concreteType": "ResizedImageUrl",
+                                                "kind": "LinkedField",
+                                                "name": "resized",
+                                                "plural": false,
+                                                "selections": [
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "src",
+                                                    "storageKey": null
+                                                  },
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "srcSet",
+                                                    "storageKey": null
+                                                  }
+                                                ],
+                                                "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
+                                              }
+                                            ],
+                                            "storageKey": null
+                                          },
+                                          (v2/*: any*/)
                                         ],
-                                        "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
+                                        "storageKey": null
                                       }
                                     ],
-                                    "storageKey": null
-                                  },
-                                  (v2/*: any*/)
+                                    "type": "Partner"
+                                  }
                                 ],
                                 "storageKey": null
                               }
                             ],
-                            "type": "Partner"
+                            "type": "Profile"
                           }
                         ],
                         "storageKey": null
                       }
                     ],
-                    "type": "Profile"
+                    "storageKey": null
                   }
                 ],
-                "storageKey": null
+                "storageKey": "orderedItemsConnection(first:50)"
               },
               (v2/*: any*/)
             ],
@@ -367,7 +399,7 @@ return {
     "metadata": {},
     "name": "PartnersFeaturedCarousel_Test_Query",
     "operationKind": "query",
-    "text": "query PartnersFeaturedCarousel_Test_Query {\n  viewer {\n    ...PartnersFeaturedCarousel_viewer_3GNcE2\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3GNcE2 on Viewer {\n  orderedSet(id: \"example\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query PartnersFeaturedCarousel_Test_Query {\n  viewer {\n    ...PartnersFeaturedCarousel_viewer_3GNcE2\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3GNcE2 on Viewer {\n  orderedSet(id: \"example\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnersFeaturedCarousel_viewer.graphql.ts
+++ b/src/v2/__generated__/PartnersFeaturedCarousel_viewer.graphql.ts
@@ -5,10 +5,14 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type PartnersFeaturedCarousel_viewer = {
     readonly orderedSet: {
-        readonly items: ReadonlyArray<{
-            readonly internalID?: string;
-            readonly " $fragmentRefs": FragmentRefs<"PartnersFeaturedCarouselCell_profile">;
-        } | null> | null;
+        readonly orderedItemsConnection: {
+            readonly edges: ReadonlyArray<{
+                readonly node: {
+                    readonly internalID?: string;
+                    readonly " $fragmentRefs": FragmentRefs<"PartnersFeaturedCarouselCell_profile">;
+                } | null;
+            } | null> | null;
+        };
     } | null;
     readonly " $refType": "PartnersFeaturedCarousel_viewer";
 };
@@ -49,32 +53,60 @@ const node: ReaderFragment = {
       "selections": [
         {
           "alias": null,
-          "args": null,
-          "concreteType": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 50
+            }
+          ],
+          "concreteType": "OrderedSetItemConnection",
           "kind": "LinkedField",
-          "name": "items",
-          "plural": true,
+          "name": "orderedItemsConnection",
+          "plural": false,
           "selections": [
             {
-              "kind": "InlineFragment",
+              "alias": null,
+              "args": null,
+              "concreteType": "OrderedSetItemEdge",
+              "kind": "LinkedField",
+              "name": "edges",
+              "plural": true,
               "selections": [
                 {
                   "alias": null,
                   "args": null,
-                  "kind": "ScalarField",
-                  "name": "internalID",
+                  "concreteType": null,
+                  "kind": "LinkedField",
+                  "name": "node",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "internalID",
+                          "storageKey": null
+                        },
+                        {
+                          "args": null,
+                          "kind": "FragmentSpread",
+                          "name": "PartnersFeaturedCarouselCell_profile"
+                        }
+                      ],
+                      "type": "Profile"
+                    }
+                  ],
                   "storageKey": null
-                },
-                {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "PartnersFeaturedCarouselCell_profile"
                 }
               ],
-              "type": "Profile"
+              "storageKey": null
             }
           ],
-          "storageKey": null
+          "storageKey": "orderedItemsConnection(first:50)"
         }
       ],
       "storageKey": null
@@ -82,5 +114,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = '7a1ee54071a4522594bd6513970e63a7';
+(node as any).hash = '3cde7259fe9f6d1b5010399bf2c6b469';
 export default node;

--- a/src/v2/__generated__/partnersRoutes_GalleriesRouteQuery.graphql.ts
+++ b/src/v2/__generated__/partnersRoutes_GalleriesRouteQuery.graphql.ts
@@ -73,18 +73,22 @@ fragment PartnersFeaturedCarouselCell_profile on Profile {
 
 fragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {
   orderedSet(id: "5638fdfb7261690296000031") {
-    items {
-      __typename
-      ... on Profile {
-        internalID
-        ...PartnersFeaturedCarouselCell_profile
-        id
-      }
-      ... on Node {
-        id
-      }
-      ... on FeaturedLink {
-        id
+    orderedItemsConnection(first: 50) {
+      edges {
+        node {
+          __typename
+          ... on Profile {
+            internalID
+            ...PartnersFeaturedCarouselCell_profile
+            id
+          }
+          ... on Node {
+            id
+          }
+          ... on FeaturedLink {
+            id
+          }
+        }
       }
     }
     id
@@ -184,39 +188,32 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": null,
-                "concreteType": null,
-                "kind": "LinkedField",
-                "name": "items",
-                "plural": true,
-                "selections": [
-                  (v0/*: any*/),
-                  (v1/*: any*/),
+                "args": [
                   {
-                    "kind": "InlineFragment",
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 50
+                  }
+                ],
+                "concreteType": "OrderedSetItemConnection",
+                "kind": "LinkedField",
+                "name": "orderedItemsConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "OrderedSetItemEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
                     "selections": [
-                      (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
-                      (v3/*: any*/),
-                      {
-                        "alias": "is_followed",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isFollowed",
-                        "storageKey": null
-                      },
                       {
                         "alias": null,
                         "args": null,
                         "concreteType": null,
                         "kind": "LinkedField",
-                        "name": "owner",
+                        "name": "node",
                         "plural": false,
                         "selections": [
                           (v0/*: any*/),
@@ -225,136 +222,171 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v2/*: any*/),
-                              (v3/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
-                                "concreteType": "Show",
+                                "kind": "ScalarField",
+                                "name": "slug",
+                                "storageKey": null
+                              },
+                              (v3/*: any*/),
+                              {
+                                "alias": "is_followed",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isFollowed",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": null,
                                 "kind": "LinkedField",
-                                "name": "featuredShow",
+                                "name": "owner",
                                 "plural": false,
                                 "selections": [
-                                  (v3/*: any*/),
+                                  (v0/*: any*/),
+                                  (v1/*: any*/),
                                   {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "status",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "statusUpdate",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v4/*: any*/),
-                                    "kind": "ScalarField",
-                                    "name": "startAt",
-                                    "storageKey": "startAt(format:\"MMM D\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v4/*: any*/),
-                                    "kind": "ScalarField",
-                                    "name": "endAt",
-                                    "storageKey": "endAt(format:\"MMM D\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isOnlineExclusive",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Location",
-                                    "kind": "LinkedField",
-                                    "name": "location",
-                                    "plural": false,
+                                    "kind": "InlineFragment",
                                     "selections": [
+                                      (v2/*: any*/),
+                                      (v3/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "city",
-                                        "storageKey": null
-                                      },
-                                      (v1/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "coverImage",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "height",
-                                            "value": 500
-                                          },
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "normalized",
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
+                                        "concreteType": "Show",
                                         "kind": "LinkedField",
-                                        "name": "resized",
+                                        "name": "featuredShow",
                                         "plural": false,
                                         "selections": [
+                                          (v3/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
                                             "kind": "ScalarField",
-                                            "name": "src",
+                                            "name": "status",
                                             "storageKey": null
                                           },
                                           {
                                             "alias": null,
                                             "args": null,
                                             "kind": "ScalarField",
-                                            "name": "srcSet",
+                                            "name": "statusUpdate",
                                             "storageKey": null
-                                          }
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": (v4/*: any*/),
+                                            "kind": "ScalarField",
+                                            "name": "startAt",
+                                            "storageKey": "startAt(format:\"MMM D\")"
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": (v4/*: any*/),
+                                            "kind": "ScalarField",
+                                            "name": "endAt",
+                                            "storageKey": "endAt(format:\"MMM D\")"
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "isOnlineExclusive",
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Location",
+                                            "kind": "LinkedField",
+                                            "name": "location",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "city",
+                                                "storageKey": null
+                                              },
+                                              (v1/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Image",
+                                            "kind": "LinkedField",
+                                            "name": "coverImage",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "height",
+                                                    "value": 500
+                                                  },
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": [
+                                                      "normalized",
+                                                      "larger",
+                                                      "large"
+                                                    ]
+                                                  }
+                                                ],
+                                                "concreteType": "ResizedImageUrl",
+                                                "kind": "LinkedField",
+                                                "name": "resized",
+                                                "plural": false,
+                                                "selections": [
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "src",
+                                                    "storageKey": null
+                                                  },
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "srcSet",
+                                                    "storageKey": null
+                                                  }
+                                                ],
+                                                "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
+                                              }
+                                            ],
+                                            "storageKey": null
+                                          },
+                                          (v1/*: any*/)
                                         ],
-                                        "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
+                                        "storageKey": null
                                       }
                                     ],
-                                    "storageKey": null
-                                  },
-                                  (v1/*: any*/)
+                                    "type": "Partner"
+                                  }
                                 ],
                                 "storageKey": null
                               }
                             ],
-                            "type": "Partner"
+                            "type": "Profile"
                           }
                         ],
                         "storageKey": null
                       }
                     ],
-                    "type": "Profile"
+                    "storageKey": null
                   }
                 ],
-                "storageKey": null
+                "storageKey": "orderedItemsConnection(first:50)"
               },
               (v1/*: any*/)
             ],
@@ -370,7 +402,7 @@ return {
     "metadata": {},
     "name": "partnersRoutes_GalleriesRouteQuery",
     "operationKind": "query",
-    "text": "query partnersRoutes_GalleriesRouteQuery {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query partnersRoutes_GalleriesRouteQuery {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/partnersRoutes_InstitutionsRouteQuery.graphql.ts
+++ b/src/v2/__generated__/partnersRoutes_InstitutionsRouteQuery.graphql.ts
@@ -73,18 +73,22 @@ fragment PartnersFeaturedCarouselCell_profile on Profile {
 
 fragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {
   orderedSet(id: "564e181a258faf3d5c000080") {
-    items {
-      __typename
-      ... on Profile {
-        internalID
-        ...PartnersFeaturedCarouselCell_profile
-        id
-      }
-      ... on Node {
-        id
-      }
-      ... on FeaturedLink {
-        id
+    orderedItemsConnection(first: 50) {
+      edges {
+        node {
+          __typename
+          ... on Profile {
+            internalID
+            ...PartnersFeaturedCarouselCell_profile
+            id
+          }
+          ... on Node {
+            id
+          }
+          ... on FeaturedLink {
+            id
+          }
+        }
       }
     }
     id
@@ -184,39 +188,32 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": null,
-                "concreteType": null,
-                "kind": "LinkedField",
-                "name": "items",
-                "plural": true,
-                "selections": [
-                  (v0/*: any*/),
-                  (v1/*: any*/),
+                "args": [
                   {
-                    "kind": "InlineFragment",
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 50
+                  }
+                ],
+                "concreteType": "OrderedSetItemConnection",
+                "kind": "LinkedField",
+                "name": "orderedItemsConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "OrderedSetItemEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
                     "selections": [
-                      (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
-                      (v3/*: any*/),
-                      {
-                        "alias": "is_followed",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isFollowed",
-                        "storageKey": null
-                      },
                       {
                         "alias": null,
                         "args": null,
                         "concreteType": null,
                         "kind": "LinkedField",
-                        "name": "owner",
+                        "name": "node",
                         "plural": false,
                         "selections": [
                           (v0/*: any*/),
@@ -225,136 +222,171 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v2/*: any*/),
-                              (v3/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
-                                "concreteType": "Show",
+                                "kind": "ScalarField",
+                                "name": "slug",
+                                "storageKey": null
+                              },
+                              (v3/*: any*/),
+                              {
+                                "alias": "is_followed",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isFollowed",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": null,
                                 "kind": "LinkedField",
-                                "name": "featuredShow",
+                                "name": "owner",
                                 "plural": false,
                                 "selections": [
-                                  (v3/*: any*/),
+                                  (v0/*: any*/),
+                                  (v1/*: any*/),
                                   {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "status",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "statusUpdate",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v4/*: any*/),
-                                    "kind": "ScalarField",
-                                    "name": "startAt",
-                                    "storageKey": "startAt(format:\"MMM D\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v4/*: any*/),
-                                    "kind": "ScalarField",
-                                    "name": "endAt",
-                                    "storageKey": "endAt(format:\"MMM D\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isOnlineExclusive",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Location",
-                                    "kind": "LinkedField",
-                                    "name": "location",
-                                    "plural": false,
+                                    "kind": "InlineFragment",
                                     "selections": [
+                                      (v2/*: any*/),
+                                      (v3/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "city",
-                                        "storageKey": null
-                                      },
-                                      (v1/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "coverImage",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "height",
-                                            "value": 500
-                                          },
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "normalized",
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
+                                        "concreteType": "Show",
                                         "kind": "LinkedField",
-                                        "name": "resized",
+                                        "name": "featuredShow",
                                         "plural": false,
                                         "selections": [
+                                          (v3/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
                                             "kind": "ScalarField",
-                                            "name": "src",
+                                            "name": "status",
                                             "storageKey": null
                                           },
                                           {
                                             "alias": null,
                                             "args": null,
                                             "kind": "ScalarField",
-                                            "name": "srcSet",
+                                            "name": "statusUpdate",
                                             "storageKey": null
-                                          }
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": (v4/*: any*/),
+                                            "kind": "ScalarField",
+                                            "name": "startAt",
+                                            "storageKey": "startAt(format:\"MMM D\")"
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": (v4/*: any*/),
+                                            "kind": "ScalarField",
+                                            "name": "endAt",
+                                            "storageKey": "endAt(format:\"MMM D\")"
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "isOnlineExclusive",
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Location",
+                                            "kind": "LinkedField",
+                                            "name": "location",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "city",
+                                                "storageKey": null
+                                              },
+                                              (v1/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Image",
+                                            "kind": "LinkedField",
+                                            "name": "coverImage",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "height",
+                                                    "value": 500
+                                                  },
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": [
+                                                      "normalized",
+                                                      "larger",
+                                                      "large"
+                                                    ]
+                                                  }
+                                                ],
+                                                "concreteType": "ResizedImageUrl",
+                                                "kind": "LinkedField",
+                                                "name": "resized",
+                                                "plural": false,
+                                                "selections": [
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "src",
+                                                    "storageKey": null
+                                                  },
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "srcSet",
+                                                    "storageKey": null
+                                                  }
+                                                ],
+                                                "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
+                                              }
+                                            ],
+                                            "storageKey": null
+                                          },
+                                          (v1/*: any*/)
                                         ],
-                                        "storageKey": "resized(height:500,version:[\"normalized\",\"larger\",\"large\"])"
+                                        "storageKey": null
                                       }
                                     ],
-                                    "storageKey": null
-                                  },
-                                  (v1/*: any*/)
+                                    "type": "Partner"
+                                  }
                                 ],
                                 "storageKey": null
                               }
                             ],
-                            "type": "Partner"
+                            "type": "Profile"
                           }
                         ],
                         "storageKey": null
                       }
                     ],
-                    "type": "Profile"
+                    "storageKey": null
                   }
                 ],
-                "storageKey": null
+                "storageKey": "orderedItemsConnection(first:50)"
               },
               (v1/*: any*/)
             ],
@@ -370,7 +402,7 @@ return {
     "metadata": {},
     "name": "partnersRoutes_InstitutionsRouteQuery",
     "operationKind": "query",
-    "text": "query partnersRoutes_InstitutionsRouteQuery {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    items {\n      __typename\n      ... on Profile {\n        internalID\n        ...PartnersFeaturedCarouselCell_profile\n        id\n      }\n      ... on Node {\n        id\n      }\n      ... on FeaturedLink {\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query partnersRoutes_InstitutionsRouteQuery {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      name\n      featuredShow {\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
There's an `items` field — that should be deprecated — that returns a fixed amount of items with no pagination options. Updates to use the connection and fetch a max of 50 items.