### PR TITLE
fix: conversation list cut off

### DIFF
--- a/src/v2/Apps/Conversation/Components/ConversationList.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationList.tsx
@@ -7,7 +7,7 @@ import {
 } from "react-relay"
 import styled from "styled-components"
 import compact from "lodash/compact"
-import { Box, Spinner } from "@artsy/palette"
+import { Box, Flex, Spinner } from "@artsy/palette"
 
 import { ConversationSnippetFragmentContainer as ConversationSnippet } from "./ConversationSnippet"
 import { ConversationListHeader } from "./ConversationListHeader"
@@ -45,7 +45,7 @@ const ConversationList: React.FC<ConversationsProps> = props => {
     .indexOf(selectedConversationID)
 
   const loadMore = () => {
-    if (!relay.hasMore()) return
+    if (fetchingMore || !relay.hasMore()) return
     setFetchingMore(true)
     relay.loadMore(PAGE_SIZE, error => {
       if (error) console.error(error)
@@ -55,13 +55,13 @@ const ConversationList: React.FC<ConversationsProps> = props => {
 
   const handleScroll = (event: React.UIEvent<HTMLElement>): void => {
     const { scrollTop, clientHeight, scrollHeight } = event.currentTarget
-    if (scrollHeight - scrollTop === clientHeight) {
+    if (scrollHeight - scrollTop <= clientHeight) {
       loadMore()
     }
   }
 
   return (
-    <Box height="100%" width="100" overflow="hidden">
+    <Flex height="100%" width="100" overflow="hidden" flexDirection="column">
       <>
         <ConversationListHeader />
         <ScrollContainer onScroll={handleScroll}>
@@ -84,7 +84,7 @@ const ConversationList: React.FC<ConversationsProps> = props => {
           ) : null}
         </ScrollContainer>
       </>
-    </Box>
+    </Flex>
   )
 }
 


### PR DESCRIPTION
[NX-3076]

The conversation list was cut off at the bottom making the last element not become fully visible causing issues when trying to load more conversations on the desktop breakpoint.

This PR fixes the issue mentioned and one re-rendering issue causing some weird rendering of the loading spinner.

https://user-images.githubusercontent.com/15792853/155956354-00191426-2861-4cf3-bf32-f90503cb532b.mov

cc @artsy/negotiate-devs 

[NX-3076]: https://artsyproduct.atlassian.net/browse/NX-3076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ