### PR TITLE
feat: Enable sorting for artwork grids that result from a keyword search

### DIFF
--- a/src/v2/Apps/Search/Routes/SearchResultsArtworks.tsx
+++ b/src/v2/Apps/Search/Routes/SearchResultsArtworks.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { SearchResultsArtworks_viewer } from "v2/__generated__/SearchResultsArtworks_viewer.graphql"
 import { ZeroState } from "v2/Apps/Search/Components/ZeroState"
 import { ArtworkFilter } from "v2/Components/ArtworkFilter"
@@ -30,6 +30,15 @@ export const SearchResultsArtworksRoute: React.FC<SearchResultsRouteProps> = pro
         sidebar?.aggregations as SharedArtworkFilterContextProps["aggregations"]
       }
       counts={sidebar?.counts as Counts}
+      sortOptions={[
+        { value: "-decayed_merch", text: "Default" },
+        { value: "-has_price,-prices", text: "Price (desc.)" },
+        { value: "-has_price,prices", text: "Price (asc.)" },
+        { value: "-partner_updated_at", text: "Recently updated" },
+        { value: "-published_at", text: "Recently added" },
+        { value: "-year", text: "Artwork year (desc.)" },
+        { value: "year", text: "Artwork year (asc.)" },
+      ]}
     />
   )
 }

--- a/src/v2/Apps/Search/Routes/__tests__/SearchResultsArtworks.jest.tsx
+++ b/src/v2/Apps/Search/Routes/__tests__/SearchResultsArtworks.jest.tsx
@@ -3,7 +3,8 @@ import { SearchResultsArtworksRouteFragmentContainer as SearchResultsArtworks } 
 import { graphql } from "react-relay"
 import { SearchResultsArtworks_Query } from "v2/__generated__/SearchResultsArtworks_Query.graphql"
 import { useTracking } from "v2/System/Analytics/useTracking"
-import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
+import { screen } from "@testing-library/react"
 import {
   artistAggregation,
   artistNationalityAggregation,
@@ -23,7 +24,7 @@ jest.mock("v2/System/Router/useRouter", () => ({
 }))
 jest.mock("v2/System/Analytics/useTracking")
 
-const { getWrapper } = setupTestWrapper<SearchResultsArtworks_Query>({
+const { renderWithRelay } = setupTestWrapperTL<SearchResultsArtworks_Query>({
   Component: ({ viewer }) => (
     <MockBoot user={{ id: "percy-z" }}>
       <SearchResultsArtworks viewer={viewer!} />
@@ -50,13 +51,17 @@ describe("SearchResultsArtworks", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
-    expect(wrapper.find("ArtworkGridItem").length).toBe(1)
+    renderWithRelay({
+      Artwork: () => ({
+        title: "Artwork title",
+      }),
+    })
+
+    expect(screen.getByText("Artwork title")).toBeInTheDocument()
   })
 
-  it("renders filters in correct order", () => {
-    const wrapper = getWrapper({
+  it("renders filters", () => {
+    renderWithRelay({
       FilterArtworksConnection: () => ({
         counts: {
           followedArtists: 10,
@@ -71,57 +76,28 @@ describe("SearchResultsArtworks", () => {
         ],
       }),
     })
-    const filterWrappers = wrapper.find("FilterExpandable")
-    const filters = [
-      {
-        label: "Artists",
-        expanded: true,
-      },
-      {
-        label: "Rarity",
-        expanded: true,
-      },
-      {
-        label: "Medium",
-        expanded: true,
-      },
-      {
-        label: "Price",
-        expanded: true,
-      },
-      {
-        label: "Size",
-        expanded: true,
-      },
-      {
-        label: "Ways to Buy",
-        expanded: true,
-      },
-      {
-        label: "Material",
-      },
-      {
-        label: "Artist Nationality or Ethnicity",
-      },
-      {
-        label: "Artwork Location",
-      },
-      {
-        label: "Time Period",
-      },
-      {
-        label: "Color",
-      },
-      {
-        label: "Galleries and Institutions",
-      },
-    ]
 
-    filters.forEach((filter, filterIndex) => {
-      const { label, expanded } = filter
+    expect(screen.getByText("Artists")).toBeInTheDocument()
+    expect(screen.getByText("Rarity")).toBeInTheDocument()
+    expect(screen.getByText("Medium")).toBeInTheDocument()
+    expect(screen.getByText("Medium")).toBeInTheDocument()
+    expect(screen.getByText("Medium")).toBeInTheDocument()
+    expect(screen.getByText("Price")).toBeInTheDocument()
+    expect(screen.getByText("Size")).toBeInTheDocument()
+    expect(screen.getByText("Ways to Buy")).toBeInTheDocument()
+    expect(screen.getByText("Material")).toBeInTheDocument()
+    expect(
+      screen.getByText("Artist Nationality or Ethnicity")
+    ).toBeInTheDocument()
+    expect(screen.getByText("Artwork Location")).toBeInTheDocument()
+    expect(screen.getByText("Time Period")).toBeInTheDocument()
+    expect(screen.getByText("Color")).toBeInTheDocument()
+    expect(screen.getByText("Galleries and Institutions")).toBeInTheDocument()
+  })
 
-      expect(filterWrappers.at(filterIndex).prop("label")).toEqual(label)
-      expect(filterWrappers.at(filterIndex).prop("expanded")).toEqual(expanded)
-    })
+  it("renders sort input", () => {
+    renderWithRelay()
+
+    expect(screen.getByText("Sort:")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-3539]

### Description
We updated keyword search functionality in order to enable sorting within the Artworks pill of the mobile search experience.

This unblocks a similar sorting capability on Force's keyword search artwork results grid, e.g. https://staging.artsy.net/search?term=banksy%20balloon%20girl

### Acceptance Criteria:
* As a user
* When I perform a search in the global search bar on artsy.net
* And I am viewing the resulting artwork grid
* Then I can re-sort the grid in the typical ways (price, recency, etc)
