### PR TITLE
fix: validates authentication and signs out if invalid

### DIFF
--- a/src/v2/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
+++ b/src/v2/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
@@ -21,6 +21,7 @@ jest.mock("../Utils/helpers", () => ({
   ...jest.requireActual("../Utils/helpers"),
   setCookies: jest.fn(),
 }))
+jest.mock("v2/Utils/Hooks/useAuthValidation")
 
 describe("authenticationRoutes", () => {
   const mockCheckForRedirect = checkForRedirect as jest.Mock

--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -17,6 +17,7 @@ import { useAuthIntent } from "v2/Utils/Hooks/useAuthIntent"
 import { AppToasts } from "./AppToasts"
 import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 import { useProductionEnvironmentWarning } from "v2/Utils/Hooks/useProductionEnvironmentWarning"
+import { useAuthValidation } from "v2/Utils/Hooks/useAuthValidation"
 
 const logger = createLogger("Apps/Components/AppShell")
 
@@ -27,6 +28,7 @@ interface AppShellProps {
 
 export const AppShell: React.FC<AppShellProps> = props => {
   useAuthIntent()
+  useAuthValidation()
 
   const { children, match } = props
   const routeConfig = findCurrentRoute(match)!

--- a/src/v2/System/Router/__tests__/RouterLink.jest.tsx
+++ b/src/v2/System/Router/__tests__/RouterLink.jest.tsx
@@ -17,6 +17,8 @@ jest.mock("v2/Components/NavBar/NavBar", () => ({
   NavBar: () => "NavBar",
 }))
 
+jest.mock("v2/Utils/Hooks/useAuthValidation")
+
 describe("RouterLink", () => {
   const renderTestRoute = () => {
     render(

--- a/src/v2/Utils/Hooks/__tests__/useAuthValidation.jest.tsx
+++ b/src/v2/Utils/Hooks/__tests__/useAuthValidation.jest.tsx
@@ -1,0 +1,67 @@
+import { renderHook } from "@testing-library/react-hooks"
+import { fetchQuery } from "react-relay"
+import { useAuthValidation } from "../useAuthValidation"
+import { logout } from "../../auth"
+import { flushPromiseQueue } from "v2/DevTools"
+
+jest.mock("react-relay")
+jest.mock("../../auth")
+
+describe("useAuthValidation", () => {
+  const mockFetchQuery = fetchQuery as jest.Mock
+  const mockLogout = logout as jest.Mock
+
+  beforeEach(() => {
+    mockLogout.mockImplementation(() => Promise.resolve())
+  })
+
+  afterEach(() => {
+    mockFetchQuery.mockClear()
+    mockLogout.mockClear()
+  })
+
+  it("does nothing if the status is logged in", async () => {
+    mockFetchQuery.mockImplementation(() =>
+      Promise.resolve({
+        authenticationStatus: "LOGGED_IN",
+      })
+    )
+
+    expect(mockLogout).not.toBeCalled()
+
+    renderHook(() => useAuthValidation())
+    await flushPromiseQueue()
+
+    expect(mockLogout).not.toBeCalled()
+  })
+
+  it("does nothing if the status is logged out", async () => {
+    mockFetchQuery.mockImplementation(() =>
+      Promise.resolve({
+        authenticationStatus: "LOGGED_OUT",
+      })
+    )
+
+    expect(mockLogout).not.toBeCalled()
+
+    renderHook(() => useAuthValidation())
+    await flushPromiseQueue()
+
+    expect(mockLogout).not.toBeCalled()
+  })
+
+  it("logs out the user if the status is invalid", async () => {
+    mockFetchQuery.mockImplementation(() =>
+      Promise.resolve({
+        authenticationStatus: "INVALID",
+      })
+    )
+
+    expect(mockLogout).not.toBeCalled()
+
+    renderHook(() => useAuthValidation())
+    await flushPromiseQueue()
+
+    expect(mockLogout).toBeCalledTimes(1)
+  })
+})

--- a/src/v2/Utils/Hooks/useAuthValidation.ts
+++ b/src/v2/Utils/Hooks/useAuthValidation.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react"
+import { fetchQuery, graphql } from "react-relay"
+import { useSystemContext } from "v2/System"
+import { logout } from "../auth"
+import { useAuthValidationQuery } from "v2/__generated__/useAuthValidationQuery.graphql"
+
+export const useAuthValidation = () => {
+  const { relayEnvironment } = useSystemContext()
+
+  useEffect(() => {
+    const exec = async () => {
+      const { authenticationStatus } = await fetchQuery<useAuthValidationQuery>(
+        relayEnvironment!,
+        graphql`
+          query useAuthValidationQuery {
+            authenticationStatus
+          }
+        `,
+        {}
+      )
+
+      if (authenticationStatus === "INVALID") {
+        await logout()
+        window.location.reload()
+        return
+      }
+    }
+
+    exec()
+  }, [relayEnvironment])
+}

--- a/src/v2/__generated__/useAuthValidationQuery.graphql.ts
+++ b/src/v2/__generated__/useAuthValidationQuery.graphql.ts
@@ -1,0 +1,59 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type AuthenticationStatus = "INVALID" | "LOGGED_IN" | "LOGGED_OUT" | "%future added value";
+export type useAuthValidationQueryVariables = {};
+export type useAuthValidationQueryResponse = {
+    readonly authenticationStatus: AuthenticationStatus;
+};
+export type useAuthValidationQuery = {
+    readonly response: useAuthValidationQueryResponse;
+    readonly variables: useAuthValidationQueryVariables;
+};
+
+
+
+/*
+query useAuthValidationQuery {
+  authenticationStatus
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "authenticationStatus",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useAuthValidationQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "useAuthValidationQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "useAuthValidationQuery",
+    "operationKind": "query",
+    "text": "query useAuthValidationQuery {\n  authenticationStatus\n}\n"
+  }
+};
+})();
+(node as any).hash = '2f2ccc765f2b0623e0c21ddb7e46eb08';
+export default node;


### PR DESCRIPTION
So this replicates what https://github.com/artsy/force/blob/main/src/lib/syncAuth.ts does but for the new app shell.

I do think we should actually refresh the session without signing out the user, if possible? But I'm not entirely sure what that entails.