### PR TITLE
refactor(hook): Update useMutation hook

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -106,9 +106,11 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({ submission }) => {
 
             if (photo.assetId) {
               removeAsset({
-                input: {
-                  assetID: photo.assetId,
-                  sessionID: !isLoggedIn ? getENV("SESSION_ID") : undefined,
+                variables: {
+                  input: {
+                    assetID: photo.assetId,
+                    sessionID: !isLoggedIn ? getENV("SESSION_ID") : undefined,
+                  },
                 },
               }).catch(error => {
                 logger.error("Remove asset error", error)
@@ -125,13 +127,15 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({ submission }) => {
 
               try {
                 const response = await addAsset({
-                  input: {
-                    assetType: "image",
-                    geminiToken: photo.geminiToken!,
-                    submissionID: submission.id,
-                    sessionID: !isLoggedIn ? getENV("SESSION_ID") : undefined,
-                    filename: photo.name,
-                    size: photo.size.toString(),
+                  variables: {
+                    input: {
+                      assetType: "image",
+                      geminiToken: photo.geminiToken!,
+                      submissionID: submission.id,
+                      sessionID: !isLoggedIn ? getENV("SESSION_ID") : undefined,
+                      filename: photo.name,
+                      size: photo.size.toString(),
+                    },
                   },
                 })
 

--- a/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
@@ -38,15 +38,15 @@ export const DeleteAccountRoute: FC = () => {
           })}
           onSubmit={async ({ explanation }) => {
             try {
-              await submitMutation(
-                { input: { explanation, url: window.location.href } },
-                {
-                  checkForErrors: res => {
-                    return res.deleteMyAccountMutation?.userAccountOrError
-                      ?.mutationError
-                  },
-                }
-              )
+              await submitMutation({
+                variables: {
+                  input: { explanation, url: window.location.href },
+                },
+                rejectIf: res => {
+                  return res.deleteMyAccountMutation?.userAccountOrError
+                    ?.mutationError
+                },
+              })
 
               sendToast({
                 variant: "success",

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsEmailPreferences/SettingsEditSettingsEmailPreferences.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsEmailPreferences/SettingsEditSettingsEmailPreferences.tsx
@@ -18,7 +18,7 @@ export const SettingsEditSettingsEmailPreferences: FC<SettingEditSettingsEmailPr
 
   const handleSelect = async (emailFrequency: string) => {
     try {
-      submitMutation({ input: { emailFrequency } })
+      submitMutation({ variables: { input: { emailFrequency } } })
 
       sendToast({
         variant: "success",

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
@@ -123,7 +123,7 @@ const SettingsEditSettingsLinkedAccountsButton: FC<SettingsEditSettingsLinkedAcc
     setMode("Disconnecting")
 
     try {
-      await submitMutation({ input: { provider } })
+      await submitMutation({ variables: { input: { provider } } })
 
       sendToast({
         variant: "success",

--- a/src/v2/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethod.tsx
+++ b/src/v2/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethod.tsx
@@ -29,14 +29,12 @@ const SettingsPaymentsMethod: FC<SettingsPaymentsMethodProps> = ({
     setMode("Deleting")
 
     try {
-      await submitMutation(
-        { input: { id: method.internalID } },
-        {
-          checkForErrors: res => {
-            return res.deleteCreditCard?.creditCardOrError?.mutationError
-          },
-        }
-      )
+      await submitMutation({
+        variables: { input: { id: method.internalID } },
+        rejectIf: res => {
+          return res.deleteCreditCard?.creditCardOrError?.mutationError
+        },
+      })
 
       sendToast({
         variant: "success",

--- a/src/v2/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethodForm.tsx
+++ b/src/v2/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethodForm.tsx
@@ -86,14 +86,12 @@ export const SettingsPaymentsMethodForm: FC<SettingsPaymentsMethodFormProps> = (
             })
           }
 
-          await submitMutation(
-            { input: { token: token.id } },
-            {
-              checkForErrors: res => {
-                return res.createCreditCard?.creditCardOrError?.mutationError
-              },
-            }
-          )
+          await submitMutation({
+            variables: { input: { token: token.id } },
+            rejectIf: res => {
+              return res.createCreditCard?.creditCardOrError?.mutationError
+            },
+          })
 
           sendToast({
             variant: "success",

--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertDeleteModal.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertDeleteModal.tsx
@@ -26,8 +26,10 @@ export const SavedSearchAlertDeleteModal: React.FC<SavedSearchAlertDeleteModalPr
     try {
       setIsDeleting(true)
       await submitDeleteAlert({
-        input: {
-          searchCriteriaID: id,
+        variables: {
+          input: {
+            searchCriteriaID: id,
+          },
         },
       })
     } catch (error) {

--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -113,12 +113,14 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
         searchCriteriaAttributes as ArtworkFilters
       )
       await submitEditAlert({
-        input: {
-          searchCriteriaID: editAlertEntity!.id,
-          attributes: searchCriteria,
-          userAlertSettings: {
-            ...values,
-            name: values.name || namePlaceholder,
+        variables: {
+          input: {
+            searchCriteriaID: editAlertEntity!.id,
+            attributes: searchCriteria,
+            userAlertSettings: {
+              ...values,
+              name: values.name || namePlaceholder,
+            },
           },
         },
       })

--- a/src/v2/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddress.tsx
+++ b/src/v2/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddress.tsx
@@ -47,15 +47,12 @@ const SettingsShippingAddress: FC<SettingsShippingAddressProps> = ({
   const handleDelete = async () => {
     setMode("Deleting")
     try {
-      await submitMutation(
-        { input: { userAddressID: address.internalID } },
-        {
-          checkForErrors: res => {
-            return res.deleteUserAddress?.userAddressOrErrors.errors?.[0]
-              .message
-          },
-        }
-      )
+      await submitMutation({
+        variables: { input: { userAddressID: address.internalID } },
+        rejectIf: res => {
+          return res.deleteUserAddress?.userAddressOrErrors.errors?.[0].message
+        },
+      })
 
       sendToast({
         variant: "success",

--- a/src/v2/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
+++ b/src/v2/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
@@ -78,12 +78,16 @@ export const SettingsShippingAddressForm: FC<SettingsShippingAddressFormProps> =
         try {
           if (isEditing) {
             await submitEditAddress({
-              input: { userAddressID: address!.internalID, attributes },
+              variables: {
+                input: { userAddressID: address!.internalID, attributes },
+              },
             })
 
             if (isDefault) {
               await submitSetDefaultAddress({
-                input: { userAddressID: address!.internalID },
+                variables: {
+                  input: { userAddressID: address!.internalID },
+                },
               })
             }
 
@@ -93,12 +97,16 @@ export const SettingsShippingAddressForm: FC<SettingsShippingAddressFormProps> =
             })
           } else {
             // Adding new address
-            const response = await submitAddAddress({ input: { attributes } })
+            const response = await submitAddAddress({
+              variables: { input: { attributes } },
+            })
             const id =
               response.createUserAddress?.userAddressOrErrors.internalID
 
             if (isDefault && id) {
-              await submitSetDefaultAddress({ input: { userAddressID: id } })
+              await submitSetDefaultAddress({
+                variables: { input: { userAddressID: id } },
+              })
             }
 
             sendToast({

--- a/src/v2/Apps/Unsubscribe/Components/UnsubscribeLoggedIn.tsx
+++ b/src/v2/Apps/Unsubscribe/Components/UnsubscribeLoggedIn.tsx
@@ -30,7 +30,7 @@ export const UnsubscribeLoggedIn: React.FC<UnsubscribeLoggedInProps> = ({
 
       setMode("Loading")
 
-      submitMutation({ input: { emailFrequency } })
+      submitMutation({ variables: { input: { emailFrequency } } })
 
       sendToast({
         variant: "success",

--- a/src/v2/Utils/Hooks/useMutation.ts
+++ b/src/v2/Utils/Hooks/useMutation.ts
@@ -12,12 +12,12 @@ export const useMutation = <T extends MutationParameters>({
 }) => {
   const { relayEnvironment } = useSystemContext()
 
-  const submitMutation = (
-    variables: T["variables"] = {},
-    options: {
-      checkForErrors?: (res: T["response"]) => unknown
-    } = {}
-  ): Promise<T["response"]> => {
+  const submitMutation = (props: {
+    variables: T["variables"]
+    rejectIf?: (res: T["response"]) => unknown
+  }): Promise<T["response"]> => {
+    const { variables = {}, rejectIf } = props
+
     return new Promise((resolve, reject) => {
       commitMutation<T>(relayEnvironment!, {
         mutation,
@@ -29,8 +29,8 @@ export const useMutation = <T extends MutationParameters>({
             return
           }
 
-          if (options.checkForErrors?.(res)) {
-            reject(options.checkForErrors?.(res))
+          if (rejectIf?.(res)) {
+            reject(rejectIf?.(res))
             return
           }
 


### PR DESCRIPTION
This updates the implementation of `useMutation`'s `submitMutation` fn to be a little clearer and somewhat more verbose. New API: 

```tsx
const { submitMutation } = useMutation(...)

await submitMutation({ 
  variables: { foo },
  rejectIf: res => res.field.hasError
})
```