### PR TITLE
fix: Reset form on submission or cancel

### DIFF
--- a/src/v2/Apps/_Preferences2/PreferencesApp.tsx
+++ b/src/v2/Apps/_Preferences2/PreferencesApp.tsx
@@ -50,7 +50,7 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
       <Formik<FormValuesForNotificationPreferences>
         // @ts-ignore
         initialValues={{ ...NOTIFICATION_FIELDS, ...initialValues }}
-        onSubmit={async values => {
+        onSubmit={async (values, actions) => {
           try {
             // TODO: Refactor mutation in Metaphysics so that we don't have to send
             // id, channel, or status (Gravity doesn't care about them)
@@ -71,6 +71,11 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
               variables: { input: { subscriptionGroups } },
             })
 
+            actions.resetForm({
+              values: { ...NOTIFICATION_FIELDS, ...getInitialValues(viewer) },
+              touched: {},
+            })
+
             sendToast({
               variant: "success",
               message: "Preferences updated sucessfully.",
@@ -86,7 +91,14 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
           }
         }}
       >
-        {({ values, setFieldValue, setFieldTouched, touched }) => (
+        {({
+          values,
+          setTouched,
+          setFieldValue,
+          setFieldTouched,
+          resetForm,
+          touched,
+        }) => (
           <Form>
             <GridColumns gridRowGap={4}>
               <Column span={10}>
@@ -240,6 +252,16 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
                   width="100%"
                   variant="secondaryOutline"
                   disabled={isEmpty(touched)}
+                  onClick={event => {
+                    event.preventDefault()
+                    resetForm({
+                      values: {
+                        ...NOTIFICATION_FIELDS,
+                        ...initialValues,
+                      },
+                      touched: {},
+                    })
+                  }}
                 >
                   Cancel
                 </Button>

--- a/src/v2/Apps/_Preferences2/__tests__/PreferencesApp.jest.tsx
+++ b/src/v2/Apps/_Preferences2/__tests__/PreferencesApp.jest.tsx
@@ -80,4 +80,24 @@ describe("PreferencesApp", () => {
       expect(checkbox).toBeChecked()
     })
   })
+
+  it("when a user clicks cancel the form is reset", () => {
+    render(<PreferencesApp></PreferencesApp>)
+
+    let checkboxes = screen.getAllByRole("checkbox")
+    let subscribeToAllCheckbox = checkboxes[0]
+
+    // eslint-disable-next-line testing-library/no-node-access
+    let cancelButton = screen.getByText("Cancel").closest("button")
+
+    fireEvent.click(subscribeToAllCheckbox)
+
+    expect(subscribeToAllCheckbox).toBeChecked()
+    expect(checkboxes[1]).toBeChecked()
+
+    fireEvent.click(cancelButton!)
+
+    expect(subscribeToAllCheckbox).not.toBeChecked()
+    expect(checkboxes[1]).not.toBeChecked()
+  })
 })


### PR DESCRIPTION
This is something I noticed that will definitely come up in the Preference Center QA!

<details>
  <a href="https://www.loom.com/share/28cb6f902ecc43f2951b0872dda0f75b">Video</a>
</details>