### PR TITLE
fix(SWA-147): Clickable area for Back button is too large

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -67,7 +67,7 @@ export const ArtworkDetails: React.FC = () => {
 
   return (
     <>
-      <BackLink py={2} mb={6} to="/consign">
+      <BackLink py={2} mb={6} to="/consign" width="min-content">
         Back
       </BackLink>
 

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
@@ -14,7 +14,7 @@ import { useSubmission } from "../Utils/useSubmission"
 import { contactInformationValidationSchema } from "../Utils/validation"
 import { BackLink } from "v2/Components/Links/BackLink"
 import { useErrorModal } from "../Utils/useErrorModal"
-import { data as sd } from "sharify"
+import { getENV } from "v2/Utils/getENV"
 import { recaptcha, RecaptchaAction } from "v2/Utils/recaptcha"
 
 const getContactInformationFormInitialValues = (
@@ -82,7 +82,7 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
           relayEnvironment,
           submission,
           user?.id,
-          !isLoggedIn ? sd.SESSION_ID : undefined
+          !isLoggedIn ? getENV("SESSION_ID") : undefined
         )
         removeSubmission()
         router.push(`/consign/submission/${submissionId}/thank-you`)
@@ -98,6 +98,7 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
       <BackLink
         py={2}
         mb={6}
+        width="min-content"
         to={`/consign/submission/${submissionId}/upload-photos`}
       >
         Back

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -46,6 +46,7 @@ export const UploadPhotos: React.FC = () => {
       <BackLink
         py={2}
         mb={6}
+        width="min-content"
         to={`/consign/submission/${submissionId}/artwork-details`}
       >
         Back


### PR DESCRIPTION
Jira Ticket:ticket: : [SWA-147](https://artsyproduct.atlassian.net/browse/SWA-147)

This PR fixes the clickable area for the Back button in the Submission flow. Also, [noticed that there are new rules for the use `sharify`](https://github.com/artsy/force/blob/e5c72b0bfb6dfca04f8273e89dbe52c8e958c6bb/.eslintrc.js#L114), so i fixed it too

**VIDEO:clapper: :**

https://user-images.githubusercontent.com/55637696/146342597-aa238744-01ba-48e2-93d9-e42d9c0f830d.mov


