### PR TITLE
feat(FX-3714): Parse old format of values for size filter

### DIFF
--- a/src/v2/Components/SavedSearchAlert/Utils/__tests__/extractPills.jest.ts
+++ b/src/v2/Components/SavedSearchAlert/Utils/__tests__/extractPills.jest.ts
@@ -1,0 +1,84 @@
+import { extractSizeLabelForOldFormat, extractSizeLabel } from "../extractPills"
+
+describe("extractSizeLabel", () => {
+  it("returns only small size filter value", () => {
+    expect(extractSizeLabel(["SMALL"])).toEqual([
+      {
+        filterName: "sizes",
+        name: "SMALL",
+        displayName: "Small (under 40cm)",
+      },
+    ])
+  })
+
+  it("returns only medium size filter value", () => {
+    expect(extractSizeLabel(["MEDIUM"])).toEqual([
+      {
+        filterName: "sizes",
+        name: "MEDIUM",
+        displayName: "Medium (40 – 100cm)",
+      },
+    ])
+  })
+
+  it("returns only large size filter value", () => {
+    expect(extractSizeLabel(["LARGE"])).toEqual([
+      {
+        filterName: "sizes",
+        name: "LARGE",
+        displayName: "Large (over 100cm)",
+      },
+    ])
+  })
+
+  it("returns small and large size filter values", () => {
+    expect(extractSizeLabel(["SMALL", "LARGE"])).toEqual([
+      {
+        filterName: "sizes",
+        name: "SMALL",
+        displayName: "Small (under 40cm)",
+      },
+      {
+        filterName: "sizes",
+        name: "LARGE",
+        displayName: "Large (over 100cm)",
+      },
+    ])
+  })
+})
+
+describe("extractSizeLabelForOldFormat", () => {
+  it("returns null value for an unknown value of the old size filter", () => {
+    expect(extractSizeLabelForOldFormat("5.0-16.0")).toBeNull()
+  })
+
+  it("returns SMALL value for old size filter value", () => {
+    expect(extractSizeLabelForOldFormat("*-16.0")).toEqual([
+      {
+        filterName: "sizes",
+        name: "SMALL",
+        displayName: "Small (under 40cm)",
+      },
+    ])
+  })
+
+  it("returns MEDIUM value for old size filter value", () => {
+    expect(extractSizeLabelForOldFormat("16.0-40.0")).toEqual([
+      {
+        filterName: "sizes",
+        name: "MEDIUM",
+        displayName: "Medium (40 – 100cm)",
+      },
+    ])
+  })
+
+  it("returns LARGE value for old size filter value", () => {
+    expect(extractSizeLabelForOldFormat("40.0-*")).toEqual([
+      {
+        filterName: "sizes",
+        name: "LARGE",
+        displayName: "Large (over 100cm)",
+      },
+    ])
+  })
+})


### PR DESCRIPTION
Type: **Feature**
Jira ticket: [FX-3714]

### Description
Previously, when creating alerts in Eigen, old format of values for the size filter was used, where the user could specify only single size option. A little later, this logic was updated to match Force (user can specify multiple options). But since the user could have previously created a saved search alert with old format, it is necessary to correctly convert old format to the new one in order for the selected filters to be displayed correctly as pills on edit alert screen.

### Acceptance Criteria
* Old format of values for the size filter should be converted to the new format
  * `dimensionRange: "*-16.0"` must be converted to `sizes: ["SMALL"]`
  * `dimensionRange: "16.0-40.0"` must be converted to `sizes: ["MEDIUM"]`
  * `dimensionRange: "40.0-*"` must be converted to `sizes: ["LARGE"]`
* Correctly display old format of values as pills
  * `dimensionRange: "*-16.0"` must be converted to `Small (under 40cm)`
  * `dimensionRange: "16.0-40.0"` must be converted to `Medium (40 – 100cm)`
  * `dimensionRange: "40.0-*"` must be converted to `Large (over 100cm)`

### Demo
For example, we have created alerts with old format of values for the size filter
<img width="544" alt="old format" src="https://user-images.githubusercontent.com/3513494/152148213-3885998e-1eb3-4792-a071-fa64de8d244c.png">

and here is the result of their conversion to a new format

https://user-images.githubusercontent.com/3513494/152148981-0409023e-05f3-4a66-ac80-6a4391104f62.mp4

[FX-3714]: https://artsyproduct.atlassian.net/browse/FX-3714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ