### PR TITLE
(Fix): add view all artworks CTA to trove rail

### DIFF
--- a/src/v2/Apps/Home/Components/HomeTroveArtworksRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeTroveArtworksRail.tsx
@@ -31,6 +31,8 @@ export const HomeTroveArtworksRail: React.FC<HomeTroveArtworksRailProps> = ({
     <Rail
       title="Trove"
       subTitle="A weekly curated selection of the best works on Artsy by emerging and sought after artists."
+      viewAllLabel="View All Works"
+      viewAllHref="/gene/trove"
       getItems={() => {
         return artworks.map(artwork => (
           <ShelfArtworkFragmentContainer


### PR DESCRIPTION
The type of this PR is: fix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-834]

### Description

<!-- Implementation description -->

The `View All Artworks` tab was missing from the Trove Rail. It now links to `/gene/trove` collection page. 

<img width="1240" alt="Screen Shot 2022-03-17 at 4 21 57 PM" src="https://user-images.githubusercontent.com/23108927/158897929-5df694d4-68b8-4552-850c-34ab2c3396ad.png">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-834]: https://artsyproduct.atlassian.net/browse/GRO-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ