### PR TITLE
feat(FX-3727): Open artist's artworks screen with applied filters when "View All" button is clicked

### DIFF
--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, Flex, Clickable, Spacer } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
+import { RouterLink } from "v2/System/Router/RouterLink"
 import { SavedSearchAlertListItem_item } from "v2/__generated__/SavedSearchAlertListItem_item.graphql"
 import { EditAlertEntity } from "../types"
 
@@ -16,6 +17,8 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
   variant,
   onEditAlertClick,
 }) => {
+  const viewAllHref = `${item.href}&search_criteria_id=${item.internalID}`
+
   return (
     <Box
       key={item.internalID}
@@ -51,9 +54,9 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
             <Text variant="sm">Edit</Text>
           </Clickable>
           <Spacer ml={2} />
-          <Clickable textDecoration="underline">
+          <RouterLink to={viewAllHref} textDecoration="underline">
             <Text variant="sm">View All</Text>
-          </Clickable>
+          </RouterLink>
         </Flex>
       </Flex>
     </Box>
@@ -67,6 +70,7 @@ export const SavedSearchAlertListItemFragmentContainer = createFragmentContainer
       fragment SavedSearchAlertListItem_item on SearchCriteria {
         internalID
         artistIDs
+        href
         userAlertSettings {
           name
         }

--- a/src/v2/__generated__/SavedSearchAlertListItem_item.graphql.ts
+++ b/src/v2/__generated__/SavedSearchAlertListItem_item.graphql.ts
@@ -7,6 +7,7 @@ import { FragmentRefs } from "relay-runtime";
 export type SavedSearchAlertListItem_item = {
     readonly internalID: string;
     readonly artistIDs: ReadonlyArray<string> | null;
+    readonly href: string;
     readonly userAlertSettings: {
         readonly name: string | null;
     };
@@ -43,6 +44,13 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "SavedSearchUserAlertSettings",
       "kind": "LinkedField",
       "name": "userAlertSettings",
@@ -62,5 +70,5 @@ const node: ReaderFragment = {
   "type": "SearchCriteria",
   "abstractKey": null
 };
-(node as any).hash = '3367af46783656daef6e8021990538f1';
+(node as any).hash = '94ac9c394d9515c367be113d028a6e94';
 export default node;

--- a/src/v2/__generated__/SavedSearchAlertsAppRefetchQuery.graphql.ts
+++ b/src/v2/__generated__/SavedSearchAlertsAppRefetchQuery.graphql.ts
@@ -28,6 +28,7 @@ query SavedSearchAlertsAppRefetchQuery {
 fragment SavedSearchAlertListItem_item on SearchCriteria {
   internalID
   artistIDs
+  href
   userAlertSettings {
     name
   }
@@ -141,6 +142,13 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "concreteType": "SavedSearchUserAlertSettings",
                         "kind": "LinkedField",
                         "name": "userAlertSettings",
@@ -226,12 +234,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "07fc3549ea97e6f404f6eef966e7c43f",
+    "cacheID": "47f82e6e5a262c8b4adc97a862f98ae1",
     "id": null,
     "metadata": {},
     "name": "SavedSearchAlertsAppRefetchQuery",
     "operationKind": "query",
-    "text": "query SavedSearchAlertsAppRefetchQuery {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  artistIDs\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query SavedSearchAlertsAppRefetchQuery {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  artistIDs\n  href\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/SavedSearchAlertsApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/SavedSearchAlertsApp_Test_Query.graphql.ts
@@ -17,6 +17,7 @@ export type SavedSearchAlertsApp_Test_QueryRawResponse = {
                 readonly node: ({
                     readonly internalID: string;
                     readonly artistIDs: ReadonlyArray<string> | null;
+                    readonly href: string;
                     readonly userAlertSettings: {
                         readonly name: string | null;
                     };
@@ -51,6 +52,7 @@ query SavedSearchAlertsApp_Test_Query {
 fragment SavedSearchAlertListItem_item on SearchCriteria {
   internalID
   artistIDs
+  href
   userAlertSettings {
     name
   }
@@ -164,6 +166,13 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "concreteType": "SavedSearchUserAlertSettings",
                         "kind": "LinkedField",
                         "name": "userAlertSettings",
@@ -249,12 +258,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bf5fcf799771f803f58ad8ff763c5969",
+    "cacheID": "bbf5bdbc492ea0b13a0fbdbf3b013edc",
     "id": null,
     "metadata": {},
     "name": "SavedSearchAlertsApp_Test_Query",
     "operationKind": "query",
-    "text": "query SavedSearchAlertsApp_Test_Query {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  artistIDs\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query SavedSearchAlertsApp_Test_Query {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  artistIDs\n  href\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/settingsRoutes_SavedSearchAlertsQuery.graphql.ts
+++ b/src/v2/__generated__/settingsRoutes_SavedSearchAlertsQuery.graphql.ts
@@ -28,6 +28,7 @@ query settingsRoutes_SavedSearchAlertsQuery {
 fragment SavedSearchAlertListItem_item on SearchCriteria {
   internalID
   artistIDs
+  href
   userAlertSettings {
     name
   }
@@ -141,6 +142,13 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "concreteType": "SavedSearchUserAlertSettings",
                         "kind": "LinkedField",
                         "name": "userAlertSettings",
@@ -226,12 +234,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e3b561583d5c067bd99b9931d310af12",
+    "cacheID": "275bb26c8291a5b97d42dcbd0bff826b",
     "id": null,
     "metadata": {},
     "name": "settingsRoutes_SavedSearchAlertsQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_SavedSearchAlertsQuery {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  artistIDs\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_SavedSearchAlertsQuery {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  artistIDs\n  href\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Type: **Feature**
Jira ticket: [FX-3727]

### Acceptance criteria
* Open artist's artworks screen when "View All" button is clicked
* Display filters as selected that were specified in saved search alert on artist's artworks screen

### Demo
https://user-images.githubusercontent.com/3513494/152999096-c45ba8dd-764b-4e4b-ab66-30658f97e584.mp4





[FX-3727]: https://artsyproduct.atlassian.net/browse/FX-3727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ