### PR TITLE
fix(auction): Fix caps case in loader

### DIFF
--- a/src/v2/Apps/Auction/Routes/Bid/Components/PricingTransparency.tsx
+++ b/src/v2/Apps/Auction/Routes/Bid/Components/PricingTransparency.tsx
@@ -60,7 +60,7 @@ const PLACEHOLDER = (
       </Text>
 
       <Row>
-        <Text variant="md">Your max bid</Text>
+        <Text variant="md">Your Max Bid</Text>
         <SkeletonText variant="md">20000</SkeletonText>
       </Row>
       <Row>


### PR DESCRIPTION
Just caught this when changing max bids in the auction/id/bid form. 