### PR TITLE
fix(FX-3636): Do not send initial values as saved search criteria

### DIFF
--- a/src/v2/Components/ArtworkFilter/SavedSearch/Utils/__tests__/savedSearchCriteria.jest.ts
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Utils/__tests__/savedSearchCriteria.jest.ts
@@ -1,0 +1,34 @@
+import { ArtworkFilters } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+import { getSearchCriteriaFromFilters } from ".."
+
+const mockedArtistId = "artist-id"
+
+const mockedFilters: ArtworkFilters = {
+  additionalGeneIDs: [],
+  attributionClass: ["limited edition", "unique", "open edition"],
+  colors: ["black"],
+  height: "*-*",
+  inquireableOnly: true,
+  locationCities: [],
+  majorPeriods: [],
+  materialsTerms: [],
+  partnerIDs: [],
+  priceRange: "1000-5000",
+  width: "*-*",
+}
+
+describe("getSearchCriteriaFromFilters", () => {
+  it("returns object only containing artist id and criteria that has been changed", () => {
+    const result = getSearchCriteriaFromFilters(mockedArtistId, mockedFilters)
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        artistID: "artist-id",
+        attributionClass: ["limited edition", "unique", "open edition"],
+        colors: ["black"],
+        inquireableOnly: true,
+        priceRange: "1000-5000",
+      })
+    )
+  })
+})

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Utils/savedSearchCriteria.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Utils/savedSearchCriteria.tsx
@@ -1,5 +1,8 @@
 import { SearchCriteriaAttributes } from "v2/__generated__/createSavedSearchAlertMutation.graphql"
-import { ArtworkFilters } from "../../ArtworkFilterContext"
+import {
+  ArtworkFilters,
+  initialArtworkFilterState,
+} from "../../ArtworkFilterContext"
 import { allowedSearchCriteriaKeys } from "./constants"
 
 export const getAllowedFiltersForSavedSearchInput = (
@@ -16,11 +19,29 @@ export const getAllowedFiltersForSavedSearchInput = (
   return allowedFilters
 }
 
+const isDefaultValue = (paramName, paramValue) => {
+  return (
+    (Array.isArray(paramValue) && !paramValue.length) ||
+    initialArtworkFilterState[paramName] === paramValue
+  )
+}
+
 export const getSearchCriteriaFromFilters = (
   artistID: string,
   filters: ArtworkFilters
 ) => {
-  const input = getAllowedFiltersForSavedSearchInput(filters)
+  const allowedFilters = getAllowedFiltersForSavedSearchInput(filters)
+
+  const input = Object.entries(allowedFilters).reduce(
+    (acc, [paramName, paramValue]) => {
+      if (!isDefaultValue(paramName, paramValue)) {
+        acc[paramName] = paramValue
+      }
+      return acc
+    },
+    {}
+  )
+
   const criteria: SearchCriteriaAttributes = {
     artistID,
     ...input,

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Utils/savedSearchCriteria.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Utils/savedSearchCriteria.tsx
@@ -20,10 +20,10 @@ export const getAllowedFiltersForSavedSearchInput = (
 }
 
 const isDefaultValue = (paramName, paramValue) => {
-  return (
-    (Array.isArray(paramValue) && !paramValue.length) ||
-    initialArtworkFilterState[paramName] === paramValue
-  )
+  if (Array.isArray(paramValue)) {
+    return !paramValue.length
+  }
+  return initialArtworkFilterState[paramName] === paramValue
 }
 
 export const getSearchCriteriaFromFilters = (


### PR DESCRIPTION
[FX-3636]

We should not send default filter values in attributes for create alert mutation

### Demo

See sent criteria for given alert

![Screenshot 2021-12-09 at 16 01 15](https://user-images.githubusercontent.com/44819355/145401176-91dd5950-2cbb-425f-a447-76351b764b36.png)

#### Before

![Screenshot 2021-12-09 at 16 02 45](https://user-images.githubusercontent.com/44819355/145401401-5f7c2043-14c3-4beb-b6be-8774257aff3e.png)


#### After

![Screenshot 2021-12-09 at 16 01 44](https://user-images.githubusercontent.com/44819355/145401248-78391636-2545-470d-b997-eaeb630de477.png)





[FX-3636]: https://artsyproduct.atlassian.net/browse/FX-3636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ