### PR TITLE
feat(FX-3545): Add app download buttons to create saved search alert modal

### DIFF
--- a/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
+++ b/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import { Box, Flex, Text } from "@artsy/palette"
+import { RouterLink } from "v2/System/Router/RouterLink"
+import { Device, DOWNLOAD_APP_URLS } from "v2/Utils/Hooks/useDeviceDetection"
+
+export const DownloadAppBanner: React.FC = () => {
+  return (
+    <Box p={2} backgroundColor="black5">
+      <Text variant="md" mb={2} textAlign="center">
+        Download the app to stay current as new artworks are available on Artsy.
+      </Text>
+      <Flex justifyContent="center" flexWrap="wrap">
+        <RouterLink
+          to={DOWNLOAD_APP_URLS[Device.iPhone]}
+          mx={2}
+          textDecoration="none"
+        >
+          <img
+            src="https://files.artsy.net/images/download-ios-app.svg"
+            width={120}
+            height={40}
+            alt="Download on the App Store"
+            loading="lazy"
+          />
+        </RouterLink>
+
+        <RouterLink
+          to={DOWNLOAD_APP_URLS[Device.Android]}
+          mx={2}
+          textDecoration="none"
+        >
+          <img
+            src="https://files.artsy.net/images/download-android-app.svg"
+            width={136}
+            height={40}
+            alt="Get it on Google Play"
+            loading="lazy"
+          />
+        </RouterLink>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
+++ b/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
@@ -53,8 +53,8 @@ export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
   }
 
   return (
-    <Box p={2} backgroundColor="black5">
-      <Text variant="md" mb={2} textAlign="center">
+    <Box p={2} pb={1} backgroundColor="black5">
+      <Text variant="md" mb={1} textAlign="center">
         Download the app to stay current as new artworks are available on Artsy.
       </Text>
       <Flex justifyContent="center" flexWrap="wrap">
@@ -62,6 +62,7 @@ export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
           <RouterLink
             to={DOWNLOAD_APP_URLS[Device.iPhone]}
             mx={2}
+            my={1}
             textDecoration="none"
             onClick={() => handleClick("iOS")}
           >
@@ -79,6 +80,7 @@ export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
           <RouterLink
             to={DOWNLOAD_APP_URLS[Device.Android]}
             mx={2}
+            my={1}
             textDecoration="none"
             onClick={() => handleClick("Android")}
           >

--- a/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
+++ b/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
@@ -2,8 +2,51 @@ import React from "react"
 import { Box, Flex, Text } from "@artsy/palette"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { Device, DOWNLOAD_APP_URLS } from "v2/Utils/Hooks/useDeviceDetection"
+import { useTracking } from "react-tracking"
+import {
+  ActionType,
+  ClickedAppDownload,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
+import { SavedSearchAttributes } from "../ArtworkFilter/SavedSearch/types"
 
-export const DownloadAppBanner: React.FC = () => {
+interface DownloadAppBannerProps {
+  savedSearchAttributes: SavedSearchAttributes
+}
+
+export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
+  savedSearchAttributes,
+}) => {
+  const tracking = useTracking()
+
+  const handleClick = (platform: "iOS" | "Android") => {
+    let destinationPath
+    let subject
+
+    if (platform === "iOS") {
+      destinationPath = DOWNLOAD_APP_URLS[Device.iPhone]
+      subject = "Download on the App Store"
+    }
+
+    if (platform === "Android") {
+      destinationPath = DOWNLOAD_APP_URLS[Device.Android]
+      subject = "Download on the Google Play"
+    }
+
+    const clickedAppDownload: ClickedAppDownload = {
+      action: ActionType.clickedAppDownload,
+      context_module: "createAlert" as ContextModule, // TODO: Use ContextModule.createAlert
+      context_page_owner_type: OwnerType.artist,
+      context_page_owner_slug: savedSearchAttributes.slug,
+      context_page_owner_id: savedSearchAttributes.id,
+      destination_path: destinationPath,
+      subject,
+    }
+
+    tracking.trackEvent(clickedAppDownload)
+  }
+
   return (
     <Box p={2} backgroundColor="black5">
       <Text variant="md" mb={2} textAlign="center">
@@ -14,6 +57,7 @@ export const DownloadAppBanner: React.FC = () => {
           to={DOWNLOAD_APP_URLS[Device.iPhone]}
           mx={2}
           textDecoration="none"
+          onClick={() => handleClick("iOS")}
         >
           <img
             src="https://files.artsy.net/images/download-ios-app.svg"
@@ -28,6 +72,7 @@ export const DownloadAppBanner: React.FC = () => {
           to={DOWNLOAD_APP_URLS[Device.Android]}
           mx={2}
           textDecoration="none"
+          onClick={() => handleClick("Android")}
         >
           <img
             src="https://files.artsy.net/images/download-android-app.svg"

--- a/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
+++ b/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
@@ -60,7 +60,7 @@ export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
           onClick={() => handleClick("iOS")}
         >
           <img
-            src="https://files.artsy.net/images/download-ios-app.svg"
+            src="https://files.artsy.net/images/download-ios-app-transparent.svg"
             width={120}
             height={40}
             alt="Download on the App Store"
@@ -75,7 +75,7 @@ export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
           onClick={() => handleClick("Android")}
         >
           <img
-            src="https://files.artsy.net/images/download-android-app.svg"
+            src="https://files.artsy.net/images/download-android-app-transparent.svg"
             width={136}
             height={40}
             alt="Get it on Google Play"

--- a/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
+++ b/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
@@ -36,7 +36,7 @@ export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
 
     if (platform === "Android") {
       destinationPath = DOWNLOAD_APP_URLS[Device.Android]
-      subject = "Download on the Google Play"
+      subject = "Get it on Google Play"
     }
 
     const clickedAppDownload: ClickedAppDownload = {

--- a/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
+++ b/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
@@ -41,7 +41,7 @@ export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
 
     const clickedAppDownload: ClickedAppDownload = {
       action: ActionType.clickedAppDownload,
-      context_module: "createAlert" as ContextModule, // TODO: Use ContextModule.createAlert
+      context_module: ContextModule.createAlert,
       context_page_owner_type: OwnerType.artist,
       context_page_owner_slug: savedSearchAttributes.slug,
       context_page_owner_id: savedSearchAttributes.id,

--- a/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
+++ b/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
@@ -1,7 +1,11 @@
 import React from "react"
 import { Box, Flex, Text } from "@artsy/palette"
 import { RouterLink } from "v2/System/Router/RouterLink"
-import { Device, DOWNLOAD_APP_URLS } from "v2/Utils/Hooks/useDeviceDetection"
+import {
+  Device,
+  DOWNLOAD_APP_URLS,
+  useDeviceDetection,
+} from "v2/Utils/Hooks/useDeviceDetection"
 import { useTracking } from "react-tracking"
 import {
   ActionType,
@@ -19,6 +23,7 @@ export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
   savedSearchAttributes,
 }) => {
   const tracking = useTracking()
+  const { device } = useDeviceDetection()
 
   const handleClick = (platform: "iOS" | "Android") => {
     let destinationPath
@@ -53,35 +58,39 @@ export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
         Download the app to stay current as new artworks are available on Artsy.
       </Text>
       <Flex justifyContent="center" flexWrap="wrap">
-        <RouterLink
-          to={DOWNLOAD_APP_URLS[Device.iPhone]}
-          mx={2}
-          textDecoration="none"
-          onClick={() => handleClick("iOS")}
-        >
-          <img
-            src="https://files.artsy.net/images/download-ios-app-transparent.svg"
-            width={120}
-            height={40}
-            alt="Download on the App Store"
-            loading="lazy"
-          />
-        </RouterLink>
+        {(device === Device.iPhone || device === Device.Unknown) && (
+          <RouterLink
+            to={DOWNLOAD_APP_URLS[Device.iPhone]}
+            mx={2}
+            textDecoration="none"
+            onClick={() => handleClick("iOS")}
+          >
+            <img
+              src="https://files.artsy.net/images/download-ios-app-transparent.svg"
+              width={120}
+              height={40}
+              alt="Download on the App Store"
+              loading="lazy"
+            />
+          </RouterLink>
+        )}
 
-        <RouterLink
-          to={DOWNLOAD_APP_URLS[Device.Android]}
-          mx={2}
-          textDecoration="none"
-          onClick={() => handleClick("Android")}
-        >
-          <img
-            src="https://files.artsy.net/images/download-android-app-transparent.svg"
-            width={136}
-            height={40}
-            alt="Get it on Google Play"
-            loading="lazy"
-          />
-        </RouterLink>
+        {(device === Device.Android || device === Device.Unknown) && (
+          <RouterLink
+            to={DOWNLOAD_APP_URLS[Device.Android]}
+            mx={2}
+            textDecoration="none"
+            onClick={() => handleClick("Android")}
+          >
+            <img
+              src="https://files.artsy.net/images/download-android-app-transparent.svg"
+              width={136}
+              height={40}
+              alt="Get it on Google Play"
+              loading="lazy"
+            />
+          </RouterLink>
+        )}
       </Flex>
     </Box>
   )

--- a/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
+++ b/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
@@ -183,7 +183,7 @@ export const SavedSearchAlertModal: React.FC<SavedSearchAlertFormProps> = ({
               </Box>
             </Box>
 
-            <DownloadAppBanner />
+            <DownloadAppBanner savedSearchAttributes={savedSearchAttributes} />
           </Join>
         </Modal>
       </Form>

--- a/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
+++ b/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
@@ -28,6 +28,8 @@ import { SavedSearchAttributes } from "../ArtworkFilter/SavedSearch/types"
 import { FilterPill } from "../ArtworkFilter/SavedSearch/Utils/FilterPillsContext"
 import { extractPills } from "./Utils/extractPills"
 import { Pills } from "../ArtworkFilter/SavedSearch/Components/Pills"
+import { RouterLink } from "v2/System/Router/RouterLink"
+import { Device, DOWNLOAD_APP_URLS } from "v2/Utils/Hooks/useDeviceDetection"
 
 interface SavedSearchAlertFormProps {
   savedSearchAttributes: SavedSearchAttributes
@@ -180,6 +182,42 @@ export const SavedSearchAlertModal: React.FC<SavedSearchAlertFormProps> = ({
                   selected={formik.values.push}
                 />
               </Box>
+            </Box>
+
+            <Box p={2} backgroundColor="black5">
+              <Text variant="md" mb={2} textAlign="center">
+                Download the app to stay current as new artworks are available
+                on Artsy.
+              </Text>
+              <Flex justifyContent="center" flexWrap="wrap">
+                <RouterLink
+                  to={DOWNLOAD_APP_URLS[Device.iPhone]}
+                  mx={2}
+                  textDecoration="none"
+                >
+                  <img
+                    src="https://files.artsy.net/images/download-ios-app.svg"
+                    width={120}
+                    height={40}
+                    alt="Download on the App Store"
+                    loading="lazy"
+                  />
+                </RouterLink>
+
+                <RouterLink
+                  to={DOWNLOAD_APP_URLS[Device.Android]}
+                  mx={2}
+                  textDecoration="none"
+                >
+                  <img
+                    src="https://files.artsy.net/images/download-android-app.svg"
+                    width={136}
+                    height={40}
+                    alt="Get it on Google Play"
+                    loading="lazy"
+                  />
+                </RouterLink>
+              </Flex>
             </Box>
           </Join>
         </Modal>

--- a/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
+++ b/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
@@ -28,8 +28,7 @@ import { SavedSearchAttributes } from "../ArtworkFilter/SavedSearch/types"
 import { FilterPill } from "../ArtworkFilter/SavedSearch/Utils/FilterPillsContext"
 import { extractPills } from "./Utils/extractPills"
 import { Pills } from "../ArtworkFilter/SavedSearch/Components/Pills"
-import { RouterLink } from "v2/System/Router/RouterLink"
-import { Device, DOWNLOAD_APP_URLS } from "v2/Utils/Hooks/useDeviceDetection"
+import { DownloadAppBanner } from "./DownloadAppBanner"
 
 interface SavedSearchAlertFormProps {
   savedSearchAttributes: SavedSearchAttributes
@@ -184,41 +183,7 @@ export const SavedSearchAlertModal: React.FC<SavedSearchAlertFormProps> = ({
               </Box>
             </Box>
 
-            <Box p={2} backgroundColor="black5">
-              <Text variant="md" mb={2} textAlign="center">
-                Download the app to stay current as new artworks are available
-                on Artsy.
-              </Text>
-              <Flex justifyContent="center" flexWrap="wrap">
-                <RouterLink
-                  to={DOWNLOAD_APP_URLS[Device.iPhone]}
-                  mx={2}
-                  textDecoration="none"
-                >
-                  <img
-                    src="https://files.artsy.net/images/download-ios-app.svg"
-                    width={120}
-                    height={40}
-                    alt="Download on the App Store"
-                    loading="lazy"
-                  />
-                </RouterLink>
-
-                <RouterLink
-                  to={DOWNLOAD_APP_URLS[Device.Android]}
-                  mx={2}
-                  textDecoration="none"
-                >
-                  <img
-                    src="https://files.artsy.net/images/download-android-app.svg"
-                    width={136}
-                    height={40}
-                    alt="Get it on Google Play"
-                    loading="lazy"
-                  />
-                </RouterLink>
-              </Flex>
-            </Box>
+            <DownloadAppBanner />
           </Join>
         </Modal>
       </Form>

--- a/src/v2/Components/SavedSearchAlert/__tests__/DownloadAppBanner.jest.tsx
+++ b/src/v2/Components/SavedSearchAlert/__tests__/DownloadAppBanner.jest.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { useTracking } from "react-tracking"
+import { DownloadAppBanner } from "../DownloadAppBanner"
+
+describe("DownloadAppBanner", () => {
+  const trackEvent = jest.fn()
+
+  const renderDownloadAppBanner = () => {
+    render(
+      <DownloadAppBanner
+        savedSearchAttributes={{
+          id: "artistId",
+          name: "artistName",
+          slug: "artistSlug",
+          type: "artist",
+        }}
+      />
+    )
+  }
+
+  beforeEach(() => {
+    const mockTracking = useTracking as jest.Mock
+    mockTracking.mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  it("tracks click on iOS button", () => {
+    renderDownloadAppBanner()
+
+    fireEvent.click(screen.getAllByRole("link")[0])
+
+    expect(trackEvent).toBeCalledWith({
+      action: "clickedAppDownload",
+      context_module: "createAlert",
+      context_page_owner_type: "artist",
+      context_page_owner_slug: "artistSlug",
+      context_page_owner_id: "artistId",
+      destination_path:
+        "https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080",
+      subject: "Download on the App Store",
+    })
+  })
+
+  it("tracks click on Android button", () => {
+    renderDownloadAppBanner()
+
+    fireEvent.click(screen.getAllByRole("link")[1])
+
+    expect(trackEvent).toBeCalledWith({
+      action: "clickedAppDownload",
+      context_module: "createAlert",
+      context_page_owner_type: "artist",
+      context_page_owner_slug: "artistSlug",
+      context_page_owner_id: "artistId",
+      destination_path:
+        "https://play.google.com/store/apps/details?id=net.artsy.app",
+      subject: "Download on the Google Play",
+    })
+  })
+})

--- a/src/v2/Components/SavedSearchAlert/__tests__/DownloadAppBanner.jest.tsx
+++ b/src/v2/Components/SavedSearchAlert/__tests__/DownloadAppBanner.jest.tsx
@@ -57,7 +57,7 @@ describe("DownloadAppBanner", () => {
       context_page_owner_id: "artistId",
       destination_path:
         "https://play.google.com/store/apps/details?id=net.artsy.app",
-      subject: "Download on the Google Play",
+      subject: "Get it on Google Play",
     })
   })
 })


### PR DESCRIPTION
Type: **Feature**
Jira ticket: [FX-3545]
Figma: [Link](https://www.figma.com/file/zbEFZqjKgKquZwtU8U44j9/Alerts?node-id=3565%3A7189)
Review app: [Link](https://download-app-banner.artsy.net/artist/banksy/works-for-sale)

### Acceptance Criteria
* display the download button depending on the platform
  * for iOS platform, only the "Download on the App Store" button is displayed
  * for Android platform, only the "Get it on Google Play" button is displayed
  * If we could not determine the platform, then we display 2 buttons at once
* when the button is clicked, the `ClickedAppDownload` event should be tracked with the values
  * action = ActionType.clickedAppDownload
  * `context_page_owner_type` = `artist`
  * `context_page_owner_id` = `artist id`
  * `context_page_owner_slug` = `artist slug`
  * `context_module` = `createAlert`
  * `destination_path` = App Store or Google Play link
  * `subject`
    * iOS = Download on the App Store
    * Android = Download on the Google Play

### Demo
#### Web
https://user-images.githubusercontent.com/3513494/148245567-3b57ba7a-95f0-4fbd-9af8-7f3343c60084.mp4

#### iOS
https://user-images.githubusercontent.com/3513494/148245768-6e4eb367-bdd5-4bef-b55c-ad7c0f4d82c5.mp4

#### Android
https://user-images.githubusercontent.com/3513494/148245802-cc3f6a19-6b2e-4fb0-9eb1-2b53bcd9ad72.mp4

[FX-3545]: https://artsyproduct.atlassian.net/browse/FX-3545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ