### PR TITLE
fix: Mark deprecated component as such

### DIFF
--- a/src/v2/Components/Toast/ToastComponent.tsx
+++ b/src/v2/Components/Toast/ToastComponent.tsx
@@ -12,6 +12,10 @@ interface ToastComponentProps {
   onCloseToast: () => void
 }
 
+/**
+ * @deprecated in favor of our Toast components in @artsy/palette
+ * https://palette-storybook.artsy.net/?path=/story/components-toast--default
+ */
 const ToastComponent: React.FC<ToastComponentProps> = ({
   notificationAction,
   showNotification,


### PR DESCRIPTION
I did this:

```
$ ag -l ToastComponent | xargs sed -i '' "s/Toast/StaleToast/g"
```

And then updated the folder/filename and added that little breadcrumb comment for Future Us in case we stumble upon this again. A better solution would be to migrate that order page that uses it over to the Palette version of Toast but it's Friday I'm doing the best I can people.

/cc @artsy/grow-devs