### PR TITLE
feat(new-routes): Add app hackathon routes

### DIFF
--- a/src/v2/Apps/_About2/AboutApp.tsx
+++ b/src/v2/Apps/_About2/AboutApp.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@artsy/palette"
+
+export const AboutApp: React.FC = () => {
+  return (
+    <>
+      <Text variant="xl">About App</Text>
+    </>
+  )
+}

--- a/src/v2/Apps/_About2/aboutRoutes.tsx
+++ b/src/v2/Apps/_About2/aboutRoutes.tsx
@@ -1,0 +1,16 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const AboutApp = loadable(
+  () => import(/* webpackChunkName: "aboutBundle" */ "./AboutApp"),
+  {
+    resolveComponent: component => component.AboutApp,
+  }
+)
+
+export const aboutRoutes: AppRouteConfig[] = [
+  {
+    path: "about2",
+    getComponent: () => AboutApp,
+  },
+]

--- a/src/v2/Apps/_ArtsyEducation2/ArtsyEducationApp.tsx
+++ b/src/v2/Apps/_ArtsyEducation2/ArtsyEducationApp.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@artsy/palette"
+
+export const ArtsyEducationApp: React.FC = () => {
+  return (
+    <>
+      <Text variant="xl">Artsy Education App</Text>
+    </>
+  )
+}

--- a/src/v2/Apps/_ArtsyEducation2/artsyEducationRoutes.tsx
+++ b/src/v2/Apps/_ArtsyEducation2/artsyEducationRoutes.tsx
@@ -1,0 +1,19 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const ArtsyEducationApp = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "artsyEducationBundle" */ "./ArtsyEducationApp"
+    ),
+  {
+    resolveComponent: component => component.ArtsyEducationApp,
+  }
+)
+
+export const artsyEducation: AppRouteConfig[] = [
+  {
+    path: "artsy-education2",
+    getComponent: () => ArtsyEducationApp,
+  },
+]

--- a/src/v2/Apps/_AuctionPartnerships2/AuctionPartnershipsApp.tsx
+++ b/src/v2/Apps/_AuctionPartnerships2/AuctionPartnershipsApp.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@artsy/palette"
+
+export const AuctionPartnershipsApp: React.FC = () => {
+  return (
+    <>
+      <Text variant="xl">Auction Partnerships App</Text>
+    </>
+  )
+}

--- a/src/v2/Apps/_AuctionPartnerships2/auctionPartnershipsRoutes.tsx
+++ b/src/v2/Apps/_AuctionPartnerships2/auctionPartnershipsRoutes.tsx
@@ -1,0 +1,19 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const AuctionPartnershipsApp = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "auctionPartnershipsBundle" */ "./AuctionPartnershipsApp"
+    ),
+  {
+    resolveComponent: component => component.AuctionPartnershipsApp,
+  }
+)
+
+export const auctionPartnershipsRoutes: AppRouteConfig[] = [
+  {
+    path: "auction-partnerships2",
+    getComponent: () => AuctionPartnershipsApp,
+  },
+]

--- a/src/v2/Apps/_Contact2/ContactApp.tsx
+++ b/src/v2/Apps/_Contact2/ContactApp.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@artsy/palette"
+
+export const ContactApp: React.FC = () => {
+  return (
+    <>
+      <Text variant="xl">Contact App</Text>
+    </>
+  )
+}

--- a/src/v2/Apps/_Contact2/contactRoutes.tsx
+++ b/src/v2/Apps/_Contact2/contactRoutes.tsx
@@ -1,0 +1,16 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const ContactApp = loadable(
+  () => import(/* webpackChunkName: "contactBundle" */ "./ContactApp"),
+  {
+    resolveComponent: component => component.ContactApp,
+  }
+)
+
+export const contactRoutes: AppRouteConfig[] = [
+  {
+    path: "contact2",
+    getComponent: () => ContactApp,
+  },
+]

--- a/src/v2/Apps/_HowAuctionsWork2/HowAuctionsWorkApp.tsx
+++ b/src/v2/Apps/_HowAuctionsWork2/HowAuctionsWorkApp.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@artsy/palette"
+
+export const HowAuctionsWorkApp: React.FC = () => {
+  return (
+    <>
+      <Text variant="xl">How Auctions Work App</Text>
+    </>
+  )
+}

--- a/src/v2/Apps/_HowAuctionsWork2/howAuctionsWorkRoutes.tsx
+++ b/src/v2/Apps/_HowAuctionsWork2/howAuctionsWorkRoutes.tsx
@@ -1,0 +1,19 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const HowAuctionsWorkApp = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "howAuctionsWorkBundle" */ "./HowAuctionsWorkApp"
+    ),
+  {
+    resolveComponent: component => component.HowAuctionsWorkApp,
+  }
+)
+
+export const howAuctionsWorkRoutes: AppRouteConfig[] = [
+  {
+    path: "how-auctions-work2",
+    getComponent: () => HowAuctionsWorkApp,
+  },
+]

--- a/src/v2/Apps/_Security/SecurityApp.tsx
+++ b/src/v2/Apps/_Security/SecurityApp.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@artsy/palette"
+
+export const SecurityApp: React.FC = () => {
+  return (
+    <>
+      <Text variant="xl">Security App</Text>
+    </>
+  )
+}

--- a/src/v2/Apps/_Security/securityRoutes.tsx
+++ b/src/v2/Apps/_Security/securityRoutes.tsx
@@ -1,0 +1,16 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const SecurityApp = loadable(
+  () => import(/* webpackChunkName: "securityBundle" */ "./SecurityApp"),
+  {
+    resolveComponent: component => component.SecurityApp,
+  }
+)
+
+export const securityRoutes: AppRouteConfig[] = [
+  {
+    path: "security2",
+    getComponent: () => SecurityApp,
+  },
+]

--- a/src/v2/Apps/_Terms2/TermsApp.tsx
+++ b/src/v2/Apps/_Terms2/TermsApp.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@artsy/palette"
+
+export const TermsApp: React.FC = () => {
+  return (
+    <>
+      <Text variant="xl">Terms App</Text>
+    </>
+  )
+}

--- a/src/v2/Apps/_Terms2/termsRoutes.tsx
+++ b/src/v2/Apps/_Terms2/termsRoutes.tsx
@@ -1,0 +1,16 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const TermsApp = loadable(
+  () => import(/* webpackChunkName: "termsBundle" */ "./TermsApp"),
+  {
+    resolveComponent: component => component.TermsApp,
+  }
+)
+
+export const termsRoutes: AppRouteConfig[] = [
+  {
+    path: "terms-and-conditions2",
+    getComponent: () => TermsApp,
+  },
+]

--- a/src/v2/Apps/_WorksForYou2/WorksForYou2App.tsx
+++ b/src/v2/Apps/_WorksForYou2/WorksForYou2App.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@artsy/palette"
+
+export const WorksForYou2App: React.FC = () => {
+  return (
+    <>
+      <Text variant="xl">Works For You 2 App</Text>
+    </>
+  )
+}

--- a/src/v2/Apps/_WorksForYou2/worksForYouRoutes.tsx
+++ b/src/v2/Apps/_WorksForYou2/worksForYouRoutes.tsx
@@ -1,0 +1,17 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const WorksForYou2App = loadable(
+  () =>
+    import(/* webpackChunkName: "worksForYou2Bundle" */ "./WorksForYou2App"),
+  {
+    resolveComponent: component => component.WorksForYou2App,
+  }
+)
+
+export const worksForYouRoutes: AppRouteConfig[] = [
+  {
+    path: "works-for-you2",
+    getComponent: () => WorksForYou2App,
+  },
+]

--- a/src/v2/routes.tsx
+++ b/src/v2/routes.tsx
@@ -1,8 +1,12 @@
 import { AppRouteConfig } from "v2/System/Router/Route"
+import { aboutRoutes } from "./Apps/_About2/aboutRoutes"
 import { artistRoutes } from "v2/Apps/Artist/artistRoutes"
 import { artistSeriesRoutes } from "v2/Apps/ArtistSeries/artistSeriesRoutes"
 import { artistsRoutes } from "v2/Apps/Artists/artistsRoutes"
+import { artsyEducation } from "./Apps/_ArtsyEducation2/artsyEducationRoutes"
 import { artworkRoutes } from "v2/Apps/Artwork/artworkRoutes"
+import { auction2Routes } from "./Apps/Auction2/auction2Routes"
+import { auctionPartnershipsRoutes } from "./Apps/_AuctionPartnerships2/auctionPartnershipsRoutes"
 import { auctionsRoutes } from "v2/Apps/Auctions/auctionsRoutes"
 import { authenticationRoutes } from "v2/Apps/Authentication/authenticationRoutes"
 import { buildAppRoutes } from "v2/System/Router/buildAppRoutes"
@@ -10,6 +14,7 @@ import { buyerGuaranteeRoutes } from "v2/Apps/BuyerGuarantee/buyerGuaranteeRoute
 import { categoriesRoutes } from "./Apps/Categories/categoriesRoutes"
 import { collectRoutes } from "v2/Apps/Collect/collectRoutes"
 import { consignRoutes } from "v2/Apps/Consign/consignRoutes"
+import { contactRoutes } from "./Apps/_Contact2/contactRoutes"
 import { conversationRoutes } from "v2/Apps/Conversation/conversationRoutes"
 import { debugRoutes } from "v2/Apps/Debug/debugRoutes"
 import { exampleRoutes } from "v2/Apps/Example/exampleRoutes"
@@ -19,6 +24,7 @@ import { fairsRoutes } from "v2/Apps/Fairs/fairsRoutes"
 import { featureRoutes } from "v2/Apps/Feature/featureRoutes"
 import { geneRoutes } from "v2/Apps/Gene/geneRoutes"
 import { homeRoutes } from "v2/Apps/Home/homeRoutes"
+import { howAuctionsWorkRoutes } from "./Apps/_HowAuctionsWork2/howAuctionsWorkRoutes"
 import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identityVerificationRoutes"
 import { orderRoutes } from "v2/Apps/Order/orderRoutes"
 import { partnerRoutes } from "v2/Apps/Partner/partnerRoutes"
@@ -27,28 +33,34 @@ import { paymentRoutes } from "v2/Apps/Payment/paymentRoutes"
 import { priceDatabaseRoutes } from "./Apps/PriceDatabase/priceDatabaseRoutes"
 import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
 import { searchRoutes } from "v2/Apps/Search/searchRoutes"
+import { securityRoutes } from "./Apps/_Security/securityRoutes"
 import { settingsRoutes } from "v2/Apps/Settings/settingsRoutes"
 import { shippingRoutes } from "v2/Apps/Shipping/shippingRoutes"
 import { showRoutes } from "v2/Apps/Show/showRoutes"
 import { showsRoutes } from "v2/Apps/Shows/showsRoutes"
 import { tagRoutes } from "./Apps/Tag/tagRoutes"
+import { termsRoutes } from "./Apps/_Terms2/termsRoutes"
 import { unsubscribeRoutes } from "./Apps/Unsubscribe/unsubscribeRoutes"
 import { viewingRoomRoutes } from "v2/Apps/ViewingRoom/viewingRoomRoutes"
-import { auction2Routes } from "./Apps/Auction2/auction2Routes"
+import { worksForYouRoutes } from "./Apps/_WorksForYou2/worksForYouRoutes"
 
 export function getAppRoutes(): AppRouteConfig[] {
   return buildAppRoutes([
+    { routes: aboutRoutes },
     { routes: artistRoutes },
     { routes: artistSeriesRoutes },
     { routes: artistsRoutes },
+    { routes: artsyEducation },
     { routes: artworkRoutes },
     { routes: auctionsRoutes },
     { routes: auction2Routes },
+    { routes: auctionPartnershipsRoutes },
     { routes: authenticationRoutes },
     { routes: buyerGuaranteeRoutes },
     { routes: categoriesRoutes },
     { routes: collectRoutes },
     { routes: consignRoutes },
+    { routes: contactRoutes },
     { routes: conversationRoutes },
     { routes: exampleRoutes },
     { routes: fairOrganizerRoutes },
@@ -57,6 +69,7 @@ export function getAppRoutes(): AppRouteConfig[] {
     { routes: featureRoutes },
     { routes: geneRoutes },
     { routes: homeRoutes },
+    { routes: howAuctionsWorkRoutes },
     { routes: identityVerificationRoutes },
     { routes: orderRoutes },
     { routes: partnerRoutes },
@@ -65,13 +78,16 @@ export function getAppRoutes(): AppRouteConfig[] {
     { routes: priceDatabaseRoutes },
     { routes: purchaseRoutes },
     { routes: searchRoutes },
+    { routes: securityRoutes },
     { routes: settingsRoutes },
     { routes: shippingRoutes },
     { routes: showRoutes },
     { routes: showsRoutes },
     { routes: tagRoutes },
+    { routes: termsRoutes },
     { routes: unsubscribeRoutes },
     { routes: viewingRoomRoutes },
+    { routes: worksForYouRoutes },
 
     // For debugging baseline app shell stuff
     { routes: debugRoutes },


### PR DESCRIPTION
This stubs out some hackathon page-migration routes: 

- contact2
- about2
- artsy-education2
- terms-and-conditions2
- how-auctions-work2
- security2
- auction-partnerships2
- works-for-you2

Ignore the `_` in the folder name for the time being; that's for us to quickly see what's WIP. 

cc/ @artsy/grow-devs 