### PR TITLE
fix(GRO-584): Remove interest based preference center cancel button

### DIFF
--- a/src/v2/Apps/_Preferences2/PreferencesApp.tsx
+++ b/src/v2/Apps/_Preferences2/PreferencesApp.tsx
@@ -107,12 +107,10 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
                 <Checkbox
                   selected={Object.values(values).every(Boolean)}
                   onSelect={value => {
-                    if (value) {
-                      Object.keys(values).forEach(field => {
-                        setFieldValue(field, true)
-                        setFieldTouched(field, true)
-                      })
-                    }
+                    Object.keys(values).forEach(field => {
+                      setFieldValue(field, value)
+                      setFieldTouched(field, value)
+                    })
                   }}
                 >
                   Email
@@ -233,12 +231,10 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
                 <Checkbox
                   selected={!Object.values(values).some(Boolean)}
                   onSelect={value => {
-                    if (value) {
-                      Object.keys(values).forEach(field => {
-                        setFieldValue(field, false)
-                        setFieldTouched(field, true)
-                      })
-                    }
+                    Object.keys(values).forEach(field => {
+                      setFieldValue(field, !value)
+                      setFieldTouched(field, !value)
+                    })
                   }}
                 >
                   Email

--- a/src/v2/Apps/_Preferences2/PreferencesApp.tsx
+++ b/src/v2/Apps/_Preferences2/PreferencesApp.tsx
@@ -92,11 +92,10 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
       >
         {({
           values,
-          setFieldValue,
-          setFieldTouched,
-          resetForm,
           isSubmitting,
           touched,
+          setFieldValue,
+          setFieldTouched,
         }) => (
           <Form>
             <GridColumns gridRowGap={4}>
@@ -246,28 +245,7 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
                 </Checkbox>
               </Column>
 
-              <Column span={2} start={9} mt={2}>
-                <Button
-                  width="100%"
-                  variant="secondaryOutline"
-                  disabled={isEmpty(touched) || isSubmitting}
-                  type="button"
-                  onClick={event => {
-                    event.preventDefault()
-                    resetForm({
-                      values: {
-                        ...NOTIFICATION_FIELDS,
-                        ...initialValues,
-                      },
-                      touched: {},
-                    })
-                  }}
-                >
-                  Cancel
-                </Button>
-              </Column>
-
-              <Column span={2} mt={2}>
+              <Column span={2} start={10} mt={2}>
                 <Button
                   width="100%"
                   type="submit"

--- a/src/v2/Apps/_Preferences2/PreferencesApp.tsx
+++ b/src/v2/Apps/_Preferences2/PreferencesApp.tsx
@@ -92,10 +92,10 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
       >
         {({
           values,
-          setTouched,
           setFieldValue,
           setFieldTouched,
           resetForm,
+          isSubmitting,
           touched,
         }) => (
           <Form>
@@ -250,7 +250,8 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
                 <Button
                   width="100%"
                   variant="secondaryOutline"
-                  disabled={isEmpty(touched)}
+                  disabled={isEmpty(touched) || isSubmitting}
+                  type="button"
                   onClick={event => {
                     event.preventDefault()
                     resetForm({
@@ -267,7 +268,11 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
               </Column>
 
               <Column span={2} mt={2}>
-                <Button width="100%" type="submit" disabled={isEmpty(touched)}>
+                <Button
+                  width="100%"
+                  type="submit"
+                  disabled={isEmpty(touched) || isSubmitting}
+                >
                   Save
                 </Button>
               </Column>

--- a/src/v2/Apps/_Preferences2/PreferencesApp.tsx
+++ b/src/v2/Apps/_Preferences2/PreferencesApp.tsx
@@ -72,7 +72,6 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
             })
 
             actions.resetForm({
-              values: { ...NOTIFICATION_FIELDS, ...getInitialValues(viewer) },
               touched: {},
             })
 

--- a/src/v2/Apps/_Preferences2/__tests__/PreferencesApp.jest.tsx
+++ b/src/v2/Apps/_Preferences2/__tests__/PreferencesApp.jest.tsx
@@ -13,17 +13,13 @@ describe("PreferencesApp", () => {
 
     // eslint-disable-next-line testing-library/no-node-access
     let saveButton = screen.getByText("Save").closest("button")
-    // eslint-disable-next-line testing-library/no-node-access
-    let cancelButton = screen.getByText("Cancel").closest("button")
     let checkboxes = screen.getAllByRole("checkbox")
 
     expect(saveButton).toBeDisabled()
-    expect(cancelButton).toBeDisabled()
 
     fireEvent.click(checkboxes[0])
 
     expect(saveButton).toBeEnabled()
-    expect(cancelButton).toBeEnabled()
   })
 
   it("allows user to uncheck all boxes with unsubscribe from all", () => {
@@ -79,25 +75,5 @@ describe("PreferencesApp", () => {
     checkboxes.forEach(checkbox => {
       expect(checkbox).toBeChecked()
     })
-  })
-
-  it("when a user clicks cancel the form is reset", () => {
-    render(<PreferencesApp></PreferencesApp>)
-
-    let checkboxes = screen.getAllByRole("checkbox")
-    let subscribeToAllCheckbox = checkboxes[0]
-
-    // eslint-disable-next-line testing-library/no-node-access
-    let cancelButton = screen.getByText("Cancel").closest("button")
-
-    fireEvent.click(subscribeToAllCheckbox)
-
-    expect(subscribeToAllCheckbox).toBeChecked()
-    expect(checkboxes[1]).toBeChecked()
-
-    fireEvent.click(cancelButton!)
-
-    expect(subscribeToAllCheckbox).not.toBeChecked()
-    expect(checkboxes[1]).not.toBeChecked()
   })
 })

--- a/src/v2/Apps/_Preferences2/__tests__/PreferencesApp.jest.tsx
+++ b/src/v2/Apps/_Preferences2/__tests__/PreferencesApp.jest.tsx
@@ -75,5 +75,11 @@ describe("PreferencesApp", () => {
     checkboxes.forEach(checkbox => {
       expect(checkbox).toBeChecked()
     })
+
+    fireEvent.click(subscribeToAllCheckbox)
+
+    checkboxes.forEach(checkbox => {
+      expect(checkbox).not.toBeChecked()
+    })
   })
 })


### PR DESCRIPTION
This branch contains a few fixes for the preference center form. After talking with @damassi and some of the other GROW engineers we decided this cancel button is a bit confusing and not worth the complexity.