### PR TITLE
feat: add simple unleash experiment in artist filters

### DIFF
--- a/docs/unleash_a-b_testing.md
+++ b/docs/unleash_a-b_testing.md
@@ -1,0 +1,53 @@
+# A/B Testing with Unleash
+
+## Creating a test
+
+- Log into unleash.artsy.net
+- Press Create feature toggle
+  - add a name, description and select the toggle type as "Experiment"
+- Go to Variants Tab and add the variant names (e.g. "control" and "experiment").
+- Go to Strategies Tab and pick your strategy, usually this will be Gradual Rollout for experiments.
+- select a stickiness parameter (userId will make sure that a user will have the same experience every time they use the website)
+- Go to Overview and enable it in development
+
+Inside the component that you want to access the variants use the `useFeatureVariant` hook.
+
+```diff
++   const variant = useFeatureVariant("my-awesome-experiment")
+
+```
+
+variant will be an object with this structure
+
+```js
+{
+  name: "my-variant-name",
+  enabled: true
+}
+```
+
+### Adding tracking data and confirming that it is received
+
+In the component that you added the experiment you just need to add the following:
+
+```diff
++  const {
++    contextPageOwnerId,
++    contextPageOwnerSlug,
++    contextPageOwnerType,
++  } = useAnalyticsContext()
+
++  useTrackVariantView({
++    experiment_name: "my-awesome-experiment",
++    variant_name: variant?.name!,
++    context_owner_id: contextPageOwnerId,
++    context_owner_slug: contextPageOwnerSlug,
++    context_owner_type: contextPageOwnerType,
++  })
+```
+
+In [segment live debugger](https://app.segment.com/artsy-engineering/sources/force-staging/debugger) you can see a live stream of all the events on staging. You can use the searchbar to filter out `Experiment Viewed`, click on the one that is yours and review that everything is in order.
+
+### Useful links
+
+[Setup an ab experiment in 3 simple steps](https://www.getunleash.io/blog/a-b-n-experiments-in-3-simple-steps)

--- a/docs/unleash_a-b_testing.md
+++ b/docs/unleash_a-b_testing.md
@@ -2,7 +2,7 @@
 
 ## Creating a test
 
-- Log into unleash.artsy.net
+- Log into [Unleash](unleash.artsy.net)
 - Press Create feature toggle
   - add a name, description and select the toggle type as "Experiment"
 - Go to Variants Tab and add the variant names (e.g. "control" and "experiment").

--- a/docs/unleash_a-b_testing.md
+++ b/docs/unleash_a-b_testing.md
@@ -38,11 +38,12 @@ In the component that you added the experiment you just need to add the followin
 +  } = useAnalyticsContext()
 
 +  useTrackVariantView({
-+    experiment_name: "my-awesome-experiment",
-+    variant_name: variant?.name!,
-+    context_owner_id: contextPageOwnerId,
-+    context_owner_slug: contextPageOwnerSlug,
-+    context_owner_type: contextPageOwnerType,
++    experimentName: "my-awesome-experiment",
++    variantName: variant?.name!,
++    contextOwnerId: contextPageOwnerId,
++    contextOwnerSlug: contextPageOwnerSlug,
++    contextOwnerType: contextPageOwnerType,
++    shouldTrackExperiment: true/false/condition
 +  })
 ```
 

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -17,6 +17,7 @@ import {
   useTrackVariantView,
 } from "v2/System/useFeatureFlag"
 import { useAnalyticsContext } from "v2/System"
+import { OwnerType } from "@artsy/cohesion"
 
 interface ArtworkFiltersProps {
   user?: User
@@ -32,6 +33,8 @@ export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
     contextPageOwnerType,
   } = useAnalyticsContext()
 
+  const isArtistPage = contextPageOwnerType === OwnerType.artist
+
   const variant = useFeatureVariant("filters-expanded-experiment")
 
   useTrackVariantView({
@@ -39,10 +42,12 @@ export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
     variant_name: variant?.name!,
     context_owner_id: contextPageOwnerId,
     context_owner_slug: contextPageOwnerSlug,
-    context_owner_type: contextPageOwnerType,
+    context_owner_type: contextPageOwnerType!,
+    should_track: isArtistPage,
   })
 
-  const isExpanded = variant?.name === "experiment" && !!variant?.enabled
+  const isExpanded =
+    isArtistPage && variant?.name === "experiment" && !!variant?.enabled
   const expandedProp = { ...(isExpanded && { expanded: isExpanded }) }
 
   return (

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { ColorFilter } from "./ColorFilter"
 import { MediumFilter } from "./MediumFilter"
 import { PriceRangeFilter } from "./PriceRangeFilter"
@@ -12,6 +12,7 @@ import { MaterialsFilter } from "./MaterialsFilter"
 import { PartnersFilter } from "./PartnersFilter"
 import { ArtistsFilter } from "./ArtistsFilter"
 import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
+import { useFeatureVariant } from "v2/System/useFeatureFlag"
 
 interface ArtworkFiltersProps {
   user?: User
@@ -21,6 +22,9 @@ interface ArtworkFiltersProps {
 // Some filters will be rendered only if there is the necessary data in aggregations (for example, ArtistsFilter)
 export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
   const { user, relayEnvironment } = props
+  const variant = useFeatureVariant("filters-expanded-experiment")
+
+  const isExpanded = variant?.name === "experiment" && !!variant?.enabled
 
   return (
     <>
@@ -30,12 +34,12 @@ export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
       <PriceRangeFilter expanded />
       <SizeFilter expanded />
       <WaysToBuyFilter expanded />
-      <MaterialsFilter />
-      <ArtistNationalityFilter />
-      <ArtworkLocationFilter />
-      <TimePeriodFilter />
-      <ColorFilter />
-      <PartnersFilter />
+      <MaterialsFilter expanded={isExpanded} />
+      <ArtistNationalityFilter expanded={isExpanded} />
+      <ArtworkLocationFilter expanded={isExpanded} />
+      <TimePeriodFilter expanded={isExpanded} />
+      <ColorFilter expanded={isExpanded} />
+      <PartnersFilter expanded={isExpanded} />
     </>
   )
 }

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -43,6 +43,7 @@ export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
   })
 
   const isExpanded = variant?.name === "experiment" && !!variant?.enabled
+  const expandedProp = { ...(isExpanded && { expanded: isExpanded }) }
 
   return (
     <>
@@ -52,12 +53,12 @@ export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
       <PriceRangeFilter expanded />
       <SizeFilter expanded />
       <WaysToBuyFilter expanded />
-      <MaterialsFilter expanded={isExpanded} />
-      <ArtistNationalityFilter expanded={isExpanded} />
-      <ArtworkLocationFilter expanded={isExpanded} />
-      <TimePeriodFilter expanded={isExpanded} />
-      <ColorFilter expanded={isExpanded} />
-      <PartnersFilter expanded={isExpanded} />
+      <MaterialsFilter {...expandedProp} />
+      <ArtistNationalityFilter {...expandedProp} />
+      <ArtworkLocationFilter {...expandedProp} />
+      <TimePeriodFilter {...expandedProp} />
+      <ColorFilter {...expandedProp} />
+      <PartnersFilter {...expandedProp} />
     </>
   )
 }

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -38,12 +38,12 @@ export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
   const variant = useFeatureVariant("filters-expanded-experiment")
 
   useTrackVariantView({
-    experiment_name: "filters-expanded-experiment",
-    variant_name: variant?.name!,
-    context_owner_id: contextPageOwnerId,
-    context_owner_slug: contextPageOwnerSlug,
-    context_owner_type: contextPageOwnerType!,
-    should_track: isArtistPage,
+    experimentName: "filters-expanded-experiment",
+    variantName: variant?.name!,
+    contextOwnerId: contextPageOwnerId,
+    contextOwnerSlug: contextPageOwnerSlug,
+    contextOwnerType: contextPageOwnerType!,
+    shouldTrackExperiment: isArtistPage,
   })
 
   const isExpanded =

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -12,7 +12,11 @@ import { MaterialsFilter } from "./MaterialsFilter"
 import { PartnersFilter } from "./PartnersFilter"
 import { ArtistsFilter } from "./ArtistsFilter"
 import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
-import { useFeatureVariant } from "v2/System/useFeatureFlag"
+import {
+  useFeatureVariant,
+  useTrackVariantView,
+} from "v2/System/useFeatureFlag"
+import { useAnalyticsContext } from "v2/System"
 
 interface ArtworkFiltersProps {
   user?: User
@@ -22,7 +26,21 @@ interface ArtworkFiltersProps {
 // Some filters will be rendered only if there is the necessary data in aggregations (for example, ArtistsFilter)
 export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
   const { user, relayEnvironment } = props
+  const {
+    contextPageOwnerId,
+    contextPageOwnerSlug,
+    contextPageOwnerType,
+  } = useAnalyticsContext()
+
   const variant = useFeatureVariant("filters-expanded-experiment")
+
+  useTrackVariantView({
+    experiment_name: "filters-expanded-experiment",
+    variant_name: variant?.name!,
+    context_owner_id: contextPageOwnerId,
+    context_owner_slug: contextPageOwnerSlug,
+    context_owner_type: contextPageOwnerType,
+  })
 
   const isExpanded = variant?.name === "experiment" && !!variant?.enabled
 

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
@@ -1,4 +1,5 @@
 import { mount } from "enzyme"
+import { useTracking } from "v2/System/Analytics/useTracking"
 import {
   ArtworkFilterContextProvider,
   initialArtworkFilterState,
@@ -10,10 +11,20 @@ import { ArtworkFilters } from "../ArtworkFilters"
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({ sm: true }),
 }))
+jest.mock("v2/System/Analytics/useTracking")
 
 describe("ArtworkFilterMobileActionSheet", () => {
   let context
   let spy
+  const trackEvent = jest.fn()
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
 
   const getWrapper = (props = {}) => {
     return mount(

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -15,9 +15,10 @@ interface VariantTrackingProperties {
   experiment_name: string
   variant_name: string
   payload?: string
-  context_owner_type?: OwnerType
+  context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string
+  should_track?: boolean
 }
 
 export function useFeatureFlag(featureName: string): boolean | null {
@@ -57,6 +58,7 @@ export function useTrackVariantView({
   context_owner_type,
   context_owner_id,
   context_owner_slug,
+  should_track = true,
 }: VariantTrackingProperties) {
   const { trackEvent } = useTracking()
 
@@ -64,7 +66,7 @@ export function useTrackVariantView({
     if (typeof window !== "undefined") {
       const trackFeatureView = shouldTrack(experiment_name, variant_name)
 
-      if (trackFeatureView) {
+      if (trackFeatureView && should_track) {
         trackEvent({
           action: ActionType.experimentViewed,
           service: "unleash",

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -2,13 +2,22 @@ import { useSystemContext, useTracking } from "v2/System"
 import { Variant } from "unleash-client"
 
 import { useEffect } from "react"
-import { ActionType, ExperimentViewed } from "@artsy/cohesion"
+import { ActionType, OwnerType } from "@artsy/cohesion"
 
 export type FeatureFlags = Record<string, FeatureFlagDetails>
 
 interface FeatureFlagDetails {
   flagEnabled: boolean
   variant: Variant
+}
+
+interface VariantTrackingProperties {
+  experiment_name: string
+  variant_name: string
+  payload?: string
+  context_owner_type?: OwnerType
+  context_owner_id?: string
+  context_owner_slug?: string
 }
 
 export function useFeatureFlag(featureName: string): boolean | null {
@@ -48,7 +57,7 @@ export function useTrackVariantView({
   context_owner_type,
   context_owner_id,
   context_owner_slug,
-}: ExperimentViewed) {
+}: VariantTrackingProperties) {
   const { trackEvent } = useTracking()
 
   useEffect(() => {

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -12,13 +12,13 @@ interface FeatureFlagDetails {
 }
 
 interface VariantTrackingProperties {
-  experiment_name: string
-  variant_name: string
+  experimentName: string
+  variantName: string
   payload?: string
-  context_owner_type: OwnerType
-  context_owner_id?: string
-  context_owner_slug?: string
-  should_track?: boolean
+  contextOwnerType: OwnerType
+  contextOwnerId?: string
+  contextOwnerSlug?: string
+  shouldTrackExperiment?: boolean
 }
 
 export function useFeatureFlag(featureName: string): boolean | null {
@@ -52,30 +52,30 @@ export function useFeatureVariant(featureName: string): Variant | null {
 }
 
 export function useTrackVariantView({
-  experiment_name,
-  variant_name,
+  experimentName,
+  variantName,
   payload,
-  context_owner_type,
-  context_owner_id,
-  context_owner_slug,
-  should_track = true,
+  contextOwnerType,
+  contextOwnerId,
+  contextOwnerSlug,
+  shouldTrackExperiment = true,
 }: VariantTrackingProperties) {
   const { trackEvent } = useTracking()
 
   useEffect(() => {
     if (typeof window !== "undefined") {
-      const trackFeatureView = shouldTrack(experiment_name, variant_name)
+      const trackFeatureView = shouldTrack(experimentName, variantName)
 
-      if (trackFeatureView && should_track) {
+      if (trackFeatureView && shouldTrackExperiment) {
         trackEvent({
           action: ActionType.experimentViewed,
           service: "unleash",
-          experiment_name,
-          variant_name,
+          experiment_name: experimentName,
+          variant_name: variantName,
           payload,
-          context_owner_type,
-          context_owner_id,
-          context_owner_slug,
+          context_owner_type: contextOwnerType,
+          context_owner_id: contextOwnerId,
+          context_owner_slug: contextOwnerSlug,
         })
       }
     }

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -11,6 +11,15 @@ interface FeatureFlagDetails {
   variant: Variant
 }
 
+interface VariantTrackingProperties {
+  experiment_name: string
+  variant_name: string
+  payload?: object
+  context_owner_type?: string
+  context_owner_id?: string
+  context_owner_slug?: string
+}
+
 export function useFeatureFlag(featureName: string): boolean | null {
   const { featureFlags } = useSystemContext()
   const flagEnabled = featureFlags?.[featureName]?.flagEnabled
@@ -48,7 +57,7 @@ export function useTrackVariantView({
   context_owner_type,
   context_owner_id,
   context_owner_slug,
-}) {
+}: VariantTrackingProperties) {
   const { trackEvent } = useTracking()
 
   useEffect(() => {

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -1,24 +1,14 @@
-import * as Schema from "v2/System/Analytics"
 import { useSystemContext, useTracking } from "v2/System"
 import { Variant } from "unleash-client"
 
 import { useEffect } from "react"
-import { OwnerType } from "@artsy/cohesion"
+import { ActionType, ExperimentViewed } from "@artsy/cohesion"
 
 export type FeatureFlags = Record<string, FeatureFlagDetails>
 
 interface FeatureFlagDetails {
   flagEnabled: boolean
   variant: Variant
-}
-
-interface VariantTrackingProperties {
-  experiment_name: string
-  variant_name: string
-  payload?: string
-  context_owner_type?: OwnerType
-  context_owner_id?: string
-  context_owner_slug?: string
 }
 
 export function useFeatureFlag(featureName: string): boolean | null {
@@ -58,7 +48,7 @@ export function useTrackVariantView({
   context_owner_type,
   context_owner_id,
   context_owner_slug,
-}: VariantTrackingProperties) {
+}: ExperimentViewed) {
   const { trackEvent } = useTracking()
 
   useEffect(() => {
@@ -67,7 +57,7 @@ export function useTrackVariantView({
 
       if (trackFeatureView) {
         trackEvent({
-          action_type: Schema.ActionType.ExperimentViewed,
+          action: ActionType.experimentViewed,
           service: "unleash",
           experiment_name,
           variant_name,

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -1,8 +1,9 @@
 import * as Schema from "v2/System/Analytics"
-import { useSystemContext } from "v2/System"
+import { useSystemContext, useTracking } from "v2/System"
 import { Variant } from "unleash-client"
-import { useTracking } from "react-tracking"
+
 import { useEffect } from "react"
+import { OwnerType } from "@artsy/cohesion"
 
 export type FeatureFlags = Record<string, FeatureFlagDetails>
 
@@ -14,8 +15,8 @@ interface FeatureFlagDetails {
 interface VariantTrackingProperties {
   experiment_name: string
   variant_name: string
-  payload?: object
-  context_owner_type?: string
+  payload?: string
+  context_owner_type?: OwnerType
   context_owner_id?: string
   context_owner_slug?: string
 }
@@ -66,7 +67,7 @@ export function useTrackVariantView({
 
       if (trackFeatureView) {
         trackEvent({
-          action: Schema.ActionType.ExperimentViewed,
+          action_type: Schema.ActionType.ExperimentViewed,
           service: "unleash",
           experiment_name,
           variant_name,


### PR DESCRIPTION
# Description

- Created `filters-expanded-experiment` flag in Unleash dashboard
- Activation strategy:
  - gradual rollout 100%
  - stickiness: `userID`
- Variants:
  - we created the [variants](https://docs.getunleash.io/advanced/toggle_variants) that contain the actual experiment. Here we define a new variant as well as a control variant. It is worth noticing that all the variants will be weighted equally. You are able to define many variants – in this example, we have created 2. “control” is the control variant, while “experiment” is the alternative we want to test.
- add tracking `ExperimentViewed` event
- updated types and imports for analytics.

### Thoughts

Noticed that there is no way of having two levels of `stickiness` 🤔 

- If we pick `sessionID` stickiness we result in having a consistent result during a session BUT if the user starts a new session they might have a different experience.
- If we pick `userID` stickiness we might have some inconsistencies like user before logging in has a different experience than after logging in.

In the end we decided to go with `userID`

Jira: [FX-3766](https://artsyproduct.atlassian.net/browse/FX-3766)