### PR TITLE
feat: Fallback to GDPR-compliant version GRO-802

### DIFF
--- a/src/v2/Components/Authentication/Views/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Views/SignUpForm.tsx
@@ -82,7 +82,8 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
     }
 
     const countryCode = this.props.requestLocation?.countryCode || ""
-    const collapseCheckboxes = !gdprCountries.includes(countryCode)
+    const collapseCheckboxes =
+      countryCode && !gdprCountries.includes(countryCode)
 
     return (
       <Formik

--- a/src/v2/Components/Authentication/__tests__/Views/SignUpForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Views/SignUpForm.jest.tsx
@@ -93,6 +93,23 @@ describe("SignUpForm", () => {
     })
   })
 
+  describe("with a missing country code", () => {
+    const countryCode = null
+
+    it("uses the GDPR label and shows the email checkbox", () => {
+      const wrapper = getWrapper({
+        RequestLocation: () => ({ countryCode }),
+      })
+
+      expect(wrapper.text()).toContain(
+        "By checking this box, you consent to our"
+      )
+      expect(wrapper.text()).toContain(
+        "Dive deeper into the art market with Artsy emails."
+      )
+    })
+  })
+
   describe("recaptcha", () => {
     it("displays recaptcha warning", () => {
       passedProps.showRecaptchaDisclaimer = true


### PR DESCRIPTION
Rather than falling back to the version of our signup form that does not have the checkboxes split out, this PR takes the opposite approach - when in doubt comply with this rule. This should not happen often but we had some trouble with ip lookups recently and that meant for visitors in GDPR countries we were not in compliance - yikes!

In terms of the code changes all I'm doing here is taking advantage of the fact that empty string is falsy in Javascript. 🤷 

https://artsyproduct.atlassian.net/browse/GRO-802

/cc @artsy/grow-devs