### PR TITLE
security(colors.js): Lock version to 1.4 due to corruption

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "@types/react": "16.9.34",
     "@types/relay-runtime": "9.1.6",
     "chokidar": "3.4.0",
+    "//": "Locking colors to 1.3.0 because 1.4.4 has been deliberately corrupted",
+    "colors": "1.3.0",
     "domelementtype": "1.3.1",
     "graphql": "14.5.8",
     "htmlparser2": "3.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6898,20 +6898,10 @@ colorette@^1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-colors@0.5.x:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
-  integrity sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=
-
-colors@^1.1.2:
+colors@0.5.x, colors@1.3.0, colors@^1.1.2, colors@~1.1.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.0.tgz#5f20c9fef6945cb1134260aab33bfbdc8295e04e"
   integrity sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==
-
-colors@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
-  integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
 
 combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
@@ -16147,7 +16137,7 @@ pascalcase@^0.1.1:
 
 "passport-apple@https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f":
   version "1.1.2"
-  resolved "https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f"
+  resolved "git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f"
   dependencies:
     jsonwebtoken "^8.5.1"
     passport-oauth2 "^1.5.0"


### PR DESCRIPTION
See https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/ 

We don't import this lib directly, but it is an ephemeral dep, which still runs the risk of an automatic update. 

<img width="135" alt="Screen Shot 2022-01-09 at 12 59 03 PM" src="https://user-images.githubusercontent.com/236943/148701024-9c5cf3f4-a97b-4260-9e53-1e31fc1e6f90.png">

