### PR TITLE
Make Marquee static with Cultural Attributes

### DIFF
--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -46,7 +46,11 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
         <PartnerHeader partner={partner} />
 
         <FullBleed mb={[2, 4]}>
-          {isBlackOwned ? <Marquee marqueeText="Black Owned" /> : <Separator />}
+          {isBlackOwned ? (
+            <Marquee speed="static" marqueeText="Black Owned" />
+          ) : (
+            <Separator />
+          )}
         </FullBleed>
 
         {(displayFullPartnerPage || partnerType === "Brand") && (


### PR DESCRIPTION
This is a quick PR to make the banner static for the Cultural Attributes banner.


Current Behavior:
Uploading Screen Recording 2022-02-28 at 7.15.32 AM.mov…

New Behavior:
<img width="1752" alt="Screen Shot 2022-02-28 at 7 16 25 AM" src="https://user-images.githubusercontent.com/30025439/156040597-aab55f81-5134-4734-86d7-02738a597bac.png">

