### PR TITLE
fix(colors): revert recent changes to artwork color filtering

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
+++ b/src/v2/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
@@ -5,7 +5,8 @@ describe("getMetadata", () => {
     it("formats medium types", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
         medium: "painting",
-        color: undefined,
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+        color: null,
       })
       expect(title).toBe("Paintings - For Sale on Artsy")
       expect(breadcrumbTitle).toBe("Paintings")
@@ -17,7 +18,8 @@ describe("getMetadata", () => {
     it("falls back to fallback meta if medium is invalid", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
         medium: "foo" as any,
-        color: undefined,
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+        color: null,
       })
       expect(title).toBe("Collect | Artsy")
       expect(breadcrumbTitle).toBe("Collect")
@@ -30,7 +32,8 @@ describe("getMetadata", () => {
   describe("color", () => {
     it("formats color types", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
-        medium: undefined,
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+        medium: null,
         color: "red",
       })
 
@@ -43,7 +46,8 @@ describe("getMetadata", () => {
 
     it("falls back to fallback meta if medium is invalid", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
-        medium: undefined,
+        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+        medium: null,
         color: "foo" as any,
       })
       expect(title).toBe("Collect | Artsy")
@@ -56,8 +60,10 @@ describe("getMetadata", () => {
 
   it("formats default types", () => {
     const { title, breadcrumbTitle, description } = getMetadata({
-      medium: undefined,
-      color: undefined,
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+      medium: null,
+      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+      color: null,
     })
 
     expect(title).toBe("Collect | Artsy")

--- a/src/v2/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
+++ b/src/v2/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
@@ -15,18 +15,21 @@ export type Medium =
 
 export type Color =
   | "black-and-white"
-  | "blue"
-  | "gray"
-  | "green"
+  | "darkblue"
+  | "darkgreen"
+  | "darkviolet"
+  | "gold"
+  | "lightblue"
+  | "lightgreen"
   | "orange"
   | "pink"
-  | "purple"
   | "red"
+  | "violet"
   | "yellow"
 
 interface Props {
-  medium: Medium | undefined
-  color: Color | undefined
+  medium: Medium
+  color: Color
 }
 
 export function getMetadata({ medium, color }: Props) {
@@ -105,14 +108,23 @@ export function getMetadata({ medium, color }: Props) {
       case "black-and-white":
         title = "Black and White Art"
         break
-      case "green":
-        title = "Green Art"
-        break
-      case "gray":
-        title = "Gray Art"
-        break
-      case "blue":
+      case "darkblue":
         title = "Blue Art"
+        break
+      case "darkgreen":
+        title = "Dark Green Art"
+        break
+      case "darkviolet":
+        title = "Dark Violet Art"
+        break
+      case "gold":
+        title = "Gold Art"
+        break
+      case "lightblue":
+        title = "Light Blue Art"
+        break
+      case "lightgreen":
+        title = "Green Art"
         break
       case "orange":
         title = "Orange Art"
@@ -123,8 +135,8 @@ export function getMetadata({ medium, color }: Props) {
       case "red":
         title = "Red Art"
         break
-      case "purple":
-        title = "Purple Art"
+      case "violet":
+        title = "Violet Art"
         break
       case "yellow":
         title = "Yellow Art"

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -21,15 +21,19 @@ import { useFilterLabelCountByKey } from "../Utils/useFilterLabelCountByKey"
 import { sortResults } from "./Utils/sortResults"
 
 export const COLOR_OPTIONS = [
-  { hex: "#BB392D", value: "red", name: "Red" },
-  { hex: "#EA6B1F", value: "orange", name: "Orange" },
-  { hex: "#E2B929", value: "yellow", name: "Yellow" },
-  { hex: "#00674A", value: "green", name: "Green" },
-  { hex: "#0A1AB4", value: "blue", name: "Blue" },
-  { hex: "#7B3D91", value: "purple", name: "Purple" },
   { hex: "#ffffff", value: "black-and-white", name: "Black and White" },
-  { hex: "#C2C2C2", value: "gray", name: "Gray" },
-  { hex: "#E1ADCD", value: "pink", name: "Pink" },
+  { hex: "#ff0000", value: "red", name: "Red" },
+  { hex: "#fbe854", value: "yellow", name: "Yellow" },
+  { hex: "#f7923a", value: "orange", name: "Orange" },
+  { hex: "#fb81cd", value: "pink", name: "Pink" },
+  { hex: "#b82c83", value: "violet", name: "Violet" },
+  { hex: "#daa520", value: "gold", name: "Gold" },
+  { hex: "#f1572c", value: "darkorange", name: "Dark Orange" },
+  { hex: "#217c44", value: "darkgreen", name: "Dark Green" },
+  { hex: "#0a1ab4", value: "darkblue", name: "Dark Blue" },
+  { hex: "#642b7f", value: "darkviolet", name: "Dark Violet" },
+  { hex: "#bccc46", value: "lightgreen", name: "Light Green" },
+  { hex: "#c2d5f1", value: "lightblue", name: "Light Blue" },
 ]
 
 type ColorOption = typeof COLOR_OPTIONS[number]

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
@@ -38,7 +38,7 @@ describe("ColorFilter", () => {
 
     wrapper.find("Checkbox").first().simulate("click")
 
-    expect(context.filters.colors).toEqual(["red"])
+    expect(context.filters.colors).toEqual(["black-and-white"])
   })
 
   it("selects multiple colors when clicked", () => {
@@ -49,7 +49,7 @@ describe("ColorFilter", () => {
     wrapper.find("Checkbox").first().simulate("click")
     wrapper.find("Checkbox").last().simulate("click")
 
-    expect(context.filters.colors).toEqual(["red", "purple"])
+    expect(context.filters.colors).toEqual(["black-and-white", "violet"])
   })
 
   it("unselects a selected a color when clicked", () => {
@@ -60,11 +60,11 @@ describe("ColorFilter", () => {
     wrapper.find("Checkbox").first().simulate("click")
     wrapper.find("Checkbox").last().simulate("click")
 
-    expect(context.filters.colors).toEqual(["red", "purple"])
+    expect(context.filters.colors).toEqual(["black-and-white", "violet"])
 
     wrapper.find("Checkbox").first().simulate("click")
 
-    expect(context.filters.colors).toEqual(["purple"])
+    expect(context.filters.colors).toEqual(["violet"])
   })
 
   describe("the `expanded` prop", () => {


### PR DESCRIPTION
In order to un-break Eigen's color filtering we'd like to revert all artworks to index the old color palette _only_, and thus we'd need to  also roll back Force's color filtering UI, i.e. revert https://github.com/artsy/force/pull/9497

(This should get merged and deployed before https://github.com/artsy/gravity/pull/15099)

See the following Slack threads:

- Diagnosis: https://artsy.slack.com/archives/C9SATFLUU/p1646667810727089 
- Fix: https://artsy.slack.com/archives/C9SATFLUU/p1646683881730749 
