### PR TITLE
feat: add copy and download buttons to 2fa recovery modal

### DIFF
--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodesActions.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodesActions.tsx
@@ -1,0 +1,61 @@
+import { Button, BorderBoxProps, Flex } from "@artsy/palette"
+import React, { useEffect, useState } from "react"
+
+interface SettingsEditSettingsTwoFactorBackupCodesActionsProps
+  extends BorderBoxProps {
+  backupSecondFactors: string[]
+}
+
+export const SettingsEditSettingsTwoFactorBackupCodesActions: React.FC<SettingsEditSettingsTwoFactorBackupCodesActionsProps> = props => {
+  const { backupSecondFactors } = props
+
+  const [supportsClipboard, setSupportsClipboard] = useState(false)
+
+  useEffect(() => {
+    // Only render the copy button if browser supports the Clipboard API
+    // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
+    if ("clipboard" in navigator) setSupportsClipboard(true)
+  }, [])
+
+  function copyCodesToClipboard() {
+    navigator.clipboard.writeText(backupSecondFactors.join("\n"))
+  }
+
+  function downloadCodes() {
+    const codes = backupSecondFactors.join("\n")
+    const element = document.createElement("a")
+    const file = new Blob([codes], { type: "text/plain" })
+    element.href = URL.createObjectURL(file)
+    element.download = "recovery_codes.txt"
+    document.body.appendChild(element) // Required for this to work in FireFox
+    element.click()
+    URL.revokeObjectURL(element.href)
+  }
+
+  return (
+    <Flex justifyContent="center">
+      {supportsClipboard && (
+        <Button
+          onClick={copyCodesToClipboard}
+          variant="secondaryOutline"
+          size="small"
+          mt={4}
+          mx={2}
+          data-test="copyButton"
+        >
+          Copy
+        </Button>
+      )}
+      <Button
+        onClick={downloadCodes}
+        variant="secondaryOutline"
+        size="small"
+        mt={4}
+        mx={2}
+        data-test="downloadButton"
+      >
+        Download
+      </Button>
+    </Flex>
+  )
+}

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodesDialog.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodesDialog.tsx
@@ -10,6 +10,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { SettingsEditSettingsTwoFactorBackupCodesDialog_me } from "v2/__generated__/SettingsEditSettingsTwoFactorBackupCodesDialog_me.graphql"
 import { SettingsEditSettingsTwoFactorBackupCodesDialogQuery } from "v2/__generated__/SettingsEditSettingsTwoFactorBackupCodesDialogQuery.graphql"
+import { SettingsEditSettingsTwoFactorBackupCodesActions } from "./SettingsEditSettingsTwoFactorBackupCodesActions"
 
 interface SettingsEditSettingsTwoFactorBackupCodesDialogProps {
   me?: SettingsEditSettingsTwoFactorBackupCodesDialog_me | null
@@ -26,19 +27,26 @@ const SettingsEditSettingsTwoFactorBackupCodesDialog: FC<SettingsEditSettingsTwo
       </Text>
 
       {me?.backupSecondFactors ? (
-        <GridColumns mt={2}>
-          {me.backupSecondFactors.map(factor => {
-            if (!factor) return null
+        <>
+          <GridColumns mt={2}>
+            {me.backupSecondFactors.map(factor => {
+              if (!factor) return null
 
-            return (
-              <Column span={6} key={factor.code}>
-                <Text variant="lg" textAlign="center">
-                  {factor.code}
-                </Text>
-              </Column>
-            )
-          })}
-        </GridColumns>
+              return (
+                <Column span={6} key={factor.code}>
+                  <Text variant="lg" textAlign="center">
+                    {factor.code}
+                  </Text>
+                </Column>
+              )
+            })}
+          </GridColumns>
+          <SettingsEditSettingsTwoFactorBackupCodesActions
+            backupSecondFactors={me.backupSecondFactors!.map(factor =>
+              factor!.code!.toString()
+            )}
+          ></SettingsEditSettingsTwoFactorBackupCodesActions>
+        </>
       ) : (
         <Skeleton>
           <GridColumns mt={2}>

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodesDialog.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodesDialog.tsx
@@ -45,7 +45,7 @@ const SettingsEditSettingsTwoFactorBackupCodesDialog: FC<SettingsEditSettingsTwo
             backupSecondFactors={me.backupSecondFactors!.map(factor =>
               factor!.code!.toString()
             )}
-          ></SettingsEditSettingsTwoFactorBackupCodesActions>
+          />
         </>
       ) : (
         <Skeleton>

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
@@ -1,5 +1,6 @@
 import { BorderBoxProps, Column, GridColumns, Text } from "@artsy/palette"
 import * as React from "react"
+import { SettingsEditSettingsTwoFactorBackupCodesActions } from "../../SettingsEditSettingsTwoFactorBackupCodesActions"
 
 interface BackupSecondFactorReminderProps extends BorderBoxProps {
   backupSecondFactors: string[]
@@ -37,6 +38,9 @@ export const BackupSecondFactorReminder: React.FC<BackupSecondFactorReminderProp
           )
         })}
       </GridColumns>
+      <SettingsEditSettingsTwoFactorBackupCodesActions
+        backupSecondFactors={backupSecondFactors}
+      />
     </>
   )
 }

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/__tests__/SettingsEditSettingsTwoFactorBackupCodesActions.jest.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/__tests__/SettingsEditSettingsTwoFactorBackupCodesActions.jest.tsx
@@ -1,0 +1,76 @@
+import { mount } from "enzyme"
+import { SettingsEditSettingsTwoFactorBackupCodesActions } from "../../SettingsEditSettingsTwoFactorBackupCodesActions"
+
+describe("Two factor authentication enrollment", () => {
+  const props = {
+    backupSecondFactors: ["d3bd78d468", "7aa4c5922c"],
+  }
+  const getWrapper = (passedProps = props) => {
+    return mount(
+      <SettingsEditSettingsTwoFactorBackupCodesActions {...passedProps} />
+    )
+  }
+
+  const getCopyButton = () => {
+    return getWrapper().find('[data-test="copyButton"]').first()
+  }
+
+  describe("when the browser does not support clipboard", () => {
+    it("displays a copy button based on browser support", () => {
+      expect(getCopyButton()).toHaveLength(0)
+    })
+  })
+
+  describe("when the browser supports clipboard", () => {
+    const mockClipboard = { writeText: jest.fn() }
+    beforeEach(() => {
+      Object.assign(navigator, {
+        clipboard: mockClipboard,
+      })
+    })
+
+    it("displays a copy button", () => {
+      const copyButton = getCopyButton()
+
+      expect(copyButton).toHaveLength(1)
+      expect(copyButton.text()).toBe("Copy")
+    })
+
+    it("enables user to copy the recovery codes", () => {
+      const copyButtonProps = getCopyButton().props()
+
+      if (copyButtonProps.onClick) copyButtonProps.onClick({} as any)
+
+      expect(navigator.clipboard.writeText).toBeCalledTimes(1)
+    })
+  })
+
+  describe("txt file download", () => {
+    const downloadButton = getWrapper()
+      .find('[data-test="downloadButton"]')
+      .first()
+
+    it("displays a download button", () => {
+      expect(downloadButton).toHaveLength(1)
+      expect(downloadButton.text()).toBe("Download")
+    })
+
+    it("enables user to download the recovery codes", () => {
+      global.URL.createObjectURL = jest.fn()
+      global.URL.revokeObjectURL = jest.fn()
+
+      // @ts-ignore: Type
+      global.Blob = (content, options) => {
+        return { content, options }
+      }
+
+      const downloadButtonProps = downloadButton.props()
+      if (downloadButtonProps.onClick) downloadButtonProps.onClick({} as any)
+
+      expect(URL.createObjectURL).toBeCalledWith({
+        content: ["d3bd78d468\n7aa4c5922c"],
+        options: { type: "text/plain" },
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds functionality allowing users to download and copy their 2FA recovery codes during the 2FA setup flow, or when they are requested via the settings page. This implementation is from @lidimayra's #8930 PR, now that the component have been moved to palette v3 with #9048 .

<img width="547" alt="Screen Shot 2021-12-14 at 2 05 28 PM" src="https://user-images.githubusercontent.com/38149304/146067803-53dda3b8-f43d-4733-84a4-a21b3c206210.png">

![2021-12-14 14 46 26](https://user-images.githubusercontent.com/38149304/146069017-6c628dad-62b0-443d-b866-1c55358c47e4.gif)

## Rational
As more partners are enrolled into 2FA, we are seeing an increase in account lockouts as users lose access to their 2FA authentication method(s). Unlocking an account requires the Trust and Safety and Platform teams to validate the ID of the requester and manually lookup and provide a code.  This functionality specifically aims to increase backup code utilization through improved UX. 

[PLATFORM-3280]

[PLATFORM-3280]: https://artsyproduct.atlassian.net/browse/PLATFORM-3280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ