### PR TITLE
fix(auction): correct artwork id in works for you rail

### DIFF
--- a/src/desktop/apps/auction/components/artwork_browser/main/artwork/GridArtwork.js
+++ b/src/desktop/apps/auction/components/artwork_browser/main/artwork/GridArtwork.js
@@ -27,7 +27,7 @@ function GridArtwork(props) {
     <a
       className={b()}
       key={saleArtwork._id}
-      href={`/artwork/${saleArtwork.id}`}
+      href={`/artwork/${saleArtwork.slug}`}
     >
       <div className={b("image-container")}>
         <div className="vam-outer">


### PR DESCRIPTION
See Slack bug reports:
- (Feb 18) https://artsy.slack.com/archives/C9SATFLUU/p1645201776039639
- (Feb 9) https://artsy.slack.com/archives/C01ADJNCS5D/p1644614111993559

This fixes some fallout from an MP v1 → v2 migration that left some id/slug confusion in its wake. The result was that some artwork bricks failed to link correctly to their corresponding artwork page.

## Before

<img width="1616" alt="before" src="https://user-images.githubusercontent.com/140521/154740239-c775712c-d8ad-4af6-9a15-ddf9a3fdfe60.png">

## After

<img width="1616" alt="after" src="https://user-images.githubusercontent.com/140521/154740240-ad034cbe-6e16-4134-a897-566879169ca4.png">


