### PR TITLE
docs: Add more recent example for --watch [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We accept [pull requests](https://github.com/artsy/force/pulls), and you may [pr
 
 ## Setup Instructions
 
-> ⚠️ If you're an Artsy Engineer, be sure to run the [general setup script](https://github.com/artsy/potential/blob/main/scripts/setup) located in [Potential](https://github.com/artsy/potential) first. 
+> ⚠️ If you're an Artsy Engineer, be sure to run the [general setup script](https://github.com/artsy/potential/blob/main/scripts/setup) located in [Potential](https://github.com/artsy/potential) first.
 
 Clone the [project on GitHub](https://github.com/artsy/force) and cd in:
 
@@ -88,7 +88,7 @@ Write tests for all new features and fixes using Mocha or Jest. Run all tests wi
 
 Mocha looks for files prefixed with `.test` or `.spec`, while Jest looks for the prefix `.jest`.
 
-To speed up your workflow try watching an individual file for changes, e.g. `yarn mocha -- --watch desktop/components/foo/bar.test.coffee`
+To speed up your workflow try watching an individual file or directory for changes, e.g. `yarn jest --watch src/v2/Components/Authentication`
 
 ## Write Code
 


### PR DESCRIPTION
I think it might be a little more helpful to show the `--watch` flag with Jest since most folks probably won't be working on the legacy CoffeScript and Mocha code.