### PR TITLE
feat: pass in node env to unleash

### DIFF
--- a/src/lib/featureFlags/unleashService.ts
+++ b/src/lib/featureFlags/unleashService.ts
@@ -12,7 +12,9 @@ export class UnleashFeatureFlagService implements FeatureFlagService {
   constructor(
     private url = UNLEASH_API,
     private appName = UNLEASH_APP_NAME,
-    private serverKey = UNLEASH_SERVER_KEY
+    private serverKey = UNLEASH_SERVER_KEY,
+    private environment = process.env.NODE_ENV,
+    private refreshInterval = 60000
   ) {}
 
   async init(): Promise<void> {
@@ -23,8 +25,8 @@ export class UnleashFeatureFlagService implements FeatureFlagService {
     this._unleash = await startUnleash({
       url: this.url,
       appName: this.appName,
-      refreshInterval: 60000,
-      environment: process.env.NODE_ENV,
+      refreshInterval: this.refreshInterval,
+      environment: this.environment,
       customHeaders: {
         Authorization: this.serverKey,
       },

--- a/src/lib/featureFlags/unleashService.ts
+++ b/src/lib/featureFlags/unleashService.ts
@@ -1,5 +1,10 @@
 import { startUnleash, Unleash } from "unleash-client"
-import { UNLEASH_API, UNLEASH_APP_NAME, UNLEASH_SERVER_KEY } from "../../config"
+import {
+  UNLEASH_API,
+  UNLEASH_APP_NAME,
+  UNLEASH_SERVER_KEY,
+  NODE_ENV,
+} from "../../config"
 import { FeatureFlagService } from "./featureFlagService"
 
 // Pass in as argument to registerFeatureFlagProvideder() when using unleash as feature flag service
@@ -13,7 +18,7 @@ export class UnleashFeatureFlagService implements FeatureFlagService {
     private url = UNLEASH_API,
     private appName = UNLEASH_APP_NAME,
     private serverKey = UNLEASH_SERVER_KEY,
-    private environment = process.env.NODE_ENV,
+    private environment = NODE_ENV,
     private refreshInterval = 60000
   ) {}
 

--- a/src/lib/featureFlags/unleashService.ts
+++ b/src/lib/featureFlags/unleashService.ts
@@ -24,6 +24,7 @@ export class UnleashFeatureFlagService implements FeatureFlagService {
       url: this.url,
       appName: this.appName,
       refreshInterval: 60000,
+      environment: process.env.NODE_ENV,
       customHeaders: {
         Authorization: this.serverKey,
       },


### PR DESCRIPTION
This PR passes in the environment to the Unleash client upon initialization. This will enable us to check for the environment in `context` from a [custom strategy.](https://docs.getunleash.io/advanced/custom_activation_strategy). Or, if we upgrade to a paid version, we can use [strategy constraints](https://docs.getunleash.io/advanced/strategy_constraints).