### PR TITLE
[GRO-834] add Trove Rail to the Artsy homepage

### DIFF
--- a/src/v2/Apps/Home/Components/HomeTroveArtworksRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeTroveArtworksRail.tsx
@@ -22,13 +22,15 @@ export const HomeTroveArtworksRail: React.FC<HomeTroveArtworksRailProps> = ({
   viewer,
 }) => {
   const artworks = extractNodes(viewer.saleArtworksConnection)
+
   if (artworks.length === 0) {
     return null
   }
+
   return (
     <Rail
       title="Trove"
-      subTitle="A weekly curated selection of the best works on Artsy by emerging and sought after Artists."
+      subTitle="A weekly curated selection of the best works on Artsy by emerging and sought after artists."
       getItems={() => {
         return artworks.map(artwork => (
           <ShelfArtworkFragmentContainer
@@ -98,7 +100,7 @@ const PLACEHOLDER = (
   <Skeleton>
     <Rail
       title="Trove"
-      subTitle="A weekly curated selection of the best works on Artsy by emerging and sought after Artists."
+      subTitle="A weekly curated selection of the best works on Artsy by emerging and sought after artists."
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
           return (

--- a/src/v2/Apps/Home/Components/HomeTroveArtworksRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeTroveArtworksRail.tsx
@@ -1,0 +1,118 @@
+import { ContextModule } from "@artsy/cohesion"
+import {
+  Box,
+  Skeleton,
+  SkeletonBox,
+  SkeletonText,
+  Spacer,
+} from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ShelfArtworkFragmentContainer } from "v2/Components/Artwork/ShelfArtwork"
+import { Rail } from "v2/Components/Rail/Rail"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { extractNodes } from "v2/Utils/extractNodes"
+import { HomeTroveArtworksRail_viewer } from "v2/__generated__/HomeTroveArtworksRail_viewer.graphql"
+import { HomeTroveArtworksRailQuery } from "v2/__generated__/HomeTroveArtworksRailQuery.graphql"
+
+interface HomeTroveArtworksRailProps {
+  viewer: HomeTroveArtworksRail_viewer
+}
+
+export const HomeTroveArtworksRail: React.FC<HomeTroveArtworksRailProps> = ({
+  viewer,
+}) => {
+  const artworks = extractNodes(viewer.saleArtworksConnection)
+  if (artworks.length === 0) {
+    return null
+  }
+  return (
+    <Rail
+      title="Trove"
+      subTitle="Trove Artwork"
+      getItems={() => {
+        return artworks.map(artwork => (
+          <ShelfArtworkFragmentContainer
+            artwork={artwork}
+            key={artwork.internalID}
+            lazyLoad
+            contextModule={ContextModule.featuredArtists}
+          />
+        ))
+      }}
+    />
+  )
+}
+
+export const HomeTroveArtworksRailFragmentContainer = createFragmentContainer(
+  HomeTroveArtworksRail,
+  {
+    viewer: graphql`
+      fragment HomeTroveArtworksRail_viewer on Viewer {
+        saleArtworksConnection(first: 12, geneIDs: "trove") {
+          edges {
+            node {
+              ...ShelfArtwork_artwork @arguments(width: 210)
+              internalID
+              slug
+              href
+              sale {
+                isClosed
+              }
+            }
+          }
+        }
+      }
+    `,
+  }
+)
+
+export const HomeTroveArtworksRailQueryRenderer: React.FC = () => {
+  return (
+    <SystemQueryRenderer<HomeTroveArtworksRailQuery>
+      placeholder={PLACEHOLDER}
+      lazyLoad
+      query={graphql`
+        query HomeTroveArtworksRailQuery {
+          viewer {
+            ...HomeTroveArtworksRail_viewer
+          }
+        }
+      `}
+      render={({ props, error }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props?.viewer) {
+          return PLACEHOLDER
+        }
+
+        return <HomeTroveArtworksRailFragmentContainer viewer={props.viewer} />
+      }}
+    />
+  )
+}
+
+const PLACEHOLDER = (
+  <Skeleton>
+    <Rail
+      title="Trove"
+      subTitle="Trove Artwork"
+      getItems={() => {
+        return [...new Array(8)].map((_, i) => {
+          return (
+            <Box width={200} key={i}>
+              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
+              <Spacer mt={1} />
+              <SkeletonText variant="md">Artist Name</SkeletonText>
+              <SkeletonText variant="md">Artwork Title</SkeletonText>
+              <SkeletonText variant="xs">Partner</SkeletonText>
+              <SkeletonText variant="xs">Price</SkeletonText>
+            </Box>
+          )
+        })
+      }}
+    />
+  </Skeleton>
+)

--- a/src/v2/Apps/Home/Components/HomeTroveArtworksRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeTroveArtworksRail.tsx
@@ -28,7 +28,7 @@ export const HomeTroveArtworksRail: React.FC<HomeTroveArtworksRailProps> = ({
   return (
     <Rail
       title="Trove"
-      subTitle="Trove Artwork"
+      subTitle="A weekly curated selection of the best works on Artsy by emerging and sought after Artists."
       getItems={() => {
         return artworks.map(artwork => (
           <ShelfArtworkFragmentContainer
@@ -98,7 +98,7 @@ const PLACEHOLDER = (
   <Skeleton>
     <Rail
       title="Trove"
-      subTitle="Trove Artwork"
+      subTitle="A weekly curated selection of the best works on Artsy by emerging and sought after Artists."
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
           return (

--- a/src/v2/Apps/Home/HomeApp.tsx
+++ b/src/v2/Apps/Home/HomeApp.tsx
@@ -1,5 +1,5 @@
 import { Spacer, Join, FullBleed } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { HomeApp_homePage } from "v2/__generated__/HomeApp_homePage.graphql"
 import { HomeApp_featuredEventsOrderedSet } from "v2/__generated__/HomeApp_featuredEventsOrderedSet.graphql"
@@ -15,6 +15,7 @@ import { HomeTrendingArtistsRailQueryRenderer } from "./Components/HomeTrendingA
 import { HomeAuctionLotsRailQueryRenderer } from "./Components/HomeAuctionLotsRail"
 import { HomeWorksForYouTabBar } from "./Components/HomeWorksForYouTabBar"
 import { MyBidsQueryRenderer } from "../Auctions/Components/MyBids/MyBids"
+import { HomeTroveArtworksRailQueryRenderer } from "./Components/HomeTroveArtworksRail"
 
 interface HomeAppProps {
   homePage: HomeApp_homePage | null
@@ -63,6 +64,8 @@ export const HomeApp: React.FC<HomeAppProps> = ({
         <HomeFeaturedGalleriesRailQueryRenderer />
 
         <HomeTrendingArtistsRailQueryRenderer />
+
+        <HomeTroveArtworksRailQueryRenderer />
       </Join>
     </>
   )

--- a/src/v2/Apps/Home/HomeApp.tsx
+++ b/src/v2/Apps/Home/HomeApp.tsx
@@ -53,6 +53,8 @@ export const HomeApp: React.FC<HomeAppProps> = ({
 
         <HomeWorksForYouTabBar />
 
+        <HomeTroveArtworksRailQueryRenderer />
+
         <HomeFeaturedMarketNewsQueryRenderer />
 
         <HomeAuctionLotsRailQueryRenderer />
@@ -64,8 +66,6 @@ export const HomeApp: React.FC<HomeAppProps> = ({
         <HomeFeaturedGalleriesRailQueryRenderer />
 
         <HomeTrendingArtistsRailQueryRenderer />
-
-        <HomeTroveArtworksRailQueryRenderer />
       </Join>
     </>
   )

--- a/src/v2/Apps/Home/__tests__/HomeTroveArtworksRail.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeTroveArtworksRail.jest.tsx
@@ -1,0 +1,47 @@
+import { graphql } from "react-relay"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { HomeTroveArtworksRailFragmentContainer } from "../Components/HomeTroveArtworksRail"
+import { HomeTroveArtworksRail_Test_Query } from "v2/__generated__/HomeTroveArtworksRail_Test_Query.graphql"
+
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper<HomeTroveArtworksRail_Test_Query>({
+  Component: props => {
+    return <HomeTroveArtworksRailFragmentContainer viewer={props.viewer!} />
+  },
+  query: graphql`
+    query HomeTroveArtworksRail_Test_Query @relay_test_operation {
+      viewer {
+        ...HomeTroveArtworksRail_viewer
+      }
+    }
+  `,
+})
+
+describe("HomeTroveArtworksRail", () => {
+  it("renders correctly", () => {
+    const wrapper = getWrapper({
+      Viewer: () => ({
+        saleArtworksConnection: {
+          edges: [
+            {
+              node: {
+                title: "Trove",
+                href: "test-href",
+                sale: {
+                  isClosed: true,
+                },
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(wrapper.text()).toContain("Trove")
+    expect(wrapper.text()).toContain(
+      "A weekly curated selection of the best works on Artsy"
+    )
+    expect(wrapper.html()).toContain("test-href")
+  })
+})

--- a/src/v2/__generated__/HomeTroveArtworksRailQuery.graphql.ts
+++ b/src/v2/__generated__/HomeTroveArtworksRailQuery.graphql.ts
@@ -1,0 +1,593 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeTroveArtworksRailQueryVariables = {};
+export type HomeTroveArtworksRailQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"HomeTroveArtworksRail_viewer">;
+    } | null;
+};
+export type HomeTroveArtworksRailQuery = {
+    readonly response: HomeTroveArtworksRailQueryResponse;
+    readonly variables: HomeTroveArtworksRailQueryVariables;
+};
+
+
+
+/*
+query HomeTroveArtworksRailQuery {
+  viewer {
+    ...HomeTroveArtworksRail_viewer
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    lotLabel
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment HomeTroveArtworksRail_viewer on Viewer {
+  saleArtworksConnection(first: 12, geneIDs: "trove") {
+    edges {
+      node {
+        ...ShelfArtwork_artwork_1s6r3G
+        internalID
+        slug
+        href
+        sale {
+          isClosed
+          id
+        }
+        id
+      }
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment ShelfArtwork_artwork_1s6r3G on Artwork {
+  image {
+    resized(width: 210) {
+      src
+      srcSet
+      width
+      height
+    }
+    aspectRatio
+    height
+  }
+  imageTitle
+  title
+  href
+  is_saved: isSaved
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeTroveArtworksRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "HomeTroveArtworksRail_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeTroveArtworksRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 12
+              },
+              {
+                "kind": "Literal",
+                "name": "geneIDs",
+                "value": "trove"
+              }
+            ],
+            "concreteType": "SaleArtworksConnection",
+            "kind": "LinkedField",
+            "name": "saleArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "SaleArtwork",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 210
+                              }
+                            ],
+                            "concreteType": "ResizedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "resized",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "width",
+                                "storageKey": null
+                              },
+                              (v0/*: any*/)
+                            ],
+                            "storageKey": "resized(width:210)"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          },
+                          (v0/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "imageTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/),
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v3/*: any*/),
+                          (v1/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v1/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "type",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/),
+                          {
+                            "alias": "is_live_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isLiveOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_preview",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isPreview",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "display_timely_at",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "displayTimelyAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotLabel",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_inquireable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isInquireable",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_biddable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isBiddable",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v3/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "saleArtworksConnection(first:12,geneIDs:\"trove\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "0bb123fb07fac5e9670db700026ec490",
+    "id": null,
+    "metadata": {},
+    "name": "HomeTroveArtworksRailQuery",
+    "operationKind": "query",
+    "text": "query HomeTroveArtworksRailQuery {\n  viewer {\n    ...HomeTroveArtworksRail_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotLabel\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment HomeTroveArtworksRail_viewer on Viewer {\n  saleArtworksConnection(first: 12, geneIDs: \"trove\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork_1s6r3G\n        internalID\n        slug\n        href\n        sale {\n          isClosed\n          id\n        }\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+  }
+};
+})();
+(node as any).hash = '83b44cf669e0aca1d6035a81f96bd45a';
+export default node;

--- a/src/v2/__generated__/HomeTroveArtworksRail_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeTroveArtworksRail_Test_Query.graphql.ts
@@ -1,0 +1,754 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeTroveArtworksRail_Test_QueryVariables = {};
+export type HomeTroveArtworksRail_Test_QueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"HomeTroveArtworksRail_viewer">;
+    } | null;
+};
+export type HomeTroveArtworksRail_Test_Query = {
+    readonly response: HomeTroveArtworksRail_Test_QueryResponse;
+    readonly variables: HomeTroveArtworksRail_Test_QueryVariables;
+};
+
+
+
+/*
+query HomeTroveArtworksRail_Test_Query {
+  viewer {
+    ...HomeTroveArtworksRail_viewer
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    lotLabel
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment HomeTroveArtworksRail_viewer on Viewer {
+  saleArtworksConnection(first: 12, geneIDs: "trove") {
+    edges {
+      node {
+        ...ShelfArtwork_artwork_1s6r3G
+        internalID
+        slug
+        href
+        sale {
+          isClosed
+          id
+        }
+        id
+      }
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment ShelfArtwork_artwork_1s6r3G on Artwork {
+  image {
+    resized(width: 210) {
+      src
+      srcSet
+      width
+      height
+    }
+    aspectRatio
+    height
+  }
+  imageTitle
+  title
+  href
+  is_saved: isSaved
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v6 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v7 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v9 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeTroveArtworksRail_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "HomeTroveArtworksRail_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeTroveArtworksRail_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 12
+              },
+              {
+                "kind": "Literal",
+                "name": "geneIDs",
+                "value": "trove"
+              }
+            ],
+            "concreteType": "SaleArtworksConnection",
+            "kind": "LinkedField",
+            "name": "saleArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "SaleArtwork",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 210
+                              }
+                            ],
+                            "concreteType": "ResizedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "resized",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "width",
+                                "storageKey": null
+                              },
+                              (v0/*: any*/)
+                            ],
+                            "storageKey": "resized(width:210)"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          },
+                          (v0/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "imageTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/),
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v3/*: any*/),
+                          (v1/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v1/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "type",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/),
+                          {
+                            "alias": "is_live_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isLiveOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_preview",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isPreview",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "display_timely_at",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "displayTimelyAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotLabel",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_inquireable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isInquireable",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_biddable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isBiddable",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v3/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "saleArtworksConnection(first:12,geneIDs:\"trove\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "735b4e8d9e6a0717fab943f315aae3e0",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "viewer": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Viewer"
+        },
+        "viewer.saleArtworksConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworksConnection"
+        },
+        "viewer.saleArtworksConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "SaleArtwork"
+        },
+        "viewer.saleArtworksConnection.edges.id": (v6/*: any*/),
+        "viewer.saleArtworksConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "viewer.saleArtworksConnection.edges.node.artists": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Artist"
+        },
+        "viewer.saleArtworksConnection.edges.node.artists.href": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists.id": (v6/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists.name": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.collecting_institution": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.cultural_maker": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.date": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.href": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.id": (v6/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "viewer.saleArtworksConnection.edges.node.image.aspectRatio": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Float"
+        },
+        "viewer.saleArtworksConnection.edges.node.image.height": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.resized": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ResizedImageUrl"
+        },
+        "viewer.saleArtworksConnection.edges.node.image.resized.height": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.resized.src": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.resized.srcSet": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.resized.width": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.imageTitle": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.internalID": (v6/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.is_biddable": (v10/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.is_inquireable": (v10/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.is_saved": (v10/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "viewer.saleArtworksConnection.edges.node.partner.href": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.id": (v6/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.name": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.type": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "viewer.saleArtworksConnection.edges.node.sale.display_timely_at": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.id": (v6/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.isClosed": (v10/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.is_auction": (v10/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.is_closed": (v10/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.is_live_open": (v10/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.is_open": (v10/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.is_preview": (v10/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtwork"
+        },
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkCounts"
+        },
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.counts.bidder_positions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FormattedNumber"
+        },
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkHighestBid"
+        },
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.id": (v6/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotLabel": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkOpeningBid"
+        },
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_message": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.slug": (v6/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.title": (v7/*: any*/)
+      }
+    },
+    "name": "HomeTroveArtworksRail_Test_Query",
+    "operationKind": "query",
+    "text": "query HomeTroveArtworksRail_Test_Query {\n  viewer {\n    ...HomeTroveArtworksRail_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotLabel\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment HomeTroveArtworksRail_viewer on Viewer {\n  saleArtworksConnection(first: 12, geneIDs: \"trove\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork_1s6r3G\n        internalID\n        slug\n        href\n        sale {\n          isClosed\n          id\n        }\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+  }
+};
+})();
+(node as any).hash = '86893a834bfd312c9ea5612485e152c4';
+export default node;

--- a/src/v2/__generated__/HomeTroveArtworksRail_viewer.graphql.ts
+++ b/src/v2/__generated__/HomeTroveArtworksRail_viewer.graphql.ts
@@ -1,0 +1,136 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeTroveArtworksRail_viewer = {
+    readonly saleArtworksConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly slug: string;
+                readonly href: string | null;
+                readonly sale: {
+                    readonly isClosed: boolean | null;
+                } | null;
+                readonly " $fragmentRefs": FragmentRefs<"ShelfArtwork_artwork">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "HomeTroveArtworksRail_viewer";
+};
+export type HomeTroveArtworksRail_viewer$data = HomeTroveArtworksRail_viewer;
+export type HomeTroveArtworksRail_viewer$key = {
+    readonly " $data"?: HomeTroveArtworksRail_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"HomeTroveArtworksRail_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "HomeTroveArtworksRail_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 12
+        },
+        {
+          "kind": "Literal",
+          "name": "geneIDs",
+          "value": "trove"
+        }
+      ],
+      "concreteType": "SaleArtworksConnection",
+      "kind": "LinkedField",
+      "name": "saleArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SaleArtwork",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "slug",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "href",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Sale",
+                  "kind": "LinkedField",
+                  "name": "sale",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "isClosed",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "width",
+                      "value": 210
+                    }
+                  ],
+                  "kind": "FragmentSpread",
+                  "name": "ShelfArtwork_artwork"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "saleArtworksConnection(first:12,geneIDs:\"trove\")"
+    }
+  ],
+  "type": "Viewer",
+  "abstractKey": null
+};
+(node as any).hash = '0d22f283a8a454b40356c18b49d08c6b';
+export default node;


### PR DESCRIPTION
This PR solves: [GRO-834]

To get more artwork on the homepage and available for users to check out!

### logged out 
<img width="537" alt="Screen Shot 2022-03-08 at 12 43 57 PM" src="https://user-images.githubusercontent.com/23108927/157304816-17b1a5cd-210b-4aa0-90c9-b827fa35c1e2.png">

### logged in 
<img width="532" alt="Screen Shot 2022-03-08 at 12 44 33 PM" src="https://user-images.githubusercontent.com/23108927/157304831-f44e4463-5408-4abe-a456-3f6515215a86.png">


Note: We're gonna want to remove Trove as an item on the carousel for `logged in` / `logged out` states which is something an admin does. 

Gotta coordinate with Jenna before pushing this live. 

[GRO-834]: https://artsyproduct.atlassian.net/browse/GRO-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ