### PR TITLE
refactor: add featureFlags to SystemContext

### DIFF
--- a/src/lib/featureFlags/FeatureFlagProvider.tsx
+++ b/src/lib/featureFlags/FeatureFlagProvider.tsx
@@ -1,26 +1,10 @@
-import * as React from "react"
-
-const FeatureFlagContext = React.createContext<EnabledFeatureFlags>({})
+import { useSystemContext } from "v2/System"
 
 export type EnabledFeatureFlags = Record<string, boolean>
 
-export function FeatureFlagProvider({
-  featureFlags,
-  children,
-}: {
-  featureFlags: EnabledFeatureFlags
-  children: any
-}) {
-  return (
-    <FeatureFlagContext.Provider value={featureFlags}>
-      {children}
-    </FeatureFlagContext.Provider>
-  )
-}
-
 export function useFeatureFlag(flagName) {
-  const context = React.useContext(FeatureFlagContext)
-  if (context === undefined) {
+  const { featureFlags } = useSystemContext()
+  if (featureFlags === undefined) {
     throw new Error("useFeatureFlag must be used within a FeatureFlagProvider")
   }
 
@@ -28,5 +12,5 @@ export function useFeatureFlag(flagName) {
     return null
   }
 
-  return Object.keys(context).indexOf(flagName) !== -1 && context[flagName]
+  return Object.keys(featureFlags).indexOf(flagName) !== -1 && featureFlags[flagName]
 }

--- a/src/lib/featureFlags/FeatureFlagProvider.tsx
+++ b/src/lib/featureFlags/FeatureFlagProvider.tsx
@@ -5,12 +5,16 @@ export type EnabledFeatureFlags = Record<string, boolean>
 export function useFeatureFlag(flagName) {
   const { featureFlags } = useSystemContext()
   if (featureFlags === undefined) {
-    throw new Error("useFeatureFlag must be used within a FeatureFlagProvider")
-  }
-
-  if (!flagName) {
+    console.error("[Force] Error: featureFlags is undefined in SystemContext")
     return null
   }
 
-  return Object.keys(featureFlags).indexOf(flagName) !== -1 && featureFlags[flagName]
+  if (!flagName) {
+    console.error("[Force] Error: cannot find flagName in featureFlags")
+    return null
+  }
+
+  return (
+    Object.keys(featureFlags).indexOf(flagName) !== -1 && featureFlags[flagName]
+  )
 }

--- a/src/lib/middleware/featureFlagMiddleware.ts
+++ b/src/lib/middleware/featureFlagMiddleware.ts
@@ -29,10 +29,10 @@ export function featureFlagMiddleware(serviceType: symbol) {
 
         // Get features and move them to sharify
         const flags = service.getFeatures()
-        res.locals.sd.featureFlags = {}
+        res.locals.sd.FEATURE_FLAGS = {}
         if (flags) {
           for (let flag of flags) {
-            res.locals.sd.featureFlags[flag] = service.enabled(
+            res.locals.sd.FEATURE_FLAGS[flag] = service.enabled(
               flag,
               featureFlagContext
             )

--- a/src/v2/System/Router/Boot.tsx
+++ b/src/v2/System/Router/Boot.tsx
@@ -28,9 +28,7 @@ import { ClientContext } from "desktop/lib/buildClientAppContext"
 import { FlashMessage } from "v2/Components/Modal/FlashModal"
 import { SiftContainer } from "v2/Utils/SiftContainer"
 import { setupSentryClient } from "lib/setupSentryClient"
-import {
-  EnabledFeatureFlags,
-} from "lib/featureFlags/FeatureFlagProvider"
+import { EnabledFeatureFlags } from "v2/System/useFeatureFlag"
 
 export interface BootProps {
   children: React.ReactNode
@@ -84,21 +82,21 @@ export const Boot = track(undefined, {
           <SystemContextProvider {...contextProps}>
             <AnalyticsContext.Provider value={context?.analytics}>
               <ErrorBoundary>
-                  <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
-                    <ResponsiveProvider
-                      mediaQueries={themeProps.mediaQueries}
-                      initialMatchingMediaQueries={onlyMatchMediaQueries as any}
-                    >
-                      <ToastsProvider>
-                        <Grid fluid maxWidth="100%">
-                          <FlashMessage />
-                          <FocusVisible />
-                          <SiftContainer />
-                          {children}
-                        </Grid>
-                      </ToastsProvider>
-                    </ResponsiveProvider>
-                  </MediaContextProvider>
+                <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
+                  <ResponsiveProvider
+                    mediaQueries={themeProps.mediaQueries}
+                    initialMatchingMediaQueries={onlyMatchMediaQueries as any}
+                  >
+                    <ToastsProvider>
+                      <Grid fluid maxWidth="100%">
+                        <FlashMessage />
+                        <FocusVisible />
+                        <SiftContainer />
+                        {children}
+                      </Grid>
+                    </ToastsProvider>
+                  </ResponsiveProvider>
+                </MediaContextProvider>
               </ErrorBoundary>
             </AnalyticsContext.Provider>
           </SystemContextProvider>

--- a/src/v2/System/Router/Boot.tsx
+++ b/src/v2/System/Router/Boot.tsx
@@ -30,7 +30,6 @@ import { SiftContainer } from "v2/Utils/SiftContainer"
 import { setupSentryClient } from "lib/setupSentryClient"
 import {
   EnabledFeatureFlags,
-  FeatureFlagProvider,
 } from "lib/featureFlags/FeatureFlagProvider"
 
 export interface BootProps {
@@ -71,6 +70,7 @@ export const Boot = track(undefined, {
   } = props
 
   const contextProps = {
+    featureFlags,
     ...rest,
     ...context,
   }
@@ -84,7 +84,6 @@ export const Boot = track(undefined, {
           <SystemContextProvider {...contextProps}>
             <AnalyticsContext.Provider value={context?.analytics}>
               <ErrorBoundary>
-                <FeatureFlagProvider featureFlags={featureFlags}>
                   <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
                     <ResponsiveProvider
                       mediaQueries={themeProps.mediaQueries}
@@ -100,7 +99,6 @@ export const Boot = track(undefined, {
                       </ToastsProvider>
                     </ResponsiveProvider>
                   </MediaContextProvider>
-                </FeatureFlagProvider>
               </ErrorBoundary>
             </AnalyticsContext.Provider>
           </SystemContextProvider>

--- a/src/v2/System/Router/__tests__/buildClientApp.jest.tsx
+++ b/src/v2/System/Router/__tests__/buildClientApp.jest.tsx
@@ -101,6 +101,7 @@ describe("buildClientApp", () => {
           {context => {
             expect(Object.keys(context).sort()).toEqual([
               "analytics",
+              "featureFlags",
               "isEigen",
               "isFetching",
               "isLoggedIn",

--- a/src/v2/System/Router/__tests__/buildServerApp.jest.tsx
+++ b/src/v2/System/Router/__tests__/buildServerApp.jest.tsx
@@ -172,6 +172,7 @@ describe("buildServerApp", () => {
           {context => {
             expect(Object.keys(context).sort()).toEqual([
               "analytics",
+              "featureFlags",
               "initialMatchingMediaQueries",
               "isEigen",
               "isFetching",

--- a/src/v2/System/Router/buildClientApp.tsx
+++ b/src/v2/System/Router/buildClientApp.tsx
@@ -113,7 +113,7 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
             user={user}
             relayEnvironment={relayEnvironment}
             routes={routes}
-            featureFlags={getENV('featureFlags')}
+            featureFlags={getENV("FEATURE_FLAGS")}
           >
             <Router resolver={resolver} />
           </Boot>

--- a/src/v2/System/Router/buildClientApp.tsx
+++ b/src/v2/System/Router/buildClientApp.tsx
@@ -28,6 +28,7 @@ import { trackingMiddleware } from "v2/System/Analytics/trackingMiddleware"
 import { RenderError, RenderPending, RenderReady } from "./RenderStatus"
 import { shouldUpdateScroll } from "./Utils/shouldUpdateScroll"
 import { buildClientAppContext } from "desktop/lib/buildClientAppContext"
+import { getENV } from "v2/Utils/getENV"
 
 interface Resolve {
   ClientApp: ComponentType<any>
@@ -43,7 +44,6 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
         history = {},
         initialRoute = "/",
         routes = [],
-        featureFlags = {},
       } = config
       const clientContext = buildClientAppContext(context)
 
@@ -113,7 +113,7 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
             user={user}
             relayEnvironment={relayEnvironment}
             routes={routes}
-            featureFlags={featureFlags}
+            featureFlags={getENV('featureFlags')}
           >
             <Router resolver={resolver} />
           </Boot>

--- a/src/v2/System/Router/buildServerApp.tsx
+++ b/src/v2/System/Router/buildServerApp.tsx
@@ -82,7 +82,6 @@ export function buildServerApp(
         loadableFile = "loadable-stats.json",
         loadablePath = "public/assets",
         assetsPath = "/assets",
-        featureFlags = {},
       } = config
 
       // Find and execute pre-render hooks
@@ -156,7 +155,7 @@ export function buildServerApp(
               onlyMatchMediaQueries={matchingMediaQueries}
               relayEnvironment={relayEnvironment}
               routes={routes}
-              featureFlags={featureFlags}
+              featureFlags={res.locals.sd.featureFlags}
             >
               {farceResults.element}
             </Boot>

--- a/src/v2/System/Router/buildServerApp.tsx
+++ b/src/v2/System/Router/buildServerApp.tsx
@@ -155,7 +155,7 @@ export function buildServerApp(
               onlyMatchMediaQueries={matchingMediaQueries}
               relayEnvironment={relayEnvironment}
               routes={routes}
-              featureFlags={res.locals.sd.featureFlags}
+              featureFlags={res.locals.sd.FEATURE_FLAGS}
             >
               {farceResults.element}
             </Boot>

--- a/src/v2/System/Server/sharifyHelpers.ts
+++ b/src/v2/System/Server/sharifyHelpers.ts
@@ -47,7 +47,7 @@ const V2_SHARIFY_ALLOWLIST = [
   "VOLLEY_ENDPOINT",
   "WEBFONT_URL",
   "ZENDESK_KEY",
-  "featureFlags",
+  "FEATURE_FLAGS",
 ] as const
 
 export type SharifyKey = typeof V2_SHARIFY_ALLOWLIST[number]

--- a/src/v2/System/SystemContext.tsx
+++ b/src/v2/System/SystemContext.tsx
@@ -77,6 +77,9 @@ export interface SystemContextProps extends SystemContextState {
 
   /** Is there a logged in user? */
   isLoggedIn?: boolean
+
+  /** FetureFlags */
+  featureFlags?: Record<string, boolean>
 }
 
 export const SystemContext = createContext<SystemContextProps>({})

--- a/src/v2/System/SystemContext.tsx
+++ b/src/v2/System/SystemContext.tsx
@@ -78,7 +78,7 @@ export interface SystemContextProps extends SystemContextState {
   /** Is there a logged in user? */
   isLoggedIn?: boolean
 
-  /** FetureFlags */
+  /** FeatureFlags */
   featureFlags?: Record<string, boolean>
 }
 

--- a/src/v2/System/__tests__/useFeatureFlag.jest.tsx
+++ b/src/v2/System/__tests__/useFeatureFlag.jest.tsx
@@ -25,6 +25,7 @@ describe("useFeatureFlag", () => {
   })
 
   it("returns null when we don't pass in an argument", () => {
+    // @ts-ignore
     const result = useFeatureFlag()
     expect(result).toBe(null)
     expect(console.error).toHaveBeenLastCalledWith(

--- a/src/v2/System/__tests__/useFeatureFlag.jest.tsx
+++ b/src/v2/System/__tests__/useFeatureFlag.jest.tsx
@@ -1,0 +1,44 @@
+import { useFeatureFlag } from "../useFeatureFlag"
+import { useSystemContext } from "v2/System/useSystemContext"
+
+jest.mock("v2/System/useSystemContext")
+
+describe("useFeatureFlag", () => {
+  const mockUseSystemContext = useSystemContext as jest.Mock
+
+  beforeEach(() => {
+    mockUseSystemContext.mockImplementation(() => ({
+      featureFlags: {
+        feature: true,
+      },
+    }))
+  })
+
+  it("returns true when the feature flag is present", () => {
+    const result = useFeatureFlag("feature")
+    expect(result).toBe(true)
+  })
+
+  it("returns false when the feature flag is not present", () => {
+    const result = useFeatureFlag("notAvailable")
+    expect(result).toBe(false)
+  })
+
+  it("returns null when we don't pass in an argument", () => {
+    const result = useFeatureFlag()
+    expect(result).toBe(null)
+    expect(console.error).toHaveBeenLastCalledWith(
+      `[Force] Error: no argument passed into useFeatureFlag`
+    )
+  })
+
+  it("returns null when we don't have featureFlags", () => {
+    mockUseSystemContext.mockImplementation(() => ({}))
+
+    const result = useFeatureFlag("feature")
+    expect(result).toBe(null)
+    expect(console.error).toHaveBeenLastCalledWith(
+      "[Force] Error: featureFlags is undefined in SystemContext"
+    )
+  })
+})

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -2,7 +2,7 @@ import { useSystemContext } from "v2/System"
 
 export type EnabledFeatureFlags = Record<string, boolean>
 
-export function useFeatureFlag(flagName) {
+export function useFeatureFlag(flagName: string): boolean | null {
   const { featureFlags } = useSystemContext()
   if (featureFlags === undefined) {
     console.error("[Force] Error: featureFlags is undefined in SystemContext")
@@ -10,7 +10,7 @@ export function useFeatureFlag(flagName) {
   }
 
   if (!flagName) {
-    console.error("[Force] Error: cannot find flagName in featureFlags")
+    console.error("[Force] Error: no argument passed into useFeatureFlag")
     return null
   }
 

--- a/src/v2/client.tsx
+++ b/src/v2/client.tsx
@@ -10,7 +10,6 @@ import { getClientParam } from "./Utils/getClientParam"
 import { buildClientApp } from "v2/System/Router/client"
 import { syncNonCacheableData } from "./System/Client/syncSharify"
 import { loadSegment } from "lib/analytics/segmentOneTrustIntegration/segmentOneTrustIntegration"
-import { getENV } from "./Utils/getENV"
 
 async function setupClient() {
   syncNonCacheableData()
@@ -50,7 +49,6 @@ async function setupClient() {
 
   const { ClientApp } = await buildClientApp({
     routes: getAppRoutes(),
-    featureFlags: getENV("featureFlags"),
   })
 
   // Rehydrate

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -28,7 +28,6 @@ app.get(
         req,
         res,
         routes,
-        featureFlags: res.locals.sd.featureFlags,
       })
 
       if (redirect) {


### PR DESCRIPTION
This PR simplifies the Unleash implementation by removing the previously used custom React `Context.Provider` in favor of `Force`'s `SystemContext`. 

## Related PRs
- https://github.com/artsy/force/pull/9498
- https://github.com/artsy/force/pull/9393

## Follow-ups
- Allow for experimentation by implementing `useVariant` and analytics tracking. [PLATFORM-3922]

[PLATFORM-3922]: https://artsyproduct.atlassian.net/browse/PLATFORM-3922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ