### PR TITLE
feat: Set h1 for fairs page GRO-855

### DIFF
--- a/src/v2/Apps/Fairs/Routes/FairsIndex.tsx
+++ b/src/v2/Apps/Fairs/Routes/FairsIndex.tsx
@@ -88,6 +88,7 @@ export const FairsIndex: React.FC<FairsIndexProps> = ({
 
             <Text
               variant="lg"
+              as="h1"
               color="white100"
               position="absolute"
               top={0}


### PR DESCRIPTION
DeepCrawl noticed that we forgot to set an H1 on the mweb version of this page - oops!

https://artsyproduct.atlassian.net/browse/GRO-855

/cc @artsy/grow-devs