### PR TITLE
feat(CX-2409): When the user has the SWA<>MYCollection feature enabled - show updated copy

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
@@ -30,11 +30,12 @@ export const ThankYou: React.FC = () => {
       <Box maxWidth="720px" mt={4}>
         <Text variant="lg" color="black60">
           We will email you within 1-3 days to confirm if your artwork has been
-          accepted or not.
+          accepted or not. In the meantime your submission will appear in the
+          feature, My Collection, on the Artsy app.
         </Text>
         <Text variant="lg" mt={2} color="black60">
-          In the meantime your submission will appear in the feature, My
-          Collection, on the Artsy app.
+          With low fees, informed pricing, and multiple sales options, why not
+          submit another piece with Artsy.
         </Text>
       </Box>
 

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
@@ -26,7 +26,7 @@ export const ThankYou: React.FC = () => {
 
   return (
     <>
-      {!isSWAMCEnabled ? (
+      {isSWAMCEnabled ? (
         <>
           <Text variant="xxl" mt={4}>
             Your artwork has been submitted

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
@@ -6,11 +6,13 @@ import { DownloadApps } from "./Components/DownloadApps"
 import { AnalyticsSchema, useSystemContext, useTracking } from "v2/System"
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { useRouter } from "v2/System/Router/useRouter"
+import { useFeatureFlag } from "v2/System/useFeatureFlag"
 
 export const ThankYou: React.FC = () => {
   const { user, isLoggedIn } = useSystemContext()
   const { match } = useRouter()
   const { trackEvent } = useTracking()
+  const isSWAMCEnabled = useFeatureFlag("swa_my_collection")
 
   const trackSubmitAnotherWorkClick = () =>
     trackEvent({
@@ -24,20 +26,40 @@ export const ThankYou: React.FC = () => {
 
   return (
     <>
-      <Text variant="xxl" mt={4}>
-        Your artwork has been submitted
-      </Text>
-      <Box maxWidth="720px" mt={4}>
-        <Text variant="lg" color="black60">
-          We will email you within 1-3 days to confirm if your artwork has been
-          accepted or not. In the meantime your submission will appear in the
-          feature, My Collection, on the Artsy app.
-        </Text>
-        <Text variant="lg" mt={2} color="black60">
-          With low fees, informed pricing, and multiple sales options, why not
-          submit another piece with Artsy.
-        </Text>
-      </Box>
+      {!isSWAMCEnabled ? (
+        <>
+          <Text variant="xxl" mt={4}>
+            Your artwork has been submitted
+          </Text>
+          <Box maxWidth="720px" mt={4}>
+            <Text variant="lg" color="black60">
+              We will email you within 1-3 days to confirm if your artwork has
+              been accepted or not. In the meantime your submission will appear
+              in the feature, My Collection, on the Artsy app.
+            </Text>
+            <Text variant="lg" mt={2} color="black60">
+              With low fees, informed pricing, and multiple sales options, why
+              not submit another piece with Artsy.
+            </Text>
+          </Box>
+        </>
+      ) : (
+        <>
+          <Text variant="xxl" mt={4}>
+            Thank you for submitting a work
+          </Text>
+          <Box maxWidth="720px" mt={4}>
+            <Text variant="lg">
+              We’ll email you within 1–3 business days to let you know the
+              status of your submission.
+            </Text>
+            <Text variant="lg" mt={2}>
+              In the meantime, feel free to submit another work—and benefit from
+              Artsy’s low fees, informed pricing, and multiple selling options.
+            </Text>
+          </Box>
+        </>
+      )}
 
       <Flex
         py={2}

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
@@ -25,16 +25,16 @@ export const ThankYou: React.FC = () => {
   return (
     <>
       <Text variant="xxl" mt={4}>
-        Thank you for submitting a work
+        Your artwork has been submitted
       </Text>
       <Box maxWidth="720px" mt={4}>
-        <Text variant="lg">
-          We’ll email you within 1–3 business days to let you know the status of
-          your submission.
+        <Text variant="lg" color="black60">
+          We will email you within 1-3 days to confirm if your artwork has been
+          accepted or not.
         </Text>
-        <Text variant="lg" mt={2}>
-          In the meantime, feel free to submit another work—and benefit from
-          Artsy’s low fees, informed pricing, and multiple selling options.
+        <Text variant="lg" mt={2} color="black60">
+          In the meantime your submission will appear in the feature, My
+          Collection, on the Artsy app.
         </Text>
       </Box>
 

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYou.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYou.jest.tsx
@@ -46,30 +46,81 @@ describe("ThankYou page", () => {
     })
   })
 
-  it("renders correctly", () => {
-    const wrapper = mount(<ThankYou />)
-    const text = wrapper.text()
+  describe("when ff enabled", () => {
+    beforeEach(() => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => {
+        return {
+          featureFlags: {
+            swa_my_collection: {
+              flagEnabled: true,
+            },
+          },
+        }
+      })
+    })
+    it("renders correctly", () => {
+      const wrapper = mount(<ThankYou />)
+      const text = wrapper.text()
 
-    expect(text).toContain("Your artwork has been submitted")
-    expect(text).toContain(
-      "We will email you within 1-3 days to confirm if your artwork has been accepted or not. In the meantime your submission will appear in the feature, My Collection, on the Artsy app."
-    )
-    expect(text).toContain(
-      "With low fees, informed pricing, and multiple sales options, why not submit another piece with Artsy."
-    )
+      expect(text).toContain("Your artwork has been submitted")
+      expect(text).toContain(
+        "We will email you within 1-3 days to confirm if your artwork has been accepted or not. In the meantime your submission will appear in the feature, My Collection, on the Artsy app."
+      )
+      expect(text).toContain(
+        "With low fees, informed pricing, and multiple sales options, why not submit another piece with Artsy."
+      )
 
-    expect(
-      wrapper.find("button[data-test-id='submit-another-work']").text()
-    ).toContain("Submit Another Work")
+      expect(
+        wrapper.find("button[data-test-id='submit-another-work']").text()
+      ).toContain("Submit Another Work")
 
-    expect(
-      wrapper.find("button[data-test-id='go-to-artsy-homepage']").text()
-    ).toContain("Back to Artsy Homepage")
+      expect(
+        wrapper.find("button[data-test-id='go-to-artsy-homepage']").text()
+      ).toContain("Back to Artsy Homepage")
 
-    expect(text).toContain("View My Collection on the Artsy App")
+      expect(text).toContain("View My Collection on the Artsy App")
 
-    expect(wrapper.find("SoldRecentlyQueryRenderer").length).toBe(1)
-    expect(wrapper.find("FAQ").length).toBe(1)
+      expect(wrapper.find("SoldRecentlyQueryRenderer").length).toBe(1)
+      expect(wrapper.find("FAQ").length).toBe(1)
+    })
+  })
+  describe("when ff disabled", () => {
+    beforeEach(() => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => {
+        return {
+          featureFlags: {
+            swa_my_collection: {
+              flagEnabled: false,
+            },
+          },
+        }
+      })
+    })
+    it("renders correctly", () => {
+      const wrapper = mount(<ThankYou />)
+      const text = wrapper.text()
+
+      expect(text).toContain("Thank you for submitting a work")
+      expect(text).toContain(
+        "We’ll email you within 1–3 business days to let you know the status of your submission."
+      )
+      expect(text).toContain(
+        "In the meantime, feel free to submit another work—and benefit from Artsy’s low fees, informed pricing, and multiple selling options."
+      )
+
+      expect(
+        wrapper.find("button[data-test-id='submit-another-work']").text()
+      ).toContain("Submit Another Work")
+
+      expect(
+        wrapper.find("button[data-test-id='go-to-artsy-homepage']").text()
+      ).toContain("Back to Artsy Homepage")
+
+      expect(text).toContain("View My Collection on the Artsy App")
+
+      expect(wrapper.find("SoldRecentlyQueryRenderer").length).toBe(1)
+      expect(wrapper.find("FAQ").length).toBe(1)
+    })
   })
 
   describe("when user logged in", () => {

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYou.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYou.jest.tsx
@@ -50,12 +50,12 @@ describe("ThankYou page", () => {
     const wrapper = mount(<ThankYou />)
     const text = wrapper.text()
 
-    expect(text).toContain("Thank you for submitting a work")
+    expect(text).toContain("Your artwork has been submitted")
     expect(text).toContain(
-      "We’ll email you within 1–3 business days to let you know the status of your submission"
+      "We will email you within 1-3 days to confirm if your artwork has been accepted or not. In the meantime your submission will appear in the feature, My Collection, on the Artsy app."
     )
     expect(text).toContain(
-      "In the meantime, feel free to submit another work—and benefit from Artsy’s low fees, informed pricing, and multiple selling options"
+      "With low fees, informed pricing, and multiple sales options, why not submit another piece with Artsy."
     )
 
     expect(


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2409]

### Description
Updated copy on SWA confirmation page to mention that submission is in MyC
When FF "swa_my_collection" is disabled   | When FF "swa_my_collection" is enabled
------------- | -------------
![IMAGE 2022-03-17 14:02:19](https://user-images.githubusercontent.com/36167539/158814067-da4e9401-a31a-4c92-9d61-8c7a47fc5dc8.jpg) | ![IMAGE 2022-03-17 14:39:54](https://user-images.githubusercontent.com/36167539/158820878-dfa00151-9d0b-42c4-a8ad-35344d26d9d6.jpg)






<!-- Implementation description -->
Updated copy on SWA confirmation page to mention that submission is in MyC -daria

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2408]: https://artsyproduct.atlassian.net/browse/CX-2408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CX-2409]: https://artsyproduct.atlassian.net/browse/CX-2409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ