### PR TITLE
fix: new offer submission QA fixes

### DIFF
--- a/src/v2/Apps/Order/Components/MinPriceWarning.tsx
+++ b/src/v2/Apps/Order/Components/MinPriceWarning.tsx
@@ -1,4 +1,4 @@
-import { Clickable, Message } from "@artsy/palette"
+import { Clickable, Message, Text } from "@artsy/palette"
 import { useEffect } from "react"
 import { AnalyticsSchema, useTracking } from "v2/System/Analytics"
 
@@ -25,14 +25,19 @@ export const MinPriceWarning: React.FC<MinPriceWarningProps> = ({
   }, [])
 
   return (
-    <Message variant="default" p={2} mt={2}>
-      Galleries usually accept offers within
-      {isPriceRange ? " the displayed price range" : " 20% of the listed price"}
-      ; any lower is likely to be rejected.
-      <br />
-      <Clickable textDecoration="underline" cursor="pointer" onClick={onClick}>
-        We recommend changing your offer to {minPrice}.
-      </Clickable>
-    </Message>
+    <Clickable cursor="pointer" onClick={onClick} mt={2}>
+      <Message variant="warning" p={2}>
+        <Text>
+          Galleries usually accept offers within
+          {isPriceRange
+            ? " the displayed price range"
+            : " 20% of the listed price"}
+          ; any lower is likely to be rejected.
+        </Text>
+        <Text style={{ textDecoration: "underline" }}>
+          We recommend changing your offer to {minPrice}.
+        </Text>
+      </Message>
+    </Clickable>
   )
 }

--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -44,6 +44,13 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
     setDisplayWarning(false)
   }, [customValue])
 
+  useEffect(() => {
+    if (showError) {
+      setSelectedRadio("price-option-custom")
+      setToggle(true)
+    }
+  }, [showError])
+
   const trackClick = (offer: string, amount: number) => {
     const trackingData: ClickedOfferOption = {
       action: ActionType.clickedOfferOption,
@@ -72,7 +79,9 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
   const getRangeOptions = () => {
     const minPriceRange = listPrice?.minPrice?.major
     const maxPriceRange = listPrice?.maxPrice?.major
-    const midPriceRange = (Number(minPriceRange) + Number(maxPriceRange)) / 2
+    const midPriceRange = Math.round(
+      (Number(minPriceRange) + Number(maxPriceRange)) / 2
+    )
 
     const getRangeDetails = [
       { value: minPriceRange, description: "Low-end of range" },
@@ -91,7 +100,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
       if (listPrice?.major) {
         return {
           key: `price-option-${idx}`,
-          value: listPrice.major * (1 - pricePercentage),
+          value: Math.round(listPrice.major * (1 - pricePercentage)),
           description: `${pricePercentage * 100}% below the list price`,
         }
       }
@@ -141,8 +150,9 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
         .concat(
           <BorderedRadio
             id="scrollTo--price-option-custom"
-            value="custom"
+            value="price-option-custom"
             label="Different amount"
+            error={showError}
             onSelect={() => {
               customValue && onChange(customValue)
               setToggle(true)


### PR DESCRIPTION
During QA, we found the following issues:

1. If the user clicked "continue" without selecting an option, no error would be displayed.
2. Amounts with a decimal point would cause the mutation to fail.
3. The message for when the offer is too low should have been a `variant="warning"`.
4. The whole ☝️ message should be clickable.

Fixes are as follow:

1. If that edge case occurs, the "different amount" option will be automatically selected, displaying an error.
2. Amounts are now rounded to avoid decimals.
3. Corrected to use  `variant="warning"`.
4. The message is now wrapped in a `Clickable`.

https://user-images.githubusercontent.com/7117670/151882749-c6018842-db0c-4752-a60c-7df505638031.mov
cc @artsy/negotiate-devs 

