### PR TITLE
Fix: old order events not showing up in conversations

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -303,7 +303,7 @@ export const ConversationPaginationContainer = createPaginationContainer(
         unread
         orderConnection(
           first: 10
-          states: [APPROVED, FULFILLED, SUBMITTED]
+          states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED, CANCELED]
           participantType: BUYER
         ) {
           edges {


### PR DESCRIPTION
I caused this bug as part of my sidebar PR because I removed `CANCELED` and `REFUNDED` events from the conversation query and I don't even remember why I did it - the sidebar component was already filtering those events out. Sorry everyone :(

