### PR TITLE
feat(NOSF2): change order of options starting with the exact price

### DIFF
--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -96,17 +96,26 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
     }))
   }
 
+  const fixedPrice = Number(listPrice?.major)
+
+  const percentagePrices = [
+    { value: fixedPrice, description: "Exact price" },
+    {
+      value: Number([Math.round(fixedPrice * (1 - 0.1))]),
+      description: "10% below the list price",
+    },
+    {
+      value: Number([Math.round(fixedPrice * (1 - 0.2))]),
+      description: "20% below the list price",
+    },
+  ]
+
   const getPercentageOptions = () => {
-    return [0.2, 0.15, 0.1].map((pricePercentage, idx) => {
-      if (listPrice?.major) {
-        return {
-          key: `price-option-${idx}`,
-          value: Math.round(listPrice.major * (1 - pricePercentage)),
-          description: `${pricePercentage * 100}% below the list price`,
-        }
-      }
-      return
-    })
+    return percentagePrices.map((percentagePrice, idx) => ({
+      key: `price-option-${idx}`,
+      value: percentagePrice.value!,
+      description: percentagePrice.description,
+    }))
   }
 
   const priceOptions = artwork?.isPriceRange

--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -114,7 +114,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
   const priceOptions = artwork?.isPriceRange
     ? getRangeOptions()
     : getPercentageOptions()
-  const minPrice = priceOptions[0]?.value!
+  const minPrice = priceOptions[2]?.value!
 
   const { scrollTo } = useScrollTo({
     selectorOrRef: "#scrollTo--price-option-custom",

--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -96,16 +96,16 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
     }))
   }
 
-  const fixedPrice = Number(listPrice?.major)
+  const exactPrice = Number(listPrice?.major)
 
   const percentagePrices = [
-    { value: fixedPrice, description: "Exact price" },
+    { value: exactPrice, description: "Exact price" },
     {
-      value: Number([Math.round(fixedPrice * (1 - 0.1))]),
+      value: Number([Math.round(exactPrice * (1 - 0.1))]),
       description: "10% below the list price",
     },
     {
-      value: Number([Math.round(fixedPrice * (1 - 0.2))]),
+      value: Number([Math.round(exactPrice * (1 - 0.2))]),
       description: "20% below the list price",
     },
   ]

--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -96,26 +96,19 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
     }))
   }
 
-  const exactPrice = Number(listPrice?.major)
-
-  const percentagePrices = [
-    { value: exactPrice, description: "Exact price" },
-    {
-      value: Number([Math.round(exactPrice * (1 - 0.1))]),
-      description: "10% below the list price",
-    },
-    {
-      value: Number([Math.round(exactPrice * (1 - 0.2))]),
-      description: "20% below the list price",
-    },
-  ]
-
   const getPercentageOptions = () => {
-    return percentagePrices.map((percentagePrice, idx) => ({
-      key: `price-option-${idx}`,
-      value: percentagePrice.value!,
-      description: percentagePrice.description,
-    }))
+    return [0, 0.1, 0.2].map((pricePercentage, idx) => {
+      if (listPrice?.major) {
+        return {
+          key: `price-option-${idx}`,
+          value: Math.round(listPrice.major * (1 - pricePercentage)),
+          description: !!pricePercentage
+            ? `${pricePercentage * 100}% below the list price`
+            : "Exact price",
+        }
+      }
+      return
+    })
   }
 
   const priceOptions = artwork?.isPriceRange

--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -102,9 +102,10 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
         return {
           key: `price-option-${idx}`,
           value: Math.round(listPrice.major * (1 - pricePercentage)),
-          description: !!pricePercentage
-            ? `${pricePercentage * 100}% below the list price`
-            : "Exact price",
+          description:
+            pricePercentage !== 0
+              ? `${pricePercentage * 100}% below the list price`
+              : "Exact price",
         }
       }
       return

--- a/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
@@ -164,30 +164,31 @@ describe("PriceOptions", () => {
       expect(radios).toHaveLength(4)
     })
     it("correctly formats values", () => {
-      expect(radios[0]).toHaveTextContent("€80.00")
-      expect(radios[1]).toHaveTextContent("€85.00")
-      expect(radios[2]).toHaveTextContent("€90.00")
+      expect(radios[0]).toHaveTextContent("€100")
+      expect(radios[1]).toHaveTextContent("€90")
+      expect(radios[2]).toHaveTextContent("€80")
       expect(radios[3]).toHaveTextContent("Different amount")
     })
     it("correctly tracks the clicking of an option", async () => {
       fireEvent.click(radios[0])
       expect(trackEvent).toHaveBeenLastCalledWith(
-        expect.objectContaining(
-          getTrackingObject("20% below the list price", 80, "EUR")
-        )
+        expect.objectContaining(getTrackingObject("Exact price", 100, "EUR"))
       )
+
       fireEvent.click(radios[1])
-      expect(trackEvent).toHaveBeenLastCalledWith(
-        expect.objectContaining(
-          getTrackingObject("15% below the list price", 85, "EUR")
-        )
-      )
-      fireEvent.click(radios[2])
       expect(trackEvent).toHaveBeenLastCalledWith(
         expect.objectContaining(
           getTrackingObject("10% below the list price", 90, "EUR")
         )
       )
+
+      fireEvent.click(radios[2])
+      expect(trackEvent).toHaveBeenLastCalledWith(
+        expect.objectContaining(
+          getTrackingObject("20% below the list price", 80, "EUR")
+        )
+      )
+
       fireEvent.click(radios[3])
       expect(trackEvent).toHaveBeenCalledWith(
         expect.objectContaining(getTrackingObject("Different amount", 0, "EUR"))
@@ -225,9 +226,9 @@ describe("PriceOptions", () => {
       expect(selected).toHaveTextContent("Offer amount missing or invalid.")
     })
     it("correctly rounds the values and displays the currency symbol", () => {
-      expect(radios[0]).toHaveTextContent("A$79.00") // %80 would be A$79.20
-      expect(radios[1]).toHaveTextContent("A$84.00") // %85 would be A$84.15
-      expect(radios[2]).toHaveTextContent("A$89.00") // %90 would be A$89.10
+      expect(radios[0]).toHaveTextContent("A$99.00") // Exact price
+      expect(radios[1]).toHaveTextContent("A$89.00") // %90 would be A$89.10
+      expect(radios[2]).toHaveTextContent("A$79.00") // %80 would be A$79.20
     })
   })
 })

--- a/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
@@ -132,7 +132,7 @@ describe("PriceOptions", () => {
       fireEvent.click(radios[3])
       const input = await within(radios[3]).findByRole("textbox")
       const notice = await screen.findByText(
-        "Offers lower than the displayed price range are often declined. We recommend changing your offer to US$200.00."
+        "Offers lower than the displayed price range are often declined. We recommend changing your offer to US$100.00."
       )
       expect(notice).toBeInTheDocument()
       expect(trackEvent).toHaveBeenCalledWith(
@@ -164,9 +164,9 @@ describe("PriceOptions", () => {
       expect(radios).toHaveLength(4)
     })
     it("correctly formats values", () => {
-      expect(radios[0]).toHaveTextContent("€100")
-      expect(radios[1]).toHaveTextContent("€90")
-      expect(radios[2]).toHaveTextContent("€80")
+      expect(radios[0]).toHaveTextContent("€100.00")
+      expect(radios[1]).toHaveTextContent("€90.00")
+      expect(radios[2]).toHaveTextContent("€80.00")
       expect(radios[3]).toHaveTextContent("Different amount")
     })
     it("correctly tracks the clicking of an option", async () => {

--- a/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
@@ -92,13 +92,13 @@ describe("Offer InitialMutation", () => {
       expect(page.transactionSummary.text()).toContain("Your offer")
 
       await page.selectPriceOption(0)
-      expect(page.transactionSummary.text()).toContain("Your offerUS$12,800.00")
+      expect(page.transactionSummary.text()).toContain("Your offerUS$16,000.00")
 
       await page.selectPriceOption(1)
-      expect(page.transactionSummary.text()).toContain("Your offerUS$13,600.00")
+      expect(page.transactionSummary.text()).toContain("Your offerUS$14,400.00")
 
       await page.selectPriceOption(2)
-      expect(page.transactionSummary.text()).toContain("Your offerUS$14,400.00")
+      expect(page.transactionSummary.text()).toContain("Your offerUS$12,800.00")
     })
 
     it("shows final offer binding notice", () => {


### PR DESCRIPTION
The type of this PR is: Feature
This PR solves: [NX-3109](https://artsyproduct.atlassian.net/browse/NX-3109)

Reversed order of price options for exact price. First option is now replaced with the exact price.

<img width="618" alt="Screenshot 2022-03-23 at 12 13 53" src="https://user-images.githubusercontent.com/17580625/159688079-4c55ec58-b386-4022-935e-4f5e95a49d1a.png">

