### PR TITLE
fix: update when the price too low notice shows up

### DIFF
--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -35,13 +35,11 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
 
   const [customValue, setCustomValue] = useState<number>()
   const [toggle, setToggle] = useState(false)
-  const [displayWarning, setDisplayWarning] = useState(false)
   const [selectedRadio, setSelectedRadio] = useState<string>()
   const listPrice = artwork?.listPrice
 
   useEffect(() => {
     if (!!customValue) onChange(customValue)
-    setDisplayWarning(false)
   }, [customValue])
 
   useEffect(() => {
@@ -166,16 +164,13 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
                   id="OfferForm_offerValue"
                   showError={showError}
                   onChange={setCustomValue}
-                  onBlur={() => {
-                    setDisplayWarning(true)
-                  }}
                   onFocus={() => {
                     onFocus()
                     scrollTo()
                   }}
                   noTitle
                 />
-                {displayWarning && !!customValue && customValue < minPrice && (
+                {(!customValue || customValue < minPrice) && (
                   <MinPriceWarning
                     isPriceRange={!!artwork?.isPriceRange}
                     onClick={selectMinPrice}

--- a/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
@@ -124,15 +124,13 @@ describe("PriceOptions", () => {
         )
       )
       fireEvent.click(radios[3])
-      expect(trackEvent).toHaveBeenLastCalledWith(
+      expect(trackEvent).toHaveBeenCalledWith(
         expect.objectContaining(getTrackingObject("Different amount", 0, "USD"))
       )
     })
-    it("display and tracks the offer too low notice", async () => {
+    it("correctly displays and tracks the offer too low notice", async () => {
       fireEvent.click(radios[3])
       const input = await within(radios[3]).findByRole("textbox")
-      fireEvent.change(input, { target: { value: 50 } })
-      fireEvent.blur(input)
       const notice = await screen.findByText(
         "We recommend changing your offer to US$100.00."
       )
@@ -143,12 +141,11 @@ describe("PriceOptions", () => {
           flow: "Make offer",
         })
       )
+      fireEvent.change(input, { target: { value: 180 } })
+      expect(notice).not.toBeInTheDocument()
     })
     it("selects the first option when clicking on the low price notice", async () => {
       fireEvent.click(radios[3])
-      const input = await within(radios[3]).findByRole("textbox")
-      fireEvent.change(input, { target: { value: 50 } })
-      fireEvent.blur(input)
       const notice = await screen.findByText(
         "We recommend changing your offer to US$100.00."
       )
@@ -206,7 +203,7 @@ describe("PriceOptions", () => {
         )
       )
       fireEvent.click(radios[3])
-      expect(trackEvent).toHaveBeenLastCalledWith(
+      expect(trackEvent).toHaveBeenCalledWith(
         expect.objectContaining(getTrackingObject("Different amount", 0, "EUR"))
       )
     })
@@ -233,6 +230,7 @@ describe("PriceOptions", () => {
     })
     it("displays the error and automatically selects the custom value option when an error is passed", async () => {
       const selected = await screen.findByRole("radio", { checked: true })
+      expect(selected).toBeInTheDocument()
       expect(selected).toHaveTextContent("Different amount")
       expect(selected).toHaveTextContent("Offer amount missing or invalid.")
     })


### PR DESCRIPTION
Based on a request from design to change the "Offer too low" notice always to be visible until the user has entered an amount higher than 80% of the listed price.

https://user-images.githubusercontent.com/7117670/152004741-628f0c74-9c0a-4bc6-be97-34d9e28c66c6.mov

cc @artsy/negotiate-devs 