### PR TITLE
fix: incorrect import causing 500

### DIFF
--- a/src/desktop/models/mixins/relations/inquiry_outcome.js
+++ b/src/desktop/models/mixins/relations/inquiry_outcome.js
@@ -5,13 +5,13 @@
  */
 export const InquiryOutcomeRelations = {
   related() {
+    const { Artwork } = require("../../artwork")
 
-    const Artwork = require('../../artwork');
+    const inquireable =
+      this.get("inquireable_type") === "Artwork"
+        ? new Artwork(this.get("inquireable"))
+        : undefined
 
-    const inquireable = this.get('inquireable_type')  === 'Artwork' ?
-      new Artwork(this.get('inquireable')) : undefined;
-
-    return this.__related__ =
-      {inquireable};
-  }
-};
+    return (this.__related__ = { inquireable })
+  },
+}


### PR DESCRIPTION
Tiny fix for a `500` when trying to access the `/inquiry/:id/user_outcome` route reported by @bhoggard .
The actual error was: `TypeError: Artwork is not a constructor`, which seems to have been caused by decaffeination.
cc: @artsy/negotiate-devs 