### PR TITLE
fix: Corrected logic which led to one event firing multiple times

### DIFF
--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -49,6 +49,10 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
     }
   }, [showError])
 
+  useEffect(() => {
+    if (toggle) trackClick("Different amount", 0)
+  }, [toggle])
+
   const trackClick = (offer: string, amount: number) => {
     const trackingData: ClickedOfferOption = {
       action: ActionType.clickedOfferOption,
@@ -60,7 +64,6 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
       offer,
       amount,
     }
-
     tracking.trackEvent(trackingData)
   }
 
@@ -153,8 +156,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
             error={showError}
             onSelect={() => {
               customValue && onChange(customValue)
-              setToggle(true)
-              trackClick("Different amount", 0)
+              !toggle && setToggle(true)
             }}
             key="price-option-custom"
           >

--- a/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
@@ -135,7 +135,7 @@ describe("PriceOptions", () => {
         "We recommend changing your offer to US$100.00."
       )
       expect(notice).toBeInTheDocument()
-      expect(trackEvent).toHaveBeenLastCalledWith(
+      expect(trackEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           action_type: "Viewed offer too low",
           flow: "Make offer",


### PR DESCRIPTION
Because of how the triggering of the "different amount" option was set up, whenever the user would interact with anything on that radio, it would cause the event to fire continuously. Corrected to only fire once on selection.