### PR TITLE
feature: Track Page Cache Metrics

### DIFF
--- a/src/lib/middleware/redisPageCache.ts
+++ b/src/lib/middleware/redisPageCache.ts
@@ -132,7 +132,10 @@ export function redisPageCacheMiddleware(
         debugLog(`[Redis Page Cache]: Reading ${cacheKeyForRequest} from cache`)
         cachedResponseServed = true
         setTimingHeader(res, "redisCacheHit")
-        return res.send(html.toString("utf-8"))
+        res.locals.cachedPageAvailable = true
+        res.locals.cachedPageData = html.toString("utf-8")
+        next()
+        return
       }
 
       setTimingHeader(res, "redisCacheMiss")

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -29,6 +29,11 @@ const { routes, routePaths } = getRouteConfig()
 app.get(
   routePaths,
   async (req: ArtsyRequest, res: ArtsyResponse, next: NextFunction) => {
+    if (res.locals.cachedPageAvailable) {
+      res.send(res.locals.cachedPageData)
+      return
+    }
+
     try {
       const {
         status,


### PR DESCRIPTION
Due to some limitations in how Datadog determines what route to use for a trace, the cached page data needs to be returned in the final route. This allows the trace to select the correct URL.