### PR TITLE
fix: unselecting price filter option

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -52,9 +52,10 @@ const PRICE_RANGES = [
 type CustomRange = (number | "*")[]
 
 const DEFAULT_CUSTOM_RANGE: CustomRange = ["*", "*"]
+const DEFAULT_PRICE_RANGE = "*-*"
 
-const parseRange = (range?: string) => {
-  return range?.split("-").map(s => {
+const parseRange = (range: string = DEFAULT_PRICE_RANGE) => {
+  return range.split("-").map(s => {
     if (s === "*") return s
     return parseInt(s, 10)
   })
@@ -118,13 +119,15 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
       return
     }
 
-    if (selectedOption !== null) {
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+    if (selectedOption) {
       setCustomRange(parseRange(selectedOption))
+      setFilter("priceRange", selectedOption)
+    } else {
+      setCustomRange(DEFAULT_CUSTOM_RANGE)
+      setFilter("priceRange", DEFAULT_PRICE_RANGE)
     }
 
     setShowCustom(false)
-    setFilter("priceRange", selectedOption)
   }
 
   const tokens = useThemeConfig({


### PR DESCRIPTION
### Description
When user unselects price filter option the `null` value is passed to filter state and it causes error in `extractFiltersPills` helper

### Demo
Before

https://user-images.githubusercontent.com/56556580/146011862-6b5888b9-0ad5-4b96-a46c-5e0788d4f6a6.mov

After

https://user-images.githubusercontent.com/56556580/146012269-891afa6e-8d84-4cd4-8ef6-e0219861a69a.mov
