### PR TITLE
feat: Add nft medium type to filter

### DIFF
--- a/src/v2/Apps/Artwork/Utils/createCollectUrl.tsx
+++ b/src/v2/Apps/Artwork/Utils/createCollectUrl.tsx
@@ -52,6 +52,7 @@ const filterCategories = {
   Installation: "installation",
   Jewelry: "jewelry",
   "Mixed Media": "mixed-media",
+  NFT: "nft",
   Other: "",
   Painting: "painting",
   "Performance Art": "performance-art",
@@ -63,5 +64,4 @@ const filterCategories = {
   "Textile Arts": "textiles",
   "Video/Film/Animation": "film-slash-video",
   "Work on Paper": "work-on-paper",
-  NFT: "nft",
 }

--- a/src/v2/Apps/Artwork/Utils/createCollectUrl.tsx
+++ b/src/v2/Apps/Artwork/Utils/createCollectUrl.tsx
@@ -63,4 +63,5 @@ const filterCategories = {
   "Textile Arts": "textiles",
   "Video/Film/Animation": "film-slash-video",
   "Work on Paper": "work-on-paper",
+  NFT: "nft",
 }

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, Flex, useThemeConfig } from "@artsy/palette"
-import { FC } from "react"
+import { FC, useContext } from "react"
 import {
   SelectedFiltersCountsLabels,
   useArtworkFilterContext,
@@ -10,6 +10,7 @@ import { sortResults } from "./ResultsFilter"
 import { FilterExpandable } from "./FilterExpandable"
 import { useFilterLabelCountByKey } from "../Utils/useFilterLabelCountByKey"
 import { userIsAdmin } from "v2/Utils/user"
+import { SystemContext } from "v2/System"
 
 export interface MediumFilterProps {
   expanded?: boolean
@@ -17,6 +18,7 @@ export interface MediumFilterProps {
 
 export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
   const { aggregations, counts, ...filterContext } = useArtworkFilterContext()
+  const { user } = useContext(SystemContext)
 
   const filtersCount = useFilterLabelCountByKey(
     SelectedFiltersCountsLabels.additionalGeneIDs
@@ -28,7 +30,7 @@ export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
     counts: [],
   }
 
-  const filteredHardcodedMediums = userIsAdmin()
+  const filteredHardcodedMediums = userIsAdmin(user)
     ? hardcodedMediums
     : hardcodedMediums.filter(medium => medium.value !== "nft")
 

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, Flex, useThemeConfig } from "@artsy/palette"
-import { FC, useContext } from "react"
+import { FC } from "react"
 import {
   SelectedFiltersCountsLabels,
   useArtworkFilterContext,
@@ -10,7 +10,7 @@ import { sortResults } from "./ResultsFilter"
 import { FilterExpandable } from "./FilterExpandable"
 import { useFilterLabelCountByKey } from "../Utils/useFilterLabelCountByKey"
 import { userIsAdmin } from "v2/Utils/user"
-import { SystemContext } from "v2/System"
+import { useSystemContext } from "v2/System"
 
 export interface MediumFilterProps {
   expanded?: boolean
@@ -18,7 +18,7 @@ export interface MediumFilterProps {
 
 export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
   const { aggregations, counts, ...filterContext } = useArtworkFilterContext()
-  const { user } = useContext(SystemContext)
+  const { user } = useSystemContext()
 
   const filtersCount = useFilterLabelCountByKey(
     SelectedFiltersCountsLabels.additionalGeneIDs

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -138,4 +138,8 @@ export const hardcodedMediums = [
     value: "ephemera-or-merchandise",
     name: "Ephemera or Merchandise",
   },
+  {
+    value: "nft",
+    name: "NFT",
+  },
 ]

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -9,6 +9,7 @@ import { intersection } from "lodash"
 import { sortResults } from "./ResultsFilter"
 import { FilterExpandable } from "./FilterExpandable"
 import { useFilterLabelCountByKey } from "../Utils/useFilterLabelCountByKey"
+import { userIsAdmin } from "v2/Utils/user"
 
 export interface MediumFilterProps {
   expanded?: boolean
@@ -26,8 +27,13 @@ export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
     slice: "",
     counts: [],
   }
+
+  const filteredHardcodedMediums = userIsAdmin()
+    ? hardcodedMediums
+    : hardcodedMediums.filter(medium => medium.value !== "nft")
+
   const allowedMediums =
-    mediums && mediums.counts.length ? mediums.counts : hardcodedMediums
+    mediums && mediums.counts.length ? mediums.counts : filteredHardcodedMediums
 
   const toggleMediumSelection = (selected, slug) => {
     let geneIDs =


### PR DESCRIPTION
[PX-4828](https://artsyproduct.atlassian.net/browse/PX-4828)

This PR adds "NFT" to the artwork grid filter (I believe also used on fair page and collections page) behind an admin flag.

Also adds "NFT" to `createCollectUrl`.

I guess this needs gravity/crispr? work to actually show works marked as "NFT"? Am I missing something in Force?

Admin:
<img width="1248" alt="Screen Shot 2022-01-12 at 9 57 15 AM" src="https://user-images.githubusercontent.com/9466631/149164775-e7b49e42-624e-4dcf-a535-885085c4ae35.png">

Non admin:
<img width="1226" alt="Screen Shot 2022-01-12 at 9 48 57 AM" src="https://user-images.githubusercontent.com/9466631/149164782-6abfec42-de5e-43b4-abae-d30f5e82fa81.png">

Checked:
<img width="1556" alt="Screen Shot 2022-01-12 at 6 43 52 PM" src="https://user-images.githubusercontent.com/9466631/149240606-f9882ef7-4906-487b-b237-2bbe3c9a107e.png">


