### PR TITLE
chore: Skipping rounding for custom size values

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -27,6 +27,7 @@ export const SIZES = [
   { displayName: "Medium (40 – 100cm)", name: "MEDIUM" },
   { displayName: "Large (over 100cm)", name: "LARGE" },
 ]
+const ONE_IN_TO_CM = 2.54
 
 type CustomRange = (number | "*")[]
 
@@ -35,7 +36,9 @@ type CustomSize = {
   width: CustomRange
 }
 
-const convertToCentimeters = (element: number) => Math.round(element * 2.54)
+const convertToCentimeters = (element: number) => {
+  return Math.round(element * ONE_IN_TO_CM)
+}
 
 export const parseRange = (range?: string) => {
   return range?.split("-").map(s => {
@@ -49,7 +52,7 @@ const convertRangeElementToInches = (element: number | "*") => {
     return element
   }
 
-  return Math.round((element / 2.54) * 100) / 100
+  return element / ONE_IN_TO_CM
 }
 
 const convertRangeToInches = (range: CustomRange) => {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
@@ -100,8 +100,12 @@ describe("SizeFilter", () => {
     userEvent.click(screen.getByText("Set size"))
 
     expect(currentContext().filters?.sizes).toEqual([])
-    expect(currentContext().filters?.height).toEqual("4.72-6.3")
-    expect(currentContext().filters?.width).toEqual("4.72-6.3")
+    expect(currentContext().filters?.height).toEqual(
+      "4.724409448818897-6.299212598425196"
+    )
+    expect(currentContext().filters?.width).toEqual(
+      "4.724409448818897-6.299212598425196"
+    )
   })
 
   it("updates the filter values when only one dimension is added", () => {
@@ -113,7 +117,9 @@ describe("SizeFilter", () => {
     userEvent.click(screen.getByText("Set size"))
 
     expect(currentContext().filters?.sizes).toEqual([])
-    expect(currentContext().filters?.height).toEqual("4.72-9.45")
+    expect(currentContext().filters?.height).toEqual(
+      "4.724409448818897-9.448818897637794"
+    )
     expect(currentContext().filters?.width).toEqual("*-*")
   })
 
@@ -139,8 +145,12 @@ describe("SizeFilter", () => {
 
     // assert: state and ui are updated
     expect(currentContext().filters?.sizes).toEqual([])
-    expect(currentContext().filters?.width).toEqual("0.39-0.79")
-    expect(currentContext().filters?.height).toEqual("1.18-1.57")
+    expect(currentContext().filters?.width).toEqual(
+      "0.39370078740157477-0.7874015748031495"
+    )
+    expect(currentContext().filters?.height).toEqual(
+      "1.1811023622047243-1.574803149606299"
+    )
     expect(screen.queryByDisplayValue("1")).toBeInTheDocument()
     expect(screen.queryByDisplayValue("2")).toBeInTheDocument()
     expect(screen.queryByDisplayValue("3")).toBeInTheDocument()


### PR DESCRIPTION
Type: **Chore**
Jira ticket: [FX-3667]

### Context
If the user specifies the same custom size values for Force and Eigen, they will be converted to inches differently. In turn, this can add problems when working with saved search alerts (for example, a user can create an alert with the same criteria)

#### Force
* width: 100 - 199 cm -> 39.37 - 78.35 in
* height: 200 - 299 cm -> 78.74 - 117.72 in

#### Eigen
* width: 100 - 199 cm -> 39.37007874015748 - 78.34645669291338 in
* height: 200 - 299 cm -> 78.74015748031496 - 117.71653543307086 in

#### Acceptance Criteria
* Values from cm to in should be converted equally to Force and to Eigen

[FX-3667]: https://artsyproduct.atlassian.net/browse/FX-3667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ