### PR TITLE
feat(hooks): Add useMode hook and update refs

### DIFF
--- a/src/v2/Apps/Article/Components/ArticleZoomGallery/ArticleZoomGalleryFigure.tsx
+++ b/src/v2/Apps/Article/Components/ArticleZoomGallery/ArticleZoomGalleryFigure.tsx
@@ -1,8 +1,9 @@
 import { CloseIcon, Spinner } from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
-import { FC, ImgHTMLAttributes, useEffect, useRef, useState } from "react"
+import { FC, ImgHTMLAttributes, useEffect, useRef } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
+import { useMode } from "v2/Utils/Hooks/useMode"
 import { ArticleZoomGalleryFigure_figure } from "v2/__generated__/ArticleZoomGalleryFigure_figure.graphql"
 
 interface ArticleZoomGalleryFigureProps {
@@ -82,33 +83,29 @@ const Img = styled.img`
   transition: opacity 250ms;
 `
 
-enum Mode {
-  Loading,
-  Ready,
-  Error,
-}
+type Mode = "Loading" | "Ready" | "Error"
 
 const Image: FC<ImgHTMLAttributes<HTMLImageElement>> = props => {
-  const [mode, setMode] = useState<Mode>(Mode.Loading)
+  const [mode, setMode] = useMode<Mode>("Loading")
 
   const ref = useRef<HTMLImageElement>(null)
 
   useEffect(() => {
     if (ref.current?.complete) {
-      setMode(Mode.Ready)
+      setMode("Ready")
     }
   }, [ref])
 
   return (
     <>
-      {mode === Mode.Loading && <Spinner />}
-      {mode === Mode.Error && <ImgError />}
+      {mode === "Loading" && <Spinner />}
+      {mode === "Error" && <ImgError />}
 
       <Img
         ref={ref as any}
         alt=""
-        onLoad={() => setMode(Mode.Ready)}
-        onError={() => setMode(Mode.Error)}
+        onLoad={() => setMode("Ready")}
+        onError={() => setMode("Error")}
         {...props}
       />
     </>

--- a/src/v2/Apps/Authentication/Routes/ResetPasswordRoute.tsx
+++ b/src/v2/Apps/Authentication/Routes/ResetPasswordRoute.tsx
@@ -12,15 +12,11 @@ import React, { useState } from "react"
 import { MetaTags } from "v2/Components/MetaTags"
 import { useRouter } from "v2/System/Router/useRouter"
 import { resetPassword } from "v2/Utils/auth"
-
-enum Mode {
-  Pending,
-  Loading,
-  Success,
-  Error,
-}
+import { useMode } from "v2/Utils/Hooks/useMode"
 
 interface ResetPasswordRouteProps {}
+
+type Mode = "Pending" | "Loading" | "Success" | "Error"
 
 export const ResetPasswordRoute: React.FC<ResetPasswordRouteProps> = () => {
   const { match } = useRouter()
@@ -29,7 +25,7 @@ export const ResetPasswordRoute: React.FC<ResetPasswordRouteProps> = () => {
 
   const { sendToast } = useToasts()
 
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
   const [state, setState] = useState({ password: "", passwordConfirmation: "" })
 
   const handleSubmit = async (event: React.FormEvent<HTMLElement>) => {
@@ -46,7 +42,7 @@ export const ResetPasswordRoute: React.FC<ResetPasswordRouteProps> = () => {
       return
     }
 
-    setMode(Mode.Loading)
+    setMode("Loading")
 
     try {
       await resetPassword({
@@ -60,7 +56,7 @@ export const ResetPasswordRoute: React.FC<ResetPasswordRouteProps> = () => {
         ttl: 10000,
       })
 
-      setMode(Mode.Success)
+      setMode("Success")
 
       window.location.assign(query.reset_password_redirect_to || "/login")
     } catch (err) {
@@ -68,7 +64,7 @@ export const ResetPasswordRoute: React.FC<ResetPasswordRouteProps> = () => {
 
       sendToast({ variant: "error", message: err.message })
 
-      setMode(Mode.Error)
+      setMode("Error")
     }
   }
 
@@ -80,10 +76,10 @@ export const ResetPasswordRoute: React.FC<ResetPasswordRouteProps> = () => {
   const verb = query.set_password ? "Set" : "Change"
 
   const label = {
-    [Mode.Pending]: `${verb} My Password`,
-    [Mode.Loading]: `${verb} My Password`,
-    [Mode.Success]: "Password Updated",
-    [Mode.Error]: `${verb} My Password`,
+    ["Pending"]: `${verb} My Password`,
+    ["Loading"]: `${verb} My Password`,
+    ["Success"]: "Password Updated",
+    ["Error"]: `${verb} My Password`,
   }[mode]
 
   return (
@@ -133,8 +129,8 @@ export const ResetPasswordRoute: React.FC<ResetPasswordRouteProps> = () => {
 
           <Button
             width="100%"
-            loading={mode === Mode.Loading}
-            disabled={mode === Mode.Success}
+            loading={mode === "Loading"}
+            disabled={mode === "Success"}
           >
             {label}
           </Button>

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useEffect } from "react"
+import { FC, useEffect } from "react"
 import {
   Box,
   Button,
@@ -15,6 +15,7 @@ import {
 import { useRouter } from "v2/System/Router/useRouter"
 import { useUnlinkSettingsLinkedAccount } from "./useUnlinkSettingsLinkedAccount"
 import { getENV } from "v2/Utils/getENV"
+import { useMode } from "v2/Utils/Hooks/useMode"
 
 interface SettingsEditSettingsLinkedAccountsProps {
   me: SettingsEditSettingsLinkedAccounts_me
@@ -84,19 +85,14 @@ export const SettingsEditSettingsLinkedAccountsFragmentContainer = createFragmen
   }
 )
 
-enum Mode {
-  Disconnected,
-  Connecting,
-  Connected,
-  Disconnecting,
-}
-
 interface SettingsEditSettingsLinkedAccountsButtonProps {
   icon: JSX.Element
   me: SettingsEditSettingsLinkedAccounts_me
   href?: string
   provider: AuthenticationProvider
 }
+
+type Mode = "Disconnected" | "Connecting" | "Connected" | "Disconnecting"
 
 const SettingsEditSettingsLinkedAccountsButton: FC<SettingsEditSettingsLinkedAccountsButtonProps> = ({
   icon,
@@ -111,20 +107,20 @@ const SettingsEditSettingsLinkedAccountsButton: FC<SettingsEditSettingsLinkedAcc
   const { sendToast } = useToasts()
   const { submitMutation } = useUnlinkSettingsLinkedAccount()
 
-  const [mode, setMode] = useState(
-    isConnected ? Mode.Connected : Mode.Disconnected
+  const [mode, setMode] = useMode<Mode>(
+    isConnected ? "Connected" : "Disconnected"
   )
 
   const handleClick = async (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
-    if (mode === Mode.Disconnected) {
-      setMode(Mode.Connecting)
+    if (mode === "Disconnected") {
+      setMode("Connecting")
       return // Pass through
     }
 
     event.preventDefault()
-    setMode(Mode.Disconnecting)
+    setMode("Disconnecting")
 
     try {
       await submitMutation({ input: { provider } })
@@ -134,7 +130,7 @@ const SettingsEditSettingsLinkedAccountsButton: FC<SettingsEditSettingsLinkedAcc
         message: "Account disconnected.",
       })
 
-      setMode(Mode.Disconnected)
+      setMode("Disconnected")
     } catch (err) {
       console.error(err)
 
@@ -144,22 +140,22 @@ const SettingsEditSettingsLinkedAccountsButton: FC<SettingsEditSettingsLinkedAcc
         description: err.message,
       })
 
-      setMode(Mode.Connected)
+      setMode("Connected")
     }
   }
 
   const action = {
-    [Mode.Connecting]: "Connect",
-    [Mode.Connected]: "Disconnect",
-    [Mode.Disconnected]: "Connect",
-    [Mode.Disconnecting]: "Connect",
+    ["Connecting"]: "Connect",
+    ["Connected"]: "Disconnect",
+    ["Disconnected"]: "Connect",
+    ["Disconnecting"]: "Connect",
   }[mode]
 
   return (
     <Button
       onClick={handleClick}
-      loading={mode === Mode.Connecting || mode === Mode.Disconnecting}
-      {...(mode === Mode.Connected
+      loading={mode === "Connecting" || mode === "Disconnecting"}
+      {...(mode === "Connected"
         ? { variant: "secondaryOutline" }
         : {
             variant: "primaryBlack",

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsPassword.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsPassword.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react"
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import {
   Text,
@@ -14,29 +14,27 @@ import { Form, Formik } from "formik"
 import { useUpdateSettingsPassword } from "../useUpdateSettingsPassword"
 import { logout } from "v2/Utils/auth"
 import { SettingsEditSettingsPassword_me } from "v2/__generated__/SettingsEditSettingsPassword_me.graphql"
-
-enum Mode {
-  Pending,
-  Active,
-}
+import { useMode } from "v2/Utils/Hooks/useMode"
 
 interface SettingsEditSettingsPasswordProps {
   me: SettingsEditSettingsPassword_me
 }
 
+type Mode = "Pending" | "Active"
+
 export const SettingsEditSettingsPassword: FC<SettingsEditSettingsPasswordProps> = ({
   me: { hasPassword },
 }) => {
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
   const { sendToast } = useToasts()
   const { submitUpdateSettingsPassword } = useUpdateSettingsPassword()
 
   const handleActivate = () => {
-    setMode(Mode.Active)
+    setMode("Active")
   }
 
   const handleCancel = () => {
-    setMode(Mode.Pending)
+    setMode("Pending")
   }
 
   return (
@@ -45,7 +43,7 @@ export const SettingsEditSettingsPassword: FC<SettingsEditSettingsPasswordProps>
         Password
       </Text>
 
-      {mode === Mode.Pending ? (
+      {mode === "Pending" ? (
         <>
           {hasPassword && (
             <Input

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodes.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodes.tsx
@@ -8,26 +8,23 @@ import {
   Text,
   useToasts,
 } from "@artsy/palette"
-import { useState, FC } from "react"
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useMode } from "v2/Utils/Hooks/useMode"
 import { SettingsEditSettingsTwoFactorBackupCodes_me } from "v2/__generated__/SettingsEditSettingsTwoFactorBackupCodes_me.graphql"
 import { SettingsEditSettingsTwoFactorBackupCodesDialogQueryRenderer } from "./SettingsEditSettingsTwoFactorBackupCodesDialog"
 import { useCreateSettingsBackupSecondFactors } from "./useCreateSettingsBackupSecondFactorsMutation"
-
-enum Mode {
-  Pending,
-  Show,
-  Creating,
-}
 
 interface SettingsEditSettingsTwoFactorBackupCodesProps {
   me: SettingsEditSettingsTwoFactorBackupCodes_me
 }
 
+type Mode = "Pending" | "Show" | "Creating"
+
 export const SettingsEditSettingsTwoFactorBackupCodes: FC<SettingsEditSettingsTwoFactorBackupCodesProps> = ({
   me,
 }) => {
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
 
   const { sendToast } = useToasts()
 
@@ -36,27 +33,27 @@ export const SettingsEditSettingsTwoFactorBackupCodes: FC<SettingsEditSettingsTw
   } = useCreateSettingsBackupSecondFactors()
 
   const handleGenerate = async () => {
-    setMode(Mode.Creating)
+    setMode("Creating")
 
     try {
       await submitCreateSettingsBackupSecondFactors()
 
-      setMode(Mode.Show)
+      setMode("Show")
     } catch (err) {
       console.error(err)
 
       sendToast({ variant: "error", message: err.message })
 
-      setMode(Mode.Pending)
+      setMode("Pending")
     }
   }
 
   const handleShow = () => {
-    setMode(Mode.Show)
+    setMode("Show")
   }
 
   const handleClose = () => {
-    setMode(Mode.Pending)
+    setMode("Pending")
   }
 
   return (
@@ -101,7 +98,7 @@ export const SettingsEditSettingsTwoFactorBackupCodes: FC<SettingsEditSettingsTw
 
               <Button
                 onClick={handleGenerate}
-                loading={mode === Mode.Creating}
+                loading={mode === "Creating"}
                 variant="secondaryGray"
                 width={["100%", "auto"]}
               >
@@ -111,7 +108,7 @@ export const SettingsEditSettingsTwoFactorBackupCodes: FC<SettingsEditSettingsTw
           ) : (
             <Button
               onClick={handleGenerate}
-              loading={mode === Mode.Creating}
+              loading={mode === "Creating"}
               variant="secondaryGray"
             >
               Set up
@@ -120,7 +117,7 @@ export const SettingsEditSettingsTwoFactorBackupCodes: FC<SettingsEditSettingsTw
         </Flex>
       </Flex>
 
-      {mode === Mode.Show && (
+      {mode === "Show" && (
         <ModalDialog
           title="Your backup codes"
           onClose={handleClose}

--- a/src/v2/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethod.tsx
+++ b/src/v2/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethod.tsx
@@ -5,30 +5,28 @@ import {
   Text,
   useToasts,
 } from "@artsy/palette"
-import { FC, useState } from "react"
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useMode } from "v2/Utils/Hooks/useMode"
 import { SettingsPaymentsMethod_method } from "v2/__generated__/SettingsPaymentsMethod_method.graphql"
 import { useDeleteCreditCard } from "../useDeleteCreditCard"
-
-enum Mode {
-  Pending,
-  Deleting,
-}
 
 interface SettingsPaymentsMethodProps {
   method: SettingsPaymentsMethod_method
 }
 
+type Mode = "Pending" | "Deleting"
+
 const SettingsPaymentsMethod: FC<SettingsPaymentsMethodProps> = ({
   method,
 }) => {
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
 
   const { sendToast } = useToasts()
   const { submitMutation } = useDeleteCreditCard()
 
   const handleClick = async () => {
-    setMode(Mode.Deleting)
+    setMode("Deleting")
 
     try {
       await submitMutation(
@@ -88,9 +86,9 @@ const SettingsPaymentsMethod: FC<SettingsPaymentsMethodProps> = ({
         </Text>
       </Flex>
 
-      <Clickable onClick={handleClick} disabled={mode === Mode.Deleting}>
+      <Clickable onClick={handleClick} disabled={mode === "Deleting"}>
         <Text variant="md" color="red100">
-          {mode === Mode.Deleting ? "Removing" : "Remove"}
+          {mode === "Deleting" ? "Removing" : "Remove"}
         </Text>
       </Clickable>
     </Flex>

--- a/src/v2/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethods.tsx
+++ b/src/v2/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethods.tsx
@@ -1,37 +1,35 @@
 import { Text, Button, Message, GridColumns, Column } from "@artsy/palette"
-import { FC, useState } from "react"
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { CreditCardInputProvider } from "v2/Components/CreditCardInput"
 import { extractNodes } from "v2/Utils/extractNodes"
+import { useMode } from "v2/Utils/Hooks/useMode"
 import { SettingsPaymentsMethods_me } from "v2/__generated__/SettingsPaymentsMethods_me.graphql"
 import { SettingsPaymentsMethodFragmentContainer } from "./SettingsPaymentsMethod"
 import { SettingsPaymentsMethodForm } from "./SettingsPaymentsMethodForm"
-
-enum Mode {
-  Pending,
-  Adding,
-}
 
 interface SettingsPaymentsMethodsProps {
   me: SettingsPaymentsMethods_me
 }
 
+type Mode = "Pending" | "Adding"
+
 const SettingsPaymentsMethods: FC<SettingsPaymentsMethodsProps> = ({ me }) => {
   const methods = extractNodes(me.creditCards)
 
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
 
   const handleClick = () => {
-    setMode(Mode.Adding)
+    setMode("Adding")
   }
 
   const handleClose = () => {
-    setMode(Mode.Pending)
+    setMode("Pending")
   }
 
   return (
     <>
-      {mode === Mode.Adding && (
+      {mode === "Adding" && (
         <CreditCardInputProvider>
           <SettingsPaymentsMethodForm onClose={handleClose} />
         </CreditCardInputProvider>

--- a/src/v2/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddress.tsx
+++ b/src/v2/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddress.tsx
@@ -7,9 +7,10 @@ import {
   useToasts,
 } from "@artsy/palette"
 import { pick } from "lodash"
-import { FC, useState } from "react"
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { compactObject } from "v2/Utils/compactObject"
+import { useMode } from "v2/Utils/Hooks/useMode"
 import { SettingsShippingAddress_address } from "v2/__generated__/SettingsShippingAddress_address.graphql"
 import { useDeleteAddress } from "../useDeleteAddress"
 import {
@@ -17,20 +18,16 @@ import {
   SettingsShippingAddressForm,
 } from "./SettingsShippingAddressForm"
 
-enum Mode {
-  Pending,
-  Editing,
-  Deleting,
-}
-
 interface SettingsShippingAddressProps {
   address: SettingsShippingAddress_address
 }
 
+type Mode = "Pending" | "Editing" | "Deleting"
+
 const SettingsShippingAddress: FC<SettingsShippingAddressProps> = ({
   address,
 }) => {
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
   const { submitMutation } = useDeleteAddress()
   const { sendToast } = useToasts()
 
@@ -44,11 +41,11 @@ const SettingsShippingAddress: FC<SettingsShippingAddressProps> = ({
   ].filter(Boolean)
 
   const handleEdit = () => {
-    setMode(Mode.Editing)
+    setMode("Editing")
   }
 
   const handleDelete = async () => {
-    setMode(Mode.Deleting)
+    setMode("Deleting")
     try {
       await submitMutation(
         { input: { userAddressID: address.internalID } },
@@ -78,12 +75,12 @@ const SettingsShippingAddress: FC<SettingsShippingAddressProps> = ({
   }
 
   const handleClose = () => {
-    setMode(Mode.Pending)
+    setMode("Pending")
   }
 
   return (
     <>
-      {mode === Mode.Editing && (
+      {mode === "Editing" && (
         <SettingsShippingAddressForm
           onClose={handleClose}
           address={{
@@ -128,17 +125,17 @@ const SettingsShippingAddress: FC<SettingsShippingAddressProps> = ({
             <Clickable
               mr={1}
               onClick={handleEdit}
-              disabled={mode === Mode.Editing}
+              disabled={mode === "Editing"}
             >
-              {mode === Mode.Editing ? "Editing" : "Edit"}
+              {mode === "Editing" ? "Editing" : "Edit"}
             </Clickable>
 
             <Clickable
               color="red100"
               onClick={handleDelete}
-              disabled={mode === Mode.Deleting}
+              disabled={mode === "Deleting"}
             >
-              {mode === Mode.Deleting ? "Deleting" : "Delete"}
+              {mode === "Deleting" ? "Deleting" : "Delete"}
             </Clickable>
           </Text>
         </Flex>

--- a/src/v2/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddresses.tsx
+++ b/src/v2/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddresses.tsx
@@ -1,38 +1,36 @@
 import { Button, Column, GridColumns, Message, Text } from "@artsy/palette"
-import { FC, useState } from "react"
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { extractNodes } from "v2/Utils/extractNodes"
 import { SettingsShippingAddresses_me } from "v2/__generated__/SettingsShippingAddresses_me.graphql"
 import { SettingsShippingAddressForm } from "./SettingsShippingAddressForm"
 import { SettingsShippingAddressFragmentContainer } from "./SettingsShippingAddress"
-
-enum Mode {
-  Pending,
-  Adding,
-}
+import { useMode } from "v2/Utils/Hooks/useMode"
 
 interface SettingsShippingAddressesProps {
   me: SettingsShippingAddresses_me
 }
+
+type Mode = "Pending" | "Adding"
 
 export const SettingsShippingAddresses: FC<SettingsShippingAddressesProps> = ({
   me,
 }) => {
   const addresses = extractNodes(me.addresses)
 
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
 
   const handleClick = () => {
-    setMode(Mode.Adding)
+    setMode("Adding")
   }
 
   const handleClose = () => {
-    setMode(Mode.Pending)
+    setMode("Pending")
   }
 
   return (
     <>
-      {mode === Mode.Adding && (
+      {mode === "Adding" && (
         <SettingsShippingAddressForm onClose={handleClose} />
       )}
 

--- a/src/v2/Apps/Unsubscribe/Components/UnsubscribeLoggedIn.tsx
+++ b/src/v2/Apps/Unsubscribe/Components/UnsubscribeLoggedIn.tsx
@@ -5,17 +5,13 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System"
 import { UpdateUserEmailPreferencesMutation } from "v2/Components/UserSettings/UserEmailPreferences/UserEmailPreferencesMutation"
 import { UnsubscribeLoggedIn_me } from "v2/__generated__/UnsubscribeLoggedIn_me.graphql"
-
-enum Mode {
-  Pending,
-  Loading,
-  Success,
-  Error,
-}
+import { useMode } from "v2/Utils/Hooks/useMode"
 
 interface UnsubscribeLoggedInProps {
   me: UnsubscribeLoggedIn_me
 }
+
+type Mode = "Pending" | "Loading" | "Success" | "Error"
 
 export const UnsubscribeLoggedIn: React.FC<UnsubscribeLoggedInProps> = ({
   me,
@@ -25,7 +21,7 @@ export const UnsubscribeLoggedIn: React.FC<UnsubscribeLoggedInProps> = ({
   const [emailFrequency, setEmailFrequency] = useState(
     me.emailFrequency ?? "daily"
   )
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const { sendToast } = useToasts()
@@ -34,7 +30,7 @@ export const UnsubscribeLoggedIn: React.FC<UnsubscribeLoggedInProps> = ({
     try {
       timeoutRef.current && clearTimeout(timeoutRef.current)
 
-      setMode(Mode.Loading)
+      setMode("Loading")
 
       await UpdateUserEmailPreferencesMutation(
         relayEnvironment!,
@@ -47,8 +43,8 @@ export const UnsubscribeLoggedIn: React.FC<UnsubscribeLoggedInProps> = ({
         message: "Your email preferences have been updated.",
       })
 
-      setMode(Mode.Success)
-      timeoutRef.current = setTimeout(() => setMode(Mode.Pending), 5000)
+      setMode("Success")
+      timeoutRef.current = setTimeout(() => setMode("Pending"), 5000)
     } catch (err) {
       console.error(err)
 
@@ -58,8 +54,8 @@ export const UnsubscribeLoggedIn: React.FC<UnsubscribeLoggedInProps> = ({
         description: err.message,
       })
 
-      setMode(Mode.Error)
-      timeoutRef.current = setTimeout(() => setMode(Mode.Pending), 5000)
+      setMode("Error")
+      timeoutRef.current = setTimeout(() => setMode("Pending"), 5000)
     }
   }
 
@@ -81,15 +77,15 @@ export const UnsubscribeLoggedIn: React.FC<UnsubscribeLoggedInProps> = ({
 
       <Button
         onClick={handleClick}
-        loading={mode === Mode.Loading}
+        loading={mode === "Loading"}
         width={["100%", "auto"]}
       >
         {
           {
-            [Mode.Pending]: "Update preferences",
-            [Mode.Loading]: "Update preferences",
-            [Mode.Success]: "Updated preferences",
-            [Mode.Error]: "There was an error",
+            ["Pending"]: "Update preferences",
+            ["Loading"]: "Update preferences",
+            ["Success"]: "Updated preferences",
+            ["Error"]: "There was an error",
           }[mode]
         }
       </Button>

--- a/src/v2/Apps/Unsubscribe/Components/UnsubscribeLoggedOut.tsx
+++ b/src/v2/Apps/Unsubscribe/Components/UnsubscribeLoggedOut.tsx
@@ -1,24 +1,20 @@
 import { Button, Checkbox, Spacer, useToasts } from "@artsy/palette"
-import { useRef, useState } from "react";
-import * as React from "react";
-import { data as sd } from "sharify"
-
-enum Mode {
-  Pending,
-  Loading,
-  Success,
-  Error,
-}
+import { useRef, useState } from "react"
+import * as React from "react"
+import { getENV } from "v2/Utils/getENV"
+import { useMode } from "v2/Utils/Hooks/useMode"
 
 interface UnsubscribeLoggedOutProps {
   authenticationToken: string
 }
 
+type Mode = "Pending" | "Loading" | "Success" | "Error"
+
 export const UnsubscribeLoggedOut: React.FC<UnsubscribeLoggedOutProps> = ({
   authenticationToken,
 }) => {
   const [emailTypes, setEmailTypes] = useState<string[]>([])
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const { sendToast } = useToasts()
@@ -27,14 +23,14 @@ export const UnsubscribeLoggedOut: React.FC<UnsubscribeLoggedOutProps> = ({
     try {
       timeoutRef.current && clearTimeout(timeoutRef.current)
 
-      setMode(Mode.Loading)
+      setMode("Loading")
 
-      const res = await fetch(`${sd.API_URL}/api/v1/me/unsubscribe`, {
+      const res = await fetch(`${getENV("API_URL")}/api/v1/me/unsubscribe`, {
         headers: {
           Accept: "application/json",
           "Content-Type": "application/json",
           "X-Requested-With": "XMLHttpRequest",
-          "X-Xapp-Token": sd.ARTSY_XAPP_TOKEN,
+          "X-Xapp-Token": getENV("ARTSY_XAPP_TOKEN"),
         },
         method: "POST",
         credentials: "same-origin",
@@ -45,7 +41,7 @@ export const UnsubscribeLoggedOut: React.FC<UnsubscribeLoggedOutProps> = ({
       })
 
       if (res.ok) {
-        setMode(Mode.Success)
+        setMode("Success")
 
         sendToast({
           variant: "success",
@@ -63,8 +59,8 @@ export const UnsubscribeLoggedOut: React.FC<UnsubscribeLoggedOutProps> = ({
         description: err.text,
       })
 
-      setMode(Mode.Error)
-      timeoutRef.current = setTimeout(() => setMode(Mode.Pending), 5000)
+      setMode("Error")
+      timeoutRef.current = setTimeout(() => setMode("Pending"), 5000)
     } catch (err) {
       console.error(err)
 
@@ -74,8 +70,8 @@ export const UnsubscribeLoggedOut: React.FC<UnsubscribeLoggedOutProps> = ({
         description: err.message,
       })
 
-      setMode(Mode.Error)
-      timeoutRef.current = setTimeout(() => setMode(Mode.Pending), 5000)
+      setMode("Error")
+      timeoutRef.current = setTimeout(() => setMode("Pending"), 5000)
     }
   }
 
@@ -91,7 +87,7 @@ export const UnsubscribeLoggedOut: React.FC<UnsubscribeLoggedOutProps> = ({
       <Checkbox
         onSelect={handleSelect("all")}
         selected={emailTypes.includes("all")}
-        disabled={mode === Mode.Success}
+        disabled={mode === "Success"}
       >
         Opt out of all email
       </Checkbox>
@@ -100,15 +96,15 @@ export const UnsubscribeLoggedOut: React.FC<UnsubscribeLoggedOutProps> = ({
 
       <Button
         onClick={handleClick}
-        loading={mode === Mode.Loading}
-        disabled={emailTypes.length === 0 || mode === Mode.Success}
+        loading={mode === "Loading"}
+        disabled={emailTypes.length === 0 || mode === "Success"}
       >
         {
           {
-            [Mode.Pending]: "Update preferences",
-            [Mode.Loading]: "Update preferences",
-            [Mode.Success]: "Updated preferences",
-            [Mode.Error]: "There was an error",
+            ["Pending"]: "Update preferences",
+            ["Loading"]: "Update preferences",
+            ["Success"]: "Updated preferences",
+            ["Error"]: "There was an error",
           }[mode]
         }
       </Button>

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -20,6 +20,7 @@ import { themeGet } from "@styled-system/theme-get"
 import { FilterExpandable } from "./FilterExpandable"
 import { isCustomValue } from "./Utils/isCustomValue"
 import { useFilterLabelCountByKey } from "../Utils/useFilterLabelCountByKey"
+import { useMode } from "v2/Utils/Hooks/useMode"
 
 // Disables arrows in numeric inputs
 export const NumericInput = styled(LabeledInput).attrs({ type: "number" })`
@@ -73,10 +74,12 @@ export interface PriceRangeFilterProps {
   expanded?: boolean
 }
 
+type Mode = "resting" | "done"
+
 export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
   expanded,
 }) => {
-  const [mode, setMode] = useState<"resting" | "done">("resting")
+  const [mode, setMode] = useMode<Mode>("resting")
 
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
   const { priceRange: initialRange, reset } = currentlySelectedFilters?.() ?? {}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -21,6 +21,7 @@ import { Media } from "v2/Utils/Responsive"
 import { FilterExpandable } from "./FilterExpandable"
 import { isCustomValue } from "./Utils/isCustomValue"
 import { useFilterLabelCountByKey } from "../Utils/useFilterLabelCountByKey"
+import { useMode } from "v2/Utils/Hooks/useMode"
 
 export const SIZES = [
   { displayName: "Small (under 40cm)", name: "SMALL" },
@@ -84,6 +85,8 @@ export interface SizeFilterProps {
   expanded?: boolean
 }
 
+type Mode = "resting" | "done"
+
 export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
   const { currentlySelectedFilters, setFilters } = useArtworkFilterContext()
   const {
@@ -109,7 +112,7 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     isCustomValue(width) || isCustomValue(height)
   )
   const [customSize, setCustomSize] = useState<CustomSize>(initialCustomSize)
-  const [mode, setMode] = useState<"resting" | "done">("resting")
+  const [mode, setMode] = useMode<Mode>("resting")
 
   const handleInputChange = (dimension: "height" | "width", index: number) => ({
     currentTarget: { value },

--- a/src/v2/Components/Inquiry/Views/InquiryBasicInfo.tsx
+++ b/src/v2/Components/Inquiry/Views/InquiryBasicInfo.tsx
@@ -25,23 +25,19 @@ import { useState } from "react"
 import { useUpdateMyUserProfile } from "../Hooks/useUpdateMyUserProfile"
 import { logger } from "../util"
 import { compactObject } from "v2/Utils/compactObject"
-
-enum Mode {
-  Pending,
-  Loading,
-  Success,
-  Error,
-}
+import { useMode } from "v2/Utils/Hooks/useMode"
 
 interface InquiryBasicInfoProps {
   artwork: InquiryBasicInfo_artwork
   me: InquiryBasicInfo_me | null
 }
 
+type Mode = "Pending" | "Loading" | "Success" | "Error"
+
 const InquiryBasicInfo: React.FC<InquiryBasicInfoProps> = ({ artwork, me }) => {
   const { next, setContext, relayEnvironment } = useInquiryContext()
 
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
 
   const { submitUpdateMyUserProfile } = useUpdateMyUserProfile({
     relayEnvironment: relayEnvironment.current!,
@@ -76,7 +72,7 @@ const InquiryBasicInfo: React.FC<InquiryBasicInfoProps> = ({ artwork, me }) => {
   const handleSubmit = async (event: React.FormEvent<HTMLElement>) => {
     event.preventDefault()
 
-    setMode(Mode.Loading)
+    setMode("Loading")
 
     const input = compactObject(state)
 
@@ -84,11 +80,11 @@ const InquiryBasicInfo: React.FC<InquiryBasicInfoProps> = ({ artwork, me }) => {
 
     try {
       await submitUpdateMyUserProfile(input)
-      setMode(Mode.Success)
+      setMode("Success")
       next()
     } catch (err) {
       logger.error(err)
-      setMode(Mode.Error)
+      setMode("Error")
     }
   }
 
@@ -98,7 +94,7 @@ const InquiryBasicInfo: React.FC<InquiryBasicInfoProps> = ({ artwork, me }) => {
         Tell {artwork.partner?.name ?? "us"} a little bit about yourself.
       </Text>
 
-      {mode === Mode.Error && (
+      {mode === "Error" && (
         <Banner variant="error" dismissable my={2}>
           Something went wrong. Please try again.
         </Banner>
@@ -139,8 +135,8 @@ const InquiryBasicInfo: React.FC<InquiryBasicInfoProps> = ({ artwork, me }) => {
       <Button
         type="submit"
         width="100%"
-        loading={mode === Mode.Loading}
-        disabled={mode === Mode.Success}
+        loading={mode === "Loading"}
+        disabled={mode === "Success"}
       >
         Next
       </Button>

--- a/src/v2/Components/Inquiry/Views/InquiryCommercialInterest.tsx
+++ b/src/v2/Components/Inquiry/Views/InquiryCommercialInterest.tsx
@@ -5,18 +5,12 @@ import { useInquiryContext } from "../Hooks/useInquiryContext"
 import { useUpdateMyUserProfile } from "../Hooks/useUpdateMyUserProfile"
 import { logger } from "../util"
 
-enum Mode {
-  Pending,
-  Loading3,
-  Loading2,
-  Success,
-  Error,
-}
+type Mode = "Pending" | "Loading3" | "Loading2" | "Success" | "Error"
 
 export const InquiryCommercialInterest: React.FC = () => {
   const { next, setContext, relayEnvironment } = useInquiryContext()
 
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useState<Mode>("Pending")
 
   const { submitUpdateMyUserProfile } = useUpdateMyUserProfile({
     relayEnvironment: relayEnvironment.current!,
@@ -25,15 +19,15 @@ export const InquiryCommercialInterest: React.FC = () => {
   const handleClick = (value: 2 | 3) => async () => {
     setContext({ collectorLevel: value })
 
-    setMode({ 2: Mode.Loading2, 3: Mode.Loading3 }[value])
+    setMode({ 2: "Loading2", 3: "Loading3" }[value] as Mode)
 
     try {
       await submitUpdateMyUserProfile({ collectorLevel: value })
-      setMode(Mode.Success)
+      setMode("Success")
       next()
     } catch (err) {
       logger.error(err)
-      setMode(Mode.Error)
+      setMode("Error")
     }
   }
 
@@ -43,7 +37,7 @@ export const InquiryCommercialInterest: React.FC = () => {
         Have you bought art from a gallery or auction house before?
       </Text>
 
-      {mode === Mode.Error && (
+      {mode === "Error" && (
         <Banner variant="error" dismissable my={2}>
           Something went wrong. Please try again.
         </Banner>
@@ -53,8 +47,8 @@ export const InquiryCommercialInterest: React.FC = () => {
         variant="secondaryOutline"
         width="100%"
         onClick={handleClick(3)}
-        loading={mode === Mode.Loading3}
-        disabled={mode === Mode.Success || mode === Mode.Loading2}
+        loading={mode === "Loading3"}
+        disabled={mode === "Success" || mode === "Loading2"}
         mb={1}
       >
         Yes
@@ -64,8 +58,8 @@ export const InquiryCommercialInterest: React.FC = () => {
         variant="secondaryOutline"
         width="100%"
         onClick={handleClick(2)}
-        loading={mode === Mode.Loading2}
-        disabled={mode === Mode.Success || mode === Mode.Loading3}
+        loading={mode === "Loading2"}
+        disabled={mode === "Success" || mode === "Loading3"}
       >
         Not yet
       </Button>

--- a/src/v2/Components/Inquiry/Views/InquiryInquiry.tsx
+++ b/src/v2/Components/Inquiry/Views/InquiryInquiry.tsx
@@ -14,7 +14,7 @@ import {
   TextArea,
 } from "@artsy/palette"
 import { useSystemContext } from "v2/System"
-import * as React from "react";
+import * as React from "react"
 import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { InquiryInquiry_artwork } from "v2/__generated__/InquiryInquiry_artwork.graphql"
@@ -29,13 +29,7 @@ import {
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { logger } from "../util"
 
-enum Mode {
-  Pending,
-  Confirm,
-  Sending,
-  Error,
-  Success,
-}
+type Mode = "Pending" | "Confirm" | "Sending" | "Error" | "Success"
 
 interface InquiryInquiryProps {
   artwork: InquiryInquiry_artwork
@@ -46,13 +40,13 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
 
   const { next, setInquiry, inquiry, artworkID } = useInquiryContext()
 
-  const [mode, setMode] = useState<Mode>(Mode.Pending)
+  const [mode, setMode] = useState<Mode>("Pending")
 
   const { submitArtworkInquiryRequest } = useArtworkInquiryRequest()
 
   const handleTextAreaChange = ({ value }: { value: string }) => {
-    if (mode === Mode.Confirm && value !== DEFAULT_MESSAGE) {
-      setMode(Mode.Pending)
+    if (mode === "Confirm" && value !== DEFAULT_MESSAGE) {
+      setMode("Pending")
     }
 
     setInquiry(prevState => ({ ...prevState, message: value }))
@@ -67,8 +61,8 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
   const handleSubmit = async (event: React.FormEvent<HTMLElement>) => {
     event.preventDefault()
 
-    if (inquiry.message === DEFAULT_MESSAGE && mode !== Mode.Confirm) {
-      setMode(Mode.Confirm)
+    if (inquiry.message === DEFAULT_MESSAGE && mode !== "Confirm") {
+      setMode("Confirm")
       return
     }
 
@@ -79,28 +73,28 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
       return
     }
 
-    setMode(Mode.Sending)
+    setMode("Sending")
 
     try {
       await submitArtworkInquiryRequest({
         artworkID,
         message: inquiry.message,
       })
-      setMode(Mode.Success)
+      setMode("Success")
       await wait(500)
       next()
     } catch (err) {
       logger.error(err)
-      setMode(Mode.Error)
+      setMode("Error")
     }
   }
 
   const label = {
-    [Mode.Pending]: "Send",
-    [Mode.Confirm]: "Send Anyway?",
-    [Mode.Sending]: "Send",
-    [Mode.Success]: "Sent",
-    [Mode.Error]: "Error",
+    ["Pending"]: "Send",
+    ["Confirm"]: "Send Anyway?",
+    ["Sending"]: "Send",
+    ["Success"]: "Sent",
+    ["Error"]: "Error",
   }[mode]
 
   return (
@@ -195,7 +189,7 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
 
       <Spacer mt={1} />
 
-      {mode === Mode.Confirm && (
+      {mode === "Confirm" && (
         <Banner variant="defaultLight">
           We recommend personalizing your message to get a faster answer from
           the gallery.
@@ -208,8 +202,8 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
         type="submit"
         display="block"
         width="100%"
-        loading={mode === Mode.Sending}
-        disabled={mode === Mode.Success}
+        loading={mode === "Sending"}
+        disabled={mode === "Success"}
       >
         {label}
       </Button>

--- a/src/v2/Components/Inquiry/Views/InquiryInstitutionalAffiliations.tsx
+++ b/src/v2/Components/Inquiry/Views/InquiryInstitutionalAffiliations.tsx
@@ -6,25 +6,20 @@ import {
   TextArea,
   TextAreaChange,
 } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { useState } from "react"
 import { useInquiryContext } from "../Hooks/useInquiryContext"
 import { useUpdateCollectorProfile } from "../Hooks/useUpdateCollectorProfile"
 import { logger } from "../util"
 
-enum Mode {
-  Pending,
-  Loading,
-  Success,
-  Error,
-}
+type Mode = "Pending" | "Loading" | "Success" | "Error"
 
 export const InquiryInstitutionalAffiliations: React.FC = () => {
   const { next } = useInquiryContext()
 
   const { submitUpdateCollectorProfile } = useUpdateCollectorProfile()
 
-  const [mode, setMode] = useState(Mode.Pending)
+  const [mode, setMode] = useState<Mode>("Pending")
 
   const [institutionalAffiliations, setInstitutionalAffiliations] = useState<
     string | null
@@ -35,7 +30,7 @@ export const InquiryInstitutionalAffiliations: React.FC = () => {
   }
 
   const handleClick = async () => {
-    setMode(Mode.Loading)
+    setMode("Loading")
 
     if (institutionalAffiliations === null) {
       next()
@@ -44,11 +39,11 @@ export const InquiryInstitutionalAffiliations: React.FC = () => {
 
     try {
       await submitUpdateCollectorProfile({ institutionalAffiliations })
-      setMode(Mode.Success)
+      setMode("Success")
       next()
     } catch (err) {
       logger.error(err)
-      setMode(Mode.Error)
+      setMode("Error")
     }
   }
 
@@ -65,7 +60,7 @@ export const InquiryInstitutionalAffiliations: React.FC = () => {
         Collector groups, memberships, etc.
       </Text>
 
-      {mode === Mode.Error && (
+      {mode === "Error" && (
         <Banner variant="error" dismissable my={2}>
           Something went wrong. Please try again.
         </Banner>
@@ -81,8 +76,8 @@ export const InquiryInstitutionalAffiliations: React.FC = () => {
       <Button
         width="100%"
         onClick={handleClick}
-        loading={mode === Mode.Loading}
-        disabled={mode === Mode.Success}
+        loading={mode === "Loading"}
+        disabled={mode === "Success"}
       >
         Next
       </Button>

--- a/src/v2/Components/Inquiry/Views/InquiryLogin.tsx
+++ b/src/v2/Components/Inquiry/Views/InquiryLogin.tsx
@@ -9,8 +9,8 @@ import {
   Spacer,
   Text,
 } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import { useState } from "react"
+import * as React from "react"
 import { createRelaySSREnvironment } from "v2/System/Relay/createRelaySSREnvironment"
 import { wait } from "v2/Utils/wait"
 import { useInquiryContext } from "../Hooks/useInquiryContext"
@@ -27,14 +27,13 @@ import {
   SuccessfullyLoggedIn,
 } from "@artsy/cohesion"
 
-enum Mode {
-  Pending,
-  Loading,
-  TwoFactor,
-  OnDemand,
-  Error,
-  Success,
-}
+type Mode =
+  | "Pending"
+  | "Loading"
+  | "TwoFactor"
+  | "OnDemand"
+  | "Error"
+  | "Success"
 
 interface InquiryLoginState {
   password: string
@@ -52,7 +51,7 @@ export const InquiryLogin: React.FC = () => {
   } = useInquiryContext()
   const { navigateTo } = useInquiryAccountContext()
 
-  const [mode, setMode] = useState<Mode>(Mode.Pending)
+  const [mode, setMode] = useState<Mode>("Pending")
 
   const [state, setState] = useState<InquiryLoginState>({
     password: "",
@@ -66,7 +65,7 @@ export const InquiryLogin: React.FC = () => {
   const handleSubmit = async (event: React.FormEvent<HTMLElement>) => {
     event.preventDefault()
 
-    setMode(Mode.Loading)
+    setMode("Loading")
 
     try {
       const { user } = await login({ email: inquiry.email!, ...state })
@@ -99,7 +98,7 @@ export const InquiryLogin: React.FC = () => {
         contactGallery: !engine.decide("askSpecialist"),
       })
 
-      setMode(Mode.Success)
+      setMode("Success")
       await wait(500)
       next()
 
@@ -117,7 +116,7 @@ export const InquiryLogin: React.FC = () => {
       trackEvent(options)
     } catch (err) {
       if (err.message === "missing on-demand authentication code") {
-        setMode(Mode.OnDemand)
+        setMode("OnDemand")
         return
       }
 
@@ -125,12 +124,12 @@ export const InquiryLogin: React.FC = () => {
         err.message === "missing two-factor authentication code" ||
         err.message === "invalid two-factor authentication code"
       ) {
-        setMode(Mode.TwoFactor)
+        setMode("TwoFactor")
         return
       }
 
       // TODO: Improve error messaging
-      setMode(Mode.Error)
+      setMode("Error")
       logger.error(err)
     }
   }
@@ -139,7 +138,7 @@ export const InquiryLogin: React.FC = () => {
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
     setState(prevState => ({ ...prevState, [name]: event.target.value }))
-    mode === Mode.Error && setMode(Mode.Pending)
+    mode === "Error" && setMode("Pending")
   }
 
   const handleClick = () => {
@@ -165,20 +164,20 @@ export const InquiryLogin: React.FC = () => {
           placeholder="Enter your password"
           onChange={handleInputChange("password")}
           type="password"
-          error={mode === Mode.Error && "Invalid password"}
+          error={mode === "Error" && "Invalid password"}
           required
           autoFocus
           my={1}
         />
 
-        {mode === Mode.OnDemand && (
+        {mode === "OnDemand" && (
           <Message mt={2} mb={1}>
             Your safety and security are important to us. Please check your
             email for a one-time authentication code to complete your login.
           </Message>
         )}
 
-        {(mode === Mode.TwoFactor || mode === Mode.OnDemand) && (
+        {(mode === "TwoFactor" || mode === "OnDemand") && (
           <Input
             name="authenticationCode"
             title="Authentication Code"
@@ -196,8 +195,8 @@ export const InquiryLogin: React.FC = () => {
           type="submit"
           display="block"
           width="100%"
-          loading={mode === Mode.Loading}
-          disabled={mode === Mode.Success}
+          loading={mode === "Loading"}
+          disabled={mode === "Success"}
         >
           Login and Send Message
         </Button>

--- a/src/v2/Components/Inquiry/Views/InquiryResetPassword.tsx
+++ b/src/v2/Components/Inquiry/Views/InquiryResetPassword.tsx
@@ -1,6 +1,6 @@
 import { Button, Skeleton, SkeletonText, Spacer, Text } from "@artsy/palette"
-import { useState, useEffect } from "react";
-import * as React from "react";
+import { useState, useEffect } from "react"
+import * as React from "react"
 import { useInquiryContext } from "../Hooks/useInquiryContext"
 import { forgotPassword } from "v2/Utils/auth"
 import { useInquiryAccountContext, Screen } from "./InquiryAccount"
@@ -13,17 +13,13 @@ import {
   ResetYourPassword,
 } from "@artsy/cohesion"
 
-enum Mode {
-  Resetting,
-  Error,
-  Done,
-}
+type Mode = "Resetting" | "Error" | "Done"
 
 export const InquiryResetPassword: React.FC = () => {
   const { inquiry } = useInquiryContext()
   const { navigateTo } = useInquiryAccountContext()
 
-  const [mode, setMode] = useState<Mode>(Mode.Resetting)
+  const [mode, setMode] = useState<Mode>("Resetting")
 
   const { trackEvent } = useTracking()
 
@@ -31,7 +27,7 @@ export const InquiryResetPassword: React.FC = () => {
     const init = async () => {
       try {
         await forgotPassword({ email: inquiry.email! })
-        setMode(Mode.Done)
+        setMode("Done")
 
         const options: ResetYourPassword = {
           action: ActionType.resetYourPassword,
@@ -45,7 +41,7 @@ export const InquiryResetPassword: React.FC = () => {
 
         trackEvent(options)
       } catch (err) {
-        setMode(Mode.Error)
+        setMode("Error")
       }
     }
 
@@ -57,14 +53,14 @@ export const InquiryResetPassword: React.FC = () => {
   }
 
   const message = {
-    [Mode.Resetting]: `Please check your email (${inquiry.email}) for instructions on how to reset your password.`,
-    [Mode.Done]: `Please check your email (${inquiry.email}) for instructions on how to reset your password.`,
-    [Mode.Error]: "There was an error resetting your password.",
+    ["Resetting"]: `Please check your email (${inquiry.email}) for instructions on how to reset your password.`,
+    ["Done"]: `Please check your email (${inquiry.email}) for instructions on how to reset your password.`,
+    ["Error"]: "There was an error resetting your password.",
   }[mode]
 
   return (
     <>
-      {mode === Mode.Resetting ? (
+      {mode === "Resetting" ? (
         <Skeleton>
           <SkeletonText variant="lg" mr={4}>
             {message}

--- a/src/v2/Components/Inquiry/Views/InquirySignUp.tsx
+++ b/src/v2/Components/Inquiry/Views/InquirySignUp.tsx
@@ -16,14 +16,9 @@ import {
   Intent,
 } from "@artsy/cohesion"
 import { useTracking } from "v2/System/Analytics/useTracking"
+import { useMode } from "v2/Utils/Hooks/useMode"
 
-enum Mode {
-  Pending,
-  Loading,
-  Error,
-  Done,
-  Success,
-}
+type Mode = "Pending" | "Loading" | "Error" | "Done" | "Success"
 
 interface InquirySignUpState {
   name: string
@@ -32,7 +27,7 @@ interface InquirySignUpState {
 }
 
 export const InquirySignUp: React.FC = () => {
-  const [mode, setMode] = useState<Mode>(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
   const [error, setError] = useState("")
 
   const {
@@ -57,7 +52,7 @@ export const InquirySignUp: React.FC = () => {
   const handleSubmit = async (event: React.FormEvent<HTMLElement>) => {
     event.preventDefault()
 
-    setMode(Mode.Loading)
+    setMode("Loading")
 
     try {
       const { user } = await signUp(state)
@@ -76,7 +71,7 @@ export const InquirySignUp: React.FC = () => {
         contactGallery: !engine.decide("askSpecialist"),
       })
 
-      setMode(Mode.Success)
+      setMode("Success")
       await wait(500)
       next()
 
@@ -95,7 +90,7 @@ export const InquirySignUp: React.FC = () => {
       trackEvent(options)
     } catch (err) {
       setError(err.message)
-      setMode(Mode.Error)
+      setMode("Error")
       logger.error(err)
     }
   }
@@ -104,7 +99,7 @@ export const InquirySignUp: React.FC = () => {
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
     setState(prevState => ({ ...prevState, [name]: event.target.value }))
-    mode === Mode.Error && setMode(Mode.Pending)
+    mode === "Error" && setMode("Pending")
   }
 
   return (
@@ -146,7 +141,7 @@ export const InquirySignUp: React.FC = () => {
           placeholder="Your password"
           onChange={handleInputChange("password")}
           defaultValue={state.password}
-          error={mode === Mode.Error && error}
+          error={mode === "Error" && error}
           type="password"
           required
           my={1}
@@ -158,8 +153,8 @@ export const InquirySignUp: React.FC = () => {
           type="submit"
           display="block"
           width="100%"
-          loading={mode === Mode.Loading}
-          disabled={mode === Mode.Success}
+          loading={mode === "Loading"}
+          disabled={mode === "Success"}
         >
           Create Account and Send Message
         </Button>

--- a/src/v2/Components/Inquiry/Views/InquirySpecialist.tsx
+++ b/src/v2/Components/Inquiry/Views/InquirySpecialist.tsx
@@ -7,27 +7,22 @@ import {
   Text,
   TextArea,
 } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import * as React from "react"
 import { useSystemContext } from "v2/System/useSystemContext"
 import { wait } from "v2/Utils/wait"
 import { useArtworkInquiryRequest } from "../Hooks/useArtworkInquiryRequest"
 import { InquiryState, useInquiryContext } from "../Hooks/useInquiryContext"
 import { logger } from "../util"
+import { useMode } from "v2/Utils/Hooks/useMode"
 
-enum Mode {
-  Pending,
-  Sending,
-  Error,
-  Success,
-}
+type Mode = "Pending" | "Sending" | "Error" | "Success"
 
 export const InquirySpecialist: React.FC = () => {
   const { user } = useSystemContext()
 
   const { next, setInquiry, inquiry, artworkID } = useInquiryContext()
 
-  const [mode, setMode] = useState<Mode>(Mode.Pending)
+  const [mode, setMode] = useMode<Mode>("Pending")
 
   const handleTextAreaChange = ({ value }: { value: string }) => {
     setInquiry(prevState => ({ ...prevState, message: value }))
@@ -51,7 +46,7 @@ export const InquirySpecialist: React.FC = () => {
       return
     }
 
-    setMode(Mode.Sending)
+    setMode("Sending")
 
     try {
       await submitArtworkInquiryRequest({
@@ -59,20 +54,20 @@ export const InquirySpecialist: React.FC = () => {
         message: inquiry.message,
         contactGallery: false,
       })
-      setMode(Mode.Success)
+      setMode("Success")
       await wait(500)
       next()
     } catch (err) {
       logger.error(err)
-      setMode(Mode.Error)
+      setMode("Error")
     }
   }
 
   const label = {
-    [Mode.Pending]: "Send",
-    [Mode.Sending]: "Send",
-    [Mode.Success]: "Sent",
-    [Mode.Error]: "Error",
+    ["Pending"]: "Send",
+    ["Sending"]: "Send",
+    ["Success"]: "Sent",
+    ["Error"]: "Error",
   }[mode]
 
   return (
@@ -147,8 +142,8 @@ export const InquirySpecialist: React.FC = () => {
         type="submit"
         display="block"
         width="100%"
-        loading={mode === Mode.Sending}
-        disabled={mode === Mode.Success}
+        loading={mode === "Sending"}
+        disabled={mode === "Success"}
       >
         {label}
       </Button>

--- a/src/v2/Utils/Hooks/useMode.ts
+++ b/src/v2/Utils/Hooks/useMode.ts
@@ -1,0 +1,16 @@
+import { useState } from "react"
+
+/**
+ * This is basically just a wrapper around `useState` for intent signaling.
+ *
+ * @example
+ *
+ * type Mode = "Start" | "End"
+ *
+ * const [mode, setMode] = useMode<Mode>('Start')
+ *
+ * if (mode === 'Start') {
+ *   doSomething()
+ * }
+ */
+export const useMode = useState


### PR DESCRIPTION
We've been using the `enum Mode` pattern for a little while now and i'm always thinking we could eliminate the extra code around enums. 

What this does is gives us a new `useMode` hook which is an alias to `useState`. While its not much, it does formalize the fact that we're using the mode pattern, and instead of enums uses string unions. Enums are a weird feature of TypeScript that can lead to problems in different contexts. 

cc @artsy/grow-devs 