### PR TITLE
[feat]: Replace or remove some references to the word consign

### DIFF
--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHowToSell.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHowToSell.tsx
@@ -51,7 +51,7 @@ const ArtistConsignHowtoSell: React.FC<ArtistConsignHowtoSellProps> = ({
           <Section
             icon={<EnvelopeIcon width={30} height={30} />}
             text="Receive offers"
-            description="If your work is accepted, you’ll receive competitive consignment
+            description="If your work is accepted, you’ll receive competitive
             offers from auction houses, galleries, and collectors."
           />
           <Section

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/FAQ.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/FAQ.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Expandable, Join, Spacer, Text } from "@artsy/palette"
 
 export const FAQ: React.FC = () => {
@@ -70,10 +70,10 @@ export const FAQ: React.FC = () => {
               <a href="/consign" target="_blank">
                 Sell with Artsy program
               </a>{" "}
-              in which we currently accept consignments of works by artists that
-              are already in our database who have a resale market and
-              substantial collector demand. To learn more about our Sell with
-              Artsy program, please visit our Help Center article on{" "}
+              in which we currently accept works by artists that are already in
+              our database who have a resale market and substantial collector
+              demand. To learn more about our Sell with Artsy program, please
+              visit our Help Center article on{" "}
               <a
                 href="https://support.artsy.net/hc/en-us/articles/1500006366381"
                 target="_blank"

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/FAQ.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/FAQ.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { Expandable, Join, Spacer, Text } from "@artsy/palette"
 
 export const FAQ: React.FC = () => {

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/HowToSell.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/HowToSell.tsx
@@ -37,7 +37,7 @@ export const HowToSell: React.FC = () => {
           <Section
             icon={<MultipleOffersIcon width={50} height={50} />}
             text="Receive multiple offers"
-            description="If your work is accepted, you’ll receive competitive consignment offers from Artsy’s curated auctions, auction houses, and galleries."
+            description="If your work is accepted, you’ll receive competitive offers from Artsy’s curated auctions, auction houses, and galleries."
           />
         </Column>
 

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -81,8 +81,8 @@ export const ArtworkDetails: React.FC = () => {
         &#8226; All fields are required to submit a work.
       </Text>
       <Text mb={[2, 6]} variant="sm" color="black60">
-        &#8226; Unfortunately we are not accepting consignments directly from
-        artists at this time.
+        &#8226; We currently do not allow artists to sell their own work on
+        Artsy.
       </Text>
 
       <Formik<ArtworkDetailsFormModel>

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
@@ -221,7 +221,7 @@ describe("ArtistAutocomplete", () => {
       wrapper.update()
 
       expect(wrapper.find("div[color='red100']").text()).toBe(
-        "Unfortunately, we currently do not have enough demand for this artist’s work to be consigned."
+        "Unfortunately, we currently do not have enough demand for this artist’s work to be submitted."
       )
     })
   })

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
@@ -97,7 +97,7 @@ describe("ArtworkDetails", () => {
       expect(text).toContain("Tell us about your artwork")
       expect(text).toContain("All fields are required to submit a work.")
       expect(text).toContain(
-        "Unfortunately we are not accepting consignments directly from artists at this time."
+        "We currently do not allow artists to sell their own work on Artsy."
       )
       expect(wrapper.find(ArtworkDetailsForm)).toBeTruthy()
       expect(wrapper.find("[data-test-id='save-button']")).toBeTruthy()

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/validation.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/validation.ts
@@ -5,7 +5,7 @@ export const artworkDetailsValidationSchema = yup.object().shape({
   artistId: yup
     .string()
     .required(
-      "Unfortunately, we currently do not have enough demand for this artist’s work to be consigned."
+      "Unfortunately, we currently do not have enough demand for this artist’s work to be submitted."
     ),
   year: yup.string().required().trim(),
   title: yup.string().required().trim(),


### PR DESCRIPTION
### Description 

Ticket: [SWA-80 ](https://artsyproduct.atlassian.net/browse/SWA-80)

As per legal requirements, we are not allowed to use the words 'consign' or 'consignment' in places where users have access. This PR replaces or removes some of such references to the words. The exact places where the words should be replaced/removed are discussed and determined in [this google doc](https://docs.google.com/document/d/1CyIph7Iqts-6nV9YNhV98ejQniLTQ45x9SQokFeMP3g/edit) by our product and legal teams. 