### PR TITLE
fix(articles): ports scrolling auth modal

### DIFF
--- a/src/desktop/assets/articles.ts
+++ b/src/desktop/assets/articles.ts
@@ -1,10 +1,9 @@
 import $ from "jquery"
+// eslint-disable-next-line no-restricted-imports
 import { data as sd } from "sharify"
 
 $(() => {
-  if (location.pathname === "/articles") {
-    return require("../apps/articles/client/magazine.coffee").init()
-  } else if (location.pathname === "/news") {
+  if (location.pathname === "/news") {
     return require("../apps/articles/client/news")
   } else if (
     location.pathname ===

--- a/src/v2/Apps/Articles/ArticlesApp.tsx
+++ b/src/v2/Apps/Articles/ArticlesApp.tsx
@@ -6,12 +6,15 @@ import { MetaTags } from "v2/Components/MetaTags"
 import { ArticlesIndexArticlesPaginationContainer } from "./Components/ArticlesIndexArticles"
 import { getENV } from "v2/Utils/getENV"
 import { ArticlesApp_viewer } from "v2/__generated__/ArticlesApp_viewer.graphql"
+import { useScrollingAuthModal } from "./Utils/useScrollingAuthModal"
 
 interface ArticlesAppProps {
   viewer: ArticlesApp_viewer
 }
 
 const ArticlesApp: FC<ArticlesAppProps> = ({ viewer }) => {
+  useScrollingAuthModal()
+
   return (
     <>
       <MetaTags

--- a/src/v2/Apps/Articles/Utils/useScrollingAuthModal.tsx
+++ b/src/v2/Apps/Articles/Utils/useScrollingAuthModal.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react"
+import { handleScrollingAuthModal } from "desktop/lib/openAuthModal"
+import { ContextModule, Intent } from "@artsy/cohesion"
+import { mediator } from "lib/mediator"
+import Cookies from "cookies-js"
+import { getENV } from "v2/Utils/getENV"
+
+const KEY = "editorial-signup-dismissed"
+
+const setCookie = () => {
+  Cookies.set(KEY, 1, { expires: 31536000 })
+}
+
+export const useScrollingAuthModal = () => {
+  useEffect(() => {
+    // Does not display if previously dismissed, is mobile, or is logged in
+    if (Cookies.get(KEY) || getENV("IS_MOBILE") || getENV("CURRENT_USER")) {
+      return
+    }
+
+    handleScrollingAuthModal({
+      intent: Intent.viewEditorial,
+      contextModule: ContextModule.popUpModal,
+      copy: "Sign up for the best stories in art and visual culture",
+      destination: location.href,
+      afterSignUpAction: {
+        action: "editorialSignup",
+      },
+    })
+
+    mediator.once("modal:closed", setCookie)
+    mediator.once("auth:sign_up:success", setCookie)
+  }, [])
+}


### PR DESCRIPTION
Ports over the code from [AuthWrapper.tsx](https://github.com/artsy/force/blob/main/src/desktop/apps/articles/components/AuthWrapper.tsx) (— the existing code is still used on `/news`). This should fix the failing Integrity specs (cc @joeyAghion).