### PR TITLE
[GRO-853 & 854]: update metatags for /galleries and /institutions for SEO

### DIFF
--- a/src/v2/Apps/Partners/Routes/GalleriesRoute.tsx
+++ b/src/v2/Apps/Partners/Routes/GalleriesRoute.tsx
@@ -34,6 +34,7 @@ const GalleriesRoute: React.FC<GalleriesRouteProps> = ({ viewer }) => {
       <MetaTags
         title="Galleries | Artsy"
         description="Browse art and design galleries around the globe by location and specialty and explore artists, artworks, shows, and fair booths."
+        pathname="galleries"
       />
 
       <Join separator={<Spacer mt={4} />}>

--- a/src/v2/Apps/Partners/Routes/InstitutionsRoute.tsx
+++ b/src/v2/Apps/Partners/Routes/InstitutionsRoute.tsx
@@ -35,6 +35,7 @@ const InstitutionsRoute: React.FC<InstitutionsRouteProps> = ({ viewer }) => {
       <MetaTags
         title="Institutions | Artsy"
         description="Artsy promotes the collections, shows, and programs of the Louvre, Getty Museum, Robert Rauschenberg Foundation, and 600+ other museums and institutions worldwide."
+        pathname="institutions"
       />
 
       <Join separator={<Spacer mt={4} />}>


### PR DESCRIPTION
The type of this PR is: chore

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-853] & [GRO-854]

### Description

<!-- Implementation description -->
Making these pages canonical to the homepage rather than a self-referring canonical so they can be properly crawled. 

<img width="902" alt="Screen Shot 2022-03-16 at 6 36 09 PM" src="https://user-images.githubusercontent.com/23108927/158709153-c945dd05-97f0-4469-a9df-aac8a0806cdc.png">





[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-853]: https://artsyproduct.atlassian.net/browse/GRO-853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-854]: https://artsyproduct.atlassian.net/browse/GRO-854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ