### PR TITLE
chore(FX-3678): correctly track event for create alert button

### DIFF
--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
@@ -39,15 +39,16 @@ export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
 
   const handleOpenForm = () => {
     openModal()
+  }
+
+  const handleClick = () => {
     tracking.trackEvent({
       action: ActionType.clickedCreateAlert,
       context_page_owner_type: savedSearchAttributes.type as PageOwnerType,
       context_page_owner_id: savedSearchAttributes.id,
       context_page_owner_slug: savedSearchAttributes.slug,
     })
-  }
 
-  const handleClick = () => {
     if (isLoggedIn) {
       handleOpenForm()
     } else {

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/__tests__/CreateAlertButton.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/__tests__/CreateAlertButton.jest.tsx
@@ -4,9 +4,9 @@ import { useTracking } from "v2/System/Analytics/useTracking"
 import * as openAuthModal from "v2/Utils/openAuthModal"
 import { SavedSearchAttributes } from "v2/Components/ArtworkFilter/SavedSearch/types"
 import { ExtractProps } from "v2/Utils/ExtractProps"
-import { CreateAlertButton } from "../SavedSearch/Components/CreateAlertButton"
+import { CreateAlertButton } from "../CreateAlertButton"
 import { mediator } from "lib/mediator"
-import { ArtworkFilterContextProvider } from "../ArtworkFilterContext"
+import { ArtworkFilterContextProvider } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 
 jest.mock("v2/System/useSystemContext")
 jest.mock("v2/System/Analytics/useTracking")
@@ -119,6 +119,20 @@ describe("CreateAlertButton", () => {
         contextModule: "artworkGrid",
         intent: "createAlert",
       })
+    })
+
+    it("tracks event", () => {
+      renderButton()
+      const button = screen.getByText("Create an Alert")
+      fireEvent.click(button)
+      expect(trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "clickedCreateAlert",
+          context_page_owner_type: "artist",
+          context_page_owner_id: "test-artist-id",
+          context_page_owner_slug: "example-slug",
+        })
+      )
     })
   })
 })


### PR DESCRIPTION
Type: **Chore**
Jira ticket: [FX-3678]

### Description
When logged out and I click “Create alert”, I see the `authImpression` analytics event but never see the `clickedCreateAlert` event come through - even after I'm successfully logged in and the modal pops up.

### Acceptance Criteria
* `clickedCreateAlert` event should be tracked when an unauthorized user clicks on “Create Alert” button

[FX-3678]: https://artsyproduct.atlassian.net/browse/FX-3678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ