### PR TITLE
fix(payment): Buyer can't accept seller's offer when payment requires authentication

### DIFF
--- a/src/v2/Apps/Order/Routes/Accept/index.tsx
+++ b/src/v2/Apps/Order/Routes/Accept/index.tsx
@@ -3,7 +3,7 @@ import { Accept_order } from "v2/__generated__/Accept_order.graphql"
 import { TwoColumnLayout } from "v2/Apps/Order/Components/TwoColumnLayout"
 import { track } from "v2/System/Analytics"
 import { RouteConfig, Router } from "found"
-import { Component } from "react";
+import { Component } from "react"
 import { Media } from "v2/Utils/Responsive"
 import {
   OrderStepper,
@@ -86,7 +86,7 @@ export class Accept extends Component<AcceptProps & StripeProps> {
 
   onSubmit = async () => {
     try {
-      const orderOrError = (await this.acceptOffer()).commerceBuyerAcceptOffer
+      let orderOrError = (await this.acceptOffer()).commerceBuyerAcceptOffer
         ?.orderOrError
 
       if (!orderOrError?.error) {
@@ -124,7 +124,7 @@ export class Accept extends Component<AcceptProps & StripeProps> {
         })
       }
 
-      this.props.router.push(`/orders/${this.props.order.internalID}/status`)
+      this.onSubmit()
     } catch (error) {
       logger.error(error)
       this.props.dialog.showErrorDialog()

--- a/src/v2/Apps/Order/Routes/Accept/index.tsx
+++ b/src/v2/Apps/Order/Routes/Accept/index.tsx
@@ -86,7 +86,7 @@ export class Accept extends Component<AcceptProps & StripeProps> {
 
   onSubmit = async () => {
     try {
-      let orderOrError = (await this.acceptOffer()).commerceBuyerAcceptOffer
+      const orderOrError = (await this.acceptOffer()).commerceBuyerAcceptOffer
         ?.orderOrError
 
       if (!orderOrError?.error) {


### PR DESCRIPTION
Addresses [TX-72] Pair w/ @starsirius on this fix.

The bug originally demonstrated in this ticket was resolved by the time I got to it, but there was still a secondary bug to be addressed: after the user went through the card verification process they were redirected back to the payment screen.

The issue was solved by removing a redirect to the `/status` route and instead resubmitting the form for the user. 

[TX-72]: https://artsyproduct.atlassian.net/browse/TX-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ