### PR TITLE
GRO-787: Updated: Specialist page with new email for a specialist

### DIFF
--- a/src/v2/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
+++ b/src/v2/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
@@ -37,7 +37,6 @@ export const MeetTheSpecialistsIndex: React.FC = () => {
         content="Whether you’re seeking a specific work for your collection or wish to sell, Artsy’s globe-spanning team is ready to source, sell, advise, and research on your behalf. Contact a specialist today."
       />
       <Box mt={4}>
-        <Text variant={"xs"}>Private Sales</Text>
         <Text as="h1" variant={["xl", "xxl"]}>
           Meet the Specialists
         </Text>
@@ -286,7 +285,7 @@ const auctionSpecialists = [
     name: "Alan Zeng",
     title: "Senior Specialist, Street Art",
     location: "New York",
-    email: "alan.zeng@artsy.net",
+    email: "alan@artsy.net",
     photo: { url: "http://files.artsy.net/images/alan.png" },
   },
 ]


### PR DESCRIPTION
Small change to remove unneeded `Private Sales` header and update a specialists email

New Behavior:
<img width="1460" alt="Screen Shot 2022-02-24 at 9 18 42 AM" src="https://user-images.githubusercontent.com/30025439/155575574-68183cdb-e38f-4193-a0e4-3b31d4579a5e.png">

<img width="1137" alt="Screen Shot 2022-02-24 at 9 18 35 AM" src="https://user-images.githubusercontent.com/30025439/155575620-724ee46b-4919-4307-a06d-de8f3fee659b.png">

