### PR TITLE
[PLATFORM-3744] Set artifacts for smoke-test-on-live-env in case of failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,8 @@ jobs:
       - run:
           name: Run Smoke Tests on Staging
           command: ./node_modules/.bin/cypress run --config baseUrl=$SMOKE_TEST_TARGET
+      - store_artifacts:
+          path: cypress/screenshots
 
 not_master_or_staging_or_release: &not_master_or_staging_or_release
   filters:


### PR DESCRIPTION
[PLATFORM-3744]

When cypress tests fail on `smoke-test-on-live-env`, we want the screenshots to be stored in the artifacts tab, so we don't need to run it again locally to detect the issue.

To test this setting, I changed it to run on this branch and changed an integration test to force it to fail. The result can be seen in [here](https://app.circleci.com/pipelines/github/artsy/force/22072/workflows/11f486a9-992e-4faf-aa8c-d36715f5a38c/jobs/167809/artifacts)

<img width="692" alt="Screenshot 2021-11-25 at 11 53 30" src="https://user-images.githubusercontent.com/8002618/143428796-7bd5723a-87c1-4b48-9017-71eedd8ae16e.png">

[PLATFORM-3744]: https://artsyproduct.atlassian.net/browse/PLATFORM-3744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ