### PR TITLE
fix: Reaction Import in V2

### DIFF
--- a/src/v2/Apps/Conversation/Components/ConversationHeader.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationHeader.tsx
@@ -5,7 +5,7 @@ import { themeGet } from "@styled-system/theme-get"
 
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { DetailIcon, DetailsProps } from "./DetailsHeader"
-import { Media } from "@artsy/reaction/dist/Utils/Responsive"
+import { Media } from "v2/Utils/Responsive"
 
 export const LARGE_SCREEN_HEADER_HEIGHT = "85px"
 export const SMALL_SCREEN_HEADER_HEIGHT = "55px"


### PR DESCRIPTION
Clean up an import that is erroneously causing `@arsty/reaction` to be
imported into v2.