### PR TITLE
feat: Upon email alert click scroll down to artwork grid immediately

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilterAnchor.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterAnchor.tsx
@@ -1,0 +1,29 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import React from "react"
+import { themeProps } from "@artsy/palette-tokens"
+import { useNavBarHeight } from "../NavBar/useNavBarHeight"
+import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { useSticky } from "../Sticky"
+
+// Based on this answer https://stackoverflow.com/a/13184714
+export const ArtworkFilterAnchor = () => {
+  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
+  const { mobile, desktop } = useNavBarHeight()
+  const { offsetTop } = useSticky()
+  const outerOffset = isMobile ? -5 : 20
+  const offset = (isMobile ? mobile : desktop) + offsetTop + outerOffset
+
+  return (
+    <a
+      id="jump--artworkFilter"
+      style={{
+        display: "block",
+        position: "relative",
+        visibility: "hidden",
+        top: -offset,
+      }}
+    />
+  )
+}

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -54,6 +54,7 @@ import { Works_partner } from "v2/__generated__/Works_partner.graphql"
 import { CollectionArtworksFilter_collection } from "v2/__generated__/CollectionArtworksFilter_collection.graphql"
 import { FiltersPills } from "./SavedSearch/Components/FiltersPills"
 import { SavedSearchAttributes } from "./SavedSearch/types"
+import { ArtworkFilterAnchor } from "./ArtworkFilterAnchor"
 
 /**
  * Primary ArtworkFilter which is wrapped with a context and refetch container.
@@ -144,7 +145,7 @@ export const BaseArtworkFilter: React.FC<
   Filters,
   relayVariables = {},
   children,
-  offset,
+  offset = 0,
   savedSearchProps,
   enableCreateAlert = false,
   ...rest
@@ -268,8 +269,7 @@ export const BaseArtworkFilter: React.FC<
 
   return (
     <Box mt={tokens.mt} {...rest}>
-      <Box id="jump--artworkFilter" />
-
+      <ArtworkFilterAnchor />
       {/* Mobile Artwork Filter */}
       <Media at="xs">
         <Box mb={1}>


### PR DESCRIPTION
Type: Feature
Jira ticket: [FX-3607]

Description
- Clicking the CTA in the email alert should lead the user directly to the artworks they want to see on the Artist’s Works for Sale tab
- The effect should be that the screen “jumps” right to the artwork grid on the artist artwork tab, rather than land at the top of the mWeb page


[FX-3607]: https://artsyproduct.atlassian.net/browse/FX-3607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ