### PR TITLE
fix: Fix timer showing time to end when sale has not yet started

### DIFF
--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
@@ -23,7 +23,8 @@ export const FairOrganizerHeader: React.FC<FairOrganizerHeaderProps> = ({
   const { startAt, exhibitionPeriod, href } = fair
 
   const currentTime = useCurrentTime({ syncWithServer: true })
-  const showTimer = DateTime.fromISO(currentTime) < DateTime.fromISO(startAt!)
+  const fairHasNotStarted =
+    DateTime.fromISO(currentTime) < DateTime.fromISO(startAt!)
 
   return (
     <Box>
@@ -50,7 +51,10 @@ export const FairOrganizerHeader: React.FC<FairOrganizerHeaderProps> = ({
         <Column span={6}>
           <Flex flexDirection="column">
             <Box>
-              {showTimer && (
+              {/* endAt is not passed to the Timer because this timer will always run
+              before the fair starts and therefore the timer only needs to know the length
+              of time before the fair begins, so the fair's end time is irrelevant */}
+              {fairHasNotStarted && (
                 <>
                   <Timer
                     variant={["lg", "xl"]}

--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
@@ -51,9 +51,9 @@ export const FairOrganizerHeader: React.FC<FairOrganizerHeaderProps> = ({
         <Column span={6}>
           <Flex flexDirection="column">
             <Box>
-              {/* endAt is not passed to the Timer because this timer will always run
-              before the fair starts and therefore the timer only needs to know the length
-              of time before the fair begins, so the fair's end time is irrelevant */}
+              {/* endAt is not passed to the Timer because this timer will only be shown
+              before the fair starts. Therefore the timer only needs to know the length
+              of time before the fair begins. The fair's end time is irrelevant. */}
               {fairHasNotStarted && (
                 <>
                   <Timer

--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { DateTime } from "luxon"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Box, Column, Flex, GridColumns, Spacer, Text } from "@artsy/palette"
@@ -55,7 +55,8 @@ export const FairOrganizerHeader: React.FC<FairOrganizerHeaderProps> = ({
                   <Timer
                     variant={["lg", "xl"]}
                     label="Opens in:"
-                    endDate={startAt!}
+                    startDate={startAt!}
+                    endDate=""
                   />
                   <Spacer mt={30} />
                 </>

--- a/src/v2/Components/Timer.tsx
+++ b/src/v2/Components/Timer.tsx
@@ -14,6 +14,7 @@ const SEPARATOR = <>&nbsp;&nbsp;</>
 export const Timer: React.FC<
   {
     endDate: string
+    startDate?: string
     labelWithTimeRemaining?: string
     labelWithoutTimeRemaining?: string
     label?: string
@@ -21,13 +22,14 @@ export const Timer: React.FC<
     TextProps
 > = ({
   endDate,
+  startDate,
   labelWithTimeRemaining,
   labelWithoutTimeRemaining,
   label = "",
   variant = "md",
   ...rest
 }) => {
-  const { hasEnded, time } = useTimer(endDate)
+  const { hasEnded, time } = useTimer(endDate, startDate)
   const { days, hours, minutes, seconds } = time
 
   const tokens = useThemeConfig({

--- a/src/v2/Components/__tests__/Timer.jest.tsx
+++ b/src/v2/Components/__tests__/Timer.jest.tsx
@@ -11,58 +11,143 @@ require("v2/Utils/getCurrentTimeAsIsoString").__setCurrentTime(
 )
 
 const getTimerText = timerComponent =>
+  // eslint-disable-next-line testing-library/await-async-query
   timerComponent.root.findAllByType(Text)[0].props.children.join("")
 
-it("formats the remaining time in '00d  00h  00m  00s'", () => {
-  let timer
+describe("when the end date is set", () => {
+  it("formats the remaining time in '00d  00h  00m  00s'", () => {
+    let timer
 
-  // Thursday, May 14, 2018 10:24:31.000 AM UTC
-  timer = renderer.create(<Timer endDate="2018-05-14T10:24:31+00:00" />)
-  expect(getTimerText(timer)).toMatch("03d")
-  expect(getTimerText(timer)).toMatch("14h")
-  expect(getTimerText(timer)).toMatch("01m")
-  expect(getTimerText(timer)).toMatch("59s")
+    // Thursday, May 14, 2018 10:24:31.000 AM UTC
+    timer = renderer.create(<Timer endDate="2018-05-14T10:24:31+00:00" />)
+    expect(getTimerText(timer)).toMatch("03d")
+    expect(getTimerText(timer)).toMatch("14h")
+    expect(getTimerText(timer)).toMatch("01m")
+    expect(getTimerText(timer)).toMatch("59s")
 
-  // Thursday, May 10, 2018 8:42:32.000 PM UTC
-  timer = renderer.create(<Timer endDate="2018-05-10T20:42:32+00:00" />)
-  expect(getTimerText(timer)).toMatch("00d")
-  expect(getTimerText(timer)).toMatch("00h")
-  expect(getTimerText(timer)).toMatch("20m")
-  expect(getTimerText(timer)).toMatch("00s")
+    // Thursday, May 10, 2018 8:42:32.000 PM UTC
+    timer = renderer.create(<Timer endDate="2018-05-10T20:42:32+00:00" />)
+    expect(getTimerText(timer)).toMatch("00d")
+    expect(getTimerText(timer)).toMatch("00h")
+    expect(getTimerText(timer)).toMatch("20m")
+    expect(getTimerText(timer)).toMatch("00s")
 
-  // Thursday, May 10, 2018 8:22:42.000 PM UTC
-  timer = renderer.create(<Timer endDate="2018-05-10T20:22:42+00:00" />)
-  expect(getTimerText(timer)).toMatch("00d")
-  expect(getTimerText(timer)).toMatch("00h")
-  expect(getTimerText(timer)).toMatch("0m")
-  expect(getTimerText(timer)).toMatch("10s")
+    // Thursday, May 10, 2018 8:22:42.000 PM UTC
+    timer = renderer.create(<Timer endDate="2018-05-10T20:22:42+00:00" />)
+    expect(getTimerText(timer)).toMatch("00d")
+    expect(getTimerText(timer)).toMatch("00h")
+    expect(getTimerText(timer)).toMatch("0m")
+    expect(getTimerText(timer)).toMatch("10s")
 
-  // In the past
-  timer = renderer.create(<Timer endDate="2018-04-10T20:22:42+00:00" />)
-  expect(getTimerText(timer)).toMatch("00d")
-  expect(getTimerText(timer)).toMatch("00h")
-  expect(getTimerText(timer)).toMatch("00m")
-  expect(getTimerText(timer)).toMatch("00s")
+    // In the past
+    timer = renderer.create(<Timer endDate="2018-04-10T20:22:42+00:00" />)
+    expect(getTimerText(timer)).toMatch("00d")
+    expect(getTimerText(timer)).toMatch("00h")
+    expect(getTimerText(timer)).toMatch("00m")
+    expect(getTimerText(timer)).toMatch("00s")
+  })
+
+  it("counts down to zero", () => {
+    let timer = renderer.create(<Timer endDate="2018-05-14T10:23:10+00:00" />)
+    expect(getTimerText(timer)).toMatch("03d")
+    expect(getTimerText(timer)).toMatch("14h")
+    expect(getTimerText(timer)).toMatch("00m")
+    expect(getTimerText(timer)).toMatch("38s")
+
+    timer = renderer.create(<Timer endDate="2018-05-14T10:23:08+00:00" />)
+    jest.runOnlyPendingTimers()
+    expect(getTimerText(timer)).toMatch("03d")
+    expect(getTimerText(timer)).toMatch("14h")
+    expect(getTimerText(timer)).toMatch("00m")
+    expect(getTimerText(timer)).toMatch("36s")
+
+    timer = renderer.create(<Timer endDate="2018-05-14T10:22:08+00:00" />)
+    jest.runOnlyPendingTimers()
+    expect(getTimerText(timer)).toMatch("03d")
+    expect(getTimerText(timer)).toMatch("13h")
+    expect(getTimerText(timer)).toMatch("59m")
+    expect(getTimerText(timer)).toMatch("36s")
+  })
 })
 
-it("counts down to zero", () => {
-  let timer = renderer.create(<Timer endDate="2018-05-14T10:23:10+00:00" />)
-  expect(getTimerText(timer)).toMatch("03d")
-  expect(getTimerText(timer)).toMatch("14h")
-  expect(getTimerText(timer)).toMatch("00m")
-  expect(getTimerText(timer)).toMatch("38s")
+describe("when the start date and the end dates are set", () => {
+  it("formats the remaining time in '00d  00h  00m  00s'", () => {
+    let timer
 
-  timer = renderer.create(<Timer endDate="2018-05-14T10:23:08+00:00" />)
-  jest.runOnlyPendingTimers()
-  expect(getTimerText(timer)).toMatch("03d")
-  expect(getTimerText(timer)).toMatch("14h")
-  expect(getTimerText(timer)).toMatch("00m")
-  expect(getTimerText(timer)).toMatch("36s")
+    // Starts Thursday, May 12, 2018 10:24:31.000 AM UTC
+    timer = renderer.create(
+      <Timer
+        startDate="2018-05-12T10:24:31+00:00"
+        endDate="2018-05-14T10:24:31+00:00"
+      />
+    )
+    expect(getTimerText(timer)).toMatch("01d")
+    expect(getTimerText(timer)).toMatch("14h")
+    expect(getTimerText(timer)).toMatch("01m")
+    expect(getTimerText(timer)).toMatch("59s")
 
-  timer = renderer.create(<Timer endDate="2018-05-14T10:22:08+00:00" />)
-  jest.runOnlyPendingTimers()
-  expect(getTimerText(timer)).toMatch("03d")
-  expect(getTimerText(timer)).toMatch("13h")
-  expect(getTimerText(timer)).toMatch("59m")
-  expect(getTimerText(timer)).toMatch("36s")
+    // Starts Thursday, May 10, 2018 8:42:32.000 PM UTC
+    timer = renderer.create(
+      <Timer
+        startDate="2018-05-10T10:24:31+00:00"
+        endDate="2018-05-10T20:42:32+00:00"
+      />
+    )
+    expect(getTimerText(timer)).toMatch("00d")
+    expect(getTimerText(timer)).toMatch("00h")
+    expect(getTimerText(timer)).toMatch("20m")
+    expect(getTimerText(timer)).toMatch("00s")
+
+    // Starts Thursday, May 10, 2018 8:22:42.000 PM UTC
+    timer = renderer.create(
+      <Timer
+        startDate="2018-05-10T20:22:42+00:00"
+        endDate="2018-05-10T20:22:42+00:00"
+      />
+    )
+    expect(getTimerText(timer)).toMatch("00d")
+    expect(getTimerText(timer)).toMatch("00h")
+    expect(getTimerText(timer)).toMatch("0m")
+    expect(getTimerText(timer)).toMatch("10s")
+
+    // Start date in the past, end date in the future
+    timer = renderer.create(
+      <Timer
+        startDate="2018-04-10T20:22:42+00:00"
+        endDate="2018-05-10T20:22:42+00:00"
+      />
+    )
+    expect(getTimerText(timer)).toMatch("00d")
+    expect(getTimerText(timer)).toMatch("00h")
+    expect(getTimerText(timer)).toMatch("0m")
+    expect(getTimerText(timer)).toMatch("10s")
+  })
+
+  it("counts down to zero", () => {
+    let timer = renderer.create(
+      <Timer startDate="2018-05-14T10:23:10+00:00" endDate="" />
+    )
+    expect(getTimerText(timer)).toMatch("03d")
+    expect(getTimerText(timer)).toMatch("14h")
+    expect(getTimerText(timer)).toMatch("00m")
+    expect(getTimerText(timer)).toMatch("38s")
+
+    timer = renderer.create(
+      <Timer startDate="2018-05-14T10:23:08+00:00" endDate="" />
+    )
+    jest.runOnlyPendingTimers()
+    expect(getTimerText(timer)).toMatch("03d")
+    expect(getTimerText(timer)).toMatch("14h")
+    expect(getTimerText(timer)).toMatch("00m")
+    expect(getTimerText(timer)).toMatch("36s")
+
+    timer = renderer.create(
+      <Timer startDate="2018-05-14T10:22:08+00:00" endDate="" />
+    )
+    jest.runOnlyPendingTimers()
+    expect(getTimerText(timer)).toMatch("03d")
+    expect(getTimerText(timer)).toMatch("13h")
+    expect(getTimerText(timer)).toMatch("59m")
+    expect(getTimerText(timer)).toMatch("36s")
+  })
 })

--- a/src/v2/Components/__tests__/Timer.jest.tsx
+++ b/src/v2/Components/__tests__/Timer.jest.tsx
@@ -70,7 +70,7 @@ describe("when the end date is set", () => {
   })
 })
 
-describe("when the start date and the end dates are set", () => {
+describe("when the start and the end dates are set", () => {
   it("formats the remaining time before start when the start date is in the future", () => {
     let timer
 
@@ -89,8 +89,8 @@ describe("when the start date and the end dates are set", () => {
     // Starts Thursday, May 10, 2018 8:42:32.000 PM UTC
     timer = renderer.create(
       <Timer
-        startDate="2018-05-10T10:24:31+00:00"
-        endDate="2018-05-10T20:42:32+00:00"
+        startDate="2018-05-10T20:42:32+00:00"
+        endDate="2018-05-12T20:42:32+00:00"
       />
     )
     expect(getTimerText(timer)).toMatch("00d")
@@ -102,7 +102,7 @@ describe("when the start date and the end dates are set", () => {
     timer = renderer.create(
       <Timer
         startDate="2018-05-10T20:22:42+00:00"
-        endDate="2018-05-10T20:22:42+00:00"
+        endDate="2018-05-12T20:22:42+00:00"
       />
     )
     expect(getTimerText(timer)).toMatch("00d")

--- a/src/v2/Components/__tests__/Timer.jest.tsx
+++ b/src/v2/Components/__tests__/Timer.jest.tsx
@@ -71,7 +71,7 @@ describe("when the end date is set", () => {
 })
 
 describe("when the start date and the end dates are set", () => {
-  it("formats the remaining time in '00d  00h  00m  00s'", () => {
+  it("formats the remaining time before start when the start date is in the future", () => {
     let timer
 
     // Starts Thursday, May 12, 2018 10:24:31.000 AM UTC
@@ -109,9 +109,10 @@ describe("when the start date and the end dates are set", () => {
     expect(getTimerText(timer)).toMatch("00h")
     expect(getTimerText(timer)).toMatch("0m")
     expect(getTimerText(timer)).toMatch("10s")
+  })
 
-    // Start date in the past, end date in the future
-    timer = renderer.create(
+  it("formats the time before sale end when the start date has passed", () => {
+    const timer = renderer.create(
       <Timer
         startDate="2018-04-10T20:22:42+00:00"
         endDate="2018-05-10T20:22:42+00:00"
@@ -123,7 +124,7 @@ describe("when the start date and the end dates are set", () => {
     expect(getTimerText(timer)).toMatch("10s")
   })
 
-  it("counts down to zero", () => {
+  it("counts down to zero when the start date is populated", () => {
     let timer = renderer.create(
       <Timer startDate="2018-05-14T10:23:10+00:00" endDate="" />
     )

--- a/src/v2/Utils/Hooks/useTimer.tsx
+++ b/src/v2/Utils/Hooks/useTimer.tsx
@@ -35,6 +35,8 @@ export const useTimer = (endDate: string, startAt: string = ""): Timer => {
   )
   const hasStarted = Math.floor(timeBeforeStart.seconds) <= 0
 
+  // If startAt is passed into this hook and it is in the future,
+  // show the time before start. Otherwise show the time before end.
   const duration =
     hasStarted || startAt === "" ? timeBeforeEnd : timeBeforeStart
 

--- a/src/v2/Utils/Hooks/useTimer.tsx
+++ b/src/v2/Utils/Hooks/useTimer.tsx
@@ -35,7 +35,8 @@ export const useTimer = (endDate: string, startAt: string = ""): Timer => {
   )
   const hasStarted = Math.floor(timeBeforeStart.seconds) <= 0
 
-  const duration = hasStarted ? timeBeforeEnd : timeBeforeStart
+  const duration =
+    hasStarted || startAt === "" ? timeBeforeEnd : timeBeforeStart
 
   const days = extractTime(duration.as("days"))
   const hours = extractTime(duration.as("hours") % 24)

--- a/src/v2/Utils/Hooks/useTimer.tsx
+++ b/src/v2/Utils/Hooks/useTimer.tsx
@@ -25,15 +25,17 @@ const extractTime = (time: number) => {
 export const useTimer = (endDate: string, startAt: string = ""): Timer => {
   const currentTime = useCurrentTime({ syncWithServer: true })
 
-  const duration = Duration.fromISO(
+  const timeBeforeEnd = Duration.fromISO(
     DateTime.fromISO(endDate).diff(DateTime.fromISO(currentTime)).toString()
   )
-  const hasEnded = Math.floor(duration.seconds) <= 0
+  const hasEnded = Math.floor(timeBeforeEnd.seconds) <= 0
 
   const timeBeforeStart = Duration.fromISO(
     DateTime.fromISO(startAt).diff(DateTime.fromISO(currentTime)).toString()
   )
   const hasStarted = Math.floor(timeBeforeStart.seconds) <= 0
+
+  const duration = hasStarted ? timeBeforeEnd : timeBeforeStart
 
   const days = extractTime(duration.as("days"))
   const hours = extractTime(duration.as("hours") % 24)


### PR DESCRIPTION
When working on the lot page timer, I forgot to conditionally show the time until the sale ends vs. the time until the sale starts based on whether or not the sale has started. This PR fixes that.
https://artsyproduct.atlassian.net/browse/BID-272

**Uses of `useTimer` and `<Timer/>**

_Fair Timer_
Currently live fair:
<img width="357" alt="Screen Shot 2022-03-17 at 4 04 20 PM" src="https://user-images.githubusercontent.com/9466631/158886247-4d5c7999-ab87-4bef-b869-3815743904c7.png">

Past fair:
<img width="433" alt="Screen Shot 2022-03-17 at 4 04 43 PM" src="https://user-images.githubusercontent.com/9466631/158886303-6c372393-80c5-4da9-b67b-8fc707d258f0.png">

Upcoming fair:
<img width="325" alt="Screen Shot 2022-03-17 at 4 05 37 PM" src="https://user-images.githubusercontent.com/9466631/158886431-4dd7a91c-1e1f-4751-8437-9cd2bdbbd0d4.png">


_Lot Timer:_
Sale start date is in the future:
Before (date corresponding with end of sale):
<img width="521" alt="Screen Shot 2022-03-17 at 9 10 49 AM" src="https://user-images.githubusercontent.com/9466631/158822818-6d212ab9-9ef8-43da-a5cc-7559c2efba40.png">

After (date corresponding with beginning of sale):
<img width="357" alt="Screen Shot 2022-03-17 at 9 15 55 AM" src="https://user-images.githubusercontent.com/9466631/158822801-aa7c5db5-aef8-4d8b-aba4-f68c72033fb9.png">

_Auction Timer:_
In progress live sale:
<img width="233" alt="Screen Shot 2022-03-17 at 4 13 27 PM" src="https://user-images.githubusercontent.com/9466631/158887636-e16c658a-90c0-41a9-af34-41044a22217d.png">

Upcoming live sale:
<img width="179" alt="Screen Shot 2022-03-17 at 4 14 18 PM" src="https://user-images.githubusercontent.com/9466631/158887741-46ab6766-0050-4b4c-8f5a-ec180a290065.png">

Upcoming OO sale:
<img width="185" alt="Screen Shot 2022-03-17 at 4 15 43 PM" src="https://user-images.githubusercontent.com/9466631/158887948-edc83acb-4b2a-4380-b81c-71bbe5285c9c.png">

