### PR TITLE
fix(jest): Properly log out runtime JS errors

### DIFF
--- a/src/v2/Apps/Home/Components/HomeAuctionLotsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeAuctionLotsRail.tsx
@@ -5,7 +5,7 @@ import {
   SkeletonText,
   SkeletonBox,
 } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"

--- a/src/v2/jest.envSetup.ts
+++ b/src/v2/jest.envSetup.ts
@@ -90,9 +90,11 @@ if (process.env.ALLOW_CONSOLE_LOGS !== "true") {
         // eslint-disable-next-line no-console
         if (console[type] === originalLoggers[type]) {
           const handler = (...args) => {
-            // FIXME: React 16.8.x doesn't support async `act` testing hooks and so this
-            // suppresses for now. Remove once we upgrade to React 16.9.
-            // @see https://github.com/facebook/react/issues/14769
+            const runtimeErrorStackTrace = args[1]
+            if (runtimeErrorStackTrace) {
+              originalLoggers.error(runtimeErrorStackTrace)
+            }
+
             if (
               args[0] &&
               args[0].includes &&


### PR DESCRIPTION
Spent a long while trying to figure out why my relay tests weren't passing when I knew they were correct and realized that we've been silently suppressing runtime errors in our relay tests! Somehow this has been missed for years.

This restores logging if there's a runtime error by capturing the common second argument for such failures. 

<img width="936" alt="Screen Shot 2022-03-09 at 9 42 44 PM" src="https://user-images.githubusercontent.com/236943/157597206-9c3a8998-2c0a-4baa-8866-2d02c125cec9.png">