### PR TITLE
DONTMERGE: Adds NFTs link to the nav bar

### DIFF
--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import * as React from "react";
+import { useEffect, useState } from "react"
+import * as React from "react"
 import {
   Button,
   Flex,
@@ -377,19 +377,21 @@ export const NavBar: React.FC = track(
                   Shows
                 </NavBarItemLink>
 
+                <NavBarItemLink href="/institutions" onClick={handleClick}>
+                  Museums
+                </NavBarItemLink>
+
                 <NavBarItemLink
-                  // Hide link at smaller viewports — corresponding display inside of `MoreNavMenu`
-                  // If we need to do this again, consider a more abstract solution
-                  display={["none", "none", "flex", "flex"]}
-                  href="/institutions"
+                  href="https://nft.artsy.net"
                   onClick={handleClick}
                 >
-                  Museums
+                  NFTs
                 </NavBarItemLink>
               </Flex>
 
               <Flex alignItems="stretch" display={["none", "none", "flex"]}>
                 <NavBarItemButton
+                  display={["none", "none", "flex", "flex"]}
                   px={0}
                   pl={1}
                   onClick={() => {


### PR DESCRIPTION
In preparation for the NFT sale we are running, this PR adds a link to `NFTs` (destination: https://nft.artsy.net) to the nav bar.

In order to avoid a weird line break, this PR also hides the "Download App" link except at the two largest breakpoints.

![image](https://user-images.githubusercontent.com/2081340/150862854-82031ae9-c32a-4958-b242-388de8f5e1e6.png)

Will wait to merge until I get the go-ahead from @GuillaumeDelg .