### PR TITLE
feat: Handle error case for bid when the bid was placed when a lot is closed but sale is still open

### DIFF
--- a/src/v2/Apps/Auction/Components/Form/ErrorStatus.tsx
+++ b/src/v2/Apps/Auction/Components/Form/ErrorStatus.tsx
@@ -54,6 +54,12 @@ export const ErrorStatus = () => {
           message,
         }
       }
+      case "LOT_CLOSED": {
+        return {
+          title: "Lot Closed",
+          message,
+        }
+      }
       case "ERROR":
       case "SUBMISSION_FAILED":
       default: {

--- a/src/v2/Apps/Auction/Components/Form/Utils/errorMessages.ts
+++ b/src/v2/Apps/Auction/Components/Form/Utils/errorMessages.ts
@@ -35,7 +35,7 @@ const BIDDING_STATE_TO_MESSAGE: Record<
   OUTBID: "Your bid wasn't high enough. Please select a higher bid.",
   RESERVE_NOT_MET:
     "Your bid is below the reserve price. Please select a higher bid.",
-  SALE_CLOSED: "This sale had been closed. Please browse other open sales.",
+  SALE_CLOSED: "This sale has closed. Please browse other open sales.",
   LOT_CLOSED:
     "This lot has closed. Please browse other open lots for this sale.",
 }

--- a/src/v2/Apps/Auction/Components/Form/Utils/errorMessages.ts
+++ b/src/v2/Apps/Auction/Components/Form/Utils/errorMessages.ts
@@ -17,6 +17,7 @@ export type BiddingStatus =
   | "PENDING"
   | "RESERVE_NOT_MET"
   | "SALE_CLOSED"
+  | "LOT_CLOSED"
   | "SUCCESS"
   | "WINNING"
 
@@ -35,6 +36,8 @@ const BIDDING_STATE_TO_MESSAGE: Record<
   RESERVE_NOT_MET:
     "Your bid is below the reserve price. Please select a higher bid.",
   SALE_CLOSED: "This sale had been closed. Please browse other open sales.",
+  LOT_CLOSED:
+    "This lot has closed. Please browse other open lots for this sale.",
 }
 
 const SYSTEM_ERROR = {

--- a/src/v2/Apps/Auction/Components/Form/__tests__/ErrorStatus.jest.tsx
+++ b/src/v2/Apps/Auction/Components/Form/__tests__/ErrorStatus.jest.tsx
@@ -69,6 +69,12 @@ describe("ErrorStatus", () => {
       expect(wrapper.text()).toContain("Sale Closed")
     })
 
+    it("LOT_CLOSED", () => {
+      status = "LOT_CLOSED"
+      const wrapper = getWrapper()
+      expect(wrapper.text()).toContain("Lot Closed")
+    })
+
     it("ERROR", () => {
       status = "ERROR"
       const wrapper = getWrapper()


### PR DESCRIPTION
Do not merge until [MP work](https://github.com/artsy/metaphysics/pull/3893) is merged.

[BID-257](https://artsyproduct.atlassian.net/browse/BID-257)

Show a different error to handle cascading end times when the lot is closed but the sale is still open.

Screenshot:
<img width="442" alt="Screen Shot 2022-03-23 at 1 09 02 PM" src="https://user-images.githubusercontent.com/9466631/159761023-da826b7d-3609-4ec2-8951-b4c684fa1f5a.png">
