### PR TITLE
[GRO-734](feat): small design fixes for /about2

### DIFF
--- a/src/v2/Apps/_About2/AboutApp.tsx
+++ b/src/v2/Apps/_About2/AboutApp.tsx
@@ -98,7 +98,7 @@ const SellWithArtsy: React.FC = () => {
             style={{
               objectFit: "cover",
             }}
-            alt="a Molly Green art piece titled Cached"
+            alt=""
           />
         </Box>
       )}
@@ -206,7 +206,7 @@ const AppDownload: React.FC = () => {
             height="100%"
             srcSet={image.srcSet}
             lazyLoad
-            alt="painting of two iphones displaying the artsy mobile app"
+            alt=""
           />
         </ResponsiveBox>
       </Column>
@@ -237,7 +237,7 @@ const CollectorInfo: React.FC = () => {
             height="100%"
             srcSet={image.srcSet}
             lazyLoad
-            alt="picture of the Collection for Carole Server by Emily Johnston"
+            alt=""
           />
         </ResponsiveBox>
         <Text variant="xs" textColor="black60" mt={0.5}>

--- a/src/v2/Apps/_About2/AboutApp.tsx
+++ b/src/v2/Apps/_About2/AboutApp.tsx
@@ -156,10 +156,13 @@ const SellWithArtsy: React.FC = () => {
 }
 
 const AppDownload: React.FC = () => {
-  const image = resized("http://files.artsy.net/download_artsy_apps_img.jpg", {
-    width: 910,
-    height: 652,
-  })
+  const image = resized(
+    "http://files.artsy.net/images/about2/appstore_image.png",
+    {
+      width: 910,
+      height: 652,
+    }
+  )
 
   return (
     <GridColumns gridRowGap={4}>
@@ -181,7 +184,7 @@ const AppDownload: React.FC = () => {
             rel="noopener noreferrer"
           >
             <Image
-              src="http://files.artsy.net/images/download-ios-app-transparent.svg"
+              src="http://files.artsy.net/images/download-ios-app.svg"
               mr={4}
             />
           </a>
@@ -190,7 +193,7 @@ const AppDownload: React.FC = () => {
             target="_blank"
             rel="noopener noreferrer"
           >
-            <Image src="http://files.artsy.net/images/download-android-app-transparent.svg" />
+            <Image src="http://files.artsy.net/images/download-android-app.svg" />
           </a>
         </Flex>
       </Column>

--- a/src/v2/Apps/_About2/AboutApp.tsx
+++ b/src/v2/Apps/_About2/AboutApp.tsx
@@ -157,7 +157,7 @@ const SellWithArtsy: React.FC = () => {
 
 const AppDownload: React.FC = () => {
   const image = resized(
-    "http://files.artsy.net/images/about2/appstore_image.png",
+    "http://files.artsy.net/images/about2/appstore_image_highres.png",
     {
       width: 910,
       height: 652,


### PR DESCRIPTION
I replaced the app store image in the App section to one without a caption and replaced the transparent app store buttons with ones with color. The big image is still low res, but this can get shipped without it for now. 