### PR TITLE
Move client name to end of user agent string for artwork submissions

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/__tests__/createConsignSubmission.jest.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/__tests__/createConsignSubmission.jest.ts
@@ -32,7 +32,7 @@ describe("createOrUpdateConsignSubmission", () => {
       relayEnvironment,
       submission
     )
-    const userAgent = `Artsy-Force ${navigator.userAgent}`
+    const userAgent = `${navigator.userAgent} Artsy-Force`
 
     expect(mockCreateMutation).toHaveBeenCalled()
     expect(mockCreateMutation).toHaveBeenCalledWith(relayEnvironment, {

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/__tests__/createConsignSubmission.jest.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/__tests__/createConsignSubmission.jest.ts
@@ -32,7 +32,7 @@ describe("createOrUpdateConsignSubmission", () => {
       relayEnvironment,
       submission
     )
-    const userAgent = `${navigator.userAgent} Artsy-Force`
+    const userAgent = `${navigator.userAgent} Artsy-Web Force`
 
     expect(mockCreateMutation).toHaveBeenCalled()
     expect(mockCreateMutation).toHaveBeenCalledWith(relayEnvironment, {

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/createOrUpdateConsignSubmission.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/createOrUpdateConsignSubmission.ts
@@ -25,7 +25,7 @@ export const createOrUpdateConsignSubmission = async (
   } else {
     submissionId = await createConsignSubmissionMutation(relayEnvironment, {
       ...submission,
-      userAgent: `${navigator.userAgent} Artsy-Force`,
+      userAgent: `${navigator.userAgent} Artsy-Web Force`,
     } as CreateSubmissionMutationInput)
   }
 

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/createOrUpdateConsignSubmission.ts
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/Utils/createOrUpdateConsignSubmission.ts
@@ -25,7 +25,7 @@ export const createOrUpdateConsignSubmission = async (
   } else {
     submissionId = await createConsignSubmissionMutation(relayEnvironment, {
       ...submission,
-      userAgent: `Artsy-Force ${navigator.userAgent}`,
+      userAgent: `${navigator.userAgent} Artsy-Force`,
     } as CreateSubmissionMutationInput)
   }
 


### PR DESCRIPTION
We started recording user agents when creating artwork submissions from Force in #9192 so that we can easily identify the source of a submission when debugging issues in Convection.

We originally added `Artsy-Force` to the front of the user agent string, but after looking through existing submissions in Convection, I realized that Eigen:

1. Adds its identifying information at the end of the user agent string, and
2. Uses the `Artsy-Mobile/[version] Eigen/[version]` convention

I would like to propose we change the user agent string that Force sends to Convection to be `... Artsy-Web Force` so that we are consistent with the existing pattern, which should make our lives a bit easier when we parse user agent strings.