### PR TITLE
enh: add rebuild to detect-secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
 
             To fix, run:
               git reset --soft HEAD^
-              yarn detect-secrets
+              yarn detect-secrets:hook
           EOF
             exit $code
           fi
@@ -414,10 +414,10 @@ workflows:
             - horizon/block
             - validate_production_schema
           post-steps:
-          # notify: practice-web, dev
+            # notify: practice-web, dev
             - slack/notify:
                 event: fail
-                channel: 'C2TQ4PT8R, C02BC3HEJ'
+                channel: "C2TQ4PT8R, C02BC3HEJ"
                 template: basic_fail_1
 
       # Other

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -110,7 +110,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_secret",
       "pattern": [
-        "(foo|secret|reset|true|toggle|trackForgotClick|passwordNextButton)",
+        "(foo|secret|reset|true|toggle|trackForgotClick|passwordNextButton|hook)",
         "^https://.*$",
         "^onPassword.*$"
       ]

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "cypress:run": "./node_modules/.bin/cypress run",
     "cypress": "./node_modules/.bin/cypress open",
     "delete-review-app": "kubectl --context staging delete namespace",
-    "detect-secrets": "scripts/detect-secrets.sh",
+    "detect-secrets:hook": "scripts/detect-secrets.sh hook",
+    "detect-secrets:rebuild": "scripts/detect-secrets.sh rebuild",
     "docker": "DOCKER_BUILDKIT=1; BUILDKIT_PROGRESS=plain; COMPOSE_DOCKER_CLI_BUILD=1; docker build .",
     "docker:builder": "yarn docker --target builder -t force:builder",
     "docker:electron": "yarn docker --target electron-runner -t force:electron",
@@ -442,7 +443,7 @@
     }
   },
   "lint-staged": {
-    "*": "yarn detect-secrets",
+    "*": "yarn detect-secrets:hook",
     "*.@(md)": [
       "yarn prettier-write"
     ],

--- a/scripts/detect-secrets.sh
+++ b/scripts/detect-secrets.sh
@@ -7,17 +7,25 @@ GREEN=$(tput setaf 2)
 NO_COLOR=$(tput sgr0)
 
 HELP="${RED}command not found: detect-secrets${NO_COLOR}
-
 To install the command line tool re-run: ${GREEN}https://github.com/artsy/potential/blob/main/scripts/setup${NO_COLOR}
 To learn more about this tool: ${GREEN}https://www.notion.so/artsy/Detect-Secrets-cd11d994dabf45f6a3c18e07acb5431c${NO_COLOR}
-
 You can bypass this hook using --no-verify option. ${RED}USE AT YOUR OWN RISK!${NO_COLOR}"
 
-echo 'Executing detect-secrets...'
 if which detect-secrets > /dev/null; test $? != 0; then
   echo "${HELP}"
   exit 1
-else
-  detect-secrets-hook --baseline .secrets.baseline $(git diff --staged --name-only)
 fi
-echo "${GREEN}No secrets detected!${NO_COLOR}"
+
+hook() {
+  echo 'Executing detect-secrets-hook...'
+  detect-secrets-hook --baseline .secrets.baseline $(git diff --staged --name-only)
+  echo "${GREEN}No secrets detected!${NO_COLOR}"
+}
+
+rebuild() {
+  echo 'Executing detect-secrets scan...'
+  detect-secrets scan --baseline .secrets.baseline
+  echo "${GREEN}Baseline re-generated!${NO_COLOR}"
+}
+
+$1


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Following a [recent issue](https://artsy.slack.com/archives/CP9P4KR35/p1647897472182919) when `.secrets.baseline` became out of sync, (_as requested_) this adds yarn support to rebuild the _baseline_ when is necessary.

Modified the existing script to include functions and updated the calling code, references to use the new form.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ