### PR TITLE
(Double revert!) Allow for redirecting outside of artsy.net (within reason) after auth

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -146,63 +146,63 @@
         "filename": "src/config.ts",
         "hashed_secret": "cb7910b388d3066900fe2af1942a46817c46d329",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 47
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/config.ts",
         "hashed_secret": "3f845c458dbcf7c4bee4be6c02440c754882c270",
         "is_verified": false,
-        "line_number": 47
+        "line_number": 48
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/config.ts",
         "hashed_secret": "f83913bbf45e92c31a11a52dcd55de047f515bd1",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 49
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/config.ts",
         "hashed_secret": "b6977e58b0b5cb9fce41e1632df17d6263d9016c",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 50
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/config.ts",
         "hashed_secret": "f347153cbbbac117be7de356317cfa065864392e",
         "is_verified": false,
-        "line_number": 59
+        "line_number": 60
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/config.ts",
         "hashed_secret": "d40d2a9d95cce5051476edb87e21f03c5202b4fd",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 61
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/config.ts",
         "hashed_secret": "e5f00840dfe1479a2f4ee1f0833d0d2a828c0784",
         "is_verified": false,
-        "line_number": 71
+        "line_number": 72
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/config.ts",
         "hashed_secret": "61063161509eac1a7ba9bf7eb5a9b72b4b086c5c",
         "is_verified": false,
-        "line_number": 72
+        "line_number": 73
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/config.ts",
         "hashed_secret": "e88b861dd023258e4bbecae2721a214c49564a7c",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 102
       }
     ],
     "src/desktop/apps/article/__tests__/routes.jest.ts": [
@@ -803,5 +803,5 @@
       }
     ]
   },
-  "generated_at": "2022-01-04T05:53:43Z"
+  "generated_at": "2022-01-12T20:33:25Z"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export const APPLICATION_NAME: any = "force-staging"
 export const APPLY_URL: any = "http://apply.artsy.net"
 export const ARTSY_EDITORIAL_CHANNEL: any = "5759e3efb5989e6f98f77993"
 export const AUCTION_ZENDESK_KEY: any = null
+export const ALLOWED_REDIRECT_HOSTS: any = "localhost"
 export const CDN_URL: any = "https://d1s2w0upia4e9w.cloudfront.net"
 export const CLIENT_ID: any = null
 export const CLIENT_SECRET: any = null

--- a/src/typings/sharify.d.ts
+++ b/src/typings/sharify.d.ts
@@ -17,6 +17,7 @@ declare module "sharify" {
      */
     export interface GlobalData {
       readonly ADMIN_URL: string
+      readonly ALLOWED_REDIRECT_HOSTS: string
       readonly APP_URL: string
       readonly ARTIST_COLLECTIONS_RAIL?: string // TODO: remove after CollectionsRail a/b test
       readonly CDN_URL: string

--- a/src/v2/Apps/Authentication/Server/__tests__/redirectPostAuth.jest.ts
+++ b/src/v2/Apps/Authentication/Server/__tests__/redirectPostAuth.jest.ts
@@ -14,8 +14,10 @@ describe("redirectPostAuth", () => {
       switch (key) {
         case "APP_URL":
           return "https://artsy.net"
+        case "API_URL":
+          return "https://api.artsy.net"
         case "ALLOWED_REDIRECT_HOSTS":
-          return "api.artsy.net,live.artsy.net,foo.test.com,localhost"
+          return "live.artsy.net,foo.test.com,localhost"
         case "NODE_ENV":
           return "development"
       }
@@ -43,7 +45,7 @@ describe("redirectPostAuth", () => {
   }
 
   it("redirects to an allowed external URL", () => {
-    const url = "https://api.artsy.net/foo"
+    const url = "https://live.artsy.net/foo"
     const encodedUrl = encodeURI(url)
 
     setup({
@@ -54,6 +56,16 @@ describe("redirectPostAuth", () => {
 
   it("redirects to the APP_URL", () => {
     const url = "https://artsy.net/collect"
+    const encodedUrl = encodeURI(url)
+
+    setup({
+      req: { query: { redirectTo: encodedUrl } },
+    })
+    expect(redirectSpy).toHaveBeenCalledWith(encodedUrl)
+  })
+
+  it("redirects to the API_URL", () => {
+    const url = "https://api.artsy.net/auth"
     const encodedUrl = encodeURI(url)
 
     setup({

--- a/src/v2/Apps/Authentication/Server/__tests__/redirectPostAuth.jest.ts
+++ b/src/v2/Apps/Authentication/Server/__tests__/redirectPostAuth.jest.ts
@@ -52,6 +52,16 @@ describe("redirectPostAuth", () => {
     expect(redirectSpy).toHaveBeenCalledWith(encodedUrl)
   })
 
+  it("redirects to the APP_URL", () => {
+    const url = "https://artsy.net/collect"
+    const encodedUrl = encodeURI(url)
+
+    setup({
+      req: { query: { redirectTo: encodedUrl } },
+    })
+    expect(redirectSpy).toHaveBeenCalledWith(encodedUrl)
+  })
+
   it("does not redirect to a disallowed external URL", () => {
     const url = "https://another.web.site/foo"
 

--- a/src/v2/Apps/Authentication/Server/__tests__/redirectPostAuth.jest.ts
+++ b/src/v2/Apps/Authentication/Server/__tests__/redirectPostAuth.jest.ts
@@ -1,0 +1,104 @@
+import { redirectPostAuth } from "../redirectPostAuth"
+import { getENV } from "v2/Utils/getENV"
+
+jest.mock("v2/Utils/getENV", () => ({
+  getENV: jest.fn(),
+}))
+
+describe("redirectPostAuth", () => {
+  const mockGetENV = getENV as jest.Mock
+  const redirectSpy = jest.fn()
+
+  beforeEach(() => {
+    mockGetENV.mockImplementation(key => {
+      switch (key) {
+        case "APP_URL":
+          return "https://artsy.net"
+        case "ALLOWED_REDIRECT_HOSTS":
+          return "api.artsy.net,live.artsy.net,foo.test.com,localhost"
+        case "NODE_ENV":
+          return "development"
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const setup = ({ req = {}, res = {} }) => {
+    redirectPostAuth({
+      req: {
+        get: (() => "") as any,
+        header: (() => "") as any,
+        body: {},
+        ...req,
+      },
+      res: {
+        locals: { sd: { APP_URL: "https://artsy.net" } },
+        redirect: redirectSpy,
+        ...res,
+      },
+    })
+  }
+
+  it("redirects to an allowed external URL", () => {
+    const url = "https://api.artsy.net/foo"
+    const encodedUrl = encodeURI(url)
+
+    setup({
+      req: { query: { redirectTo: encodedUrl } },
+    })
+    expect(redirectSpy).toHaveBeenCalledWith(encodedUrl)
+  })
+
+  it("does not redirect to a disallowed external URL", () => {
+    const url = "https://another.web.site/foo"
+
+    setup({
+      req: { query: { redirectTo: encodeURI(url) } },
+    })
+
+    expect(redirectSpy).toHaveBeenCalledWith("https://artsy.net/")
+  })
+
+  it("does not redirect to a non-artsy.net subdomain, even if included in allowed hosts list", () => {
+    const url = "https://foo.test.com/hackme"
+
+    setup({
+      req: { query: { redirectTo: encodeURI(url) } },
+    })
+
+    expect(redirectSpy).toHaveBeenCalledWith("https://artsy.net/")
+  })
+
+  it("does not redirect to localhost if not in development", () => {
+    mockGetENV.mockImplementation(key => {
+      switch (key) {
+        case "APP_URL":
+          return "https://artsy.net"
+        case "ALLOWED_REDIRECT_HOSTS":
+          return "api.artsy.net,live.artsy.net,foo.test.com,localhost"
+        case "NODE_ENV":
+          return "production"
+      }
+    })
+    const url = "http://localhost:3000/foo"
+
+    setup({
+      req: { query: { redirectTo: encodeURI(url) } },
+    })
+
+    expect(redirectSpy).toHaveBeenCalledWith("https://artsy.net/")
+  })
+
+  it("redirects to localhost if in development", () => {
+    const url = "http://localhost:3000/foo"
+
+    setup({
+      req: { query: { redirectTo: encodeURI(url) } },
+    })
+
+    expect(redirectSpy).toHaveBeenCalledWith("http://localhost:3000/foo")
+  })
+})

--- a/src/v2/Apps/Authentication/Server/redirectPostAuth.ts
+++ b/src/v2/Apps/Authentication/Server/redirectPostAuth.ts
@@ -17,7 +17,10 @@ export function redirectPostAuth({ req, res }) {
 
   let redirectURL = new URL(redirectTo)
 
-  if (!allowedHosts.includes(redirectURL.hostname)) {
+  if (
+    !allowedHosts.includes(redirectURL.hostname) &&
+    redirectURL.origin !== getENV("APP_URL")
+  ) {
     redirectURL = new URL("/", getENV("APP_URL"))
   }
 

--- a/src/v2/Apps/Authentication/Server/redirectPostAuth.ts
+++ b/src/v2/Apps/Authentication/Server/redirectPostAuth.ts
@@ -1,0 +1,25 @@
+import { getENV } from "v2/Utils/getENV"
+
+export function redirectPostAuth({ req, res }) {
+  const redirectTo = req.query["redirectTo"]
+
+  const configuredAllowedHosts =
+    getENV("ALLOWED_REDIRECT_HOSTS")?.split(",") || []
+
+  // verify that this is a *.artsy.net domain
+  const allowedHosts = configuredAllowedHosts.filter(url => {
+    if (url === "localhost" && getENV("NODE_ENV") === "development") return true
+
+    const splitHostname = url.split(".")
+    splitHostname.shift()
+    return splitHostname.join(".") === "artsy.net"
+  })
+
+  let redirectURL = new URL(redirectTo)
+
+  if (!allowedHosts.includes(redirectURL.hostname)) {
+    redirectURL = new URL("/", getENV("APP_URL"))
+  }
+
+  res.redirect(redirectURL.href)
+}

--- a/src/v2/Apps/Authentication/Server/redirectPostAuth.ts
+++ b/src/v2/Apps/Authentication/Server/redirectPostAuth.ts
@@ -19,7 +19,8 @@ export function redirectPostAuth({ req, res }) {
 
   if (
     !allowedHosts.includes(redirectURL.hostname) &&
-    redirectURL.origin !== getENV("APP_URL")
+    redirectURL.origin !== getENV("APP_URL") &&
+    redirectURL.origin !== getENV("API_URL")
   ) {
     redirectURL = new URL("/", getENV("APP_URL"))
   }

--- a/src/v2/Apps/Authentication/Utils/helpers.ts
+++ b/src/v2/Apps/Authentication/Utils/helpers.ts
@@ -17,6 +17,7 @@ import { pick } from "lodash"
 import { mediator } from "lib/mediator"
 import { reportError } from "v2/Utils/errors"
 import { trackEvent } from "lib/analytics/helpers"
+import { getENV } from "v2/Utils/getENV"
 
 interface AnalyticsOptions {
   auth_redirect: string
@@ -103,7 +104,13 @@ export const handleSubmit = async (
 
       const result = await apiAuthWithRedirectUrl(res, afterAuthURL)
 
-      window.location.assign(result.href)
+      if (result.origin === getENV("APP_URL")) {
+        window.location.assign(result.href)
+      }
+
+      window.location.assign(
+        `/auth-redirect?redirectTo=${encodeURIComponent(result.href)}`
+      )
     },
     error: error => {
       formikBag.setStatus(error)
@@ -143,9 +150,9 @@ export async function apiAuthWithRedirectUrl(
   response: Response,
   redirectPath: URL
 ): Promise<URL> {
-  const redirectUrl = sd.APP_URL + redirectPath.pathname + redirectPath.search
   const accessToken = (response["user"] || {}).accessToken
-  const appRedirectURL = new URL(redirectUrl)
+
+  const appRedirectURL = redirectPath
 
   // There isn't an access token when we don't have a valid session, for example,
   // when the user is resetting their password.

--- a/src/v2/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
+++ b/src/v2/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
@@ -7,6 +7,7 @@ import qs from "qs"
 import { authenticationRoutes } from "../authenticationRoutes"
 import { checkForRedirect } from "../Server/checkForRedirect"
 import { setReferer } from "../Server/setReferer"
+import { getENV } from "v2/Utils/getENV"
 
 jest.mock("../Server/checkForRedirect", () => ({
   checkForRedirect: jest.fn(),
@@ -22,10 +23,14 @@ jest.mock("../Utils/helpers", () => ({
   setCookies: jest.fn(),
 }))
 jest.mock("v2/Utils/Hooks/useAuthValidation")
+jest.mock("v2/Utils/getENV", () => ({
+  getENV: jest.fn(),
+}))
 
 describe("authenticationRoutes", () => {
   const mockCheckForRedirect = checkForRedirect as jest.Mock
   const mockSetReferer = setReferer as jest.Mock
+  const mockGetENV = getENV as jest.Mock
 
   const renderClientRoute = route => {
     render(
@@ -240,6 +245,27 @@ describe("authenticationRoutes", () => {
             status: 301,
           })
         )
+      })
+    })
+  })
+
+  describe("/auth-redirect", () => {
+    mockGetENV.mockImplementation(key => {
+      switch (key) {
+        case "APP_URL":
+          return "https://artsy.net"
+        case "ALLOWED_REDIRECT_HOSTS":
+          return "off.artsy.net"
+      }
+    })
+
+    describe("server", () => {
+      it("redirects to redirectTo", () => {
+        const { res, onServerSideRender } = renderServerRoute(
+          "/auth-redirect?redirectTo=https://off.artsy.net/blah"
+        )
+        onServerSideRender()
+        expect(res.redirect).toHaveBeenCalledWith("https://off.artsy.net/blah")
       })
     })
   })

--- a/src/v2/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/v2/Apps/Authentication/authenticationRoutes.tsx
@@ -6,6 +6,7 @@ import { setReferer } from "./Server/setReferer"
 import { flow } from "lodash"
 import { redirectIfLoggedIn } from "./Server/redirectIfLoggedIn"
 import { setCookies } from "./Utils/helpers"
+import { redirectPostAuth } from "./Server/redirectPostAuth"
 
 const ForgotPasswordRoute = loadable(
   () =>
@@ -111,6 +112,12 @@ export const authenticationRoutes: AppRouteConfig[] = [
     path: "/sign_up",
     render: ({ match }) => {
       throw new RedirectException(`/signup${match.location.search}`, 301)
+    },
+  },
+  {
+    path: "/auth-redirect",
+    onServerSideRender: props => {
+      redirectPostAuth(props)
     },
   },
 ]


### PR DESCRIPTION
I reverted this PR originally because I realized that it didn't work well in the "default" case (when no env vars were set), which was not intentional.

This includes the original commits, with the addition of two:
1. Allow for redirecting to the `APP_URL` 
2. Allow for redirecting to the `API_URL`

This way, our `ALLOWED_REDIRECT_HOSTS` list does not need to include those, and be saved for other, less-trivial hosts.