### PR TITLE
chore: fix save search bell color

### DIFF
--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
@@ -84,7 +84,7 @@ export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
         size="small"
         {...props}
       >
-        <BellIcon mr={0.5} color="currentColor" />
+        <BellIcon mr={0.5} fill="currentColor" />
         Create an Alert
       </Button>
       <SavedSearchAlertModal


### PR DESCRIPTION
When hovering over the "save alert" button, the bell color currently doesn't change. Quick fix!
Before:
<img width="320" alt="Screen Shot 2022-01-28 at 6 22 32 PM" src="https://user-images.githubusercontent.com/5361806/151593320-081bbb15-1a0d-4e9b-8f72-eddbccf9daaa.png">

After:
<img width="359" alt="Screen Shot 2022-01-28 at 6 22 24 PM" src="https://user-images.githubusercontent.com/5361806/151593315-a810fdff-d41d-499c-8f4f-45377edc997a.png">
