### PR TITLE
fix: SWA-263 Resources: label is missing spaces at artsy.net/consign

### DIFF
--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/PromoSpace.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/PromoSpace.tsx
@@ -1,16 +1,16 @@
-import * as React from "react";
+import * as React from "react"
 import { Banner, Box, FullBleed } from "@artsy/palette"
 
 export const PromoSpace: React.FC = () => {
   return (
     <FullBleed>
       <Banner variant="defaultLight">
-        Gallerist or art dealer?{" "}
+        Gallerist or art dealer?&nbsp;
         <a href="https://partners.artsy.net" target="_blank">
           Become a partner
-        </a>{" "}
+        </a>
         <Box as="span" display={["none", "inline"]}>
-          to access the largest global online art marketplace
+          &nbsp;to access the largest global online art marketplace
         </Box>
       </Banner>
     </FullBleed>


### PR DESCRIPTION
- change syntax from {" "} to `&nbsp;` because then the space is not removed when using flexbox