### PR TITLE
chore: add offset for filter pill

### DIFF
--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -344,6 +344,7 @@ export const BaseArtworkFilter: React.FC<
                   <Button
                     size="small"
                     onClick={() => toggleMobileActionSheet(true)}
+                    mr={2}
                   >
                     <Flex justifyContent="space-between" alignItems="center">
                       <FilterIcon fill="white100" />


### PR DESCRIPTION
Type: **Chore**

### Description
Add an offset to the right for the "Filter" pill (in this way, we will be safe so that the elements don’t overlap)

### Before
<img width="374" alt="screenshot" src="https://user-images.githubusercontent.com/3513494/145595917-bc285afd-88fe-4979-988c-e24ee8841290.png">

### After
https://user-images.githubusercontent.com/3513494/145595850-63a8b9ba-d441-44ff-bc17-c70a76c1f473.mp4


