### PR TITLE
feat: change low offer modal in offer submission page

### DIFF
--- a/src/v2/Apps/Order/Routes/Offer/index.tsx
+++ b/src/v2/Apps/Order/Routes/Offer/index.tsx
@@ -83,7 +83,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
     this.props.dialog.showErrorDialog({
       continueButtonText: "OK",
       message:
-        "Offers within 25% of the list price are most likely to receive a response.",
+        "Offers within 20% of the list price are most likely to receive a response.",
       title: "Offer may be too low",
     })
   }
@@ -162,7 +162,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
     if (
       !isPriceHidden &&
       !lowSpeedBumpEncountered &&
-      offerValue * 100 < listPriceCents * 0.75 &&
+      offerValue * 100 < listPriceCents * 0.8 &&
       !isRangeOffer
     ) {
       this.showLowSpeedbump()

--- a/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
@@ -280,7 +280,7 @@ describe("Offer InitialMutation", () => {
 
         await page.expectAndDismissErrorDialogMatching(
           "Offer may be too low",
-          "Offers within 25% of the list price are most likely to receive a response",
+          "Offers within 20% of the list price are most likely to receive a response",
           "OK"
         )
 


### PR DESCRIPTION
[NX-3075]

Changes the modal message when the offer is under 20% list price; before was popping up when the offer was 25% under list price.

![image](https://user-images.githubusercontent.com/15792853/156134889-b47ef407-81bb-439e-a740-e981ddeb787a.png)


[NX-3075]: https://artsyproduct.atlassian.net/browse/NX-3075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ