### PR TITLE
chore: remove new offer submission flag

### DIFF
--- a/src/v2/Apps/Order/Routes/Offer/index.tsx
+++ b/src/v2/Apps/Order/Routes/Offer/index.tsx
@@ -32,7 +32,6 @@ import { getOfferItemFromOrder } from "v2/Apps/Order/Utils/offerItemExtractor"
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { isNil } from "lodash"
 import { appendCurrencySymbol } from "v2/Apps/Order/Utils/currencyUtils"
-import { userHasLabFeature } from "v2/Utils/user"
 import { SystemContextProps, withSystemContext } from "v2/System"
 
 export interface OfferProps extends SystemContextProps {
@@ -238,11 +237,6 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
     const isInquiryCheckout = !artwork?.isPriceRange && !artwork?.price
     const isEdition = artwork?.isEdition
 
-    const newOfferSubmissionEnabled = userHasLabFeature(
-      this.props.user,
-      "New Offer Submissions"
-    )
-
     return (
       <>
         <OrderStepper currentStep="Offer" steps={offerFlowSteps} />
@@ -253,8 +247,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
               style={isCommittingMutation ? { pointerEvents: "none" } : {}}
               id="offer-page-left-column"
             >
-              {(!newOfferSubmissionEnabled ||
-                isInquiryCheckout ||
+              {(isInquiryCheckout ||
                 isEdition) && (
                 <>
                   <Flex flexDirection="column">
@@ -270,7 +263,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
                   {priceNote}
                 </>
               )}
-              {newOfferSubmissionEnabled && !isInquiryCheckout && !isEdition && (
+              {!isInquiryCheckout && !isEdition && (
                 <>
                   <Text variant="lg" color="black80" mt={2}>
                     Select an Option

--- a/src/v2/Apps/Order/Routes/__tests__/Utils/OrderAppTestPage.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Utils/OrderAppTestPage.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@artsy/palette"
+import { BorderedRadio, Button } from "@artsy/palette"
 import { Stepper } from "@artsy/palette"
 import { ArtworkSummaryItemFragmentContainer } from "v2/Apps/Order/Components/ArtworkSummaryItem"
 import { BuyerGuarantee } from "v2/Apps/Order/Components/BuyerGuarantee"
@@ -6,6 +6,7 @@ import { ConditionsOfSaleDisclaimer } from "v2/Apps/Order/Components/ConditionsO
 import { CreditCardSummaryItemFragmentContainer } from "v2/Apps/Order/Components/CreditCardSummaryItem"
 import { OfferInput } from "v2/Apps/Order/Components/OfferInput"
 import { OrderStepper } from "v2/Apps/Order/Components/OrderStepper"
+import { PriceOptions } from "v2/Apps/Order/Components/PriceOptions"
 import { ShippingArtaSummaryItemFragmentContainer } from "v2/Apps/Order/Components/ShippingArtaSummaryItem"
 import { ShippingSummaryItemFragmentContainer } from "v2/Apps/Order/Components/ShippingSummaryItem"
 import { TransactionDetailsSummaryItem } from "v2/Apps/Order/Components/TransactionDetailsSummaryItem"
@@ -69,11 +70,29 @@ export class OrderAppTestPage extends RootTestPage {
     return expectOne(this.find(OfferInput))
   }
 
+  get priceOptions() {
+    return expectOne(this.find(PriceOptions))
+  }
+
   /** PAGE ACTIONS **/
 
   async clickSubmit() {
     this.submitButton.simulate("click")
     await this.update()
+  }
+
+  async selectCustomAmount() {
+    this.priceOptions.find(BorderedRadio).last().simulate("click")
+    await this.update()
+  }
+
+  async selectPriceOption(option: number) {
+    this.priceOptions.find(BorderedRadio).at(option).simulate("click")
+    await this.update()
+  }
+
+  async selectRandomPriceOption() {
+    await this.selectPriceOption(Math.floor(Math.random() * 3))
   }
 
   async dismissModal() {
@@ -114,6 +133,7 @@ export class OrderAppTestPage extends RootTestPage {
   }
 
   async setOfferAmount(amount: number) {
+    if (this.find(PriceOptions).length) this.selectCustomAmount()
     this.offerInput.props().onChange(amount)
     await this.update()
   }

--- a/src/v2/Apps/__tests__/Fixtures/Order.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Order.ts
@@ -66,7 +66,7 @@ const OrderArtworkNodeWithoutShipping = {
   is_offerable: true as boolean,
   listPrice: {
     __typename: "Money",
-    major: 10000,
+    major: 16000,
   },
   medium: "Oil and pencil on panel",
   onlyShipsDomestically: false,


### PR DESCRIPTION
[NX-3015]

This PR removes flag checks for the "New Offer Submission" page and updates tests accordingly.
cc @artsy/negotiate-devs 

[NX-3015]: https://artsyproduct.atlassian.net/browse/NX-3015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ