### PR TITLE
fix(GRO-892): Redirect from the old /sale path to /auction

### DIFF
--- a/src/v2/Apps/Auction/auctionRoutes.tsx
+++ b/src/v2/Apps/Auction/auctionRoutes.tsx
@@ -1,4 +1,5 @@
 import loadable from "@loadable/component"
+import { Redirect } from "found"
 import { graphql } from "relay-runtime"
 import { getInitialFilterState } from "v2/Components/ArtworkFilter/Utils/getInitialFilterState"
 import { AppRouteConfig } from "v2/System/Router/Route"
@@ -165,6 +166,16 @@ export const auctionRoutes: AppRouteConfig[] = [
         }
       }
     `,
+  },
+  {
+    // Redirect from the old route to the new one
+    path: "/sale/:slug?",
+    children: [
+      new Redirect({
+        from: "/",
+        to: "/auction/:slug?",
+      }) as any,
+    ],
   },
 ]
 


### PR DESCRIPTION
The type of this PR is: **Bugfix** (kinda)

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-892]

### Description

I'm not 100% certain this is the preferred way to accomplish this with our router, but it does seem to work! 😆 

cc @damon is this fine to do?

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-892]: https://artsyproduct.atlassian.net/browse/GRO-892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ