### PR TITLE
chore: replace superagent with fetch

### DIFF
--- a/src/v2/Apps/Artwork/Server/__tests__/handleArtworkImageDownload.jest.ts
+++ b/src/v2/Apps/Artwork/Server/__tests__/handleArtworkImageDownload.jest.ts
@@ -1,7 +1,7 @@
 import { handleArtworkImageDownload } from "../handleArtworkImageDownload"
 
 jest.mock("desktop/models/artwork", () => {
-  return { 
+  return {
     Artwork: class {
       fetch() {
         return new Promise<void>(resolve => {
@@ -14,11 +14,20 @@ jest.mock("desktop/models/artwork", () => {
       downloadableUrl() {
         return ""
       }
-    }
+    },
   }
 })
 
 describe("artworkMiddleware", () => {
+  beforeAll(() => {
+    // @ts-ignore
+    global.fetch = jest.fn(() => Promise.resolve({ url: "foo" }))
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
   it("returns a downloadable request if downloadable", async () => {
     const spy = jest.fn()
     const req = {

--- a/src/v2/Apps/Artwork/Server/handleArtworkImageDownload.ts
+++ b/src/v2/Apps/Artwork/Server/handleArtworkImageDownload.ts
@@ -1,3 +1,5 @@
+import "isomorphic-fetch"
+
 export const handleArtworkImageDownload = async ({ req, res }) => {
   const { Artwork } = require("desktop/models/artwork")
   const artwork = new Artwork({ id: req.params.artworkID })
@@ -5,12 +7,13 @@ export const handleArtworkImageDownload = async ({ req, res }) => {
     cache: true,
   })
 
-  if (artwork.isDownloadable(req.user)) {
-    const request = require("superagent")
-    const imageRequest = request.get(artwork.downloadableUrl(req.user))
-    if (req.user) {
-      imageRequest.set("X-ACCESS-TOKEN", req.user.get("accessToken"))
-    }
-    res.redirect(302, imageRequest.url)
+  if (req.user && artwork.isDownloadable(req.user)) {
+    const request = await fetch(artwork.downloadableUrl(req.user), {
+      headers: {
+        "X-ACCESS-TOKEN": req.user.get("accessToken"),
+      },
+    })
+
+    res.redirect(302, request.url)
   }
 }


### PR DESCRIPTION
Follow-up to https://github.com/artsy/force/pull/9066 

Replaces use of superagent with fetch-api which we use all over.  

