### PR TITLE
Isolate review apps' cached pages from staging's (PLATFORM-3779 and PLATFORM-4034)

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -36,6 +36,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: PAGE_CACHE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: KEEPALIVE_TIMEOUT_SECONDS
               value: "95"
             - name: HEADERS_TIMEOUT_SECONDS


### PR DESCRIPTION
Inconsistent Integrity failures alerted us to this problem of cached review apps' pages polluting staging's responses. It frequently manifests as CORS violations (attempting to submit data from staging to a different subdomain) when logging in or signing up, but could theoretically affect any functionality since the included javascript assets might be incorrectly based on a review app's code.

Steps to reproduce:
* as an admin, clear Force's staging cache (`/clear-cache`)
* incognito and unauthenticated, visit the home page of a review app
* visit staging's home page
* note references to review app's subdomain in the HTML source

This kubernetes declaration appears to be all that's needed to isolate review apps' cached pages from staging's. (Review apps' cache keys will be prefixed with the review app's identifier.) Other cache invocations, presumably containing upstream data, are left alone since we haven't had the same pollution problem with them. I've also left production's configuration unchanged.

I experimented by:

```
hokusai staging update --dry-run --skip-checks
hokusai staging update --skip-checks
```
...and then verifying in the kubernetes dash that the environment variable was correctly set to `default` and repeating the steps above without reproducing the problem.

https://artsyproduct.atlassian.net/browse/PLATFORM-3779
https://artsyproduct.atlassian.net/browse/PLATFORM-4034