### PR TITLE
fix: Render dimensions when digits are present

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarSizeInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarSizeInfo.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from "@artsy/palette"
-import { Component } from "react";
+import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { ArtworkSidebarSizeInfo_piece } from "v2/__generated__/ArtworkSidebarSizeInfo_piece.graphql"
@@ -11,16 +11,22 @@ export interface ArtworkSidebarSizeInfoProps {
 export class ArtworkSidebarSizeInfo extends Component<
   ArtworkSidebarSizeInfoProps
 > {
+  sizeInfoMissing = (dimensions, edition_of) => {
+    const dimensionsPresent =
+      /\d/.test(dimensions?.in) || /\d/.test(dimensions?.cm)
+
+    return !edition_of?.length && !dimensionsPresent
+  }
+
   render() {
     const {
       piece: { dimensions, edition_of },
     } = this.props
-    if (
-      !(edition_of && edition_of.length) &&
-      !(dimensions && (dimensions.in || dimensions.cm))
-    ) {
+
+    if (this.sizeInfoMissing(dimensions, edition_of)) {
       return null
     }
+
     return (
       <Box color="black60">
         {dimensions?.in && <Text variant="md">{dimensions.in}</Text>}

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarMetadata.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarMetadata.jest.tsx
@@ -6,6 +6,7 @@ import {
   FilledOutMetadataMultipleEditionSets,
   FilledOutMetadataNoEditions,
   FilledOutMetadataOneEditionSet,
+  FilledOutMetadataNoSizeInfo,
   MetadataForAuctionWork,
 } from "../../../../__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarMetadata"
 import { ArtworkSidebarClassification } from "../../ArtworkSidebar/ArtworkSidebarClassification"
@@ -55,7 +56,7 @@ describe("ArtworkSidebarMetadata", () => {
       )
     })
 
-    it("displays dimentions", () => {
+    it("displays dimensions", () => {
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const html = wrapper.html()
 
@@ -85,7 +86,7 @@ describe("ArtworkSidebarMetadata", () => {
       expect(wrapper.html()).toContain("Serigraph")
     })
 
-    it("displays edition dimentions", () => {
+    it("displays edition dimensions", () => {
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const html = wrapper.html()
       expect(html).toContain("14 × 18 in")
@@ -119,7 +120,7 @@ describe("ArtworkSidebarMetadata", () => {
       expect(wrapper.html()).toContain("Premium high gloss archival print")
     })
 
-    it("does not render edition dimentions or details", () => {
+    it("does not render edition dimensions or details", () => {
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find(ArtworkSidebarSizeInfo).length).toBe(0)
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
@@ -147,6 +148,17 @@ describe("ArtworkSidebarMetadata", () => {
       expect(wrapper.find(ArtworkSidebarSizeInfo).html()).toBe(null)
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       expect(wrapper.find(ArtworkSidebarClassification).html()).toBe(null)
+    })
+  })
+
+  describe("for artwork with no size info", () => {
+    it("does not render any size info", async () => {
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+      wrapper = await getWrapper(FilledOutMetadataNoSizeInfo)
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+      const html = wrapper.html()
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+      expect(wrapper.find(ArtworkSidebarSizeInfo).html()).toBe(null)
     })
   })
 
@@ -184,7 +196,7 @@ describe("ArtworkSidebarMetadata", () => {
       expect(wrapper.html()).toContain("Lithograph in colors, on laid paper")
     })
 
-    it("displays edition dimentions", () => {
+    it("displays edition dimensions", () => {
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const html = wrapper.html()
 

--- a/src/v2/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarMetadata.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarMetadata.ts
@@ -22,6 +22,27 @@ export const FilledOutMetadataNoEditions: ArtworkSidebarMetadata_Test_QueryRawRe
   title: "Easel (Vydock)",
 }
 
+export const FilledOutMetadataNoSizeInfo: ArtworkSidebarMetadata_Test_QueryRawResponse["artwork"] = {
+  ...FullArtworkFixture,
+  __isSellable: "Artwork",
+  attributionClass: {
+    id: "opaque-attribution-class-id",
+    shortDescription: "This is a unique work",
+  },
+  date: "1995",
+  dimensions: {
+    cm: null,
+    in: null,
+  },
+  edition_of: "",
+  edition_sets: [],
+  id: "filled_out_metadata_no_editions",
+  is_biddable: false,
+  medium: "Acrylic and graphite on bonded aluminium",
+  sale_artwork: null,
+  title: "Easel (Vydock)",
+}
+
 export const FilledOutMetadataOneEditionSet: ArtworkSidebarMetadata_Test_QueryRawResponse["artwork"] = {
   ...FullArtworkFixture,
   __isSellable: "Artwork",


### PR DESCRIPTION
JIRA Card: https://artsyproduct.atlassian.net/browse/GRO-710

In cases where a dimension field contains no digits ([production example](https://www.artsy.net/artwork/larva-labs-sealed-cryptopunk-number-934)), we shouldn't be rendering blank dimensions.

<details>
<summary>Broken Example - Before (local)</summary>
<img src="https://user-images.githubusercontent.com/11466782/149570997-e51c80af-5b60-4822-a452-a1d8e281ce4f.png" />
</details>
<details>
<summary>Broken Example - After (local)</summary>
<img src="https://user-images.githubusercontent.com/11466782/149571510-f73027e2-1982-4bb9-84a8-939f4f2fa9a3.png" />
</details>
<details>
<summary>Artwork with Dimensions and Editions - After (local)</summary>
![image]()
<img src="https://user-images.githubusercontent.com/11466782/149571749-376b3eec-1403-4173-a594-9f266895cfa9.png" />
</details>