### PR TITLE
feat: add server error logging in middleware

### DIFF
--- a/src/lib/middleware/errorHandler.tsx
+++ b/src/lib/middleware/errorHandler.tsx
@@ -36,6 +36,7 @@ import {
   injectGlobalStyles,
   ThemeProviderV3,
 } from "@artsy/palette"
+import createLogger from "v2/Utils/logger"
 
 const { GlobalStyles } = injectGlobalStyles()
 
@@ -67,6 +68,12 @@ export const errorHandlerMiddleware = async (
 
   if (enableLogging && err.status !== 404) {
     console.log(detail)
+  }
+
+  // Log server errors (code, stack trace) when in production mode
+  if (NODE_ENV === "production" && code >= 500) {
+    const logger = createLogger("lib/middleware/errorHandlerMiddleware")
+    logger.error(code, detail)
   }
 
   try {

--- a/src/lib/middleware/errorHandler.tsx
+++ b/src/lib/middleware/errorHandler.tsx
@@ -39,6 +39,7 @@ import {
 import createLogger from "v2/Utils/logger"
 
 const { GlobalStyles } = injectGlobalStyles()
+const logger = createLogger("lib/middleware/errorHandlerMiddleware")
 
 export const errorHandlerMiddleware = async (
   err: any,
@@ -68,11 +69,8 @@ export const errorHandlerMiddleware = async (
 
   if (enableLogging && err.status !== 404) {
     console.log(detail)
-  }
-
-  // Log server errors (code, stack trace) when in production mode
-  if (NODE_ENV === "production" && code >= 500) {
-    const logger = createLogger("lib/middleware/errorHandlerMiddleware")
+  } else if (code >= 500) {
+    // Log server errors (code, stack trace) when in production mode
     logger.error(code, detail)
   }
 

--- a/src/lib/middleware/errorHandler.tsx
+++ b/src/lib/middleware/errorHandler.tsx
@@ -68,7 +68,7 @@ export const errorHandlerMiddleware = async (
   const detail = err.stack
 
   if (enableLogging && err.status !== 404) {
-    console.log(detail)
+    logger.log(detail)
   } else if (code >= 500) {
     // Log server errors (code, stack trace) when in production mode
     logger.error(code, detail)
@@ -111,7 +111,7 @@ export const errorHandlerMiddleware = async (
       mount: false, // Does not mount the client-side
     })
   } catch (err) {
-    console.error(err)
+    logger.error(err)
     res.status(code).send(enableLogging ? message : "")
   }
 }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4003

This change is an action item following [#inc-141](https://artsy.app.opsgenie.com/incident/detail/0f3fd6e1-9e57-40a5-a41b-92bc54a86356). During investigations responders noticed that the observed 504 errors were _not_ recorded in papertrail, making troubleshooting more difficult.

This adds server error logging to force middleware _errorHandler_ when in production mode.