### PR TITLE
feat(offer): use submitOfferOrderWithConversation mutation

### DIFF
--- a/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
@@ -27,6 +27,10 @@ jest.mock("v2/Utils/Events", () => ({
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
 }))
+jest.mock("v2/Utils/user", () => ({
+  getUser: jest.fn(),
+  userHasLabFeature: jest.fn().mockReturnValue(false),
+}))
 
 const mockPostEvent = require("v2/Utils/Events").postEvent as jest.Mock
 
@@ -230,6 +234,10 @@ describe("Offer InitialMutation", () => {
       await page.clickSubmit()
       expect(mutations.mockFetch).toHaveBeenCalled()
       expect(routes.mockPushRoute).toHaveBeenCalledWith("/orders/1234/shipping")
+    })
+
+    it("adds a custom note given no note present", async () => {
+      // TOFIX add the test when the feature flag is retired
     })
 
     it("routes to shipping screen after mutation completes - custom amount", async () => {

--- a/src/v2/__generated__/ReviewSubmitOfferOrderWithConversationMutation.graphql.ts
+++ b/src/v2/__generated__/ReviewSubmitOfferOrderWithConversationMutation.graphql.ts
@@ -1,0 +1,288 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
+export type CommerceSubmitOrderWithOfferInput = {
+    clientMutationId?: string | null;
+    confirmedSetupIntentId?: string | null;
+    offerId: string;
+};
+export type ReviewSubmitOfferOrderWithConversationMutationVariables = {
+    input: CommerceSubmitOrderWithOfferInput;
+};
+export type ReviewSubmitOfferOrderWithConversationMutationResponse = {
+    readonly submitOfferOrderWithConversation: {
+        readonly orderOrError: {
+            readonly order?: {
+                readonly state: CommerceOrderStateEnum;
+            };
+            readonly actionData?: {
+                readonly clientSecret: string;
+            };
+            readonly error?: {
+                readonly type: string;
+                readonly code: string;
+                readonly data: string | null;
+            };
+        };
+    } | null;
+};
+export type ReviewSubmitOfferOrderWithConversationMutation = {
+    readonly response: ReviewSubmitOfferOrderWithConversationMutationResponse;
+    readonly variables: ReviewSubmitOfferOrderWithConversationMutationVariables;
+};
+
+
+
+/*
+mutation ReviewSubmitOfferOrderWithConversationMutation(
+  $input: CommerceSubmitOrderWithOfferInput!
+) {
+  submitOfferOrderWithConversation(input: $input) {
+    orderOrError {
+      __typename
+      ... on CommerceOrderWithMutationSuccess {
+        order {
+          __typename
+          state
+          id
+        }
+      }
+      ... on CommerceOrderRequiresAction {
+        actionData {
+          clientSecret
+        }
+      }
+      ... on CommerceOrderWithMutationFailure {
+        error {
+          type
+          code
+          data
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "state",
+  "storageKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommerceOrderActionData",
+      "kind": "LinkedField",
+      "name": "actionData",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "clientSecret",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "CommerceOrderRequiresAction",
+  "abstractKey": null
+},
+v4 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommerceApplicationError",
+      "kind": "LinkedField",
+      "name": "error",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "type",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "code",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "data",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "CommerceOrderWithMutationFailure",
+  "abstractKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ReviewSubmitOfferOrderWithConversationMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CommerceSubmitOrderWithOfferPayload",
+        "kind": "LinkedField",
+        "name": "submitOfferOrderWithConversation",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "CommerceOrderWithMutationSuccess",
+                "abstractKey": null
+              },
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ReviewSubmitOfferOrderWithConversationMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CommerceSubmitOrderWithOfferPayload",
+        "kind": "LinkedField",
+        "name": "submitOfferOrderWithConversation",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              (v5/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "CommerceOrderWithMutationSuccess",
+                "abstractKey": null
+              },
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "3e636d64f54d1ae9bbfc1380e72523b2",
+    "id": null,
+    "metadata": {},
+    "name": "ReviewSubmitOfferOrderWithConversationMutation",
+    "operationKind": "mutation",
+    "text": "mutation ReviewSubmitOfferOrderWithConversationMutation(\n  $input: CommerceSubmitOrderWithOfferInput!\n) {\n  submitOfferOrderWithConversation(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        order {\n          __typename\n          state\n          id\n        }\n      }\n      ... on CommerceOrderRequiresAction {\n        actionData {\n          clientSecret\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'dcd075ed38e1f8fc071367a7e5ba85c5';
+export default node;


### PR DESCRIPTION
[NX-3044]
@artsy/negotiate-devs 

Uses submitOfferOrderWithConversation mutation in order to create conversation and like to the offer and make an offer.
Also creates a note to be used as the first message of the conversation when no note is provided.

[NX-3044]: https://artsyproduct.atlassian.net/browse/NX-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ