### PR TITLE
feat(TX-253): release new tax display messaging 

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -1,4 +1,3 @@
-import { userHasLabFeature } from "v2/Utils/user"
 import { ContextModule, Intent } from "@artsy/cohesion"
 import {
   Box,
@@ -375,10 +374,6 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
       is_inquireable: isInquireable,
       is_sold: isSold,
     } = artwork
-    const avalaraPhase2Enabled = userHasLabFeature(
-      this.props.user,
-      "Avalara Phase 2"
-    )
 
     const {
       isCommittingCreateOrderMutation,
@@ -437,7 +432,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
               <Spacer mt={1} />
             )}
 
-          {avalaraPhase2Enabled && artworkEcommerceAvailable && !isSold && (
+          {artworkEcommerceAvailable && !isSold && (
             <Text variant="xs" color="black60">
               Taxes may apply at checkout.{" "}
               <a
@@ -461,14 +456,6 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
               {artwork.shippingInfo}
             </Text>
           )}
-
-          {!avalaraPhase2Enabled &&
-            artworkEcommerceAvailable &&
-            artwork.priceIncludesTaxDisplay && (
-              <Text variant="xs" color="black60">
-                {artwork.priceIncludesTaxDisplay}
-              </Text>
-            )}
 
           {isInquireable || isAcquireable || isOfferable ? (
             artwork.sale_message && <Spacer mt={2} />

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.jest.tsx
@@ -90,34 +90,6 @@ describe("ArtworkSidebarCommercial", () => {
       })
     })
   })
-  it("displays if the artwork price includes tax", async () => {
-    const artwork = Object.assign(
-      {},
-      {
-        ...ArtworkBuyNowMakeOffer,
-        priceIncludesTaxDisplay: "VAT included in price",
-        is_for_sale: true,
-      }
-    )
-
-    const wrapper = getWrapper(artwork)
-
-    expect(wrapper.text()).toContain("VAT included in price")
-  })
-
-  it("does not display artwork price includes tax if untrue", async () => {
-    const artwork = Object.assign(
-      {},
-      {
-        ...ArtworkSingleEditionHiddenAvailability,
-        priceIncludesTaxDisplay: null,
-      }
-    )
-
-    const wrapper = getWrapper(artwork)
-
-    expect(wrapper.text()).not.toContain("VAT included in price")
-  })
 
   it("displays single editioned hidden availability inquire work", async () => {
     const artwork = Object.assign({}, ArtworkSingleEditionHiddenAvailability)

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial2.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial2.jest.tsx
@@ -3,6 +3,8 @@ import {
   ArtworkOfferableFromInquiryPriceRange,
   ArtworkOfferableAndInquireablePriceHidden,
   ForSaleArtworkWithMultipleEditions,
+  ArtworkSold,
+  ArtworkBuyNowMakeOffer,
 } from "v2/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarCommercial"
 
 import { commitMutation as _commitMutation, graphql } from "react-relay"
@@ -65,5 +67,23 @@ describe("ArtworkSidebarCommercial RTL", () => {
     })
 
     expect(screen.getAllByRole("radio").length).toBe(4)
+  })
+
+  it("displays 'Taxes may apply at checkout.'", () => {
+    renderWithRelay({
+      Artwork: () => ArtworkBuyNowMakeOffer,
+    })
+
+    expect(screen.getByText("Taxes may apply at checkout.")).toBeInTheDocument()
+  })
+
+  it("does not display 'Taxes may apply at checkout.' if artwork is sold", () => {
+    renderWithRelay({
+      Artwork: () => ArtworkSold,
+    })
+
+    expect(
+      screen.queryByText("Taxes may apply at checkout.")
+    ).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
[TX-253](https://artsyproduct.atlassian.net/browse/TX-253)

This PR removes the "VAT included in price" message and replaces it with "Taxes may apply at checkout. Learn More." in preparation for Avalara phase two release. 