### PR TITLE
GRO-787 & GRO-789: User sees general support CTAs on /meet-the-specialists and updated copy/design on page

### DIFF
--- a/src/v2/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
+++ b/src/v2/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
@@ -31,6 +31,7 @@ export const MeetTheSpecialistsIndex: React.FC = () => {
   return (
     <>
       <Box mt={4}>
+        <Text variant={"xs"}>Private Sales</Text>
         <Text as="h1" variant={["xl", "xxl"]}>
           Meet the Specialists
         </Text>
@@ -41,6 +42,25 @@ export const MeetTheSpecialistsIndex: React.FC = () => {
           advise, and research on your behalf.
         </Text>
       </Box>
+
+      <Box mt={2}>
+        <Text variant="xs">
+          Have a question about Artsy? Check out our{" "}
+          <RouterLink to={"https://support.artsy.net"}>help center</RouterLink>{" "}
+          or email <a href="mailto:support@artsy.net">support@artsy.net</a>.
+        </Text>
+
+        <Text variant={"xs"}>
+          Have a question about bidding on Artsy? Email{" "}
+          <a href="mailto:specialist@artsy.net">specialist@artsy.net</a>.
+        </Text>
+
+        <Text variant={"xs"}>
+          Have a question about an existing order or offer? Email{" "}
+          <a href="mailto:specialist@artsy.net">orders@artsy.net</a>.
+        </Text>
+      </Box>
+
       <Spacer mb={120} />
 
       <GridColumns>

--- a/src/v2/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
+++ b/src/v2/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
@@ -12,6 +12,7 @@ import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { Media } from "v2/Utils/Responsive"
 import { crop } from "v2/Utils/resizer"
+import { Meta, Title } from "react-head"
 
 export const MeetTheSpecialistsIndex: React.FC = () => {
   const resizeImage = (
@@ -30,6 +31,11 @@ export const MeetTheSpecialistsIndex: React.FC = () => {
 
   return (
     <>
+      <Title>Art Advisory, Specialists, and Collector Services | Artsy</Title>
+      <Meta
+        name="description"
+        content="Whether you’re seeking a specific work for your collection or wish to sell, Artsy’s globe-spanning team is ready to source, sell, advise, and research on your behalf. Contact a specialist today."
+      />
       <Box mt={4}>
         <Text variant={"xs"}>Private Sales</Text>
         <Text as="h1" variant={["xl", "xxl"]}>

--- a/src/v2/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
+++ b/src/v2/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
@@ -67,7 +67,7 @@ export const MeetTheSpecialistsIndex: React.FC = () => {
         </Text>
       </Box>
 
-      <Spacer mb={120} />
+      <Spacer mb={12} />
 
       <GridColumns>
         <Column span={4} start={1}>


### PR DESCRIPTION
[GRO-787]
[GRO-789]

Added additional copy to the Meet The Specialist page, including links to help center and support emails. Also included an update to the SEO elements, added in a title tag and meta description.

FIGMA DESIGN: https://www.figma.com/file/m6gDpKHEWDbYJyrwsVZDBr/Artsy-3.0-Design-System

New Displays!

Desktop

<img width="1792" alt="Screen Shot 2022-02-22 at 2 14 58 PM" src="https://user-images.githubusercontent.com/30025439/155229057-1f78e9f7-9b67-4e61-b9ef-8285c3c997bf.png">

Mobile

<img width="428" alt="Screen Shot 2022-02-22 at 2 15 08 PM" src="https://user-images.githubusercontent.com/30025439/155229085-da81f765-80c5-450e-90a5-b3b889c7133f.png">

[GRO-787]: https://artsyproduct.atlassian.net/browse/GRO-787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

SEO Title Tag and Meta Added:
<img width="1286" alt="Screen Shot 2022-02-23 at 7 36 13 AM" src="https://user-images.githubusercontent.com/30025439/155352810-803e7e94-251a-4807-b502-c8811184584f.png">



[GRO-789]: https://artsyproduct.atlassian.net/browse/GRO-789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ