### PR TITLE
[DRAFT] cannot set headers after they are sent to the client

### DIFF
--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -8,6 +8,7 @@ import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { initialAuctionResultsFilterState } from "./Routes/AuctionResults/AuctionResultsFilterContext"
 import { allowedAuctionResultFilters } from "./Utils/allowedAuctionResultFilters"
 import { enableArtistPageCTA } from "./Server/enableArtistPageCTA"
+import { redirect } from "v2/System/Server/redirectHelper"
 
 const ArtistApp = loadable(
   () => import(/* webpackChunkName: "artistBundle" */ "./ArtistApp"),
@@ -87,7 +88,12 @@ export const artistRoutes: AppRouteConfig[] = [
     path: "/artist/:artistID",
     ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => ArtistApp,
-    onServerSideRender: enableArtistPageCTA,
+    onServerSideRender: props => {
+      redirect({
+        onRedirect: () => enableArtistPageCTA(props),
+        ...props,
+      })
+    },
     onClientSideRender: () => {
       ArtistApp.preload()
       OverviewRoute.preload()
@@ -107,7 +113,12 @@ export const artistRoutes: AppRouteConfig[] = [
       {
         path: "/",
         getComponent: () => OverviewRoute,
-        onServerSideRender: enableArtistPageCTA,
+        onServerSideRender: props => {
+          redirect({
+            onRedirect: () => enableArtistPageCTA(props),
+            ...props,
+          })
+        },
         onClientSideRender: () => {
           OverviewRoute.preload()
         },

--- a/src/v2/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/v2/Apps/Authentication/authenticationRoutes.tsx
@@ -152,6 +152,7 @@ export const authenticationRoutes: AppRouteConfig[] = [
     path: "/auth-redirect",
     onServerSideRender: props => {
       redirectPostAuth(props)
+      props.res.locals.hasRedirected = true
     },
   },
 ]

--- a/src/v2/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/v2/Apps/Authentication/authenticationRoutes.tsx
@@ -8,6 +8,7 @@ import { redirectIfLoggedIn } from "./Server/redirectIfLoggedIn"
 import { setCookies } from "./Utils/helpers"
 import { redirectPostAuth } from "./Server/redirectPostAuth"
 import { stringify } from "qs"
+import { redirect } from "v2/System/Server/redirectHelper"
 
 const ForgotPasswordRoute = loadable(
   () =>
@@ -96,12 +97,13 @@ export const authenticationRoutes: AppRouteConfig[] = [
       if (req.query.reset_password_token) {
         const { reset_password_token, ...rest } = req.query
         req.session.RESET_PASSWORD_TOKEN = reset_password_token
-        res.redirect(
-          `/reset_password${
+        redirect({
+          url: `/reset_password${
             // Pass along any other query params
             Object.keys(rest).length > 0 ? `?${stringify(rest)}` : ""
-          }`
-        )
+          }`,
+          ...{ req, res },
+        })
         return
       }
 
@@ -151,8 +153,10 @@ export const authenticationRoutes: AppRouteConfig[] = [
   {
     path: "/auth-redirect",
     onServerSideRender: props => {
-      redirectPostAuth(props)
-      props.res.locals.hasRedirected = true
+      redirect({
+        onRedirect: () => redirectPostAuth(props),
+        ...props,
+      })
     },
   },
 ]

--- a/src/v2/Apps/Collect/collectRoutes.tsx
+++ b/src/v2/Apps/Collect/collectRoutes.tsx
@@ -5,6 +5,7 @@ import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters
 
 import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { redirectCollectionToArtistSeries } from "./Server/redirectCollectionToArtistSeries"
+import { redirect } from "v2/System/Server/redirectHelper"
 
 const CollectApp = loadable(
   () => import(/* webpackChunkName: "collectBundle" */ "./Routes/Collect"),
@@ -61,7 +62,12 @@ export const collectRoutes: AppRouteConfig[] = [
   {
     path: "/collection/:slug",
     getComponent: () => CollectionApp,
-    onServerSideRender: redirectCollectionToArtistSeries,
+    onServerSideRender: props => {
+      redirect({
+        onRedirect: () => redirectCollectionToArtistSeries(props),
+        ...props,
+      })
+    },
     onClientSideRender: () => {
       CollectionApp.preload()
     },

--- a/src/v2/Apps/Search/searchRoutes.tsx
+++ b/src/v2/Apps/Search/searchRoutes.tsx
@@ -5,6 +5,7 @@ import loadable from "@loadable/component"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
 import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { redirectQueryToTerm } from "./Server/redirectQueryToTerm"
+import { redirect } from "v2/System/Server/redirectHelper"
 
 const SearchResultsArtists = loadable(
   () =>
@@ -104,7 +105,12 @@ export const searchRoutes: AppRouteConfig[] = [
   {
     path: "/search",
     getComponent: () => SearchApp,
-    onServerSideRender: redirectQueryToTerm,
+    onServerSideRender: props => {
+      redirect({
+        onRedirect: () => redirectQueryToTerm(props),
+        ...props,
+      })
+    },
     onClientSideRender: () => {
       SearchApp.preload()
     },

--- a/src/v2/Apps/WorksForYou/worksForYouRoutes.tsx
+++ b/src/v2/Apps/WorksForYou/worksForYouRoutes.tsx
@@ -1,6 +1,7 @@
 import loadable from "@loadable/component"
 import { graphql } from "relay-runtime"
 import { AppRouteConfig } from "v2/System/Router/Route"
+import { redirect } from "v2/System/Server/redirectHelper"
 
 const WorksForYouApp = loadable(
   () => import(/* webpackChunkName: "worksForYouBundle" */ "./WorksForYouApp"),
@@ -15,7 +16,7 @@ export const worksForYouRoutes: AppRouteConfig[] = [
     getComponent: () => WorksForYouApp,
     onServerSideRender: ({ req, res }) => {
       if (!req.user) {
-        res.redirect("/")
+        redirect({ url: "/", ...{ req, res } })
       }
     },
     onClientSideRender: () => {

--- a/src/v2/System/Server/redirectHelper.ts
+++ b/src/v2/System/Server/redirectHelper.ts
@@ -1,0 +1,25 @@
+import { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
+
+interface RedirectProps {
+  onRedirect?: () => void
+  url?: string
+  status?: number
+  req: ArtsyRequest
+  res: ArtsyResponse
+}
+
+export function redirect({
+  url = "/",
+  status = 302,
+  onRedirect,
+  req,
+  res,
+}: RedirectProps) {
+  res.locals.hasRedirected = true
+
+  if (onRedirect) {
+    onRedirect()
+  } else {
+    res.redirect(url, status)
+  }
+}

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -30,6 +30,10 @@ app.get(
         routes,
       })
 
+      if (res.locals.hasRedirected) {
+        return
+      }
+
       if (redirect) {
         res.redirect(status ?? 302, redirect.url)
         return


### PR DESCRIPTION
## Background

As a followup to #[inc-141](https://artsy.app.opsgenie.com/incident/detail/0f3fd6e1-9e57-40a5-a41b-92bc54a86356) (_Force 504 errors and unleash request spike_) the velocity team is looking to update the [sentryFilters](https://github.com/artsy/force/blob/main/src/lib/analytics/sentryFilters.ts#L18) removing the _[response timeout](https://artsyproduct.atlassian.net/browse/PLATFORM-4004)_ from the list of ignored errors (which currently does not end up in sentry). As of today 10AM ET, the sentry statistics over the last 24h are:

<img width="1630" alt="Screen Shot 2022-03-04 at 10 07 56 AM" src="https://user-images.githubusercontent.com/29984068/156788199-a7a9bdff-856b-42fe-b499-f0efd8b641ff.png">


The decision to do this was a result of not being able to trace the 504s seen during the mentioned incident. One of the concerns is that removing this type of error from filters may contribute to us hitting sentry rate limits. As I started to look at sentry (and papertrail) I noticed that the following error is occurring many times throughout the day: _Cannot set headers after they are sent to the client_.

<img width="1902" alt="Screen Shot 2022-03-04 at 9 58 24 AM" src="https://user-images.githubusercontent.com/29984068/156786514-6c7b153e-493c-459e-aa09-5d22adb3fbf9.png">

Going by sentry issue title, this affects multiple endpoints:

<img width="1628" alt="Screen Shot 2022-03-04 at 10 29 05 AM" src="https://user-images.githubusercontent.com/29984068/156791956-db7bc26a-6772-42bb-9cc4-448f9e0c1470.png">


According to sentry, the error was first seen on Jan 31st.

### Problem

_During the request lifecycle (server side), the application is doing some redirecting and there seems to be logic missing that tells the server to stop processing a request once the necessary redirects have been triggered._

I decided to look into this specific error (and other errors) before updating the sentry filters and introducing another type of error being sent to sentry.

As far as the specific exception is concerned, _Cannot set headers after they are sent to the client_, the frequency in sentry is:

```
~90/h (vs 2nd most seen error ~30)
~2k/day (vs 2nd most seen error ~500)
~65k/mo (vs 2nd most seen error 16k)
```

During our weekly mob @artsy/velocity-engineers spent some time discussing this issue. We were able to reproduce the issue and introduce a _hacky_ fix, mostly for the sake of demonstration to start a discussion about whether a more appropriate fix should be introduced.

### Demonstration

Running force (locally) in production mode and then signing in results in the following:

```
GET /auth-redirect?redirectTo=https%3A%2F%2Fstagingapi.artsy.net%2Fusers%2Fsign_in%3Fredirect_uri%3Dhttp%253A%252F%252Flocalhost%253A5000%252F%26trust_token... 302 1388.480ms 127.0.0.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
lib/middleware/errorHandlerMiddleware | 500 Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (_http_outgoing.js:561:11)
    at ServerResponse.header (/Users/ozzievasdi/code/force/node_modules/express/lib/response.js:767:10)
    at ServerResponse.send (/Users/ozzievasdi/code/force/node_modules/express/lib/response.js:170:12)
    at done (/Users/ozzievasdi/code/force/node_modules/express/lib/response.js:1004:10)
    at tryHandleCache (/Users/ozzievasdi/code/force/node_modules/ejs/lib/ejs.js:278:5)
    at View.exports.renderFile [as engine] (/Users/ozzievasdi/code/force/node_modules/ejs/lib/ejs.js:489:10)
    at View.render (/Users/ozzievasdi/code/force/node_modules/express/lib/view.js:135:8)
    at tryRender (/Users/ozzievasdi/code/force/node_modules/express/lib/application.js:640:10)
    at Function.render (/Users/ozzievasdi/code/force/node_modules/express/lib/application.js:592:3)
    at ServerResponse.render (/Users/ozzievasdi/code/force/node_modules/express/lib/response.js:1008:7)
    at n.renderServerApp (/Users/ozzievasdi/code/force/server.dist.js:1:574465)
    at /Users/ozzievasdi/code/force/server.dist.js:1:3114205
    at tryCatch (/Users/ozzievasdi/code/force/node_modules/regenerator-runtime/runtime.js:45:40)
    at Generator.invoke [as _invoke] (/Users/ozzievasdi/code/force/node_modules/regenerator-runtime/runtime.js:274:22)
    at Generator.prototype.<computed> [as next] (/Users/ozzievasdi/code/force/node_modules/regenerator-runtime/runtime.js:97:21)
    at asyncGeneratorStep (/Users/ozzievasdi/code/force/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
```

This is one path, that was obvious from looking at papertrail, to trigger this error. There are likely others. The committed change prevents this one error from being thrown but as mentioned previously, there are likely other redirect related conditions that would trigger it.

### Open Questions

- Is it worth pursuing a more appropriate fix for this issue?
- What would be an appropriate fix for something like this?
- If the fix is deemed worth it, who is in the best position to tackle the fix?

> I tried to capture the problem as best as I could. Hope this is enough to start a meaningful discussion.