### PR TITLE
feat(NOSF2): reverse order of options for range price

### DIFF
--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -85,9 +85,9 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
     )
 
     const getRangeDetails = [
-      { value: minPriceRange, description: "Low-end of range" },
-      { value: midPriceRange, description: "Midpoint" },
       { value: maxPriceRange, description: "Top-end of range" },
+      { value: midPriceRange, description: "Midpoint" },
+      { value: minPriceRange, description: "Low-end of range" },
     ]
     return getRangeDetails.map((rangePrice, idx) => ({
       key: `price-option-${idx}`,

--- a/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
@@ -84,9 +84,9 @@ describe("PriceOptions", () => {
       expect(radios).toHaveLength(4)
     })
     it("correctly formats values", () => {
-      expect(radios[0]).toHaveTextContent("US$100.00")
+      expect(radios[0]).toHaveTextContent("US$200.00")
       expect(radios[1]).toHaveTextContent("US$150.00")
-      expect(radios[2]).toHaveTextContent("US$200.00")
+      expect(radios[2]).toHaveTextContent("US$100.00")
       expect(radios[3]).toHaveTextContent("Different amount")
     })
     it("fires click event with correct value", () => {
@@ -110,7 +110,7 @@ describe("PriceOptions", () => {
       fireEvent.click(radios[0])
       expect(trackEvent).toHaveBeenLastCalledWith(
         expect.objectContaining(
-          getTrackingObject("Low-end of range", 100, "USD")
+          getTrackingObject("Top-end of range", 200, "USD")
         )
       )
       fireEvent.click(radios[1])
@@ -120,7 +120,7 @@ describe("PriceOptions", () => {
       fireEvent.click(radios[2])
       expect(trackEvent).toHaveBeenLastCalledWith(
         expect.objectContaining(
-          getTrackingObject("Top-end of range", 200, "USD")
+          getTrackingObject("Low-end of range", 100, "USD")
         )
       )
       fireEvent.click(radios[3])
@@ -132,7 +132,7 @@ describe("PriceOptions", () => {
       fireEvent.click(radios[3])
       const input = await within(radios[3]).findByRole("textbox")
       const notice = await screen.findByText(
-        "Offers lower than the displayed price range are often declined. We recommend changing your offer to US$100.00."
+        "Offers lower than the displayed price range are often declined. We recommend changing your offer to US$200.00."
       )
       expect(notice).toBeInTheDocument()
       expect(trackEvent).toHaveBeenCalledWith(
@@ -141,20 +141,20 @@ describe("PriceOptions", () => {
           flow: "Make offer",
         })
       )
-      fireEvent.change(input, { target: { value: 180 } })
+      fireEvent.change(input, { target: { value: 200 } })
       expect(notice).not.toBeInTheDocument()
     })
     it("selects the first option when clicking on the low price notice", async () => {
       fireEvent.click(radios[3])
       const notice = await screen.findByText(
-        "Offers lower than the displayed price range are often declined. We recommend changing your offer to US$100.00."
+        "Offers lower than the displayed price range are often declined. We recommend changing your offer to US$200.00."
       )
       fireEvent.click(notice)
       const selected = screen.getAllByRole("radio", { checked: true })
-      expect(selected[0]).toHaveTextContent("US$100.00")
+      expect(selected[0]).toHaveTextContent("US$200.00")
       expect(trackEvent).toHaveBeenLastCalledWith(
         expect.objectContaining(
-          getTrackingObject("We recommend changing your offer", 100, "USD")
+          getTrackingObject("We recommend changing your offer", 200, "USD")
         )
       )
     })


### PR DESCRIPTION
The type of this PR is: Feature

This PR solves [NX-3110](https://artsyproduct.atlassian.net/browse/NX-3110)

Reversed order for options with range price, from high to low price.
<img width="588" alt="Screenshot 2022-03-23 at 13 12 08" src="https://user-images.githubusercontent.com/17580625/159696770-baab5d00-2c51-4c98-a446-70468ba1b30e.png">
