### PR TITLE
feat(FX-3682): don't apply highlighted state for artist pill

### DIFF
--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/ArtworkGridFilterPills.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/ArtworkGridFilterPills.tsx
@@ -42,7 +42,7 @@ export const ArtworkGridFilterPills: FC<ArtworkGridFilterPillsProps> = ({
   }
 
   return (
-    <Flex flexWrap="wrap" mx={-PILL_HORIZONTAL_MARGIN_SIZE}>
+    <Flex flexWrap="wrap" mx={-PILL_HORIZONTAL_MARGIN_SIZE} mb={2}>
       <Pills items={pills} onDeletePress={removePill} />
       {savedSearchAttributes && (
         <CreateAlertButton

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/Pills.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/Pills.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { CloseIcon, Pill } from "@artsy/palette"
 import { FilterPill } from "../Utils/FilterPillsContext"
+import styled from "styled-components"
 
 const CLOSE_ICON_SIZE = 15
 
@@ -14,25 +15,38 @@ export const Pills: React.FC<PillsProps> = props => {
 
   return (
     <>
-      {items.map(item => (
-        <Pill
-          key={`filter-label-${item.name}`}
-          variant="textSquare"
-          mx={0.5}
-          mb={1}
-          onClick={() => onDeletePress(item)}
-        >
-          {item.displayName}
-          {!item.isDefault && (
+      {items.map(item => {
+        const key = `filter-label-${item.name}`
+
+        if (item.isDefault) {
+          return (
+            <DefaultPill key={key} variant="textSquare" mx={0.5}>
+              {item.displayName}
+            </DefaultPill>
+          )
+        }
+
+        return (
+          <Pill
+            key={key}
+            variant="textSquare"
+            mx={0.5}
+            onClick={() => onDeletePress(item)}
+          >
+            {item.displayName}
             <CloseIcon
               fill="currentColor"
               width={CLOSE_ICON_SIZE}
               height={CLOSE_ICON_SIZE}
               ml={0.5}
             />
-          )}
-        </Pill>
-      ))}
+          </Pill>
+        )
+      })}
     </>
   )
 }
+
+const DefaultPill = styled(Pill)`
+  pointer-events: none;
+`


### PR DESCRIPTION
Type: **Feature**
Jira ticket: [FX-3682]

### Description
If a user clicks or hovers the mouse cursor over the artist pill, then the highlighted state is applied to it (see attached video)

### Acceptance Criteria
* Artist pill should not apply any visual changes when clicking or hovering over it

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/150116002-0b33f843-e8ce-440a-8e09-7a63eab8fdcd.mp4

#### After
https://user-images.githubusercontent.com/3513494/150116077-ae0b6f3b-403a-4b5b-80eb-1633dd74435c.mp4

[FX-3682]: https://artsyproduct.atlassian.net/browse/FX-3682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ