### PR TITLE
chore: Move server-side artwork imports

### DIFF
--- a/src/v2/Apps/Artwork/Server/handleArtworkImageDownload.ts
+++ b/src/v2/Apps/Artwork/Server/handleArtworkImageDownload.ts
@@ -1,14 +1,12 @@
-import request from "superagent"
-
-const { Artwork } = require("desktop/models/artwork")
-
 export const handleArtworkImageDownload = async ({ req, res }) => {
+  const { Artwork } = require("desktop/models/artwork")
   const artwork = new Artwork({ id: req.params.artworkID })
   await artwork.fetch({
     cache: true,
   })
 
   if (artwork.isDownloadable(req.user)) {
+    const request = require("superagent")
     const imageRequest = request.get(artwork.downloadableUrl(req.user))
     if (req.user) {
       imageRequest.set("X-ACCESS-TOKEN", req.user.get("accessToken"))


### PR DESCRIPTION
Closes https://github.com/artsy/force/pull/9065 

Moves imports so that they're only requested server-side. 

