### PR TITLE
feat: Remove admin flag for NFT medium filter and move above fold

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -8,8 +8,6 @@ import { ShowMore, INITIAL_ITEMS_TO_SHOW } from "./ShowMore"
 import { intersection } from "lodash"
 import { FilterExpandable } from "./FilterExpandable"
 import { useFilterLabelCountByKey } from "../Utils/useFilterLabelCountByKey"
-import { userIsAdmin } from "v2/Utils/user"
-import { useSystemContext } from "v2/System"
 import { sortResults } from "./Utils/sortResults"
 
 export interface MediumFilterProps {
@@ -18,7 +16,6 @@ export interface MediumFilterProps {
 
 export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
   const { aggregations, counts, ...filterContext } = useArtworkFilterContext()
-  const { user } = useSystemContext()
 
   const filtersCount = useFilterLabelCountByKey(
     SelectedFiltersCountsLabels.additionalGeneIDs
@@ -30,12 +27,8 @@ export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
     counts: [],
   }
 
-  const filteredHardcodedMediums = userIsAdmin(user)
-    ? hardcodedMediums
-    : hardcodedMediums.filter(medium => medium.value !== "nft")
-
   const allowedMediums =
-    mediums && mediums.counts.length ? mediums.counts : filteredHardcodedMediums
+    mediums && mediums.counts.length ? mediums.counts : hardcodedMediums
 
   const toggleMediumSelection = (selected, slug) => {
     let geneIDs =
@@ -115,6 +108,10 @@ export const hardcodedMediums = [
     name: "Work on Paper",
   },
   {
+    value: "nft",
+    name: "NFT",
+  },
+  {
     value: "design",
     name: "Design",
   },
@@ -145,9 +142,5 @@ export const hardcodedMediums = [
   {
     value: "ephemera-or-merchandise",
     name: "Ephemera or Merchandise",
-  },
-  {
-    value: "nft",
-    name: "NFT",
   },
 ]


### PR DESCRIPTION
Removing the admin flag for the NFT medium type and moving it up above the fold in the medium filter on artsy.net/collect

Thanks to @SamRozen's [ping in Slack](https://artsy.slack.com/archives/C02STV6RDT4/p1643834792432649), now noticing that we have ~15 works populated [here](https://www.artsy.net/collect/nft) that partners added themselves in the last couple weeks. This is even before we've done the migration that we're planning for next week: manually switching the medium type on ~230 works to "NFT" so they populate here too. I think that's enough to roll out to production.

How it looks above the fold:
<img width="1409" alt="Screen Shot 2022-02-04 at 4 29 40 PM" src="https://user-images.githubusercontent.com/9466631/152606154-2874b09b-0006-4101-b53b-24395f48bb9e.png">