### PR TITLE
fix(artists): prevents 500s when missing data

### DIFF
--- a/src/v2/Apps/Artists/Components/ArtistsCarouselCell.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsCarouselCell.tsx
@@ -23,31 +23,23 @@ const ArtistsCarouselCell: React.FC<ArtistsCarouselCellProps> = ({
 
   if (!image) return null
 
-  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-  const slug = getSlug(featuredLink.href)
+  const slug = getSlug(featuredLink.href ?? "")
 
   return (
     <>
-      <RouterLink
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-        key={featuredLink.internalID}
-        to={featuredLink.href}
-        display="block"
-        textDecoration="none"
-      >
-        <Image
-          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-          src={image.thumb.src}
-          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-          srcSet={image.thumb.srcSet}
-          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-          width={image.thumb.width}
-          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-          height={image.thumb.height}
-          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-          alt={featuredLink.title}
-          lazyLoad
-        />
+      <RouterLink to={featuredLink.href} display="block" textDecoration="none">
+        {image.thumb ? (
+          <Image
+            src={image.thumb.src}
+            srcSet={image.thumb.srcSet}
+            width={image.thumb.width}
+            height={image.thumb.height}
+            alt=""
+            lazyLoad
+          />
+        ) : (
+          <Box width={600} height={450} bg="black10" />
+        )}
       </RouterLink>
 
       <Box
@@ -60,13 +52,10 @@ const ArtistsCarouselCell: React.FC<ArtistsCarouselCellProps> = ({
         height={50}
       >
         <RouterLink
-          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-          key={featuredLink.internalID}
-          to={featuredLink.href}
-          dispaly="block"
+          to={featuredLink.href!}
+          display="block"
           textDecoration="none"
-          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-          aria-label={featuredLink.title}
+          aria-label={featuredLink.title ?? "Unknown Artist"}
         >
           <Text variant="lg">{featuredLink.title}</Text>
 

--- a/src/v2/Apps/Artists/Routes/ArtistsIndex.tsx
+++ b/src/v2/Apps/Artists/Routes/ArtistsIndex.tsx
@@ -18,6 +18,7 @@ import { ArtistsArtistCardFragmentContainer } from "../Components/ArtistsArtistC
 import { ArtistsCarouselCellFragmentContainer } from "../Components/ArtistsCarouselCell"
 import { ArtistsLetterNav } from "../Components/ArtistsLetterNav"
 import { Media } from "v2/Utils/Responsive"
+import { compact } from "lodash"
 
 interface ArtistsIndexProps {
   featuredArtists: ArtistsIndex_featuredArtists
@@ -56,21 +57,19 @@ export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
 
         {artists && (
           <Shelf my={2}>
-            {/*  @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
-            {artists.map((featuredLink, index) => {
-              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-              if (!featuredLink.internalID) return null
+            {compact(
+              artists.map((featuredLink, index) => {
+                if (!featuredLink?.internalID) return null
 
-              return (
-                <ArtistsCarouselCellFragmentContainer
-                  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-                  key={featuredLink.internalID}
-                  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-                  featuredLink={featuredLink}
-                  index={index}
-                />
-              )
-            })}
+                return (
+                  <ArtistsCarouselCellFragmentContainer
+                    key={featuredLink.internalID}
+                    featuredLink={featuredLink}
+                    index={index}
+                  />
+                )
+              })
+            )}
           </Shelf>
         )}
       </Media>
@@ -79,23 +78,24 @@ export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
 
       {genes && (
         <Join separator={<Spacer mt={6} />}>
-          {genes?.map(gene => {
-            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-            if (gene.trendingArtists?.length === 0) return null
+          {genes?.map((gene, i) => {
+            if (
+              !gene ||
+              !gene.trendingArtists ||
+              gene.trendingArtists.length === 0
+            )
+              return null
 
             return (
-              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-              <React.Fragment key={gene.name}>
+              <React.Fragment key={gene.name ?? i}>
                 <Box display="flex" justifyContent="space-between" mb={2}>
-                  {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
-                  <RouterLink to={gene.href} noUnderline>
+                  <RouterLink to={gene.href!} noUnderline>
                     <Text variant="lg" as="h2">
-                      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                       {gene.name}
                     </Text>
                   </RouterLink>
-                  {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
-                  <RouterLink to={gene.href} noUnderline>
+
+                  <RouterLink to={gene.href!} noUnderline>
                     <Text variant="md" color="black60">
                       View
                     </Text>
@@ -103,12 +103,11 @@ export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
                 </Box>
 
                 <GridColumns gridRowGap={[2, 0]}>
-                  {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                   {gene.trendingArtists.map(artist => {
+                    if (!artist) return null
+
                     return (
-                      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                       <Column key={artist.internalID} span={[12, 6, 3, 3]}>
-                        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
                         <ArtistsArtistCardFragmentContainer artist={artist} />
                       </Column>
                     )


### PR DESCRIPTION
This page was done prior to strict-mode being enabled which would have dealt with these errors. This page being down is causing a smoke test to fail as well.
