### PR TITLE
feat(FX-3641): Show Create Alert button when user both logged in and out

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
@@ -21,7 +21,7 @@ import {
   StackableBorderBox,
   Text,
 } from "@artsy/palette"
-import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
+import { openAuthToSatisfyIntent } from "v2/Utils/openAuthModal"
 
 export interface ArtworkDetailsAboutTheWorkFromPartnerProps {
   artwork: ArtworkDetailsAboutTheWorkFromPartner_artwork
@@ -45,7 +45,7 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends Component<
   }
 
   handleOpenAuth = (mediator, partner) => {
-    openAuthToFollowSaveCreate(mediator, {
+    openAuthToSatisfyIntent(mediator, {
       entity: partner,
       contextModule: ContextModule.aboutTheWork,
       intent: Intent.followPartner,

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
@@ -21,7 +21,7 @@ import {
   StackableBorderBox,
   Text,
 } from "@artsy/palette"
-import { openAuthToFollowSave } from "v2/Utils/openAuthModal"
+import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
 
 export interface ArtworkDetailsAboutTheWorkFromPartnerProps {
   artwork: ArtworkDetailsAboutTheWorkFromPartner_artwork
@@ -45,7 +45,7 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends Component<
   }
 
   handleOpenAuth = (mediator, partner) => {
-    openAuthToFollowSave(mediator, {
+    openAuthToFollowSaveCreate(mediator, {
       entity: partner,
       contextModule: ContextModule.aboutTheWork,
       intent: Intent.followPartner,

--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerFollowButton.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerFollowButton.tsx
@@ -4,7 +4,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { FairOrganizerFollowButton_fairOrganizer } from "v2/__generated__/FairOrganizerFollowButton_fairOrganizer.graphql"
 import { useSystemContext } from "v2/System"
 import { fairOrganizerFollowMutation } from "../Mutations/FairOrganizerFollowMutation"
-import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
+import { openAuthToSatisfyIntent } from "v2/Utils/openAuthModal"
 import { ContextModule, Intent } from "@artsy/cohesion"
 
 interface FairOrganizerFollowButtonProps {
@@ -26,7 +26,7 @@ export const FairOrganizerFollowButton: React.FC<FairOrganizerFollowButtonProps>
         return true
       }
 
-      openAuthToFollowSaveCreate(mediator!, {
+      openAuthToSatisfyIntent(mediator!, {
         contextModule: ContextModule.fairOrganizerHeader,
         entity: {
           slug: fairOrganizer.slug,

--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerFollowButton.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerFollowButton.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import * as React from "react"
 import { Button } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairOrganizerFollowButton_fairOrganizer } from "v2/__generated__/FairOrganizerFollowButton_fairOrganizer.graphql"
 import { useSystemContext } from "v2/System"
 import { fairOrganizerFollowMutation } from "../Mutations/FairOrganizerFollowMutation"
-import { openAuthToFollowSave } from "v2/Utils/openAuthModal"
+import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
 import { ContextModule, Intent } from "@artsy/cohesion"
 
 interface FairOrganizerFollowButtonProps {
@@ -26,7 +26,7 @@ export const FairOrganizerFollowButton: React.FC<FairOrganizerFollowButtonProps>
         return true
       }
 
-      openAuthToFollowSave(mediator!, {
+      openAuthToFollowSaveCreate(mediator!, {
         contextModule: ContextModule.fairOrganizerHeader,
         entity: {
           slug: fairOrganizer.slug,

--- a/src/v2/Apps/FairOrginizer/Components/__tests__/FairOrganizerFollowButton.jest.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/__tests__/FairOrganizerFollowButton.jest.tsx
@@ -2,7 +2,7 @@ import { graphql } from "react-relay"
 import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 import { FairOrganizerFollowButton_Test_Query } from "v2/__generated__/FairOrganizerFollowButton_Test_Query.graphql"
 import { FairOrganizerFollowButtonFragmentContainer } from "../FairOrganizerFollowButton"
-import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
+import { openAuthToSatisfyIntent } from "v2/Utils/openAuthModal"
 import { useSystemContext } from "v2/System/useSystemContext"
 import { fairOrganizerFollowMutation } from "../../Mutations/FairOrganizerFollowMutation"
 
@@ -27,7 +27,7 @@ describe("FairOrganizerFollowButton", () => {
   )
 
   const mockUseSystemContext = useSystemContext as jest.Mock
-  const mockOpenAuthToFollowSave = openAuthToFollowSaveCreate as jest.Mock
+  const mockOpenAuthToSatisfyIntent = openAuthToSatisfyIntent as jest.Mock
   const mockFairOrganizerFollowMutation = fairOrganizerFollowMutation as jest.Mock
 
   beforeEach(() => {
@@ -76,7 +76,7 @@ describe("FairOrganizerFollowButton", () => {
     })
     wrapper.simulate("click")
 
-    expect(mockOpenAuthToFollowSave).toHaveBeenCalledWith("mediator", {
+    expect(mockOpenAuthToSatisfyIntent).toHaveBeenCalledWith("mediator", {
       contextModule: "fairOrganizerHeader",
       entity: { name: "fairOrganizerName", slug: "faiOrganizerSlug" },
       intent: "followPartner",

--- a/src/v2/Apps/FairOrginizer/Components/__tests__/FairOrganizerFollowButton.jest.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/__tests__/FairOrganizerFollowButton.jest.tsx
@@ -2,7 +2,7 @@ import { graphql } from "react-relay"
 import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 import { FairOrganizerFollowButton_Test_Query } from "v2/__generated__/FairOrganizerFollowButton_Test_Query.graphql"
 import { FairOrganizerFollowButtonFragmentContainer } from "../FairOrganizerFollowButton"
-import { openAuthToFollowSave } from "v2/Utils/openAuthModal"
+import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
 import { useSystemContext } from "v2/System/useSystemContext"
 import { fairOrganizerFollowMutation } from "../../Mutations/FairOrganizerFollowMutation"
 
@@ -27,7 +27,7 @@ describe("FairOrganizerFollowButton", () => {
   )
 
   const mockUseSystemContext = useSystemContext as jest.Mock
-  const mockOpenAuthToFollowSave = openAuthToFollowSave as jest.Mock
+  const mockOpenAuthToFollowSave = openAuthToFollowSaveCreate as jest.Mock
   const mockFairOrganizerFollowMutation = fairOrganizerFollowMutation as jest.Mock
 
   beforeEach(() => {

--- a/src/v2/Components/Artwork/SaveButton/useSaveArtwork.ts
+++ b/src/v2/Components/Artwork/SaveButton/useSaveArtwork.ts
@@ -1,6 +1,6 @@
 import { useSystemContext } from "v2/System"
 import { AuthContextModule, Intent } from "@artsy/cohesion"
-import { openAuthToFollowSave } from "v2/Utils/openAuthModal"
+import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
 import { SaveArtwork } from "./SaveArtworkMutation"
 
 type Artwork = {
@@ -52,7 +52,7 @@ export const useSaveArtwork = ({
         console.error("Artwork/Save Error saving artwork: ", err)
       }
     } else {
-      openAuthToFollowSave(mediator!, {
+      openAuthToFollowSaveCreate(mediator!, {
         contextModule,
         intent: Intent.saveArtwork,
         entity: {

--- a/src/v2/Components/Artwork/SaveButton/useSaveArtwork.ts
+++ b/src/v2/Components/Artwork/SaveButton/useSaveArtwork.ts
@@ -1,6 +1,6 @@
 import { useSystemContext } from "v2/System"
 import { AuthContextModule, Intent } from "@artsy/cohesion"
-import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
+import { openAuthToSatisfyIntent } from "v2/Utils/openAuthModal"
 import { SaveArtwork } from "./SaveArtworkMutation"
 
 type Artwork = {
@@ -52,7 +52,7 @@ export const useSaveArtwork = ({
         console.error("Artwork/Save Error saving artwork: ", err)
       }
     } else {
-      openAuthToFollowSaveCreate(mediator!, {
+      openAuthToSatisfyIntent(mediator!, {
         contextModule,
         intent: Intent.saveArtwork,
         entity: {

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/ArtworkGridFilterPills.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/ArtworkGridFilterPills.tsx
@@ -14,7 +14,7 @@ import { Pills } from "./Pills"
 const PILL_HORIZONTAL_MARGIN_SIZE = 0.5
 
 export interface ArtworkGridFilterPillsProps {
-  savedSearchAttributes: SavedSearchAttributes | null
+  savedSearchAttributes?: SavedSearchAttributes
 }
 
 export const ArtworkGridFilterPills: FC<ArtworkGridFilterPillsProps> = ({

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
@@ -10,7 +10,7 @@ import {
 } from "@artsy/cohesion"
 import { SavedSearchAlertModal } from "v2/Components/SavedSearchAlert/SavedSearchAlertModal"
 import { SavedSearchAlertMutationResult } from "v2/Components/SavedSearchAlert/SavedSearchAlertModel"
-import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
+import { openAuthToSatisfyIntent } from "v2/Utils/openAuthModal"
 import { mediator } from "lib/mediator"
 
 interface CreateAlertButtonProps extends ButtonProps {
@@ -45,7 +45,7 @@ export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
     if (isLoggedIn) {
       handleOpenForm()
     } else {
-      openAuthToFollowSaveCreate(mediator, {
+      openAuthToSatisfyIntent(mediator, {
         entity: {
           name: savedSearchAttributes.name,
           slug: savedSearchAttributes.slug,

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
@@ -1,10 +1,17 @@
 import React, { useState } from "react"
 import { BellIcon, Button, ButtonProps } from "@artsy/palette"
 import { SavedSearchAttributes } from "../types"
-import { useTracking } from "v2/System"
-import { ActionType, PageOwnerType } from "@artsy/cohesion"
+import { useSystemContext, useTracking } from "v2/System"
+import {
+  ActionType,
+  ContextModule,
+  Intent,
+  PageOwnerType,
+} from "@artsy/cohesion"
 import { SavedSearchAlertModal } from "v2/Components/SavedSearchAlert/SavedSearchAlertModal"
 import { SavedSearchAlertMutationResult } from "v2/Components/SavedSearchAlert/SavedSearchAlertModel"
+import { openAuthModal } from "v2/Utils/openAuthModal"
+import { ModalType } from "v2/Components/Authentication/Types"
 
 interface CreateAlertButtonProps extends ButtonProps {
   savedSearchAttributes: SavedSearchAttributes
@@ -15,6 +22,7 @@ export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
   ...props
 }) => {
   const tracking = useTracking()
+  const { isLoggedIn, mediator } = useSystemContext()
   const [visibleForm, setVisibleForm] = useState(false)
 
   const handleOpenForm = () => {
@@ -25,6 +33,18 @@ export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
       context_page_owner_id: savedSearchAttributes.id,
       context_page_owner_slug: savedSearchAttributes.slug,
     })
+  }
+
+  const handleClick = () => {
+    if (isLoggedIn) {
+      handleOpenForm()
+    } else {
+      openAuthModal(mediator!, {
+        mode: ModalType.login,
+        contextModule: ContextModule.worksForSaleRail,
+        intent: Intent.login,
+      })
+    }
   }
 
   const handleComplete = (result: SavedSearchAlertMutationResult) => {
@@ -42,7 +62,7 @@ export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
   return (
     <>
       <Button
-        onClick={handleOpenForm}
+        onClick={handleClick}
         variant="secondaryOutline"
         size="small"
         {...props}

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { BellIcon, Button, ButtonProps } from "@artsy/palette"
 import { SavedSearchAttributes } from "../types"
 import { useSystemContext, useTracking } from "v2/System"
@@ -29,7 +29,13 @@ export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
     setVisibleForm(true)
   }
 
-  mediator?.on("auth:login:success", openModal)
+  useEffect(() => {
+    mediator.on("auth:login:success", openModal)
+
+    return () => {
+      mediator.off("auth:login:success")
+    }
+  }, [])
 
   const handleOpenForm = () => {
     openModal()

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
@@ -4,7 +4,7 @@ import { SavedSearchAttributes } from "../types"
 import { useSystemContext, useTracking } from "v2/System"
 import {
   ActionType,
-  AuthIntent,
+  Intent,
   ContextModule,
   PageOwnerType,
 } from "@artsy/cohesion"
@@ -51,7 +51,7 @@ export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
           slug: savedSearchAttributes.slug,
         },
         contextModule: ContextModule.artworkGrid,
-        intent: "createAlert" as AuthIntent,
+        intent: Intent.createAlert,
       })
     }
   }

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
@@ -50,7 +50,7 @@ export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
           name: savedSearchAttributes.name,
           slug: savedSearchAttributes.slug,
         },
-        contextModule: ContextModule.worksForSaleRail,
+        contextModule: ContextModule.artworkGrid,
         intent: "createAlert" as AuthIntent,
       })
     }

--- a/src/v2/Components/ArtworkFilter/__tests__/CreateAlertButton.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/CreateAlertButton.jest.tsx
@@ -6,6 +6,7 @@ import { SavedSearchAttributes } from "v2/Components/ArtworkFilter/SavedSearch/t
 import { ExtractProps } from "v2/Utils/ExtractProps"
 import { CreateAlertButton } from "../SavedSearch/Components/CreateAlertButton"
 import { mediator } from "lib/mediator"
+import { ArtworkFilterContextProvider } from "../ArtworkFilterContext"
 
 jest.mock("v2/System/useSystemContext")
 jest.mock("v2/System/Analytics/useTracking")
@@ -27,7 +28,11 @@ describe("CreateAlertButton", () => {
   const CreateAlertButtonTest = (
     props: ExtractProps<typeof CreateAlertButton>
   ) => {
-    return <CreateAlertButton {...props} />
+    return (
+      <ArtworkFilterContextProvider>
+        <CreateAlertButton {...props} />
+      </ArtworkFilterContextProvider>
+    )
   }
 
   const openAuthToSatisfyIntent = jest.spyOn(

--- a/src/v2/Components/ArtworkFilter/__tests__/CreateAlertButton.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/CreateAlertButton.jest.tsx
@@ -30,9 +30,9 @@ describe("CreateAlertButton", () => {
     return <CreateAlertButton {...props} />
   }
 
-  const openAuthToFollowSaveCreate = jest.spyOn(
+  const openAuthToSatisfyIntent = jest.spyOn(
     openAuthModal,
-    "openAuthToFollowSaveCreate"
+    "openAuthToSatisfyIntent"
   )
 
   const trackEvent = jest.fn()
@@ -108,7 +108,7 @@ describe("CreateAlertButton", () => {
       renderButton()
       const button = screen.getByText("Create an Alert")
       fireEvent.click(button)
-      expect(openAuthToFollowSaveCreate).toHaveBeenCalledWith(mediator, {
+      expect(openAuthToSatisfyIntent).toHaveBeenCalledWith(mediator, {
         entity: {
           name: "test-artist-name",
           slug: "example-slug",

--- a/src/v2/Components/ArtworkFilter/__tests__/CreateAlertButton.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/CreateAlertButton.jest.tsx
@@ -1,0 +1,121 @@
+import { render, screen, within, fireEvent } from "@testing-library/react"
+import { useSystemContext } from "v2/System/useSystemContext"
+import { useTracking } from "v2/System/Analytics/useTracking"
+import * as openAuthModal from "v2/Utils/openAuthModal"
+import { SavedSearchAttributes } from "v2/Components/ArtworkFilter/SavedSearch/types"
+import { ExtractProps } from "v2/Utils/ExtractProps"
+import { CreateAlertButton } from "../SavedSearch/Components/CreateAlertButton"
+import { mediator } from "lib/mediator"
+
+jest.mock("v2/System/useSystemContext")
+jest.mock("v2/System/Analytics/useTracking")
+
+const savedSearchAttributes: SavedSearchAttributes = {
+  type: "artist",
+  id: "test-artist-id",
+  name: "test-artist-name",
+  slug: "example-slug",
+}
+
+describe("CreateAlertButton", () => {
+  const renderButton = () => {
+    render(
+      <CreateAlertButtonTest savedSearchAttributes={savedSearchAttributes} />
+    )
+  }
+
+  const CreateAlertButtonTest = (
+    props: ExtractProps<typeof CreateAlertButton>
+  ) => {
+    return <CreateAlertButton {...props} />
+  }
+
+  const openAuthToFollowSaveCreate = jest.spyOn(
+    openAuthModal,
+    "openAuthToFollowSaveCreate"
+  )
+
+  const trackEvent = jest.fn()
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  afterEach(() => {
+    trackEvent.mockReset()
+  })
+
+  it("renders correctly", () => {
+    ;(useSystemContext as jest.Mock).mockImplementation(() => {
+      return {
+        isLoggedIn: true,
+      }
+    })
+    renderButton()
+    expect(screen.getByText("Create an Alert")).toBeInTheDocument()
+  })
+
+  describe("when logged in", () => {
+    beforeEach(() => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => {
+        return {
+          isLoggedIn: true,
+        }
+      })
+    })
+
+    it("pops up the Create an Alert modal when clicked", () => {
+      renderButton()
+      expect(
+        within(screen.getByRole("form")).queryByText("Create an Alert")
+      ).not.toBeInTheDocument()
+      const button = screen.getByText("Create an Alert")
+      fireEvent.click(button)
+      expect(
+        within(screen.getByRole("form")).getByText("Create an Alert")
+      ).toBeInTheDocument()
+    })
+
+    it("tracks event", () => {
+      renderButton()
+      const button = screen.getByText("Create an Alert")
+      fireEvent.click(button)
+      expect(trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "clickedCreateAlert",
+          context_page_owner_type: "artist",
+          context_page_owner_id: "test-artist-id",
+          context_page_owner_slug: "example-slug",
+        })
+      )
+    })
+  })
+
+  describe("when logged out", () => {
+    beforeEach(() => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => {
+        return {
+          isLoggedIn: false,
+        }
+      })
+    })
+
+    it("pops up the auth modal when clicked", () => {
+      renderButton()
+      const button = screen.getByText("Create an Alert")
+      fireEvent.click(button)
+      expect(openAuthToFollowSaveCreate).toHaveBeenCalledWith(mediator, {
+        entity: {
+          name: "test-artist-name",
+          slug: "example-slug",
+        },
+        contextModule: "worksForSaleRail",
+        intent: "createAlert",
+      })
+    })
+  })
+})

--- a/src/v2/Components/ArtworkFilter/__tests__/CreateAlertButton.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/CreateAlertButton.jest.tsx
@@ -113,7 +113,7 @@ describe("CreateAlertButton", () => {
           name: "test-artist-name",
           slug: "example-slug",
         },
-        contextModule: "worksForSaleRail",
+        contextModule: "artworkGrid",
         intent: "createAlert",
       })
     })

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -170,7 +170,7 @@ export const BaseArtworkFilter: React.FC<
   const [showMobileActionSheet, toggleMobileActionSheet] = useState(false)
   const filterContext = useArtworkFilterContext()
   const previousFilters = usePrevious(filterContext.filters)
-  const { user, isLoggedIn } = useSystemContext()
+  const { user } = useSystemContext()
   const { pills = [], setPills } = useFilterPillsContext()
   const appliedFiltersTotalCount = getTotalSelectedFiltersCount(
     filterContext.selectedFiltersCounts
@@ -182,8 +182,6 @@ export const BaseArtworkFilter: React.FC<
     () => getAllowedFiltersForSavedSearchInput(filterContext.filters ?? {}),
     [filterContext.filters]
   )
-  const savedSearchAttributes =
-    isLoggedIn && savedSearchProps ? savedSearchProps : null
 
   const showCreateAlert = enableCreateAlert && !!pills.length
 
@@ -357,7 +355,7 @@ export const BaseArtworkFilter: React.FC<
           {showCreateAlert && (
             <>
               <ArtworkGridFilterPills
-                savedSearchAttributes={savedSearchAttributes}
+                savedSearchAttributes={savedSearchProps}
               />
               <Spacer mt={4} />
             </>
@@ -413,7 +411,7 @@ export const BaseArtworkFilter: React.FC<
             {showCreateAlert && (
               <>
                 <ArtworkGridFilterPills
-                  savedSearchAttributes={savedSearchAttributes}
+                  savedSearchAttributes={savedSearchProps}
                 />
                 <Spacer mt={4} />
               </>

--- a/src/v2/Components/Authentication/Types.ts
+++ b/src/v2/Components/Authentication/Types.ts
@@ -41,7 +41,7 @@ export interface FormProps {
 }
 
 export interface AfterSignUpAction {
-  action: "save" | "follow" | "editorialSignup"
+  action: "save" | "follow" | "editorialSignup" | "createAlert"
   objectId?: string
   kind?: "artist" | "artworks" | "gene" | "profile" | "show"
 }

--- a/src/v2/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/v2/Components/FollowButton/FollowArtistButton.tsx
@@ -21,7 +21,7 @@ import {
   createFragmentContainer,
   graphql,
 } from "react-relay"
-import { openAuthToFollowSave } from "v2/Utils/openAuthModal"
+import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
 import {
   AnalyticsContextProps,
   withAnalyticsContext,
@@ -103,7 +103,7 @@ export class FollowArtistButton extends React.Component<Props> {
       this.followArtistForUser()
     } else {
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      openAuthToFollowSave(mediator, {
+      openAuthToFollowSaveCreate(mediator, {
         contextModule,
         entity: artist,
         intent: Intent.followArtist,

--- a/src/v2/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/v2/Components/FollowButton/FollowArtistButton.tsx
@@ -21,7 +21,7 @@ import {
   createFragmentContainer,
   graphql,
 } from "react-relay"
-import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
+import { openAuthToSatisfyIntent } from "v2/Utils/openAuthModal"
 import {
   AnalyticsContextProps,
   withAnalyticsContext,
@@ -103,7 +103,7 @@ export class FollowArtistButton extends React.Component<Props> {
       this.followArtistForUser()
     } else {
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      openAuthToFollowSaveCreate(mediator, {
+      openAuthToSatisfyIntent(mediator, {
         contextModule,
         entity: artist,
         intent: Intent.followArtist,

--- a/src/v2/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/v2/Components/FollowButton/FollowGeneButton.tsx
@@ -5,7 +5,7 @@ import { FollowButton } from "./Button"
 import { FollowGeneButton_gene } from "v2/__generated__/FollowGeneButton_gene.graphql"
 import { FollowGeneButtonMutation } from "v2/__generated__/FollowGeneButtonMutation.graphql"
 import { ButtonProps } from "@artsy/palette"
-import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
+import { openAuthToSatisfyIntent } from "v2/Utils/openAuthModal"
 import { Intent, ContextModule } from "@artsy/cohesion"
 
 interface FollowGeneButtonProps extends ButtonProps {
@@ -21,7 +21,7 @@ const FollowGeneButton: React.FC<FollowGeneButtonProps> = ({
   const handleClick = () => {
     if (!user) {
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      openAuthToFollowSaveCreate(mediator, {
+      openAuthToSatisfyIntent(mediator, {
         entity: gene,
         contextModule: ContextModule.geneHeader,
         intent: Intent.followGene,

--- a/src/v2/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/v2/Components/FollowButton/FollowGeneButton.tsx
@@ -5,7 +5,7 @@ import { FollowButton } from "./Button"
 import { FollowGeneButton_gene } from "v2/__generated__/FollowGeneButton_gene.graphql"
 import { FollowGeneButtonMutation } from "v2/__generated__/FollowGeneButtonMutation.graphql"
 import { ButtonProps } from "@artsy/palette"
-import { openAuthToFollowSave } from "v2/Utils/openAuthModal"
+import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
 import { Intent, ContextModule } from "@artsy/cohesion"
 
 interface FollowGeneButtonProps extends ButtonProps {
@@ -21,7 +21,7 @@ const FollowGeneButton: React.FC<FollowGeneButtonProps> = ({
   const handleClick = () => {
     if (!user) {
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      openAuthToFollowSave(mediator, {
+      openAuthToFollowSaveCreate(mediator, {
         entity: gene,
         contextModule: ContextModule.geneHeader,
         intent: Intent.followGene,

--- a/src/v2/Components/FollowButton/FollowProfileButton.tsx
+++ b/src/v2/Components/FollowButton/FollowProfileButton.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import track, { TrackingProp } from "react-tracking"
 import { FollowProfileButton_profile } from "../../__generated__/FollowProfileButton_profile.graphql"
 import { FollowButton } from "./Button"
-import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
+import { openAuthToSatisfyIntent } from "v2/Utils/openAuthModal"
 import {
   AuthContextModule,
   FollowedArgs,
@@ -118,7 +118,7 @@ export class FollowProfileButton extends React.Component<Props> {
       this.trackFollow()
     } else {
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      openAuthToFollowSaveCreate(mediator, {
+      openAuthToSatisfyIntent(mediator, {
         entity: {
           // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           name: profile.name,

--- a/src/v2/Components/FollowButton/FollowProfileButton.tsx
+++ b/src/v2/Components/FollowButton/FollowProfileButton.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import track, { TrackingProp } from "react-tracking"
 import { FollowProfileButton_profile } from "../../__generated__/FollowProfileButton_profile.graphql"
 import { FollowButton } from "./Button"
-import { openAuthToFollowSave } from "v2/Utils/openAuthModal"
+import { openAuthToFollowSaveCreate } from "v2/Utils/openAuthModal"
 import {
   AuthContextModule,
   FollowedArgs,
@@ -118,7 +118,7 @@ export class FollowProfileButton extends React.Component<Props> {
       this.trackFollow()
     } else {
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      openAuthToFollowSave(mediator, {
+      openAuthToFollowSaveCreate(mediator, {
         entity: {
           // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           name: profile.name,

--- a/src/v2/Components/FollowButton/__tests__/FollowArtistButton.jest.tsx
+++ b/src/v2/Components/FollowButton/__tests__/FollowArtistButton.jest.tsx
@@ -9,7 +9,10 @@ import * as openAuthModal from "v2/Utils/openAuthModal"
 import { AnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
 import { mockLocation } from "v2/DevTools/mockLocation"
 
-const openAuthToFollowSave = jest.spyOn(openAuthModal, "openAuthToFollowSave")
+const openAuthToFollowSaveCreate = jest.spyOn(
+  openAuthModal,
+  "openAuthToFollowSaveCreate"
+)
 jest.mock("react-relay", () => ({
   commitMutation: jest.fn(),
   createFragmentContainer: component => component,
@@ -56,7 +59,7 @@ describe("FollowArtistButton", () => {
       const component = getWrapper()
       component.find(FollowButton).simulate("click")
 
-      expect(openAuthToFollowSave).toBeCalledWith(mediator, {
+      expect(openAuthToFollowSaveCreate).toBeCalledWith(mediator, {
         contextModule: "artistsToFollowRail",
         entity: {
           counts: {

--- a/src/v2/Components/FollowButton/__tests__/FollowArtistButton.jest.tsx
+++ b/src/v2/Components/FollowButton/__tests__/FollowArtistButton.jest.tsx
@@ -9,9 +9,9 @@ import * as openAuthModal from "v2/Utils/openAuthModal"
 import { AnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
 import { mockLocation } from "v2/DevTools/mockLocation"
 
-const openAuthToFollowSaveCreate = jest.spyOn(
+const openAuthToSatisfyIntent = jest.spyOn(
   openAuthModal,
-  "openAuthToFollowSaveCreate"
+  "openAuthToSatisfyIntent"
 )
 jest.mock("react-relay", () => ({
   commitMutation: jest.fn(),
@@ -59,7 +59,7 @@ describe("FollowArtistButton", () => {
       const component = getWrapper()
       component.find(FollowButton).simulate("click")
 
-      expect(openAuthToFollowSaveCreate).toBeCalledWith(mediator, {
+      expect(openAuthToSatisfyIntent).toBeCalledWith(mediator, {
         contextModule: "artistsToFollowRail",
         entity: {
           counts: {

--- a/src/v2/Components/FollowButton/__tests__/FollowGeneButton.jest.tsx
+++ b/src/v2/Components/FollowButton/__tests__/FollowGeneButton.jest.tsx
@@ -86,14 +86,14 @@ describe("FollowGeneButton", () => {
         }),
       })
 
-      const openAuthToFollowSave = jest.spyOn(
+      const openAuthToFollowSaveCreate = jest.spyOn(
         openAuthModal,
-        "openAuthToFollowSave"
+        "openAuthToFollowSaveCreate"
       )
 
       wrapper.find(FollowButton).simulate("click")
 
-      expect(openAuthToFollowSave).toBeCalledWith(mediator, {
+      expect(openAuthToFollowSaveCreate).toBeCalledWith(mediator, {
         intent: "followGene",
         contextModule: "geneHeader",
         entity: {

--- a/src/v2/Components/FollowButton/__tests__/FollowGeneButton.jest.tsx
+++ b/src/v2/Components/FollowButton/__tests__/FollowGeneButton.jest.tsx
@@ -86,14 +86,14 @@ describe("FollowGeneButton", () => {
         }),
       })
 
-      const openAuthToFollowSaveCreate = jest.spyOn(
+      const openAuthToSatisfyIntent = jest.spyOn(
         openAuthModal,
-        "openAuthToFollowSaveCreate"
+        "openAuthToSatisfyIntent"
       )
 
       wrapper.find(FollowButton).simulate("click")
 
-      expect(openAuthToFollowSaveCreate).toBeCalledWith(mediator, {
+      expect(openAuthToSatisfyIntent).toBeCalledWith(mediator, {
         intent: "followGene",
         contextModule: "geneHeader",
         entity: {

--- a/src/v2/Components/FollowButton/__tests__/FollowProfileButton.jest.tsx
+++ b/src/v2/Components/FollowButton/__tests__/FollowProfileButton.jest.tsx
@@ -9,9 +9,9 @@ import * as openAuthModal from "v2/Utils/openAuthModal"
 import { AnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
 import { ArtworkDetailsFixture } from "v2/Apps/__tests__/Fixtures/Artwork/ArtworkDetails"
 
-const openAuthToFollowSaveCreate = jest.spyOn(
+const openAuthToSatisfyIntent = jest.spyOn(
   openAuthModal,
-  "openAuthToFollowSaveCreate"
+  "openAuthToSatisfyIntent"
 )
 jest.mock("react-relay", () => ({
   commitMutation: jest.fn(),
@@ -52,7 +52,7 @@ describe("FollowProfileButton", () => {
       const component = getWrapper(props, {} as any)
       component.find(FollowButton).simulate("click")
 
-      expect(openAuthToFollowSaveCreate).toBeCalledWith(mediator, {
+      expect(openAuthToSatisfyIntent).toBeCalledWith(mediator, {
         contextModule: "aboutTheWork",
         entity: {
           name: "Salon 94",

--- a/src/v2/Components/FollowButton/__tests__/FollowProfileButton.jest.tsx
+++ b/src/v2/Components/FollowButton/__tests__/FollowProfileButton.jest.tsx
@@ -9,7 +9,10 @@ import * as openAuthModal from "v2/Utils/openAuthModal"
 import { AnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
 import { ArtworkDetailsFixture } from "v2/Apps/__tests__/Fixtures/Artwork/ArtworkDetails"
 
-const openAuthToFollowSave = jest.spyOn(openAuthModal, "openAuthToFollowSave")
+const openAuthToFollowSaveCreate = jest.spyOn(
+  openAuthModal,
+  "openAuthToFollowSaveCreate"
+)
 jest.mock("react-relay", () => ({
   commitMutation: jest.fn(),
   createFragmentContainer: component => component,
@@ -49,7 +52,7 @@ describe("FollowProfileButton", () => {
       const component = getWrapper(props, {} as any)
       component.find(FollowButton).simulate("click")
 
-      expect(openAuthToFollowSave).toBeCalledWith(mediator, {
+      expect(openAuthToFollowSaveCreate).toBeCalledWith(mediator, {
         contextModule: "aboutTheWork",
         entity: {
           name: "Salon 94",

--- a/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
+++ b/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
@@ -126,7 +126,7 @@ export const SavedSearchAlertModal: React.FC<SavedSearchAlertFormProps> = ({
 
   return (
     <FormikProvider value={formik}>
-      <Form onSubmit={formik.handleSubmit}>
+      <Form onSubmit={formik.handleSubmit} role="form">
         <Modal
           show={visible}
           onClose={onClose}

--- a/src/v2/Utils/Hooks/useAuthIntent/index.ts
+++ b/src/v2/Utils/Hooks/useAuthIntent/index.ts
@@ -1,4 +1,5 @@
 import Cookies from "cookies-js"
+import { mediator } from "lib/mediator"
 import { useEffect } from "react"
 import { Environment } from "react-relay"
 import { useSystemContext } from "v2/System"
@@ -10,6 +11,7 @@ import { saveArtworkMutation } from "./mutations/AuthIntentSaveArtworkMutation"
 const AFTER_AUTH_ACTION_KEY = "afterSignUpAction"
 
 export type AfterAuthAction =
+  | { action: "createAlert"; kind: "artist"; objectId: string }
   | { action: "follow"; kind: "artist"; objectId: string }
   | { action: "follow"; kind: "profile"; objectId: string }
   | { action: "follow"; kind: "gene"; objectId: string }
@@ -49,6 +51,20 @@ export const runAuthIntent = async (
   try {
     await (() => {
       switch (value.action) {
+        case "createAlert":
+          if (value.kind === "artist") {
+            if (mediator.ready("auth:login:success")) {
+              mediator.trigger("auth:login:success")
+              return
+            }
+            const intervalId = setInterval(() => {
+              if (mediator.ready("auth:login:success")) {
+                mediator.trigger("auth:login:success")
+                clearInterval(intervalId)
+              }
+            }, 100)
+          }
+          break
         case "follow":
           switch (value.kind) {
             case "artist":

--- a/src/v2/Utils/Hooks/useAuthIntent/index.ts
+++ b/src/v2/Utils/Hooks/useAuthIntent/index.ts
@@ -3,6 +3,7 @@ import { mediator } from "lib/mediator"
 import { useEffect } from "react"
 import { Environment } from "react-relay"
 import { useSystemContext } from "v2/System"
+import { triggerEvent } from "v2/Utils/openAuthModal"
 import { followArtistMutation } from "./mutations/AuthIntentFollowArtistMutation"
 import { followGeneMutation } from "./mutations/AuthIntentFollowGeneMutation"
 import { followProfileMutation } from "./mutations/AuthIntentFollowProfileMutation"
@@ -53,16 +54,7 @@ export const runAuthIntent = async (
       switch (value.action) {
         case "createAlert":
           if (value.kind === "artist") {
-            if (mediator.ready("auth:login:success")) {
-              mediator.trigger("auth:login:success")
-              return
-            }
-            const intervalId = setInterval(() => {
-              if (mediator.ready("auth:login:success")) {
-                mediator.trigger("auth:login:success")
-                clearInterval(intervalId)
-              }
-            }, 100)
+            triggerEvent(mediator, "auth:login:success")
           }
           break
         case "follow":

--- a/src/v2/Utils/__tests__/openAuthModal.jest.ts
+++ b/src/v2/Utils/__tests__/openAuthModal.jest.ts
@@ -4,7 +4,7 @@ import { mockLocation } from "v2/DevTools/mockLocation"
 import {
   AuthModalOptions,
   openAuthModal,
-  openAuthToFollowSaveCreate,
+  openAuthToSatisfyIntent,
 } from "../openAuthModal"
 
 const artistArgs: AuthModalOptions = {
@@ -65,10 +65,10 @@ describe("openAuth Helpers", () => {
     })
   })
 
-  describe("#openAuthToFollowSaveCreateAlert", () => {
+  describe("#openAuthToSatisfyIntent", () => {
     describe("desktop", () => {
       it("transforms args for following artists", () => {
-        openAuthToFollowSaveCreate(mediator, artistArgs)
+        openAuthToSatisfyIntent(mediator, artistArgs)
 
         expect(mediator.trigger).toBeCalledWith("open:auth", {
           afterSignUpAction: {
@@ -84,7 +84,7 @@ describe("openAuth Helpers", () => {
       })
 
       it("transforms args for following partners", () => {
-        openAuthToFollowSaveCreate(mediator, partnerArgs)
+        openAuthToSatisfyIntent(mediator, partnerArgs)
 
         expect(mediator.trigger).toBeCalledWith("open:auth", {
           afterSignUpAction: {
@@ -100,7 +100,7 @@ describe("openAuth Helpers", () => {
       })
 
       it("transforms args for saving artworks", () => {
-        openAuthToFollowSaveCreate(mediator, artworkArgs)
+        openAuthToSatisfyIntent(mediator, artworkArgs)
 
         expect(mediator.trigger).toBeCalledWith("open:auth", {
           afterSignUpAction: {

--- a/src/v2/Utils/__tests__/openAuthModal.jest.ts
+++ b/src/v2/Utils/__tests__/openAuthModal.jest.ts
@@ -4,7 +4,7 @@ import { mockLocation } from "v2/DevTools/mockLocation"
 import {
   AuthModalOptions,
   openAuthModal,
-  openAuthToFollowSave,
+  openAuthToFollowSaveCreate,
 } from "../openAuthModal"
 
 const artistArgs: AuthModalOptions = {
@@ -65,10 +65,10 @@ describe("openAuth Helpers", () => {
     })
   })
 
-  describe("#openAuthToFollowSave", () => {
+  describe("#openAuthToFollowSaveCreateAlert", () => {
     describe("desktop", () => {
       it("transforms args for following artists", () => {
-        openAuthToFollowSave(mediator, artistArgs)
+        openAuthToFollowSaveCreate(mediator, artistArgs)
 
         expect(mediator.trigger).toBeCalledWith("open:auth", {
           afterSignUpAction: {
@@ -84,7 +84,7 @@ describe("openAuth Helpers", () => {
       })
 
       it("transforms args for following partners", () => {
-        openAuthToFollowSave(mediator, partnerArgs)
+        openAuthToFollowSaveCreate(mediator, partnerArgs)
 
         expect(mediator.trigger).toBeCalledWith("open:auth", {
           afterSignUpAction: {
@@ -100,7 +100,7 @@ describe("openAuth Helpers", () => {
       })
 
       it("transforms args for saving artworks", () => {
-        openAuthToFollowSave(mediator, artworkArgs)
+        openAuthToFollowSaveCreate(mediator, artworkArgs)
 
         expect(mediator.trigger).toBeCalledWith("open:auth", {
           afterSignUpAction: {

--- a/src/v2/Utils/openAuthModal.ts
+++ b/src/v2/Utils/openAuthModal.ts
@@ -13,21 +13,25 @@ export interface AuthModalOptions extends ModalOptions {
 }
 
 export const openAuthModal = (mediator: Mediator, options: ModalOptions) => {
-  if (authModalReady(mediator)) {
-    mediator.trigger("open:auth", options)
+  triggerEvent(mediator, "open:auth", options)
+}
+
+export const triggerEvent = (
+  mediator: Mediator,
+  eventName: string,
+  options?: ModalOptions
+) => {
+  if (mediator.ready(eventName)) {
+    mediator.trigger(eventName, options)
     return
   }
 
   const intervalId = setInterval(() => {
-    if (authModalReady(mediator)) {
-      mediator.trigger("open:auth", options)
+    if (mediator.ready(eventName)) {
+      mediator.trigger(eventName, options)
       clearInterval(intervalId)
     }
   }, 100)
-}
-
-const authModalReady = (mediator: Mediator): boolean => {
-  return mediator.ready("open:auth")
 }
 
 export const openAuthToFollowSaveCreate = (

--- a/src/v2/Utils/openAuthModal.ts
+++ b/src/v2/Utils/openAuthModal.ts
@@ -30,7 +30,7 @@ const authModalReady = (mediator: Mediator): boolean => {
   return mediator.ready("open:auth")
 }
 
-export const openAuthToFollowSave = (
+export const openAuthToFollowSaveCreate = (
   mediator: Mediator,
   options: AuthModalOptions
 ) => {
@@ -96,6 +96,23 @@ function getDesktopIntentToSaveArtwork({
   }
 }
 
+const getDesktopIntentToCreateAlert = ({
+  contextModule,
+  entity,
+  intent,
+}: AuthModalOptions): ModalOptions => {
+  return {
+    afterSignUpAction: {
+      action: "createAlert",
+      kind: "artist",
+      objectId: entity.slug,
+    },
+    contextModule,
+    intent,
+    mode: ModalType.signup,
+  }
+}
+
 function getDesktopIntent(options: AuthModalOptions): ModalOptions {
   switch (options.intent) {
     case Intent.followArtist:
@@ -104,6 +121,8 @@ function getDesktopIntent(options: AuthModalOptions): ModalOptions {
       return getDesktopIntentToFollow(options)
     case Intent.saveArtwork:
       return getDesktopIntentToSaveArtwork(options)
+    case "createAlert" as AuthIntent:
+      return getDesktopIntentToCreateAlert(options)
     default:
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       return undefined

--- a/src/v2/Utils/openAuthModal.ts
+++ b/src/v2/Utils/openAuthModal.ts
@@ -34,7 +34,7 @@ export const triggerEvent = (
   }, 100)
 }
 
-export const openAuthToFollowSaveCreate = (
+export const openAuthToSatisfyIntent = (
   mediator: Mediator,
   options: AuthModalOptions
 ) => {

--- a/src/v2/Utils/openAuthModal.ts
+++ b/src/v2/Utils/openAuthModal.ts
@@ -125,7 +125,7 @@ function getDesktopIntent(options: AuthModalOptions): ModalOptions {
       return getDesktopIntentToFollow(options)
     case Intent.saveArtwork:
       return getDesktopIntentToSaveArtwork(options)
-    case "createAlert" as AuthIntent:
+    case Intent.createAlert:
       return getDesktopIntentToCreateAlert(options)
     default:
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION


### PR DESCRIPTION
[FX-3641]

At the moment Create an Alert button is visible on artworks grid page for logged in users and hidden for logged out users. Instead, the button should be visible for both logged in and logged out users.

### Acceptance Criteria

- Create an Alert button is visible regardless of whether user is logged in or logged out
- If a user that is logged in clicks the button they see the Create an Alert modal
- If a user that is logged out clicks the button they see the standard login screen pop up where they are prompted to login/create account

Also, after successful auth Create Alert modal pops up without additional button click.

### Demo

https://user-images.githubusercontent.com/44819355/146196258-5e4aef51-c913-4f71-997a-27453c97fdcc.mov




[FX-3641]: https://artsyproduct.atlassian.net/browse/FX-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ