### PR TITLE
feat[FX-3718]: update color palette

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
+++ b/src/v2/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
@@ -5,7 +5,7 @@ describe("getMetadata", () => {
     it("formats medium types", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
         medium: "painting",
-        color: null,
+        color: undefined,
       })
       expect(title).toBe("Paintings - For Sale on Artsy")
       expect(breadcrumbTitle).toBe("Paintings")
@@ -17,7 +17,7 @@ describe("getMetadata", () => {
     it("falls back to fallback meta if medium is invalid", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
         medium: "foo" as any,
-        color: null,
+        color: undefined,
       })
       expect(title).toBe("Collect | Artsy")
       expect(breadcrumbTitle).toBe("Collect")
@@ -30,7 +30,7 @@ describe("getMetadata", () => {
   describe("color", () => {
     it("formats color types", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
-        medium: null,
+        medium: undefined,
         color: "red",
       })
 
@@ -43,7 +43,7 @@ describe("getMetadata", () => {
 
     it("falls back to fallback meta if medium is invalid", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
-        medium: null,
+        medium: undefined,
         color: "foo" as any,
       })
       expect(title).toBe("Collect | Artsy")
@@ -56,8 +56,8 @@ describe("getMetadata", () => {
 
   it("formats default types", () => {
     const { title, breadcrumbTitle, description } = getMetadata({
-      medium: null,
-      color: null,
+      medium: undefined,
+      color: undefined,
     })
 
     expect(title).toBe("Collect | Artsy")

--- a/src/v2/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
+++ b/src/v2/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
@@ -5,7 +5,6 @@ describe("getMetadata", () => {
     it("formats medium types", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
         medium: "painting",
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         color: null,
       })
       expect(title).toBe("Paintings - For Sale on Artsy")
@@ -18,7 +17,6 @@ describe("getMetadata", () => {
     it("falls back to fallback meta if medium is invalid", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
         medium: "foo" as any,
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         color: null,
       })
       expect(title).toBe("Collect | Artsy")
@@ -32,7 +30,6 @@ describe("getMetadata", () => {
   describe("color", () => {
     it("formats color types", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         medium: null,
         color: "red",
       })
@@ -46,7 +43,6 @@ describe("getMetadata", () => {
 
     it("falls back to fallback meta if medium is invalid", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         medium: null,
         color: "foo" as any,
       })
@@ -60,9 +56,7 @@ describe("getMetadata", () => {
 
   it("formats default types", () => {
     const { title, breadcrumbTitle, description } = getMetadata({
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       medium: null,
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       color: null,
     })
 

--- a/src/v2/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
+++ b/src/v2/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
@@ -26,8 +26,8 @@ export type Color =
   | "yellow"
 
 interface Props {
-  medium: Medium | null
-  color: Color | null
+  medium: Medium | undefined
+  color: Color | undefined
 }
 
 export function getMetadata({ medium, color }: Props) {

--- a/src/v2/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
+++ b/src/v2/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
@@ -15,21 +15,19 @@ export type Medium =
 
 export type Color =
   | "black-and-white"
-  | "darkblue"
-  | "darkgreen"
-  | "darkviolet"
+  | "blue"
   | "gold"
-  | "lightblue"
-  | "lightgreen"
+  | "gray"
+  | "green"
   | "orange"
   | "pink"
+  | "purple"
   | "red"
-  | "violet"
   | "yellow"
 
 interface Props {
-  medium: Medium
-  color: Color
+  medium: Medium | null
+  color: Color | null
 }
 
 export function getMetadata({ medium, color }: Props) {
@@ -108,23 +106,17 @@ export function getMetadata({ medium, color }: Props) {
       case "black-and-white":
         title = "Black and White Art"
         break
-      case "darkblue":
-        title = "Blue Art"
-        break
-      case "darkgreen":
-        title = "Dark Green Art"
-        break
-      case "darkviolet":
-        title = "Dark Violet Art"
+      case "green":
+        title = "Green Art"
         break
       case "gold":
         title = "Gold Art"
         break
-      case "lightblue":
-        title = "Light Blue Art"
+      case "gray":
+        title = "Gray Art"
         break
-      case "lightgreen":
-        title = "Green Art"
+      case "blue":
+        title = "Blue Art"
         break
       case "orange":
         title = "Orange Art"
@@ -135,8 +127,8 @@ export function getMetadata({ medium, color }: Props) {
       case "red":
         title = "Red Art"
         break
-      case "violet":
-        title = "Violet Art"
+      case "purple":
+        title = "Purple Art"
         break
       case "yellow":
         title = "Yellow Art"

--- a/src/v2/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
+++ b/src/v2/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
@@ -16,7 +16,6 @@ export type Medium =
 export type Color =
   | "black-and-white"
   | "blue"
-  | "gold"
   | "gray"
   | "green"
   | "orange"
@@ -108,9 +107,6 @@ export function getMetadata({ medium, color }: Props) {
         break
       case "green":
         title = "Green Art"
-        break
-      case "gold":
-        title = "Gold Art"
         break
       case "gray":
         title = "Gray Art"

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -29,7 +29,6 @@ export const COLOR_OPTIONS = [
   { hex: "#ffffff", value: "black-and-white", name: "Black and White" },
   { hex: "#C2C2C2", value: "gray", name: "Gray" },
   { hex: "#E1ADCD", value: "pink", name: "Pink" },
-  { hex: "#A78036", value: "gold", name: "Gold" },
 ]
 
 type ColorOption = typeof COLOR_OPTIONS[number]

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -20,19 +20,16 @@ import { useFilterLabelCountByKey } from "../Utils/useFilterLabelCountByKey"
 import { sortResults } from "./Utils/sortResults"
 
 export const COLOR_OPTIONS = [
+  { hex: "#BB392D", value: "red", name: "Red" },
+  { hex: "#EA6B1F", value: "orange", name: "Orange" },
+  { hex: "#E2B929", value: "yellow", name: "Yellow" },
+  { hex: "#00674A", value: "green", name: "Green" },
+  { hex: "#0A1AB4", value: "blue", name: "Blue" },
+  { hex: "#7B3D91", value: "purple", name: "Purple" },
   { hex: "#ffffff", value: "black-and-white", name: "Black and White" },
-  { hex: "#ff0000", value: "red", name: "Red" },
-  { hex: "#fbe854", value: "yellow", name: "Yellow" },
-  { hex: "#f7923a", value: "orange", name: "Orange" },
-  { hex: "#fb81cd", value: "pink", name: "Pink" },
-  { hex: "#b82c83", value: "violet", name: "Violet" },
-  { hex: "#daa520", value: "gold", name: "Gold" },
-  { hex: "#f1572c", value: "darkorange", name: "Dark Orange" },
-  { hex: "#217c44", value: "darkgreen", name: "Dark Green" },
-  { hex: "#0a1ab4", value: "darkblue", name: "Dark Blue" },
-  { hex: "#642b7f", value: "darkviolet", name: "Dark Violet" },
-  { hex: "#bccc46", value: "lightgreen", name: "Light Green" },
-  { hex: "#c2d5f1", value: "lightblue", name: "Light Blue" },
+  { hex: "#C2C2C2", value: "gray", name: "Gray" },
+  { hex: "#E1ADCD", value: "pink", name: "Pink" },
+  { hex: "#A78036", value: "gold", name: "Gold" },
 ]
 
 type ColorOption = typeof COLOR_OPTIONS[number]

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
@@ -38,7 +38,7 @@ describe("ColorFilter", () => {
 
     wrapper.find("Checkbox").first().simulate("click")
 
-    expect(context.filters.colors).toEqual(["black-and-white"])
+    expect(context.filters.colors).toEqual(["red"])
   })
 
   it("selects multiple colors when clicked", () => {
@@ -49,7 +49,7 @@ describe("ColorFilter", () => {
     wrapper.find("Checkbox").first().simulate("click")
     wrapper.find("Checkbox").last().simulate("click")
 
-    expect(context.filters.colors).toEqual(["black-and-white", "violet"])
+    expect(context.filters.colors).toEqual(["red", "purple"])
   })
 
   it("unselects a selected a color when clicked", () => {
@@ -60,11 +60,11 @@ describe("ColorFilter", () => {
     wrapper.find("Checkbox").first().simulate("click")
     wrapper.find("Checkbox").last().simulate("click")
 
-    expect(context.filters.colors).toEqual(["black-and-white", "violet"])
+    expect(context.filters.colors).toEqual(["red", "purple"])
 
     wrapper.find("Checkbox").first().simulate("click")
 
-    expect(context.filters.colors).toEqual(["violet"])
+    expect(context.filters.colors).toEqual(["purple"])
   })
 
   describe("the `expanded` prop", () => {


### PR DESCRIPTION
Updates Force's color filter palette to reflect the changes from https://github.com/artsy/gravity/pull/15040 and https://github.com/artsy/gravity/pull/15051/files.

This should not be merged until all the Gravity PRs have been merged and artworks are reindexed to have the new color values!

<img width="228" alt="Screen Shot 2022-02-25 at 6 37 50 PM" src="https://user-images.githubusercontent.com/5361806/155763371-12ded2a1-d7f9-427a-a8f6-10597bd4b678.png">

Jira ticket: https://artsyproduct.atlassian.net/browse/FX-3718