### PR TITLE
User on gallery detail page for black owned gallery sees ribbon

### DIFF
--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -9,6 +9,7 @@ import { PartnerMetaFragmentContainer } from "./Components/PartnerMeta"
 import { StickyProvider } from "v2/Components/Sticky"
 import { PartnerArtistsLoadingContextProvider } from "./Utils/PartnerArtistsLoadingContext"
 import { HttpError } from "found"
+import { Ribbon } from "v2/Components/Ribbon"
 
 export interface PartnerAppProps {
   partner: PartnerApp_partner
@@ -24,11 +25,15 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
     displayFullPartnerPage,
     isDefaultProfilePublic,
     partnerPageEligible,
+    categories,
   } = partner
 
   if (!isDefaultProfilePublic || !partnerPageEligible) {
     throw new HttpError(404)
   }
+
+  const isBlackOwned =
+    categories!.filter(c => c && c.name === "Black Owned").length > 0
 
   return (
     <PartnerArtistsLoadingContextProvider>
@@ -42,7 +47,7 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
         <PartnerHeader partner={partner} />
 
         <FullBleed mb={[2, 4]}>
-          <Separator />
+          {isBlackOwned ? <Ribbon ribbonText="Black Owned" /> : <Separator />}
         </FullBleed>
 
         {(displayFullPartnerPage || partnerType === "Brand") && (
@@ -62,6 +67,10 @@ export const PartnerAppFragmentContainer = createFragmentContainer(PartnerApp, {
       displayFullPartnerPage
       partnerPageEligible
       isDefaultProfilePublic
+      categories {
+        id
+        name
+      }
       profile {
         ...PartnerHeaderImage_profile
       }

--- a/src/v2/Components/Ribbon.tsx
+++ b/src/v2/Components/Ribbon.tsx
@@ -1,0 +1,85 @@
+import { Flex, Text } from "@artsy/palette"
+import * as React from "react"
+import { Media } from "v2/Utils/Responsive"
+
+interface RibbonProps {
+  ribbonText: string
+  ribbonDivider?: string
+}
+
+export const Ribbon: React.FC<RibbonProps> = ({
+  ribbonText,
+  ribbonDivider = "•",
+}) => {
+  return (
+    <>
+      <Media lessThan="sm">
+        <Flex
+          bg="black100"
+          justifyContent="space-between"
+          alignItems="center"
+          px={0.5}
+          height={20}
+        >
+          <Text variant="md" color="white">
+            {ribbonDivider}
+          </Text>
+          <Text variant="xs" color="white">
+            {ribbonText}
+          </Text>
+          <Text variant="md" color="white">
+            {ribbonDivider}
+          </Text>
+          <Text variant="xs" color="white">
+            {ribbonText}
+          </Text>
+          <Text variant="md" color="white">
+            {ribbonDivider}
+          </Text>
+        </Flex>
+      </Media>
+      <Media greaterThanOrEqual="sm">
+        <Flex
+          bg="black100"
+          justifyContent="space-between"
+          alignItems="center"
+          height={20}
+        >
+          <Text variant="xs" color="white">
+            {ribbonText}
+          </Text>
+          <Text variant="md" color="white">
+            {ribbonDivider}
+          </Text>
+          <Text variant="xs" color="white">
+            {ribbonText}
+          </Text>
+          <Text variant="md" color="white">
+            {ribbonDivider}
+          </Text>
+          <Text variant="xs" color="white">
+            {ribbonText}
+          </Text>
+          <Text variant="md" color="white">
+            {ribbonDivider}
+          </Text>
+          <Text variant="xs" color="white">
+            {ribbonText}
+          </Text>
+          <Text variant="md" color="white">
+            {ribbonDivider}
+          </Text>
+          <Text variant="xs" color="white">
+            {ribbonText}
+          </Text>
+          <Text variant="md" color="white">
+            {ribbonDivider}
+          </Text>
+          <Text variant="xs" color="white">
+            {ribbonText}
+          </Text>
+        </Flex>
+      </Media>
+    </>
+  )
+}

--- a/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
@@ -64,6 +64,10 @@ fragment PartnerApp_partner on Partner {
   displayFullPartnerPage
   partnerPageEligible
   isDefaultProfilePublic
+  categories {
+    id
+    name
+  }
   profile {
     ...PartnerHeaderImage_profile
     id
@@ -152,14 +156,14 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
+  "name": "name",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "slug",
   "storageKey": null
 },
 v4 = {
@@ -192,45 +196,45 @@ v8 = {
 },
 v9 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "FormattedNumber"
+  "type": "ID"
 },
 v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Boolean"
+  "type": "String"
 },
 v11 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "ID"
+  "type": "FormattedNumber"
 },
 v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "LocationConnection"
+  "type": "Boolean"
 },
 v13 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "LocationConnection"
+},
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "LocationEdge"
 },
-v14 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Location"
-},
 v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "String"
+  "type": "Location"
 },
 v16 = {
   "enumValues": null,
@@ -328,6 +332,19 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "PartnerCategory",
+            "kind": "LinkedField",
+            "name": "categories",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "Profile",
             "kind": "LinkedField",
             "name": "profile",
@@ -410,8 +427,8 @@ return {
                 ],
                 "storageKey": null
               },
-              (v2/*: any*/),
               (v3/*: any*/),
+              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -569,8 +586,8 @@ return {
             ],
             "storageKey": null
           },
-          (v3/*: any*/),
           (v2/*: any*/),
+          (v3/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -735,7 +752,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f82ab7af3e9899e3457a61703d46d1f6",
+    "cacheID": "a910efd4e5a88bea389a02c853637790",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -752,31 +769,39 @@ return {
           "type": "ArticleConnection"
         },
         "partner.articles.totalCount": (v8/*: any*/),
+        "partner.categories": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "PartnerCategory"
+        },
+        "partner.categories.id": (v9/*: any*/),
+        "partner.categories.name": (v10/*: any*/),
         "partner.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerCounts"
         },
-        "partner.counts.displayableShows": (v9/*: any*/),
-        "partner.counts.eligibleArtworks": (v9/*: any*/),
-        "partner.displayArtistsSection": (v10/*: any*/),
-        "partner.displayFullPartnerPage": (v10/*: any*/),
-        "partner.displayWorksSection": (v10/*: any*/),
-        "partner.id": (v11/*: any*/),
-        "partner.isDefaultProfilePublic": (v10/*: any*/),
-        "partner.locations": (v12/*: any*/),
-        "partner.locations.edges": (v13/*: any*/),
-        "partner.locations.edges.node": (v14/*: any*/),
-        "partner.locations.edges.node.city": (v15/*: any*/),
-        "partner.locations.edges.node.id": (v11/*: any*/),
+        "partner.counts.displayableShows": (v11/*: any*/),
+        "partner.counts.eligibleArtworks": (v11/*: any*/),
+        "partner.displayArtistsSection": (v12/*: any*/),
+        "partner.displayFullPartnerPage": (v12/*: any*/),
+        "partner.displayWorksSection": (v12/*: any*/),
+        "partner.id": (v9/*: any*/),
+        "partner.isDefaultProfilePublic": (v12/*: any*/),
+        "partner.locations": (v13/*: any*/),
+        "partner.locations.edges": (v14/*: any*/),
+        "partner.locations.edges.node": (v15/*: any*/),
+        "partner.locations.edges.node.city": (v10/*: any*/),
+        "partner.locations.edges.node.id": (v9/*: any*/),
         "partner.locations.totalCount": (v8/*: any*/),
-        "partner.locationsConnection": (v12/*: any*/),
-        "partner.locationsConnection.edges": (v13/*: any*/),
-        "partner.locationsConnection.edges.node": (v14/*: any*/),
-        "partner.locationsConnection.edges.node.address": (v15/*: any*/),
-        "partner.locationsConnection.edges.node.address2": (v15/*: any*/),
-        "partner.locationsConnection.edges.node.city": (v15/*: any*/),
+        "partner.locationsConnection": (v13/*: any*/),
+        "partner.locationsConnection.edges": (v14/*: any*/),
+        "partner.locationsConnection.edges.node": (v15/*: any*/),
+        "partner.locationsConnection.edges.node.address": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.address2": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.city": (v10/*: any*/),
         "partner.locationsConnection.edges.node.coordinates": {
           "enumValues": null,
           "nullable": true,
@@ -785,25 +810,25 @@ return {
         },
         "partner.locationsConnection.edges.node.coordinates.lat": (v16/*: any*/),
         "partner.locationsConnection.edges.node.coordinates.lng": (v16/*: any*/),
-        "partner.locationsConnection.edges.node.country": (v15/*: any*/),
-        "partner.locationsConnection.edges.node.id": (v11/*: any*/),
-        "partner.locationsConnection.edges.node.phone": (v15/*: any*/),
-        "partner.locationsConnection.edges.node.postalCode": (v15/*: any*/),
-        "partner.locationsConnection.edges.node.state": (v15/*: any*/),
+        "partner.locationsConnection.edges.node.country": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.id": (v9/*: any*/),
+        "partner.locationsConnection.edges.node.phone": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.postalCode": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.state": (v10/*: any*/),
         "partner.meta": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerMeta"
         },
-        "partner.meta.description": (v15/*: any*/),
-        "partner.meta.image": (v15/*: any*/),
-        "partner.meta.title": (v15/*: any*/),
-        "partner.name": (v15/*: any*/),
+        "partner.meta.description": (v10/*: any*/),
+        "partner.meta.image": (v10/*: any*/),
+        "partner.meta.title": (v10/*: any*/),
+        "partner.name": (v10/*: any*/),
         "partner.notRepresentedArtists": (v17/*: any*/),
         "partner.notRepresentedArtists.totalCount": (v8/*: any*/),
-        "partner.partnerPageEligible": (v10/*: any*/),
-        "partner.partnerType": (v15/*: any*/),
+        "partner.partnerPageEligible": (v12/*: any*/),
+        "partner.partnerType": (v10/*: any*/),
         "partner.profile": {
           "enumValues": null,
           "nullable": true,
@@ -819,17 +844,17 @@ return {
         },
         "partner.profile.icon.resized.src": (v19/*: any*/),
         "partner.profile.icon.resized.srcSet": (v19/*: any*/),
-        "partner.profile.id": (v11/*: any*/),
+        "partner.profile.id": (v9/*: any*/),
         "partner.profile.image": (v18/*: any*/),
-        "partner.profile.image.url": (v15/*: any*/),
-        "partner.profile.internalID": (v11/*: any*/),
-        "partner.profile.is_followed": (v10/*: any*/),
-        "partner.profile.name": (v15/*: any*/),
-        "partner.profile.slug": (v11/*: any*/),
+        "partner.profile.image.url": (v10/*: any*/),
+        "partner.profile.internalID": (v9/*: any*/),
+        "partner.profile.is_followed": (v12/*: any*/),
+        "partner.profile.name": (v10/*: any*/),
+        "partner.profile.slug": (v9/*: any*/),
         "partner.representedArtists": (v17/*: any*/),
         "partner.representedArtists.totalCount": (v8/*: any*/),
-        "partner.slug": (v11/*: any*/),
-        "partner.type": (v15/*: any*/),
+        "partner.slug": (v9/*: any*/),
+        "partner.type": (v10/*: any*/),
         "partner.viewingRooms": {
           "enumValues": null,
           "nullable": true,
@@ -841,7 +866,7 @@ return {
     },
     "name": "PartnerApp_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
+    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerApp_partner.graphql.ts
+++ b/src/v2/__generated__/PartnerApp_partner.graphql.ts
@@ -9,6 +9,10 @@ export type PartnerApp_partner = {
     readonly displayFullPartnerPage: boolean | null;
     readonly partnerPageEligible: boolean | null;
     readonly isDefaultProfilePublic: boolean | null;
+    readonly categories: ReadonlyArray<{
+        readonly id: string;
+        readonly name: string | null;
+    } | null> | null;
     readonly profile: {
         readonly " $fragmentRefs": FragmentRefs<"PartnerHeaderImage_profile">;
     } | null;
@@ -60,6 +64,31 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
+      "concreteType": "PartnerCategory",
+      "kind": "LinkedField",
+      "name": "categories",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "Profile",
       "kind": "LinkedField",
       "name": "profile",
@@ -92,5 +121,5 @@ const node: ReaderFragment = {
   "type": "Partner",
   "abstractKey": null
 };
-(node as any).hash = '7ddbd3bf8397f8a6457dd30b85420462';
+(node as any).hash = '9ab19f514efb71031e2ccf955bc30515';
 export default node;

--- a/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -72,6 +72,10 @@ fragment PartnerApp_partner on Partner {
   displayFullPartnerPage
   partnerPageEligible
   isDefaultProfilePublic
+  categories {
+    id
+    name
+  }
   profile {
     ...PartnerHeaderImage_profile
     id
@@ -181,14 +185,14 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
+  "name": "name",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "slug",
   "storageKey": null
 },
 v7 = {
@@ -270,6 +274,19 @@ return {
             "args": null,
             "kind": "ScalarField",
             "name": "isDefaultProfilePublic",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PartnerCategory",
+            "kind": "LinkedField",
+            "name": "categories",
+            "plural": true,
+            "selections": [
+              (v4/*: any*/),
+              (v5/*: any*/)
+            ],
             "storageKey": null
           },
           {
@@ -357,8 +374,8 @@ return {
                 ],
                 "storageKey": null
               },
-              (v5/*: any*/),
               (v6/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -516,8 +533,8 @@ return {
             ],
             "storageKey": null
           },
-          (v6/*: any*/),
           (v5/*: any*/),
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -682,12 +699,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1e517ad99c75f99e463802269f1f8f63",
+    "cacheID": "ec8f5fdbc388ebec242d278cd0fa7eaf",
     "id": null,
     "metadata": {},
     "name": "partnerRoutes_PartnerQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
   }
 };
 })();


### PR DESCRIPTION
[GRO-771]

There might be a less repetitive solution and I'm open to suggestions, but everything I tried seemed overly complex or confusing so I just did the straightforward thing. The "Black Owned" category doesn't actually exist yet, so I used a different category to get the screenshots. 

<img width="563" alt="Screen Shot 2022-02-01 at 1 36 16 PM" src="https://user-images.githubusercontent.com/5643895/152030669-3cd6fba4-a972-4a9a-8d2d-14f1cea526fe.png">
<img width="966" alt="Screen Shot 2022-02-01 at 1 36 08 PM" src="https://user-images.githubusercontent.com/5643895/152030684-cb036257-c8bb-49ba-88e2-0518599f711c.png">



[GRO-771]: https://artsyproduct.atlassian.net/browse/GRO-771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ