### PR TITLE
refactor: Ability to reuse SavedSearchCreateAlertButton component on different grids

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
@@ -1,17 +1,5 @@
-import React, { useState } from "react"
-import {
-  Separator,
-  Spacer,
-  Flex,
-  Button,
-  BellIcon,
-  Text,
-  Box,
-} from "@artsy/palette"
-import {
-  SavedSearchAlertContextProvider,
-  useSavedSearchAlertContext,
-} from "v2/Components/SavedSearchAlert/SavedSearchAlertContext"
+import React from "react"
+import { Separator, Spacer, Flex, Text, Box } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { CreateArtworkAlertSection_artwork } from "v2/__generated__/CreateArtworkAlertSection_artwork.graphql"
 import {
@@ -21,52 +9,14 @@ import {
 import { compact } from "lodash"
 import { checkboxValues } from "v2/Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
 import { getAllowedSearchCriteria } from "v2/Components/SavedSearchAlert/Utils/savedSearchCriteria"
-import { SavedSearchAlertModal } from "v2/Components/SavedSearchAlert/SavedSearchAlertModal"
 import { OwnerType } from "@artsy/cohesion"
+import { SavedSearchCreateAlertButton } from "v2/Components/SavedSearchAlert/Components/SavedSearchCreateAlertButton"
 
 interface CreateArtworkAlertSectionProps {
   artwork: CreateArtworkAlertSection_artwork
 }
 
-export const CreateArtworkAlertSection: React.FC = () => {
-  const [visible, setVisible] = useState(false)
-  const { entity } = useSavedSearchAlertContext()
-
-  const openModal = () => setVisible(true)
-  const closeModal = () => setVisible(false)
-
-  return (
-    <Box my={2}>
-      <Separator />
-      <Spacer m={2} />
-      <Flex
-        flexDirection="row"
-        py={1}
-        alignItems="center"
-        justifyContent="space-between"
-      >
-        <Text variant="xs" mr={2}>
-          Be notified when a similar piece is available
-        </Text>
-        <Button variant="secondaryOutline" size="small" onClick={openModal}>
-          <BellIcon mr={0.5} fill="currentColor" />
-          <Text variant="xs">Create Alert</Text>
-        </Button>
-      </Flex>
-
-      {visible ? (
-        <SavedSearchAlertModal
-          initialValues={{ name: "", email: true, push: false }}
-          entity={entity}
-          onClose={closeModal}
-          onComplete={closeModal}
-        />
-      ) : null}
-    </Box>
-  )
-}
-
-export const CreateArtworkAlertSectionContainer: React.FC<CreateArtworkAlertSectionProps> = ({
+export const CreateArtworkAlertSection: React.FC<CreateArtworkAlertSectionProps> = ({
   artwork,
 }) => {
   const artists = compact(artwork.artists)
@@ -94,14 +44,29 @@ export const CreateArtworkAlertSectionContainer: React.FC<CreateArtworkAlertSect
   const allowedCriteria = getAllowedSearchCriteria(criteria)
 
   return (
-    <SavedSearchAlertContextProvider criteria={allowedCriteria} entity={entity}>
-      <CreateArtworkAlertSection />
-    </SavedSearchAlertContextProvider>
+    <Box my={2}>
+      <Separator />
+      <Spacer m={2} />
+      <Flex
+        flexDirection="row"
+        py={1}
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <Text variant="xs" mr={2}>
+          Be notified when a similar piece is available
+        </Text>
+        <SavedSearchCreateAlertButton
+          entity={entity}
+          criteria={allowedCriteria}
+        />
+      </Flex>
+    </Box>
   )
 }
 
 export const CreateArtworkAlertSectionFragmentContainer = createFragmentContainer(
-  CreateArtworkAlertSectionContainer,
+  CreateArtworkAlertSection,
   {
     artwork: graphql`
       fragment CreateArtworkAlertSection_artwork on Artwork {

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/CreateArtworkAlertSection.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/CreateArtworkAlertSection.jest.tsx
@@ -6,8 +6,12 @@ import {
 } from "../CreateArtworkAlertSection"
 import { CreateArtworkAlertSection_Test_Query } from "v2/__generated__/CreateArtworkAlertSection_Test_Query.graphql"
 import { fireEvent, screen } from "@testing-library/react"
+import { useTracking } from "react-tracking"
+import { useSystemContext } from "v2/System"
 
 jest.unmock("react-relay")
+jest.mock("react-tracking")
+jest.mock("v2/System/useSystemContext")
 
 const { renderWithRelay } = setupTestWrapperTL<
   CreateArtworkAlertSection_Test_Query
@@ -23,6 +27,26 @@ const { renderWithRelay } = setupTestWrapperTL<
 })
 
 describe("CreateArtworkAlertSection", () => {
+  const mockuseTracking = useTracking as jest.Mock
+  const trackEvent = jest.fn()
+  const mockuseSystemContext = useSystemContext as jest.Mock
+
+  beforeEach(() => {
+    mockuseTracking.mockImplementation(() => ({
+      trackEvent,
+    }))
+
+    mockuseSystemContext.mockImplementation(() => {
+      return {
+        isLoggedIn: true,
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   it("should correctly render placeholder", () => {
     const placeholder = "Artworks like: Some artwork title"
     renderWithRelay({

--- a/src/v2/Components/SavedSearchAlert/Components/SavedSearchAlertArtworkGridFilterPills.tsx
+++ b/src/v2/Components/SavedSearchAlert/Components/SavedSearchAlertArtworkGridFilterPills.tsx
@@ -26,11 +26,12 @@ export const SavedSearchAlertArtworkGridFilterPills: React.FC<SavedSearchAlertAr
     savedSearchEntity,
     filters ?? {}
   )
+  const metric = filters?.metric ?? DEFAULT_METRIC
   const pills = extractPills({
     criteria,
     aggregations,
     entity: savedSearchEntity,
-    metric: filters?.metric ?? DEFAULT_METRIC,
+    metric,
   })
 
   const removePill = (pill: FilterPill) => {
@@ -54,6 +55,9 @@ export const SavedSearchAlertArtworkGridFilterPills: React.FC<SavedSearchAlertAr
       <SavedSearchAlertPills items={pills} onDeletePress={removePill} />
       <SavedSearchCreateAlertButton
         entity={savedSearchEntity}
+        criteria={criteria}
+        metric={metric}
+        aggregations={aggregations}
         ml={PILL_HORIZONTAL_MARGIN_SIZE}
       />
     </Flex>

--- a/src/v2/Components/SavedSearchAlert/Components/SavedSearchCreateAlertButton.tsx
+++ b/src/v2/Components/SavedSearchAlert/Components/SavedSearchCreateAlertButton.tsx
@@ -5,14 +5,26 @@ import { ActionType, Intent, ContextModule } from "@artsy/cohesion"
 import { openAuthToSatisfyIntent } from "v2/Utils/openAuthModal"
 import { mediator } from "lib/mediator"
 import { SavedSearchAlertModalContainer } from "../SavedSearchAlertModal"
-import { SavedSearchAlertMutationResult, SavedSearchEntity } from "../types"
+import {
+  SavedSearchAlertMutationResult,
+  SavedSearchEntity,
+  SearchCriteriaAttributes,
+} from "../types"
+import { Metric } from "v2/Components/ArtworkFilter/Utils/metrics"
+import { Aggregations } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 
 export interface SavedSearchCreateAlertButtonProps extends ButtonProps {
   entity: SavedSearchEntity
+  criteria: SearchCriteriaAttributes
+  metric?: Metric
+  aggregations?: Aggregations
 }
 
 export const SavedSearchCreateAlertButton: React.FC<SavedSearchCreateAlertButtonProps> = ({
   entity,
+  criteria,
+  metric,
+  aggregations,
   ...props
 }) => {
   const tracking = useTracking()
@@ -91,6 +103,9 @@ export const SavedSearchCreateAlertButton: React.FC<SavedSearchCreateAlertButton
         visible={visibleForm}
         initialValues={{ name: "", email: true, push: false }}
         entity={entity}
+        criteria={criteria}
+        metric={metric}
+        aggregations={aggregations}
         onClose={() => setVisibleForm(false)}
         onComplete={handleComplete}
       />

--- a/src/v2/Components/SavedSearchAlert/Components/__tests__/CreateAlertButton.jest.tsx
+++ b/src/v2/Components/SavedSearchAlert/Components/__tests__/CreateAlertButton.jest.tsx
@@ -7,7 +7,6 @@ import {
   SavedSearchCreateAlertButtonProps,
 } from "../SavedSearchCreateAlertButton"
 import { mediator } from "lib/mediator"
-import { ArtworkFilterContextProvider } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { SavedSearchEntity } from "../../types"
 import { OwnerType } from "@artsy/cohesion"
 
@@ -30,15 +29,11 @@ const savedSearchEntity: SavedSearchEntity = {
 
 describe("CreateAlertButton", () => {
   const renderButton = () => {
-    render(<CreateAlertButtonTest entity={savedSearchEntity} />)
+    render(<CreateAlertButtonTest entity={savedSearchEntity} criteria={{}} />)
   }
 
   const CreateAlertButtonTest = (props: SavedSearchCreateAlertButtonProps) => {
-    return (
-      <ArtworkFilterContextProvider>
-        <SavedSearchCreateAlertButton {...props} />
-      </ArtworkFilterContextProvider>
-    )
+    return <SavedSearchCreateAlertButton {...props} />
   }
 
   const openAuthToSatisfyIntent = jest.spyOn(

--- a/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
+++ b/src/v2/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
@@ -13,7 +13,7 @@ import {
 } from "@artsy/palette"
 import { createSavedSearchAlert } from "./Mutations/createSavedSearchAlert"
 import { useSystemContext } from "v2/System"
-import { useArtworkFilterContext } from "../ArtworkFilter/ArtworkFilterContext"
+import { Aggregations } from "../ArtworkFilter/ArtworkFilterContext"
 import createLogger from "v2/Utils/logger"
 import {
   SavedSearchAlertContextProvider,
@@ -25,9 +25,10 @@ import {
   SavedSearchAlertMutationResult,
   SavedSearchEntity,
   SearchCriteriaAttributeKeys,
+  SearchCriteriaAttributes,
 } from "./types"
-import { getSearchCriteriaFromFilters } from "./Utils/savedSearchCriteria"
 import { SavedSearchAlertPills } from "./Components/SavedSearchAlertPills"
+import { Metric } from "../ArtworkFilter/Utils/metrics"
 
 interface SavedSearchAlertFormProps {
   entity: SavedSearchEntity
@@ -39,6 +40,9 @@ interface SavedSearchAlertFormProps {
 export interface SavedSearchAlertFormContainerProps
   extends SavedSearchAlertFormProps {
   visible?: boolean
+  criteria: SearchCriteriaAttributes
+  metric?: Metric
+  aggregations: Aggregations | undefined
 }
 
 const logger = createLogger(
@@ -175,18 +179,15 @@ export const SavedSearchAlertModal: React.FC<SavedSearchAlertFormProps> = ({
 }
 
 export const SavedSearchAlertModalContainer: React.FC<SavedSearchAlertFormContainerProps> = props => {
-  const { visible, entity } = props
-  const { aggregations, filters } = useArtworkFilterContext()
+  const { visible, entity, criteria, metric, aggregations } = props
 
   if (visible) {
-    const criteria = getSearchCriteriaFromFilters(entity, filters ?? {})
-
     return (
       <SavedSearchAlertContextProvider
         criteria={criteria}
         aggregations={aggregations}
         entity={entity}
-        metric={filters?.metric!}
+        metric={metric}
       >
         <SavedSearchAlertModal {...props} />
       </SavedSearchAlertContextProvider>

--- a/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
+++ b/src/v2/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
@@ -1,14 +1,11 @@
 import { OwnerType } from "@artsy/cohesion"
 import { render, screen, fireEvent } from "@testing-library/react"
-import {
-  ArtworkFilterContextProvider,
-  ArtworkFiltersState,
-} from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+import { ArtworkFiltersState } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import {
   SavedSearchAlertModalContainer,
   SavedSearchAlertFormContainerProps,
 } from "../SavedSearchAlertModal"
-import { SavedSearchEntity } from "../types"
+import { SavedSearchEntity, SearchCriteriaAttributes } from "../types"
 
 const formInitialValues = {
   name: "",
@@ -30,7 +27,7 @@ const savedSearchEntity: SavedSearchEntity = {
   },
 }
 
-const defaultFilters: ArtworkFiltersState = {
+const defaultCriteria: SearchCriteriaAttributes = {
   attributionClass: ["open edition"],
   priceRange: "25000-50000",
 }
@@ -44,19 +41,19 @@ interface Props extends Partial<SavedSearchAlertFormContainerProps> {
 
 describe("SavedSearchAlertModal", () => {
   const TestComponent = (props: Props) => {
-    const { filters = defaultFilters, ...rest } = props
+    const { criteria = defaultCriteria, ...rest } = props
 
     return (
-      <ArtworkFilterContextProvider filters={filters}>
-        <SavedSearchAlertModalContainer
-          visible
-          initialValues={formInitialValues}
-          entity={savedSearchEntity}
-          onClose={onCloseMock}
-          onComplete={onCompleteMock}
-          {...rest}
-        />
-      </ArtworkFilterContextProvider>
+      <SavedSearchAlertModalContainer
+        visible
+        initialValues={formInitialValues}
+        entity={savedSearchEntity}
+        criteria={criteria}
+        aggregations={[]}
+        onClose={onCloseMock}
+        onComplete={onCompleteMock}
+        {...rest}
+      />
     )
   }
 


### PR DESCRIPTION
Type: **Refactor** & **Enhancement**

### Description
These changes will allow us to reuse [SavedSearchCreateAlertButton](https://github.com/artsy/force/blob/dimatretyak/refactor/reuse-create-alert-button/src/v2/Components/SavedSearchAlert/Components/SavedSearchCreateAlertButton.tsx) component and its logic (this will be useful for the [FX-3788](https://artsyproduct.atlassian.net/browse/FX-3788) task)