### PR TITLE
fix: Prevent duplicate pageview event in search GRO-653

### DIFF
--- a/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
@@ -20,12 +20,17 @@ export const FirstSuggestionItem: React.FC<SuggestionItemProps> = ({
   isHighlighted,
   query,
 }) => {
+  const handleClick = event => {
+    event.preventDefault()
+  }
+
   return (
     <SuggestionItemLink
-      to={href}
+      bg={isHighlighted ? "black5" : "white100"}
       borderBottom="1px solid"
       borderBottomColor="black10"
-      bg={isHighlighted ? "black5" : "white100"}
+      onClick={handleClick}
+      to={href}
     >
       <Text variant="sm">See full results for &ldquo;{query}&rdquo;</Text>
     </SuggestionItemLink>
@@ -40,8 +45,16 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = props => {
     showAuctionResultsButton,
   } = props
 
+  const handleClick = event => {
+    event.preventDefault()
+  }
+
   return (
-    <SuggestionItemLink to={href} bg={isHighlighted ? "black5" : "white100"}>
+    <SuggestionItemLink
+      bg={isHighlighted ? "black5" : "white100"}
+      onClick={handleClick}
+      to={href}
+    >
       <DefaultSuggestion {...props} />
       <QuickNavigation
         href={href}


### PR DESCRIPTION
This PR disables the underlying `RouterLink` click behavior in favor of letting the `SearchBar` navigate:

https://github.com/artsy/force/blob/6baaeb7283df84d1fd04c852d978acf83cb1343e/src/v2/Components/Search/SearchBar.tsx#L268-L296

Steps to reproduce this bug are in the Jira ticket!

https://artsyproduct.atlassian.net/browse/GRO-653

/cc @artsy/grow-devs