### PR TITLE
feat: Use article byline on homepage GRO-721

### DIFF
--- a/src/v2/Apps/Home/Components/HomeFeaturedMarketNews.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedMarketNews.tsx
@@ -95,7 +95,7 @@ const HomeFeaturedMarketNews: React.FC<HomeFeaturedMarketNewsProps> = ({
             <Text variant="xl">{firstArticle.title}</Text>
 
             <Text variant="lg" mt={1}>
-              By {firstArticle.author?.name}
+              By {firstArticle.byline}
             </Text>
           </StyledRouterLink>
         </Column>
@@ -149,7 +149,7 @@ const HomeFeaturedMarketNews: React.FC<HomeFeaturedMarketNewsProps> = ({
                       <Text variant="lg">{article.title}</Text>
                     
                     <Text variant="md" mt={1}>
-                      By {article.author?.name}
+                      By {article.byline}
                     </Text>
                   </Box>
                 </StyledRouterLink>
@@ -205,6 +205,7 @@ export const HomeFeaturedMarketNewsFragmentContainer = createFragmentContainer(
       fragment HomeFeaturedMarketNews_articles on Article @relay(plural: true) {
         internalID
         href
+        byline
         slug
         title
         publishedAt(format: "MMM D YYYY")
@@ -224,9 +225,6 @@ export const HomeFeaturedMarketNewsFragmentContainer = createFragmentContainer(
             src
             srcSet
           }
-        }
-        author {
-          name
         }
       }
     `,

--- a/src/v2/__generated__/HomeFeaturedMarketNewsQuery.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedMarketNewsQuery.graphql.ts
@@ -28,6 +28,7 @@ query HomeFeaturedMarketNewsQuery {
 fragment HomeFeaturedMarketNews_articles on Article {
   internalID
   href
+  byline
   slug
   title
   publishedAt(format: "MMM D YYYY")
@@ -46,10 +47,6 @@ fragment HomeFeaturedMarketNews_articles on Article {
       src
       srcSet
     }
-  }
-  author {
-    name
-    id
   }
 }
 */
@@ -101,14 +98,7 @@ v1 = [
     "name": "srcSet",
     "storageKey": null
   }
-],
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-};
+];
 return {
   "fragment": {
     "argumentDefinitions": [],
@@ -162,6 +152,13 @@ return {
             "args": null,
             "kind": "ScalarField",
             "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "byline",
             "storageKey": null
           },
           {
@@ -261,35 +258,22 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "Author",
-            "kind": "LinkedField",
-            "name": "author",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "name",
-                "storageKey": null
-              },
-              (v2/*: any*/)
-            ],
+            "kind": "ScalarField",
+            "name": "id",
             "storageKey": null
-          },
-          (v2/*: any*/)
+          }
         ],
         "storageKey": "articles(featured:true,published:true,sort:\"PUBLISHED_AT_DESC\")"
       }
     ]
   },
   "params": {
-    "cacheID": "94e1010b40c49118279612c3055a32cd",
+    "cacheID": "f56c926a863f77974714f278a832b7ed",
     "id": null,
     "metadata": {},
     "name": "HomeFeaturedMarketNewsQuery",
     "operationKind": "query",
-    "text": "query HomeFeaturedMarketNewsQuery {\n  articles(featured: true, published: true, sort: PUBLISHED_AT_DESC) {\n    ...HomeFeaturedMarketNews_articles\n    id\n  }\n}\n\nfragment HomeFeaturedMarketNews_articles on Article {\n  internalID\n  href\n  slug\n  title\n  publishedAt(format: \"MMM D YYYY\")\n  vertical\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n  author {\n    name\n    id\n  }\n}\n"
+    "text": "query HomeFeaturedMarketNewsQuery {\n  articles(featured: true, published: true, sort: PUBLISHED_AT_DESC) {\n    ...HomeFeaturedMarketNews_articles\n    id\n  }\n}\n\nfragment HomeFeaturedMarketNews_articles on Article {\n  internalID\n  href\n  byline\n  slug\n  title\n  publishedAt(format: \"MMM D YYYY\")\n  vertical\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/HomeFeaturedMarketNews_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedMarketNews_Test_Query.graphql.ts
@@ -28,6 +28,7 @@ query HomeFeaturedMarketNews_Test_Query {
 fragment HomeFeaturedMarketNews_articles on Article {
   internalID
   href
+  byline
   slug
   title
   publishedAt(format: "MMM D YYYY")
@@ -46,10 +47,6 @@ fragment HomeFeaturedMarketNews_articles on Article {
       src
       srcSet
     }
-  }
-  author {
-    name
-    id
   }
 }
 */
@@ -86,11 +83,10 @@ var v0 = [
   }
 ],
 v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
 },
 v2 = {
   "enumValues": null,
@@ -102,21 +98,15 @@ v3 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "String"
-},
-v4 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
   "type": "CroppedImageUrl"
 },
-v5 = {
+v4 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v6 = {
+v5 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -175,6 +165,13 @@ return {
             "args": null,
             "kind": "ScalarField",
             "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "byline",
             "storageKey": null
           },
           {
@@ -274,30 +271,17 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "Author",
-            "kind": "LinkedField",
-            "name": "author",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "name",
-                "storageKey": null
-              },
-              (v1/*: any*/)
-            ],
+            "kind": "ScalarField",
+            "name": "id",
             "storageKey": null
-          },
-          (v1/*: any*/)
+          }
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "29d59e1ac1d375c0a1d07685a43feb54",
+    "cacheID": "981cd1efae80e73412f85643c6844058",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -307,43 +291,36 @@ return {
           "plural": true,
           "type": "Article"
         },
-        "articles.author": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Author"
-        },
-        "articles.author.id": (v2/*: any*/),
-        "articles.author.name": (v3/*: any*/),
-        "articles.href": (v3/*: any*/),
+        "articles.byline": (v1/*: any*/),
+        "articles.href": (v1/*: any*/),
         "articles.id": (v2/*: any*/),
         "articles.internalID": (v2/*: any*/),
-        "articles.publishedAt": (v3/*: any*/),
-        "articles.slug": (v3/*: any*/),
+        "articles.publishedAt": (v1/*: any*/),
+        "articles.slug": (v1/*: any*/),
         "articles.thumbnailImage": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "articles.thumbnailImage.large": (v4/*: any*/),
-        "articles.thumbnailImage.large.height": (v5/*: any*/),
-        "articles.thumbnailImage.large.src": (v6/*: any*/),
-        "articles.thumbnailImage.large.srcSet": (v6/*: any*/),
-        "articles.thumbnailImage.large.width": (v5/*: any*/),
-        "articles.thumbnailImage.small": (v4/*: any*/),
-        "articles.thumbnailImage.small.height": (v5/*: any*/),
-        "articles.thumbnailImage.small.src": (v6/*: any*/),
-        "articles.thumbnailImage.small.srcSet": (v6/*: any*/),
-        "articles.thumbnailImage.small.width": (v5/*: any*/),
-        "articles.thumbnailTitle": (v3/*: any*/),
-        "articles.title": (v3/*: any*/),
-        "articles.vertical": (v3/*: any*/)
+        "articles.thumbnailImage.large": (v3/*: any*/),
+        "articles.thumbnailImage.large.height": (v4/*: any*/),
+        "articles.thumbnailImage.large.src": (v5/*: any*/),
+        "articles.thumbnailImage.large.srcSet": (v5/*: any*/),
+        "articles.thumbnailImage.large.width": (v4/*: any*/),
+        "articles.thumbnailImage.small": (v3/*: any*/),
+        "articles.thumbnailImage.small.height": (v4/*: any*/),
+        "articles.thumbnailImage.small.src": (v5/*: any*/),
+        "articles.thumbnailImage.small.srcSet": (v5/*: any*/),
+        "articles.thumbnailImage.small.width": (v4/*: any*/),
+        "articles.thumbnailTitle": (v1/*: any*/),
+        "articles.title": (v1/*: any*/),
+        "articles.vertical": (v1/*: any*/)
       }
     },
     "name": "HomeFeaturedMarketNews_Test_Query",
     "operationKind": "query",
-    "text": "query HomeFeaturedMarketNews_Test_Query {\n  articles {\n    ...HomeFeaturedMarketNews_articles\n    id\n  }\n}\n\nfragment HomeFeaturedMarketNews_articles on Article {\n  internalID\n  href\n  slug\n  title\n  publishedAt(format: \"MMM D YYYY\")\n  vertical\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n  author {\n    name\n    id\n  }\n}\n"
+    "text": "query HomeFeaturedMarketNews_Test_Query {\n  articles {\n    ...HomeFeaturedMarketNews_articles\n    id\n  }\n}\n\nfragment HomeFeaturedMarketNews_articles on Article {\n  internalID\n  href\n  byline\n  slug\n  title\n  publishedAt(format: \"MMM D YYYY\")\n  vertical\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/HomeFeaturedMarketNews_articles.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedMarketNews_articles.graphql.ts
@@ -7,6 +7,7 @@ import { FragmentRefs } from "relay-runtime";
 export type HomeFeaturedMarketNews_articles = ReadonlyArray<{
     readonly internalID: string;
     readonly href: string | null;
+    readonly byline: string | null;
     readonly slug: string | null;
     readonly title: string | null;
     readonly publishedAt: string | null;
@@ -25,9 +26,6 @@ export type HomeFeaturedMarketNews_articles = ReadonlyArray<{
             readonly src: string;
             readonly srcSet: string;
         } | null;
-    } | null;
-    readonly author: {
-        readonly name: string | null;
     } | null;
     readonly " $refType": "HomeFeaturedMarketNews_articles";
 }>;
@@ -90,6 +88,13 @@ return {
       "args": null,
       "kind": "ScalarField",
       "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "byline",
       "storageKey": null
     },
     {
@@ -185,29 +190,11 @@ return {
         }
       ],
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Author",
-      "kind": "LinkedField",
-      "name": "author",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "name",
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
     }
   ],
   "type": "Article",
   "abstractKey": null
 };
 })();
-(node as any).hash = '1b97e3b9f42df81f9275d86ec85c55f1';
+(node as any).hash = '6621a96fea6a270326d3f30f39a7d49d';
 export default node;


### PR DESCRIPTION
All I did here was switch from the `article.name` to the `byline` field that was already added by @dzucconi - here's some visual proof:

### before

<img width="1350" alt="Screen Shot 2022-02-07 at 3 41 47 PM" src="https://user-images.githubusercontent.com/79799/152877575-3c4983ba-f1a1-4b9d-950f-7e6447f6d0f9.png">

### after

<img width="1350" alt="Screen Shot 2022-02-07 at 3 41 37 PM" src="https://user-images.githubusercontent.com/79799/152877536-5e9b906c-3962-4f39-80e8-7ed8b8e52ccb.png">

I was expecting to have to deal with some test fallout but...I think it was all correctly regenerated by relay? Pretty magical! ✨ 

https://artsyproduct.atlassian.net/browse/GRO-721

/cc @artsy/grow-devs