### PR TITLE
chore: Wrap lot image and title in a link back to the artwork page

### DIFF
--- a/src/v2/Apps/Auction/Components/LotInfo.tsx
+++ b/src/v2/Apps/Auction/Components/LotInfo.tsx
@@ -3,6 +3,7 @@ import { LotInfo_artwork } from "v2/__generated__/LotInfo_artwork.graphql"
 import { LotInfo_saleArtwork } from "v2/__generated__/LotInfo_saleArtwork.graphql"
 import * as React from "react"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
+import { RouterLink } from "v2/System/Router/RouterLink"
 
 interface Props {
   artwork: LotInfo_artwork
@@ -16,28 +17,32 @@ export const LotInfo: React.FC<Props> = ({ artwork, saleArtwork }) => {
     counts: { bidderPositions: bidCount },
   } = saleArtwork
   return (
-    <Flex py={4}>
+    <Flex id="our-parent-flex-box" py={4}>
       <Box maxWidth="150px" width="100%" height="auto" p={0}>
-        <div
-          style={{
-            width: "100%",
-            paddingBottom: "100%",
-            backgroundImage: `url(${artwork.imageUrl})`,
-            backgroundSize: "contain",
-          }}
-        />
+        <RouterLink to={`/artwork/${artwork.slug}`}>
+          <div
+            style={{
+              width: "100%",
+              paddingBottom: "100%",
+              backgroundImage: `url(${artwork.imageUrl})`,
+              backgroundSize: "contain",
+            }}
+          />
+        </RouterLink>
       </Box>
       <Flex pl={2} pt={1} flexDirection="column">
-        <Text variant="md" color="black100">
-          Lot {saleArtwork.lotLabel}
-        </Text>
-        <Text variant="md" color="black100">
-          <i>{artwork.title}</i>
-          {artwork.date && `, ${artwork.date}`}
-        </Text>
-        <Text variant="md" color="black100">
-          {artwork.artistNames}
-        </Text>
+        <RouterLink to={`/artwork/${artwork.slug}`} textDecoration="none">
+          <Text variant="md" color="black100">
+            Lot {saleArtwork.lotLabel}
+          </Text>
+          <Text variant="md" color="black100">
+            <i>{artwork.title}</i>
+            {artwork.date && `, ${artwork.date}`}
+          </Text>
+          <Text variant="md" color="black100">
+            {artwork.artistNames}
+          </Text>
+        </RouterLink>
         <br />
         <Text variant="md" color="black100" fontWeight="bold">
           Current Bid: {saleArtwork.minimumNextBid?.display}
@@ -60,6 +65,7 @@ export const LotInfoFragmentContainer = createFragmentContainer(LotInfo, {
       title
       imageUrl
       artistNames
+      slug
     }
   `,
   saleArtwork: graphql`

--- a/src/v2/Apps/Auction/Components/LotInfo.tsx
+++ b/src/v2/Apps/Auction/Components/LotInfo.tsx
@@ -17,7 +17,7 @@ export const LotInfo: React.FC<Props> = ({ artwork, saleArtwork }) => {
     counts: { bidderPositions: bidCount },
   } = saleArtwork
   return (
-    <Flex id="our-parent-flex-box" py={4}>
+    <Flex py={4}>
       <Box maxWidth="150px" width="100%" height="auto" p={0}>
         <RouterLink to={`/artwork/${artwork.slug}`}>
           <div

--- a/src/v2/__generated__/ConfirmBidValidTestQuery.graphql.ts
+++ b/src/v2/__generated__/ConfirmBidValidTestQuery.graphql.ts
@@ -157,6 +157,7 @@ fragment LotInfo_artwork on Artwork {
   title
   imageUrl
   artistNames
+  slug
 }
 
 fragment LotInfo_saleArtwork on SaleArtwork {
@@ -533,7 +534,7 @@ return {
     "metadata": {},
     "name": "ConfirmBidValidTestQuery",
     "operationKind": "query",
-    "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    internalID\n    slug\n    saleArtwork(saleID: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      internalID\n      slug\n      sale {\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n        id\n      }\n      id\n    }\n    id\n  }\n  me {\n    internalID\n    hasQualifiedCreditCards\n    ...ConfirmBid_me\n    id\n  }\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    slug\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n}\n\nfragment ConfirmBid_me on Me {\n  internalID\n  hasQualifiedCreditCards\n  ...BidForm_me\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n"
+    "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    internalID\n    slug\n    saleArtwork(saleID: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      internalID\n      slug\n      sale {\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n        id\n      }\n      id\n    }\n    id\n  }\n  me {\n    internalID\n    hasQualifiedCreditCards\n    ...ConfirmBid_me\n    id\n  }\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    slug\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n}\n\nfragment ConfirmBid_me on Me {\n  internalID\n  hasQualifiedCreditCards\n  ...BidForm_me\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n  slug\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/LotInfo_artwork.graphql.ts
+++ b/src/v2/__generated__/LotInfo_artwork.graphql.ts
@@ -9,6 +9,7 @@ export type LotInfo_artwork = {
     readonly title: string | null;
     readonly imageUrl: string | null;
     readonly artistNames: string | null;
+    readonly slug: string;
     readonly " $refType": "LotInfo_artwork";
 };
 export type LotInfo_artwork$data = LotInfo_artwork;
@@ -59,9 +60,16 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "artistNames",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
     }
   ],
   "type": "Artwork"
 };
-(node as any).hash = 'b97e574bb5ba20c56fcba68e82f78ffb';
+(node as any).hash = '8282283c0a119d9ce6e05a8b03e648c4';
 export default node;

--- a/src/v2/__generated__/auctionRoutes_ConfirmBidQuery.graphql.ts
+++ b/src/v2/__generated__/auctionRoutes_ConfirmBidQuery.graphql.ts
@@ -163,6 +163,7 @@ fragment LotInfo_artwork on Artwork {
   title
   imageUrl
   artistNames
+  slug
 }
 
 fragment LotInfo_saleArtwork on SaleArtwork {
@@ -553,7 +554,7 @@ return {
     "metadata": {},
     "name": "auctionRoutes_ConfirmBidQuery",
     "operationKind": "query",
-    "text": "query auctionRoutes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    internalID\n    slug\n    saleArtwork(saleID: $saleID) {\n      internalID\n      slug\n      sale {\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        id\n      }\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      id\n    }\n    ...LotInfo_artwork\n    id\n  }\n  me {\n    internalID\n    hasQualifiedCreditCards\n    ...ConfirmBid_me\n    id\n  }\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    slug\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n}\n\nfragment ConfirmBid_me on Me {\n  internalID\n  hasQualifiedCreditCards\n  ...BidForm_me\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n"
+    "text": "query auctionRoutes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    internalID\n    slug\n    saleArtwork(saleID: $saleID) {\n      internalID\n      slug\n      sale {\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        id\n      }\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      id\n    }\n    ...LotInfo_artwork\n    id\n  }\n  me {\n    internalID\n    hasQualifiedCreditCards\n    ...ConfirmBid_me\n    id\n  }\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    slug\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n}\n\nfragment ConfirmBid_me on Me {\n  internalID\n  hasQualifiedCreditCards\n  ...BidForm_me\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n  slug\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Collab with @nspinazz89 on [BID-121](https://artsyproduct.atlassian.net/browse/BID-121)

Wraps the lot image and lot #/title/date/artists in a link that redirects to the artwork page.

I wanted to link the Artsy logo back to the artwork page too, but it seemed to be used in Jade templates (!?!?!?!) so I think it's OK to leave as is?
<img width="948" alt="Screen Shot 2021-12-15 at 5 19 19 PM" src="https://user-images.githubusercontent.com/9466631/146273799-ccaaea7b-8719-42da-81f7-4340156c8893.png">

