### PR TITLE
chore(FX-3730): update alerts copy

### DIFF
--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -154,7 +154,7 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
           <Box>
             <Join separator={<Spacer mt={[4, 6]} />}>
               <Input
-                title="Name"
+                title="Alert Name"
                 name="name"
                 placeholder={namePlaceholder}
                 value={values.name}

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/CreateAlertButton.tsx
@@ -90,7 +90,7 @@ export const CreateAlertButton: React.FC<CreateAlertButtonProps> = ({
         {...props}
       >
         <BellIcon mr={0.5} fill="currentColor" />
-        Create an Alert
+        Create Alert
       </Button>
       <SavedSearchAlertModal
         visible={visibleForm}

--- a/src/v2/Components/ArtworkFilter/SavedSearch/Components/__tests__/CreateAlertButton.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/SavedSearch/Components/__tests__/CreateAlertButton.jest.tsx
@@ -61,7 +61,7 @@ describe("CreateAlertButton", () => {
       }
     })
     renderButton()
-    expect(screen.getByText("Create an Alert")).toBeInTheDocument()
+    expect(screen.getByText("Create Alert")).toBeInTheDocument()
   })
 
   describe("when logged in", () => {
@@ -73,11 +73,11 @@ describe("CreateAlertButton", () => {
       })
     })
 
-    it("pops up the Create an Alert modal when clicked", () => {
+    it("pops up the Create Alert modal when clicked", () => {
       renderButton()
       expect(screen.queryByTestId("CreateAlertModal")).not.toBeInTheDocument()
 
-      const button = screen.getByText("Create an Alert")
+      const button = screen.getByText("Create Alert")
       fireEvent.click(button)
 
       expect(screen.getByTestId("CreateAlertModal")).toBeInTheDocument()
@@ -85,7 +85,7 @@ describe("CreateAlertButton", () => {
 
     it("tracks event", () => {
       renderButton()
-      const button = screen.getByText("Create an Alert")
+      const button = screen.getByText("Create Alert")
       fireEvent.click(button)
       expect(trackEvent).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -109,7 +109,7 @@ describe("CreateAlertButton", () => {
 
     it("pops up the auth modal when clicked", () => {
       renderButton()
-      const button = screen.getByText("Create an Alert")
+      const button = screen.getByText("Create Alert")
       fireEvent.click(button)
       expect(openAuthToSatisfyIntent).toHaveBeenCalledWith(mediator, {
         entity: {
@@ -124,7 +124,7 @@ describe("CreateAlertButton", () => {
 
     it("tracks event", () => {
       renderButton()
-      const button = screen.getByText("Create an Alert")
+      const button = screen.getByText("Create Alert")
       fireEvent.click(button)
       expect(trackEvent).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkGridFilterPills.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkGridFilterPills.jest.tsx
@@ -62,7 +62,7 @@ describe("ArtworkGridFilterPills", () => {
     expect(screen.getByText("Red")).toBeInTheDocument()
     expect(screen.getByText("Open Edition")).toBeInTheDocument()
     expect(screen.getAllByTitle("Close")).toHaveLength(2)
-    expect(screen.getByText("Create an Alert")).toBeInTheDocument()
+    expect(screen.getByText("Create Alert")).toBeInTheDocument()
   })
 
   it("renders default pills without CloseIcon", () => {

--- a/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
+++ b/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
@@ -55,7 +55,7 @@ export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
   return (
     <Box p={2} pb={1} backgroundColor="black5">
       <Text variant="md" mb={1} textAlign="center">
-        Get alerts direct to your phone when you download the Artsy app.
+        Get alerts direct to your mobile when you download the Artsy app.
       </Text>
       <Flex justifyContent="center" flexWrap="wrap">
         {(device === Device.iPhone || device === Device.Unknown) && (

--- a/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
+++ b/src/v2/Components/SavedSearchAlert/DownloadAppBanner.tsx
@@ -55,7 +55,7 @@ export const DownloadAppBanner: React.FC<DownloadAppBannerProps> = ({
   return (
     <Box p={2} pb={1} backgroundColor="black5">
       <Text variant="md" mb={1} textAlign="center">
-        Download the app to stay current as new artworks are available on Artsy.
+        Get alerts direct to your phone when you download the Artsy app.
       </Text>
       <Flex justifyContent="center" flexWrap="wrap">
         {(device === Device.iPhone || device === Device.Unknown) && (

--- a/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
+++ b/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
@@ -135,7 +135,7 @@ export const SavedSearchAlertModal: React.FC<SavedSearchAlertFormProps> = ({
           return (
             <ModalDialog
               onClose={onClose}
-              title="Create an Alert"
+              title="Create Alert"
               data-testid="CreateAlertModal"
               footer={
                 <Button
@@ -150,7 +150,7 @@ export const SavedSearchAlertModal: React.FC<SavedSearchAlertFormProps> = ({
             >
               <Join separator={<Spacer mt={4} />}>
                 <Input
-                  title="Name"
+                  title="Alert Name"
                   name="name"
                   placeholder={namePlaceholder}
                   value={values.name}

--- a/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
+++ b/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
@@ -52,7 +52,7 @@ describe("SavedSearchAlertModal", () => {
 
   it("is not rendered when visible=false", () => {
     render(<TestComponent visible={false} />)
-    expect(screen.queryByText("Name")).not.toBeInTheDocument()
+    expect(screen.queryByText("Alert Name")).not.toBeInTheDocument()
     expect(screen.queryByText("Filters")).not.toBeInTheDocument()
     expect(screen.queryByText("Test Artist")).not.toBeInTheDocument()
     expect(screen.queryByText("Open Edition")).not.toBeInTheDocument()
@@ -64,7 +64,7 @@ describe("SavedSearchAlertModal", () => {
 
   it("renders correctly", () => {
     render(<TestComponent />)
-    expect(screen.getByText("Name")).toBeInTheDocument()
+    expect(screen.getByText("Alert Name")).toBeInTheDocument()
     expect(screen.getByText("Filters")).toBeInTheDocument()
     expect(screen.getByText("Test Artist")).toBeInTheDocument()
     expect(screen.getByText("Open Edition")).toBeInTheDocument()
@@ -77,7 +77,7 @@ describe("SavedSearchAlertModal", () => {
     expect(screen.getAllByRole("checkbox")[1]).not.toBeChecked()
   })
 
-  it("name generated correctly", () => {
+  it("alert name generated correctly", () => {
     render(<TestComponent />)
     expect(screen.getByRole("textbox")).toHaveAttribute(
       "placeholder",


### PR DESCRIPTION
Type: **Chore**
Jira ticket: [FX-3730]

[Figma](https://www.figma.com/file/xsnfIWE7H67ZndGoEPVtN0/Alerts-Sandbox?node-id=1255%3A19002) documents the specific screens for copy edits

### Acceptance criteria
* Create alert modal
  * title: `Create Alert`
  * name field title: `Alert Name`
  * download app badges: `Get alerts direct to your mobile when you download the Artsy app.`
* Create alert button label on artworks grid: `Create Alert`

### Useful links
* [Figma](https://www.figma.com/file/xsnfIWE7H67ZndGoEPVtN0/Alerts-Sandbox?node-id=1255%3A19002)
* [Google doc](https://docs.google.com/document/d/1QexY-xIeQS8mH8cTjfCFUZYaSMveczsJmkYcAU7bX7g/edit#)

### Demo
<img width="1279" alt="button" src="https://user-images.githubusercontent.com/3513494/153184161-b035681b-4c3a-40aa-a7cf-f0528121e344.png">

<img width="1044" alt="Banksy - 2181 Artworks for Sale on Artsy 2022-02-09 18-34-41" src="https://user-images.githubusercontent.com/3513494/153234504-171dcd79-1865-4019-bb47-01caf514fedf.png">


[FX-3730]: https://artsyproduct.atlassian.net/browse/FX-3730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ