### PR TITLE
feat: change copies from input field in Offer

### DIFF
--- a/src/v2/Apps/Order/Components/MinPriceWarning.tsx
+++ b/src/v2/Apps/Order/Components/MinPriceWarning.tsx
@@ -22,19 +22,15 @@ export const MinPriceWarning: React.FC<MinPriceWarningProps> = ({
       flow: AnalyticsSchema.Flow.MakeOffer,
       order_id: orderID,
     })
-  }, [])
+  }, [orderID, tracking])
 
   return (
     <Clickable cursor="pointer" onClick={onClick} mt={2}>
       <Message variant="warning" p={2}>
         <Text>
-          Galleries usually accept offers within
           {isPriceRange
-            ? " the displayed price range"
-            : " 20% of the listed price"}
-          ; any lower is likely to be rejected.
-        </Text>
-        <Text style={{ textDecoration: "underline" }}>
+            ? "Offers lower than the displayed price range are often declined. "
+            : "Offers less than 20% of the list price are often declined. "}
           We recommend changing your offer to {minPrice}.
         </Text>
       </Message>

--- a/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
@@ -132,7 +132,7 @@ describe("PriceOptions", () => {
       fireEvent.click(radios[3])
       const input = await within(radios[3]).findByRole("textbox")
       const notice = await screen.findByText(
-        "We recommend changing your offer to US$100.00."
+        "Offers lower than the displayed price range are often declined. We recommend changing your offer to US$100.00."
       )
       expect(notice).toBeInTheDocument()
       expect(trackEvent).toHaveBeenCalledWith(
@@ -147,7 +147,7 @@ describe("PriceOptions", () => {
     it("selects the first option when clicking on the low price notice", async () => {
       fireEvent.click(radios[3])
       const notice = await screen.findByText(
-        "We recommend changing your offer to US$100.00."
+        "Offers lower than the displayed price range are often declined. We recommend changing your offer to US$100.00."
       )
       fireEvent.click(notice)
       const selected = screen.getAllByRole("radio", { checked: true })
@@ -183,7 +183,7 @@ describe("PriceOptions", () => {
       expect(radios[2]).toHaveTextContent("€90.00")
       expect(radios[3]).toHaveTextContent("Different amount")
     })
-    it("correctly tracks the clicking of an option", () => {
+    it("correctly tracks the clicking of an option", async () => {
       fireEvent.click(radios[0])
       expect(trackEvent).toHaveBeenLastCalledWith(
         expect.objectContaining(
@@ -206,6 +206,10 @@ describe("PriceOptions", () => {
       expect(trackEvent).toHaveBeenCalledWith(
         expect.objectContaining(getTrackingObject("Different amount", 0, "EUR"))
       )
+      const notice = await screen.findByText(
+        "Offers less than 20% of the list price are often declined. We recommend changing your offer to €80.00."
+      )
+      expect(notice).toBeInTheDocument()
     })
   })
   describe("Error Handling", () => {


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR solves [NX-3111]

### Description

Changes the copies from the low amount warning in the Offer. Slightly adjust the design removing underline decoration and not breaking the line anymore/

Price
![Screenshot 2022-03-23 at 10 40 09](https://user-images.githubusercontent.com/15792853/159671573-dd53e28e-b227-48bf-95bd-c0b33e2978f2.png)

Price Range
![Screenshot 2022-03-23 at 10 51 51](https://user-images.githubusercontent.com/15792853/159671893-590e0445-6004-49b5-ac89-52cd85b11c3c.png)

@artsy/negotiate-devs 




[NX-3111]: https://artsyproduct.atlassian.net/browse/NX-3111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ