### PR TITLE
Conditional removal of "Price includes tax" messaging

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -379,9 +379,13 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
       is_inquireable: isInquireable,
     } = artwork
     const isPriceListed = !isPriceHidden
-    const labFeatureEnabled = userHasLabFeature(
+    const makeOfferEnabled = userHasLabFeature(
       this.props.user,
       "Make Offer On All Eligible Artworks"
+    )
+    const avalaraPhase2Enabled = userHasLabFeature(
+      this.props.user,
+      "Avalara Phase 2"
     )
 
     const {
@@ -391,7 +395,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
     } = this.state
 
     const editionSelectableOnInquireable = !!(
-      artwork.is_inquireable && labFeatureEnabled
+      artwork.is_inquireable && makeOfferEnabled
     )
     const artworkEcommerceAvailable = !!(
       artwork.is_acquireable ||
@@ -408,7 +412,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
 
     const shouldDisplayMakeOfferButton: boolean | null =
       isOfferable ||
-      (isPriceListed && isOfferableFromInquiry && labFeatureEnabled)
+      (isPriceListed && isOfferableFromInquiry && makeOfferEnabled)
 
     const shouldDisplayMakeOfferAsPrimary: boolean | null =
       shouldDisplayMakeOfferButton && shouldDisplayContactGalleryButton
@@ -460,11 +464,13 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
             </Text>
           )}
 
-          {artworkEcommerceAvailable && artwork.priceIncludesTaxDisplay && (
-            <Text variant="xs" color="black60">
-              {artwork.priceIncludesTaxDisplay}
-            </Text>
-          )}
+          {!avalaraPhase2Enabled &&
+            artworkEcommerceAvailable &&
+            artwork.priceIncludesTaxDisplay && (
+              <Text variant="xs" color="black60">
+                {artwork.priceIncludesTaxDisplay}
+              </Text>
+            )}
 
           {isInquireable || isAcquireable || isOfferable ? (
             artwork.sale_message && <Spacer mt={2} />

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -452,6 +452,19 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
               <Spacer mt={1} />
             )}
 
+          {avalaraPhase2Enabled && (
+            <Text variant="xs" color="black60">
+              Taxes may apply at checkout.{" "}
+              <a
+                href="https://support.artsy.net/hc/en-us/articles/360047294733-How-is-sales-tax-and-VAT-handled-on-works-listed-with-secure-checkout-"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Learn more.
+              </a>
+            </Text>
+          )}
+
           {artworkEcommerceAvailable && artwork.shippingOrigin && (
             <Text variant="xs" color="black60">
               Ships from {artwork.shippingOrigin}

--- a/src/v2/Utils/user.ts
+++ b/src/v2/Utils/user.ts
@@ -28,9 +28,7 @@ export function getUser(user: User | null | undefined): User | null {
 
 export function userHasLabFeature(user: User, featureName: string): boolean {
   const lab_features = get(user, u => u?.lab_features, [])
-  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-  const hasLabFeature = lab_features.includes(featureName)
-  return hasLabFeature
+  return lab_features ? lab_features.includes(featureName) : false
 }
 
 export function userIsAdmin(user?: User): boolean {


### PR DESCRIPTION
Addresses [TX-89]

Add "Avalara Phase 2" feature flag var to `ArtworkSideBarCommercial`. Set the text display to be disabled upon activation of the phase 2 flag. 

[TX-89]: https://artsyproduct.atlassian.net/browse/TX-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ