### PR TITLE
feat (GRO-639): User sees updated visuals for auth options

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@artsy/fresnel": "3.2.2",
     "@artsy/gemup": "0.1.0",
     "@artsy/multienv": "^1.2.0",
-    "@artsy/palette": "18.20.0",
+    "@artsy/palette": "18.21.0",
     "@artsy/palette-charts": "17.20.0",
     "@artsy/reaction": "29.2.1",
     "@artsy/stitch": "6.4.2",

--- a/src/v2/Components/Authentication/Components/AuthenticationFooter.tsx
+++ b/src/v2/Components/Authentication/Components/AuthenticationFooter.tsx
@@ -1,4 +1,15 @@
-import { Box, BoxProps, Clickable, Text, Join, Spacer } from "@artsy/palette"
+import {
+  Box,
+  BoxProps,
+  Clickable,
+  IconButton,
+  Join,
+  Text,
+  Spacer,
+  FacebookIcon,
+  AppleIcon,
+  GoogleIcon,
+} from "@artsy/palette"
 import * as React from "react"
 import styled from "styled-components"
 import { ModalType } from "../Types"
@@ -28,41 +39,47 @@ export const AuthenticationFooter: React.FC<AuthenticationFooterProps> = ({
           case "login": {
             return (
               <>
-                {"Log in using "}
-                <Clickable
-                  color="black60"
-                  textDecoration="underline"
-                  onClick={onAppleLogin}
-                >
-                  Apple
-                </Clickable>
-                {", "}
-                <Clickable
-                  color="black60"
-                  textDecoration="underline"
-                  onClick={onGoogleLogin}
-                >
-                  Google
-                </Clickable>
-                {", "}
-                {" or "}
-                <Clickable
-                  color="black60"
-                  textDecoration="underline"
-                  onClick={onFacebookLogin}
-                >
-                  Facebook
-                </Clickable>
-                {". "}
-                {"Don’t have an account? "}
-                <Clickable
-                  color="black60"
-                  textDecoration="underline"
-                  onClick={() => handleTypeChange?.("signup" as ModalType)}
-                  data-test="signup"
-                >
-                  Sign up.
-                </Clickable>
+                <Join separator={<Spacer mt={2} />}>
+                  <IconButton
+                    color="black100"
+                    onClick={onAppleLogin}
+                    variant="secondaryOutline"
+                    icon={<AppleIcon />}
+                    width="100%"
+                  >
+                    Continue with Apple
+                  </IconButton>
+                  <IconButton
+                    color="black100"
+                    onClick={onGoogleLogin}
+                    variant="secondaryOutline"
+                    icon={<GoogleIcon />}
+                    width="100%"
+                  >
+                    Continue with Google
+                  </IconButton>
+                  <IconButton
+                    color="black100"
+                    onClick={onFacebookLogin}
+                    variant="secondaryOutline"
+                    icon={<FacebookIcon fill="blue100" />}
+                    width="100%"
+                  >
+                    Continue with Facebook
+                  </IconButton>
+                </Join>
+                <Spacer mt={2} />
+                <Box>
+                  {"Don't have an account? "}
+                  <Clickable
+                    color="black60"
+                    textDecoration="underline"
+                    onClick={() => handleTypeChange?.("signup" as ModalType)}
+                    data-test="signup"
+                  >
+                    Sign up.
+                  </Clickable>
+                </Box>
               </>
             )
           }
@@ -96,32 +113,35 @@ export const AuthenticationFooter: React.FC<AuthenticationFooterProps> = ({
             return (
               <Join separator={<Spacer mt={1} />}>
                 <Box>
-                  {"Sign up using "}
-                  <Clickable
-                    color="black60"
-                    textDecoration="underline"
-                    onClick={onAppleLogin}
-                  >
-                    Apple
-                  </Clickable>
-                  {", "}
-                  <Clickable
-                    color="black60"
-                    textDecoration="underline"
-                    onClick={onGoogleLogin}
-                  >
-                    Google
-                  </Clickable>
-                  {", "}
-                  {" or "}
-                  <Clickable
-                    color="black60"
-                    textDecoration="underline"
-                    onClick={onFacebookLogin}
-                  >
-                    Facebook
-                  </Clickable>
-                  {". "}
+                  <Join separator={<Spacer mt={2} />}>
+                    <IconButton
+                      color="black100"
+                      onClick={onAppleLogin}
+                      variant="secondaryOutline"
+                      icon={<AppleIcon />}
+                      width="100%"
+                    >
+                      Continue with Apple
+                    </IconButton>
+                    <IconButton
+                      color="black100"
+                      onClick={onGoogleLogin}
+                      variant="secondaryOutline"
+                      icon={<GoogleIcon />}
+                      width="100%"
+                    >
+                      Continue with Google
+                    </IconButton>
+                    <IconButton
+                      color="black100"
+                      onClick={onFacebookLogin}
+                      variant="secondaryOutline"
+                      icon={<FacebookIcon fill="blue100" />}
+                      width="100%"
+                    >
+                      Continue with Facebook
+                    </IconButton>
+                  </Join>
                 </Box>
 
                 <Box>

--- a/src/v2/Components/Authentication/Views/LoginForm.tsx
+++ b/src/v2/Components/Authentication/Views/LoginForm.tsx
@@ -157,6 +157,10 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
                   Log in
                 </Button>
 
+                <Text variant="sm" textAlign="center" color="black60">
+                  or
+                </Text>
+
                 <AuthenticationFooter
                   mode={"login" as ModalType}
                   handleTypeChange={() =>

--- a/src/v2/Components/Authentication/Views/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Views/SignUpForm.tsx
@@ -171,6 +171,50 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                   )}
                 </Box>
 
+                {status && !status.success && (
+                  <Banner variant="error">{status.error}</Banner>
+                )}
+
+                <Button type="submit" loading={isSubmitting} width="100%">
+                  Sign up
+                </Button>
+
+                <Text variant="sm" textAlign="center" color="black60">
+                  or
+                </Text>
+
+                <AuthenticationFooter
+                  mode={"signup" as ModalType}
+                  handleTypeChange={() =>
+                    this.props.handleTypeChange?.(ModalType.login)
+                  }
+                  onAppleLogin={async e => {
+                    if (!values.accepted_terms_of_service) {
+                      setTouched({ accepted_terms_of_service: true })
+                      await validateForm()
+                    } else {
+                      this.props.onAppleLogin?.(e)
+                    }
+                  }}
+                  onFacebookLogin={async e => {
+                    if (!values.accepted_terms_of_service) {
+                      setTouched({ accepted_terms_of_service: true })
+                      await validateForm()
+                    } else {
+                      this.props.onFacebookLogin?.(e)
+                    }
+                  }}
+                  onGoogleLogin={async e => {
+                    if (!values.accepted_terms_of_service) {
+                      setTouched({ accepted_terms_of_service: true })
+                      await validateForm()
+                    } else {
+                      this.props.onGoogleLogin?.(e)
+                    }
+                  }}
+                  showRecaptchaDisclaimer={this.props.showRecaptchaDisclaimer}
+                />
+
                 {collapseCheckboxes ? (
                   <AuthenticationCheckbox
                     error={!!termsErrorMessage}
@@ -238,46 +282,6 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                     promotional content. Unsubscribe at any time.
                   </AuthenticationCheckbox>
                 )}
-
-                {status && !status.success && (
-                  <Banner variant="error">{status.error}</Banner>
-                )}
-
-                <Button type="submit" loading={isSubmitting} width="100%">
-                  Sign up
-                </Button>
-
-                <AuthenticationFooter
-                  mode={"signup" as ModalType}
-                  handleTypeChange={() =>
-                    this.props.handleTypeChange?.(ModalType.login)
-                  }
-                  onAppleLogin={async e => {
-                    if (!values.accepted_terms_of_service) {
-                      setTouched({ accepted_terms_of_service: true })
-                      await validateForm()
-                    } else {
-                      this.props.onAppleLogin?.(e)
-                    }
-                  }}
-                  onFacebookLogin={async e => {
-                    if (!values.accepted_terms_of_service) {
-                      setTouched({ accepted_terms_of_service: true })
-                      await validateForm()
-                    } else {
-                      this.props.onFacebookLogin?.(e)
-                    }
-                  }}
-                  onGoogleLogin={async e => {
-                    if (!values.accepted_terms_of_service) {
-                      setTouched({ accepted_terms_of_service: true })
-                      await validateForm()
-                    } else {
-                      this.props.onGoogleLogin?.(e)
-                    }
-                  }}
-                  showRecaptchaDisclaimer={this.props.showRecaptchaDisclaimer}
-                />
               </Join>
             </Box>
           )

--- a/src/v2/Components/Authentication/__tests__/FormSwitcher.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/FormSwitcher.jest.tsx
@@ -1,5 +1,5 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
-import { Clickable } from "@artsy/palette"
+import { Clickable, IconButton } from "@artsy/palette"
 import { mount } from "enzyme"
 import { ForgotPasswordForm } from "../Views/ForgotPasswordForm"
 import { LoginForm } from "../Views/LoginForm"
@@ -114,8 +114,8 @@ describe("FormSwitcher", () => {
       })
 
       wrapper
-        .find(Clickable)
-        .findWhere(node => node.text() === "Apple")
+        .find(IconButton)
+        .findWhere(node => node.text().includes("Continue with Apple"))
         .first()
         .simulate("click")
 

--- a/src/v2/Components/Authentication/__tests__/Views/LoginForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Views/LoginForm.jest.tsx
@@ -15,6 +15,7 @@ describe("LoginForm", () => {
       handleSubmit: jest.fn(),
       onFacebookLogin: jest.fn(),
       onAppleLogin: jest.fn(),
+      onGoogleLogin: jest.fn(),
     }
     window.grecaptcha.execute.mockClear()
   })
@@ -56,7 +57,7 @@ describe("LoginForm", () => {
     wrapper.update()
 
     setTimeout(() => {
-      const submitButton = wrapper.find("Button")
+      const submitButton = wrapper.find("Button").at(0)
       expect((submitButton.props() as any).loading).toEqual(true)
       done()
     })
@@ -144,7 +145,10 @@ describe("LoginForm", () => {
 
     it("does not render email errors for social sign ups", done => {
       const wrapper = getWrapper()
-      const socialLink = wrapper.find("Clickable").at(0)
+      const socialLink = wrapper.find("IconButton").at(0)
+
+      expect(socialLink.text()).toContain("Continue with Apple")
+
       socialLink.simulate("click")
       wrapper.update()
 

--- a/src/v2/Components/Authentication/__tests__/Views/SignUpForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Views/SignUpForm.jest.tsx
@@ -110,11 +110,9 @@ describe("SignUpForm", () => {
       const wrapper = getWrapper()
 
       const appleLink = wrapper
-        .find("Clickable")
-        .findWhere(node => node.text() === "Apple")
+        .find("IconButton")
+        .findWhere(node => node.text().includes("Continue with Apple"))
         .first()
-
-      expect(appleLink.text()).toEqual("Apple")
 
       appleLink.simulate("click")
 
@@ -129,11 +127,9 @@ describe("SignUpForm", () => {
       const wrapper = getWrapper()
 
       const facebookLink = wrapper
-        .find("Clickable")
-        .findWhere(node => node.text() === "Facebook")
+        .find("IconButton")
+        .findWhere(node => node.text().includes("Continue with Facebook"))
         .first()
-
-      expect(facebookLink.text()).toEqual("Facebook")
 
       facebookLink.simulate("click")
 
@@ -148,11 +144,9 @@ describe("SignUpForm", () => {
       const wrapper = getWrapper()
 
       const googleLink = wrapper
-        .find("Clickable")
-        .findWhere(node => node.text() === "Google")
+        .find("IconButton")
+        .findWhere(node => node.text().includes("Continue with Google"))
         .first()
-
-      expect(googleLink.text()).toEqual("Google")
 
       googleLink.simulate("click")
 
@@ -167,11 +161,9 @@ describe("SignUpForm", () => {
       const wrapper = getWrapper()
 
       const appleLink = wrapper
-        .find("Clickable")
-        .findWhere(node => node.text() === "Apple")
+        .find("IconButton")
+        .findWhere(node => node.text().includes("Continue with Apple"))
         .first()
-
-      expect(appleLink.text()).toEqual("Apple")
 
       appleLink.simulate("click")
 
@@ -186,11 +178,9 @@ describe("SignUpForm", () => {
       const wrapper = getWrapper()
 
       const appleLink = wrapper
-        .find("Clickable")
-        .findWhere(node => node.text() === "Apple")
+        .find("IconButton")
+        .findWhere(node => node.text().includes("Continue with Apple"))
         .first()
-
-      expect(appleLink.text()).toEqual("Apple")
 
       appleLink.simulate("click")
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,7 +94,26 @@
   resolved "https://registry.yarnpkg.com/@artsy/palette-tokens/-/palette-tokens-2.6.0.tgz#3d780ff65994fef0daadef29d43d11f89470b728"
   integrity sha512-UQP6P+xv/5hm82ep0z5X3kCFFnk03H6y8kdW/wTU+xPq45ESUay7aNFYXeub47tmW2v6dXJ8Oa01Z0iwc6BVpA==
 
-"@artsy/palette@18.20.0", "@artsy/palette@^18.20.0":
+"@artsy/palette@18.21.0":
+  version "18.21.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-18.21.0.tgz#deeb82a4786e3cfd7ffefe3ea4d4e86bc813fe07"
+  integrity sha512-ZezrvlAtxbWc8F/lTBxTBTHN7ALOuqKIYR3ArJO9ukvonooSl8HGJ/ZQ9Ws85WlEkyrw0BpJNgvz+9O3H34fRg==
+  dependencies:
+    "@artsy/palette-tokens" "^2.6.0"
+    "@seznam/compose-react-refs" "^1.0.6"
+    "@styled-system/theme-get" "^5.1.2"
+    lodash "^4.17.21"
+    luxon "^1.15"
+    proportional-scale "^4.0.0"
+    react-lazy-load-image-component "1.5.0"
+    react-remove-scroll "^2.3.0"
+    styled-bootstrap-grid "3.1.0"
+    styled-system "^5.1.5"
+    trunc-html "^1.1.2"
+    use-cursor "^1.2.3"
+    use-keyboard-list-navigation "2.4.2"
+
+"@artsy/palette@^18.20.0":
   version "18.20.0"
   resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-18.20.0.tgz#c8cc3aee5d45f009797557a726d4ec649216295b"
   integrity sha512-MWmmbj1hrzqzYU3/jwAn1wkub9LGMqHrnN7N1YIq7csVOhVFS13A2uw8TQ6GOYom+ccWR0THyR6mMQIli2LKuw==


### PR DESCRIPTION
The designs accompanying this ticket are quite a bit broader in scope than the ticket itself, and there were some changes to the legal text that we aren't totally sure about ([related Slack thread](https://artsy.slack.com/archives/C01ADJNCS5D/p1643746728541839)).

To match those designs, it seems like we'll have to rewrite most of the view logic.

We settled on leaving things in this halfway state since we'll be revisiting the modal fairly soon anyway.

Ticket: [GRO-639](https://artsyproduct.atlassian.net/browse/GRO-639)

<details>
<summary>Log in modal (after)</summary>
<img width="583" alt="image" src="https://user-images.githubusercontent.com/11466782/153265959-bc90cf34-f07b-4daa-ab25-35490011874a.png">
</details>

<details>
<summary>Sign up modal (after)</summary>
<img width="549" alt="image" src="https://user-images.githubusercontent.com/11466782/153266089-74c2977a-8d5f-4701-bef1-31138a66a64c.png">
</details>