### PR TITLE
Revert "chore(deps): update dep typescript from 4.3.5 to v4.6.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -417,7 +417,7 @@
     "stylus-loader": "3.0.2",
     "supertest": "2.0.1",
     "terser-webpack-plugin": "4.1.0",
-    "typescript": "4.6.2",
+    "typescript": "4.3.5",
     "typescript-styled-plugin": "0.15.0",
     "vscode-apollo-relay": "1.5.2",
     "webpack": "4.44.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20870,10 +20870,10 @@ typescript-template-language-service-decorator@^2.2.0:
   resolved "https://registry.yarnpkg.com/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.2.0.tgz#4ee6d580f307fb9239978e69626f2775b8a59b2a"
   integrity sha512-xiolqt1i7e22rpqMaprPgSFVgU64u3b9n6EJlAaUYE61jumipKAdI1+O5khPlWslpTUj80YzjUKjJ2jxT0D74w==
 
-typescript@4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+typescript@4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 ua-parser-js@^0.7.18:
   version "0.7.28"


### PR DESCRIPTION
This reverts commit 1f83593e851cd4aebcd6ef5166b68f6c0a1d10c2.

Will disable typescript from being automerged.