### PR TITLE
feat(SWA-129): As a collector, I am required to enter artwork location

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
@@ -82,13 +82,15 @@ export const ArtistAutoComplete: React.FC<{ onError: () => void }> = ({
 
   const updateSuggestions = async (value: string) => {
     setSuggestions([])
-    if (value.trim().length > 2 && relayEnvironment) {
+    if (!value.trim()) return
+
+    if (relayEnvironment) {
       try {
         setIsLoading(true)
         const suggestions = await fetchSuggestions(value, relayEnvironment)
         setIsError(false)
         setIsLoading(false)
-        if (suggestions) {
+        if (suggestions?.edges?.length) {
           const options = extractNodes(suggestions)
           setSuggestions(
             options.map(option => ({
@@ -119,9 +121,8 @@ export const ArtistAutoComplete: React.FC<{ onError: () => void }> = ({
     handleSuggestionsFetchRequested(value)
   }
 
-  const handleClick = ({ currentTarget: { value } }) => {
+  const handleClick = () => {
     setFieldTouched("artistName", false)
-    handleSuggestionsFetchRequested(value)
   }
 
   const handleClear = () => {
@@ -130,10 +131,7 @@ export const ArtistAutoComplete: React.FC<{ onError: () => void }> = ({
     setFieldValue("artistName", "")
   }
 
-  const handleSelect = (
-    { text, value }: ArtistAutocompleteOption,
-    index: number
-  ) => {
+  const handleSelect = ({ text, value }: ArtistAutocompleteOption) => {
     setFieldValue("artistId", value)
     setFieldValue("artistName", text)
   }

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtworkDetailsForm.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtworkDetailsForm.tsx
@@ -21,6 +21,7 @@ import { useRouter } from "v2/System/Router/useRouter"
 import { ArtworkSidebarClassificationsModalQueryRenderer } from "v2/Apps/Artwork/Components/ArtworkSidebarClassificationsModal"
 import { useSubmission } from "../../Utils/useSubmission"
 import { ArtistAutoComplete } from "./ArtistAutocomplete"
+import { LocationAutoComplete } from "./LocationAutocomplete"
 
 export const getArtworkDetailsFormInitialValues = () => ({
   artistId: "",
@@ -36,6 +37,8 @@ export const getArtworkDetailsFormInitialValues = () => ({
   depth: "",
   units: "in",
   provenance: "",
+  locationId: "",
+  location: "",
 })
 
 const rarityOptions = checkboxValues.map(({ name, value }) => ({
@@ -59,6 +62,8 @@ export interface ArtworkDetailsFormModel {
   depth: string
   units: string
   provenance: string
+  location: string
+  locationId: string
 }
 
 export const ArtworkDetailsForm: React.FC = () => {
@@ -68,7 +73,7 @@ export const ArtworkDetailsForm: React.FC = () => {
     },
   } = useRouter()
 
-  const [isArtistApiError, setIsArtistApiError] = useState(false)
+  const [isApiError, setIsApiError] = useState(false)
   const [isRarityModalOpen, setIsRarityModalOpen] = useState(false)
   const [isProvenanceModalOpen, setIsProvenanceModalOpen] = useState(false)
 
@@ -96,11 +101,11 @@ export const ArtworkDetailsForm: React.FC = () => {
   return (
     <>
       <ErrorModal
-        show={isArtistApiError}
+        show={isApiError}
         headerText="An error occurred"
         contactEmail="consign@artsymail.com"
         closeText="Close"
-        onClose={() => setIsArtistApiError(false)}
+        onClose={() => setIsApiError(false)}
       />
       <ArtworkSidebarClassificationsModalQueryRenderer
         onClose={() => setIsRarityModalOpen(false)}
@@ -138,7 +143,7 @@ export const ArtworkDetailsForm: React.FC = () => {
 
       <GridColumns>
         <Column span={6}>
-          <ArtistAutoComplete onError={() => setIsArtistApiError(true)} />
+          <ArtistAutoComplete onError={() => setIsApiError(true)} />
         </Column>
         <Column span={6} mt={[2, 0]}>
           <Input
@@ -317,6 +322,9 @@ export const ArtworkDetailsForm: React.FC = () => {
             onChange={handleChange}
             value={values.provenance}
           />
+        </Column>
+        <Column span={6} mt={[1, 0]}>
+          <LocationAutoComplete onError={() => setIsApiError(true)} />
         </Column>
       </GridColumns>
     </>

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/LocationAutocomplete.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/LocationAutocomplete.tsx
@@ -91,25 +91,25 @@ export const LocationAutoComplete: React.FC<{ onError: () => void }> = ({
 
   const updateSuggestions = async (value: string) => {
     setSuggestions([])
-    if (value.trim().length > 2) {
-      try {
-        setIsLoading(true)
-        const suggestions = await fetchSuggestions(value)
-        setIsError(false)
-        setIsLoading(false)
-        if (suggestions) {
-          setSuggestions(
-            suggestions.map(option => ({
-              text: option.description!,
-              value: option.place_id!,
-            }))
-          )
-        }
-      } catch {
-        setIsLoading(false)
-        setIsError(true)
-        onError()
+    if (!value.trim()) return
+
+    try {
+      setIsLoading(true)
+      const suggestions = await fetchSuggestions(value)
+      setIsError(false)
+      setIsLoading(false)
+      if (suggestions) {
+        setSuggestions(
+          suggestions.map(option => ({
+            text: option.description!,
+            value: option.place_id!,
+          }))
+        )
       }
+    } catch {
+      setIsLoading(false)
+      setIsError(true)
+      onError()
     }
   }
 
@@ -126,9 +126,8 @@ export const LocationAutoComplete: React.FC<{ onError: () => void }> = ({
     handleSuggestionsFetchRequested(value)
   }
 
-  const handleClick = ({ currentTarget: { value } }) => {
+  const handleClick = () => {
     setFieldTouched("location", false)
-    handleSuggestionsFetchRequested(value)
   }
 
   const handleClear = () => {

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/LocationAutocomplete.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/LocationAutocomplete.tsx
@@ -1,0 +1,177 @@
+import {
+  AutocompleteInput,
+  AutocompleteInputOptionType,
+  Flex,
+  Input,
+  Text,
+} from "@artsy/palette"
+import { ArtworkDetailsFormModel } from "./ArtworkDetailsForm"
+import { useFormikContext } from "formik"
+import { data as sd } from "sharify"
+import { useLoadScript } from "v2/Utils/Hooks/useLoadScript"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { debounce } from "lodash"
+import { useRouter } from "v2/System/Router/useRouter"
+
+const DEBOUNCE_DELAY = 300
+const GOOGLE_PLACES_API_SRC = `https://maps.googleapis.com/maps/api/js?key=${sd.GOOGLE_MAPS_API_KEY}&libraries=places&v=weekly&language=en&sessiontoken=${sd.SESSION_ID}&callback=__googleMapsCallback`
+
+export const LocationAutoComplete: React.FC<{ onError: () => void }> = ({
+  onError,
+}) => {
+  const [suggestions, setSuggestions] = useState<
+    Array<AutocompleteInputOptionType>
+  >([])
+  const [isError, setIsError] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [ready, setReady] = useState(false)
+  const [initialized, setInitialized] = useState(false)
+  const {
+    values,
+    setFieldValue,
+    errors,
+    touched,
+    setFieldTouched,
+  } = useFormikContext<ArtworkDetailsFormModel>()
+  const {
+    match: {
+      params: { id },
+    },
+  } = useRouter()
+
+  const autocompleteServiceRef = useRef<any | null>(null)
+
+  useLoadScript({ id: "google-maps-js", src: GOOGLE_PLACES_API_SRC })
+
+  useEffect(() => {
+    if (!initialized) {
+      if (!id || (values.location && values.locationId)) {
+        setInitialized(true)
+        setIsError(false)
+      }
+    }
+  }, [values.location, values.locationId, initialized, id])
+
+  useEffect(() => {
+    if (!isError) return
+
+    setInitialized(false)
+    setFieldValue("locationId", "")
+    setFieldValue("location", "")
+  }, [isError])
+
+  useEffect(() => {
+    // @ts-ignore
+    if (typeof google === "undefined") {
+      // @ts-ignore
+      window.__googleMapsCallback = () => {
+        setReady(true)
+      }
+      return
+    }
+
+    setReady(true)
+  }, [])
+
+  useEffect(() => {
+    // @ts-ignore
+    if (typeof google === "undefined" || !ready) return
+    // @ts-ignore
+    autocompleteServiceRef.current = new google.maps.places.AutocompleteService()
+  }, [ready])
+
+  const fetchSuggestions = async (searchQuery: string) => {
+    const res = await autocompleteServiceRef.current.getPlacePredictions({
+      input: searchQuery,
+      types: ["(cities)"],
+    })
+
+    return res?.predictions
+  }
+
+  const updateSuggestions = async (value: string) => {
+    setSuggestions([])
+    if (value.trim().length > 2) {
+      try {
+        setIsLoading(true)
+        const suggestions = await fetchSuggestions(value)
+        setIsError(false)
+        setIsLoading(false)
+        if (suggestions) {
+          setSuggestions(
+            suggestions.map(option => ({
+              text: option.description!,
+              value: option.place_id!,
+            }))
+          )
+        }
+      } catch {
+        setIsLoading(false)
+        setIsError(true)
+        onError()
+      }
+    }
+  }
+
+  const handleSuggestionsFetchRequested = useMemo(
+    () => debounce(updateSuggestions, DEBOUNCE_DELAY),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  const handleChange = ({ target: { value } }) => {
+    setFieldTouched("location", false)
+    setFieldValue("locationId", "")
+    setFieldValue("location", value)
+    handleSuggestionsFetchRequested(value)
+  }
+
+  const handleClick = ({ currentTarget: { value } }) => {
+    setFieldTouched("location", false)
+    handleSuggestionsFetchRequested(value)
+  }
+
+  const handleClear = () => {
+    setSuggestions([])
+    setFieldValue("locationId", "")
+    setFieldValue("location", "")
+  }
+
+  const handleSelect = ({ text, value }: AutocompleteInputOptionType) => {
+    setFieldValue("locationId", value)
+    setFieldValue("location", text)
+  }
+
+  const handleClose = () => {
+    setFieldTouched("location")
+  }
+
+  const renderOption = (option: AutocompleteInputOptionType) => (
+    <Flex alignItems="center" p={1} width="100%">
+      <Text ml={1} variant="md">
+        {option.text}
+      </Text>
+    </Flex>
+  )
+
+  return initialized ? (
+    <AutocompleteInput
+      title="Location"
+      placeholder="Enter City Where Artwork Is Located"
+      data-test-id="autocomplete-location"
+      spellCheck={false}
+      loading={isLoading}
+      defaultValue={values.location}
+      error={values.location.trim() && touched.location && errors.locationId}
+      onChange={handleChange}
+      onClick={handleClick}
+      onClear={handleClear}
+      options={suggestions || []}
+      onSelect={handleSelect}
+      onClose={handleClose}
+      renderOption={renderOption}
+    />
+  ) : (
+    <Input title="Location" placeholder="Enter City Where Artwork Is Located" />
+  )
+}

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
@@ -103,39 +103,20 @@ describe("ArtistAutocomplete", () => {
   })
 
   describe("Query", () => {
-    describe("sends request", () => {
-      it("when the 3rd character is entered", async () => {
-        await simulateTyping(wrapper, "Ban")
+    it("starts when character is entered", async () => {
+      await simulateTyping(wrapper, "B")
 
-        const searchString = (fetchQuery as jest.Mock).mock.calls[0][2]
-          .searchQuery
+      const searchString = (fetchQuery as jest.Mock).mock.calls[0][2]
+        .searchQuery
 
-        expect(fetchQuery).toHaveBeenCalledTimes(1)
-        expect(searchString).toBe("Ban")
-      })
-
-      it("spaces are not counted", async () => {
-        await simulateTyping(wrapper, " Ba n")
-
-        const searchString = (fetchQuery as jest.Mock).mock.calls[0][2]
-          .searchQuery
-
-        expect(fetchQuery).toHaveBeenCalledTimes(1)
-        expect(searchString).toBe(" Ba n")
-      })
+      expect(fetchQuery).toHaveBeenCalledTimes(1)
+      expect(searchString).toBe("B")
     })
-    describe("doesn't sends request", () => {
-      it("when less then 3 character is entered", async () => {
-        await simulateTyping(wrapper, "Ba")
 
-        expect(fetchQuery).toHaveBeenCalledTimes(0)
-      })
+    it("doesn't starts if it's space", async () => {
+      await simulateTyping(wrapper, " ")
 
-      it("spaces are not counted", async () => {
-        simulateTyping(wrapper, " Ba ")
-
-        expect(fetchQuery).toHaveBeenCalledTimes(0)
-      })
+      expect(fetchQuery).toHaveBeenCalledTimes(0)
     })
   })
 

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme"
 import { ArtworkDetails } from "../ArtworkDetails"
 import {
   ArtworkDetailsForm,
+  ArtworkDetailsFormModel,
   getArtworkDetailsFormInitialValues,
 } from "../Components/ArtworkDetailsForm"
 import {
@@ -13,7 +14,7 @@ import { MockBoot } from "v2/DevTools"
 import { Breakpoint } from "v2/Utils/Responsive"
 import { flushPromiseQueue } from "v2/DevTools"
 
-const validForm = {
+const validForm: ArtworkDetailsFormModel = {
   artistId: "artistId",
   artistName: "Banksy",
   year: "2021",
@@ -27,9 +28,11 @@ const validForm = {
   depth: "5",
   units: "cm",
   provenance: "provenance",
+  location: "NY, USA",
+  locationId: "locationId",
 }
 
-const validFormWithSpaces = {
+const validFormWithSpaces: ArtworkDetailsFormModel = {
   artistId: "artistId",
   artistName: "Banksy",
   year: " 2021 ",
@@ -43,6 +46,8 @@ const validFormWithSpaces = {
   depth: " 5 ",
   units: " cm ",
   provenance: "  provenance  ",
+  location: "  NY, USA  ",
+  locationId: "locationId",
 }
 
 const utmParams = { utmMedium: "Medium", utmSource: "Source", utmTerm: "Term" }
@@ -140,6 +145,11 @@ describe("ArtworkDetails", () => {
       expect(wrapper.find("input[name='provenance']").prop("value")).toBe(
         "provenance"
       )
+      expect(
+        wrapper
+          .find("input[data-test-id='autocomplete-location']")
+          .prop("value")
+      ).toBe("NY, USA")
     })
 
     describe("Correct steps", () => {

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetailsForm.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetailsForm.jest.tsx
@@ -43,6 +43,10 @@ describe("ArtworkDetailsForm", () => {
     expect(wrapper.find("Radio[value='in']").length).toBe(1)
     expect(wrapper.find("Radio[value='cm']").length).toBe(1)
     expect(wrapper.find("input[name='provenance']").length).toBe(1)
+    expect(wrapper.find("input[name='provenance']").length).toBe(1)
+    expect(
+      wrapper.find("input[data-test-id='autocomplete-location']").length
+    ).toBe(1)
   })
 
   describe("Rarity", () => {
@@ -115,7 +119,9 @@ describe("ArtworkDetailsForm", () => {
   it("if units are 'in' renders size fields correctly", () => {
     const sizeFields = wrapper
       .find(LabeledInput)
-      .filterWhere(n => n.prop("title") !== "Artist")
+      .filterWhere(
+        n => n.prop("title") !== "Artist" && n.prop("title") !== "Location"
+      )
 
     sizeFields.forEach((node: ReactWrapper) => {
       expect(node.text()).toBe("in")
@@ -126,7 +132,9 @@ describe("ArtworkDetailsForm", () => {
     wrapper.find("Radio[value='cm']").simulate("click")
     const sizeFields = wrapper
       .find(LabeledInput)
-      .filterWhere(n => n.prop("title") !== "Artist")
+      .filterWhere(
+        n => n.prop("title") !== "Artist" && n.prop("title") !== "Location"
+      )
 
     sizeFields.forEach((node: ReactWrapper) => {
       expect(node.text()).toBe("cm")

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/LocationAutocomplete.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/LocationAutocomplete.jest.tsx
@@ -190,7 +190,7 @@ describe("ArtistAutocomplete", () => {
 
   describe("Shows an error", () => {
     it("if focus moved out without selected suggestion", async () => {
-      await simulateTyping(wrapper, "Ban")
+      await simulateTyping(wrapper, "Min")
       expect(wrapper.find("div[color='red100']").length).toBe(0)
 
       const handleClose: () => void = wrapper
@@ -201,7 +201,7 @@ describe("ArtistAutocomplete", () => {
       wrapper.update()
 
       expect(wrapper.find("div[color='red100']").text()).toBe(
-        "Please, select a location from suggestions"
+        `Could not find ${formikValues.location}`
       )
     })
   })

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/LocationAutocomplete.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/LocationAutocomplete.jest.tsx
@@ -1,0 +1,208 @@
+import { mount, ReactWrapper } from "enzyme"
+import {
+  ArtworkDetailsFormModel,
+  getArtworkDetailsFormInitialValues,
+} from "../Components/ArtworkDetailsForm"
+import { LocationAutoComplete } from "../Components/LocationAutocomplete"
+import { Form, Formik } from "formik"
+import { Input } from "@artsy/palette"
+import { SystemContextProvider } from "v2/System"
+import { flushPromiseQueue } from "v2/DevTools"
+import { artworkDetailsValidationSchema } from "../../Utils/validation"
+
+jest.mock("v2/System/Router/useRouter", () => ({
+  useRouter: jest.fn(() => ({ match: { params: { id: null } } })),
+}))
+
+const mockGetPlacePredictions = jest.fn().mockResolvedValue({
+  predictions: [
+    { description: "Minden, Germany", place_id: "111" },
+    { description: "Minsk, Belarus", place_id: "222" },
+  ],
+})
+const AutocompleteService = jest.fn().mockImplementation(() => ({
+  getPlacePredictions: mockGetPlacePredictions,
+}))
+const setupGoogleMapsMock = () => {
+  // @ts-ignore
+  global.window.google = { maps: { places: { AutocompleteService } } }
+}
+
+const mockErrorHandler = jest.fn()
+let formikValues: ArtworkDetailsFormModel
+const renderArtistAutosuggest = (values: ArtworkDetailsFormModel) =>
+  mount(
+    <SystemContextProvider>
+      <Formik<ArtworkDetailsFormModel>
+        initialValues={values}
+        onSubmit={jest.fn()}
+        validationSchema={artworkDetailsValidationSchema}
+      >
+        {({ values }) => {
+          formikValues = values
+          return (
+            <Form>
+              <LocationAutoComplete onError={() => mockErrorHandler(true)} />
+            </Form>
+          )
+        }}
+      </Formik>
+    </SystemContextProvider>
+  )
+
+const inputSelector = "input[data-test-id='autocomplete-location']"
+const optionsSelector = "button[role='option']"
+
+const simulateTyping = async (wrapper: ReactWrapper, text: string) => {
+  const locationInput = wrapper.find(inputSelector)
+  locationInput
+    .simulate("focus")
+    .simulate("change", { target: { value: text } })
+  await new Promise(r => setTimeout(r, 500))
+  await flushPromiseQueue()
+  wrapper.update()
+}
+
+const simulateSelectSuggestion = async (wrapper: ReactWrapper, idx: number) => {
+  wrapper.find(inputSelector).simulate("focus")
+  const suggestion = wrapper.find(optionsSelector).at(idx)
+  suggestion.simulate("mouseenter").simulate("mousedown").simulate("mouseup")
+  await flushPromiseQueue()
+  wrapper.update()
+}
+
+describe("ArtistAutocomplete", () => {
+  let wrapper: ReactWrapper
+
+  beforeAll(() => {
+    setupGoogleMapsMock()
+  })
+
+  beforeEach(async () => {
+    wrapper = renderArtistAutosuggest(getArtworkDetailsFormInitialValues())
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders correctly", () => {
+    const input = wrapper.find(Input)
+    expect(wrapper.find(inputSelector).length).toBe(1)
+    expect(input.prop("placeholder")).toBe(
+      "Enter City Where Artwork Is Located"
+    )
+    expect(input.prop("title")).toBe("Location")
+  })
+
+  describe("Query", () => {
+    describe("sends request", () => {
+      it("when the 3rd character is entered", async () => {
+        await simulateTyping(wrapper, "Min")
+
+        const searchString = mockGetPlacePredictions.mock.calls[0][0].input
+
+        expect(mockGetPlacePredictions).toHaveBeenCalledTimes(1)
+        expect(searchString).toBe("Min")
+      })
+
+      it("spaces are not counted", async () => {
+        await simulateTyping(wrapper, " Mi n")
+
+        const searchString = mockGetPlacePredictions.mock.calls[0][0].input
+
+        expect(mockGetPlacePredictions).toHaveBeenCalledTimes(1)
+        expect(searchString).toBe(" Mi n")
+      })
+    })
+    describe("doesn't sends request", () => {
+      it("when less then 3 character is entered", async () => {
+        await simulateTyping(wrapper, "Mi")
+
+        expect(mockGetPlacePredictions).toHaveBeenCalledTimes(0)
+      })
+
+      it("spaces are not counted", async () => {
+        simulateTyping(wrapper, " Mi ")
+
+        expect(mockGetPlacePredictions).toHaveBeenCalledTimes(0)
+      })
+    })
+  })
+
+  describe("LocationAutocomplete component", () => {
+    it("fires error handler with correct arg when query failed", async () => {
+      mockGetPlacePredictions.mockRejectedValueOnce("query failed")
+
+      await simulateTyping(wrapper, "Par")
+
+      expect(mockErrorHandler).toHaveBeenCalledTimes(1)
+      expect(mockErrorHandler).toHaveBeenCalledWith(true)
+    })
+  })
+
+  describe("Suggestions", () => {
+    it("render suggestions", async () => {
+      const correctSuggestionsLabels = ["Minden, Germany", "Minsk, Belarus"]
+      await simulateTyping(wrapper, "Min")
+
+      const suggestions = wrapper.find(optionsSelector)
+
+      suggestions.forEach((node, idx) => {
+        expect(node.text()).toBe(correctSuggestionsLabels[idx])
+      })
+    })
+
+    it("suggestion selected", async () => {
+      await simulateTyping(wrapper, "Min")
+      await simulateSelectSuggestion(wrapper, 0)
+      expect(wrapper.find(inputSelector).prop("value")).toBe("Minden, Germany")
+      expect(formikValues.location).toBe("Minden, Germany")
+      expect(formikValues.locationId).toBe("111")
+      expect(wrapper.find(optionsSelector).length).toBe(0)
+
+      await simulateTyping(wrapper, "Mins")
+      await simulateSelectSuggestion(wrapper, 1)
+      expect(wrapper.find(inputSelector).prop("value")).toBe("Minsk, Belarus")
+      expect(formikValues.location).toBe("Minsk, Belarus")
+      expect(formikValues.locationId).toBe("222")
+      expect(wrapper.find(optionsSelector).length).toBe(0)
+    })
+
+    it("renders suggestions after focus backed to input", async () => {
+      await simulateTyping(wrapper, "Min")
+      await simulateSelectSuggestion(wrapper, 0)
+      expect(wrapper.find(optionsSelector).length).toBe(0)
+
+      wrapper.find(inputSelector).simulate("focus")
+      expect(wrapper.find(optionsSelector).length).toBe(2)
+    })
+
+    it("resets locationId if changing input", async () => {
+      await simulateTyping(wrapper, "Min")
+      await simulateSelectSuggestion(wrapper, 1)
+      expect(formikValues.locationId).toBe("222")
+
+      await simulateTyping(wrapper, "A")
+      expect(formikValues.locationId).toBe("")
+    })
+  })
+
+  describe("Shows an error", () => {
+    it("if focus moved out without selected suggestion", async () => {
+      await simulateTyping(wrapper, "Ban")
+      expect(wrapper.find("div[color='red100']").length).toBe(0)
+
+      const handleClose: () => void = wrapper
+        .find("AutocompleteInput")
+        .prop("onClose")
+      handleClose()
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(wrapper.find("div[color='red100']").text()).toBe(
+        "Please, select a location from suggestions"
+      )
+    })
+  })
+})

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/LocationAutocomplete.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/LocationAutocomplete.jest.tsx
@@ -96,37 +96,19 @@ describe("ArtistAutocomplete", () => {
   })
 
   describe("Query", () => {
-    describe("sends request", () => {
-      it("when the 3rd character is entered", async () => {
-        await simulateTyping(wrapper, "Min")
+    it("starts when character is entered", async () => {
+      await simulateTyping(wrapper, "M")
 
-        const searchString = mockGetPlacePredictions.mock.calls[0][0].input
+      const searchString = mockGetPlacePredictions.mock.calls[0][0].input
 
-        expect(mockGetPlacePredictions).toHaveBeenCalledTimes(1)
-        expect(searchString).toBe("Min")
-      })
-
-      it("spaces are not counted", async () => {
-        await simulateTyping(wrapper, " Mi n")
-
-        const searchString = mockGetPlacePredictions.mock.calls[0][0].input
-
-        expect(mockGetPlacePredictions).toHaveBeenCalledTimes(1)
-        expect(searchString).toBe(" Mi n")
-      })
+      expect(mockGetPlacePredictions).toHaveBeenCalledTimes(1)
+      expect(searchString).toBe("M")
     })
-    describe("doesn't sends request", () => {
-      it("when less then 3 character is entered", async () => {
-        await simulateTyping(wrapper, "Mi")
 
-        expect(mockGetPlacePredictions).toHaveBeenCalledTimes(0)
-      })
+    it("doesn't starts if it's space", async () => {
+      await simulateTyping(wrapper, " ")
 
-      it("spaces are not counted", async () => {
-        simulateTyping(wrapper, " Mi ")
-
-        expect(mockGetPlacePredictions).toHaveBeenCalledTimes(0)
-      })
+      expect(mockGetPlacePredictions).toHaveBeenCalledTimes(0)
     })
   })
 

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/__tests__/createConsignSubmission.jest.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/__tests__/createConsignSubmission.jest.ts
@@ -65,6 +65,8 @@ describe("createConsignSubmission", () => {
         editionSize: "",
         depth: "",
         provenance: "provenance",
+        location: "location",
+        locationId: "locationID",
       },
       uploadPhotosForm: {
         photos: [
@@ -132,6 +134,7 @@ describe("createConsignSubmission", () => {
       userName: undefined,
       userPhone: undefined,
       provenance: "provenance",
+      locationCity: "location",
     }
 
     expect(createConsignSubmissionMutation).toHaveBeenCalled()

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/__tests__/useSubmission.jest.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/__tests__/useSubmission.jest.ts
@@ -81,6 +81,8 @@ describe("useSubmission", () => {
         units: "in",
         year: "2020",
         provenance: "provenance",
+        location: "location",
+        locationId: "locationId",
       },
     }
 

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/createConsignSubmissionInput.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/createConsignSubmissionInput.ts
@@ -23,6 +23,7 @@ export const createConsignSubmissionInput = (
     depth: submission.artworkDetailsForm.depth,
     dimensionsMetric: submission.artworkDetailsForm.units,
     provenance: submission.artworkDetailsForm.provenance,
+    locationCity: submission.artworkDetailsForm.location,
     state: "SUBMITTED",
     userEmail: user?.email,
     userName: user?.name,

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/validation.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/validation.ts
@@ -36,9 +36,13 @@ export const artworkDetailsValidationSchema = yup.object().shape({
     .trim(),
   units: yup.string().required(),
   provenance: yup.string().trim(),
-  locationId: yup
-    .string()
-    .required("Please, select a location from suggestions"),
+  locationId: yup.string().test((value, ctx) =>
+    value
+      ? true
+      : ctx.createError({
+          message: `Could not find ${ctx.parent.location}`,
+        })
+  ),
 })
 
 /*

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/validation.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/validation.ts
@@ -36,6 +36,9 @@ export const artworkDetailsValidationSchema = yup.object().shape({
     .trim(),
   units: yup.string().required(),
   provenance: yup.string().trim(),
+  locationId: yup
+    .string()
+    .required("Please, select a location from suggestions"),
 })
 
 /*


### PR DESCRIPTION
Jira Ticket:ticket: : [SWA-129](https://artsyproduct.atlassian.net/browse/SWA-129)

This PR adds the `Location` autocomplete field to the `ArtworkDetailsForm` in the `Submission flow`.

**VIDEO:clapper: :**

https://user-images.githubusercontent.com/55637696/144232988-f7452fa5-f544-43b1-b362-e2a9ef040b81.mov

https://user-images.githubusercontent.com/55637696/144233380-c5cb199a-e66b-45ff-b046-d9978db4b8a1.mov

https://user-images.githubusercontent.com/55637696/144233808-95f70726-de4b-4b34-baf1-9f0a821a8b53.mov


