### PR TITLE
feat(GRO-817): Allow user to link a Google account

### DIFF
--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   FacebookIcon,
+  GoogleIcon,
   Spacer,
   Text,
   useToasts,
@@ -67,6 +68,15 @@ export const SettingsEditSettingsLinkedAccounts: FC<SettingsEditSettingsLinkedAc
             
           </Box>
         }
+      />
+
+      <Spacer mt={2} />
+
+      <SettingsEditSettingsLinkedAccountsButton
+        me={me}
+        provider="GOOGLE"
+        href={authenticationPaths?.googlePath}
+        icon={<GoogleIcon mr={0.5} />}
       />
     </>
   )

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/__tests__/SettingsEditSettingsLinkedAccounts.jest.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/__tests__/SettingsEditSettingsLinkedAccounts.jest.tsx
@@ -8,6 +8,7 @@ jest.mock("v2/Utils/getENV", () => ({
   getENV: jest.fn().mockReturnValue({
     applePath: "/users/auth/apple",
     facebookPath: "/users/auth/facebook",
+    googlePath: "/users/auth/google",
   }),
 }))
 
@@ -29,6 +30,7 @@ describe("SettingsEditSettingsLinkedAccounts", () => {
     expect(screen.getByText("Linked Accounts")).toBeInTheDocument()
     expect(screen.getByText("Connect Facebook Account")).toBeInTheDocument()
     expect(screen.getByText("Connect Apple Account")).toBeInTheDocument()
+    expect(screen.getByText("Connect Google Account")).toBeInTheDocument()
   })
 
   it("renders the link if the accounts are disconnected", () => {
@@ -40,16 +42,22 @@ describe("SettingsEditSettingsLinkedAccounts", () => {
 
     expect(links[0]).toHaveAttribute("href", "/users/auth/facebook")
     expect(links[1]).toHaveAttribute("href", "/users/auth/apple")
+    expect(links[2]).toHaveAttribute("href", "/users/auth/google")
   })
 
   it("renders the buttons if the accounts are connected", () => {
     renderWithRelay({
       Me: () => ({
-        authentications: [{ provider: "FACEBOOK" }, { provider: "APPLE" }],
+        authentications: [
+          { provider: "FACEBOOK" },
+          { provider: "APPLE" },
+          { provider: "GOOGLE" },
+        ],
       }),
     })
 
     expect(screen.getByText("Disconnect Facebook Account")).toBeInTheDocument()
     expect(screen.getByText("Disconnect Apple Account")).toBeInTheDocument()
+    expect(screen.getByText("Disconnect Google Account")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
I noticed that it's not currently possible to link a Google account to an already existing account.

I'm having a bit of trouble testing this locally (cors issues with ngrok), but I think it should work. @dzucconi would love your feedback since you're blamed for this feature in the first place!