### PR TITLE
Remove references to removed auth providers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -195,7 +195,7 @@
         "filename": "src/config.ts",
         "hashed_secret": "e88b861dd023258e4bbecae2721a214c49564a7c",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 102
       }
     ],
     "src/desktop/apps/article/__tests__/routes.jest.ts": [
@@ -708,5 +708,5 @@
       }
     ]
   },
-  "generated_at": "2022-02-14T11:35:19Z"
+  "generated_at": "2022-02-18T20:53:01Z"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,8 +85,6 @@ export const GOOGLE_SECRET: any = null
 export const GOOGLE_MAPS_API_KEY: any = null
 export const IMAGE_PROXY: any = "GEMINI"
 export const IP_DENYLIST: any = ""
-export const LINKEDIN_KEY: any = null
-export const LINKEDIN_SECRET: any = null
 export const METAPHYSICS_ENDPOINT: any =
   "https://metaphysics-production.artsy.net"
 export const NODE_ENV: any = "development"

--- a/src/lib/__tests__/current_user.jest.ts
+++ b/src/lib/__tests__/current_user.jest.ts
@@ -360,7 +360,7 @@ describe("CurrentUser", () => {
 
     beforeEach(() => {
       authentications = [
-        { id: "1", provider: "twitter", uid: "123456789" },
+        { id: "1", provider: "google", uid: "123456789" },
         { id: "2", provider: "facebook", uid: "987654321" },
       ]
     })
@@ -368,18 +368,18 @@ describe("CurrentUser", () => {
     describe("relation", () => {
       it("should inject initial authentications", () => {
         const user = new CurrentUser({ authentications: authentications })
-        user.isLinkedTo("twitter").should.be.true()
+        user.isLinkedTo("google").should.be.true()
         user.isLinkedTo("facebook").should.be.true()
       })
     })
 
     describe("#isLinkedTo", () => {
       it("determines if an account is linked to an app provider", () => {
-        user.isLinkedTo("twitter").should.be.false()
+        user.isLinkedTo("google").should.be.false()
 
         user.related().authentications.reset(authentications)
 
-        user.isLinkedTo("twitter").should.be.true()
+        user.isLinkedTo("google").should.be.true()
         user.isLinkedTo("facebook").should.be.true()
       })
     })

--- a/src/mobile/components/layout/stylesheets/embedded.styl
+++ b/src/mobile/components/layout/stylesheets/embedded.styl
@@ -27,8 +27,6 @@
 // Social icons
 .auth-page-facebook
   background-image url('/images/facebook.svg') !important
-.auth-page-twitter
-  background-image url('/images/twitter.svg') !important
 
 .a-z-page-toggle.feed-icon
   background-image url('/images/filter-button.png') !important

--- a/src/typings/sharify.d.ts
+++ b/src/typings/sharify.d.ts
@@ -65,7 +65,6 @@ declare module "sharify" {
         applePath?: string
         facebookPath?: string
         googlePath?: string
-        twitterPath?: string
         signupPagePath?: string
         loginPagePath?: string
         logoutPath?: string

--- a/src/v2/Apps/Authentication/Components/ModalContainer.tsx
+++ b/src/v2/Apps/Authentication/Components/ModalContainer.tsx
@@ -98,7 +98,6 @@ export class ModalContainer extends Component<any> {
           apple: sd.AP.applePath,
           facebook: sd.AP.facebookPath,
           google: sd.AP.googlePath,
-          twitter: sd.AP.twitterPath,
         }}
         csrf={Cookies && Cookies.get && Cookies.get("CSRF_TOKEN")}
         handleSubmit={handleSubmit}

--- a/src/v2/Components/Authentication/FormSwitcher.tsx
+++ b/src/v2/Components/Authentication/FormSwitcher.tsx
@@ -24,7 +24,6 @@ export interface FormSwitcherProps {
   onAppleLogin?: (e: Event) => void
   onFacebookLogin?: (e: Event) => void
   onGoogleLogin?: (e: Event) => void
-  onTwitterLogin?: (e: Event) => void
   options: ModalOptions
   title?: string
   showRecaptchaDisclaimer?: boolean
@@ -32,7 +31,6 @@ export interface FormSwitcherProps {
     apple: string
     facebook: string
     google: string
-    twitter?: string
   }
   tracking?: TrackingProp
   type: ModalType

--- a/src/v2/Components/Authentication/ModalManager.tsx
+++ b/src/v2/Components/Authentication/ModalManager.tsx
@@ -31,7 +31,6 @@ export interface ModalManagerProps {
     apple: string
     facebook: string
     google: string
-    twitter?: string
     forgot?: string
   }
   tracking?: TrackingProp

--- a/test.mocha.js
+++ b/test.mocha.js
@@ -31,7 +31,6 @@ sd.AP = {
   signupPagePath: "/signup",
   facebookPath: "/facebook",
   googlePath: "/google",
-  twitterPath: "/twitter",
 }
 sd.APP_URL = "http://artsy.net"
 sd.RECAPTCHA_KEY = "RECAPTCHA_KEY"


### PR DESCRIPTION
Twitter and LinkedIn authentication support [was previously removed](https://github.com/artsy/artsy-passport/pull/131), so I think we should delete these references to that code too.