### PR TITLE
feat: update NFTs nav link to /nft

### DIFF
--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -382,10 +382,7 @@ export const NavBar: React.FC = track(
                   Museums
                 </NavBarItemLink>
 
-                <NavBarItemLink
-                  href="https://nft.artsy.net"
-                  onClick={handleClick}
-                >
+                <NavBarItemLink href="/nft" onClick={handleClick}>
                   NFTs
                 </NavBarItemLink>
               </Flex>

--- a/src/v2/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
+++ b/src/v2/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
@@ -111,10 +111,7 @@ export const NavBarMobileMenu: React.FC<NavBarMobileMenuProps> = ({
               Museums
             </NavBarMobileMenuItemLink>
 
-            <NavBarMobileMenuItemLink
-              to="https://nft.artsy.net"
-              onClick={handleClick}
-            >
+            <NavBarMobileMenuItemLink to="/nft" onClick={handleClick}>
               NFTs
             </NavBarMobileMenuItemLink>
 

--- a/src/v2/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
+++ b/src/v2/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
@@ -65,7 +65,7 @@ describe("NavBarMobileMenu", () => {
         ["/fairs", "Fairs"],
         ["/shows", "Shows"],
         ["/institutions", "Museums"],
-        ["https://nft.artsy.net", "NFTs"],
+        ["/nft", "NFTs"],
         ["/consign", "Sell"],
         ["/price-database", "Price Database"],
         ["/articles", "Editorial"],


### PR DESCRIPTION
This commit updates the NFTs nav link to a relative `/nft` href. This will match a currently [registered vanity shortcut](https://artsy.net/nft) to `/gene/nft`.

The gene is currently unpublished so the page a user is redirected to throws a Forbidden 403 error.

We can either:
- Publish the gene, which will make the gene page visible
- Update the vanity shortcut to another visible page. The collect page filtered
  to artworks of the NFT medium type, for example.

Either way, changing the nav link to not point directly to a specific subdomain gives us more flexibility and a UI to change where this link redirects a user to.

Link to a related [Slack thread](https://artsy.slack.com/archives/CHVFQ06DV/p1645020706482189) 🔒 