### PR TITLE
GRO-862: Signed out user flow error for preference center

### DIFF
--- a/src/v2/Apps/_Preferences2/PreferencesApp.tsx
+++ b/src/v2/Apps/_Preferences2/PreferencesApp.tsx
@@ -16,6 +16,7 @@ import {
   SubGroupStatus,
 } from "v2/__generated__/PreferencesApp_viewer.graphql"
 import { useEditNotificationPreferences } from "./useEditNotificationPreferences"
+import { useRouter } from "v2/System/Router/useRouter"
 
 const NOTIFICATION_FIELDS = {
   recommendedByArtsy: false,
@@ -38,6 +39,8 @@ interface FormValuesForNotificationPreferences {
 }
 
 export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
+  const { match } = useRouter()
+  const authenticationToken = match?.location?.query?.authentication_token
   const { sendToast } = useToasts()
   const { submitMutation } = useEditNotificationPreferences()
   let initialValues = getInitialValues(viewer) // Shape the response from Metaphysics for Formik
@@ -68,7 +71,7 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
             )
 
             await submitMutation({
-              variables: { input: { subscriptionGroups } },
+              variables: { input: { authenticationToken, subscriptionGroups } },
             })
 
             actions.resetForm({
@@ -274,8 +277,9 @@ export const PreferencesAppFragmentContainer = createFragmentContainer(
   PreferencesApp,
   {
     viewer: graphql`
-      fragment PreferencesApp_viewer on Viewer {
-        notificationPreferences {
+      fragment PreferencesApp_viewer on Viewer
+        @argumentDefinitions(authenticationToken: { type: "String" }) {
+        notificationPreferences(authenticationToken: $authenticationToken) {
           id
           name
           channel

--- a/src/v2/Apps/_Preferences2/preferencesRoutes.tsx
+++ b/src/v2/Apps/_Preferences2/preferencesRoutes.tsx
@@ -16,10 +16,15 @@ export const preferencesRoutes: AppRouteConfig[] = [
     onClientSideRender: () => {
       PreferencesApp.preload()
     },
+    prepareVariables: (_params, props) => {
+      const authenticationToken = props.location?.query?.authentication_token
+      return { authenticationToken }
+    },
     query: graphql`
-      query preferencesRoutes_PreferencesQuery {
+      query preferencesRoutes_PreferencesQuery($authenticationToken: String) {
         viewer @principalField {
           ...PreferencesApp_viewer
+            @arguments(authenticationToken: $authenticationToken)
         }
       }
     `,

--- a/src/v2/Apps/_Preferences2/useEditNotificationPreferences.tsx
+++ b/src/v2/Apps/_Preferences2/useEditNotificationPreferences.tsx
@@ -9,12 +9,7 @@ export const useEditNotificationPreferences = () => {
         $input: updateNotificationPreferencesMutationInput!
       ) {
         updateNotificationPreferences(input: $input) {
-          notificationPreferences {
-            id
-            name
-            channel
-            status
-          }
+          clientMutationId
         }
       }
     `,

--- a/src/v2/__generated__/PreferencesApp_viewer.graphql.ts
+++ b/src/v2/__generated__/PreferencesApp_viewer.graphql.ts
@@ -23,14 +23,26 @@ export type PreferencesApp_viewer$key = {
 
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "authenticationToken"
+    }
+  ],
   "kind": "Fragment",
   "metadata": null,
   "name": "PreferencesApp_viewer",
   "selections": [
     {
       "alias": null,
-      "args": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "authenticationToken",
+          "variableName": "authenticationToken"
+        }
+      ],
       "concreteType": "NotificationPreference",
       "kind": "LinkedField",
       "name": "notificationPreferences",
@@ -71,5 +83,5 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = '01bda47ed61d24ee44a4fc13d32eba93';
+(node as any).hash = '407ddcff82ae4483ee244e3633b65cc9';
 export default node;

--- a/src/v2/__generated__/preferencesRoutes_PreferencesQuery.graphql.ts
+++ b/src/v2/__generated__/preferencesRoutes_PreferencesQuery.graphql.ts
@@ -4,7 +4,9 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type preferencesRoutes_PreferencesQueryVariables = {};
+export type preferencesRoutes_PreferencesQueryVariables = {
+    authenticationToken?: string | null;
+};
 export type preferencesRoutes_PreferencesQueryResponse = {
     readonly viewer: {
         readonly " $fragmentRefs": FragmentRefs<"PreferencesApp_viewer">;
@@ -18,14 +20,16 @@ export type preferencesRoutes_PreferencesQuery = {
 
 
 /*
-query preferencesRoutes_PreferencesQuery {
+query preferencesRoutes_PreferencesQuery(
+  $authenticationToken: String
+) {
   viewer @principalField {
-    ...PreferencesApp_viewer
+    ...PreferencesApp_viewer_4kNil9
   }
 }
 
-fragment PreferencesApp_viewer on Viewer {
-  notificationPreferences {
+fragment PreferencesApp_viewer_4kNil9 on Viewer {
+  notificationPreferences(authenticationToken: $authenticationToken) {
     id
     name
     channel
@@ -34,9 +38,24 @@ fragment PreferencesApp_viewer on Viewer {
 }
 */
 
-const node: ConcreteRequest = {
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "authenticationToken"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "authenticationToken",
+    "variableName": "authenticationToken"
+  }
+];
+return {
   "fragment": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "preferencesRoutes_PreferencesQuery",
@@ -50,7 +69,7 @@ const node: ConcreteRequest = {
         "plural": false,
         "selections": [
           {
-            "args": null,
+            "args": (v1/*: any*/),
             "kind": "FragmentSpread",
             "name": "PreferencesApp_viewer"
           }
@@ -63,7 +82,7 @@ const node: ConcreteRequest = {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "preferencesRoutes_PreferencesQuery",
     "selections": [
@@ -77,7 +96,7 @@ const node: ConcreteRequest = {
         "selections": [
           {
             "alias": null,
-            "args": null,
+            "args": (v1/*: any*/),
             "concreteType": "NotificationPreference",
             "kind": "LinkedField",
             "name": "notificationPreferences",
@@ -120,13 +139,14 @@ const node: ConcreteRequest = {
     ]
   },
   "params": {
-    "cacheID": "fef6226dc7dfcc8f2bcb1368e0b37438",
+    "cacheID": "edd1b2c59aa9370d63d57be3a6c9649f",
     "id": null,
     "metadata": {},
     "name": "preferencesRoutes_PreferencesQuery",
     "operationKind": "query",
-    "text": "query preferencesRoutes_PreferencesQuery {\n  viewer @principalField {\n    ...PreferencesApp_viewer\n  }\n}\n\nfragment PreferencesApp_viewer on Viewer {\n  notificationPreferences {\n    id\n    name\n    channel\n    status\n  }\n}\n"
+    "text": "query preferencesRoutes_PreferencesQuery(\n  $authenticationToken: String\n) {\n  viewer @principalField {\n    ...PreferencesApp_viewer_4kNil9\n  }\n}\n\nfragment PreferencesApp_viewer_4kNil9 on Viewer {\n  notificationPreferences(authenticationToken: $authenticationToken) {\n    id\n    name\n    channel\n    status\n  }\n}\n"
   }
 };
-(node as any).hash = '5d943fd9f5d8230da4d0c1eade889dd2';
+})();
+(node as any).hash = '0fae2794f8107dcaf8ff3139fddb79c1';
 export default node;

--- a/src/v2/__generated__/useEditNotificationPreferencesMutation.graphql.ts
+++ b/src/v2/__generated__/useEditNotificationPreferencesMutation.graphql.ts
@@ -20,12 +20,7 @@ export type useEditNotificationPreferencesMutationVariables = {
 };
 export type useEditNotificationPreferencesMutationResponse = {
     readonly updateNotificationPreferences: {
-        readonly notificationPreferences: ReadonlyArray<{
-            readonly id: string;
-            readonly name: string;
-            readonly channel: string;
-            readonly status: SubGroupStatus;
-        }>;
+        readonly clientMutationId: string | null;
     } | null;
 };
 export type useEditNotificationPreferencesMutation = {
@@ -40,12 +35,7 @@ mutation useEditNotificationPreferencesMutation(
   $input: updateNotificationPreferencesMutationInput!
 ) {
   updateNotificationPreferences(input: $input) {
-    notificationPreferences {
-      id
-      name
-      channel
-      status
-    }
+    clientMutationId
   }
 }
 */
@@ -76,40 +66,8 @@ v1 = [
       {
         "alias": null,
         "args": null,
-        "concreteType": "NotificationPreference",
-        "kind": "LinkedField",
-        "name": "notificationPreferences",
-        "plural": true,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "channel",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "status",
-            "storageKey": null
-          }
-        ],
+        "kind": "ScalarField",
+        "name": "clientMutationId",
         "storageKey": null
       }
     ],
@@ -134,14 +92,14 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "05796965738e62feb0ef874b03da06fa",
+    "cacheID": "8e045f8ecea20e507b87e6c0e9456a6a",
     "id": null,
     "metadata": {},
     "name": "useEditNotificationPreferencesMutation",
     "operationKind": "mutation",
-    "text": "mutation useEditNotificationPreferencesMutation(\n  $input: updateNotificationPreferencesMutationInput!\n) {\n  updateNotificationPreferences(input: $input) {\n    notificationPreferences {\n      id\n      name\n      channel\n      status\n    }\n  }\n}\n"
+    "text": "mutation useEditNotificationPreferencesMutation(\n  $input: updateNotificationPreferencesMutationInput!\n) {\n  updateNotificationPreferences(input: $input) {\n    clientMutationId\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '8c71aa73bdbe0de2fb1536c56e536690';
+(node as any).hash = '4796a39f28e7655ed5eeaabfa43b012c';
 export default node;


### PR DESCRIPTION
[GRO-862]
Added: Resolving authentication token not being passed properly for Preference Center updated. Being updated in Braze, but throwing an error that is citing a lack of user.

Need to see why toast is throwing us this error, even though Braze is successfully updating.

[GRO-862]: https://artsyproduct.atlassian.net/browse/GRO-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ