### PR TITLE
chore(FX-3677): update the filter counting logic for name input

### DIFF
--- a/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
+++ b/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
@@ -59,7 +59,7 @@ export const SavedSearchAlertModal: React.FC<SavedSearchAlertFormProps> = ({
     filterContext.aggregations,
     savedSearchAttributes
   )
-  const namePlaceholder = getNamePlaceholder(name, pills.length)
+  const namePlaceholder = getNamePlaceholder(name, pills)
 
   useEffect(() => {
     setFilters(filtersFromContext)

--- a/src/v2/Components/SavedSearchAlert/Utils/__tests__/getNamePlaceholder.jest.ts
+++ b/src/v2/Components/SavedSearchAlert/Utils/__tests__/getNamePlaceholder.jest.ts
@@ -1,0 +1,49 @@
+import { FilterPill } from "v2/Components/ArtworkFilter/SavedSearch/Utils/FilterPillsContext"
+import { getNamePlaceholder } from "../getNamePlaceholder"
+
+describe("getNamePlaceholder", () => {
+  it("returns the singular form", () => {
+    const pills: FilterPill[] = [
+      {
+        isDefault: true,
+        name: "banksy",
+        displayName: "Banksy",
+      },
+      {
+        filterName: "attributionClass",
+        name: "unique",
+        displayName: "Unique",
+      },
+    ]
+    expect(getNamePlaceholder("artistName", pills)).toBe(
+      "artistName • 1 filter"
+    )
+  })
+
+  it("returns the plural form", () => {
+    const pills: FilterPill[] = [
+      {
+        isDefault: true,
+        name: "banksy",
+        displayName: "Banksy",
+      },
+      {
+        filterName: "attributionClass",
+        name: "unique",
+        displayName: "Unique",
+      },
+      {
+        filterName: "attributionClass",
+        name: "limited edition",
+        displayName: "Limited Edition",
+      },
+    ]
+    expect(getNamePlaceholder("artistName", pills)).toBe(
+      "artistName • 2 filters"
+    )
+  })
+
+  it("returns only artist name when pills are empty", () => {
+    expect(getNamePlaceholder("artistName", [])).toBe("artistName")
+  })
+})

--- a/src/v2/Components/SavedSearchAlert/Utils/getNamePlaceholder.tsx
+++ b/src/v2/Components/SavedSearchAlert/Utils/getNamePlaceholder.tsx
@@ -1,7 +1,12 @@
-export const getNamePlaceholder = (
-  artistName: string,
-  filtersCount: number
-) => {
-  const filtersCountLabel = filtersCount > 1 ? "filters" : "filter"
-  return `${artistName} • ${filtersCount} ${filtersCountLabel}`
+import { FilterPill } from "v2/Components/ArtworkFilter/SavedSearch/Utils/FilterPillsContext"
+
+export const getNamePlaceholder = (artistName: string, pills: FilterPill[]) => {
+  const filteredPills = pills.filter(pill => !pill.isDefault)
+  const filtersCountLabel = filteredPills.length > 1 ? "filters" : "filter"
+
+  if (filteredPills.length === 0) {
+    return artistName
+  }
+
+  return `${artistName} • ${filteredPills.length} ${filtersCountLabel}`
 }

--- a/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
+++ b/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
@@ -83,7 +83,7 @@ describe("SavedSearchAlertModal", () => {
     renderModal({})
     expect(screen.getByRole("textbox")).toHaveAttribute(
       "placeholder",
-      "Test Artist • 3 filters"
+      "Test Artist • 2 filters"
     )
   })
 


### PR DESCRIPTION
Type: **Chore**
Jira ticket: [FX-3677]

### Acceptance Criteria
* should **not display** "• 1 filter" in name input if no filter is selected and only the artist's name is displayed as a pill (for example, _Banksy_)
* should **display** "• 1 filter" in name input when a user adds a filter (for example, _Banksy • 1 filter_)

### Demo
https://user-images.githubusercontent.com/3513494/149126899-55aba2d9-9639-49f2-b965-a84610c99df1.mp4

[FX-3677]: https://artsyproduct.atlassian.net/browse/FX-3677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ