### PR TITLE
feat(script): Add clean:relay to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bundle-report:assets": "WEBPACK_ANALYZE=true yarn build:assets",
     "bundle-report:server": "WEBPACK_ANALYZE=true yarn build:server",
     "clean": "scripts/clean.sh",
+    "clean:relay": "rm -rf '$TMPDIR'/RelayFindGraphQLTags-*",
     "compile": "babel src/v2 --out-dir dist/v2 -s --source-map --extensions '.js,.jsx,.ts,.tsx' --ignore src/v2/**/__tests__",
     "cypress:run": "./node_modules/.bin/cypress run",
     "cypress": "./node_modules/.bin/cypress open",


### PR DESCRIPTION
We've run into problems with relay's cache being corrupted during a rebase. This adds a command to quickly clear it:

```
yarn clean:relay
```