### PR TITLE
refactor: handle errors setting experimentsViewed on local storage

### DIFF
--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -104,5 +104,15 @@ function getExperimentsViewed(): string[] {
 }
 
 function setExperimentsViewed(experiments: string[]) {
-  window.localStorage.setItem("experimentsViewed", JSON.stringify(experiments))
+  try {
+    window.localStorage.setItem(
+      "experimentsViewed",
+      JSON.stringify(experiments)
+    )
+  } catch (e) {
+    console.error(
+      "[Force] Error: unable to set experimentsViewed on local storage: ",
+      e
+    )
+  }
 }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR solves [PLATFORM-4051]

### Description

If a user’s local storage is full, we have an uncaught exception breaking the app when trying to set `experimentsViewed`. The error should be handled and logged, but not break the app. Discussion of the original issue [here](https://artsy.slack.com/archives/C9YNS4X32/p1647876898691489). 