### PR TITLE
Feat: analytics support for useVariant

### DIFF
--- a/src/v2/System/__tests__/useFeatureFlag.jest.tsx
+++ b/src/v2/System/__tests__/useFeatureFlag.jest.tsx
@@ -1,12 +1,21 @@
 import { useFeatureFlag, useFeatureVariant } from "../useFeatureFlag"
 import { useSystemContext } from "v2/System/useSystemContext"
+import { useTracking } from "react-tracking"
 
 jest.mock("v2/System/useSystemContext")
 
 const mockUseSystemContext = useSystemContext as jest.Mock
 let mockFeatureFlags
+let trackEvent
 
 beforeAll(() => {
+  trackEvent = jest.fn()
+  ;(useTracking as jest.Mock).mockImplementation(() => {
+    return {
+      trackEvent,
+    }
+  })
+
   mockFeatureFlags = {
     featureFlags: {
       "feature-a": {

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -57,6 +57,7 @@ export function useFeatureVariant(featureName: string): Variant | null {
 }
 
 function shouldTrack(featureName: string, variantName: string): boolean {
+  // Value to set and read from the experimentsViewed key in localStorage.
   const experimentName = `${featureName}+${variantName}`
   const viewedExperiments = getExperimentsViewed()
 

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -1,5 +1,7 @@
+import * as Schema from "v2/System/Analytics"
 import { useSystemContext } from "v2/System"
 import { Variant } from "unleash-client"
+import { useTracking } from "react-tracking"
 
 export type FeatureFlags = Record<string, FeatureFlagDetails>
 
@@ -25,6 +27,7 @@ export function useFeatureFlag(featureName: string): boolean | null {
 
 export function useFeatureVariant(featureName: string): Variant | null {
   const { featureFlags } = useSystemContext()
+  const { trackEvent } = useTracking()
   const variant = featureFlags?.[featureName]?.variant
 
   if (!variant) {
@@ -35,5 +38,47 @@ export function useFeatureVariant(featureName: string): Variant | null {
     return null
   }
 
+  // detremine if we should track the experimentView
+  if (typeof window !== "undefined") {
+    let trackFeatureView = maybeTrackFeatureView(featureName, variant.name)
+
+    if (trackFeatureView) {
+      trackEvent({
+        action: Schema.ActionType.ExperimentViewed,
+        service: "unleash",
+        experiment_name: featureName,
+        variant_name: variant.name,
+        payload: variant.payload,
+      })
+    }
+  }
+
   return variant
+}
+
+function maybeTrackFeatureView(featureName, variantName) {
+  const experimentName = `${featureName}+${variantName}`
+  let viewedExperiments = getExperimentsViewed()
+
+  if (viewedExperiments.includes(experimentName)) {
+    return false
+  }
+
+  viewedExperiments.push(experimentName)
+  setExperimentsViewed(viewedExperiments)
+
+  return true
+}
+
+function getExperimentsViewed() {
+  let experimentsViewed = window.localStorage.getItem("experimentsViewed")
+
+  return experimentsViewed === null ? [] : JSON.parse(experimentsViewed)
+}
+
+function setExperimentsViewed(_viewedExperiments) {
+  window.localStorage.setItem(
+    "experimentsViewed",
+    JSON.stringify(_viewedExperiments)
+  )
 }

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -27,7 +27,6 @@ export function useFeatureFlag(featureName: string): boolean | null {
 
 export function useFeatureVariant(featureName: string): Variant | null {
   const { featureFlags } = useSystemContext()
-  const { trackEvent } = useTracking()
   const variant = featureFlags?.[featureName]?.variant
 
   if (!variant) {
@@ -38,22 +37,35 @@ export function useFeatureVariant(featureName: string): Variant | null {
     return null
   }
 
-  // detremine if we should track the experimentView
+  return variant
+}
+
+export function useTrackVariantView({
+  experiment_name,
+  variant_name,
+  payload,
+  context_owner_type,
+  context_owner_id,
+  context_owner_slug,
+}) {
+  const { trackEvent } = useTracking()
+
   if (typeof window !== "undefined") {
-    const trackFeatureView = shouldTrack(featureName, variant.name)
+    const trackFeatureView = shouldTrack(experiment_name, variant_name)
 
     if (trackFeatureView) {
       trackEvent({
         action: Schema.ActionType.ExperimentViewed,
         service: "unleash",
-        experiment_name: featureName,
-        variant_name: variant.name,
-        payload: variant.payload,
+        experiment_name,
+        variant_name,
+        payload,
+        context_owner_type,
+        context_owner_id,
+        context_owner_slug,
       })
     }
   }
-
-  return variant
 }
 
 function shouldTrack(featureName: string, variantName: string): boolean {

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -56,7 +56,10 @@ export function useFeatureVariant(featureName: string): Variant | null {
   return variant
 }
 
-function maybeTrackFeatureView(featureName, variantName) {
+function maybeTrackFeatureView(
+  featureName: string,
+  variantName: string
+): boolean {
   const experimentName = `${featureName}+${variantName}`
   let viewedExperiments = getExperimentsViewed()
 
@@ -70,13 +73,13 @@ function maybeTrackFeatureView(featureName, variantName) {
   return true
 }
 
-function getExperimentsViewed() {
+function getExperimentsViewed(): string[] {
   let experimentsViewed = window.localStorage.getItem("experimentsViewed")
 
   return experimentsViewed === null ? [] : JSON.parse(experimentsViewed)
 }
 
-function setExperimentsViewed(_viewedExperiments) {
+function setExperimentsViewed(_viewedExperiments: string[]) {
   window.localStorage.setItem(
     "experimentsViewed",
     JSON.stringify(_viewedExperiments)

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -40,7 +40,7 @@ export function useFeatureVariant(featureName: string): Variant | null {
 
   // detremine if we should track the experimentView
   if (typeof window !== "undefined") {
-    let trackFeatureView = maybeTrackFeatureView(featureName, variant.name)
+    const trackFeatureView = shouldTrack(featureName, variant.name)
 
     if (trackFeatureView) {
       trackEvent({
@@ -56,12 +56,9 @@ export function useFeatureVariant(featureName: string): Variant | null {
   return variant
 }
 
-function maybeTrackFeatureView(
-  featureName: string,
-  variantName: string
-): boolean {
+function shouldTrack(featureName: string, variantName: string): boolean {
   const experimentName = `${featureName}+${variantName}`
-  let viewedExperiments = getExperimentsViewed()
+  const viewedExperiments = getExperimentsViewed()
 
   if (viewedExperiments.includes(experimentName)) {
     return false
@@ -79,9 +76,6 @@ function getExperimentsViewed(): string[] {
   return experimentsViewed === null ? [] : JSON.parse(experimentsViewed)
 }
 
-function setExperimentsViewed(_viewedExperiments: string[]) {
-  window.localStorage.setItem(
-    "experimentsViewed",
-    JSON.stringify(_viewedExperiments)
-  )
+function setExperimentsViewed(experiments: string[]) {
+  window.localStorage.setItem("experimentsViewed", JSON.stringify(experiments))
 }

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -2,6 +2,7 @@ import * as Schema from "v2/System/Analytics"
 import { useSystemContext } from "v2/System"
 import { Variant } from "unleash-client"
 import { useTracking } from "react-tracking"
+import { useEffect } from "react"
 
 export type FeatureFlags = Record<string, FeatureFlagDetails>
 
@@ -50,22 +51,24 @@ export function useTrackVariantView({
 }) {
   const { trackEvent } = useTracking()
 
-  if (typeof window !== "undefined") {
-    const trackFeatureView = shouldTrack(experiment_name, variant_name)
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const trackFeatureView = shouldTrack(experiment_name, variant_name)
 
-    if (trackFeatureView) {
-      trackEvent({
-        action: Schema.ActionType.ExperimentViewed,
-        service: "unleash",
-        experiment_name,
-        variant_name,
-        payload,
-        context_owner_type,
-        context_owner_id,
-        context_owner_slug,
-      })
+      if (trackFeatureView) {
+        trackEvent({
+          action: Schema.ActionType.ExperimentViewed,
+          service: "unleash",
+          experiment_name,
+          variant_name,
+          payload,
+          context_owner_type,
+          context_owner_id,
+          context_owner_slug,
+        })
+      }
     }
-  }
+  }, [])
 }
 
 function shouldTrack(featureName: string, variantName: string): boolean {


### PR DESCRIPTION
This PR adds analytics to the `useVariant` hook by sending an `Experiment Viewed` event to segment on the first instance the user is shown the flag's variation. 

### Considerations
To track if a user has seen the experiment before we are simply storing an array on `localStorage` with the name of the feature flag and the variant e.g., `${featureName}+${variantName}`.  On each `useFeatureVariant` we check the array to see if the experiment has been viewed before, and push it onto the array if not. This is a simple approach, but has the disadvantage of potentially sending multiple events for a single user in cases where they have cleared application storage from their browser. I'm not sure we can get around this issue by sticking with client-side tracking of repeat views. 

### Related PRs
- #9513
- #9498
- #9393
- #9547
- https://github.com/artsy/cohesion/pull/304

### Follow-ups
- Add support for caching (don't cache views with experiments)
- Confirm client-side tacking of repeat views is the approach we want to stick with.