### PR TITLE
bug: Fix underline inconsistency

### DIFF
--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
@@ -1,9 +1,10 @@
 import { FC, useEffect } from "react"
 import {
-  Box,
-  Button,
+  AppleIcon,
   FacebookIcon,
   GoogleIcon,
+  IconButton,
+  Join,
   Spacer,
   Text,
   useToasts,
@@ -50,34 +51,28 @@ export const SettingsEditSettingsLinkedAccounts: FC<SettingsEditSettingsLinkedAc
         Linked Accounts
       </Text>
 
-      <SettingsEditSettingsLinkedAccountsButton
-        me={me}
-        provider="FACEBOOK"
-        href={authenticationPaths?.facebookPath}
-        icon={<FacebookIcon mr={0.5} fill="currentColor" />}
-      />
+      <Join separator={<Spacer mt={2} />}>
+        <SettingsEditSettingsLinkedAccountsButton
+          me={me}
+          provider="FACEBOOK"
+          href={authenticationPaths?.facebookPath}
+          icon={<FacebookIcon fill="currentColor" />}
+        />
 
-      <Spacer mt={2} />
+        <SettingsEditSettingsLinkedAccountsButton
+          me={me}
+          provider="APPLE"
+          href={authenticationPaths?.applePath}
+          icon={<AppleIcon fill="currentColor" />}
+        />
 
-      <SettingsEditSettingsLinkedAccountsButton
-        me={me}
-        provider="APPLE"
-        href={authenticationPaths?.applePath}
-        icon={
-          <Box display="inline-block" mr={0.5}>
-            
-          </Box>
-        }
-      />
-
-      <Spacer mt={2} />
-
-      <SettingsEditSettingsLinkedAccountsButton
-        me={me}
-        provider="GOOGLE"
-        href={authenticationPaths?.googlePath}
-        icon={<GoogleIcon mr={0.5} />}
-      />
+        <SettingsEditSettingsLinkedAccountsButton
+          me={me}
+          provider="GOOGLE"
+          href={authenticationPaths?.googlePath}
+          icon={<GoogleIcon />}
+        />
+      </Join>
     </>
   )
 }
@@ -162,7 +157,7 @@ const SettingsEditSettingsLinkedAccountsButton: FC<SettingsEditSettingsLinkedAcc
   }[mode]
 
   return (
-    <Button
+    <IconButton
       onClick={handleClick}
       loading={mode === "Connecting" || mode === "Disconnecting"}
       {...(mode === "Connected"
@@ -172,9 +167,9 @@ const SettingsEditSettingsLinkedAccountsButton: FC<SettingsEditSettingsLinkedAcc
             as: "a",
             href: href,
           })}
+      icon={icon}
     >
-      {icon} {action} {provider.charAt(0) + provider.slice(1).toLowerCase()}{" "}
-      Account
-    </Button>
+      {action} {provider.charAt(0) + provider.slice(1).toLowerCase()} Account
+    </IconButton>
   )
 }

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/__tests__/SettingsEditSettingsLinkedAccounts.jest.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/__tests__/SettingsEditSettingsLinkedAccounts.jest.tsx
@@ -31,6 +31,9 @@ describe("SettingsEditSettingsLinkedAccounts", () => {
     expect(screen.getByText("Connect Facebook Account")).toBeInTheDocument()
     expect(screen.getByText("Connect Apple Account")).toBeInTheDocument()
     expect(screen.getByText("Connect Google Account")).toBeInTheDocument()
+    expect(screen.getByTitle("Facebook")).toBeInTheDocument()
+    expect(screen.getByTitle("Apple Icon")).toBeInTheDocument()
+    expect(screen.getByTitle("Google Icon")).toBeInTheDocument()
   })
 
   it("renders the link if the accounts are disconnected", () => {


### PR DESCRIPTION
I noticed that the Apple logo had an underline beneath it, I fixed that
by using the AppleIcon from palette.

While in this file, I went ahead and changed things over to the
IconButton component too, just to be consistent.

📹 [Loom Video](loom.com/share/58ac7c9d1bc646ccb26b2110d1e338b7)
