### PR TITLE
PLATFORM-4004 sentry(errors): edit sentry filters

### DIFF
--- a/src/lib/analytics/sentryFilters.ts
+++ b/src/lib/analytics/sentryFilters.ts
@@ -15,7 +15,7 @@ export const IGNORED_ERRORS = [
   "pktAnnotationHighlighter", // Pocket ios app errors on opening articles
   "Request has been terminated Possible causes: the network is offline, Origin is not allowed by Access-Control-Allow-Origin",
   "Request has been terminated Possible causes: the network is offline",
-  "Response timeout",
+  "Cannot set headers after they are sent to the client",
   "SecurityError: Blocked a frame with origin", // Facebook scripts error on opening articles
   "TypeError Qg.m(gpt/pubads_impl_2021052601)",
 ]


### PR DESCRIPTION
A followup to #[inc-141](https://artsy.app.opsgenie.com/incident/detail/0f3fd6e1-9e57-40a5-a41b-92bc54a86356) (_Force 504 errors and unleash request spike_) this removes _Response Timeout_ error type from ignored sentry errors.

Additionally, following [a suggestion](https://github.com/artsy/force/pull/9546#issuecomment-1059311495) this adds a new type of error (for the time being) to the ignored list as it is deemed harmless.