### PR TITLE
fix(FX-3642): Add sizes to the allowed filters list

### DIFF
--- a/src/v2/Components/ArtworkFilter/SavedSearch/Utils/constants.ts
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Utils/constants.ts
@@ -29,6 +29,7 @@ export const allowedSearchCriteriaKeys = [
   "materialsTerms",
   "priceRange",
   "dimensionRange",
+  "sizes",
   "height",
   "width",
 ]


### PR DESCRIPTION
[FX-3642]

When creating saved search alert on web with one or more size checkboxes selected (Small, Medium, Large), the alert is created without sizes criteria

#### Before

https://user-images.githubusercontent.com/44819355/145367146-8274e873-8068-4a6a-950d-d754f965112c.mp4


#### After

https://user-images.githubusercontent.com/44819355/145366638-e07ce5ed-c5c6-48fe-9107-128d637bc998.mp4





[FX-3642]: https://artsyproduct.atlassian.net/browse/FX-3642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ