### PR TITLE
docs(best-practices): Add entry on tracking

### DIFF
--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -25,6 +25,7 @@ Links should point to specific commits, and not a branch (in case the branch or 
 - [Add smoke tests for new routes](#add-smoke-tests-for-new-routes)
 - [Adding global script tags](#adding-global-script-tags)
 - [Adding or removing a Segment destination](#adding-or-removing-a-segment-destination)
+- [Tracking events](#tracking-events)
 
 ## Current Preferred Practices
 
@@ -200,3 +201,24 @@ When adding global script tags (for, say, marketing-related needs), we need to a
 ### Adding or removing a Segment destination
 
 Due to us having [integrated Segment with OneTrust Cookie Consent](https://github.com/artsy/force/pull/8853), each Segment Destination must be assigned a proper cookie category. When we add or remove a Destination, we have to update the Destination/category mapping in [this table](https://www.notion.so/artsy/Cookie-Consent-01dace52a765476ea4e9353260ce9a7f#3ec509bfb40b4d08985f6d81a306f7bf) and [object](https://github.com/artsy/force/blob/7a1b74c0736d01c67facb9108da14af043f2ee9b/src/lib/analytics/segmentOneTrustIntegration/setSegmentDestinationPref.ts#L7). This applies only to Destinations that are associated with Segment `force-staging` and `force-production` Sources and that are actually enabled.
+
+### Tracking Events
+
+We use [react-tracking](https://github.com/nytimes/react-tracking) for tracking events defined in [artsy/cohesion](https://github.com/artsy/cohesion). To use, import the hook as well as the associated schema bits:
+
+```tsx
+import { useTracking } from "react-tracking"
+import { ContextModule } from "@artsy/cohesion"
+
+const MyApp = () => {
+  const { trackEvent } = useTracking()
+
+  return (
+    <Button onClick={() => {
+      trackEvent({
+        contextModule: ContextModule.myApp,
+      })
+    }}>
+  )
+}
+```


### PR DESCRIPTION
Adds an entry to our best practices doc around tracking. 

Example:

```tsx
import { useTracking } from "react-tracking"
import { ContextModule } from "@artsy/cohesion"

const MyApp = () => {
  const { trackEvent } = useTracking()

  return (
    <Button onClick={() => {
      trackEvent({
        contextModule: ContextModule.myApp,
      })
    }}>
  )
}
```