### PR TITLE
feat(NX-3014): Scroll to focus functionality when entering custom offer price

### DIFF
--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -106,7 +106,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
   // trackClick("We recommend changing your offer", priceOptions[0]?.value!)
 
   const { scrollTo } = useScrollTo({
-    selectorOrRef: "#price-option-custom",
+    selectorOrRef: "#scrollTo--price-option-custom",
     behavior: "smooth",
   })
 
@@ -134,7 +134,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
         ))
         .concat(
           <BorderedRadio
-            id="price-option-custom"
+            id="scrollTo--price-option-custom"
             value="custom"
             label="Different amount"
             onSelect={() => {

--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -12,6 +12,7 @@ import { ActionType, ClickedOfferOption, PageOwnerType } from "@artsy/cohesion"
 import { PriceOptions_artwork } from "v2/__generated__/PriceOptions_artwork.graphql"
 import { PriceOptions_order } from "v2/__generated__/PriceOptions_order.graphql"
 import { appendCurrencySymbol } from "../Utils/currencyUtils"
+import { useScrollTo } from "v2/Utils/Hooks/useScrollTo"
 
 export interface PriceOptionsProps {
   onChange: (value: number) => void
@@ -104,6 +105,11 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
   // TODO: add call bellow when the feature is implemented
   // trackClick("We recommend changing your offer", priceOptions[0]?.value!)
 
+  const { scrollTo } = useScrollTo({
+    selectorOrRef: "#price-option-custom",
+    behavior: "smooth",
+  })
+
   return (
     <RadioGroup>
       {compact(priceOptions)
@@ -128,6 +134,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
         ))
         .concat(
           <BorderedRadio
+            id="price-option-custom"
             value="custom"
             label="Different amount"
             onSelect={() => {
@@ -143,7 +150,10 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
                   id="OfferForm_offerValue"
                   showError={showError}
                   onChange={setCustomValue}
-                  onFocus={onFocus}
+                  onFocus={() => {
+                    onFocus
+                    scrollTo()
+                  }}
                   noTitle
                 />
               </Flex>

--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -151,7 +151,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
                   showError={showError}
                   onChange={setCustomValue}
                   onFocus={() => {
-                    onFocus
+                    onFocus()
                     scrollTo()
                   }}
                   noTitle

--- a/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
@@ -13,6 +13,10 @@ const trackEvent = jest.fn()
 
 const mockUseTracking = useTracking as jest.Mock
 
+jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
+  __internal__useMatchMedia: () => ({}),
+}))
+
 const { renderWithRelay } = setupTestWrapperTL<PriceOptions_Test_Query>({
   Component: props => (
     <PriceOptionsFragmentContainer


### PR DESCRIPTION
Added scroll to focus functionality when entering custom offer price.

Screenshot before toggle or text input was pressed:
![image](https://user-images.githubusercontent.com/36167539/150013218-f11b581c-44e3-4179-a96b-da9bed43ef2d.png)


Screenshot after toggle or text input was pressed:
![image](https://user-images.githubusercontent.com/36167539/150013165-c241a36f-c327-45df-a3dc-5dc8f6957271.png)


