### PR TITLE
notify #dev on failed prod deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,9 +414,10 @@ workflows:
             - horizon/block
             - validate_production_schema
           post-steps:
+          # notify: practice-web, dev
             - slack/notify:
                 event: fail
-                channel: "practice-web"
+                channel: 'C2TQ4PT8R, C02BC3HEJ'
                 template: basic_fail_1
 
       # Other


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

Action item from incident review (#141). Notify engineering when a force deploy fails.

Looking at #practice-web channel, I do not see any post-steps logging, only the slack notifications from the [validate_production_schema](https://github.com/artsy/force/blob/main/.circleci/config.yml#L33). I wonder if using channel IDs would help as the configuration seems correct to me.

The slack app _should_ be able to send notifications to #dev as it is authorized to do so:

<img width="438" alt="Screen Shot 2022-03-17 at 3 32 49 PM" src="https://user-images.githubusercontent.com/29984068/158881608-24ece062-31b2-4fc1-aac9-32f7fb71b49d.png">




[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ