### PR TITLE
Mc jones/unleash cache key

### DIFF
--- a/src/lib/middleware/__tests__/featureFlagMiddleware.jest.ts
+++ b/src/lib/middleware/__tests__/featureFlagMiddleware.jest.ts
@@ -1,0 +1,44 @@
+import { createFeatureFlagsCachePrefix } from "../featureFlagMiddleware"
+
+let featureFlags
+
+describe("createFeatureFlagsCachePrefix", () => {
+  beforeEach(() => {
+    featureFlags = {
+      "feature-a": {
+        flagEnabled: true,
+        variant: {
+          enabled: true,
+          name: "variant-a",
+        },
+      },
+      "feature-b": {
+        flagEnabled: false,
+        variant: {
+          enabled: false,
+          name: "disabled",
+        },
+      },
+      "feature-c": {
+        flagEnabled: true,
+        variant: {
+          enabled: true,
+          name: "variant-c",
+        },
+      },
+    }
+  })
+
+  it("returns a string of enabled feature flags and variants", () => {
+    const cachePrefix = createFeatureFlagsCachePrefix(featureFlags)
+    expect(cachePrefix).toBe("feature-a:variant-a|feature-c:variant-c")
+  })
+
+  it("returns an empty string when there are no feature flags enabled", () => {
+    delete featureFlags["feature-a"]
+    delete featureFlags["feature-c"]
+
+    const cachePrefix = createFeatureFlagsCachePrefix(featureFlags)
+    expect(cachePrefix).toBe("")
+  })
+})

--- a/src/lib/middleware/__tests__/redisPageCache.jest.ts
+++ b/src/lib/middleware/__tests__/redisPageCache.jest.ts
@@ -14,7 +14,7 @@ jest.mock("lib/cache", () => ({
 
 jest
   .spyOn(featureFlagMiddleware, "createFeatureFlagsCachePrefix")
-  .mockImplementation(() => "featureA:variantA|featureB:disabled")
+  .mockImplementation(() => "feature-a:variant-a|feature-b:disabled")
 
 jest.mock("config", () => ({
   PAGE_CACHE_ENABLED: true,
@@ -59,12 +59,12 @@ describe("pageCacheMiddleware", () => {
   it("sets up cache for valid pageTypes", async () => {
     redisPageCacheMiddleware(req, res, next)
     expect(cache.set).toBeCalledWith(
-      "page-cache|none|featureA:variantA|featureB:disabled|1|https://artsy.net/artist/test-artist",
+      "page-cache|none|feature-a:variant-a|feature-b:disabled|1|https://artsy.net/artist/test-artist",
       expect.anything(),
       600
     )
     expect(cache.get.mock.calls[0][0]).toBe(
-      "page-cache|none|featureA:variantA|featureB:disabled|1|https://artsy.net/artist/test-artist"
+      "page-cache|none|feature-a:variant-a|feature-b:disabled|1|https://artsy.net/artist/test-artist"
     )
     await new Promise<void>(resolve => {
       setTimeout(() => {

--- a/src/lib/middleware/featureFlagMiddleware.ts
+++ b/src/lib/middleware/featureFlagMiddleware.ts
@@ -4,6 +4,7 @@ import {
   createFeatureFlagService,
   FeatureFlagService,
 } from "lib/featureFlags/featureFlagService"
+import { FeatureFlags } from "v2/System/useFeatureFlag"
 
 export function featureFlagMiddleware(serviceType: symbol) {
   let service
@@ -45,4 +46,18 @@ export function featureFlagMiddleware(serviceType: symbol) {
         next()
       })
   }
+}
+
+export function createFeatureFlagsCachePrefix(
+  featureFlags: FeatureFlags
+): string {
+  const flagsEnabledList: string[] = []
+
+  for (const key in featureFlags) {
+    if (featureFlags[key].flagEnabled) {
+      flagsEnabledList.push(`${key}:${featureFlags[key].variant.name}`)
+    }
+  }
+
+  return flagsEnabledList.join("|")
 }

--- a/src/lib/middleware/redisPageCache.ts
+++ b/src/lib/middleware/redisPageCache.ts
@@ -14,6 +14,7 @@ import {
 } from "../../config"
 import { RequestRecorder } from "./requestRecorder"
 import util from "util"
+import { createFeatureFlagsCachePrefix } from "./featureFlagMiddleware"
 
 const debugLog = util.debuglog("redisCache")
 
@@ -69,10 +70,22 @@ export function redisPageCacheMiddleware(
       return `${test}:${outcome}`
     }).join("|") || "none"
 
+  // Generate cache key that indlues all currently enabled featureFlags and
+  // variants
+  const featureFlagsCacheKey = createFeatureFlagsCachePrefix(
+    res.locals.FEATURE_FLAGS
+  )
+
   // `key` should be a full URL w/ query params, and not a path.
   // This is to separate URL's like `/collect` and `/collect?acquireable=true`.
   const cacheKey = (key: string) => {
-    return [PAGE_CACHE_NAMESPACE, abTestPrefix, PAGE_CACHE_VERSION, key]
+    return [
+      PAGE_CACHE_NAMESPACE,
+      abTestPrefix,
+      featureFlagsCacheKey,
+      PAGE_CACHE_VERSION,
+      key,
+    ]
       .filter(Boolean)
       .join("|")
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -127,6 +127,10 @@ export function initializeMiddleware(app) {
     app.use(splitTestMiddleware)
   }
 
+  // Need sharify for unleash
+  registerFeatureFlagService(UnleashService, UnleashFeatureFlagService)
+  app.use(featureFlagMiddleware(UnleashService))
+
   // Initialize caches
   applyCacheMiddleware(app)
 
@@ -152,10 +156,6 @@ export function initializeMiddleware(app) {
 
   // Static assets
   applyStaticAssetMiddlewares(app)
-
-  // Need sharify for unleash
-  registerFeatureFlagService(UnleashService, UnleashFeatureFlagService)
-  app.use(featureFlagMiddleware(UnleashService))
 }
 
 function applySecurityMiddleware(app) {


### PR DESCRIPTION
This PR adds caching support for our feature flag and experimentation strategy. Following the same approach as our current split test implementation, we generate a list of running feature flags per request and add that to the cache key.

### Considerations
We currently have an [active A/B test running](https://github.com/artsy/force/pull/9538), so the new approach in this PR will be running alongside the old approach until it is completed. Once the final A/B test is complete, we will remove the legacy code and just use the `unleash` based implementation.

### Related PRs
- https://github.com/artsy/force/pull/9513
- https://github.com/artsy/force/pull/9498
- https://github.com/artsy/force/pull/9393
- https://github.com/artsy/force/pull/9547
- https://github.com/artsy/cohesion/pull/304

### Follow-ups
- Run a trivial experiment with new implementation
- Remove legacy split test code

[PLATFORM-4024]