### PR TITLE
Remove unused codecov orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 orbs:
   artsy-remote-docker: artsy/remote-docker@0.1.14
   aws-s3: circleci/aws-s3@2.0.0
-  codecov: codecov/codecov@1.2.5
   hokusai: artsy/hokusai@0.10.0
   horizon: artsy/release@0.0.1
   node: artsy/node@2.0.0


### PR DESCRIPTION
The `codecov` orb has been unused for a long time. And yet, renovate keeps bumping the version and rebasing the open PR (https://github.com/artsy/force/pull/9169), wasting CI time.

Next challenge: how to get renovate to stop rebasing all of these bump PRs constantly.
