### PR TITLE
[WIP] fix(TX-67): html showing in messages 

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,8 @@
     "jsdom": "11.6.2",
     "jwt-decode": "2.2.0",
     "knox": "0.9.2",
+    "linkify-html": "^3.0.4",
+    "linkifyjs": "^3.0.4",
     "lodash": "4.17.21",
     "mailcheck": "1.1.1",
     "memoize-one": "^5.2.1",

--- a/src/v2/Apps/Conversation/Components/Message.tsx
+++ b/src/v2/Apps/Conversation/Components/Message.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "relay-runtime"
-import Linkify from "react-linkify"
+import linkifyHtml from "linkify-html"
 import {
   Box,
   BoxProps,
@@ -114,15 +114,6 @@ export const Message: React.FC<MessageProps> = props => {
   const textColor = isFromUser ? "white100" : "black100"
   const alignSelf = isFromUser ? "flex-end" : undefined
 
-  // react-linkify v1.0.0-alpha has a bug that `properties` doesn't work.
-  // This is a workaround to specify target for now.
-  // https://github.com/tasti/react-linkify/issues/78#issuecomment-514754050
-  const linkTargetDecorator = (href, text, key) => (
-    <a href={href} key={key} target="_blank">
-      {text}
-    </a>
-  )
-
   return (
     <>
       <Box
@@ -136,9 +127,13 @@ export const Message: React.FC<MessageProps> = props => {
         maxWidth="66.67%"
         width="fit-content"
       >
-        <MessageText variant="md" color={textColor}>
-          <Linkify componentDecorator={linkTargetDecorator}>{body}</Linkify>
-        </MessageText>
+        <MessageText
+          variant="md"
+          color={textColor}
+          dangerouslySetInnerHTML={{
+            __html: linkifyHtml(body!, { target: "_blank" }),
+          }}
+        />
       </Box>
       {!!message?.attachments?.length &&
         message?.attachments?.map(attachment => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13486,12 +13486,22 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+linkify-html@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/linkify-html/-/linkify-html-3.0.4.tgz#e6a66671da83ec41fed2a5a70d5191f050cc0201"
+  integrity sha512-pQrMEkEaKfbVj/eCUyi+5lgmRwaCt1MOuzHexyCOZp40iLGEH6j/6kMqg2WLCGKYET70SvFGOoSe5aAnDsoJoQ==
+
 linkify-it@^2.0.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
   integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
   dependencies:
     uc.micro "^1.0.1"
+
+linkifyjs@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-3.0.4.tgz#469a1b44903d179e3b23317fd3c4e995453765b9"
+  integrity sha512-JWw1HHMx54g8mEsG7JwI8I/xh7qeJbF6L9u1dQOYW91RdRqDYpnTn1UaNXYkmLD967Vk0xGuyHzuRnkSApby3w==
 
 lint-staged@10.2.6:
   version "10.2.6"


### PR DESCRIPTION
[TX-67](https://artsyproduct.atlassian.net/browse/TX-67)

This PR is attempting to fix the issue where links to some messages from Artsy (specifically from Zendesk) are being rendered as HTML code. 

**I'm really not sure of the best solution for this one, so other opinions and ideas would be greatly appreciated!**

My first idea was to use `react-html-parser`, however, there was an issue where links are not showing on new lines and I wasn’t sure how to fix it:

<img width="731" alt="Screenshot 2021-11-05 at 3 08 45 PM (1)" src="https://user-images.githubusercontent.com/50849237/145380802-318f1cd7-f703-4a8a-87ee-427700a2de08.png">

The second idea (and what I'm using in this PR) is to use `dangerouslySetInnerHTML`. To make this work with Linkify, we need to replace `react-linkify` with `linkify-html`. Using `linkify-html` also removes the need for the `linkTargetDecorator()` workaround. 

We could use [sanitize-html](https://www.npmjs.com/package/sanitize-html) to remove the danger of using `dangerouslySetInnerHTML`. But now I feel we would be adding a lot of dependencies for a seemingly simple issue. 

### Before and After

<img width="480" alt="Screenshot 2021-12-09 at 11 38 40 AM" src="https://user-images.githubusercontent.com/50849237/145381247-ea8c634a-3907-4172-8a46-30ed142eb3f2.png">


<img width="982" alt="Screenshot 2021-12-09 at 10 20 32 AM" src="https://user-images.githubusercontent.com/50849237/145381178-55e3e500-1c19-461e-91ba-53b348bdfc0a.png">
