### PR TITLE
feat(GRO-818): hero unit video layout

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -769,6 +769,8 @@ type ArticleEdge {
 }
 
 type ArticleFeatureSection {
+  # Only YouTube and Vimeo are supported
+  embed(autoPlay: Boolean = false): String
   image: Image
   layout: ArticleFeatureSectionType!
   title: String

--- a/src/v2/Apps/Article/ArticleApp.tsx
+++ b/src/v2/Apps/Article/ArticleApp.tsx
@@ -21,10 +21,6 @@ const ArticleApp: FC<ArticleAppProps> = ({ article }) => {
         // TODO: Add description, remaining tags
       />
 
-      {!article.hero &&
-        article.layout !== "SERIES" &&
-        article.layout !== "VIDEO" && <Spacer mt={4} />}
-
       <Join separator={<Spacer mt={4} />}>
         {(() => {
           switch (article.layout) {
@@ -79,9 +75,6 @@ export const ArticleAppFragmentContainer = createFragmentContainer(ArticleApp, {
     fragment ArticleApp_article on Article {
       internalID
       title
-      hero {
-        __typename
-      }
       layout
       channelID
       ...ArticleBody_article

--- a/src/v2/Apps/Article/Components/ArticleHeader.tsx
+++ b/src/v2/Apps/Article/Components/ArticleHeader.tsx
@@ -5,9 +5,17 @@ import {
   FullBleedHeaderOverlay,
   MIN_HEIGHT,
 } from "v2/Components/FullBleedHeader"
-import { Box, FullBleed, Image, ResponsiveBox, Text } from "@artsy/palette"
+import {
+  Box,
+  FullBleed,
+  Image,
+  ResponsiveBox,
+  Spacer,
+  Text,
+} from "@artsy/palette"
 import { ArticleHeader_article } from "v2/__generated__/ArticleHeader_article.graphql"
 import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
+import styled from "styled-components"
 
 interface ArticleHeaderProps {
   article: ArticleHeader_article
@@ -19,6 +27,8 @@ const ArticleHeader: FC<ArticleHeaderProps> = ({ article }) => {
   if (!article.hero) {
     return (
       <>
+        <Spacer mt={4} />
+
         <Text variant="xs" textTransform="uppercase" mb={1}>
           {article.vertical}
         </Text>
@@ -97,19 +107,39 @@ const ArticleHeader: FC<ArticleHeaderProps> = ({ article }) => {
 
     case "BASIC": {
       return (
-        <Box textAlign="center" m={[2, 4]}>
-          <Text variant="xs" textTransform="uppercase" mb={1}>
-            {article.vertical}
-          </Text>
+        <>
+          <Spacer mt={4} />
 
-          <Text variant="xxl" flex={1}>
-            {article.title}
-          </Text>
+          <Box textAlign="center">
+            {article.hero.embed && (
+              <ResponsiveBox
+                aspectWidth={16}
+                aspectHeight={9}
+                maxWidth="100%"
+                bg="black10"
+                mb={4}
+              >
+                <Video
+                  dangerouslySetInnerHTML={{ __html: article.hero.embed }}
+                />
+              </ResponsiveBox>
+            )}
 
-          <Text variant="xxl" color="black60" mb={2}>
-            {article.byline}
-          </Text>
-        </Box>
+            {article.vertical && (
+              <Text variant="xs" textTransform="uppercase" mb={1}>
+                {article.vertical}
+              </Text>
+            )}
+
+            <Text variant="xxl" flex={1}>
+              {article.title}
+            </Text>
+
+            <Text variant="xxl" color="black60" mb={2}>
+              {article.byline}
+            </Text>
+          </Box>
+        </>
       )
     }
 
@@ -166,6 +196,7 @@ export const ArticleHeaderFragmentContainer = createFragmentContainer(
         hero {
           ... on ArticleFeatureSection {
             layout
+            embed
             image {
               url
               split: resized(width: 900) {
@@ -183,3 +214,14 @@ export const ArticleHeaderFragmentContainer = createFragmentContainer(
     `,
   }
 )
+
+const Video = styled.div`
+  width: 100%;
+  height: 100%;
+
+  > iframe {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+`

--- a/src/v2/Apps/Components/AppToasts.tsx
+++ b/src/v2/Apps/Components/AppToasts.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Box, Column, GridColumns, Toasts } from "@artsy/palette"
+import { Box, Column, GridColumns, Toasts, useToasts } from "@artsy/palette"
 import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 import { AppContainer } from "./AppContainer"
 
@@ -9,6 +9,9 @@ interface AppToastsProps {
 
 export const AppToasts: React.FC<AppToastsProps> = ({ accomodateNav }) => {
   const { height } = useNavBarHeight()
+  const { toasts } = useToasts()
+
+  if (toasts.length === 0) return null
 
   return (
     <Box

--- a/src/v2/__generated__/ArticleApp_article.graphql.ts
+++ b/src/v2/__generated__/ArticleApp_article.graphql.ts
@@ -8,9 +8,6 @@ export type ArticleLayout = "CLASSIC" | "FEATURE" | "NEWS" | "SERIES" | "STANDAR
 export type ArticleApp_article = {
     readonly internalID: string;
     readonly title: string | null;
-    readonly hero: {
-        readonly __typename: string;
-    } | null;
     readonly layout: ArticleLayout;
     readonly channelID: string | null;
     readonly " $fragmentRefs": FragmentRefs<"ArticleBody_article" | "ArticleSeries_article" | "ArticleVideo_article">;
@@ -47,24 +44,6 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": null,
-      "kind": "LinkedField",
-      "name": "hero",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "__typename",
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
       "kind": "ScalarField",
       "name": "layout",
       "storageKey": null
@@ -95,5 +74,5 @@ const node: ReaderFragment = {
   "type": "Article",
   "abstractKey": null
 };
-(node as any).hash = '30b4abc9011f2bd5f4a690cac9951c63';
+(node as any).hash = 'b1e639d69f9c6c9168cd17dc250074ed';
 export default node;

--- a/src/v2/__generated__/ArticleBody_test_Query.graphql.ts
+++ b/src/v2/__generated__/ArticleBody_test_Query.graphql.ts
@@ -85,6 +85,7 @@ fragment ArticleHeader_article on Article {
     __typename
     ... on ArticleFeatureSection {
       layout
+      embed
       image {
         url
         split: resized(width: 900) {
@@ -320,54 +321,61 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "url",
+  "name": "embed",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
+  "name": "url",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "src",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "srcSet",
   "storageKey": null
 },
-v8 = [
-  (v6/*: any*/),
-  (v7/*: any*/)
+v9 = [
+  (v7/*: any*/),
+  (v8/*: any*/)
 ],
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "height",
   "value": 60
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -376,25 +384,25 @@ v13 = {
     "large"
   ]
 },
-v14 = [
-  (v13/*: any*/),
+v15 = [
+  (v14/*: any*/),
   {
     "kind": "Literal",
     "name": "width",
     "value": 1220
   }
 ],
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v16 = [
-  (v6/*: any*/),
+v17 = [
   (v7/*: any*/),
-  (v15/*: any*/),
+  (v8/*: any*/),
+  (v16/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -403,7 +411,7 @@ v16 = [
     "storageKey": null
   }
 ],
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
@@ -413,25 +421,25 @@ v17 = {
   "selections": [
     {
       "alias": null,
-      "args": (v14/*: any*/),
+      "args": (v15/*: any*/),
       "concreteType": "ResizedImageUrl",
       "kind": "LinkedField",
       "name": "resized",
       "plural": false,
-      "selections": (v16/*: any*/),
+      "selections": (v17/*: any*/),
       "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:1220)"
     }
   ],
   "storageKey": null
 },
-v18 = [
+v19 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v19 = [
+v20 = [
   {
     "alias": null,
     "args": null,
@@ -440,21 +448,21 @@ v19 = [
     "storageKey": null
   }
 ],
-v20 = {
+v21 = {
   "kind": "InlineFragment",
   "selections": [
-    (v11/*: any*/)
+    (v12/*: any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v21 = {
+v22 = {
   "kind": "Literal",
   "name": "width",
   "value": 80
 },
-v22 = [
-  (v11/*: any*/),
+v23 = [
+  (v12/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -471,79 +479,79 @@ v22 = [
             "name": "height",
             "value": 80
           },
-          (v13/*: any*/),
-          (v21/*: any*/)
+          (v14/*: any*/),
+          (v22/*: any*/)
         ],
         "concreteType": "CroppedImageUrl",
         "kind": "LinkedField",
         "name": "cropped",
         "plural": false,
-        "selections": (v16/*: any*/),
+        "selections": (v17/*: any*/),
         "storageKey": "cropped(height:80,version:[\"normalized\",\"larger\",\"large\"],width:80)"
       },
       {
         "alias": "large",
-        "args": (v14/*: any*/),
+        "args": (v15/*: any*/),
         "concreteType": "ResizedImageUrl",
         "kind": "LinkedField",
         "name": "resized",
         "plural": false,
-        "selections": (v16/*: any*/),
+        "selections": (v17/*: any*/),
         "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:1220)"
       }
     ],
     "storageKey": null
   }
 ],
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v26 = {
+v27 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "CroppedImageUrl"
 },
-v27 = {
+v28 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v28 = {
+v29 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ResizedImageUrl"
 },
-v29 = {
+v30 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v30 = {
+v31 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v31 = {
+v32 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -612,6 +620,7 @@ return {
                 "kind": "InlineFragment",
                 "selections": [
                   (v4/*: any*/),
+                  (v5/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -620,7 +629,7 @@ return {
                     "name": "image",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": "split",
                         "args": [
@@ -634,7 +643,7 @@ return {
                         "kind": "LinkedField",
                         "name": "resized",
                         "plural": false,
-                        "selections": (v8/*: any*/),
+                        "selections": (v9/*: any*/),
                         "storageKey": "resized(width:900)"
                       },
                       {
@@ -655,7 +664,7 @@ return {
                         "kind": "LinkedField",
                         "name": "cropped",
                         "plural": false,
-                        "selections": (v8/*: any*/),
+                        "selections": (v9/*: any*/),
                         "storageKey": "cropped(height:900,width:1600)"
                       }
                     ],
@@ -676,7 +685,7 @@ return {
             "name": "authors",
             "plural": true,
             "selections": [
-              (v9/*: any*/),
+              (v10/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -702,7 +711,7 @@ return {
                   {
                     "alias": null,
                     "args": [
-                      (v10/*: any*/),
+                      (v11/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -713,13 +722,13 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v8/*: any*/),
+                    "selections": (v9/*: any*/),
                     "storageKey": "cropped(height:60,width:60)"
                   }
                 ],
                 "storageKey": null
               },
-              (v11/*: any*/)
+              (v12/*: any*/)
             ],
             "storageKey": null
           },
@@ -733,11 +742,11 @@ return {
             "plural": false,
             "selections": [
               (v1/*: any*/),
-              (v5/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": null
           },
-          (v12/*: any*/),
+          (v13/*: any*/),
           {
             "alias": null,
             "args": [
@@ -790,7 +799,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v11/*: any*/),
+                          (v12/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -798,7 +807,7 @@ return {
                             "name": "caption",
                             "storageKey": null
                           },
-                          (v17/*: any*/)
+                          (v18/*: any*/)
                         ],
                         "type": "ArticleImageSection",
                         "abstractKey": null
@@ -806,7 +815,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v12/*: any*/),
+                          (v13/*: any*/),
                           (v1/*: any*/),
                           {
                             "alias": null,
@@ -831,15 +840,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
-                              (v11/*: any*/),
                               (v12/*: any*/),
-                              (v9/*: any*/)
+                              (v13/*: any*/),
+                              (v10/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -852,15 +861,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v9/*: any*/),
+                              (v10/*: any*/),
+                              (v13/*: any*/),
                               (v12/*: any*/),
-                              (v11/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -893,7 +902,7 @@ return {
                                 "name": "isClosed",
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": "is_live_open",
                                 "args": null,
@@ -944,7 +953,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v19/*: any*/),
+                                "selections": (v20/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -954,10 +963,10 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v19/*: any*/),
+                                "selections": (v20/*: any*/),
                                 "storageKey": null
                               },
-                              (v11/*: any*/)
+                              (v12/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -968,13 +977,13 @@ return {
                             "name": "isInquireable",
                             "storageKey": null
                           },
-                          (v11/*: any*/),
-                          (v17/*: any*/)
+                          (v12/*: any*/),
+                          (v18/*: any*/)
                         ],
                         "type": "Artwork",
                         "abstractKey": null
                       },
-                      (v20/*: any*/)
+                      (v21/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1022,17 +1031,17 @@ return {
                       (v3/*: any*/),
                       {
                         "kind": "InlineFragment",
-                        "selections": (v22/*: any*/),
+                        "selections": (v23/*: any*/),
                         "type": "ArticleImageSection",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v22/*: any*/),
+                        "selections": (v23/*: any*/),
                         "type": "Artwork",
                         "abstractKey": null
                       },
-                      (v20/*: any*/)
+                      (v21/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1082,7 +1091,7 @@ return {
                         "kind": "LinkedField",
                         "name": "cropped",
                         "plural": false,
-                        "selections": (v8/*: any*/),
+                        "selections": (v9/*: any*/),
                         "storageKey": "cropped(height:512,width:910)"
                       }
                     ],
@@ -1095,14 +1104,8 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v5/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "embed",
-                    "storageKey": null
-                  }
+                  (v6/*: any*/),
+                  (v5/*: any*/)
                 ],
                 "type": "ArticleSectionSocialEmbed",
                 "abstractKey": null
@@ -1110,8 +1113,8 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v5/*: any*/),
-                  (v15/*: any*/),
+                  (v6/*: any*/),
+                  (v16/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1149,7 +1152,7 @@ return {
                 "storageKey": null
               },
               (v1/*: any*/),
-              (v12/*: any*/),
+              (v13/*: any*/),
               (v2/*: any*/),
               {
                 "alias": null,
@@ -1162,31 +1165,31 @@ return {
                   {
                     "alias": null,
                     "args": [
-                      (v10/*: any*/),
-                      (v21/*: any*/)
+                      (v11/*: any*/),
+                      (v22/*: any*/)
                     ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v8/*: any*/),
+                    "selections": (v9/*: any*/),
                     "storageKey": "cropped(height:60,width:80)"
                   }
                 ],
                 "storageKey": null
               },
-              (v11/*: any*/)
+              (v12/*: any*/)
             ],
             "storageKey": null
           },
-          (v11/*: any*/)
+          (v12/*: any*/)
         ],
         "storageKey": "article(id:\"example\")"
       }
     ]
   },
   "params": {
-    "cacheID": "64e1ccaf3529f5af7b683b5a31e83efc",
+    "cacheID": "6c31058d0b1e35f87a2a4c05b8f7f68d",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1202,30 +1205,31 @@ return {
           "plural": true,
           "type": "Author"
         },
-        "article.authors.bio": (v23/*: any*/),
-        "article.authors.id": (v24/*: any*/),
-        "article.authors.image": (v25/*: any*/),
-        "article.authors.image.cropped": (v26/*: any*/),
-        "article.authors.image.cropped.src": (v27/*: any*/),
-        "article.authors.image.cropped.srcSet": (v27/*: any*/),
-        "article.authors.initials": (v23/*: any*/),
-        "article.authors.name": (v23/*: any*/),
-        "article.byline": (v23/*: any*/),
+        "article.authors.bio": (v24/*: any*/),
+        "article.authors.id": (v25/*: any*/),
+        "article.authors.image": (v26/*: any*/),
+        "article.authors.image.cropped": (v27/*: any*/),
+        "article.authors.image.cropped.src": (v28/*: any*/),
+        "article.authors.image.cropped.srcSet": (v28/*: any*/),
+        "article.authors.initials": (v24/*: any*/),
+        "article.authors.name": (v24/*: any*/),
+        "article.byline": (v24/*: any*/),
         "article.hero": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArticleHero"
         },
-        "article.hero.__typename": (v27/*: any*/),
-        "article.hero.image": (v25/*: any*/),
-        "article.hero.image.split": (v28/*: any*/),
-        "article.hero.image.split.src": (v27/*: any*/),
-        "article.hero.image.split.srcSet": (v27/*: any*/),
-        "article.hero.image.text": (v26/*: any*/),
-        "article.hero.image.text.src": (v27/*: any*/),
-        "article.hero.image.text.srcSet": (v27/*: any*/),
-        "article.hero.image.url": (v23/*: any*/),
+        "article.hero.__typename": (v28/*: any*/),
+        "article.hero.embed": (v24/*: any*/),
+        "article.hero.image": (v26/*: any*/),
+        "article.hero.image.split": (v29/*: any*/),
+        "article.hero.image.split.src": (v28/*: any*/),
+        "article.hero.image.split.srcSet": (v28/*: any*/),
+        "article.hero.image.text": (v27/*: any*/),
+        "article.hero.image.text.src": (v28/*: any*/),
+        "article.hero.image.text.srcSet": (v28/*: any*/),
+        "article.hero.image.url": (v24/*: any*/),
         "article.hero.layout": {
           "enumValues": [
             "BASIC",
@@ -1237,8 +1241,8 @@ return {
           "plural": false,
           "type": "ArticleFeatureSectionType"
         },
-        "article.href": (v23/*: any*/),
-        "article.id": (v24/*: any*/),
+        "article.href": (v24/*: any*/),
+        "article.id": (v25/*: any*/),
         "article.layout": {
           "enumValues": [
             "CLASSIC",
@@ -1258,112 +1262,112 @@ return {
           "plural": false,
           "type": "ArticleNewsSource"
         },
-        "article.newsSource.title": (v23/*: any*/),
-        "article.newsSource.url": (v23/*: any*/),
-        "article.postscript": (v23/*: any*/),
-        "article.publishedAt": (v23/*: any*/),
+        "article.newsSource.title": (v24/*: any*/),
+        "article.newsSource.url": (v24/*: any*/),
+        "article.postscript": (v24/*: any*/),
+        "article.publishedAt": (v24/*: any*/),
         "article.relatedArticles": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "Article"
         },
-        "article.relatedArticles.byline": (v23/*: any*/),
-        "article.relatedArticles.href": (v23/*: any*/),
-        "article.relatedArticles.id": (v24/*: any*/),
-        "article.relatedArticles.internalID": (v24/*: any*/),
-        "article.relatedArticles.thumbnailImage": (v25/*: any*/),
-        "article.relatedArticles.thumbnailImage.cropped": (v26/*: any*/),
-        "article.relatedArticles.thumbnailImage.cropped.src": (v27/*: any*/),
-        "article.relatedArticles.thumbnailImage.cropped.srcSet": (v27/*: any*/),
-        "article.relatedArticles.title": (v23/*: any*/),
+        "article.relatedArticles.byline": (v24/*: any*/),
+        "article.relatedArticles.href": (v24/*: any*/),
+        "article.relatedArticles.id": (v25/*: any*/),
+        "article.relatedArticles.internalID": (v25/*: any*/),
+        "article.relatedArticles.thumbnailImage": (v26/*: any*/),
+        "article.relatedArticles.thumbnailImage.cropped": (v27/*: any*/),
+        "article.relatedArticles.thumbnailImage.cropped.src": (v28/*: any*/),
+        "article.relatedArticles.thumbnailImage.cropped.srcSet": (v28/*: any*/),
+        "article.relatedArticles.title": (v24/*: any*/),
         "article.sections": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "ArticleSections"
         },
-        "article.sections.__typename": (v27/*: any*/),
-        "article.sections.body": (v23/*: any*/),
+        "article.sections.__typename": (v28/*: any*/),
+        "article.sections.body": (v24/*: any*/),
         "article.sections.counts": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArticleSectionImageSetCounts"
         },
-        "article.sections.counts.figures": (v29/*: any*/),
+        "article.sections.counts.figures": (v30/*: any*/),
         "article.sections.cover": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArticleSectionImageSetFigure"
         },
-        "article.sections.cover.__isNode": (v27/*: any*/),
-        "article.sections.cover.__typename": (v27/*: any*/),
-        "article.sections.cover.id": (v24/*: any*/),
-        "article.sections.cover.image": (v25/*: any*/),
-        "article.sections.cover.image.large": (v28/*: any*/),
-        "article.sections.cover.image.large.height": (v30/*: any*/),
-        "article.sections.cover.image.large.src": (v27/*: any*/),
-        "article.sections.cover.image.large.srcSet": (v27/*: any*/),
-        "article.sections.cover.image.large.width": (v30/*: any*/),
-        "article.sections.cover.image.small": (v26/*: any*/),
-        "article.sections.cover.image.small.height": (v29/*: any*/),
-        "article.sections.cover.image.small.src": (v27/*: any*/),
-        "article.sections.cover.image.small.srcSet": (v27/*: any*/),
-        "article.sections.cover.image.small.width": (v29/*: any*/),
-        "article.sections.embed": (v23/*: any*/),
+        "article.sections.cover.__isNode": (v28/*: any*/),
+        "article.sections.cover.__typename": (v28/*: any*/),
+        "article.sections.cover.id": (v25/*: any*/),
+        "article.sections.cover.image": (v26/*: any*/),
+        "article.sections.cover.image.large": (v29/*: any*/),
+        "article.sections.cover.image.large.height": (v31/*: any*/),
+        "article.sections.cover.image.large.src": (v28/*: any*/),
+        "article.sections.cover.image.large.srcSet": (v28/*: any*/),
+        "article.sections.cover.image.large.width": (v31/*: any*/),
+        "article.sections.cover.image.small": (v27/*: any*/),
+        "article.sections.cover.image.small.height": (v30/*: any*/),
+        "article.sections.cover.image.small.src": (v28/*: any*/),
+        "article.sections.cover.image.small.srcSet": (v28/*: any*/),
+        "article.sections.cover.image.small.width": (v30/*: any*/),
+        "article.sections.embed": (v24/*: any*/),
         "article.sections.figures": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "ArticleSectionImageCollectionFigure"
         },
-        "article.sections.figures.__isNode": (v27/*: any*/),
-        "article.sections.figures.__typename": (v27/*: any*/),
+        "article.sections.figures.__isNode": (v28/*: any*/),
+        "article.sections.figures.__typename": (v28/*: any*/),
         "article.sections.figures.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "article.sections.figures.artists.href": (v23/*: any*/),
-        "article.sections.figures.artists.id": (v24/*: any*/),
-        "article.sections.figures.artists.name": (v23/*: any*/),
-        "article.sections.figures.caption": (v23/*: any*/),
-        "article.sections.figures.collecting_institution": (v23/*: any*/),
-        "article.sections.figures.cultural_maker": (v23/*: any*/),
-        "article.sections.figures.date": (v23/*: any*/),
-        "article.sections.figures.href": (v23/*: any*/),
-        "article.sections.figures.id": (v24/*: any*/),
-        "article.sections.figures.image": (v25/*: any*/),
-        "article.sections.figures.image.resized": (v28/*: any*/),
-        "article.sections.figures.image.resized.height": (v30/*: any*/),
-        "article.sections.figures.image.resized.src": (v27/*: any*/),
-        "article.sections.figures.image.resized.srcSet": (v27/*: any*/),
-        "article.sections.figures.image.resized.width": (v30/*: any*/),
-        "article.sections.figures.is_inquireable": (v31/*: any*/),
+        "article.sections.figures.artists.href": (v24/*: any*/),
+        "article.sections.figures.artists.id": (v25/*: any*/),
+        "article.sections.figures.artists.name": (v24/*: any*/),
+        "article.sections.figures.caption": (v24/*: any*/),
+        "article.sections.figures.collecting_institution": (v24/*: any*/),
+        "article.sections.figures.cultural_maker": (v24/*: any*/),
+        "article.sections.figures.date": (v24/*: any*/),
+        "article.sections.figures.href": (v24/*: any*/),
+        "article.sections.figures.id": (v25/*: any*/),
+        "article.sections.figures.image": (v26/*: any*/),
+        "article.sections.figures.image.resized": (v29/*: any*/),
+        "article.sections.figures.image.resized.height": (v31/*: any*/),
+        "article.sections.figures.image.resized.src": (v28/*: any*/),
+        "article.sections.figures.image.resized.srcSet": (v28/*: any*/),
+        "article.sections.figures.image.resized.width": (v31/*: any*/),
+        "article.sections.figures.is_inquireable": (v32/*: any*/),
         "article.sections.figures.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "article.sections.figures.partner.href": (v23/*: any*/),
-        "article.sections.figures.partner.id": (v24/*: any*/),
-        "article.sections.figures.partner.name": (v23/*: any*/),
-        "article.sections.figures.partner.type": (v23/*: any*/),
+        "article.sections.figures.partner.href": (v24/*: any*/),
+        "article.sections.figures.partner.id": (v25/*: any*/),
+        "article.sections.figures.partner.name": (v24/*: any*/),
+        "article.sections.figures.partner.type": (v24/*: any*/),
         "article.sections.figures.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "article.sections.figures.sale.id": (v24/*: any*/),
-        "article.sections.figures.sale.is_auction": (v31/*: any*/),
-        "article.sections.figures.sale.is_closed": (v31/*: any*/),
-        "article.sections.figures.sale.is_live_open": (v31/*: any*/),
-        "article.sections.figures.sale.is_open": (v31/*: any*/),
+        "article.sections.figures.sale.id": (v25/*: any*/),
+        "article.sections.figures.sale.is_auction": (v32/*: any*/),
+        "article.sections.figures.sale.is_closed": (v32/*: any*/),
+        "article.sections.figures.sale.is_live_open": (v32/*: any*/),
+        "article.sections.figures.sale.is_open": (v32/*: any*/),
         "article.sections.figures.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -1388,22 +1392,22 @@ return {
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "article.sections.figures.sale_artwork.highest_bid.display": (v23/*: any*/),
-        "article.sections.figures.sale_artwork.id": (v24/*: any*/),
+        "article.sections.figures.sale_artwork.highest_bid.display": (v24/*: any*/),
+        "article.sections.figures.sale_artwork.id": (v25/*: any*/),
         "article.sections.figures.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "article.sections.figures.sale_artwork.opening_bid.display": (v23/*: any*/),
-        "article.sections.figures.sale_message": (v23/*: any*/),
-        "article.sections.figures.title": (v23/*: any*/),
-        "article.sections.height": (v30/*: any*/),
-        "article.sections.image": (v25/*: any*/),
-        "article.sections.image.cropped": (v26/*: any*/),
-        "article.sections.image.cropped.src": (v27/*: any*/),
-        "article.sections.image.cropped.srcSet": (v27/*: any*/),
+        "article.sections.figures.sale_artwork.opening_bid.display": (v24/*: any*/),
+        "article.sections.figures.sale_message": (v24/*: any*/),
+        "article.sections.figures.title": (v24/*: any*/),
+        "article.sections.height": (v31/*: any*/),
+        "article.sections.image": (v26/*: any*/),
+        "article.sections.image.cropped": (v27/*: any*/),
+        "article.sections.image.cropped.src": (v28/*: any*/),
+        "article.sections.image.cropped.srcSet": (v28/*: any*/),
         "article.sections.layout": {
           "enumValues": [
             "COLUMN_WIDTH",
@@ -1414,7 +1418,7 @@ return {
           "plural": false,
           "type": "ArticleSectionImageCollectionLayout"
         },
-        "article.sections.mobileHeight": (v30/*: any*/),
+        "article.sections.mobileHeight": (v31/*: any*/),
         "article.sections.setLayout": {
           "enumValues": [
             "FULL",
@@ -1424,15 +1428,15 @@ return {
           "plural": false,
           "type": "ArticleSectionImageSetLayout"
         },
-        "article.sections.title": (v23/*: any*/),
-        "article.sections.url": (v23/*: any*/),
-        "article.title": (v23/*: any*/),
-        "article.vertical": (v23/*: any*/)
+        "article.sections.title": (v24/*: any*/),
+        "article.sections.url": (v24/*: any*/),
+        "article.title": (v24/*: any*/),
+        "article.vertical": (v24/*: any*/)
       }
     },
     "name": "ArticleBody_test_Query",
     "operationKind": "query",
-    "text": "query ArticleBody_test_Query {\n  article(id: \"example\") {\n    ...ArticleBody_article\n    id\n  }\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHeader_article\n  ...ArticleByline_article\n  layout\n  title\n  newsSource {\n    title\n    url\n  }\n  href\n  publishedAt(format: \"MMM D, YYYY h:mma\")\n  sections {\n    __typename\n    ...ArticleSectionText_section\n    ...ArticleSectionImageCollection_section\n    ...ArticleSectionImageSet_section\n    ...ArticleSectionVideo_section\n    ...ArticleSectionSocialEmbed_section\n    ...ArticleSectionEmbed_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 80, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHeader_article on Article {\n  title\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ... on ArticleImageSection {\n      id\n      caption\n      image {\n        resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      ...Metadata_artwork\n      id\n      image {\n        resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n"
+    "text": "query ArticleBody_test_Query {\n  article(id: \"example\") {\n    ...ArticleBody_article\n    id\n  }\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHeader_article\n  ...ArticleByline_article\n  layout\n  title\n  newsSource {\n    title\n    url\n  }\n  href\n  publishedAt(format: \"MMM D, YYYY h:mma\")\n  sections {\n    __typename\n    ...ArticleSectionText_section\n    ...ArticleSectionImageCollection_section\n    ...ArticleSectionImageSet_section\n    ...ArticleSectionVideo_section\n    ...ArticleSectionSocialEmbed_section\n    ...ArticleSectionEmbed_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 80, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHeader_article on Article {\n  title\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ... on ArticleImageSection {\n      id\n      caption\n      image {\n        resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      ...Metadata_artwork\n      id\n      image {\n        resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ArticleHeader_article.graphql.ts
+++ b/src/v2/__generated__/ArticleHeader_article.graphql.ts
@@ -11,6 +11,7 @@ export type ArticleHeader_article = {
     readonly byline: string | null;
     readonly hero: {
         readonly layout?: ArticleFeatureSectionType;
+        readonly embed?: string | null;
         readonly image?: {
             readonly url: string | null;
             readonly split: {
@@ -98,6 +99,13 @@ return {
             {
               "alias": null,
               "args": null,
+              "kind": "ScalarField",
+              "name": "embed",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
               "concreteType": "Image",
               "kind": "LinkedField",
               "name": "image",
@@ -162,5 +170,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'e4df2bea08b84e8b824460f0a7c84a6b';
+(node as any).hash = '70e55082ea529a8654b5c9cc0cce871a';
 export default node;

--- a/src/v2/__generated__/articleRoutes_ArticleQuery.graphql.ts
+++ b/src/v2/__generated__/articleRoutes_ArticleQuery.graphql.ts
@@ -32,9 +32,6 @@ query articleRoutes_ArticleQuery(
 fragment ArticleApp_article on Article {
   internalID
   title
-  hero {
-    __typename
-  }
   layout
   channelID
   ...ArticleBody_article
@@ -102,6 +99,7 @@ fragment ArticleHeader_article on Article {
     __typename
     ... on ArticleFeatureSection {
       layout
+      embed
       image {
         url
         split: resized(width: 900) {
@@ -388,75 +386,82 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
+  "name": "layout",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "layout",
+  "name": "byline",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "url",
+  "name": "__typename",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
+  "name": "embed",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "srcSet",
+  "name": "url",
   "storageKey": null
 },
-v9 = [
-  (v7/*: any*/),
-  (v8/*: any*/)
-],
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "src",
+  "storageKey": null
+},
 v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "byline",
+  "name": "srcSet",
   "storageKey": null
 },
-v11 = {
+v11 = [
+  (v9/*: any*/),
+  (v10/*: any*/)
+],
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "kind": "Literal",
   "name": "height",
   "value": 60
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -465,25 +470,25 @@ v15 = {
     "large"
   ]
 },
-v16 = [
-  (v15/*: any*/),
+v17 = [
+  (v16/*: any*/),
   {
     "kind": "Literal",
     "name": "width",
     "value": 1220
   }
 ],
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v18 = [
-  (v7/*: any*/),
-  (v8/*: any*/),
-  (v17/*: any*/),
+v19 = [
+  (v9/*: any*/),
+  (v10/*: any*/),
+  (v18/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -492,7 +497,7 @@ v18 = [
     "storageKey": null
   }
 ],
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
@@ -502,25 +507,25 @@ v19 = {
   "selections": [
     {
       "alias": null,
-      "args": (v16/*: any*/),
+      "args": (v17/*: any*/),
       "concreteType": "ResizedImageUrl",
       "kind": "LinkedField",
       "name": "resized",
       "plural": false,
-      "selections": (v18/*: any*/),
+      "selections": (v19/*: any*/),
       "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:1220)"
     }
   ],
   "storageKey": null
 },
-v20 = [
+v21 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v21 = [
+v22 = [
   {
     "alias": null,
     "args": null,
@@ -529,21 +534,21 @@ v21 = [
     "storageKey": null
   }
 ],
-v22 = {
+v23 = {
   "kind": "InlineFragment",
   "selections": [
-    (v13/*: any*/)
+    (v14/*: any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v23 = {
+v24 = {
   "kind": "Literal",
   "name": "width",
   "value": 80
 },
-v24 = [
-  (v13/*: any*/),
+v25 = [
+  (v14/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -560,38 +565,38 @@ v24 = [
             "name": "height",
             "value": 80
           },
-          (v15/*: any*/),
-          (v23/*: any*/)
+          (v16/*: any*/),
+          (v24/*: any*/)
         ],
         "concreteType": "CroppedImageUrl",
         "kind": "LinkedField",
         "name": "cropped",
         "plural": false,
-        "selections": (v18/*: any*/),
+        "selections": (v19/*: any*/),
         "storageKey": "cropped(height:80,version:[\"normalized\",\"larger\",\"large\"],width:80)"
       },
       {
         "alias": "large",
-        "args": (v16/*: any*/),
+        "args": (v17/*: any*/),
         "concreteType": "ResizedImageUrl",
         "kind": "LinkedField",
         "name": "resized",
         "plural": false,
-        "selections": (v18/*: any*/),
+        "selections": (v19/*: any*/),
         "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:1220)"
       }
     ],
     "storageKey": null
   }
 ],
-v25 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "description",
   "storageKey": null
 },
-v26 = {
+v27 = {
   "alias": null,
   "args": null,
   "concreteType": "ArticleSponsor",
@@ -666,6 +671,22 @@ return {
         "selections": [
           (v2/*: any*/),
           (v3/*: any*/),
+          (v4/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "channelID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "vertical",
+            "storageKey": null
+          },
+          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -674,11 +695,12 @@ return {
             "name": "hero",
             "plural": false,
             "selections": [
-              (v4/*: any*/),
+              (v6/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v5/*: any*/),
+                  (v4/*: any*/),
+                  (v7/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -687,7 +709,7 @@ return {
                     "name": "image",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": "split",
                         "args": [
@@ -701,7 +723,7 @@ return {
                         "kind": "LinkedField",
                         "name": "resized",
                         "plural": false,
-                        "selections": (v9/*: any*/),
+                        "selections": (v11/*: any*/),
                         "storageKey": "resized(width:900)"
                       },
                       {
@@ -722,7 +744,7 @@ return {
                         "kind": "LinkedField",
                         "name": "cropped",
                         "plural": false,
-                        "selections": (v9/*: any*/),
+                        "selections": (v11/*: any*/),
                         "storageKey": "cropped(height:900,width:1600)"
                       }
                     ],
@@ -735,22 +757,6 @@ return {
             ],
             "storageKey": null
           },
-          (v5/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "channelID",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "vertical",
-            "storageKey": null
-          },
-          (v10/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -759,7 +765,7 @@ return {
             "name": "authors",
             "plural": true,
             "selections": [
-              (v11/*: any*/),
+              (v12/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -785,7 +791,7 @@ return {
                   {
                     "alias": null,
                     "args": [
-                      (v12/*: any*/),
+                      (v13/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -796,13 +802,13 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v9/*: any*/),
+                    "selections": (v11/*: any*/),
                     "storageKey": "cropped(height:60,width:60)"
                   }
                 ],
                 "storageKey": null
               },
-              (v13/*: any*/)
+              (v14/*: any*/)
             ],
             "storageKey": null
           },
@@ -815,11 +821,11 @@ return {
             "plural": false,
             "selections": [
               (v3/*: any*/),
-              (v6/*: any*/)
+              (v8/*: any*/)
             ],
             "storageKey": null
           },
-          (v14/*: any*/),
+          (v15/*: any*/),
           {
             "alias": null,
             "args": [
@@ -841,7 +847,7 @@ return {
             "name": "sections",
             "plural": true,
             "selections": [
-              (v4/*: any*/),
+              (v6/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -859,7 +865,7 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v5/*: any*/),
+                  (v4/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -868,11 +874,11 @@ return {
                     "name": "figures",
                     "plural": true,
                     "selections": [
-                      (v4/*: any*/),
+                      (v6/*: any*/),
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v13/*: any*/),
+                          (v14/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -880,7 +886,7 @@ return {
                             "name": "caption",
                             "storageKey": null
                           },
-                          (v19/*: any*/)
+                          (v20/*: any*/)
                         ],
                         "type": "ArticleImageSection",
                         "abstractKey": null
@@ -888,7 +894,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v14/*: any*/),
+                          (v15/*: any*/),
                           (v3/*: any*/),
                           {
                             "alias": null,
@@ -913,15 +919,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
-                              (v13/*: any*/),
                               (v14/*: any*/),
-                              (v11/*: any*/)
+                              (v15/*: any*/),
+                              (v12/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -934,15 +940,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
+                              (v15/*: any*/),
                               (v14/*: any*/),
-                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -975,7 +981,7 @@ return {
                                 "name": "isClosed",
                                 "storageKey": null
                               },
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": "is_live_open",
                                 "args": null,
@@ -1026,7 +1032,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v21/*: any*/),
+                                "selections": (v22/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -1036,10 +1042,10 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v21/*: any*/),
+                                "selections": (v22/*: any*/),
                                 "storageKey": null
                               },
-                              (v13/*: any*/)
+                              (v14/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1050,13 +1056,13 @@ return {
                             "name": "isInquireable",
                             "storageKey": null
                           },
-                          (v13/*: any*/),
-                          (v19/*: any*/)
+                          (v14/*: any*/),
+                          (v20/*: any*/)
                         ],
                         "type": "Artwork",
                         "abstractKey": null
                       },
-                      (v22/*: any*/)
+                      (v23/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1101,20 +1107,20 @@ return {
                     "name": "cover",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
+                      (v6/*: any*/),
                       {
                         "kind": "InlineFragment",
-                        "selections": (v24/*: any*/),
+                        "selections": (v25/*: any*/),
                         "type": "ArticleImageSection",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v24/*: any*/),
+                        "selections": (v25/*: any*/),
                         "type": "Artwork",
                         "abstractKey": null
                       },
-                      (v22/*: any*/)
+                      (v23/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1164,7 +1170,7 @@ return {
                         "kind": "LinkedField",
                         "name": "cropped",
                         "plural": false,
-                        "selections": (v9/*: any*/),
+                        "selections": (v11/*: any*/),
                         "storageKey": "cropped(height:512,width:910)"
                       }
                     ],
@@ -1177,14 +1183,8 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v6/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "embed",
-                    "storageKey": null
-                  }
+                  (v8/*: any*/),
+                  (v7/*: any*/)
                 ],
                 "type": "ArticleSectionSocialEmbed",
                 "abstractKey": null
@@ -1192,8 +1192,8 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v6/*: any*/),
-                  (v17/*: any*/),
+                  (v8/*: any*/),
+                  (v18/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1225,8 +1225,8 @@ return {
             "selections": [
               (v2/*: any*/),
               (v3/*: any*/),
-              (v14/*: any*/),
-              (v10/*: any*/),
+              (v15/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1238,14 +1238,14 @@ return {
                   {
                     "alias": null,
                     "args": [
-                      (v12/*: any*/),
-                      (v23/*: any*/)
+                      (v13/*: any*/),
+                      (v24/*: any*/)
                     ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v9/*: any*/),
+                    "selections": (v11/*: any*/),
                     "storageKey": "cropped(height:60,width:80)"
                   },
                   {
@@ -1266,13 +1266,13 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v9/*: any*/),
+                    "selections": (v11/*: any*/),
                     "storageKey": "cropped(height:580,width:869)"
                   }
                 ],
                 "storageKey": null
               },
-              (v13/*: any*/),
+              (v14/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1280,7 +1280,7 @@ return {
                 "name": "thumbnailTitle",
                 "storageKey": null
               },
-              (v25/*: any*/),
+              (v26/*: any*/),
               {
                 "alias": null,
                 "args": [
@@ -1305,12 +1305,12 @@ return {
             "name": "series",
             "plural": false,
             "selections": [
-              (v25/*: any*/)
+              (v26/*: any*/)
             ],
             "storageKey": null
           },
+          (v27/*: any*/),
           (v26/*: any*/),
-          (v25/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1327,7 +1327,7 @@ return {
                 "name": "coverImage",
                 "plural": false,
                 "selections": [
-                  (v6/*: any*/)
+                  (v8/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1338,7 +1338,7 @@ return {
                 "name": "credits",
                 "storageKey": null
               },
-              (v25/*: any*/),
+              (v26/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1359,7 +1359,7 @@ return {
                 "name": "releaseDate",
                 "storageKey": "releaseDate(format:\"MMM DD, YYYY h:mma\")"
               },
-              (v6/*: any*/)
+              (v8/*: any*/)
             ],
             "storageKey": null
           },
@@ -1372,25 +1372,25 @@ return {
             "plural": false,
             "selections": [
               (v3/*: any*/),
-              (v25/*: any*/),
               (v26/*: any*/),
-              (v13/*: any*/)
+              (v27/*: any*/),
+              (v14/*: any*/)
             ],
             "storageKey": null
           },
-          (v13/*: any*/)
+          (v14/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "1d782f0c68e467c8b55b041dff66eca4",
+    "cacheID": "c8b8b924dc7c85061838c9d9b561e4bd",
     "id": null,
     "metadata": {},
     "name": "articleRoutes_ArticleQuery",
     "operationKind": "query",
-    "text": "query articleRoutes_ArticleQuery(\n  $id: String!\n) {\n  article(id: $id) @principalField {\n    ...ArticleApp_article\n    id\n  }\n}\n\nfragment ArticleApp_article on Article {\n  internalID\n  title\n  hero {\n    __typename\n  }\n  layout\n  channelID\n  ...ArticleBody_article\n  ...ArticleSeries_article\n  ...ArticleVideo_article\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHeader_article\n  ...ArticleByline_article\n  layout\n  title\n  newsSource {\n    title\n    url\n  }\n  href\n  publishedAt(format: \"MMM D, YYYY h:mma\")\n  sections {\n    __typename\n    ...ArticleSectionText_section\n    ...ArticleSectionImageCollection_section\n    ...ArticleSectionImageSet_section\n    ...ArticleSectionVideo_section\n    ...ArticleSectionSocialEmbed_section\n    ...ArticleSectionEmbed_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 80, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHeader_article on Article {\n  title\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ... on ArticleImageSection {\n      id\n      caption\n      image {\n        resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      ...Metadata_artwork\n      id\n      image {\n        resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSeries_article on Article {\n  title\n  byline\n  href\n  series {\n    description\n  }\n  sponsor {\n    ...ArticleSponsor_sponsor\n  }\n  relatedArticles {\n    internalID\n    href\n    title\n    thumbnailTitle\n    byline\n    description\n    publishedAt(format: \"MMM DD, YYYY\")\n    thumbnailImage {\n      display: cropped(width: 869, height: 580) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleSponsor_sponsor on ArticleSponsor {\n  partnerLightLogo\n  partnerDarkLogo\n  partnerLogoLink\n}\n\nfragment ArticleVideo_article on Article {\n  title\n  href\n  description\n  media {\n    coverImage {\n      url\n    }\n    credits\n    description\n    duration\n    releaseDate(format: \"MMM DD, YYYY h:mma\")\n    url\n  }\n  seriesArticle {\n    title\n    description\n    sponsor {\n      ...ArticleSponsor_sponsor\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n"
+    "text": "query articleRoutes_ArticleQuery(\n  $id: String!\n) {\n  article(id: $id) @principalField {\n    ...ArticleApp_article\n    id\n  }\n}\n\nfragment ArticleApp_article on Article {\n  internalID\n  title\n  layout\n  channelID\n  ...ArticleBody_article\n  ...ArticleSeries_article\n  ...ArticleVideo_article\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHeader_article\n  ...ArticleByline_article\n  layout\n  title\n  newsSource {\n    title\n    url\n  }\n  href\n  publishedAt(format: \"MMM D, YYYY h:mma\")\n  sections {\n    __typename\n    ...ArticleSectionText_section\n    ...ArticleSectionImageCollection_section\n    ...ArticleSectionImageSet_section\n    ...ArticleSectionVideo_section\n    ...ArticleSectionSocialEmbed_section\n    ...ArticleSectionEmbed_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 80, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHeader_article on Article {\n  title\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ... on ArticleImageSection {\n      id\n      caption\n      image {\n        resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      ...Metadata_artwork\n      id\n      image {\n        resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSeries_article on Article {\n  title\n  byline\n  href\n  series {\n    description\n  }\n  sponsor {\n    ...ArticleSponsor_sponsor\n  }\n  relatedArticles {\n    internalID\n    href\n    title\n    thumbnailTitle\n    byline\n    description\n    publishedAt(format: \"MMM DD, YYYY\")\n    thumbnailImage {\n      display: cropped(width: 869, height: 580) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleSponsor_sponsor on ArticleSponsor {\n  partnerLightLogo\n  partnerDarkLogo\n  partnerLogoLink\n}\n\nfragment ArticleVideo_article on Article {\n  title\n  href\n  description\n  media {\n    coverImage {\n      url\n    }\n    credits\n    description\n    duration\n    releaseDate(format: \"MMM DD, YYYY h:mma\")\n    url\n  }\n  seriesArticle {\n    title\n    description\n    sponsor {\n      ...ArticleSponsor_sponsor\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Closes [GRO-818](https://artsyproduct.atlassian.net/browse/GRO-818)

As mentioned here: https://github.com/artsy/metaphysics/pull/3777 — Positron hero units have a `url` associated with them, but the function of that URL changes depending on the specific layout. In the case of a "basic" layout we use it as an embed. 🤷 

![](https://static.damonzucconi.com/_capture/4OHf4AnX.png)