### PR TITLE
fix(SWA-152): The add photo button should return to white after adding a photo

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/PhotoDropzone.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/PhotoDropzone.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, Button, BoxProps } from "@artsy/palette"
 import { useFormikContext } from "formik"
 import { cloneDeep } from "lodash"
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { FileRejection, useDropzone } from "react-dropzone"
 import { Media } from "v2/Utils/Responsive"
 import { CustomErrorCode, MBSize, Photo } from "../../Utils/fileUtils"
@@ -77,6 +77,7 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
 }) => {
   const [customErrors, setCustomErrors] = useState<Array<FileRejection>>([])
   const { values } = useFormikContext<UploadPhotosFormModel>()
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
 
   const { getRootProps, getInputProps, open, fileRejections } = useDropzone({
     onDropAccepted: files => {
@@ -89,8 +90,14 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
       if (acceptedFiles.length) {
         onDrop(acceptedFiles)
       }
-
       setCustomErrors(errors)
+      buttonRef.current?.blur()
+    },
+    onFileDialogCancel: () => {
+      buttonRef.current?.blur()
+    },
+    onDropRejected: () => {
+      buttonRef.current?.blur()
     },
     accept: ["image/jpeg", "image/png"],
     noClick: true,
@@ -124,6 +131,7 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
         </Text>
 
         <Button
+          ref={buttonRef}
           width={["100%", "auto"]}
           type="button"
           mt={4}


### PR DESCRIPTION
Jira Ticket:ticket: : [SWA-152](https://artsyproduct.atlassian.net/browse/SWA-152)

This PR `adds blur call` for the "Add Photo" button after the user uploads a valid file, pushes cancel in the file dialog, or uploads an invalid file.

**VIDEO:clapper: :**

https://user-images.githubusercontent.com/55637696/145185117-4f09a61c-353a-4724-bc87-0eb5ba5e2d97.mov


