### PR TITLE
feat[GRO-734]: Tmcmeans/about2 palette v3 refactor

### DIFF
--- a/cypress/integration/about2.spec.ts
+++ b/cypress/integration/about2.spec.ts
@@ -1,0 +1,6 @@
+describe("About", () => {
+  it("renders page content", () => {
+    cy.get("h1").should("contain", "For the Love of Art")
+    cy.title().should("eq", "About | Artsy")
+  })
+})

--- a/cypress/integration/about2.spec.ts
+++ b/cypress/integration/about2.spec.ts
@@ -1,5 +1,8 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
 describe("About", () => {
   it("renders page content", () => {
+    visitWithStatusRetries("about")
     cy.get("h1").should("contain", "For the Love of Art")
     cy.title().should("eq", "About | Artsy")
   })

--- a/src/v2/Apps/_About2/AboutApp.tsx
+++ b/src/v2/Apps/_About2/AboutApp.tsx
@@ -134,7 +134,7 @@ const RailComponent: React.FC<RailComponentProps> = props => {
         width={props.width}
         height={props.height}
         src={props.imgUrl}
-        alt=""
+        alt="carousel of artwork images with titles and gallery names"
       />
       <Text variant="md">{props.name}</Text>
       <Text variant="md" color="black60">
@@ -177,7 +177,7 @@ const SellWithArtsy: React.FC = () => {
             style={{
               objectFit: "cover",
             }}
-            alt=""
+            alt="a Molly Green art piece titled Cached"
           />
         </Box>
       )}
@@ -282,7 +282,7 @@ const AppDownload: React.FC = () => {
             height="100%"
             srcSet={image.srcSet}
             lazyLoad
-            alt=""
+            alt="painting of two iphones displaying the artsy mobile app"
           />
         </ResponsiveBox>
       </Column>
@@ -313,11 +313,11 @@ const CollectorInfo: React.FC = () => {
             height="100%"
             srcSet={image.srcSet}
             lazyLoad
-            alt=""
+            alt="picture of the Collection for Carole Server by Emily Johnston"
           />
         </ResponsiveBox>
         <Text variant="xs" textColor="black60" mt={0.5}>
-          The Collection fo Carole Server by Emily Johnston for Artsy 2015.
+          The Collection for Carole Server by Emily Johnston for Artsy 2015.
           Courtesy of Carole Server.
         </Text>
       </Column>

--- a/src/v2/Apps/_About2/AboutApp.tsx
+++ b/src/v2/Apps/_About2/AboutApp.tsx
@@ -108,11 +108,11 @@ export const AboutApp: React.FC = () => {
       <Spacer my={12} />
 
       <Join separator={<Spacer mt={6} />}>
-        <SellWithArtsyComponent />
-        <AppDownloadComponent />
-        <CollectorInfoComponent />
+        <SellWithArtsy />
+        <AppDownload />
+        <CollectorInfo />
         <Separator />
-        <ArtsySpecialistsComponent />
+        <ArtsySpecialists />
       </Join>
     </>
   )
@@ -147,7 +147,7 @@ const RailComponent: React.FC<RailComponentProps> = props => {
   )
 }
 
-const SellWithArtsyComponent: React.FC = () => {
+const SellWithArtsy: React.FC = () => {
   const image = resized(
     "http://files.artsy.net/images/molly_green_original.jpeg",
     { width: 640 }
@@ -234,7 +234,7 @@ const SellWithArtsyComponent: React.FC = () => {
   )
 }
 
-const AppDownloadComponent: React.FC = () => {
+const AppDownload: React.FC = () => {
   const image = resized("http://files.artsy.net/download_artsy_apps_img.jpg", {
     width: 910,
     height: 652,
@@ -290,7 +290,7 @@ const AppDownloadComponent: React.FC = () => {
   )
 }
 
-const CollectorInfoComponent: React.FC = () => {
+const CollectorInfo: React.FC = () => {
   const image = resized(
     "http://files.artsy.net/about2_page_collector_img.jpg",
     {
@@ -343,7 +343,7 @@ const CollectorInfoComponent: React.FC = () => {
   )
 }
 
-const ArtsySpecialistsComponent: React.FC = () => {
+const ArtsySpecialists: React.FC = () => {
   return (
     <GridColumns gridRowGap={4}>
       <Column span={6}>


### PR DESCRIPTION
This PR is for doing a little bit of code cleanup and adding tests for the new `/about2` page. 

I guess I should have split up the small naming convention changes/adding alt tag stuff and the smoke test but the test is so small that I didn't feel it needed a new PR. Hoping the smoke test will pass in CircleCI, though because it's not passing on my local machine. 