### PR TITLE
chore: add horizontal offsets for histogram

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilterNew.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilterNew.tsx
@@ -127,7 +127,7 @@ export const PriceRangeFilterNew: FC<PriceRangeFilterNewProps> = ({
         </Box>
       </Flex>
 
-      <Box mt={4} mx={[RANGE_DOT_SIZE / 2, 0]}>
+      <Box mt={4} mx={`${RANGE_DOT_SIZE / 2}px`}>
         {bars.length > 0 ? (
           <Histogram
             bars={bars}


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description
Add horizontal offsets (`12px`) for histogram

### Demo
#### Before
<img width="486" alt="hisogram-before" src="https://user-images.githubusercontent.com/3513494/159339316-511385a4-c83f-4b49-bcef-9a138a385431.png">

#### After
<img width="486" alt="histogram-after" src="https://user-images.githubusercontent.com/3513494/159339343-caa4b6eb-f0c5-4b41-9280-53e111212ddf.png">



<!-- Implementation description -->
