### PR TITLE
feat(FX-3595): Filter pills interaction

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -24,6 +24,7 @@ export const initialArtworkFilterState: ArtworkFilters = {
   locationCities: [],
   artistNationalities: [],
   materialsTerms: [],
+  priceRange: "*-*",
   height: "*-*",
   width: "*-*",
 }

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -24,9 +24,9 @@ export const initialArtworkFilterState: ArtworkFilters = {
   locationCities: [],
   artistNationalities: [],
   materialsTerms: [],
-  priceRange: "*-*",
   height: "*-*",
   width: "*-*",
+  priceRange: "*-*",
 }
 
 /**

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -15,7 +15,7 @@ import { sortResults } from "./ResultsFilter"
 import { FilterExpandable } from "./FilterExpandable"
 import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 
-const COLOR_OPTIONS = [
+export const COLOR_OPTIONS = [
   { hex: "#ffffff", value: "black-and-white", name: "Black and White" },
   { hex: "#ff0000", value: "red", name: "Red" },
   { hex: "#fbe854", value: "yellow", name: "Yellow" },

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -134,7 +134,7 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
 
   // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const selection = currentlySelectedFilters().priceRange
-  const hasSelection = selection && selection.length > 0
+  const hasSelection = selection && isCustomValue(selection)
 
   useEffect(() => {
     // if price filter or filters state is being reset, then also clear local input state

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -15,6 +15,7 @@ import styled from "styled-components"
 import { Media } from "v2/Utils/Responsive"
 import { themeGet } from "@styled-system/theme-get"
 import { FilterExpandable } from "./FilterExpandable"
+import { isCustomValue } from "./Utils/isCustomValue"
 
 // Disables arrows in numeric inputs
 export const NumericInput = styled(LabeledInput).attrs({ type: "number" })`
@@ -79,8 +80,8 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
   const numericInitialRange = parseRange(initialRange)
 
   const isCustomRange =
-    // Has some kind of price range set (isn't blank)
-    !!initialRange &&
+    // Has some kind of price range set (isn't default)
+    isCustomValue(initialRange) &&
     // And isn't a pre-defined price range option
     PRICE_RANGES.find(range => range.value === initialRange) === undefined
 
@@ -136,11 +137,11 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
   const hasSelection = selection && selection.length > 0
 
   useEffect(() => {
-    // if filter state is being reset, then also clear local input state
-    if (reset) {
+    // if price filter or filters state is being reset, then also clear local input state
+    if (reset || !isCustomValue(initialRange)) {
       setCustomRange(["*", "*"])
     }
-  }, [reset])
+  }, [reset, initialRange])
 
   return (
     <FilterExpandable label="Price" expanded={hasSelection || expanded}>

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -18,6 +18,7 @@ import {
 import { NumericInput } from "./PriceRangeFilter"
 import { Media } from "v2/Utils/Responsive"
 import { FilterExpandable } from "./FilterExpandable"
+import { isCustomValue } from "./Utils/isCustomValue"
 
 export const SIZES = [
   { displayName: "Small (under 40cm)", name: "SMALL" },
@@ -74,8 +75,6 @@ const getValue = (value: CustomRange[number]) => {
   return value === "*" || value === 0 ? "" : value
 }
 
-export const isCustomSize = (value?: string) => value !== "*-*"
-
 export interface SizeFilterProps {
   expanded?: boolean
 }
@@ -88,13 +87,16 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     reset,
   } = currentlySelectedFilters?.() as ArtworkFiltersState
 
-  const initialCustomSize = {
-    height: parseRange(height) as CustomRange,
-    width: parseRange(width) as CustomRange,
-  }
+  const initialCustomSize = React.useMemo(
+    () => ({
+      height: parseRange(height) as CustomRange,
+      width: parseRange(width) as CustomRange,
+    }),
+    [width, height]
+  )
 
   const [showCustom, setShowCustom] = useState(
-    isCustomSize(width) || isCustomSize(height)
+    isCustomValue(width) || isCustomValue(height)
   )
   const [customSize, setCustomSize] = useState<CustomSize>(initialCustomSize)
   const [mode, setMode] = useState<"resting" | "done">("resting")
@@ -171,13 +173,17 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     }
   }, [reset])
 
+  useEffect(() => {
+    setCustomSize(initialCustomSize)
+  }, [initialCustomSize])
+
   const selection = currentlySelectedFilters?.().sizes
   const customHeight = currentlySelectedFilters?.().height
   const customWidth = currentlySelectedFilters?.().width
   const hasSelection =
     (selection && selection.length > 0) ||
-    isCustomSize(customHeight) ||
-    isCustomSize(customWidth)
+    isCustomValue(customHeight) ||
+    isCustomValue(customWidth)
 
   return (
     <FilterExpandable label="Size" expanded={hasSelection || expanded}>

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -19,7 +19,7 @@ import { NumericInput } from "./PriceRangeFilter"
 import { Media } from "v2/Utils/Responsive"
 import { FilterExpandable } from "./FilterExpandable"
 
-const SIZES = [
+export const SIZES = [
   { displayName: "Small (under 40cm)", name: "SMALL" },
   { displayName: "Medium (40 – 100cm)", name: "MEDIUM" },
   { displayName: "Large (over 100cm)", name: "LARGE" },

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -10,6 +10,9 @@ export interface TimePeriodFilterProps {
   expanded?: boolean // set to true to force expansion
 }
 
+export const getTimePeriodToDisplay = period =>
+  isNaN(period) ? period : `${period}s`
+
 export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({ expanded }) => {
   const { aggregations, ...filterContext } = useArtworkFilterContext()
   // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
@@ -74,7 +77,7 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({ expanded }) => {
                 onSelect={selected => togglePeriodSelection(selected, name)}
                 my={tokens.my}
               >
-                {isNaN(name as any) ? name : `${name}s`}
+                {getTimePeriodToDisplay(name)}
               </Checkbox>
             )
           })}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/Utils/isCustomValue.ts
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/Utils/isCustomValue.ts
@@ -1,0 +1,1 @@
+export const isCustomValue = (value?: string) => value !== "*-*"

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, Flex, useThemeConfig } from "@artsy/palette"
-import { isEmpty } from "lodash"
+import { entries, isEmpty } from "lodash"
 import { FC } from "react"
 import {
   ArtworkFilters,
@@ -17,6 +17,25 @@ export interface WaysToBuyFilterProps {
   expanded?: boolean
 }
 
+export const WAYS_TO_BUY_OPTIONS = {
+  acquireable: {
+    name: "Buy Now",
+    countName: "ecommerce_artworks",
+  },
+  offerable: {
+    name: "Make Offer",
+    countName: "has_make_offer_artworks",
+  },
+  atAuction: {
+    name: "Bid",
+    countName: "auction_artworks",
+  },
+  inquireableOnly: {
+    name: "Inquire",
+    countName: "for_sale_artworks",
+  },
+}
+
 export const WaysToBuyFilter: FC<WaysToBuyFilterProps> = ({ expanded }) => {
   const filterContext = useArtworkFilterContext()
 
@@ -31,32 +50,17 @@ export const WaysToBuyFilter: FC<WaysToBuyFilterProps> = ({ expanded }) => {
     return !Boolean(condition)
   }
 
-  const checkboxes: WayToBuy[] = [
-    {
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      disabled: isDisabled(filterContext.counts.ecommerce_artworks),
-      name: "Buy Now",
-      state: "acquireable",
+  const checkboxes: WayToBuy[] = entries(WAYS_TO_BUY_OPTIONS).reduce(
+    (acc, [state, value]) => {
+      acc.push({
+        state: state as keyof ArtworkFilters,
+        name: value.name,
+        disabled: isDisabled(filterContext.counts?.[value.countName]),
+      })
+      return acc
     },
-    {
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      disabled: isDisabled(filterContext.counts.has_make_offer_artworks),
-      name: "Make Offer",
-      state: "offerable",
-    },
-    {
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      disabled: isDisabled(filterContext.counts.auction_artworks),
-      name: "Bid",
-      state: "atAuction",
-    },
-    {
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      disabled: isDisabled(filterContext.counts.for_sale_artworks),
-      name: "Inquire",
-      state: "inquireableOnly",
-    },
-  ]
+    [] as WayToBuy[]
+  )
 
   const tokens = useThemeConfig({
     v2: { my: 0.5 },

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/FiltersPills.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/FiltersPills.tsx
@@ -14,6 +14,7 @@ const CLOSE_ICON_SIZE = 15
 
 export interface DefaultFilterPill {
   isDefault: true
+  name: string
   displayName: string
 }
 
@@ -56,9 +57,9 @@ export const FiltersPills: FC<FiltersPillsProps> = ({
   return (
     <>
       <Flex flexWrap="wrap" mx={-PILL_HORIZONTAL_MARGIN_SIZE}>
-        {pills.map((pill, index) => (
+        {pills.map(pill => (
           <Pill
-            key={`filter-label-${index}`}
+            key={`filter-label-${pill.name}`}
             variant="textSquare"
             mx={PILL_HORIZONTAL_MARGIN_SIZE}
             mb={1}

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/FiltersPills.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/FiltersPills.tsx
@@ -27,7 +27,7 @@ export interface NonDefaultFilterPill {
 
 export type FilterPill = DefaultFilterPill | NonDefaultFilterPill
 
-interface FiltersPillsProps {
+export interface FiltersPillsProps {
   pills: FilterPill[]
   savedSearchAttributes: SavedSearchAttributes
 }

--- a/src/v2/Components/ArtworkFilter/Utils/allowedFilters.ts
+++ b/src/v2/Components/ArtworkFilter/Utils/allowedFilters.ts
@@ -1,3 +1,6 @@
+import { entries } from "lodash"
+import { ArtworkFiltersState } from "../ArtworkFilterContext"
+
 export const allowedFilters = (
   filterParams: Record<string, any> = {}
 ): Record<string, any> => {
@@ -22,6 +25,17 @@ export const allowedFilters = (
 
     obj[key] = filterParams[key]
     return obj
+  }, {})
+}
+
+export const getAllowedFiltersForSavedSearchInput = (
+  filters: ArtworkFiltersState
+) => {
+  return entries(filters).reduce((acc, [paramName, paramValue]) => {
+    if (ALLOWED_SEARCH_CRITERIA_KEYS.includes(paramName)) {
+      acc[paramName] = paramValue
+    }
+    return acc
   }, {})
 }
 
@@ -90,5 +104,24 @@ const SUPPORTED_INPUT_ARGS = [
   "sizes",
   "sort",
   "tagID",
+  "width",
+]
+
+export const ALLOWED_SEARCH_CRITERIA_KEYS = [
+  "artistID",
+  "locationCities",
+  "colors",
+  "partnerIDs",
+  "additionalGeneIDs",
+  "attributionClass",
+  "majorPeriods",
+  "acquireable",
+  "atAuction",
+  "inquireableOnly",
+  "offerable",
+  "materialsTerms",
+  "priceRange",
+  "sizes",
+  "height",
   "width",
 ]

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -43,7 +43,10 @@ import {
   ContextModule,
   ClickedChangePage,
 } from "@artsy/cohesion"
-import { allowedFilters } from "./Utils/allowedFilters"
+import {
+  allowedFilters,
+  getAllowedFiltersForSavedSearchInput,
+} from "./Utils/allowedFilters"
 import { Sticky } from "v2/Components/Sticky"
 import { ScrollRefContext } from "./ArtworkFilters/useScrollContext"
 import { ArtworkSortFilter } from "./ArtworkFilters/ArtworkSortFilter"
@@ -54,6 +57,7 @@ import { Works_partner } from "v2/__generated__/Works_partner.graphql"
 import { CollectionArtworksFilter_collection } from "v2/__generated__/CollectionArtworksFilter_collection.graphql"
 import { FiltersPills } from "./SavedSearch/Components/FiltersPills"
 import { SavedSearchAttributes } from "./SavedSearch/types"
+import { extractPills } from "../SavedSearchAlert/Utils/extractPills"
 
 /**
  * Primary ArtworkFilter which is wrapped with a context and refetch container.
@@ -163,6 +167,7 @@ export const BaseArtworkFilter: React.FC<
 
   const { filtered_artworks } = viewer
   const hasFilter = filtered_artworks && filtered_artworks.id
+  const filters = getAllowedFiltersForSavedSearchInput(filterContext.filters!)
 
   const defaultPill = !!savedSearchProps?.name
     ? {
@@ -170,8 +175,17 @@ export const BaseArtworkFilter: React.FC<
         isDefault: true,
       }
     : null
-  const pills = compact([defaultPill])
 
+  const filterPills = extractPills(filters, filterContext.aggregations!).map(
+    pill => {
+      return {
+        name: pill,
+        isDefault: false,
+      }
+    }
+  )
+
+  const pills = compact([defaultPill, ...filterPills])
   const showCreateAlert = enableCreateAlert && !!pills.length
 
   /**

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -55,7 +55,10 @@ import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvi
 import { TagArtworkFilter_tag } from "v2/__generated__/TagArtworkFilter_tag.graphql"
 import { Works_partner } from "v2/__generated__/Works_partner.graphql"
 import { CollectionArtworksFilter_collection } from "v2/__generated__/CollectionArtworksFilter_collection.graphql"
-import { FiltersPills } from "./SavedSearch/Components/FiltersPills"
+import {
+  DefaultFilterPill,
+  FiltersPills,
+} from "./SavedSearch/Components/FiltersPills"
 import { SavedSearchAttributes } from "./SavedSearch/types"
 import { extractPills } from "../SavedSearchAlert/Utils/extractPills"
 
@@ -169,21 +172,14 @@ export const BaseArtworkFilter: React.FC<
   const hasFilter = filtered_artworks && filtered_artworks.id
   const filters = getAllowedFiltersForSavedSearchInput(filterContext.filters!)
 
-  const defaultPill = !!savedSearchProps?.name
+  const defaultPill: DefaultFilterPill | null = !!savedSearchProps?.name
     ? {
-        name: savedSearchProps.name,
+        displayName: savedSearchProps.name,
         isDefault: true,
       }
     : null
 
-  const filterPills = extractPills(filters, filterContext.aggregations!).map(
-    pill => {
-      return {
-        name: pill,
-        isDefault: false,
-      }
-    }
-  )
+  const filterPills = extractPills(filters, filterContext.aggregations!)
 
   const pills = compact([defaultPill, ...filterPills])
   const showCreateAlert = enableCreateAlert && !!pills.length

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -174,8 +174,9 @@ export const BaseArtworkFilter: React.FC<
 
   const defaultPill: DefaultFilterPill | null = !!savedSearchProps?.name
     ? {
-        displayName: savedSearchProps.name,
         isDefault: true,
+        name: savedSearchProps.slug,
+        displayName: savedSearchProps.name,
       }
     : null
 

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -180,7 +180,7 @@ export const BaseArtworkFilter: React.FC<
       }
     : null
 
-  const filterPills = extractPills(filters, filterContext.aggregations!)
+  const filterPills = extractPills(filters, filterContext.aggregations)
 
   const pills = compact([defaultPill, ...filterPills])
   const showCreateAlert = enableCreateAlert && !!pills.length

--- a/src/v2/Components/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/v2/Components/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -36,7 +36,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = ({
   const filters = filterContext.currentlySelectedFilters?.() || {}
 
   const pills = extractPills(filters, filterContext.aggregations!)
-  const namePlaceholder = getNamePlaceholder(name, pills)
+  const namePlaceholder = getNamePlaceholder(name, pills.length)
 
   const formik = useFormik<SavedSearchAleftFormValues>({
     initialValues,

--- a/src/v2/Components/SavedSearchAlert/Utils/extractPills.ts
+++ b/src/v2/Components/SavedSearchAlert/Utils/extractPills.ts
@@ -91,6 +91,7 @@ export const extractPills = (
       return (
         paramValue && {
           filterName: paramName,
+          name: paramName,
           displayName: WAYS_TO_BUY_OPTIONS[paramName].name,
         }
       )

--- a/src/v2/Components/SavedSearchAlert/Utils/extractPills.ts
+++ b/src/v2/Components/SavedSearchAlert/Utils/extractPills.ts
@@ -76,7 +76,7 @@ const extractPriceLabel = (range: string) => {
 
 export const extractPills = (
   filters: ArtworkFilters,
-  aggregations: Aggregations
+  aggregations: Aggregations = []
 ) => {
   const pills: NonDefaultFilterPill[] = Object.entries(filters).map(filter => {
     const [paramName, paramValue] = filter

--- a/src/v2/Components/SavedSearchAlert/Utils/getNamePlaceholder.tsx
+++ b/src/v2/Components/SavedSearchAlert/Utils/getNamePlaceholder.tsx
@@ -1,4 +1,7 @@
-export const getNamePlaceholder = (artistName: string, pills: string[]) => {
-  const filtersCountLabel = pills.length > 1 ? "filters" : "filter"
-  return `${artistName} • ${pills.length} ${filtersCountLabel}`
+export const getNamePlaceholder = (
+  artistName: string,
+  filtersCount: number
+) => {
+  const filtersCountLabel = filtersCount > 1 ? "filters" : "filter"
+  return `${artistName} • ${filtersCount} ${filtersCountLabel}`
 }


### PR DESCRIPTION
[FX-3595]

Acceptance Criteria:
-When selecting a filter, user sees pill with selected option name on top of the artworks grid
-When tapping on the 'X' of a pill it disappears and the filter related to this pill gets unselected

Changes are available with `ENABLE_SAVED_SEARCH` feature flag enabled

### Demo

https://user-images.githubusercontent.com/44819355/144020160-671ea960-7770-4e67-816b-59a4a8d72b33.mp4



[FX-3595]: https://artsyproduct.atlassian.net/browse/FX-3595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ