### PR TITLE
feat(TX-217): update buyer total messaging

### DIFF
--- a/src/v2/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/v2/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -69,11 +69,7 @@ export class TransactionDetailsSummaryItem extends React.Component<
         <Spacer mb={2} />
         <Entry
           label="Total"
-          value={
-            this.buyerTotalDisplayAmount()
-              ? this.buyerTotalDisplayAmount()
-              : "Waiting for final costs"
-          }
+          value={this.buyerTotalDisplayAmount()}
           final
           data-test="buyerTotalDisplayAmount"
         />
@@ -229,13 +225,21 @@ export class TransactionDetailsSummaryItem extends React.Component<
   buyerTotalDisplayAmount = () => {
     const { order } = this.props
     const currency = order.currencyCode
+    const totalPlaceholder = this.avalaraPhase2enabled
+      ? "Waiting for final costs"
+      : null
 
     switch (order.mode) {
       case "BUY":
-        return appendCurrencySymbol(order.buyerTotal, currency)
+        return (
+          appendCurrencySymbol(order.buyerTotal, currency) || totalPlaceholder
+        )
       case "OFFER":
         const offer = this.getOffer()
-        return offer && appendCurrencySymbol(offer.buyerTotal, currency)
+        return (
+          (offer && appendCurrencySymbol(offer.buyerTotal, currency)) ||
+          totalPlaceholder
+        )
     }
   }
 

--- a/src/v2/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/v2/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -69,7 +69,11 @@ export class TransactionDetailsSummaryItem extends React.Component<
         <Spacer mb={2} />
         <Entry
           label="Total"
-          value={this.buyerTotalDisplayAmount()}
+          value={
+            this.buyerTotalDisplayAmount()
+              ? this.buyerTotalDisplayAmount()
+              : "Waiting for final costs"
+          }
           final
           data-test="buyerTotalDisplayAmount"
         />
@@ -225,6 +229,7 @@ export class TransactionDetailsSummaryItem extends React.Component<
   buyerTotalDisplayAmount = () => {
     const { order } = this.props
     const currency = order.currencyCode
+
     switch (order.mode) {
       case "BUY":
         return appendCurrencySymbol(order.buyerTotal, currency)

--- a/src/v2/Apps/Order/Components/__tests__/TransactionDetailsSummary.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/TransactionDetailsSummary.jest.tsx
@@ -123,9 +123,7 @@ describe("TransactionDetailsSummaryItem", () => {
           shippingTotal: null,
           shippingTotalCents: null,
         },
-        {
-          user: { lab_features: ["Avalara Phase 2"] },
-        }
+        { user: { lab_features: ["Avalara Phase 2"] } }
       )
 
       const text = transactionSummary.text()
@@ -153,9 +151,7 @@ describe("TransactionDetailsSummaryItem", () => {
           shippingTotal: null,
           shippingTotalCents: null,
         },
-        {
-          user: { lab_features: ["Avalara Phase 2"] },
-        }
+        { user: { lab_features: ["Avalara Phase 2"] } }
       )
 
       const text = transactionSummary.text()
@@ -174,6 +170,20 @@ describe("TransactionDetailsSummaryItem", () => {
       const text = transactionSummary.text()
 
       expect(text).not.toMatch("List price")
+    })
+
+    it("shows 'Waiting for final costs' when buyer total has not been calucuated yet", async () => {
+      const transactionSummary = await render(
+        {
+          ...transactionSummaryBuyOrder,
+          buyerTotal: null,
+        },
+        { user: { lab_features: ["Avalara Phase 2"] } }
+      )
+
+      const text = transactionSummary.text()
+
+      expect(text).toMatch("TotalWaiting for final costs")
     })
   })
 


### PR DESCRIPTION
[TX-217](https://artsyproduct.atlassian.net/browse/TX-217)

This PR adds a conditional to display "Waiting for final costs" for the "Total" transaction detail line item when the total has not yet been calculated. Nothing was displayed previously.

### Before
<img width="570" alt="Screenshot 2022-03-02 at 10 31 09 AM" src="https://user-images.githubusercontent.com/50849237/156334282-cae88df6-d22a-4392-8e59-fb8f0ec9ec5b.png"> 

### After
<img width="580" alt="Screenshot 2022-03-02 at 10 06 12 AM" src="https://user-images.githubusercontent.com/50849237/156333949-d3a0e3d9-84c8-4be0-8189-14cf4177d506.png">
