### PR TITLE
Updated: Changed the phone number on artsy.net/auction sale pages

### DIFF
--- a/src/desktop/apps/auction/components/layout/auction_info/Registration.tsx
+++ b/src/desktop/apps/auction/components/layout/auction_info/Registration.tsx
@@ -4,6 +4,7 @@ import { connect } from "react-redux"
 import { Button, Sans } from "@artsy/palette"
 import { bidderQualifications } from "v2/Utils/identityVerificationRequirements"
 import { ZendeskWrapper } from "v2/Components/ZendeskWrapper"
+// eslint-disable-next-line no-restricted-imports
 import { data as sd } from "sharify"
 
 const RegistrationMessage: React.FC<{ color?: string }> = ({
@@ -190,7 +191,7 @@ const Registration: React.FC<RegistrationProps> = props => {
             <br />
             <a href="mailto:specialist@artsy.net">specialist@artsy.net</a>
             <br />
-            +1-646-381-3901
+            +1-845-582-3967
           </div>
         </div>
       )}

--- a/src/v2/Apps/Auction2/Components/AuctionDetails/AuctionInfoSidebar.tsx
+++ b/src/v2/Apps/Auction2/Components/AuctionDetails/AuctionInfoSidebar.tsx
@@ -27,7 +27,7 @@ const AuctionInfoSidebar: React.FC<AuctionInfoSidebarProps> = ({ sale }) => {
         <a href="mailto:specialist@artsy.net">
           <Text variant="sm">specialist@artsy.net</Text>
         </a>
-        <Text variant="sm">+1-646-381-3901</Text>
+        <Text variant="sm">+1-845-582-3967</Text>
       </Box>
     </Join>
   )


### PR DESCRIPTION
[GRO-826]
Replaced the old `Contact Us:` phone number with the newest number +1-845-582-3967

New Behavior:
<img width="1768" alt="Screen Shot 2022-02-23 at 9 04 14 AM" src="https://user-images.githubusercontent.com/30025439/155383272-8cd10b98-257d-4106-8741-c03863b33008.png">



[GRO-826]: https://artsyproduct.atlassian.net/browse/GRO-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ