### PR TITLE
feat(FX-3786): add create alert button in artwork screen

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
@@ -4,6 +4,7 @@ import { Separator, Spacer, Flex, Button, BellIcon, Text } from "@artsy/palette"
 export const CreateArtworkAlertSection: React.FC = () => {
   return (
     <>
+      <Spacer m={2} />
       <Separator />
       <Spacer m={2} />
       <Flex

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
@@ -20,17 +20,13 @@ export const CreateArtworkAlertSection: React.FC = () => {
         alignItems="center"
         justifyContent="space-between"
       >
-        <Flex flex={1}>
-          <Text variant="xs">
-            Be notified when a similar piece is available
-          </Text>
-        </Flex>
-        <Flex flex={1} justifyContent="flex-end">
-          <Button variant="secondaryOutline" size="small">
-            <BellIcon mr={0.5} fill="currentColor" />
-            <Text variant="xs">Create Alert</Text>
-          </Button>
-        </Flex>
+        <Text variant="xs" mr={2}>
+          Be notified when a similar piece is available
+        </Text>
+        <Button variant="secondaryOutline" size="small">
+          <BellIcon mr={0.5} fill="currentColor" />
+          <Text variant="xs">Create Alert</Text>
+        </Button>
       </Flex>
     </Box>
   )

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
@@ -1,10 +1,17 @@
 import React from "react"
-import { Separator, Spacer, Flex, Button, BellIcon, Text } from "@artsy/palette"
+import {
+  Separator,
+  Spacer,
+  Flex,
+  Button,
+  BellIcon,
+  Text,
+  Box,
+} from "@artsy/palette"
 
 export const CreateArtworkAlertSection: React.FC = () => {
   return (
-    <>
-      <Spacer m={2} />
+    <Box my={2}>
       <Separator />
       <Spacer m={2} />
       <Flex
@@ -13,7 +20,7 @@ export const CreateArtworkAlertSection: React.FC = () => {
         alignItems="center"
         justifyContent="space-between"
       >
-        <Flex flex={1} justifyContent="flex-start">
+        <Flex flex={1}>
           <Text variant="xs">
             Be notified when a similar piece is available
           </Text>
@@ -25,7 +32,6 @@ export const CreateArtworkAlertSection: React.FC = () => {
           </Button>
         </Flex>
       </Flex>
-      <Spacer m={2} />
-    </>
+    </Box>
   )
 }

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
@@ -13,12 +13,12 @@ export const CreateArtworkAlertSection: React.FC = () => {
         justifyContent="space-between"
       >
         <Flex flex={1} justifyContent="flex-start">
-          <Text variant="xs" color="blue100">
+          <Text variant="xs">
             Be notified when a similar piece is available
           </Text>
         </Flex>
         <Flex flex={1} justifyContent="flex-end">
-          <Button focus variant="secondaryOutline" size="small">
+          <Button variant="secondaryOutline" size="small">
             <BellIcon mr={0.5} fill="currentColor" />
             <Text variant="xs">Create Alert</Text>
           </Button>

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { Separator, Spacer, Flex, Button, BellIcon, Text } from "@artsy/palette"
+
+export const CreateArtworkAlertSection: React.FC = () => {
+  return (
+    <>
+      <Separator />
+      <Spacer m={2} />
+      <Flex
+        flexDirection="row"
+        py={1}
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <Flex flex={1} justifyContent="flex-start">
+          <Text variant="xs" color="blue100">
+            Be notified when a similar piece is available
+          </Text>
+        </Flex>
+        <Flex flex={1} justifyContent="flex-end">
+          <Button focus variant="secondaryOutline" size="small">
+            <BellIcon mr={0.5} fill="currentColor" />
+            <Text variant="xs">Create Alert</Text>
+          </Button>
+        </Flex>
+      </Flex>
+      <Spacer m={2} />
+    </>
+  )
+}

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebar.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebar.jest.tsx
@@ -2,7 +2,12 @@ import { ArtworkSidebarFragmentContainer } from "v2/Apps/Artwork/Components/Artw
 import { ArtworkSidebarArtists } from "v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists"
 import { ArtworkSidebarMetadata } from "v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarMetadata"
 import { graphql } from "react-relay"
-import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import {
+  setupTestWrapper,
+  setupTestWrapperTL,
+} from "v2/DevTools/setupTestWrapper"
+import { screen } from "@testing-library/react"
+import { useSystemContext } from "v2/System"
 
 jest.unmock("react-relay")
 jest.mock("../ArtworkSidebarClassification", () => ({
@@ -11,6 +16,10 @@ jest.mock("../ArtworkSidebarClassification", () => ({
 jest.mock("v2/System/Analytics/useTracking", () => ({
   useTracking: () => ({ trackEvent: jest.fn() }),
 }))
+jest.mock("v2/System/useSystemContext")
+
+const mockUseSystemContext = useSystemContext as jest.Mock
+let mockFeatureFlags
 
 const { getWrapper } = setupTestWrapper({
   Component: ArtworkSidebarFragmentContainer,
@@ -26,7 +35,34 @@ const { getWrapper } = setupTestWrapper({
   `,
 })
 
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: ArtworkSidebarFragmentContainer,
+  query: graphql`
+    query ArtworkSidebar_Test_Query @relay_test_operation {
+      artwork(id: "josef-albers-homage-to-the-square-85") {
+        ...ArtworkSidebar_artwork
+      }
+      me {
+        ...ArtworkSidebar_me
+      }
+    }
+  `,
+})
+
 describe("ArtworkSidebar", () => {
+  beforeEach(() => {
+    mockFeatureFlags = {
+      featureFlags: {
+        "artwork-page-create-alert": {
+          flagEnabled: false,
+          variant: { name: "enabled", enabled: false },
+        },
+      },
+    }
+
+    mockUseSystemContext.mockImplementation(() => mockFeatureFlags)
+  })
+
   it("renders ArtworkSidebarArtists component", () => {
     const wrapper = getWrapper()
     expect(wrapper.find(ArtworkSidebarArtists).length).toBe(1)
@@ -35,5 +71,34 @@ describe("ArtworkSidebar", () => {
   it("renders Metadata component", () => {
     const wrapper = getWrapper()
     expect(wrapper.find(ArtworkSidebarMetadata).length).toBe(1)
+  })
+
+  it("renders the create alert section when artwork-page-create-alert ff is enabled", () => {
+    mockFeatureFlags = {
+      featureFlags: {
+        "artwork-page-create-alert": {
+          flagEnabled: true,
+          variant: { name: "enabled", enabled: false },
+        },
+      },
+    }
+
+    mockUseSystemContext.mockImplementationOnce(() => mockFeatureFlags)
+
+    renderWithRelay()
+
+    expect(screen.queryByText(/Create Alert/i)).toBeInTheDocument()
+    expect(
+      screen.queryByText(/Be notified when a similar piece is available/i)
+    ).toBeInTheDocument()
+  })
+
+  it("does not render the create alert section when artwork-page-create-alert ff is enabled", () => {
+    renderWithRelay()
+
+    expect(screen.queryByText(/Create Alert/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Be notified when a similar piece is available/i)
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebar.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebar.jest.tsx
@@ -21,32 +21,25 @@ jest.mock("v2/System/useSystemContext")
 const mockUseSystemContext = useSystemContext as jest.Mock
 let mockFeatureFlags
 
+const ARTWORKSIDEBAR_TEST_QUERY = graphql`
+  query ArtworkSidebar_Test_Query @relay_test_operation {
+    artwork(id: "josef-albers-homage-to-the-square-85") {
+      ...ArtworkSidebar_artwork
+    }
+    me {
+      ...ArtworkSidebar_me
+    }
+  }
+`
+
 const { getWrapper } = setupTestWrapper({
   Component: ArtworkSidebarFragmentContainer,
-  query: graphql`
-    query ArtworkSidebar_Test_Query @relay_test_operation {
-      artwork(id: "josef-albers-homage-to-the-square-85") {
-        ...ArtworkSidebar_artwork
-      }
-      me {
-        ...ArtworkSidebar_me
-      }
-    }
-  `,
+  query: ARTWORKSIDEBAR_TEST_QUERY,
 })
 
 const { renderWithRelay } = setupTestWrapperTL({
   Component: ArtworkSidebarFragmentContainer,
-  query: graphql`
-    query ArtworkSidebar_Test_Query @relay_test_operation {
-      artwork(id: "josef-albers-homage-to-the-square-85") {
-        ...ArtworkSidebar_artwork
-      }
-      me {
-        ...ArtworkSidebar_me
-      }
-    }
-  `,
+  query: ARTWORKSIDEBAR_TEST_QUERY,
 })
 
 describe("ArtworkSidebar", () => {

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/index.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/index.tsx
@@ -16,6 +16,8 @@ import { VerifiedSellerFragmentContainer } from "../TrustSignals/VerifiedSeller"
 import { BuyerGuaranteeFragmentContainer } from "../TrustSignals/BuyerGuarantee"
 import { ArtworkSidebarExtraLinksFragmentContainer } from "./ArtworkSidebarExtraLinks"
 import { ArtworkSidebarAuctionPollingRefetchContainer } from "./ArtworkSidebarAuctionInfoPolling"
+import { useFeatureFlag } from "v2/System/useFeatureFlag"
+import { CreateArtworkAlertSection } from "./CreateArtworkAlertSection"
 
 export interface ArtworkSidebarProps {
   artwork: ArtworkSidebar_artwork
@@ -28,6 +30,10 @@ export const ArtworkSidebar: React.FC<ArtworkSidebarProps> = ({
   artwork,
   me,
 }) => {
+  const shouldShowCreateAlertSection = useFeatureFlag(
+    "artwork-page-create-alert"
+  )
+
   return (
     <ArtworkSidebarContainer data-test={ContextModule.artworkSidebar}>
       <ArtworkSidebarArtistsFragmentContainer artwork={artwork} />
@@ -67,6 +73,7 @@ export const ArtworkSidebar: React.FC<ArtworkSidebarProps> = ({
         <VerifiedSellerFragmentContainer artwork={artwork} />
         <BuyerGuaranteeFragmentContainer artwork={artwork} />
       </Join>
+      {!!shouldShowCreateAlertSection && <CreateArtworkAlertSection />}
       <ArtworkSidebarExtraLinksFragmentContainer artwork={artwork} />
     </ArtworkSidebarContainer>
   )


### PR DESCRIPTION
# Description

⚠️ This feature is behind a feature flag ⚠️

This ticket resolves [FX-3786](https://artsyproduct.atlassian.net/browse/FX-3786)

- introduced `artwork-page-create-alert` feature flag in [unleash](https://unleash.artsy.net/projects/default/features2/artwork-page-create-alert) 
- added `CreateArtworkAlertSection` to be displayed in all artwork screens when ff is enabled
- button is currently not doing anything follow up work will be addressed in another pr.

### Screenshots
|Desktop| mobile small | mobile |
|--|--|--|
|![Screenshot 2022-03-09 at 17 15 14](https://user-images.githubusercontent.com/21178754/157483137-b18ec1f3-8382-4ff5-950a-b3a60d75cb9a.png)|![Screenshot 2022-03-09 at 17 15 04](https://user-images.githubusercontent.com/21178754/157483143-072f95fa-b899-492b-a014-2e406ada14da.png)|![Screenshot 2022-03-09 at 17 14 49](https://user-images.githubusercontent.com/21178754/157483145-38b3470c-2571-4fd1-b3a8-168106d682a7.png)|

