### PR TITLE
feat(FX-3768): Add additional event tracking

### DIFF
--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -36,7 +36,7 @@ import {
 import { getAllowedSearchCriteria } from "v2/Components/SavedSearchAlert/Utils/savedSearchCriteria"
 import { SavedSearchAlertPills } from "v2/Components/SavedSearchAlert/Components/SavedSearchAlertPills"
 import { useTracking } from "react-tracking"
-import { ActionType, EditedSavedSearch, OwnerType } from "@artsy/cohesion"
+import { ActionType } from "@artsy/cohesion"
 
 const logger = createLogger(
   "v2/Apps/SavedSearchAlerts/Components/SavedSearchAlertEditForm"
@@ -111,15 +111,12 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
         },
       })
 
-      const action: EditedSavedSearch = {
+      trackEvent({
         action: ActionType.editedSavedSearch,
-        context_screen_owner_type: OwnerType.savedSearch,
-        context_screen_owner_id: editAlertEntity.id,
+        saved_search_id: editAlertEntity.id,
         current: JSON.stringify(userAlertSettings),
         changed: JSON.stringify(updatedAlertSettings),
-      }
-
-      trackEvent(action)
+      })
 
       onCompleted()
     } catch (error) {

--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/__tests__/SavedSearchAlertEditForm.jest.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/__tests__/SavedSearchAlertEditForm.jest.tsx
@@ -5,6 +5,7 @@ import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
 import { SavedSearchAlertEditForm_Test_Query } from "v2/__generated__/SavedSearchAlertEditForm_Test_Query.graphql"
 import { EditAlertEntity } from "../../types"
 import { SavedSearchAlertEditFormFragmentContainer } from "../SavedSearchAlertEditForm"
+import { useTracking } from "react-tracking"
 
 const mockEditSavedSearchAlert = jest.fn()
 
@@ -24,9 +25,17 @@ const defaultEditAlertEntity: EditAlertEntity = {
 describe("SavedSearchAlertEditForm", () => {
   const mockOnCompleted = jest.fn()
   const mockOnDeleteClick = jest.fn()
+  const trackEvent = jest.fn()
 
   beforeEach(() => {
     jest.clearAllMocks()
+
+    const mockTracking = useTracking as jest.Mock
+    mockTracking.mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
   })
 
   const { renderWithRelay } = setupTestWrapperTL<
@@ -118,6 +127,42 @@ describe("SavedSearchAlertEditForm", () => {
     fireEvent.click(saveAlertButton)
 
     await waitFor(() => expect(mockOnCompleted).toBeCalled())
+  })
+
+  it("should track editedSavedSearch event when alert info is successfully updated", async () => {
+    renderWithRelay({
+      Artist: () => artistMocked,
+      FilterArtworksConnection: () => filterArtworksConnectionMocked,
+      SearchCriteria: () => savedSearchAlertMocked,
+    })
+
+    fireEvent.change(screen.getByDisplayValue("Alert #1"), {
+      target: { value: "Updated Name" },
+    })
+
+    const saveAlertButton = screen.getByRole("button", {
+      name: "Save Alert",
+    })
+
+    fireEvent.click(saveAlertButton)
+
+    await waitFor(() => expect(mockOnCompleted).toBeCalled())
+
+    expect(trackEvent).toBeCalledWith({
+      action: "editedSavedSearch",
+      context_screen_owner_type: "savedSearch",
+      context_screen_owner_id: "alert-id",
+      current: JSON.stringify({
+        name: "Alert #1",
+        email: true,
+        push: false,
+      }),
+      changed: JSON.stringify({
+        name: "Updated Name",
+        push: false,
+        email: true,
+      }),
+    })
   })
 
   describe("Save Alert button", () => {

--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/__tests__/SavedSearchAlertEditForm.jest.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/__tests__/SavedSearchAlertEditForm.jest.tsx
@@ -148,21 +148,16 @@ describe("SavedSearchAlertEditForm", () => {
 
     await waitFor(() => expect(mockOnCompleted).toBeCalled())
 
-    expect(trackEvent).toBeCalledWith({
-      action: "editedSavedSearch",
-      context_screen_owner_type: "savedSearch",
-      context_screen_owner_id: "alert-id",
-      current: JSON.stringify({
-        name: "Alert #1",
-        email: true,
-        push: false,
-      }),
-      changed: JSON.stringify({
-        name: "Updated Name",
-        push: false,
-        email: true,
-      }),
-    })
+    expect(trackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "editedSavedSearch",
+          "changed": "{\\"name\\":\\"Updated Name\\",\\"push\\":false,\\"email\\":true}",
+          "current": "{\\"name\\":\\"Alert #1\\",\\"email\\":true,\\"push\\":false}",
+          "saved_search_id": "alert-id",
+        },
+      ]
+    `)
   })
 
   describe("Save Alert button", () => {

--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -30,6 +30,8 @@ import { SavedSearchAlertEditFormDesktop } from "./Components/SavedSearchAlertEd
 import { Sticky, StickyProvider } from "v2/Components/Sticky"
 import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 import { SavedSearchAlertEditFormMobile } from "./Components/SavedSearchAlertEditFormMobile"
+import { useTracking } from "react-tracking"
+import { ActionType, DeletedSavedSearch, OwnerType } from "@artsy/cohesion"
 
 interface SavedSearchAlertsAppProps {
   me: SavedSearchAlertsApp_me
@@ -46,6 +48,7 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
     setEditAlertEntity,
   ] = useState<EditAlertEntity | null>(null)
   const { sendToast } = useToasts()
+  const { trackEvent } = useTracking()
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [loading, setLoading] = useState(false)
   const alerts = extractNodes(me.savedSearchesConnection)
@@ -77,12 +80,19 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
   }
 
   const handleDeleted = () => {
+    const action: DeletedSavedSearch = {
+      action: ActionType.deletedSavedSearch,
+      context_screen_owner_type: OwnerType.savedSearch,
+      context_screen_owner_id: editAlertEntity!.id,
+    }
+
     closeEditFormAndRefetch()
     closeDeleteModal()
 
     sendToast({
       message: "Your Alert has been deleted.",
     })
+    trackEvent(action)
   }
 
   const handleLoadMore = () => {

--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -31,7 +31,7 @@ import { Sticky, StickyProvider } from "v2/Components/Sticky"
 import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 import { SavedSearchAlertEditFormMobile } from "./Components/SavedSearchAlertEditFormMobile"
 import { useTracking } from "react-tracking"
-import { ActionType, DeletedSavedSearch, OwnerType } from "@artsy/cohesion"
+import { ActionType } from "@artsy/cohesion"
 
 interface SavedSearchAlertsAppProps {
   me: SavedSearchAlertsApp_me
@@ -80,11 +80,10 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
   }
 
   const handleDeleted = () => {
-    const action: DeletedSavedSearch = {
+    trackEvent({
       action: ActionType.deletedSavedSearch,
-      context_screen_owner_type: OwnerType.savedSearch,
-      context_screen_owner_id: editAlertEntity!.id,
-    }
+      saved_search_id: editAlertEntity!.id,
+    })
 
     closeEditFormAndRefetch()
     closeDeleteModal()
@@ -92,7 +91,6 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
     sendToast({
       message: "Your Alert has been deleted.",
     })
-    trackEvent(action)
   }
 
   const handleLoadMore = () => {

--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/__tests__/SavedSearchAlertsApp.jest.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/__tests__/SavedSearchAlertsApp.jest.tsx
@@ -3,8 +3,10 @@ import { graphql } from "react-relay"
 import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
 import { SavedSearchAlertsAppPaginationContainer } from "../SavedSearchAlertsApp"
 import { SavedSearchAlertsApp_Test_Query } from "v2/__generated__/SavedSearchAlertsApp_Test_Query.graphql"
+import { useTracking } from "react-tracking"
 
 jest.unmock("react-relay")
+jest.mock("react-tracking")
 jest.mock("react-head", () => ({
   Title: () => null,
   Meta: () => null,
@@ -15,6 +17,8 @@ jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
 }))
 
 describe("SavedSearchAlertsApp", () => {
+  const trackEvent = jest.fn()
+
   const { renderWithRelay } = setupTestWrapperTL<
     SavedSearchAlertsApp_Test_Query
   >({
@@ -26,6 +30,16 @@ describe("SavedSearchAlertsApp", () => {
         }
       }
     `,
+  })
+
+  beforeEach(() => {
+    const mockTracking = useTracking as jest.Mock
+
+    mockTracking.mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
   })
 
   it("renders all alerts", () => {


### PR DESCRIPTION
Type: **Enhancement**
Jira ticket: [FX-3768]

### Acceptance Criteria
* Add `editedSavedSearch` event when the saved search alert was updated
* Track `deletedSavedSearch` event when the saved search alert was deleted

### Useful Links
* [Find and Explore Analytics Tracking](https://docs.google.com/spreadsheets/d/1_VDAmRJz2K87FXDq7oh_tQSgwBv4syuZjaaR3sfetcI/edit#gid=121201130)
* [Notion card](https://www.notion.so/artsy/We-d-need-2-additional-event-tracking-179d8c06383e4a9eafe86f6c7eb8b466)

### Demo
#### editedSavedSearch event
https://user-images.githubusercontent.com/3513494/155741736-4785f666-d52e-43b7-9740-d76e25ed8ef5.mp4

<img width="895" alt="updated-event" src="https://user-images.githubusercontent.com/3513494/155741753-06f1ddc0-b6e3-4c00-9fab-5f57f4cc16c2.png">

#### deletedSavedSearch event
https://user-images.githubusercontent.com/3513494/155741788-3bfd2df2-e903-485c-9d98-f1df2f1d5387.mp4

<img width="895" alt="delete-event" src="https://user-images.githubusercontent.com/3513494/155741822-1fe111f0-0eff-4597-8384-38fd6fe33f99.png">


[FX-3768]: https://artsyproduct.atlassian.net/browse/FX-3768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ