### PR TITLE
feat(NX-3082): change CTA copies

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -91,9 +91,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
   renderSaleMessage(saleMessage: string) {
     return (
       <Text variant="lg" data-test="SaleMessage">
-        {saleMessage === "Contact For Price"
-          ? "Contact for Price"
-          : saleMessage}
+        {saleMessage === "Contact For Price" ? "Price on Request" : saleMessage}
       </Text>
     )
   }
@@ -496,7 +494,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
               loading={isCommittingCreateOrderMutation}
               onClick={this.handleCreateOrder.bind(this)}
             >
-              Buy now
+              Purchase
             </Button>
           )}
           {shouldDisplayMakeOfferButton && (
@@ -509,7 +507,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
                 loading={isCommittingCreateOfferOrderMutation}
                 onClick={this.handleCreateOfferOrder.bind(this)}
               >
-                Make offer
+                Make an Offer
               </Button>
             </>
           )}

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.jest.tsx
@@ -134,7 +134,7 @@ describe("ArtworkSidebarCommercial", () => {
 
     const wrapper = getWrapper(artwork)
 
-    expect(wrapper.text()).toContain("Buy now")
+    expect(wrapper.text()).toContain("Purchase")
   })
 
   it("displays sold acquireable artwork", async () => {
@@ -150,7 +150,7 @@ describe("ArtworkSidebarCommercial", () => {
 
     const wrapper = getWrapper(artwork)
 
-    expect(wrapper.text()).toContain("Make offer")
+    expect(wrapper.text()).toContain("Make an Offer")
   })
 
   it("displays artwork enrolled in Make Offer/Contact Gallery when enabled for both", async () => {
@@ -158,7 +158,7 @@ describe("ArtworkSidebarCommercial", () => {
 
     const wrapper = getWrapper(artwork)
 
-    expect(wrapper.text()).toContain("Make offer")
+    expect(wrapper.text()).toContain("Make an Offer")
     expect(wrapper.text()).toContain("Contact Gallery")
   })
 
@@ -167,8 +167,8 @@ describe("ArtworkSidebarCommercial", () => {
 
     const wrapper = getWrapper(artwork)
 
-    expect(wrapper.text()).toContain("Buy now")
-    expect(wrapper.text()).toContain("Make offer")
+    expect(wrapper.text()).toContain("Purchase")
+    expect(wrapper.text()).toContain("Make an Offer")
   })
 
   it("displays artwork enrolled in contact for price", async () => {
@@ -176,7 +176,7 @@ describe("ArtworkSidebarCommercial", () => {
 
     const wrapper = getWrapper(artwork)
 
-    expect(wrapper.text()).toContain("Contact for Price")
+    expect(wrapper.text()).toContain("Price on Request")
   })
 
   it("creates a Buy Now order and redirects to the order page", () => {

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial2.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial2.jest.tsx
@@ -35,30 +35,30 @@ describe("ArtworkSidebarCommercial RTL", () => {
     `,
   })
 
-  it("displays both Make Offer and Contact Gallery CTAs when offerable from inquiry and exact price listed", () => {
+  it("displays both Make an Offer and Contact Gallery CTAs when offerable from inquiry and exact price listed", () => {
     renderWithRelay({
       Artwork: () => ArtworkOfferableFromInquiryPriceExact,
     })
 
-    expect(screen.getByText("Make offer")).toBeInTheDocument()
+    expect(screen.getByText("Make an Offer")).toBeInTheDocument()
     expect(screen.getByText("Contact Gallery")).toBeInTheDocument()
   })
 
-  it("displays both Make Offer and Contact Gallery CTAs when offerable from inquiry and price range", () => {
+  it("displays both Make an Offer and Contact Galleryt CTAs when offerable from inquiry and price range", () => {
     renderWithRelay({
       Artwork: () => ArtworkOfferableFromInquiryPriceRange,
     })
 
-    expect(screen.getByText("Make offer")).toBeInTheDocument()
+    expect(screen.getByText("Make an Offer")).toBeInTheDocument()
     expect(screen.getByText("Contact Gallery")).toBeInTheDocument()
   })
 
-  it("does not display Make Offer CTA and only the Contact Gallery CTA when offerable from inquiry and price hidden", () => {
+  it("does not display Make an Offer CTA and only the Contact Gallery CTA when offerable from inquiry and price hidden", () => {
     renderWithRelay({
       Artwork: () => ArtworkOfferableAndInquireablePriceHidden,
     })
 
-    expect(screen.queryByText("Make offer")).not.toBeInTheDocument()
+    expect(screen.queryByText("Make an Offer")).not.toBeInTheDocument()
     expect(screen.getByText("Contact Gallery")).toBeInTheDocument()
   })
 

--- a/src/v2/Apps/Conversation/Components/OpenInquiryModalCTA.tsx
+++ b/src/v2/Apps/Conversation/Components/OpenInquiryModalCTA.tsx
@@ -57,7 +57,7 @@ export const OpenInquiryModalCTA: React.FC<OpenInquiryModalCTAProps> = ({
           variant="primaryBlack"
           onClick={() => handleOpenModal()}
         >
-          Make Offer
+          Make an Offer
         </Button>
       </Flex>
     </>

--- a/src/v2/Apps/Conversation/Components/__tests__/OpenInquiryModalCTA.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/OpenInquiryModalCTA.jest.tsx
@@ -52,7 +52,7 @@ describe("OpenInquiryModalCTA", () => {
     const link = screen.getByRole("link")
     expect(link).toHaveTextContent("The Artsy Guarantee")
     expect(link).toHaveAttribute("href", "/buyer-guarantee")
-    expect(screen.getByRole("button")).toHaveTextContent("Make Offer")
+    expect(screen.getByRole("button")).toHaveTextContent("Make an Offer")
   })
 
   it("triggers openInquiryModal when clicking in the button", () => {

--- a/src/v2/Components/Artwork/Details.tsx
+++ b/src/v2/Components/Artwork/Details.tsx
@@ -170,7 +170,7 @@ const SaleMessage: React.FC<DetailsProps> = ({
   }
 
   if (sale_message === "Contact For Price") {
-    return <>Contact for Price</>
+    return <>Price on Request</>
   }
 
   return <>{sale_message}</>

--- a/src/v2/Components/Artwork/__tests__/Details.jest.tsx
+++ b/src/v2/Components/Artwork/__tests__/Details.jest.tsx
@@ -113,7 +113,7 @@ describe("Details", () => {
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       const wrapper = await getWrapper(data)
       const html = wrapper.html()
-      expect(html).toContain("Contact for Price")
+      expect(html).toContain("Price on Request")
     })
 
     it("shows sale message if sale open and no bids", async () => {


### PR DESCRIPTION
[NX-3082]

We're changing the copies around `Buy now`, `Make offer` and `Contact for Price` but only the copies, we are not touching in any `saleMessage` coming from Gravity or other services, nor the language elsewhere, example we still call Buy now and everything related to it, only the copy has changed to Purchase.

Artwork page (Price on Request)
<img width=320 src="https://user-images.githubusercontent.com/15792853/155515820-c78b417d-fc64-48f0-a793-7adba3a90186.png" />

Search screen (Price on Request)
<img width=320 src="https://user-images.githubusercontent.com/15792853/155515897-515503e9-5ce2-4b58-a4ef-dbde449b4729.png" />

Artwork page (Purchase & Make an Offer)
<img width=320 src="https://user-images.githubusercontent.com/15792853/155516170-b6915620-03ac-4d61-abde-c86d0b9ae9b0.png" />

Conversation (Make an Offer)
<img width=320 src="https://user-images.githubusercontent.com/15792853/155516314-9a159899-8e29-44fe-b6f3-a3518436f2db.png" />


[NX-3082]: https://artsyproduct.atlassian.net/browse/NX-3082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ