### PR TITLE
feat(FX-3645): add conditional disabling for create alert button

### DIFF
--- a/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
+++ b/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
@@ -85,6 +85,8 @@ export const SavedSearchAlertModal: React.FC<SavedSearchAlertFormProps> = ({
     },
   })
 
+  const isSaveAlertButtonDisabled = !formik.values.email && !formik.values.push
+
   const handleToggleNotification = (name: "email" | "push") => (
     enabled: boolean
   ) => {
@@ -99,7 +101,12 @@ export const SavedSearchAlertModal: React.FC<SavedSearchAlertFormProps> = ({
           onClose={onClose}
           title="Create an Alert"
           FixedButton={
-            <Button type="submit" loading={formik.isSubmitting} width="100%">
+            <Button
+              type="submit"
+              disabled={isSaveAlertButtonDisabled}
+              loading={formik.isSubmitting}
+              width="100%"
+            >
               Save Alert
             </Button>
           }

--- a/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
+++ b/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
@@ -113,4 +113,19 @@ describe("SavedSearchAlertModal", () => {
     fireEvent.click(screen.getAllByRole("checkbox")[1])
     expect(screen.getAllByRole("checkbox")[1]).toBeChecked()
   })
+
+  it("saved alert button is disabled when no one notification option selected", () => {
+    renderModal({
+      props: { initialValues: { ...formInitialValues, email: false } },
+    })
+    const saveAlertButton = screen.getByRole("button", { name: "Save Alert" })
+
+    expect(saveAlertButton).toBeDisabled()
+  })
+
+  it("saved alert button is enabled when at least one notification option selected", () => {
+    renderModal({})
+
+    expect(screen.getByText("Save Alert")).toBeEnabled()
+  })
 })


### PR DESCRIPTION
Jira: [FX-3645](https://artsyproduct.atlassian.net/browse/FX-3645)

### Description
- Disable “Save Alert” button in the “Create an Alert” modal if no notification options have been selected
- Enable “Save Alert” button if selected at least one of the notification toggle options

### Changes
- Added conditional disabling for button
- Added tests for it

### Demo

https://user-images.githubusercontent.com/56556580/145979535-1b8bb70d-fbed-4c82-bdf4-20d7e1254e23.mov


