### PR TITLE
feat(CI): Better failing test output

### DIFF
--- a/scripts/jest.sh
+++ b/scripts/jest.sh
@@ -11,6 +11,8 @@ function runJest() {
     ./node_modules/.bin/jest \
       --logHeapUsage \
       --maxWorkers 3 \
+      --reporters=default
+      --reporters=jest-junit
       --config "${1}"
 }
 

--- a/src/v2/Apps/Artist/__tests__/ArtistApp.jest.tsx
+++ b/src/v2/Apps/Artist/__tests__/ArtistApp.jest.tsx
@@ -51,7 +51,7 @@ describe("ArtistApp", () => {
       expect(wrapper.find("RouteTabs").length).toBe(1)
       expect(wrapper.find("RouteTab").at(0).text()).toBe("Overview")
       expect(wrapper.find("RouteTab").at(1).text()).toBe("Artworks")
-      expect(wrapper.find("RouteTab").at(2).text()).toBe("Auction Results")
+      expect(wrapper.find("RouteTab").at(2).text()).toBe("Auction Resultss")
     })
 
     it("tabs navigate to the correct urls", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4151,9 +4151,9 @@
   integrity sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==
 
 "@types/yargs@^13.0.0":
-  version "13.0.11"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.11.tgz#def2f0c93e4bdf2c61d7e34899b17e34be28d3b1"
-  integrity sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==
+  version "13.0.12"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.12.tgz#d895a88c703b78af0465a9de88aa92c61430b092"
+  integrity sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==
   dependencies:
     "@types/yargs-parser" "*"
 


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/WP-102

This will output what tests failed in the `tests` tab in CI, versus having to parse through an endlessly scrolling log. Thanks @pvinis for the suggestion 🙏  

Now, lets see what CI thinks. 

