### PR TITLE
[NX-3084] Hide ShippingInfo for inquireable artworks

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -445,9 +445,8 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
           )}
 
           {artworkEcommerceAvailable &&
-            (artwork.shippingOrigin || artwork.shippingInfo) && (
-              <Spacer mt={1} />
-            )}
+            (artwork.shippingOrigin || artwork.shippingInfo) &&
+            !isInquireable && <Spacer mt={1} />}
 
           {avalaraPhase2Enabled && (
             <Text variant="xs" color="black60">
@@ -462,13 +461,15 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
             </Text>
           )}
 
-          {artworkEcommerceAvailable && artwork.shippingOrigin && (
-            <Text variant="xs" color="black60">
-              Ships from {artwork.shippingOrigin}
-            </Text>
-          )}
+          {artworkEcommerceAvailable &&
+            artwork.shippingOrigin &&
+            !isInquireable && (
+              <Text variant="xs" color="black60">
+                Ships from {artwork.shippingOrigin}
+              </Text>
+            )}
 
-          {artworkEcommerceAvailable && artwork.shippingInfo && (
+          {artworkEcommerceAvailable && artwork.shippingInfo && !isInquireable && (
             <Text variant="xs" color="black60">
               {artwork.shippingInfo}
             </Text>

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial2.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial2.jest.tsx
@@ -53,6 +53,14 @@ describe("ArtworkSidebarCommercial RTL", () => {
     expect(screen.getByText("Contact Gallery")).toBeInTheDocument()
   })
 
+  it("does not display ShippingInfo for inquireable artworks", () => {
+    renderWithRelay({
+      Artwork: () => ArtworkOfferableFromInquiryPriceExact,
+    })
+
+    expect(screen.queryByText("Ships from")).not.toBeInTheDocument()
+  })
+
   it("does not display Make Offer CTA and only the Contact Gallery CTA when offerable from inquiry and price hidden", () => {
     renderWithRelay({
       Artwork: () => ArtworkOfferableAndInquireablePriceHidden,


### PR DESCRIPTION
[NX-3084]

This is a quick fix just because MOOAEA project was adding the shipping info to the artwork page in artworks that didn't contain this information until now. This is leading to an unexpected message being displayed (like `Shipping null`). This was happening because this message is displayed in offerable artworks.

<img width="1287" alt="Screenshot 2022-02-15 at 12 07 09" src="https://user-images.githubusercontent.com/8002618/154050343-d4367c38-fab3-4d75-9ba6-68a5ba3898bf.png">


Changes here just aim to prevent this from being displayed in a scenario that was affected by MOOAEA project.

The actual fix might consist of understanding why the message is being returned like this from metaphysics.

```graphql
{
  artwork(id: "mark-kostabi-the-bad-poetry-of-the-grid") {
    shippingInfo
  }
}

```

```
{
  "data": {
    "artwork": {
      "shippingInfo": "Shipping: null domestic, $1,200 rest of world"
    }
  },
  ...
}
```

When querying gravity we see this artwork has an international shipping fee set, but it has no domestic shipping fee:
```
gravity:staging> artwork.domestic_shipping_fee_cents
=> nil
gravity:staging> artwork.international_shipping_fee_cents
=> 120000
```

Once we fix this, we can even discuss if we want to undo the changes from this PR.

For more details see this slack thread:
https://artsy.slack.com/archives/C9YNS4X32/p1644914386896509

[NX-3084]: https://artsyproduct.atlassian.net/browse/NX-3084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ