### PR TITLE
feat: Apply resizing logic to RSS feed items GROW-692

### DIFF
--- a/src/desktop/apps/rss/templates/news.jade
+++ b/src/desktop/apps/rss/templates/news.jade
@@ -24,9 +24,10 @@ rss(version='2.0', xmlns:atom='http://www.w3.org/2005/Atom' xmlns:content='http:
           meta(property="og:image" content="#{sd.APP_URL}/images/og_image.jpg")
         else if article.get('thumbnail_image')
           - image = article.get('thumbnail_image')
+          - resizedImage = resize(image, { width: 1000 })
           - extension = image.split('.').pop()
           - mimeType = ['jpg', 'jpeg'].includes(extension) ? 'jpeg' : extension
-          enclosure(url=image length=0 type="image/#{mimeType}")
+          enclosure(url=resizedImage length=0 type="image/#{mimeType}")
         content:encoded
           | <![CDATA[
           include article

--- a/src/desktop/apps/rss/test/news.test.js
+++ b/src/desktop/apps/rss/test/news.test.js
@@ -130,6 +130,9 @@ describe("/rss", function () {
     })
 
     return it("renders enclosures on non-video articles", function () {
+      const mockResize = url => {
+        return url
+      }
       const articles = [
         {
           layout: "standard",
@@ -148,6 +151,7 @@ describe("/rss", function () {
         sd,
         articles: new Articles(articles),
         moment,
+        resize: mockResize,
       })
       rendered.should.containEql(
         '<enclosure url="artsy.net/jpg.jpg" length="0" type="image/jpeg">'


### PR DESCRIPTION
While working on the editorial version of the widget I realized that the enclosure URL for articles in our RSS feed was not having any resizing applied to it. I only noticed this when we happened to have a massive image in the first four items and Xcode was crashing like crazy.

Anyway, with @dzucconi's help I was able to apply the `resize` mixin to the jade template that draws the RSS feed. This results in MUCH smaller image sizes:

```
jon@juggernaut:~/code/lab_notebook(main+*)% lh omg-images
total 19352
drwxr-xr-x   7 jon  staff   224B Dec  3 16:43 ./
drwxr-xr-x  28 jon  staff   896B Dec  3 15:57 ../
-rw-r--r--   1 jon  staff   211K Dec  3 15:35 first.jpg
-rw-r--r--   1 jon  staff    88K Dec  3 16:43 fourth-resized.jpg <--- nice 😎 
-rw-r--r--   1 jon  staff   8.1M Dec  3 15:37 fourth.jpg
-rw-r--r--   1 jon  staff   206K Dec  3 15:36 second.jpeg
-rw-r--r--   1 jon  staff   212K Dec  3 15:37 third.jpg
```

I picked `1000` as the width somewhat arbitrarily - open to suggestions there if anybody has a better idea.

https://artsyproduct.atlassian.net/browse/GROW-692

/cc @artsy/grow-devs