### PR TITLE
[NX-3039] Enable edition sets selection for inquireable artworks

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -98,9 +98,15 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
     )
   }
 
-  renderEditionSet(editionSet: EditionSet, includeSelectOption: boolean) {
+  renderEditionSet(
+    editionSet: EditionSet,
+    includeSelectOption: boolean,
+    editionSelectableOnInquireable: boolean
+  ) {
     const editionEcommerceAvailable =
-      editionSet?.is_acquireable || editionSet?.is_offerable
+      editionSet?.is_acquireable ||
+      editionSet?.is_offerable ||
+      editionSelectableOnInquireable
 
     const editionFragment = (
       <Flex justifyContent="space-between" flex={1}>
@@ -130,14 +136,21 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
     }
   }
 
-  renderEditionSets(includeSelectOption: boolean) {
+  renderEditionSets(
+    includeSelectOption: boolean,
+    editionSelectableOnInquireable: boolean
+  ) {
     const editionSets = this.props.artwork.edition_sets
 
     const editionSetsFragment = editionSets?.map((editionSet, index) => {
       return (
         <React.Fragment key={editionSet?.id}>
           <Box py={2}>
-            {this.renderEditionSet(editionSet, includeSelectOption)}
+            {this.renderEditionSet(
+              editionSet,
+              includeSelectOption,
+              editionSelectableOnInquireable
+            )}
           </Box>
           {index !== editionSets.length - 1 && <Separator />}
         </React.Fragment>
@@ -377,7 +390,14 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
       selectedEditionSet,
     } = this.state
 
-    const artworkEcommerceAvailable = !!(isAcquireable || isOfferable)
+    const editionSelectableOnInquireable = !!(
+      artwork.is_inquireable && labFeatureEnabled
+    )
+    const artworkEcommerceAvailable = !!(
+      artwork.is_acquireable ||
+      artwork.is_offerable ||
+      editionSelectableOnInquireable
+    )
 
     if (!artwork.sale_message && !isInquireable) {
       return <Separator />
@@ -409,7 +429,10 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
             )
           ) : (
             <>
-              {this.renderEditionSets(artworkEcommerceAvailable)}
+              {this.renderEditionSets(
+                artworkEcommerceAvailable,
+                editionSelectableOnInquireable
+              )}
 
               {selectedEditionSet && (
                 <>

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial2.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial2.jest.tsx
@@ -2,6 +2,7 @@ import {
   ArtworkOfferableFromInquiryPriceExact,
   ArtworkOfferableFromInquiryPriceRange,
   ArtworkOfferableAndInquireablePriceHidden,
+  ForSaleArtworkWithMultipleEditions,
 } from "v2/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarCommercial"
 
 import { commitMutation as _commitMutation, graphql } from "react-relay"
@@ -59,5 +60,13 @@ describe("ArtworkSidebarCommercial RTL", () => {
 
     expect(screen.queryByText("Make offer")).not.toBeInTheDocument()
     expect(screen.getByText("Contact Gallery")).toBeInTheDocument()
+  })
+
+  it("displays radio buttons for Edition Sets for inquirable artworks", () => {
+    renderWithRelay({
+      Artwork: () => ForSaleArtworkWithMultipleEditions,
+    })
+
+    expect(screen.getAllByRole("radio").length).toBe(4)
   })
 })


### PR DESCRIPTION
[NX-3039]

Even though the artwork is listed as `Contact Gallery` only, we still want to display Edition Sets select radio buttons (in case `Make Offer On All Eligible Artworks` lab feature is enabled)

**Before:**
<img width="617" alt="Screenshot 2022-01-05 at 15 52 27" src="https://user-images.githubusercontent.com/8002618/148262613-e9cd2115-4136-44e0-9ac2-e76cf9b1ae27.png">

**After:**
<img width="648" alt="Screenshot 2022-01-05 at 15 53 19" src="https://user-images.githubusercontent.com/8002618/148262625-b193abd5-5993-4b37-a9b1-013002688eba.png">

Important to have in mind that these changes are focused exclusively on **displaying** the radio buttons.
Actual usage of this data will be implemented during [NX-3051]

[NX-3039]: https://artsyproduct.atlassian.net/browse/NX-3039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NX-3051]: https://artsyproduct.atlassian.net/browse/NX-3051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ