### PR TITLE
[chore: PX-4794] Default to first shipping quote on initial page load

### DIFF
--- a/src/v2/Apps/Order/Components/ShippingQuotes.tsx
+++ b/src/v2/Apps/Order/Components/ShippingQuotes.tsx
@@ -49,7 +49,7 @@ export const ShippingQuotes: React.FC<ShippingQuotesProps> = ({
     <RadioGroup
       {...rest}
       onSelect={onSelect}
-      defaultValue={selectedShippingQuoteId}
+      defaultValue={selectedShippingQuoteId || quotes[0].id}
     >
       {quotes.map(shippingQuote => {
         const { id, displayName, price } = shippingQuote

--- a/src/v2/Apps/Order/Components/ShippingQuotes.tsx
+++ b/src/v2/Apps/Order/Components/ShippingQuotes.tsx
@@ -49,7 +49,7 @@ export const ShippingQuotes: React.FC<ShippingQuotesProps> = ({
     <RadioGroup
       {...rest}
       onSelect={onSelect}
-      defaultValue={selectedShippingQuoteId || quotes[0].id}
+      defaultValue={selectedShippingQuoteId || quotes[0]?.id}
     >
       {quotes.map(shippingQuote => {
         const { id, displayName, price } = shippingQuote

--- a/src/v2/Apps/Order/Components/__tests__/ShippingQuotes.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/ShippingQuotes.jest.tsx
@@ -65,6 +65,17 @@ describe("ShippingQuotes", () => {
     expect(shippingQuotes).toHaveLength(5)
   })
 
+  it("auto selects the first shipping quote", async () => {
+    const shippingQuotes = page
+      .find(`[data-test="shipping-quotes"]`)
+      .find(BorderedRadio)
+
+    // The id of the lowest cost shipping option in BuyOrderWithArtaShippingDetails mocked data
+    expect(shippingQuotes.first().props().value).toEqual(
+      "4a8f8080-23d3-4c0e-9811-7a41a9df6933"
+    )
+  })
+
   it("have selected quote", async () => {
     const selectedShippingQuote = page
       .find(`[data-test="shipping-quotes"]`)


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/PX-4794

Radio button for first shipping option is selected on initial load
If user selects a shipping quote for purchase and comes back to the page, the user's selection takes precedence. 

https://user-images.githubusercontent.com/12748344/154365103-01f325a2-3e60-459d-8873-94956fa3b0f4.mov


