### PR TITLE
feat: remove clickable from low offer notice text

### DIFF
--- a/src/v2/Apps/Order/Components/MinPriceWarning.tsx
+++ b/src/v2/Apps/Order/Components/MinPriceWarning.tsx
@@ -1,16 +1,14 @@
-import { Clickable, Message, Text } from "@artsy/palette"
+import { Message, Text } from "@artsy/palette"
 import { useEffect } from "react"
 import { AnalyticsSchema, useTracking } from "v2/System/Analytics"
 
 interface MinPriceWarningProps {
   isPriceRange: boolean
-  onClick: React.MouseEventHandler<HTMLButtonElement>
   minPrice: string
   orderID: string
 }
 
 export const MinPriceWarning: React.FC<MinPriceWarningProps> = ({
-  onClick,
   isPriceRange,
   minPrice,
   orderID,
@@ -25,15 +23,13 @@ export const MinPriceWarning: React.FC<MinPriceWarningProps> = ({
   }, [orderID, tracking])
 
   return (
-    <Clickable cursor="pointer" onClick={onClick} mt={2}>
-      <Message variant="warning" p={2}>
-        <Text>
-          {isPriceRange
-            ? "Offers lower than the displayed price range are often declined. "
-            : "Offers less than 20% of the list price are often declined. "}
-          We recommend changing your offer to {minPrice}.
-        </Text>
-      </Message>
-    </Clickable>
+    <Message variant="warning" p={2}>
+      <Text>
+        {isPriceRange
+          ? "Offers lower than the displayed price range are often declined. "
+          : "Offers less than 20% of the list price are often declined. "}
+        We recommend changing your offer to {minPrice}.
+      </Text>
+    </Message>
   )
 }

--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -32,10 +32,8 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
 }) => {
   const tracking = useTracking()
   const { contextPageOwnerId, contextPageOwnerType } = useAnalyticsContext()
-
   const [customValue, setCustomValue] = useState<number>()
   const [toggle, setToggle] = useState(false)
-  const [selectedRadio, setSelectedRadio] = useState<string>()
   const listPrice = artwork?.listPrice
 
   useEffect(() => {
@@ -44,7 +42,6 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
 
   useEffect(() => {
     if (showError) {
-      setSelectedRadio("price-option-custom")
       setToggle(true)
     }
   }, [showError])
@@ -120,7 +117,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
   })
 
   return (
-    <RadioGroup onSelect={setSelectedRadio} defaultValue={selectedRadio}>
+    <RadioGroup>
       {compact(priceOptions)
         .map(({ value, description, key }) => (
           <BorderedRadio

--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -114,15 +114,6 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
     : getPercentageOptions()
   const minPrice = priceOptions[0]?.value!
 
-  const selectMinPrice = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation()
-    trackClick("We recommend changing your offer", minPrice)
-    setSelectedRadio("price-option-0")
-    setToggle(false)
-    setCustomValue(undefined)
-    onChange(minPrice)
-  }
-
   const { scrollTo } = useScrollTo({
     selectorOrRef: "#scrollTo--price-option-custom",
     behavior: "smooth",
@@ -175,7 +166,6 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
                 {(!customValue || customValue < minPrice) && (
                   <MinPriceWarning
                     isPriceRange={!!artwork?.isPriceRange}
-                    onClick={selectMinPrice}
                     minPrice={asCurrency(minPrice) as string}
                     orderID={order.internalID}
                   />

--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -32,8 +32,10 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
 }) => {
   const tracking = useTracking()
   const { contextPageOwnerId, contextPageOwnerType } = useAnalyticsContext()
+
   const [customValue, setCustomValue] = useState<number>()
   const [toggle, setToggle] = useState(false)
+  const [selectedRadio, setSelectedRadio] = useState<string>()
   const listPrice = artwork?.listPrice
 
   useEffect(() => {
@@ -42,6 +44,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
 
   useEffect(() => {
     if (showError) {
+      setSelectedRadio("price-option-custom")
       setToggle(true)
     }
   }, [showError])
@@ -117,7 +120,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
   })
 
   return (
-    <RadioGroup>
+    <RadioGroup onSelect={setSelectedRadio} defaultValue={selectedRadio}>
       {compact(priceOptions)
         .map(({ value, description, key }) => (
           <BorderedRadio

--- a/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
@@ -218,6 +218,12 @@ describe("PriceOptions", () => {
         screen.queryByText("Offer amount missing or invalid.")
       ).not.toBeInTheDocument()
     })
+    it("displays the error and automatically selects the custom value option when an error is passed", async () => {
+      const selected = await screen.findByRole("radio", { checked: true })
+      expect(selected).toBeInTheDocument()
+      expect(selected).toHaveTextContent("Different amount")
+      expect(selected).toHaveTextContent("Offer amount missing or invalid.")
+    })
     it("correctly rounds the values and displays the currency symbol", () => {
       expect(radios[0]).toHaveTextContent("A$79.00") // %80 would be A$79.20
       expect(radios[1]).toHaveTextContent("A$84.00") // %85 would be A$84.15

--- a/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
@@ -144,20 +144,6 @@ describe("PriceOptions", () => {
       fireEvent.change(input, { target: { value: 200 } })
       expect(notice).not.toBeInTheDocument()
     })
-    it("selects the first option when clicking on the low price notice", async () => {
-      fireEvent.click(radios[3])
-      const notice = await screen.findByText(
-        "Offers lower than the displayed price range are often declined. We recommend changing your offer to US$200.00."
-      )
-      fireEvent.click(notice)
-      const selected = screen.getAllByRole("radio", { checked: true })
-      expect(selected[0]).toHaveTextContent("US$200.00")
-      expect(trackEvent).toHaveBeenLastCalledWith(
-        expect.objectContaining(
-          getTrackingObject("We recommend changing your offer", 200, "USD")
-        )
-      )
-    })
   })
 
   describe("Exact", () => {

--- a/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
@@ -218,12 +218,6 @@ describe("PriceOptions", () => {
         screen.queryByText("Offer amount missing or invalid.")
       ).not.toBeInTheDocument()
     })
-    it("displays the error and automatically selects the custom value option when an error is passed", async () => {
-      const selected = await screen.findByRole("radio", { checked: true })
-      expect(selected).toBeInTheDocument()
-      expect(selected).toHaveTextContent("Different amount")
-      expect(selected).toHaveTextContent("Offer amount missing or invalid.")
-    })
     it("correctly rounds the values and displays the currency symbol", () => {
       expect(radios[0]).toHaveTextContent("A$79.00") // %80 would be A$79.20
       expect(radios[1]).toHaveTextContent("A$84.00") // %85 would be A$84.15


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [NX-3112]

### Description

Removes clickable from low offer warning text

Going to inform the data team we don't have anymore the event "We recommend changing your offer" being dispatched

@artsy/negotiate-devs 


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NX-3112]: https://artsyproduct.atlassian.net/browse/NX-3112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ