### PR TITLE
feat: remove high speed bump modal from offer

### DIFF
--- a/src/v2/Apps/Order/Routes/Offer/index.tsx
+++ b/src/v2/Apps/Order/Routes/Offer/index.tsx
@@ -49,7 +49,6 @@ export interface OfferState {
   offerNoteValue: TextAreaChange
   formIsDirty: boolean
   lowSpeedBumpEncountered: boolean
-  highSpeedBumpEncountered: boolean
   isToggleRadio: boolean
 }
 
@@ -59,7 +58,6 @@ const logger = createLogger("Order/Routes/Offer/index.tsx")
 export class OfferRoute extends Component<OfferProps, OfferState> {
   state: OfferState = {
     formIsDirty: false,
-    highSpeedBumpEncountered: false,
     lowSpeedBumpEncountered: false,
     offerNoteValue: { exceedsCharacterLimit: false, value: "" },
     offerValue: 0,
@@ -87,20 +85,6 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
       message:
         "Offers within 25% of the list price are most likely to receive a response.",
       title: "Offer may be too low",
-    })
-  }
-
-  @track<OfferProps>(props => ({
-    action_type: Schema.ActionType.ViewedOfferHigherThanListPrice,
-    flow: Schema.Flow.MakeOffer,
-    order_id: props.order.internalID,
-  }))
-  showHighSpeedbump() {
-    this.setState({ highSpeedBumpEncountered: true })
-    this.props.dialog.showErrorDialog({
-      continueButtonText: "OK",
-      message: "You’re making an offer higher than the list price.",
-      title: "Offer higher than list price",
     })
   }
 
@@ -161,12 +145,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
   }
 
   onContinueButtonPressed = async () => {
-    const {
-      offerValue,
-      offerNoteValue,
-      lowSpeedBumpEncountered,
-      highSpeedBumpEncountered,
-    } = this.state
+    const { offerValue, offerNoteValue, lowSpeedBumpEncountered } = this.state
 
     if (offerValue <= 0 || offerNoteValue.exceedsCharacterLimit) {
       this.setState({ formIsDirty: true })
@@ -181,21 +160,12 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
       ?.displayPriceRange
 
     if (
+      !isPriceHidden &&
       !lowSpeedBumpEncountered &&
       offerValue * 100 < listPriceCents * 0.75 &&
       !isRangeOffer
     ) {
       this.showLowSpeedbump()
-      return
-    }
-
-    if (
-      !highSpeedBumpEncountered &&
-      this.state.offerValue * 100 > listPriceCents &&
-      !isRangeOffer &&
-      !isPriceHidden
-    ) {
-      this.showHighSpeedbump()
       return
     }
 

--- a/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
@@ -292,27 +292,6 @@ describe("Offer InitialMutation", () => {
         expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
       })
     })
-
-    describe("The 'amount too high' speed bump", () => {
-      it("shows if the offer amount is too high", async () => {
-        await page.setOfferAmount(17000)
-        await page.clickSubmit()
-
-        expect(mutations.mockFetch).not.toHaveBeenCalled()
-
-        await page.expectAndDismissErrorDialogMatching(
-          "Offer higher than list price",
-          "You’re making an offer higher than the list price",
-          "OK"
-        )
-
-        expect(mutations.mockFetch).not.toHaveBeenCalled()
-
-        await page.clickSubmit()
-
-        expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
-      })
-    })
   })
 
   describe("Analytics", () => {
@@ -341,21 +320,6 @@ describe("Offer InitialMutation", () => {
         order_id: "1234",
       }
       await page.setOfferAmount(1000)
-
-      expect(mockPostEvent).not.toHaveBeenLastCalledWith(trackData)
-
-      await page.clickSubmit()
-
-      expect(mockPostEvent).toHaveBeenLastCalledWith(trackData)
-    })
-
-    it("tracks viwing the high offer speedbump", async () => {
-      const trackData = {
-        action_type: "Viewed offer higher than listed price",
-        flow: "Make offer",
-        order_id: "1234",
-      }
-      await page.setOfferAmount(20000)
 
       expect(mockPostEvent).not.toHaveBeenLastCalledWith(trackData)
 

--- a/src/v2/Apps/Order/Routes/__tests__/Offer2.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Offer2.jest.tsx
@@ -47,7 +47,7 @@ describe("an offer on the work with price hidden", () => {
   })
 
   it("shows no modal warning when an offer made on work with hidden price", async () => {
-    await page.setOfferAmount(2000000)
+    await page.setOfferAmount(2)
     await page.clickSubmit()
     await page.expectButtonSpinnerWhenSubmitting()
     await page.expectNoModal()


### PR DESCRIPTION
[NX-3074]

- Removes high-speed bump modal when an offer is higher than the list price
- Fixes an issue when the price was hidden we showed the low-speed bump modal informing the offer was X% under the list price

@artsy/negotiate-devs 

[NX-3074]: https://artsyproduct.atlassian.net/browse/NX-3074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ