### PR TITLE
fix(auction): Fix sort filter

### DIFF
--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -206,9 +206,9 @@ export const BaseArtworkFilter: React.FC<
     const refetchVariables = {
       input: {
         first: 30,
+        ...relayRefetchInputVariables,
         ...allowedFilters(filterContext.filters),
         keyword: filterContext.filters!.term,
-        ...relayRefetchInputVariables,
       },
       ...relayVariables,
     }

--- a/src/v2/__generated__/CreateConsignSubmissionMutation.graphql.ts
+++ b/src/v2/__generated__/CreateConsignSubmissionMutation.graphql.ts
@@ -29,7 +29,6 @@ export type CreateSubmissionMutationInput = {
     locationState?: string | null;
     medium?: string | null;
     minimumPriceDollars?: number | null;
-    myCollectionArtworkID?: string | null;
     provenance?: string | null;
     sessionID?: string | null;
     signature?: boolean | null;


### PR DESCRIPTION
This fixes the sort in the artwork filter. The issue is that we were overwriting the filter state computation with the results of the `relayRefetchInputVariables`, which was new.

cc @artsy/grow-devs 