### PR TITLE
Allow for auth-ing from the API if logged into force

### DIFF
--- a/src/v2/Apps/Authentication/Utils/useAuthForm.ts
+++ b/src/v2/Apps/Authentication/Utils/useAuthForm.ts
@@ -17,12 +17,12 @@ export function useAuthForm({ canonical, pageTitle, type }: UseAuthFormProps) {
   const {
     action,
     afterSignUpAction,
-    api_login,
     contextModule,
     copy: copyQueryParam,
     destination,
     intent,
     kind,
+    oauthLogin,
     objectId,
   } = match.location.query as ModalOptions
 
@@ -55,12 +55,12 @@ export function useAuthForm({ canonical, pageTitle, type }: UseAuthFormProps) {
   const options: ModalOptions = {
     action,
     afterSignUpAction,
-    api_login,
     contextModule,
     copy: copyQueryParam,
     destination,
     intent,
     kind,
+    oauthLogin,
     objectId,
     redirectTo,
     signupReferer,

--- a/src/v2/Apps/Authentication/Utils/useAuthForm.ts
+++ b/src/v2/Apps/Authentication/Utils/useAuthForm.ts
@@ -17,6 +17,7 @@ export function useAuthForm({ canonical, pageTitle, type }: UseAuthFormProps) {
   const {
     action,
     afterSignUpAction,
+    api_login,
     contextModule,
     copy: copyQueryParam,
     destination,
@@ -54,6 +55,7 @@ export function useAuthForm({ canonical, pageTitle, type }: UseAuthFormProps) {
   const options: ModalOptions = {
     action,
     afterSignUpAction,
+    api_login,
     contextModule,
     copy: copyQueryParam,
     destination,

--- a/src/v2/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
+++ b/src/v2/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
@@ -7,6 +7,7 @@ import qs from "qs"
 import { authenticationRoutes } from "../authenticationRoutes"
 import { checkForRedirect } from "../Server/checkForRedirect"
 import { setReferer } from "../Server/setReferer"
+import { redirectIfLoggedIn } from "../Server/redirectIfLoggedIn"
 import { getENV } from "v2/Utils/getENV"
 
 jest.mock("../Server/checkForRedirect", () => ({
@@ -14,6 +15,9 @@ jest.mock("../Server/checkForRedirect", () => ({
 }))
 jest.mock("../Server/setReferer", () => ({
   setReferer: jest.fn(),
+}))
+jest.mock("../Server/redirectIfLoggedIn", () => ({
+  redirectIfLoggedIn: jest.fn(),
 }))
 jest.mock("v2/Utils/EnableRecaptcha", () => ({
   EnableRecaptcha: () => "EnableRecaptcha",
@@ -31,6 +35,7 @@ describe("authenticationRoutes", () => {
   const mockCheckForRedirect = checkForRedirect as jest.Mock
   const mockSetReferer = setReferer as jest.Mock
   const mockGetENV = getENV as jest.Mock
+  const mockRedirectIfLoggedIn = redirectIfLoggedIn as jest.Mock
 
   const renderClientRoute = route => {
     render(
@@ -74,6 +79,7 @@ describe("authenticationRoutes", () => {
 
   afterEach(() => {
     jest.restoreAllMocks()
+    mockRedirectIfLoggedIn.mockReset()
   })
 
   describe("/forgot", () => {
@@ -146,6 +152,14 @@ describe("authenticationRoutes", () => {
       describe("onServerSideRender", () => {
         it("runs middleware", () => {
           renderServerRoute("/login").onServerSideRender()
+          expect(mockRedirectIfLoggedIn).toHaveBeenCalled()
+          expect(mockCheckForRedirect).toHaveBeenCalled()
+          expect(mockSetReferer).toHaveBeenCalled()
+        })
+
+        it("skips the check for login if you are auth-ing with the API", () => {
+          renderServerRoute("/login?api_login=true").onServerSideRender()
+          expect(mockRedirectIfLoggedIn).not.toHaveBeenCalled()
           expect(mockCheckForRedirect).toHaveBeenCalled()
           expect(mockSetReferer).toHaveBeenCalled()
         })
@@ -224,6 +238,14 @@ describe("authenticationRoutes", () => {
       describe("onServerSideRender", () => {
         it("runs middleware", () => {
           renderServerRoute("/signup").onServerSideRender()
+          expect(mockRedirectIfLoggedIn).toHaveBeenCalled()
+          expect(mockCheckForRedirect).toHaveBeenCalled()
+          expect(mockSetReferer).toHaveBeenCalled()
+        })
+
+        it("skips the check for login if you are auth-ing with the API", () => {
+          renderServerRoute("/signup?api_login=true").onServerSideRender()
+          expect(mockRedirectIfLoggedIn).not.toHaveBeenCalled()
           expect(mockCheckForRedirect).toHaveBeenCalled()
           expect(mockSetReferer).toHaveBeenCalled()
         })

--- a/src/v2/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
+++ b/src/v2/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
@@ -158,7 +158,7 @@ describe("authenticationRoutes", () => {
         })
 
         it("skips the check for login if you are auth-ing with the API", () => {
-          renderServerRoute("/login?api_login=true").onServerSideRender()
+          renderServerRoute("/login?oauthLogin=true").onServerSideRender()
           expect(mockRedirectIfLoggedIn).not.toHaveBeenCalled()
           expect(mockCheckForRedirect).toHaveBeenCalled()
           expect(mockSetReferer).toHaveBeenCalled()
@@ -244,7 +244,7 @@ describe("authenticationRoutes", () => {
         })
 
         it("skips the check for login if you are auth-ing with the API", () => {
-          renderServerRoute("/signup?api_login=true").onServerSideRender()
+          renderServerRoute("/signup?oauthLogin=true").onServerSideRender()
           expect(mockRedirectIfLoggedIn).not.toHaveBeenCalled()
           expect(mockCheckForRedirect).toHaveBeenCalled()
           expect(mockSetReferer).toHaveBeenCalled()

--- a/src/v2/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/v2/Apps/Authentication/authenticationRoutes.tsx
@@ -64,7 +64,10 @@ export const authenticationRoutes: AppRouteConfig[] = [
     hideFooter: true,
     getComponent: () => LoginRoute,
     onServerSideRender: props => {
-      redirectIfLoggedIn(props)
+      if (!props.req.query.api_login) {
+        redirectIfLoggedIn(props)
+      }
+
       runAuthMiddleware(props)
     },
     onClientSideRender: ({ match }) => {
@@ -100,7 +103,10 @@ export const authenticationRoutes: AppRouteConfig[] = [
     hideFooter: true,
     getComponent: () => SignupRoute,
     onServerSideRender: props => {
-      redirectIfLoggedIn(props)
+      if (!props.req.query.api_login) {
+        redirectIfLoggedIn(props)
+      }
+
       runAuthMiddleware(props)
     },
     onClientSideRender: ({ match }) => {

--- a/src/v2/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/v2/Apps/Authentication/authenticationRoutes.tsx
@@ -64,7 +64,10 @@ export const authenticationRoutes: AppRouteConfig[] = [
     hideFooter: true,
     getComponent: () => LoginRoute,
     onServerSideRender: props => {
-      if (!props.req.query.api_login) {
+      // We need this check so we allow someone to log into the API even if they
+      // have already logged into force. Otherwise, we short-circuit and risk
+      // taking the user into an infinite redirect loop.
+      if (!props.req.query.oauthLogin) {
         redirectIfLoggedIn(props)
       }
 
@@ -103,7 +106,10 @@ export const authenticationRoutes: AppRouteConfig[] = [
     hideFooter: true,
     getComponent: () => SignupRoute,
     onServerSideRender: props => {
-      if (!props.req.query.api_login) {
+      // We need this check so we allow someone to log into the API even if they
+      // have already logged into force. Otherwise, we short-circuit and risk
+      // taking the user into an infinite redirect loop.
+      if (!props.req.query.oauthLogin) {
         redirectIfLoggedIn(props)
       }
 

--- a/src/v2/Components/Authentication/Types.ts
+++ b/src/v2/Components/Authentication/Types.ts
@@ -67,10 +67,6 @@ export interface ModalOptions {
    */
   afterSignUpAction?: AfterSignUpAction
   /*
-   * Whether or not the user is using the form via gravity's oauth flow.
-   */
-  api_login?: boolean
-  /*
    * the location where the modal was triggered.
    */
   contextModule?: AuthContextModule
@@ -104,6 +100,10 @@ export interface ModalOptions {
    * the type of modal to display.
    */
   mode?: ModalType
+  /*
+   * Whether or not the user is using the form via gravity's oauth flow.
+   */
+  oauthLogin?: boolean
   /**
    * MOBILE ONLY
    * Used to construct afterSignupAction from query params

--- a/src/v2/Components/Authentication/Types.ts
+++ b/src/v2/Components/Authentication/Types.ts
@@ -66,7 +66,10 @@ export interface ModalOptions {
    * }
    */
   afterSignUpAction?: AfterSignUpAction
-
+  /*
+   * Whether or not the user is using the form via gravity's oauth flow.
+   */
+  api_login?: boolean
   /*
    * the location where the modal was triggered.
    */


### PR DESCRIPTION
Still on the quest to allow us to use force's login form to auth into api.artsy.net! (Which will allow us to deprecate gravity's /log_in form, and we'll have one source of truth).

This PR fixes an issue that occurs when a user is logged into force, but _not_ into api.artsy.net.

Although we automatically log you into api.artsy.net after you log into force, it's possible to log out of api.artsy.net while still being logged into force. This can happen by:
- Clicking the "Sign out" button from api.artsy.net 
- If you were previously logged in but now the app you're logging into requires 2FA
- ... other pathways!

When that happens, we enter into an infinite loop:
- When you attempt to authorize, Gravity will automatically redirect you to the login form (in this scenario, force's), if you're not logged into the API
- When you visit force's login page, if [you're already logged in](https://github.com/artsy/force/blob/main/src/v2/Apps/Authentication/Server/redirectIfLoggedIn.ts#L5-L7) (to _force_), it'll automatically redirect you to the supplied `redirectTo` URL, in this case Gravity's authorize endpoint
- Then Gravity will see that you're still not logged in, and redirect you to force's login page...
- Which will redirect you back...
- And on and on

This PR fixes that ☝️ issue by having the `/login` and `/signup` routes accept a query parameter, `api_login`. If passed in, we allow you to access the form, even if you're already logged into force.

I'm interested in feedback on this. It's a blunt tool. It assumes that you won't access the `/login` route with `api_login=true` directly, only through Gravity's oauth flow (which only sends you there if you're not logged in). You could be logged into api.artsy.net, visit `/login?api_login=true`, and still see a login form.