### PR TITLE
refactor(PX-4712): shuffle around the shipping options display to match the design

### DIFF
--- a/src/v2/Apps/Order/Components/ShippingQuotes.tsx
+++ b/src/v2/Apps/Order/Components/ShippingQuotes.tsx
@@ -1,5 +1,13 @@
-import * as React from "react";
-import { BorderedRadio, BoxProps, Flex, RadioGroup, Text } from "@artsy/palette"
+import * as React from "react"
+import {
+  BorderedRadio,
+  BoxProps,
+  Column,
+  Flex,
+  GridColumns,
+  RadioGroup,
+  Text,
+} from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShippingQuotes_shippingQuotes } from "v2/__generated__/ShippingQuotes_shippingQuotes.graphql"
 import { compact } from "lodash"
@@ -55,13 +63,17 @@ export const ShippingQuotes: React.FC<ShippingQuotesProps> = ({
             position="relative"
           >
             <Flex flexDirection="column" width="100%">
-              <Flex justifyContent="space-between">
-                <Text textTransform="capitalize">{displayName}</Text>
-                <Text textTransform="capitalize" data-test="quotePrice">
-                  {price}
-                </Text>
-              </Flex>
-              <Text textColor="black60">{description}</Text>
+              <GridColumns>
+                <Column span={10}>
+                  <Text textTransform="capitalize">{displayName}</Text>
+                  <Text textColor="black60">{description}</Text>
+                </Column>
+                <Column span={2} textAlign={"right"}>
+                  <Text textTransform="capitalize" data-test="quotePrice">
+                    {price}
+                  </Text>
+                </Column>
+              </GridColumns>
             </Flex>
           </BorderedRadio>
         )

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -5,11 +5,11 @@ import {
   Checkbox,
   Collapse,
   Flex,
-  Link,
   RadioGroup,
   Spacer,
   Text,
 } from "@artsy/palette"
+import { RouterLink } from "v2/System/Router/RouterLink"
 import { Shipping_order } from "v2/__generated__/Shipping_order.graphql"
 import { CommerceOrderFulfillmentTypeEnum } from "v2/__generated__/SetShippingMutation.graphql"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "v2/Apps/Order/Components/ArtworkSummaryItem"
@@ -50,7 +50,7 @@ import { Component } from "react"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 import createLogger from "v2/Utils/logger"
 import { Media } from "v2/Utils/Responsive"
-import { BuyerGuarantee } from "../../Components/BuyerGuarantee"
+import { BuyerGuarantee } from "v2/Apps/Order/Components/BuyerGuarantee"
 import { Shipping_me } from "v2/__generated__/Shipping_me.graphql"
 import {
   startingPhoneNumber,
@@ -61,19 +61,19 @@ import {
   getShippingQuotes,
   getShippingOption,
   ShippingQuotesType,
-} from "../../Utils/shippingUtils"
+} from "v2/Apps/Order/Utils/shippingUtils"
 import {
   NEW_ADDRESS,
   SavedAddressesFragmentContainer as SavedAddresses,
-} from "../../Components/SavedAddresses"
-import { createUserAddress } from "../../Mutations/CreateUserAddress"
-import { setShipping } from "../../Mutations/SetShipping"
+} from "v2/Apps/Order/Components/SavedAddresses"
+import { createUserAddress } from "v2/Apps/Order/Mutations/CreateUserAddress"
+import { setShipping } from "v2/Apps/Order/Mutations/SetShipping"
 import { SystemContextProps, withSystemContext } from "v2/System/SystemContext"
-import { ShippingQuotesFragmentContainer } from "../../Components/ShippingQuotes"
+import { ShippingQuotesFragmentContainer } from "v2/Apps/Order/Components/ShippingQuotes"
 import { compact } from "lodash"
-import { selectShippingOption } from "../../Mutations/SelectShippingOption"
-import { updateUserAddress } from "../../Mutations/UpdateUserAddress"
-import { deleteUserAddress } from "../../Mutations/DeleteUserAddress"
+import { selectShippingOption } from "v2/Apps/Order/Mutations/SelectShippingOption"
+import { updateUserAddress } from "v2/Apps/Order/Mutations/UpdateUserAddress"
+import { deleteUserAddress } from "v2/Apps/Order/Mutations/DeleteUserAddress"
 import { CreateUserAddressMutationResponse } from "v2/__generated__/CreateUserAddressMutation.graphql"
 import { UpdateUserAddressMutationResponse } from "v2/__generated__/UpdateUserAddressMutation.graphql"
 import {
@@ -433,7 +433,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
     <>
       There was a problem getting shipping quotes. <br />
       Please contact{" "}
-      <Link href={`mailto:orders@artsy.net`}>orders@artsy.net</Link>.
+      <RouterLink to={`mailto:orders@artsy.net`}>orders@artsy.net</RouterLink>.
     </>
   )
 
@@ -571,9 +571,9 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
       >
         We need to confirm some details with you before processing this order.
         Please reach out to{" "}
-        <Link color="red100" hoverColor="red100" href="mailto:orders@artsy.net">
+        <RouterLink color="red100" to="mailto:orders@artsy.net">
           orders@artsy.net
-        </Link>{" "}
+        </RouterLink>{" "}
         for assistance.
       </Text>
     )


### PR DESCRIPTION
Ended up not adding space between the title and the description as this spacing seems fine now when things are in a table format.

Looks like:
<img width="789" alt="Screen Shot 2021-12-01 at 12 44 36 PM" src="https://user-images.githubusercontent.com/437156/144286597-428a2864-01f1-41ca-b3d5-a14bf5248ade.png">

