### PR TITLE
Add a “See details.” text link that opens up the conversation sidebar

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -215,6 +215,7 @@ const Conversation: React.FC<ConversationProps> = props => {
                 messages={conversation.messagesConnection!}
                 events={conversation.orderConnection}
                 lastViewedMessageID={conversation?.fromLastViewedMessageID}
+                setShowDetails={setShowDetails}
               />
               <Box ref={bottomOfMessageContainer as any} />
             </Flex>

--- a/src/v2/Apps/Conversation/Components/ConversationMessages.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationMessages.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "relay-runtime"
 import { Spacer } from "@artsy/palette"
@@ -20,6 +20,7 @@ interface ConversationMessageProps {
   messages: ConversationMessages_messages
   events: ConversationMessages_events | null
   lastViewedMessageID?: string | null
+  setShowDetails: (showDetails: boolean) => void
 }
 type Order = NonNullable<
   NonNullable<
@@ -32,6 +33,7 @@ export const ConversationMessages = ({
   messages,
   events,
   lastViewedMessageID,
+  setShowDetails,
 }: ConversationMessageProps) => {
   let [messagesAndEvents, setMessagesAndEvents] = useState<MessageType[][]>([])
 
@@ -72,80 +74,81 @@ export const ConversationMessages = ({
       item?.__typename !== "Message" && relevantEvents.includes(item.__typename)
     )
   }
-  return <>
-    {messagesAndEvents.map((messageGroup, groupIndex) => {
-      let today: boolean
-      let newFlagShown = false
-      if (messageGroup[0].createdAt) {
-        today = fromToday(messageGroup[0].createdAt)
-      }
+  return (
+    <>
+      {messagesAndEvents.map((messageGroup, groupIndex) => {
+        let today: boolean
+        let newFlagShown = false
+        if (messageGroup[0].createdAt) {
+          today = fromToday(messageGroup[0].createdAt)
+        }
 
-      return (
-        <Fragment
-          key={`group-${groupIndex}-${messageGroup[0]?.internalID}`}
-        >
-          {messageGroup[0].__typename === "Message" && (
-            <TimeSince
-              style={{ alignSelf: "center" }}
-              time={
-                messageGroup[0].createdAt ? messageGroup[0].createdAt : ""
-              }
-              exact
-              mb={1}
-            />
-          )}
+        return (
+          <Fragment key={`group-${groupIndex}-${messageGroup[0]?.internalID}`}>
+            {messageGroup[0].__typename === "Message" && (
+              <TimeSince
+                style={{ alignSelf: "center" }}
+                time={
+                  messageGroup[0].createdAt ? messageGroup[0].createdAt : ""
+                }
+                exact
+                mb={1}
+              />
+            )}
 
-          {[...messageGroup].reverse().map((message, messageIndex) => {
-            if (isRelevantEvent(message)) {
-              return (
-                <OrderUpdateFragmentContainer
-                  key={`event-${messageIndex}`}
-                  event={message as any}
-                />
-              )
-            }
-            if (message.__typename === "Message") {
-              const nextMessage = messageGroup[messageIndex + 1]
-              const senderChanges =
-                nextMessage && nextMessage.isFromUser !== message.isFromUser
-              const lastMessageInGroup =
-                messageIndex === messageGroup.length - 1
-              const spaceAfter = senderChanges || lastMessageInGroup ? 2 : 0.5
-
-              let showNewFlag = false
-              if (
-                !newFlagShown &&
-                !!lastViewedMessageID &&
-                message.internalID > +lastViewedMessageID &&
-                !message.isFromUser
-              ) {
-                // This marks visibility
-                showNewFlag = true
-                // This makes sure that it appears only on the first new message
-                newFlagShown = true
-              }
-
-              return (
-                <Fragment key={`message-${message.internalID}`}>
-                  {showNewFlag && <NewMessageMarker />}
-                  <Message
-                    message={message}
-                    key={message.internalID}
-                    showTimeSince={
-                      message.createdAt &&
-                      today &&
-                      messageGroup.length - 1 === messageIndex
-                    }
+            {[...messageGroup].reverse().map((message, messageIndex) => {
+              if (isRelevantEvent(message)) {
+                return (
+                  <OrderUpdateFragmentContainer
+                    key={`event-${messageIndex}`}
+                    event={message as any}
+                    setShowDetails={setShowDetails}
                   />
-                  <Spacer mb={spaceAfter} />
-                </Fragment>
-              );
-            }
-          })}
-        </Fragment>
-      );
-    })}
-  </>;
+                )
+              }
+              if (message.__typename === "Message") {
+                const nextMessage = messageGroup[messageIndex + 1]
+                const senderChanges =
+                  nextMessage && nextMessage.isFromUser !== message.isFromUser
+                const lastMessageInGroup =
+                  messageIndex === messageGroup.length - 1
+                const spaceAfter = senderChanges || lastMessageInGroup ? 2 : 0.5
+
+                let showNewFlag = false
+                if (
+                  !newFlagShown &&
+                  !!lastViewedMessageID &&
+                  message.internalID > +lastViewedMessageID &&
+                  !message.isFromUser
+                ) {
+                  // This marks visibility
+                  showNewFlag = true
+                  // This makes sure that it appears only on the first new message
+                  newFlagShown = true
+                }
+
+                return (
+                  <Fragment key={`message-${message.internalID}`}>
+                    {showNewFlag && <NewMessageMarker />}
+                    <Message
+                      message={message}
+                      key={message.internalID}
+                      showTimeSince={
+                        message.createdAt &&
+                        today &&
+                        messageGroup.length - 1 === messageIndex
+                      }
+                    />
+                    <Spacer mb={spaceAfter} />
+                  </Fragment>
+                )
+              }
+            })}
+          </Fragment>
+        )
+      })}
+    </>
+  )
 }
 
 export const ConversationMessagesFragmentContainer = createFragmentContainer(

--- a/src/v2/Apps/Conversation/Components/OrderUpdate.tsx
+++ b/src/v2/Apps/Conversation/Components/OrderUpdate.tsx
@@ -1,7 +1,8 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import {
   AlertCircleFillIcon,
+  Clickable,
   Color,
   Flex,
   IconProps,
@@ -15,12 +16,17 @@ import { TimeSince } from "./TimeSince"
 import { OrderUpdate_event } from "../../../__generated__/OrderUpdate_event.graphql"
 export interface OrderUpdateProps {
   event: OrderUpdate_event
+  setShowDetails: (showDetails: boolean) => void
 }
 
-export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event }) => {
+export const OrderUpdate: React.FC<OrderUpdateProps> = ({
+  event,
+  setShowDetails,
+}) => {
   let color: Color
   let message: string
   let Icon: React.FC<IconProps> = MoneyFillIcon
+  let renderShowDetails: boolean = false
 
   if (event.__typename === "CommerceOfferSubmittedEvent") {
     const { offer } = event
@@ -30,6 +36,7 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event }) => {
       message = `You sent ${isCounter ? "a counteroffer" : "an offer"} for ${
         event.offer.amount
       }`
+      renderShowDetails = !isCounter
     } else if (offer.fromParticipant === "SELLER") {
       color = "copper100"
       Icon = AlertCircleFillIcon
@@ -75,6 +82,17 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event }) => {
           <Flex flexDirection="column" pl={1}>
             <Text color={color} variant="xs">
               {message}
+              {renderShowDetails && (
+                <>
+                  {". "}
+                  <Clickable
+                    onClick={() => setShowDetails(true)}
+                    textDecoration="underline"
+                  >
+                    See details.
+                  </Clickable>
+                </>
+              )}
             </Text>
           </Flex>
         </Flex>

--- a/src/v2/Apps/Conversation/Components/OrderUpdate.tsx
+++ b/src/v2/Apps/Conversation/Components/OrderUpdate.tsx
@@ -26,7 +26,7 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({
   let color: Color
   let message: string
   let Icon: React.FC<IconProps> = MoneyFillIcon
-  let renderShowDetails: boolean = false
+  let action: { label?: string; onClick?: () => void } = {}
 
   if (event.__typename === "CommerceOfferSubmittedEvent") {
     const { offer } = event
@@ -36,7 +36,9 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({
       message = `You sent ${isCounter ? "a counteroffer" : "an offer"} for ${
         event.offer.amount
       }`
-      renderShowDetails = !isCounter
+      if (!isCounter) {
+        action = { label: "See details", onClick: () => setShowDetails(true) }
+      }
     } else if (offer.fromParticipant === "SELLER") {
       color = "copper100"
       Icon = AlertCircleFillIcon
@@ -82,14 +84,14 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({
           <Flex flexDirection="column" pl={1}>
             <Text color={color} variant="xs">
               {message}
-              {renderShowDetails && (
+              {action.label && action.onClick && (
                 <>
                   {". "}
                   <Clickable
-                    onClick={() => setShowDetails(true)}
+                    onClick={action.onClick}
                     textDecoration="underline"
                   >
-                    See details.
+                    {action.label}.
                   </Clickable>
                 </>
               )}

--- a/src/v2/Apps/Conversation/Components/__tests__/ConversationMessages.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/ConversationMessages.jest.tsx
@@ -11,7 +11,7 @@ const { renderWithRelay } = setupTestWrapperTL({
       <ConversationMessagesFragmentContainer
         messages={me.conversation.messagesConnection}
         events={me.conversation.orderConnection}
-        setShowDetails={() => {}}
+        setShowDetails={jest.fn()}
       />
     )
   },

--- a/src/v2/Apps/Conversation/Components/__tests__/ConversationMessages.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/ConversationMessages.jest.tsx
@@ -11,6 +11,7 @@ const { renderWithRelay } = setupTestWrapperTL({
       <ConversationMessagesFragmentContainer
         messages={me.conversation.messagesConnection}
         events={me.conversation.orderConnection}
+        setShowDetails={() => {}}
       />
     )
   },

--- a/src/v2/Apps/Conversation/Components/__tests__/OrderUpdate.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/OrderUpdate.jest.tsx
@@ -7,13 +7,18 @@ import { DateTime } from "luxon"
 
 jest.unmock("react-relay")
 
+const setShowDetailsSpy = jest.fn()
+
 const { renderWithRelay } = setupTestWrapperTL<OrderUpdate_Test_Query>({
   Component: props => {
     const event = props!.me!.conversation!.orderConnection!.edges![0]!.node!
       .orderHistory[0]
 
     return (
-      <OrderUpdateFragmentContainer event={event} setShowDetails={() => {}} />
+      <OrderUpdateFragmentContainer
+        event={event}
+        setShowDetails={setShowDetailsSpy}
+      />
     )
   },
   query: graphql`
@@ -70,7 +75,12 @@ describe("testing different statuses", () => {
     expect(
       screen.getByText(/You sent an offer for \$39999./)
     ).toBeInTheDocument()
-    expect(screen.queryByText("See details.")).toBeInTheDocument()
+
+    const action = screen.queryByText("See details.")
+    expect(action).toBeInTheDocument()
+
+    action?.click()
+    expect(setShowDetailsSpy).toHaveBeenCalledWith(true)
   })
 
   it("render counteroffer", () => {

--- a/src/v2/Apps/Conversation/Components/__tests__/OrderUpdate.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/OrderUpdate.jest.tsx
@@ -12,7 +12,9 @@ const { renderWithRelay } = setupTestWrapperTL<OrderUpdate_Test_Query>({
     const event = props!.me!.conversation!.orderConnection!.edges![0]!.node!
       .orderHistory[0]
 
-    return <OrderUpdateFragmentContainer event={event} />
+    return (
+      <OrderUpdateFragmentContainer event={event} setShowDetails={() => {}} />
+    )
   },
   query: graphql`
     query OrderUpdate_Test_Query($conversationID: String!)
@@ -36,6 +38,41 @@ const { renderWithRelay } = setupTestWrapperTL<OrderUpdate_Test_Query>({
 })
 
 describe("testing different statuses", () => {
+  it("render offer", () => {
+    const createdAt = "2021-07-04T12:16:40Z"
+    renderWithRelay({
+      Conversation: () => ({
+        orderConnection: {
+          edges: [
+            {
+              node: {
+                orderHistory: [
+                  {
+                    __typename: "CommerceOfferSubmittedEvent",
+                    createdAt,
+                    offer: {
+                      amount: "$39999",
+                      fromParticipant: "BUYER",
+                      offerAmountChanged: false,
+                      respondsTo: null,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    const date = DateTime.fromISO(createdAt)
+    expect(screen.getByText(date.toFormat("ccc, LLL d, t"))).toBeInTheDocument()
+    expect(
+      screen.getByText(/You sent an offer for \$39999./)
+    ).toBeInTheDocument()
+    expect(screen.queryByText("See details.")).toBeInTheDocument()
+  })
+
   it("render counteroffer", () => {
     const createdAt = "2021-07-04T12:46:40Z"
     renderWithRelay({
@@ -71,6 +108,7 @@ describe("testing different statuses", () => {
     expect(
       screen.getByText("You sent a counteroffer for $40000")
     ).toBeInTheDocument()
+    expect(screen.queryByText("See details.")).not.toBeInTheDocument()
   })
 
   it("render received a counteroffer", () => {
@@ -102,6 +140,7 @@ describe("testing different statuses", () => {
     expect(
       screen.getByText("You received a counteroffer for $40000")
     ).toBeInTheDocument()
+    expect(screen.queryByText("See details.")).not.toBeInTheDocument()
   })
 
   it("render Offer Accepted - Pending Action", () => {
@@ -133,6 +172,7 @@ describe("testing different statuses", () => {
     expect(
       screen.getByText("Offer Accepted - Pending Action")
     ).toBeInTheDocument()
+    expect(screen.queryByText("See details.")).not.toBeInTheDocument()
   })
 
   it("render Offer Accepted", () => {
@@ -155,6 +195,7 @@ describe("testing different statuses", () => {
       }),
     })
     expect(screen.getByText("Offer Accepted")).toBeInTheDocument()
+    expect(screen.queryByText("See details.")).not.toBeInTheDocument()
   })
   it("render Offer Declined", () => {
     renderWithRelay({
@@ -177,6 +218,7 @@ describe("testing different statuses", () => {
       }),
     })
     expect(screen.getByText("Offer Declined")).toBeInTheDocument()
+    expect(screen.queryByText("See details.")).not.toBeInTheDocument()
   })
   it("render Offer Expired", () => {
     renderWithRelay({
@@ -199,5 +241,6 @@ describe("testing different statuses", () => {
       }),
     })
     expect(screen.getByText("Offer Expired")).toBeInTheDocument()
+    expect(screen.queryByText("See details.")).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
[NX-3069](https://artsyproduct.atlassian.net/browse/NX-3069)

Because users will be pointed to the inbox after making an offer (see [NX-3041](https://artsyproduct.atlassian.net/browse/NX-3041)), we need to make it clear for them where to see the details of the offer.

Twin PR on Eigen: https://github.com/artsy/eigen/pull/6139

![image](https://user-images.githubusercontent.com/265560/151798793-fecedce2-baaa-45e5-8fd9-b2d5a7f5a2e5.png)

[Figma file](https://www.figma.com/file/PgmxHwBnoOUS4ybwpK2mTN/Make-Offer-on-all-Eligible-Artworks?node-id=525%3A3575) for reference.