### PR TITLE
feat(new-routes): Added in the Preferences2 route

### DIFF
--- a/src/v2/Apps/_Preferences2/PreferencesApp.tsx
+++ b/src/v2/Apps/_Preferences2/PreferencesApp.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@artsy/palette"
+
+export const PreferencesApp: React.FC = () => {
+  return (
+    <>
+      <Text variant="xl">Preferences App</Text>
+    </>
+  )
+}

--- a/src/v2/Apps/_Preferences2/preferencesRoutes.tsx
+++ b/src/v2/Apps/_Preferences2/preferencesRoutes.tsx
@@ -2,7 +2,7 @@ import loadable from "@loadable/component"
 import { AppRouteConfig } from "v2/System/Router/Route"
 
 const PreferencesApp = loadable(
-  () => import(/* webpackChunkName: "aboutBundle" */ "./PreferencesApp"),
+  () => import(/* webpackChunkName: "preferencesBundle" */ "./PreferencesApp"),
   {
     resolveComponent: component => component.PreferencesApp,
   }

--- a/src/v2/Apps/_Preferences2/preferencesRoutes.tsx
+++ b/src/v2/Apps/_Preferences2/preferencesRoutes.tsx
@@ -1,0 +1,16 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const PreferencesApp = loadable(
+  () => import(/* webpackChunkName: "aboutBundle" */ "./PreferencesApp"),
+  {
+    resolveComponent: component => component.PreferencesApp,
+  }
+)
+
+export const preferencesRoutes: AppRouteConfig[] = [
+  {
+    path: "/preferences2",
+    getComponent: () => PreferencesApp,
+  },
+]

--- a/src/v2/routes.tsx
+++ b/src/v2/routes.tsx
@@ -31,6 +31,7 @@ import { orderRoutes } from "v2/Apps/Order/orderRoutes"
 import { partnerRoutes } from "v2/Apps/Partner/partnerRoutes"
 import { partnersRoutes } from "v2/Apps/Partners/partnersRoutes"
 import { paymentRoutes } from "v2/Apps/Payment/paymentRoutes"
+import { preferencesRoutes } from "./Apps/_Preferences2/preferencesRoutes"
 import { priceDatabaseRoutes } from "./Apps/PriceDatabase/priceDatabaseRoutes"
 import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
 import { searchRoutes } from "v2/Apps/Search/searchRoutes"
@@ -77,6 +78,7 @@ export function getAppRoutes(): AppRouteConfig[] {
     { routes: partnerRoutes },
     { routes: partnersRoutes },
     { routes: paymentRoutes },
+    { routes: preferencesRoutes },
     { routes: priceDatabaseRoutes },
     { routes: purchaseRoutes },
     { routes: staticPageRoutes },


### PR DESCRIPTION
This is the scaffolding for the upcoming Interest-based preference center work. Set up our development route under `/preferences2`