### PR TITLE
fix(auction): misc bugs

### DIFF
--- a/src/v2/Apps/Auction/Routes/AuctionRegistrationRoute.tsx
+++ b/src/v2/Apps/Auction/Routes/AuctionRegistrationRoute.tsx
@@ -47,11 +47,18 @@ const AuctionRegistrationRoute: React.FC<AuctionRegistrationRouteProps> = ({
   useEffect(() => {
     if (redirectToSaleHome(sale)) {
       router.replace(`/auction/${sale.slug}`)
+    } else if (me.hasQualifiedCreditCards) {
+      router.replace(`/auction/${sale.slug}/confirm-registration`)
     } else {
       tracking.registrationPageView()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Will redirect to /confirm-registration above on page mount
+  if (me.hasQualifiedCreditCards) {
+    return null
+  }
 
   return (
     <ModalDialog
@@ -109,6 +116,7 @@ export const AuctionRegistrationRouteFragmentContainer = createFragmentContainer
       fragment AuctionRegistrationRoute_me on Me {
         internalID
         identityVerified
+        hasQualifiedCreditCards
       }
     `,
     sale: graphql`

--- a/src/v2/Apps/Auction/Routes/__tests__/AuctionRegistrationRoute.jest.tsx
+++ b/src/v2/Apps/Auction/Routes/__tests__/AuctionRegistrationRoute.jest.tsx
@@ -132,6 +132,28 @@ describe("AuctionRegistrationRoute", () => {
     expect(spy).toHaveBeenCalledWith("/auction/sale-slug")
   })
 
+  it("redirects to /confirm-registration if credit card on file", async () => {
+    const spy = jest.fn()
+
+    mockUseRouter.mockImplementation(() => ({
+      router: {
+        replace: spy,
+      },
+    }))
+
+    getWrapper({
+      Sale: () => ({
+        slug: "sale-slug",
+      }),
+      Me: () => ({
+        hasQualifiedCreditCards: true,
+      }),
+    })
+
+    await flushPromiseQueue()
+    expect(spy).toHaveBeenCalledWith("/auction/sale-slug/confirm-registration")
+  })
+
   it("tracks confirmation page view", async () => {
     const spy = jest.fn()
 
@@ -191,7 +213,7 @@ describe("AuctionRegistrationRoute", () => {
       }),
       Me: () => ({
         identityVerified: false,
-        hasQualifiedCreditCards: true,
+        hasQualifiedCreditCards: false,
       }),
     })
 
@@ -204,7 +226,7 @@ describe("AuctionRegistrationRoute", () => {
         requireIdentityVerification: false,
       }),
       Me: () => ({
-        hasQualifiedCreditCards: true,
+        hasQualifiedCreditCards: false,
       }),
     })
 

--- a/src/v2/Apps/Auction/auctionRoutes.tsx
+++ b/src/v2/Apps/Auction/auctionRoutes.tsx
@@ -90,6 +90,7 @@ export const auctionRoutes: AppRouteConfig[] = [
       {
         path: "register",
         getComponent: () => RegistrationRoute,
+        onServerSideRender: checkIfLoggedIn,
         query: graphql`
           query auctionRoutes_RegisterRouteQuery($slug: String!) {
             me {
@@ -104,6 +105,7 @@ export const auctionRoutes: AppRouteConfig[] = [
       {
         path: "confirm-registration",
         getComponent: () => ConfirmRegistrationRoute,
+        onServerSideRender: checkIfLoggedIn,
         query: graphql`
           query auctionRoutes_ConfirmRegistrationRouteQuery($slug: String!) {
             me {
@@ -122,15 +124,11 @@ export const auctionRoutes: AppRouteConfig[] = [
           if (!match.context.user) {
             const redirectTo = match.location.pathname + match.location.search
             match.router.push(
-              `/login?redirect-to=${redirectTo}&afterSignUpAction=${redirectTo}`
+              `/login?redirectTo=${redirectTo}&afterSignUpAction=${redirectTo}`
             )
           }
         },
-        onServerSideRender: ({ req, res }) => {
-          if (!req.user) {
-            res.redirect(`/login?redirect=${req.originalUrl}`)
-          }
-        },
+        onServerSideRender: checkIfLoggedIn,
         ignoreScrollBehavior: true,
         query: graphql`
           query auctionRoutes_BidRouteQuery(
@@ -169,3 +167,9 @@ export const auctionRoutes: AppRouteConfig[] = [
     `,
   },
 ]
+
+function checkIfLoggedIn({ req, res }) {
+  if (!req.user) {
+    res.redirect(`/login?redirectTo=${req.originalUrl}`)
+  }
+}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -284,6 +284,7 @@ export const ArtworkFilterContextProvider: React.FC<
 }) => {
   const initialFilterState = {
     ...initialArtworkFilterState,
+    sort: sortOptions?.[0].value ?? initialArtworkFilterState.sort,
     ...paramsToCamelCase(filters),
   }
 

--- a/src/v2/__generated__/AuctionRegistrationRouteTestQuery.graphql.ts
+++ b/src/v2/__generated__/AuctionRegistrationRouteTestQuery.graphql.ts
@@ -35,6 +35,7 @@ query AuctionRegistrationRouteTestQuery {
 fragment AuctionRegistrationRoute_me on Me {
   internalID
   identityVerified
+  hasQualifiedCreditCards
 }
 
 fragment AuctionRegistrationRoute_sale on Sale {
@@ -76,15 +77,15 @@ v2 = {
 },
 v3 = {
   "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "ID"
-},
-v4 = {
-  "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
 },
 v5 = {
   "enumValues": null,
@@ -155,6 +156,13 @@ return {
             "args": null,
             "kind": "ScalarField",
             "name": "identityVerified",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hasQualifiedCreditCards",
             "storageKey": null
           },
           (v2/*: any*/)
@@ -238,7 +246,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "721c00f260ee68852c31de3f66ed69b6",
+    "cacheID": "54a047cf1c2ff689d9ccad2768960a31",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -248,9 +256,10 @@ return {
           "plural": false,
           "type": "Me"
         },
-        "me.id": (v3/*: any*/),
-        "me.identityVerified": (v4/*: any*/),
-        "me.internalID": (v3/*: any*/),
+        "me.hasQualifiedCreditCards": (v3/*: any*/),
+        "me.id": (v4/*: any*/),
+        "me.identityVerified": (v3/*: any*/),
+        "me.internalID": (v4/*: any*/),
         "sale": {
           "enumValues": null,
           "nullable": true,
@@ -263,21 +272,21 @@ return {
           "plural": false,
           "type": "Bidder"
         },
-        "sale.bidder.id": (v3/*: any*/),
-        "sale.bidder.qualifiedForBidding": (v4/*: any*/),
-        "sale.id": (v3/*: any*/),
-        "sale.internalID": (v3/*: any*/),
-        "sale.isClosed": (v4/*: any*/),
-        "sale.isLiveOpen": (v4/*: any*/),
+        "sale.bidder.id": (v4/*: any*/),
+        "sale.bidder.qualifiedForBidding": (v3/*: any*/),
+        "sale.id": (v4/*: any*/),
+        "sale.internalID": (v4/*: any*/),
+        "sale.isClosed": (v3/*: any*/),
+        "sale.isLiveOpen": (v3/*: any*/),
         "sale.name": (v5/*: any*/),
-        "sale.requireIdentityVerification": (v4/*: any*/),
-        "sale.slug": (v3/*: any*/),
+        "sale.requireIdentityVerification": (v3/*: any*/),
+        "sale.slug": (v4/*: any*/),
         "sale.status": (v5/*: any*/)
       }
     },
     "name": "AuctionRegistrationRouteTestQuery",
     "operationKind": "query",
-    "text": "query AuctionRegistrationRouteTestQuery {\n  me {\n    ...AuctionRegistrationRoute_me\n    id\n  }\n  sale(id: \"foo\") {\n    ...AuctionRegistrationRoute_sale\n    id\n  }\n}\n\nfragment AuctionRegistrationRoute_me on Me {\n  internalID\n  identityVerified\n}\n\nfragment AuctionRegistrationRoute_sale on Sale {\n  slug\n  name\n  internalID\n  status\n  requireIdentityVerification\n  isClosed\n  isLiveOpen\n  bidder {\n    qualifiedForBidding\n    id\n  }\n}\n"
+    "text": "query AuctionRegistrationRouteTestQuery {\n  me {\n    ...AuctionRegistrationRoute_me\n    id\n  }\n  sale(id: \"foo\") {\n    ...AuctionRegistrationRoute_sale\n    id\n  }\n}\n\nfragment AuctionRegistrationRoute_me on Me {\n  internalID\n  identityVerified\n  hasQualifiedCreditCards\n}\n\nfragment AuctionRegistrationRoute_sale on Sale {\n  slug\n  name\n  internalID\n  status\n  requireIdentityVerification\n  isClosed\n  isLiveOpen\n  bidder {\n    qualifiedForBidding\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/AuctionRegistrationRoute_me.graphql.ts
+++ b/src/v2/__generated__/AuctionRegistrationRoute_me.graphql.ts
@@ -7,6 +7,7 @@ import { FragmentRefs } from "relay-runtime";
 export type AuctionRegistrationRoute_me = {
     readonly internalID: string;
     readonly identityVerified: boolean | null;
+    readonly hasQualifiedCreditCards: boolean | null;
     readonly " $refType": "AuctionRegistrationRoute_me";
 };
 export type AuctionRegistrationRoute_me$data = AuctionRegistrationRoute_me;
@@ -36,10 +37,17 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "identityVerified",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasQualifiedCreditCards",
+      "storageKey": null
     }
   ],
   "type": "Me",
   "abstractKey": null
 };
-(node as any).hash = '743e2c1e4789262ab1a7c5fa5ad34834';
+(node as any).hash = 'b06ca5bee581b2dc45e4b0da0ecf12e9';
 export default node;

--- a/src/v2/__generated__/auctionRoutes_RegisterRouteQuery.graphql.ts
+++ b/src/v2/__generated__/auctionRoutes_RegisterRouteQuery.graphql.ts
@@ -39,6 +39,7 @@ query auctionRoutes_RegisterRouteQuery(
 fragment AuctionRegistrationRoute_me on Me {
   internalID
   identityVerified
+  hasQualifiedCreditCards
 }
 
 fragment AuctionRegistrationRoute_sale on Sale {
@@ -150,6 +151,13 @@ return {
             "name": "identityVerified",
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hasQualifiedCreditCards",
+            "storageKey": null
+          },
           (v3/*: any*/)
         ],
         "storageKey": null
@@ -231,12 +239,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fa1ce5fe7290ea4a32e0a766698dda96",
+    "cacheID": "efd89b639accdfc0db7af7e653659edd",
     "id": null,
     "metadata": {},
     "name": "auctionRoutes_RegisterRouteQuery",
     "operationKind": "query",
-    "text": "query auctionRoutes_RegisterRouteQuery(\n  $slug: String!\n) {\n  me {\n    ...AuctionRegistrationRoute_me\n    id\n  }\n  sale(id: $slug) @principalField {\n    ...AuctionRegistrationRoute_sale\n    id\n  }\n}\n\nfragment AuctionRegistrationRoute_me on Me {\n  internalID\n  identityVerified\n}\n\nfragment AuctionRegistrationRoute_sale on Sale {\n  slug\n  name\n  internalID\n  status\n  requireIdentityVerification\n  isClosed\n  isLiveOpen\n  bidder {\n    qualifiedForBidding\n    id\n  }\n}\n"
+    "text": "query auctionRoutes_RegisterRouteQuery(\n  $slug: String!\n) {\n  me {\n    ...AuctionRegistrationRoute_me\n    id\n  }\n  sale(id: $slug) @principalField {\n    ...AuctionRegistrationRoute_sale\n    id\n  }\n}\n\nfragment AuctionRegistrationRoute_me on Me {\n  internalID\n  identityVerified\n  hasQualifiedCreditCards\n}\n\nfragment AuctionRegistrationRoute_sale on Sale {\n  slug\n  name\n  internalID\n  status\n  requireIdentityVerification\n  isClosed\n  isLiveOpen\n  bidder {\n    qualifiedForBidding\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Bugfix**

- [Link to register requiring credit card for returning bidders](https://www.notion.so/artsy/3b2ab528673e4b5892db9d7081466166?v=80f170f7972e4a20b9bad42a3650cb9a&p=9af839a5e6b24658a23b06fc768eb6e8)
- Other misc sort + pagination issue on initial load, where it wouldn't sort properly on page 2

### Description

Found an issue where when the user clicks page 2, the default sort is no longer applied. (However, if the user selected a sort, then its in the url bar, and it works fine.) 

Also fixes an issue where if a user already had a credit card on file /register would still show the registration form. Normally a user can't get to this URL from the UI, but didn't realize that ops folks were pasting it into emails. Now we'll check that condition and then redirect to /confirm-registration. 

Also added more checks around logged in status for those two routes (previously we were only checking for /bid) 

cc @artsy/grow-devs 
