### PR TITLE
[SWA-185]: Display "Processing" label on an image preview if still processing

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/PhotoThumbnail.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/PhotoThumbnail.tsx
@@ -57,6 +57,12 @@ export const PhotoThumbnail: React.FC<PhotoThumbnailProps & BoxProps> = ({
     }
   }, [photo])
 
+  useEffect(() => {
+    if (!photoSrc && photo.url) {
+      setPhotoSrc(photo.url)
+    }
+  }, [photo.url, photoSrc])
+
   const handleDelete = () => onDelete(photo)
 
   const renderThumbnail = photoSrc => {

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/PhotoThumbnail.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/PhotoThumbnail.tsx
@@ -10,7 +10,9 @@ import {
   Clickable,
   ProgressBar,
   CloseCircleIcon,
+  Spinner,
 } from "@artsy/palette"
+import { Media } from "v2/Utils/Responsive"
 import styled from "styled-components"
 import { formatFileSize, Photo } from "../../Utils/fileUtils"
 
@@ -54,12 +56,14 @@ export const PhotoThumbnail: React.FC<PhotoThumbnailProps & BoxProps> = ({
       photoSrc,
     }
 
-    if (photo.url || photo.geminiToken) {
-      return <PhotoThumbnailSuccessState {...props} />
+    if (photo.loading) {
+      return <PhotoThumbnailLoadingState {...props} />
     } else if (photo.errorMessage) {
       return <PhotoThumbnailErrorState {...props} />
-    } else if (photo.loading) {
-      return <PhotoThumbnailLoadingState {...props} />
+    } else if (photo.url || photo.file) {
+      return <PhotoThumbnailSuccessState {...props} />
+    } else if (photo.geminiToken) {
+      return <PhotoThumbnailProcessingState {...props} />
     }
   }
 
@@ -188,6 +192,54 @@ const PhotoThumbnailSuccessState: React.FC<PhotoThumbnailStateProps> = ({
           height="100%"
           width="100%"
         />
+      </Box>
+      <TruncatedLine variant="xs">{photo.name}</TruncatedLine>
+    </Flex>
+    <Flex alignItems="center" justifyContent="space-between">
+      <Text variant="xs">{formatFileSize(photo.size)}</Text>
+      <RemoveButton handleDelete={onDelete} />
+    </Flex>
+  </>
+)
+
+const PhotoThumbnailProcessingState: React.FC<PhotoThumbnailStateProps> = ({
+  onDelete,
+  photoSrc,
+  photo,
+}) => (
+  <>
+    <Flex alignItems="center">
+      <Box
+        height={[48, 120]}
+        width={[48, 120]}
+        minWidth={[48, 120]}
+        mr={[15, 2]}
+        bg="black10"
+        position="relative"
+      >
+        <Media at="xs">
+          <Spinner size="small" />
+        </Media>
+
+        <Media greaterThan="xs">
+          <Image
+            src={photoSrc}
+            style={{ objectFit: "cover" }}
+            height="100%"
+            width="100%"
+          />
+          <Flex
+            position="absolute"
+            top={0}
+            left={0}
+            right={0}
+            bottom={0}
+            alignItems="center"
+            justifyContent="center"
+          >
+            Processing
+          </Flex>
+        </Media>
       </Box>
       <TruncatedLine variant="xs">{photo.name}</TruncatedLine>
     </Flex>

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/PhotoThumbnail.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/PhotoThumbnail.tsx
@@ -27,6 +27,16 @@ const TruncatedLine = styled(Text)`
   overflow: hidden;
 `
 
+const ImageContainer = styled(Box).attrs({
+  height: [48, 120],
+  width: [48, 120],
+  minWidth: [48, 120],
+  mr: [15, 2],
+  bg: "black10",
+})`
+  cursor: default;
+`
+
 export const PhotoThumbnail: React.FC<PhotoThumbnailProps & BoxProps> = ({
   photo,
   onDelete,
@@ -134,20 +144,14 @@ const PhotoThumbnailLoadingState: React.FC<PhotoThumbnailStateProps> = ({
   photo,
 }) => (
   <Column span={[2]} display="flex" alignItems="center" flexDirection="row">
-    <Box
-      height={[48, 120]}
-      width={[48, 120]}
-      minWidth={[48, 120]}
-      mr={[15, 2]}
-      bg="black10"
-    >
+    <ImageContainer>
       <Image
         src={photoSrc}
         style={{ objectFit: "cover" }}
         height="100%"
         width="100%"
       />
-    </Box>
+    </ImageContainer>
     <ProgressBar
       width="100%"
       highlight="brand"
@@ -179,20 +183,14 @@ const PhotoThumbnailSuccessState: React.FC<PhotoThumbnailStateProps> = ({
 }) => (
   <>
     <Flex alignItems="center">
-      <Box
-        height={[48, 120]}
-        width={[48, 120]}
-        minWidth={[48, 120]}
-        mr={[15, 2]}
-        bg="black10"
-      >
+      <ImageContainer>
         <Image
           src={photoSrc}
           style={{ objectFit: "cover" }}
           height="100%"
           width="100%"
         />
-      </Box>
+      </ImageContainer>
       <TruncatedLine variant="xs">{photo.name}</TruncatedLine>
     </Flex>
     <Flex alignItems="center" justifyContent="space-between">
@@ -204,43 +202,24 @@ const PhotoThumbnailSuccessState: React.FC<PhotoThumbnailStateProps> = ({
 
 const PhotoThumbnailProcessingState: React.FC<PhotoThumbnailStateProps> = ({
   onDelete,
-  photoSrc,
   photo,
 }) => (
   <>
     <Flex alignItems="center">
-      <Box
-        height={[48, 120]}
-        width={[48, 120]}
-        minWidth={[48, 120]}
-        mr={[15, 2]}
-        bg="black10"
+      <ImageContainer
         position="relative"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
       >
         <Media at="xs">
           <Spinner size="small" />
         </Media>
 
         <Media greaterThan="xs">
-          <Image
-            src={photoSrc}
-            style={{ objectFit: "cover" }}
-            height="100%"
-            width="100%"
-          />
-          <Flex
-            position="absolute"
-            top={0}
-            left={0}
-            right={0}
-            bottom={0}
-            alignItems="center"
-            justifyContent="center"
-          >
-            Processing
-          </Flex>
+          <Text color="black60">Processing</Text>
         </Media>
-      </Box>
+      </ImageContainer>
       <TruncatedLine variant="xs">{photo.name}</TruncatedLine>
     </Flex>
     <Flex alignItems="center" justifyContent="space-between">

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/__tests__/PhotoThumbnail.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/__tests__/PhotoThumbnail.jest.tsx
@@ -169,4 +169,54 @@ describe("PhotoThumbnail", () => {
       expect(deleteFn).toHaveBeenCalledWith(defaultProps.photo)
     })
   })
+
+  describe("Processing state", () => {
+    const photo = {
+      id: "id",
+      name: "foo.png",
+      size: file.size,
+      removed: false,
+      loading: false,
+      geminiToken: "key",
+    }
+
+    beforeEach(() => {
+      //@ts-ignore
+      jest.spyOn(global, "FileReader").mockImplementation(function () {
+        this.readAsDataURL = jest.fn()
+      })
+
+      wrapper = getWrapper({
+        ...defaultProps,
+        photo: photo,
+      })
+    })
+
+    it("renders name", () => {
+      expect(wrapper.text()).toContain("foo.png")
+    })
+
+    it("renders size", () => {
+      expect(wrapper.text()).toContain("0.01 MB")
+    })
+
+    it("doesn't renders image", () => {
+      expect(wrapper.find(Image)).toHaveLength(0)
+    })
+
+    it("renders processing label", () => {
+      expect(wrapper.text()).toContain("Processing")
+    })
+
+    it("renders delete button", () => {
+      const deletePhotoThumbnail = wrapper.find("RemoveButton")
+
+      expect(deletePhotoThumbnail).toHaveLength(1)
+
+      deletePhotoThumbnail.simulate("click")
+
+      expect(deleteFn).toHaveBeenCalled()
+      expect(deleteFn).toHaveBeenCalledWith(photo)
+    })
+  })
 })

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/__tests__/PhotoThumbnail.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/__tests__/PhotoThumbnail.jest.tsx
@@ -1,4 +1,4 @@
-import { mount } from "enzyme"
+import { mount, ReactWrapper } from "enzyme"
 import {
   PhotoThumbnail,
   PhotoThumbnailProps,
@@ -25,21 +25,49 @@ const getWrapper = (props: PhotoThumbnailProps = defaultProps) =>
   mount(<PhotoThumbnail {...props} />)
 
 describe("PhotoThumbnail", () => {
-  let wrapper
+  let wrapper: ReactWrapper
 
   beforeEach(() => {
     deleteFn.mockReset()
+    //@ts-ignore
+    jest.spyOn(global, "FileReader").mockImplementation(function () {
+      this.readAsDataURL = jest.fn()
+    })
+  })
+
+  it("changes state from processing to success", () => {
+    let photo = {
+      id: "id",
+      name: "foo.png",
+      size: file.size,
+      removed: false,
+      loading: false,
+      geminiToken: "key",
+      url: "",
+    }
+
+    wrapper = getWrapper({
+      ...defaultProps,
+      photo: photo,
+    })
+
+    expect(wrapper.find(Image)).toHaveLength(0)
+
+    photo.url = "foo.png"
+    wrapper.setProps({
+      ...defaultProps,
+      photo: photo,
+    })
+
+    wrapper.update()
+
+    expect(wrapper.find(Image)).toHaveLength(1)
   })
 
   describe("error state", () => {
     let props
 
     beforeEach(() => {
-      //@ts-ignore
-      jest.spyOn(global, "FileReader").mockImplementation(function () {
-        this.readAsDataURL = jest.fn()
-      })
-
       props = {
         ...defaultProps,
         photo: {
@@ -87,11 +115,6 @@ describe("PhotoThumbnail", () => {
     let props
 
     beforeEach(() => {
-      //@ts-ignore
-      jest.spyOn(global, "FileReader").mockImplementation(function () {
-        this.readAsDataURL = jest.fn()
-      })
-
       props = {
         ...defaultProps,
         photo: {
@@ -138,11 +161,6 @@ describe("PhotoThumbnail", () => {
 
   describe("success state", () => {
     beforeEach(() => {
-      //@ts-ignore
-      jest.spyOn(global, "FileReader").mockImplementation(function () {
-        this.readAsDataURL = jest.fn()
-      })
-
       wrapper = getWrapper()
     })
 
@@ -181,11 +199,6 @@ describe("PhotoThumbnail", () => {
     }
 
     beforeEach(() => {
-      //@ts-ignore
-      jest.spyOn(global, "FileReader").mockImplementation(function () {
-        this.readAsDataURL = jest.fn()
-      })
-
       wrapper = getWrapper({
         ...defaultProps,
         photo: photo,

--- a/src/v2/__generated__/UploadPhotos_ImageRefetch_Query.graphql.ts
+++ b/src/v2/__generated__/UploadPhotos_ImageRefetch_Query.graphql.ts
@@ -1,0 +1,160 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+export type UploadPhotos_ImageRefetch_QueryVariables = {
+    id: string;
+    sessionID?: string | null;
+};
+export type UploadPhotos_ImageRefetch_QueryResponse = {
+    readonly submission: {
+        readonly id: string;
+        readonly assets: ReadonlyArray<{
+            readonly id: string;
+            readonly imageUrls: unknown | null;
+            readonly geminiToken: string | null;
+            readonly size: string | null;
+            readonly filename: string | null;
+        } | null> | null;
+    } | null;
+};
+export type UploadPhotos_ImageRefetch_Query = {
+    readonly response: UploadPhotos_ImageRefetch_QueryResponse;
+    readonly variables: UploadPhotos_ImageRefetch_QueryVariables;
+};
+
+
+
+/*
+query UploadPhotos_ImageRefetch_Query(
+  $id: ID!
+  $sessionID: String
+) {
+  submission(id: $id, sessionID: $sessionID) {
+    id
+    assets {
+      id
+      imageUrls
+      geminiToken
+      size
+      filename
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "sessionID"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "id",
+        "variableName": "id"
+      },
+      {
+        "kind": "Variable",
+        "name": "sessionID",
+        "variableName": "sessionID"
+      }
+    ],
+    "concreteType": "ConsignmentSubmission",
+    "kind": "LinkedField",
+    "name": "submission",
+    "plural": false,
+    "selections": [
+      (v1/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ConsignmentSubmissionCategoryAsset",
+        "kind": "LinkedField",
+        "name": "assets",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "imageUrls",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "geminiToken",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "size",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "filename",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "UploadPhotos_ImageRefetch_Query",
+    "selections": (v2/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "UploadPhotos_ImageRefetch_Query",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "0adfbc258a8ab403d98dd5913fbdddf4",
+    "id": null,
+    "metadata": {},
+    "name": "UploadPhotos_ImageRefetch_Query",
+    "operationKind": "query",
+    "text": "query UploadPhotos_ImageRefetch_Query(\n  $id: ID!\n  $sessionID: String\n) {\n  submission(id: $id, sessionID: $sessionID) {\n    id\n    assets {\n      id\n      imageUrls\n      geminiToken\n      size\n      filename\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '7040a50cc1e19f9ea5255fbeb1b1b390';
+export default node;


### PR DESCRIPTION
When I upload an image and navigate away from the photo upload step, if I return to the photo upload step before Gemini has finished processing a thumbnail for the image, then I see an empty grey box. Now instead text "Processing" will be shown atop of the grey box in > xs version, and in xs version we show Spinner instead

Jira - https://artsyproduct.atlassian.net/browse/SWA-185

https://user-images.githubusercontent.com/79979820/152970059-cb189aa4-f1a1-4345-a63c-9c40e864fb6c.mov

Image refeching:

https://user-images.githubusercontent.com/79979820/153593567-8338bfa1-ce4b-4f33-87aa-69f8b89b7f64.mov


