### PR TITLE
feat(FX-3681): Sign up flow should skip onboarding when trying to create alert

### DIFF
--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
@@ -59,6 +59,7 @@ export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
         },
         contextModule: ContextModule.artworkGrid,
         intent: Intent.createAlert,
+        redirectTo: location.href,
       })
     }
   }

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/__tests__/CreateAlertButton.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/__tests__/CreateAlertButton.jest.tsx
@@ -118,6 +118,7 @@ describe("CreateAlertButton", () => {
         },
         contextModule: "artworkGrid",
         intent: "createAlert",
+        redirectTo: "http://localhost/",
       })
     })
 

--- a/src/v2/Utils/openAuthModal.ts
+++ b/src/v2/Utils/openAuthModal.ts
@@ -104,6 +104,7 @@ const getDesktopIntentToCreateAlert = ({
   contextModule,
   entity,
   intent,
+  redirectTo,
 }: AuthModalOptions): ModalOptions => {
   return {
     afterSignUpAction: {
@@ -113,6 +114,7 @@ const getDesktopIntentToCreateAlert = ({
     },
     contextModule,
     intent,
+    redirectTo,
     mode: ModalType.signup,
   }
 }


### PR DESCRIPTION
Type: **Feature**
Jira ticket: [FX-3681]

### Description
If an unauthorized user clicks on the "Create Alert" button, a modal with sign up will open. After completing the sign up procedure, the user is redirected to the onboarding page

### Acceptance Criteria
* After sign up procedure, a create alert modal should opened without redirecting to the onboarding screen
* All previously selected filters should be displayed in create alert modal

### Demo
#### Without filters
https://user-images.githubusercontent.com/3513494/149965636-84b09d62-7b40-40b7-8556-3fdbb86e450e.mp4

#### With selected filters
https://user-images.githubusercontent.com/3513494/149965599-f0302fe3-cbfc-4d43-80f2-623b78f4d291.mp4

[FX-3681]: https://artsyproduct.atlassian.net/browse/FX-3681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ