### PR TITLE
chore(FX-3665): replace deprecated artistID with artistIDs[]

### DIFF
--- a/src/v2/Components/ArtworkFilter/SavedSearch/Utils/__tests__/savedSearchCriteria.jest.ts
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Utils/__tests__/savedSearchCriteria.jest.ts
@@ -18,12 +18,12 @@ const mockedFilters: ArtworkFilters = {
 }
 
 describe("getSearchCriteriaFromFilters", () => {
-  it("returns object only containing artist id and criteria that has been changed", () => {
+  it("returns object only containing artist ids and criteria that has been changed", () => {
     const result = getSearchCriteriaFromFilters(mockedArtistId, mockedFilters)
 
     expect(result).toEqual(
       expect.objectContaining({
-        artistID: "artist-id",
+        artistIDs: ["artist-id"],
         attributionClass: ["limited edition", "unique", "open edition"],
         colors: ["black"],
         inquireableOnly: true,

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Utils/savedSearchCriteria.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Utils/savedSearchCriteria.tsx
@@ -43,7 +43,7 @@ export const getSearchCriteriaFromFilters = (
   )
 
   const criteria: SearchCriteriaAttributes = {
-    artistID,
+    artistIDs: [artistID],
     ...input,
   }
 


### PR DESCRIPTION
Type: **Chore**
Jira ticket: [FX-3665]

### Description
Follow up of artsy/metaphysics#3699.

Replaces `artistID` with `artistIDs` for saved searches.

### Demo
https://user-images.githubusercontent.com/3513494/152139110-8e67b0e5-3938-492e-af38-0ba2c473fbde.mp4

#### Saved alert
<img width="608" alt="demo screenshot" src="https://user-images.githubusercontent.com/3513494/152139737-28ec08a6-ee91-4acf-b395-f831cae4a97b.png">


[FX-3665]: https://artsyproduct.atlassian.net/browse/FX-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ