### PR TITLE
[NX-3057] Remove unneeded conditionals to hide Contact Gallery button

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -403,15 +403,12 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
       return <Separator />
     }
 
-    const shouldDisplayContactGalleryButton: boolean | null =
-      isInquireable && !isAcquireable && !isOfferable
-
     const shouldDisplayMakeOfferButton: boolean | null =
       isOfferable ||
       (isPriceListed && isOfferableFromInquiry && labFeatureEnabled)
 
     const shouldDisplayMakeOfferAsPrimary: boolean | null =
-      shouldDisplayMakeOfferButton && shouldDisplayContactGalleryButton
+      shouldDisplayMakeOfferButton && isInquireable
 
     return (
       <>
@@ -496,7 +493,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
               </Button>
             </>
           )}
-          {shouldDisplayContactGalleryButton && (
+          {isInquireable && (
             <>
               <Spacer mt={shouldDisplayMakeOfferAsPrimary ? 2 : 0} />
               <Button

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.jest.tsx
@@ -153,13 +153,13 @@ describe("ArtworkSidebarCommercial", () => {
     expect(wrapper.text()).toContain("Make offer")
   })
 
-  it("displays artwork enrolled in Make Offer when enabled for both make offer and inquiry", async () => {
+  it("displays artwork enrolled in Make Offer/Contact Gallery when enabled for both", async () => {
     const artwork = Object.assign({}, ArtworkOfferableAndInquireable)
 
     const wrapper = getWrapper(artwork)
 
     expect(wrapper.text()).toContain("Make offer")
-    expect(wrapper.text()).not.toContain("Contact Gallery")
+    expect(wrapper.text()).toContain("Contact Gallery")
   })
 
   it("displays artwork enrolled in both Buy Now and Make Offer", async () => {


### PR DESCRIPTION
[NX-3077]

We had a conditional to hide the Contact Gallery button on the artwork page in case the artwork is offerable/acquireable.
This condition doesn't seem to make sense as an artwork can't be selected as `offerable` **and** `inquireable` at the same time in CMS. However, it wouldn't also make any difference in the flow either.

Given we're changing the `offerable` scenario in MOOAEA, artworks that are `inquireable` are also `offerable`, therefore, we do not want to hide the button in these cases.

Besides this, we're handling these conditionals in Gravity at this point (see https://github.com/artsy/gravity/pull/14971). Gravity is ensuring Contact Gallery button is hidden in case `offer` field is `true` (and not if `offerable?` method is `true` as it was happening here).

Force shouldn't be responsible for these rules. In order to identify if `Contact Gallery` must be displayed or not, asking if an artwork is `inquireable` should be enough.

[NX-3077]: https://artsyproduct.atlassian.net/browse/NX-3077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ