### PR TITLE
fix: Move checkbox higher in signup form GRO-835

### DIFF
--- a/src/v2/Components/Authentication/Views/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Views/SignUpForm.tsx
@@ -176,46 +176,6 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                   <Banner variant="error">{status.error}</Banner>
                 )}
 
-                <Button type="submit" loading={isSubmitting} width="100%">
-                  Sign up
-                </Button>
-
-                <Text variant="sm" textAlign="center" color="black60">
-                  or
-                </Text>
-
-                <AuthenticationFooter
-                  mode={"signup" as ModalType}
-                  handleTypeChange={() =>
-                    this.props.handleTypeChange?.(ModalType.login)
-                  }
-                  onAppleLogin={async e => {
-                    if (!values.accepted_terms_of_service) {
-                      setTouched({ accepted_terms_of_service: true })
-                      await validateForm()
-                    } else {
-                      this.props.onAppleLogin?.(e)
-                    }
-                  }}
-                  onFacebookLogin={async e => {
-                    if (!values.accepted_terms_of_service) {
-                      setTouched({ accepted_terms_of_service: true })
-                      await validateForm()
-                    } else {
-                      this.props.onFacebookLogin?.(e)
-                    }
-                  }}
-                  onGoogleLogin={async e => {
-                    if (!values.accepted_terms_of_service) {
-                      setTouched({ accepted_terms_of_service: true })
-                      await validateForm()
-                    } else {
-                      this.props.onGoogleLogin?.(e)
-                    }
-                  }}
-                  showRecaptchaDisclaimer={this.props.showRecaptchaDisclaimer}
-                />
-
                 {collapseCheckboxes ? (
                   <AuthenticationCheckbox
                     error={!!termsErrorMessage}
@@ -283,6 +243,46 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                     promotional content. Unsubscribe at any time.
                   </AuthenticationCheckbox>
                 )}
+
+                <Button type="submit" loading={isSubmitting} width="100%">
+                  Sign up
+                </Button>
+
+                <Text variant="sm" textAlign="center" color="black60">
+                  or
+                </Text>
+
+                <AuthenticationFooter
+                  mode={"signup" as ModalType}
+                  handleTypeChange={() =>
+                    this.props.handleTypeChange?.(ModalType.login)
+                  }
+                  onAppleLogin={async e => {
+                    if (!values.accepted_terms_of_service) {
+                      setTouched({ accepted_terms_of_service: true })
+                      await validateForm()
+                    } else {
+                      this.props.onAppleLogin?.(e)
+                    }
+                  }}
+                  onFacebookLogin={async e => {
+                    if (!values.accepted_terms_of_service) {
+                      setTouched({ accepted_terms_of_service: true })
+                      await validateForm()
+                    } else {
+                      this.props.onFacebookLogin?.(e)
+                    }
+                  }}
+                  onGoogleLogin={async e => {
+                    if (!values.accepted_terms_of_service) {
+                      setTouched({ accepted_terms_of_service: true })
+                      await validateForm()
+                    } else {
+                      this.props.onGoogleLogin?.(e)
+                    }
+                  }}
+                  showRecaptchaDisclaimer={this.props.showRecaptchaDisclaimer}
+                />
               </Join>
             </Box>
           )

--- a/src/v2/Components/Authentication/Views/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Views/SignUpForm.tsx
@@ -258,6 +258,7 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                     this.props.handleTypeChange?.(ModalType.login)
                   }
                   onAppleLogin={async e => {
+                    e.preventDefault()
                     if (!values.accepted_terms_of_service) {
                       setTouched({ accepted_terms_of_service: true })
                       await validateForm()
@@ -266,6 +267,7 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                     }
                   }}
                   onFacebookLogin={async e => {
+                    e.preventDefault()
                     if (!values.accepted_terms_of_service) {
                       setTouched({ accepted_terms_of_service: true })
                       await validateForm()
@@ -274,6 +276,7 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                     }
                   }}
                   onGoogleLogin={async e => {
+                    e.preventDefault()
                     if (!values.accepted_terms_of_service) {
                       setTouched({ accepted_terms_of_service: true })
                       await validateForm()


### PR DESCRIPTION
In order to improve the signup process slightly this PR does two things:

* moves the checkboxes up under the form fields
* removes lying error messages

The way I did this was: copy/paste the checkbox code, call `preventDefault` on the click events firing from the third party auth buttons.

Looks like this:
<img width="679" alt="Screen Shot 2022-02-18 at 2 12 13 PM" src="https://user-images.githubusercontent.com/79799/154757378-3d3ce6ca-7e2a-407d-a297-462a0c342c11.png">
<img width="679" alt="Screen Shot 2022-02-18 at 2 12 27 PM" src="https://user-images.githubusercontent.com/79799/154757383-3be81270-3f97-4b7e-8b98-d09126af05ef.png">
<img width="686" alt="Screen Shot 2022-02-18 at 2 33 49 PM" src="https://user-images.githubusercontent.com/79799/154757384-600aa14d-f772-4def-bd92-bceac3a735c7.png">



https://artsyproduct.atlassian.net/browse/GRO-835

/cc @artsy/grow-devs 