### PR TITLE
mc-jones/fix unleash implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,6 +250,7 @@
     "typeahead.js": "0.10.5",
     "underscore": "1.12.1",
     "underscore.string": "3.3.5",
+    "unleash-client": "^3.12.0",
     "updeep": "1.0.0",
     "use-cursor": "^1.2.3",
     "useragent": "2.3.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -128,6 +128,10 @@ export const TEAM_BLOGS: any =
   "^/life-at-artsy$|^/artsy-education$|^/buying-with-artsy$"
 export const THIRD_PARTIES_DISABLED: any = false
 export const TRACK_PAGELOAD_PATHS: any = null
+export const UNLEASH_API: any = null
+export const UNLEASH_APP_NAME: any = null
+export const UNLEASH_INSTANCE_ID: any = null
+export const UNLEASH_SERVER_KEY: any = null
 export const VANITY_BUCKET: any = "artsy-vanity-files-production"
 export const VERBOSE_LOGGING: any = false
 export const VOLLEY_ENDPOINT: any = null

--- a/src/lib/__tests__/featureFlagProvider.jest.ts
+++ b/src/lib/__tests__/featureFlagProvider.jest.ts
@@ -17,6 +17,8 @@ class TestFeatureFlagService implements FeatureFlagService {
   enabled(name: string, context?: FeatureFlagContext) {
     return name === "feature-a"
   }
+
+  getVariant: (name: string, context?: FeatureFlagContext | undefined) => any
 }
 
 describe("featureFlag tests", () => {

--- a/src/lib/__tests__/featureFlagProvider.jest.ts
+++ b/src/lib/__tests__/featureFlagProvider.jest.ts
@@ -17,8 +17,6 @@ class TestFeatureFlagService implements FeatureFlagService {
   enabled(name: string, context?: FeatureFlagContext) {
     return name === "feature-a"
   }
-
-  getVariant: (name: string, context?: FeatureFlagContext | undefined) => any
 }
 
 describe("featureFlag tests", () => {

--- a/src/lib/__tests__/featureFlagProvider.jest.ts
+++ b/src/lib/__tests__/featureFlagProvider.jest.ts
@@ -1,0 +1,34 @@
+import {
+  FeatureFlagContext,
+  FeatureFlagService,
+  createFeatureFlagService,
+  registerFeatureFlagService,
+} from "lib/featureFlags/featureFlagService"
+
+const TestServiceSymbol = Symbol("TestServiceSymbol")
+
+class TestFeatureFlagService implements FeatureFlagService {
+  init() {}
+
+  getFeatures() {
+    return ["feature-a"]
+  }
+
+  enabled(name: string, context?: FeatureFlagContext) {
+    return name === "feature-a"
+  }
+}
+
+describe("featureFlag tests", () => {
+  it("feature is enabled", async () => {
+    registerFeatureFlagService<TestFeatureFlagService>(
+      TestServiceSymbol,
+      TestFeatureFlagService
+    )
+
+    const service = await createFeatureFlagService(TestServiceSymbol)
+
+    expect(service.enabled("feature-a")).toBeTruthy()
+    expect(service.enabled("feature-b")).toBeFalsy()
+  })
+})

--- a/src/lib/featureFlags/FeatureFlagProvider.tsx
+++ b/src/lib/featureFlags/FeatureFlagProvider.tsx
@@ -1,0 +1,54 @@
+import * as React from "react"
+
+const FeatureFlagContext = React.createContext<EnabledFeatureFlags>({})
+
+export type EnabledFeatureFlags = Record<string, boolean>
+
+export function FeatureFlagProvider({
+  featureFlags,
+  children,
+}: {
+  featureFlags: EnabledFeatureFlags
+  children: any
+}) {
+  return (
+    <FeatureFlagContext.Provider value={featureFlags}>
+      {children}
+    </FeatureFlagContext.Provider>
+  )
+}
+
+export function useFeatureFlag(flagName) {
+  const context = React.useContext(FeatureFlagContext)
+  if (context === undefined) {
+    throw new Error("useFeatureFlag must be used within a FeatureFlagProvider")
+  }
+
+  if (!flagName) {
+    return null
+  }
+
+  return Object.keys(context).indexOf(flagName) !== -1 && context[flagName]
+}
+
+export function useFeatureFlagVariant(flagName) {
+  const context = React.useContext(FeatureFlagContext)
+
+  if (context === undefined) {
+    throw new Error(
+      "useFeatureVariant must be used within a FeatureFlagProvider"
+    )
+  }
+
+  if (!flagName) {
+    return null
+  }
+
+  if (!context[flagName]) {
+    throw new Error(
+      "the argument for flagName is not in the FeatureFlagContext"
+    )
+  }
+
+  return context[flagName]
+}

--- a/src/lib/featureFlags/FeatureFlagProvider.tsx
+++ b/src/lib/featureFlags/FeatureFlagProvider.tsx
@@ -30,25 +30,3 @@ export function useFeatureFlag(flagName) {
 
   return Object.keys(context).indexOf(flagName) !== -1 && context[flagName]
 }
-
-export function useFeatureFlagVariant(flagName) {
-  const context = React.useContext(FeatureFlagContext)
-
-  if (context === undefined) {
-    throw new Error(
-      "useFeatureVariant must be used within a FeatureFlagProvider"
-    )
-  }
-
-  if (!flagName) {
-    return null
-  }
-
-  if (!context[flagName]) {
-    throw new Error(
-      "the argument for flagName is not in the FeatureFlagContext"
-    )
-  }
-
-  return context[flagName]
-}

--- a/src/lib/featureFlags/featureFlagService.ts
+++ b/src/lib/featureFlags/featureFlagService.ts
@@ -3,11 +3,9 @@ export type FeatureFlags = Array<string>
 
 export type FeatureFlagContext = Record<string, any>
 
-/// MAAAAAATTTTT DONT FORGET TO FIX THESE ANYYYYS
 export interface FeatureFlagService {
   init: () => void
   getFeatures: () => FeatureFlags
-  getVariant: (name: string, context?: FeatureFlagContext) => any
   enabled: (name: string, context?: FeatureFlagContext) => boolean
 }
 

--- a/src/lib/featureFlags/featureFlagService.ts
+++ b/src/lib/featureFlags/featureFlagService.ts
@@ -1,0 +1,44 @@
+export type FeatureFlag = string
+export type FeatureFlags = Array<string>
+
+export type FeatureFlagContext = Record<string, any>
+
+/// MAAAAAATTTTT DONT FORGET TO FIX THESE ANYYYYS
+export interface FeatureFlagService {
+  init: () => void
+  getFeatures: () => FeatureFlags
+  getVariant: (name: string, context?: FeatureFlagContext) => any
+  enabled: (name: string, context?: FeatureFlagContext) => boolean
+}
+
+const registeredFeatureFlagService = new Map<symbol, any>()
+
+export async function createFeatureFlagService(
+  type: symbol
+): Promise<FeatureFlagService> {
+  if (!registeredFeatureFlagService.has(type)) {
+    throw new Error(`The type provider ${type.toString()} is not registered.`)
+  }
+
+  // Check if provider has been registered with registerFeatureFlagService()
+  const featureFlagClass = registeredFeatureFlagService.get(type)
+  if (typeof featureFlagClass !== undefined) {
+    // Instantiate a new feature flag provider instance
+    const featureFlagService = new featureFlagClass!()
+
+    // initialize featureFlag client
+    await featureFlagService.init()
+    return featureFlagService
+  } else {
+    throw new Error("FeatureFlagProvider was defined as null")
+  }
+}
+
+type ConstructorType<T> = Function & { prototype: T }
+
+export function registerFeatureFlagService<T extends FeatureFlagService>(
+  type: symbol,
+  featureFlagClass: ConstructorType<T>
+) {
+  registeredFeatureFlagService.set(type, featureFlagClass)
+}

--- a/src/lib/featureFlags/unleashService.ts
+++ b/src/lib/featureFlags/unleashService.ts
@@ -2,7 +2,7 @@ import { startUnleash, Unleash } from "unleash-client"
 import {
   UNLEASH_API,
   UNLEASH_APP_NAME,
-  // UNLEASH_INSTANCE_ID,
+  UNLEASH_INSTANCE_ID,
   UNLEASH_SERVER_KEY,
 } from "../../config"
 import { FeatureFlagService } from "./featureFlagService"
@@ -17,7 +17,7 @@ export class UnleashFeatureFlagService implements FeatureFlagService {
   constructor(
     private url = UNLEASH_API,
     private appName = UNLEASH_APP_NAME,
-    // private instanceId = UNLEASH_INSTANCE_ID,
+    private instanceId = UNLEASH_INSTANCE_ID,
     private serverKey = UNLEASH_SERVER_KEY
   ) {}
 
@@ -29,8 +29,7 @@ export class UnleashFeatureFlagService implements FeatureFlagService {
     this._unleash = await startUnleash({
       url: this.url,
       appName: this.appName,
-      instanceId: "review-app-unleash-1",
-      refreshInterval: 15000,
+      refreshInterval: 60000,
       customHeaders: {
         Authorization: this.serverKey,
       },

--- a/src/lib/featureFlags/unleashService.ts
+++ b/src/lib/featureFlags/unleashService.ts
@@ -1,4 +1,4 @@
-import { startUnleash, Unleash, destroy } from "unleash-client"
+import { startUnleash, Unleash } from "unleash-client"
 import {
   UNLEASH_API,
   UNLEASH_APP_NAME,

--- a/src/lib/featureFlags/unleashService.ts
+++ b/src/lib/featureFlags/unleashService.ts
@@ -38,10 +38,6 @@ export class UnleashFeatureFlagService implements FeatureFlagService {
     return this.unleash.isEnabled(name, context)
   }
 
-  getVariant(name: string, context?: any) {
-    return this.unleash.getVariant(name, context)
-  }
-
   private get unleash() {
     if (this._unleash === null) {
       throw new Error("UnleashFlagService has not been initialized.")

--- a/src/lib/featureFlags/unleashService.ts
+++ b/src/lib/featureFlags/unleashService.ts
@@ -1,10 +1,5 @@
 import { startUnleash, Unleash } from "unleash-client"
-import {
-  UNLEASH_API,
-  UNLEASH_APP_NAME,
-  UNLEASH_INSTANCE_ID,
-  UNLEASH_SERVER_KEY,
-} from "../../config"
+import { UNLEASH_API, UNLEASH_APP_NAME, UNLEASH_SERVER_KEY } from "../../config"
 import { FeatureFlagService } from "./featureFlagService"
 
 // Pass in as argument to registerFeatureFlagProvideder() when using unleash as feature flag service
@@ -17,7 +12,6 @@ export class UnleashFeatureFlagService implements FeatureFlagService {
   constructor(
     private url = UNLEASH_API,
     private appName = UNLEASH_APP_NAME,
-    private instanceId = UNLEASH_INSTANCE_ID,
     private serverKey = UNLEASH_SERVER_KEY
   ) {}
 

--- a/src/lib/featureFlags/unleashService.ts
+++ b/src/lib/featureFlags/unleashService.ts
@@ -2,7 +2,7 @@ import { startUnleash, Unleash } from "unleash-client"
 import {
   UNLEASH_API,
   UNLEASH_APP_NAME,
-  UNLEASH_INSTANCE_ID,
+  // UNLEASH_INSTANCE_ID,
   UNLEASH_SERVER_KEY,
 } from "../../config"
 import { FeatureFlagService } from "./featureFlagService"
@@ -17,7 +17,7 @@ export class UnleashFeatureFlagService implements FeatureFlagService {
   constructor(
     private url = UNLEASH_API,
     private appName = UNLEASH_APP_NAME,
-    private instanceId = UNLEASH_INSTANCE_ID,
+    // private instanceId = UNLEASH_INSTANCE_ID,
     private serverKey = UNLEASH_SERVER_KEY
   ) {}
 

--- a/src/lib/featureFlags/unleashService.ts
+++ b/src/lib/featureFlags/unleashService.ts
@@ -1,0 +1,58 @@
+import { startUnleash, Unleash, destroy } from "unleash-client"
+import {
+  UNLEASH_API,
+  UNLEASH_APP_NAME,
+  UNLEASH_INSTANCE_ID,
+  UNLEASH_SERVER_KEY,
+} from "../../config"
+import { FeatureFlagService } from "./featureFlagService"
+
+// Pass in as argument to registerFeatureFlagProvideder() when using unleash as feature flag service
+export const UnleashService = Symbol("UnleashService")
+
+// Class to instantiate Unleash client and set useful helper methods.
+export class UnleashFeatureFlagService implements FeatureFlagService {
+  private _unleash: Unleash | null = null
+
+  constructor(
+    private url = UNLEASH_API,
+    private appName = UNLEASH_APP_NAME,
+    private instanceId = UNLEASH_INSTANCE_ID,
+    private serverKey = UNLEASH_SERVER_KEY
+  ) {}
+
+  async init(): Promise<void> {
+    if (this._unleash !== null) {
+      throw new Error("UnleashFlagService has already been initialized.")
+    }
+
+    this._unleash = await startUnleash({
+      url: this.url,
+      appName: this.appName,
+      instanceId: "review-app-unleash-1",
+      refreshInterval: 15000,
+      customHeaders: {
+        Authorization: this.serverKey,
+      },
+    })
+  }
+
+  getFeatures() {
+    return this.unleash.getFeatureToggleDefinitions().map(flag => flag.name)
+  }
+
+  enabled(name: string, context?: any) {
+    return this.unleash.isEnabled(name, context)
+  }
+
+  getVariant(name: string, context?: any) {
+    return this.unleash.getVariant(name, context)
+  }
+
+  private get unleash() {
+    if (this._unleash === null) {
+      throw new Error("UnleashFlagService has not been initialized.")
+    }
+    return this._unleash
+  }
+}

--- a/src/lib/middleware/featureFlagMiddleware.ts
+++ b/src/lib/middleware/featureFlagMiddleware.ts
@@ -15,7 +15,7 @@ export function featureFlagMiddleware(serviceType: symbol) {
         try {
           service = await createFeatureFlagService(serviceType)
           resolve(service)
-        } catch {
+        } catch (error) {
           reject("An unknown error occurred while creating the flag service.")
         }
       }
@@ -41,7 +41,7 @@ export function featureFlagMiddleware(serviceType: symbol) {
         next()
       })
       .catch(error => {
-        console.error(error)
+        console.error("[Force] Error creating feature flag service:", error)
         next()
       })
   }

--- a/src/lib/middleware/featureFlagMiddleware.ts
+++ b/src/lib/middleware/featureFlagMiddleware.ts
@@ -14,7 +14,6 @@ export function featureFlagMiddleware(serviceType: symbol) {
       } else {
         try {
           service = await createFeatureFlagService(serviceType)
-          console.log("resolved Unleash")
           resolve(service)
         } catch {
           reject("An unknown error occurred while creating the flag service.")

--- a/src/lib/middleware/featureFlagMiddleware.ts
+++ b/src/lib/middleware/featureFlagMiddleware.ts
@@ -1,0 +1,48 @@
+import { NextFunction } from "express"
+import { ArtsyRequest, ArtsyResponse } from "./artsyExpress"
+import {
+  createFeatureFlagService,
+  FeatureFlagService,
+} from "lib/featureFlags/featureFlagService"
+
+export function featureFlagMiddleware(serviceType: symbol) {
+  let service
+  return (req: ArtsyRequest, res: ArtsyResponse, next: NextFunction) => {
+    new Promise<FeatureFlagService>(async (resolve, reject) => {
+      if (service) {
+        resolve(service)
+      } else {
+        try {
+          service = await createFeatureFlagService(serviceType)
+          resolve(service)
+        } catch {
+          reject("An unknown error occurred while creating the flag service.")
+        }
+      }
+    })
+      .then(service => {
+        // Create feature flag context per request
+        const featureFlagContext = {
+          userId: res.locals.user ? res.locals.user.id : null,
+          sessionId: res.locals.sd.SESSION_ID,
+        }
+
+        // Get features and move them to sharify
+        const flags = service.getFeatures()
+        res.locals.sd.featureFlags = {}
+        if (flags) {
+          for (let flag of flags) {
+            res.locals.sd.featureFlags[flag] = service.enabled(
+              flag,
+              featureFlagContext
+            )
+          }
+        }
+        next()
+      })
+      .catch(error => {
+        console.error(error)
+        next()
+      })
+  }
+}

--- a/src/lib/middleware/featureFlagMiddleware.ts
+++ b/src/lib/middleware/featureFlagMiddleware.ts
@@ -14,6 +14,7 @@ export function featureFlagMiddleware(serviceType: symbol) {
       } else {
         try {
           service = await createFeatureFlagService(serviceType)
+          console.log("resolved Unleash")
           resolve(service)
         } catch {
           reject("An unknown error occurred while creating the flag service.")

--- a/src/lib/middleware/featureFlagMiddleware.ts
+++ b/src/lib/middleware/featureFlagMiddleware.ts
@@ -16,7 +16,7 @@ export function featureFlagMiddleware(serviceType: symbol) {
           service = await createFeatureFlagService(serviceType)
           resolve(service)
         } catch (error) {
-          reject("An unknown error occurred while creating the flag service.")
+          reject(error)
         }
       }
     })

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -68,6 +68,12 @@ import { serverTimingHeaders } from "./lib/middleware/serverTimingHeaders"
 import { splitTestMiddleware } from "./desktop/components/split_test/splitTestMiddleware"
 import { IGNORED_ERRORS } from "./lib/analytics/sentryFilters"
 import { sharifyToCookie } from "./lib/middleware/sharifyToCookie"
+import { featureFlagMiddleware } from "lib/middleware/featureFlagMiddleware"
+import {
+  UnleashFeatureFlagService,
+  UnleashService,
+} from "lib/featureFlags/unleashService"
+import { registerFeatureFlagService } from "lib/featureFlags/featureFlagService"
 
 // Find the v2 routes, we will not be testing memory caching for legacy pages.
 
@@ -146,6 +152,10 @@ export function initializeMiddleware(app) {
 
   // Static assets
   applyStaticAssetMiddlewares(app)
+
+  // Need sharify for unleash
+  registerFeatureFlagService(UnleashService, UnleashFeatureFlagService)
+  app.use(featureFlagMiddleware(UnleashService))
 }
 
 function applySecurityMiddleware(app) {

--- a/src/typings/sharify.d.ts
+++ b/src/typings/sharify.d.ts
@@ -110,6 +110,7 @@ declare module "sharify" {
       TRACK_PAGELOAD_PATHS: string
       // FIXME: reaction migration
       stitch: any
+      unleash: any
     }
 
     export interface ResponseLocalData extends GlobalData {

--- a/src/v2/Apps/ViewingRoom/ViewingRoomsApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomsApp.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Join, Spacer, Text } from "@artsy/palette"
 import { ViewingRoomsLatestGridFragmentContainer } from "./Components/ViewingRoomsLatestGrid"
 import { ViewingRoomsMeta } from "./Components/ViewingRoomsMeta"
@@ -6,6 +6,7 @@ import { ViewingRoomsApp_allViewingRooms } from "v2/__generated__/ViewingRoomsAp
 import { ViewingRoomsApp_featuredViewingRooms } from "v2/__generated__/ViewingRoomsApp_featuredViewingRooms.graphql"
 import { ViewingRoomsFeaturedRailFragmentContainer } from "./Components/ViewingRoomsFeaturedRail"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useFeatureFlag } from "lib/featureFlags/FeatureFlagProvider"
 
 interface ViewingRoomsAppProps {
   allViewingRooms: ViewingRoomsApp_allViewingRooms
@@ -31,11 +32,15 @@ const ViewingRoomsApp: React.FC<ViewingRoomsAppProps> = props => {
           featuredViewingRooms={featuredViewingRooms}
         />
 
-        <Text variant="lg">Latest</Text>
+        {useFeatureFlag("just-a-test") && (
+          <>
+            <Text variant="lg">Latest</Text>
 
-        <ViewingRoomsLatestGridFragmentContainer
-          viewingRooms={allViewingRooms}
-        />
+            <ViewingRoomsLatestGridFragmentContainer
+              viewingRooms={allViewingRooms}
+            />
+          </>
+        )}
       </Join>
     </>
   )

--- a/src/v2/Apps/ViewingRoom/ViewingRoomsApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomsApp.tsx
@@ -6,7 +6,6 @@ import { ViewingRoomsApp_allViewingRooms } from "v2/__generated__/ViewingRoomsAp
 import { ViewingRoomsApp_featuredViewingRooms } from "v2/__generated__/ViewingRoomsApp_featuredViewingRooms.graphql"
 import { ViewingRoomsFeaturedRailFragmentContainer } from "./Components/ViewingRoomsFeaturedRail"
 import { createFragmentContainer, graphql } from "react-relay"
-import { useFeatureFlag } from "lib/featureFlags/FeatureFlagProvider"
 
 interface ViewingRoomsAppProps {
   allViewingRooms: ViewingRoomsApp_allViewingRooms
@@ -32,15 +31,11 @@ const ViewingRoomsApp: React.FC<ViewingRoomsAppProps> = props => {
           featuredViewingRooms={featuredViewingRooms}
         />
 
-        {useFeatureFlag("just-a-test") && (
-          <>
-            <Text variant="lg">Latest</Text>
+        <Text variant="lg">Latest</Text>
 
-            <ViewingRoomsLatestGridFragmentContainer
-              viewingRooms={allViewingRooms}
-            />
-          </>
-        )}
+        <ViewingRoomsLatestGridFragmentContainer
+          viewingRooms={allViewingRooms}
+        />
       </Join>
     </>
   )

--- a/src/v2/DevTools/MockBoot.tsx
+++ b/src/v2/DevTools/MockBoot.tsx
@@ -1,5 +1,5 @@
 import { Boot } from "v2/System/Router"
-import * as React from "react";
+import * as React from "react"
 import { Breakpoint } from "v2/Utils/Responsive"
 import { buildClientAppContext } from "desktop/lib/buildClientAppContext"
 
@@ -8,7 +8,15 @@ export const MockBoot: React.SFC<{
   headTags?: JSX.Element[]
   user?: User
   context?: object
-}> = ({ breakpoint = "xl", headTags, children, user = null, context = {} }) => {
+  featureFlags?: Record<string, boolean>
+}> = ({
+  breakpoint = "xl",
+  headTags,
+  children,
+  user = null,
+  context = {},
+  featureFlags = { "feature-a": true },
+}) => {
   const mockContext = buildClientAppContext(context)
   return (
     <Boot
@@ -18,6 +26,7 @@ export const MockBoot: React.SFC<{
       user={user}
       relayEnvironment={null as any}
       routes={null as any}
+      featureFlags={featureFlags}
     >
       {children}
     </Boot>

--- a/src/v2/System/Router/Boot.tsx
+++ b/src/v2/System/Router/Boot.tsx
@@ -28,6 +28,10 @@ import { ClientContext } from "desktop/lib/buildClientAppContext"
 import { FlashMessage } from "v2/Components/Modal/FlashModal"
 import { SiftContainer } from "v2/Utils/SiftContainer"
 import { setupSentryClient } from "lib/setupSentryClient"
+import {
+  EnabledFeatureFlags,
+  FeatureFlagProvider,
+} from "lib/featureFlags/FeatureFlagProvider"
 
 export interface BootProps {
   children: React.ReactNode
@@ -37,6 +41,7 @@ export interface BootProps {
   relayEnvironment: Environment
   routes: AppRouteConfig[]
   user: User | null
+  featureFlags: EnabledFeatureFlags
 }
 
 const { GlobalStyles } = injectGlobalStyles()
@@ -61,6 +66,7 @@ export const Boot = track(undefined, {
     context,
     headTags = [],
     onlyMatchMediaQueries,
+    featureFlags,
     ...rest
   } = props
 
@@ -78,21 +84,23 @@ export const Boot = track(undefined, {
           <SystemContextProvider {...contextProps}>
             <AnalyticsContext.Provider value={context?.analytics}>
               <ErrorBoundary>
-                <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
-                  <ResponsiveProvider
-                    mediaQueries={themeProps.mediaQueries}
-                    initialMatchingMediaQueries={onlyMatchMediaQueries as any}
-                  >
-                    <ToastsProvider>
-                      <Grid fluid maxWidth="100%">
-                        <FlashMessage />
-                        <FocusVisible />
-                        <SiftContainer />
-                        {children}
-                      </Grid>
-                    </ToastsProvider>
-                  </ResponsiveProvider>
-                </MediaContextProvider>
+                <FeatureFlagProvider featureFlags={featureFlags}>
+                  <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
+                    <ResponsiveProvider
+                      mediaQueries={themeProps.mediaQueries}
+                      initialMatchingMediaQueries={onlyMatchMediaQueries as any}
+                    >
+                      <ToastsProvider>
+                        <Grid fluid maxWidth="100%">
+                          <FlashMessage />
+                          <FocusVisible />
+                          <SiftContainer />
+                          {children}
+                        </Grid>
+                      </ToastsProvider>
+                    </ResponsiveProvider>
+                  </MediaContextProvider>
+                </FeatureFlagProvider>
               </ErrorBoundary>
             </AnalyticsContext.Provider>
           </SystemContextProvider>

--- a/src/v2/System/Router/buildClientApp.tsx
+++ b/src/v2/System/Router/buildClientApp.tsx
@@ -1,4 +1,4 @@
-import { ComponentType } from "react";
+import { ComponentType } from "react"
 
 import { Resolver } from "found-relay"
 import { ScrollManager } from "found-scroll"
@@ -43,6 +43,7 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
         history = {},
         initialRoute = "/",
         routes = [],
+        featureFlags = {},
       } = config
       const clientContext = buildClientAppContext(context)
 
@@ -112,6 +113,7 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
             user={user}
             relayEnvironment={relayEnvironment}
             routes={routes}
+            featureFlags={featureFlags}
           >
             <Router resolver={resolver} />
           </Boot>

--- a/src/v2/System/Router/buildServerApp.tsx
+++ b/src/v2/System/Router/buildServerApp.tsx
@@ -82,6 +82,7 @@ export function buildServerApp(
         loadableFile = "loadable-stats.json",
         loadablePath = "public/assets",
         assetsPath = "/assets",
+        featureFlags = {},
       } = config
 
       // Find and execute pre-render hooks
@@ -155,6 +156,7 @@ export function buildServerApp(
               onlyMatchMediaQueries={matchingMediaQueries}
               relayEnvironment={relayEnvironment}
               routes={routes}
+              featureFlags={featureFlags}
             >
               {farceResults.element}
             </Boot>

--- a/src/v2/System/Router/index.ts
+++ b/src/v2/System/Router/index.ts
@@ -2,7 +2,7 @@ import { RelaySSREnvironment } from "v2/System/Relay/createRelaySSREnvironment"
 import { FarceCreateRouterArgs } from "found"
 import { SystemContextProps } from "../SystemContext"
 import { AppRouteConfig } from "./Route"
-
+import { FeatureFlags } from "lib/featureFlags/featureFlagService"
 export { Link } from "found"
 export { Boot } from "./Boot"
 export { SystemContextProvider, SystemContextConsumer } from "v2/System"

--- a/src/v2/System/Router/index.ts
+++ b/src/v2/System/Router/index.ts
@@ -39,6 +39,11 @@ export interface RouterConfig {
   routes: AppRouteConfig[]
 
   /**
+   * Feature flags
+   */
+  featureFlags?: FeatureFlags
+
+  /**
    * URL passed from server
    */
   url?: string

--- a/src/v2/System/Server/sharifyHelpers.ts
+++ b/src/v2/System/Server/sharifyHelpers.ts
@@ -47,6 +47,7 @@ const V2_SHARIFY_ALLOWLIST = [
   "VOLLEY_ENDPOINT",
   "WEBFONT_URL",
   "ZENDESK_KEY",
+  "featureFlags",
 ] as const
 
 export type SharifyKey = typeof V2_SHARIFY_ALLOWLIST[number]

--- a/src/v2/client.tsx
+++ b/src/v2/client.tsx
@@ -10,6 +10,7 @@ import { getClientParam } from "./Utils/getClientParam"
 import { buildClientApp } from "v2/System/Router/client"
 import { syncNonCacheableData } from "./System/Client/syncSharify"
 import { loadSegment } from "lib/analytics/segmentOneTrustIntegration/segmentOneTrustIntegration"
+import { getENV } from "./Utils/getENV"
 
 async function setupClient() {
   syncNonCacheableData()
@@ -49,6 +50,7 @@ async function setupClient() {
 
   const { ClientApp } = await buildClientApp({
     routes: getAppRoutes(),
+    featureFlags: getENV("featureFlags"),
   })
 
   // Rehydrate

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -28,6 +28,7 @@ app.get(
         req,
         res,
         routes,
+        featureFlags: res.locals.sd.featureFlags,
       })
 
       if (redirect) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,6 +1714,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@gar/promisify@^1.0.1":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
+  integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
+
 "@graphql-inspector/core@1.14.0":
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/@graphql-inspector/core/-/core-1.14.0.tgz#c623b015c51f338312334dba133f839ba60cc512"
@@ -2239,6 +2244,14 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
+
+"@npmcli/fs@^1.0.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"
+  integrity sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==
+  dependencies:
+    "@gar/promisify" "^1.0.1"
+    semver "^7.3.5"
 
 "@npmcli/move-file@^1.0.1":
   version "1.0.1"
@@ -4650,12 +4663,21 @@ agent-base@4, agent-base@^4.3.0:
   dependencies:
     es6-promisify "^5.0.0"
 
-agent-base@6:
+agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agentkeepalive@^4.1.3:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.1.tgz#a7975cbb9f83b367f06c90cc51ff28fe7d499717"
+  integrity sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==
+  dependencies:
+    debug "^4.1.0"
+    depd "^1.1.2"
+    humanize-ms "^1.2.1"
 
 aggregate-error@^3.0.0:
   version "3.0.0"
@@ -5972,6 +5994,20 @@ boxen@^4.2.0:
     type-fest "^0.8.1"
     widest-line "^3.1.0"
 
+boxen@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.1.2.tgz#788cb686fc83c1f486dfa8a40c68fc2b831d2b50"
+  integrity sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==
+  dependencies:
+    ansi-align "^3.0.0"
+    camelcase "^6.2.0"
+    chalk "^4.1.0"
+    cli-boxes "^2.2.1"
+    string-width "^4.2.2"
+    type-fest "^0.20.2"
+    widest-line "^3.1.0"
+    wrap-ansi "^7.0.0"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -6218,6 +6254,30 @@ cacache@^15.0.5:
     promise-inflight "^1.0.1"
     rimraf "^3.0.2"
     ssri "^8.0.0"
+    tar "^6.0.2"
+    unique-filename "^1.1.1"
+
+cacache@^15.2.0:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.3.0.tgz#dc85380fb2f556fe3dda4c719bfa0ec875a7f1eb"
+  integrity sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==
+  dependencies:
+    "@npmcli/fs" "^1.0.0"
+    "@npmcli/move-file" "^1.0.1"
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    glob "^7.1.4"
+    infer-owner "^1.0.4"
+    lru-cache "^6.0.0"
+    minipass "^3.1.1"
+    minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.2"
+    mkdirp "^1.0.3"
+    p-map "^4.0.0"
+    promise-inflight "^1.0.1"
+    rimraf "^3.0.2"
+    ssri "^8.0.1"
     tar "^6.0.2"
     unique-filename "^1.1.1"
 
@@ -6588,7 +6648,7 @@ cheerio@^1.0.0-rc.2:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
-chokidar@3.4.0, chokidar@^2.0.4, chokidar@^2.1.8, chokidar@^3.0.0, chokidar@^3.2.2, chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.4.2:
+chokidar@3.4.0, chokidar@^2.0.4, chokidar@^2.1.8, chokidar@^3.0.0, chokidar@^3.2.2, chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.0.tgz#b30611423ce376357c765b9b8f904b9fba3c0be8"
   integrity sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==
@@ -6709,6 +6769,11 @@ cli-boxes@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
   integrity sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==
+
+cli-boxes@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
+  integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
 
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
@@ -7944,12 +8009,19 @@ debug@^1.0.2:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.1:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
 
 debug@~2.2.0:
   version "2.2.0"
@@ -8124,7 +8196,7 @@ depd@1.1.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.0.tgz#e1bd82c6aab6ced965b97b88b17ed3e528ca18c3"
   integrity sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=
 
-depd@~1.1.1, depd@~1.1.2:
+depd@^1.1.2, depd@~1.1.1, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
@@ -8645,7 +8717,7 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.11:
+encoding@^0.1.11, encoding@^0.1.12:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -8754,6 +8826,11 @@ enzyme@3.10.0:
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
     string.prototype.trim "^1.1.2"
+
+err-code@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
+  integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -10703,6 +10780,13 @@ global-dirs@^2.0.1:
   dependencies:
     ini "^1.3.5"
 
+global-dirs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
+  integrity sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==
+  dependencies:
+    ini "2.0.0"
+
 global-modules@2.0.0, global-modules@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-2.0.0.tgz#997605ad2345f27f51539bea26574421215c7780"
@@ -11371,7 +11455,7 @@ htmlparser2@3.10.1, htmlparser2@^3.3.0, htmlparser2@^3.9.1:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
-http-cache-semantics@^4.0.0:
+http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
@@ -11482,6 +11566,13 @@ human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+  dependencies:
+    ms "^2.0.0"
 
 humps@^2.0.1:
   version "2.0.1"
@@ -11691,6 +11782,11 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
+ini@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.8"
@@ -12093,6 +12189,19 @@ is-installed-globally@^0.3.1, is-installed-globally@^0.3.2:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
 
+is-installed-globally@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
+  integrity sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==
+  dependencies:
+    global-dirs "^3.0.0"
+    is-path-inside "^3.0.2"
+
+is-lambda@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
+  integrity sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=
+
 is-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.1.tgz#520dafc4307bb8ebc33b813de5ce7c9400d644a1"
@@ -12112,6 +12221,11 @@ is-npm@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-4.0.0.tgz#c90dd8380696df87a7a6d823c20d0b12bbe3c84d"
   integrity sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==
+
+is-npm@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-5.0.0.tgz#43e8d65cc56e1b67f8d47262cf667099193f45a8"
+  integrity sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==
 
 is-number-object@^1.0.3, is-number-object@^1.0.4:
   version "1.0.4"
@@ -12163,6 +12277,11 @@ is-path-inside@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
   integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
+
+is-path-inside@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^2.0.0:
   version "2.1.0"
@@ -13933,7 +14052,7 @@ latest-version@^3.0.0:
   dependencies:
     package-json "^4.0.0"
 
-latest-version@^5.0.0:
+latest-version@^5.0.0, latest-version@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
   integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
@@ -14581,6 +14700,28 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
+make-fetch-happen@^9.0.4:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz#53085a09e7971433e6765f7971bf63f4e05cb968"
+  integrity sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==
+  dependencies:
+    agentkeepalive "^4.1.3"
+    cacache "^15.2.0"
+    http-cache-semantics "^4.1.0"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    is-lambda "^1.0.1"
+    lru-cache "^6.0.0"
+    minipass "^3.1.3"
+    minipass-collect "^1.0.2"
+    minipass-fetch "^1.3.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    negotiator "^0.6.2"
+    promise-retry "^2.0.1"
+    socks-proxy-agent "^6.0.0"
+    ssri "^8.0.0"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -14935,6 +15076,17 @@ minipass-collect@^1.0.2:
   dependencies:
     minipass "^3.0.0"
 
+minipass-fetch@^1.3.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-1.4.1.tgz#d75e0091daac1b0ffd7e9d41629faff7d0c1f1b6"
+  integrity sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==
+  dependencies:
+    minipass "^3.1.0"
+    minipass-sized "^1.0.3"
+    minizlib "^2.0.0"
+  optionalDependencies:
+    encoding "^0.1.12"
+
 minipass-flush@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373"
@@ -14949,6 +15101,20 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
+minipass-pipeline@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz#68472f79711c084657c067c5c6ad93cddea8214c"
+  integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-sized@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/minipass-sized/-/minipass-sized-1.0.3.tgz#70ee5a7c5052070afacfbc22977ea79def353b70"
+  integrity sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==
+  dependencies:
+    minipass "^3.0.0"
+
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
@@ -14956,7 +15122,14 @@ minipass@^3.0.0, minipass@^3.1.1:
   dependencies:
     yallist "^4.0.0"
 
-minizlib@^2.1.1:
+minipass@^3.1.0, minipass@^3.1.3:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.6.tgz#3b8150aa688a711a1521af5e8779c1d3bb4f45ee"
+  integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.0.0, minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
@@ -15117,7 +15290,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.1.1:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -15131,6 +15304,11 @@ msgpack-lite@^0.1.26:
     ieee754 "^1.1.8"
     int64-buffer "^0.1.9"
     isarray "^1.0.0"
+
+murmurhash3js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/murmurhash3js/-/murmurhash3js-3.0.1.tgz#3e983e5b47c2a06f43a713174e7e435ca044b998"
+  integrity sha1-Ppg+W0fCoG9DpxMXTn5DXKBEuZg=
 
 mute-stream@0.0.6:
   version "0.0.6"
@@ -15189,6 +15367,11 @@ negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+
+negotiator@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 neo-async@^2.5.0, neo-async@^2.6.1:
   version "2.6.1"
@@ -15360,6 +15543,22 @@ node-uuid@1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
   integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
+
+nodemon@^2.0.15:
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.15.tgz#504516ce3b43d9dc9a955ccd9ec57550a31a8d4e"
+  integrity sha512-gdHMNx47Gw7b3kWxJV64NI+Q5nfl0y5DgDbiVtShiwa7Z0IZ07Ll4RLFo6AjrhzMtoEZn5PDE3/c2AbVsiCkpA==
+  dependencies:
+    chokidar "^3.5.2"
+    debug "^3.2.7"
+    ignore-by-default "^1.0.1"
+    minimatch "^3.0.4"
+    pstree.remy "^1.1.8"
+    semver "^5.7.1"
+    supports-color "^5.5.0"
+    touch "^3.1.0"
+    undefsafe "^2.0.5"
+    update-notifier "^5.1.0"
 
 nodemon@^2.0.2:
   version "2.0.4"
@@ -16699,6 +16898,14 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
+promise-retry@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"
+  integrity sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==
+  dependencies:
+    err-code "^2.0.2"
+    retry "^0.12.0"
+
 promise.allsettled@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.2.tgz#d66f78fbb600e83e863d893e98b3d4376a9c47c9"
@@ -16823,7 +17030,7 @@ psl@^1.1.28, psl@^1.1.33:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
-pstree.remy@^1.1.7:
+pstree.remy@^1.1.7, pstree.remy@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
@@ -17010,6 +17217,13 @@ pupa@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.0.1.tgz#dbdc9ff48ffbea4a26a069b6f9f7abb051008726"
   integrity sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==
+  dependencies:
+    escape-goat "^2.0.0"
+
+pupa@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.1.1.tgz#f5e8fd4afc2c5d97828faa523549ed8744a20d62"
+  integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
   dependencies:
     escape-goat "^2.0.0"
 
@@ -18525,7 +18739,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-retry@0.12.0:
+retry@0.12.0, retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
@@ -18848,6 +19062,13 @@ semver@^7.3.2, semver@^7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -19195,6 +19416,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+smart-buffer@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -19224,6 +19450,23 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+socks-proxy-agent@^6.0.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz#e664e8f1aaf4e1fb3df945f09e3d94f911137f87"
+  integrity sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==
+  dependencies:
+    agent-base "^6.0.2"
+    debug "^4.3.1"
+    socks "^2.6.1"
+
+socks@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a"
+  integrity sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.2.0"
 
 source-list-map@^2.0.0:
   version "2.0.1"
@@ -19410,6 +19653,13 @@ ssri@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.0.tgz#79ca74e21f8ceaeddfcb4b90143c458b8d988808"
   integrity sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==
+  dependencies:
+    minipass "^3.1.1"
+
+ssri@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
+  integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
   dependencies:
     minipass "^3.1.1"
 
@@ -19611,6 +19861,15 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string-width@^4.2.2:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 "string.prototype.matchall@^4.0.0 || ^3.0.1", string.prototype.matchall@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz#608f255e93e072107f5de066f81a2dfb78cf6b29"
@@ -19722,6 +19981,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -20538,6 +20804,11 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
 type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
@@ -20669,6 +20940,11 @@ undefsafe@^2.0.2:
   integrity sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==
   dependencies:
     debug "^2.2.0"
+
+undefsafe@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
+  integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
 underscore.string@3.3.5, underscore.string@^3.3.5:
   version "3.3.5"
@@ -20896,6 +21172,17 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
+unleash-client@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-3.12.0.tgz#2a9002b6ea82d849a9a81124e2d734e86af74855"
+  integrity sha512-anHJ1ZThKBejK6sY3dbAGgukg4FPWB1RAUS5XetUSqDKyScJR5OEGyDNZu2ahujSdhxPdiUJTYllqdYL3qvamw==
+  dependencies:
+    ip "^1.1.5"
+    make-fetch-happen "^9.0.4"
+    murmurhash3js "^3.0.1"
+    nodemon "^2.0.15"
+    semver "^7.3.5"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -20975,6 +21262,26 @@ update-notifier@^4.0.0:
     is-yarn-global "^0.3.0"
     latest-version "^5.0.0"
     pupa "^2.0.1"
+    semver-diff "^3.1.1"
+    xdg-basedir "^4.0.0"
+
+update-notifier@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-5.1.0.tgz#4ab0d7c7f36a231dd7316cf7729313f0214d9ad9"
+  integrity sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==
+  dependencies:
+    boxen "^5.0.0"
+    chalk "^4.1.0"
+    configstore "^5.0.1"
+    has-yarn "^2.1.0"
+    import-lazy "^2.1.0"
+    is-ci "^2.0.0"
+    is-installed-globally "^0.4.0"
+    is-npm "^5.0.0"
+    is-yarn-global "^0.3.0"
+    latest-version "^5.1.0"
+    pupa "^2.1.1"
+    semver "^7.3.4"
     semver-diff "^3.1.1"
     xdg-basedir "^4.0.0"
 


### PR DESCRIPTION
This PR is a follow-up to the initial implementation of Unleash in Force, which led to an incident due to incorrect logic in `featureFlagMiddleware`. 

### Issue
In `featureflagMiddleware`, we checked [here](https://github.com/artsy/force/blob/2706f4a2edd6b55ebd06ca9c765e8f68fccbbea1/src/lib/middleware/featureFlagMiddleware.ts#L12-L20) if there is an existing unleash client, and create one if there isn’t. We had the logic wrong and were creating a new instance of the unleash client on every request here, which caused the huge [spike of requests, leading to high latency and timeouts](https://app.datadoghq.com/apm/service/force/express.request?env=production&panel_end=1645656270957&panel_paused=true&panel_start=1645652670957&topGraphs=latency%3Alatency%2CbreakdownAs%3Apercentage%2Cerrors%3Acount%2Chits%3Acount&start=1645074000000&end=1645160340000&paused=true).  There is a review app up which simply [wraps the try/catch block](https://github.com/artsy/force/blob/review-app-unleash-test/src/lib/middleware/featureFlagMiddleware.ts#L14-L21) in an else statement, which seems to have it working as intended ([polling every 15 seconds](https://my.papertrailapp.com/events?q=unleash+ingress+UA%3D%22review-app-unleash-test%22)).

Full Incident thread [here](https://artsy.slack.com/archives/C033592FNBZ)

### Original PR
https://github.com/artsy/force/pull/9393

### Next Steps
- Remove custom react context implementation in favor of using existing `SystemContext`. [PLATFORM-3918]
- Allow for experimentation by implementing `useVariant` and analytics tracking. [PLATFORM-3922]

[PLATFORM-3918]

[PLATFORM-3918]: https://artsyproduct.atlassian.net/browse/PLATFORM-3918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ