### PR TITLE
Removes /partner from links that refer to partner.href

### DIFF
--- a/src/v2/Apps/Partners/Components/PartnersFeaturedCarouselCell.tsx
+++ b/src/v2/Apps/Partners/Components/PartnersFeaturedCarouselCell.tsx
@@ -42,7 +42,7 @@ const PartnersFeaturedCarouselCell: FC<PartnersFeaturedCarouselCellProps> = ({
         py={2}
       >
         <RouterLink
-          to={`/partner${partner.href}`}
+          to={`${partner.href}`}
           display="block"
           textDecoration="none"
         >

--- a/src/v2/Components/Cells/PartnerCell.tsx
+++ b/src/v2/Components/Cells/PartnerCell.tsx
@@ -47,7 +47,7 @@ const PartnerCell: React.FC<PartnerCellProps> = ({
 
   return (
     <RouterLink
-      to={`/partner${partner.href}`}
+      to={`${partner.href}`}
       display="block"
       textDecoration="none"
       width={width}


### PR DESCRIPTION
We noticed this bug after attempting to update metaphysics' `partner.href` handling to use the new `/partner/:partner_slug` structure.

Given that the current `partner.href` in metaphysics uses the `default_profile_id`, the correct link in these places should be the "naked" URL (`/partner/:default_profile_id` will not be correct in cases where the `default_profile_id` does not match the partner's `slug`). We should just use what metaphysics is giving us. 

Note that force has its own redirects in place to go from `/:default_profile_id` -> `/partner/:partner_slug`, so both styles work.

Once this is merged in, I will merge the change that was [reverted here](https://github.com/artsy/metaphysics/pull/3641), which will update metahpysics' `partner.href` to use the new-style URL.

From searching around, I _think_ these are the only places that needed to be fixed, but let me know if you think of others!