### PR TITLE
bugfix(artist-app): Fix missing overview tab

### DIFF
--- a/src/v2/Apps/Artist/Routes/Overview/Utils/hasOverviewContent.ts
+++ b/src/v2/Apps/Artist/Routes/Overview/Utils/hasOverviewContent.ts
@@ -4,16 +4,19 @@ export const hasOverviewContent = ({
   statuses,
   related,
   biographyBlurb,
+  insights,
 }: Pick<
   ArtistApp_sharedMetadata,
-  "statuses" | "related" | "biographyBlurb"
+  "biographyBlurb" | "insights" | "related" | "statuses"
 >): boolean => {
   const showArtistBio = biographyBlurb && Boolean(biographyBlurb.text)
   const showRelatedCategories = related?.genes?.edges?.length! > 0
+  const showCareerHighlights = insights?.length
 
   return Boolean(
     showArtistBio ||
       showRelatedCategories ||
+      showCareerHighlights ||
       statuses?.articles ||
       statuses?.cv ||
       statuses?.shows

--- a/src/v2/Apps/Artist/__tests__/ArtistApp.jest.tsx
+++ b/src/v2/Apps/Artist/__tests__/ArtistApp.jest.tsx
@@ -83,6 +83,7 @@ describe("ArtistApp", () => {
           Artist: () => ({
             biographyBlurb: null,
             related: null,
+            insights: null,
             statuses: {
               articles: false,
               cv: false,


### PR DESCRIPTION
Fixes an unreported bug I noticed on a few of these low-content artists where some overview content was appearing (and thus showing the overview page); however since we weren't checking for the condition we were hiding the overview tab. 

<img width="1081" alt="Screen Shot 2022-01-27 at 10 13 24 PM" src="https://user-images.githubusercontent.com/236943/151497205-40c9ce79-84e5-468e-b97a-b5a6f5f2aa78.png">

cc @artsy/grow-devs 
