### PR TITLE
fix(settings): accommodates users that do not have passwords setup

### DIFF
--- a/src/v2/Apps/Settings/Routes/EditSettings/SettingsEditSettingsRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/SettingsEditSettingsRoute.tsx
@@ -4,7 +4,7 @@ import { Column, GridColumns, Join, Separator } from "@artsy/palette"
 import { SettingsEditSettingsInformationFragmentContainer } from "./Components/SettingsEditSettingsInformation"
 import { SettingsEditSettingsTwoFactorFragmentContainer } from "./Components/SettingsEditSettingsTwoFactor"
 import { SettingsEditSettingsEmailPreferencesFragmentContainer } from "./Components/SettingsEditSettingsEmailPreferences/SettingsEditSettingsEmailPreferences"
-import { SettingsEditSettingsPassword } from "./Components/SettingsEditSettingsPassword"
+import { SettingsEditSettingsPasswordFragmentContainer } from "./Components/SettingsEditSettingsPassword"
 import { SettingsEditSettingsRoute_me } from "v2/__generated__/SettingsEditSettingsRoute_me.graphql"
 import { SettingsEditSettingsLinkedAccountsFragmentContainer } from "./Components/SettingsEditSettingsLinkedAccounts"
 
@@ -19,7 +19,7 @@ const SettingsEditRoute: React.FC<SettingsEditRouteProps> = ({ me }) => {
         <Join separator={<Separator my={4} />}>
           <SettingsEditSettingsInformationFragmentContainer me={me} />
 
-          <SettingsEditSettingsPassword />
+          <SettingsEditSettingsPasswordFragmentContainer me={me} />
 
           <SettingsEditSettingsTwoFactorFragmentContainer me={me} />
 
@@ -40,6 +40,7 @@ export const SettingsEditRouteFragmentContainer = createFragmentContainer(
     me: graphql`
       fragment SettingsEditSettingsRoute_me on Me {
         ...SettingsEditSettingsInformation_me
+        ...SettingsEditSettingsPassword_me
         ...SettingsEditSettingsTwoFactor_me
         ...SettingsEditSettingsEmailPreferences_me
         ...SettingsEditSettingsLinkedAccounts_me

--- a/src/v2/__generated__/SettingsEditSettingsPassword_me.graphql.ts
+++ b/src/v2/__generated__/SettingsEditSettingsPassword_me.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SettingsEditSettingsPassword_me = {
+    readonly hasPassword: boolean;
+    readonly " $refType": "SettingsEditSettingsPassword_me";
+};
+export type SettingsEditSettingsPassword_me$data = SettingsEditSettingsPassword_me;
+export type SettingsEditSettingsPassword_me$key = {
+    readonly " $data"?: SettingsEditSettingsPassword_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SettingsEditSettingsPassword_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SettingsEditSettingsPassword_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasPassword",
+      "storageKey": null
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = '7a8d2bf99ebdf91f780e1387cb9aaf6f';
+export default node;

--- a/src/v2/__generated__/SettingsEditSettingsRoute_me.graphql.ts
+++ b/src/v2/__generated__/SettingsEditSettingsRoute_me.graphql.ts
@@ -4,7 +4,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type SettingsEditSettingsRoute_me = {
-    readonly " $fragmentRefs": FragmentRefs<"SettingsEditSettingsInformation_me" | "SettingsEditSettingsTwoFactor_me" | "SettingsEditSettingsEmailPreferences_me" | "SettingsEditSettingsLinkedAccounts_me">;
+    readonly " $fragmentRefs": FragmentRefs<"SettingsEditSettingsInformation_me" | "SettingsEditSettingsPassword_me" | "SettingsEditSettingsTwoFactor_me" | "SettingsEditSettingsEmailPreferences_me" | "SettingsEditSettingsLinkedAccounts_me">;
     readonly " $refType": "SettingsEditSettingsRoute_me";
 };
 export type SettingsEditSettingsRoute_me$data = SettingsEditSettingsRoute_me;
@@ -29,6 +29,11 @@ const node: ReaderFragment = {
     {
       "args": null,
       "kind": "FragmentSpread",
+      "name": "SettingsEditSettingsPassword_me"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
       "name": "SettingsEditSettingsTwoFactor_me"
     },
     {
@@ -44,5 +49,5 @@ const node: ReaderFragment = {
   ],
   "type": "Me"
 };
-(node as any).hash = 'dec37aa800f3ecc74c7ad8d4116a9099';
+(node as any).hash = 'c49b3def6cc8f6d68da449ed6eb41c02';
 export default node;

--- a/src/v2/__generated__/settingsRoutes_SettingsEditSettingsRouteQuery.graphql.ts
+++ b/src/v2/__generated__/settingsRoutes_SettingsEditSettingsRouteQuery.graphql.ts
@@ -55,8 +55,13 @@ fragment SettingsEditSettingsLinkedAccounts_me on Me {
   }
 }
 
+fragment SettingsEditSettingsPassword_me on Me {
+  hasPassword
+}
+
 fragment SettingsEditSettingsRoute_me on Me {
   ...SettingsEditSettingsInformation_me
+  ...SettingsEditSettingsPassword_me
   ...SettingsEditSettingsTwoFactor_me
   ...SettingsEditSettingsEmailPreferences_me
   ...SettingsEditSettingsLinkedAccounts_me
@@ -180,6 +185,13 @@ return {
             "args": null,
             "kind": "ScalarField",
             "name": "phone",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hasPassword",
             "storageKey": null
           },
           {
@@ -317,7 +329,7 @@ return {
     "metadata": {},
     "name": "settingsRoutes_SettingsEditSettingsRouteQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_SettingsEditSettingsRouteQuery {\n  me {\n    ...SettingsEditSettingsRoute_me\n    id\n  }\n}\n\nfragment AppSecondFactor_me on Me {\n  hasSecondFactorEnabled\n  appSecondFactors: secondFactors(kinds: [app]) {\n    __typename\n    ... on AppSecondFactor {\n      __typename\n      internalID\n      name\n    }\n  }\n}\n\nfragment SettingsEditSettingsEmailPreferences_me on Me {\n  emailFrequency\n  id\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phone\n}\n\nfragment SettingsEditSettingsLinkedAccounts_me on Me {\n  authentications {\n    provider\n    id\n  }\n}\n\nfragment SettingsEditSettingsRoute_me on Me {\n  ...SettingsEditSettingsInformation_me\n  ...SettingsEditSettingsTwoFactor_me\n  ...SettingsEditSettingsEmailPreferences_me\n  ...SettingsEditSettingsLinkedAccounts_me\n}\n\nfragment SettingsEditSettingsTwoFactorBackupCodes_me on Me {\n  backupSecondFactors: secondFactors(kinds: [backup]) {\n    __typename\n    ... on BackupSecondFactor {\n      __typename\n    }\n  }\n}\n\nfragment SettingsEditSettingsTwoFactor_me on Me {\n  hasSecondFactorEnabled\n  ...AppSecondFactor_me\n  ...SmsSecondFactor_me\n  ...SettingsEditSettingsTwoFactorBackupCodes_me\n}\n\nfragment SmsSecondFactor_me on Me {\n  hasSecondFactorEnabled\n  smsSecondFactors: secondFactors(kinds: [sms]) {\n    __typename\n    ... on SmsSecondFactor {\n      __typename\n      internalID\n      formattedPhoneNumber\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_SettingsEditSettingsRouteQuery {\n  me {\n    ...SettingsEditSettingsRoute_me\n    id\n  }\n}\n\nfragment AppSecondFactor_me on Me {\n  hasSecondFactorEnabled\n  appSecondFactors: secondFactors(kinds: [app]) {\n    __typename\n    ... on AppSecondFactor {\n      __typename\n      internalID\n      name\n    }\n  }\n}\n\nfragment SettingsEditSettingsEmailPreferences_me on Me {\n  emailFrequency\n  id\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phone\n}\n\nfragment SettingsEditSettingsLinkedAccounts_me on Me {\n  authentications {\n    provider\n    id\n  }\n}\n\nfragment SettingsEditSettingsPassword_me on Me {\n  hasPassword\n}\n\nfragment SettingsEditSettingsRoute_me on Me {\n  ...SettingsEditSettingsInformation_me\n  ...SettingsEditSettingsPassword_me\n  ...SettingsEditSettingsTwoFactor_me\n  ...SettingsEditSettingsEmailPreferences_me\n  ...SettingsEditSettingsLinkedAccounts_me\n}\n\nfragment SettingsEditSettingsTwoFactorBackupCodes_me on Me {\n  backupSecondFactors: secondFactors(kinds: [backup]) {\n    __typename\n    ... on BackupSecondFactor {\n      __typename\n    }\n  }\n}\n\nfragment SettingsEditSettingsTwoFactor_me on Me {\n  hasSecondFactorEnabled\n  ...AppSecondFactor_me\n  ...SmsSecondFactor_me\n  ...SettingsEditSettingsTwoFactorBackupCodes_me\n}\n\nfragment SmsSecondFactor_me on Me {\n  hasSecondFactorEnabled\n  smsSecondFactors: secondFactors(kinds: [sms]) {\n    __typename\n    ... on SmsSecondFactor {\n      __typename\n      internalID\n      formattedPhoneNumber\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
A minor change here: users who sign up through social auth don't have passwords set initially. This adapts the password form to accommodate those users. This code is currently untested because we were unable to get social auth working at all locally. Though I believe this should work correctly, I'm going to just check this in staging and go from there.