### PR TITLE
fix(NOSF2): updated copy for exact price and warning message

### DIFF
--- a/src/v2/Apps/Order/Components/MinPriceWarning.tsx
+++ b/src/v2/Apps/Order/Components/MinPriceWarning.tsx
@@ -23,12 +23,12 @@ export const MinPriceWarning: React.FC<MinPriceWarningProps> = ({
   }, [orderID, tracking])
 
   return (
-    <Message variant="warning" p={2}>
+    <Message variant="warning" p={2} mt={2}>
       <Text>
         {isPriceRange
           ? "Offers lower than the displayed price range are often declined. "
-          : "Offers less than 20% of the list price are often declined. "}
-        We recommend changing your offer to {minPrice}.
+          : "Offers less than 20% off the list price are often declined. "}
+        We recommend increasing your offer to {minPrice}.
       </Text>
     </Message>
   )

--- a/src/v2/Apps/Order/Components/PriceOptions.tsx
+++ b/src/v2/Apps/Order/Components/PriceOptions.tsx
@@ -105,7 +105,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
           description:
             pricePercentage !== 0
               ? `${pricePercentage * 100}% below the list price`
-              : "Exact price",
+              : "List price",
         }
       }
       return

--- a/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PriceOptions.jest.tsx
@@ -132,7 +132,7 @@ describe("PriceOptions", () => {
       fireEvent.click(radios[3])
       const input = await within(radios[3]).findByRole("textbox")
       const notice = await screen.findByText(
-        "Offers lower than the displayed price range are often declined. We recommend changing your offer to US$100.00."
+        "Offers lower than the displayed price range are often declined. We recommend increasing your offer to US$100.00."
       )
       expect(notice).toBeInTheDocument()
       expect(trackEvent).toHaveBeenCalledWith(
@@ -172,7 +172,7 @@ describe("PriceOptions", () => {
     it("correctly tracks the clicking of an option", async () => {
       fireEvent.click(radios[0])
       expect(trackEvent).toHaveBeenLastCalledWith(
-        expect.objectContaining(getTrackingObject("Exact price", 100, "EUR"))
+        expect.objectContaining(getTrackingObject("List price", 100, "EUR"))
       )
 
       fireEvent.click(radios[1])
@@ -194,7 +194,7 @@ describe("PriceOptions", () => {
         expect.objectContaining(getTrackingObject("Different amount", 0, "EUR"))
       )
       const notice = await screen.findByText(
-        "Offers less than 20% of the list price are often declined. We recommend changing your offer to €80.00."
+        "Offers less than 20% off the list price are often declined. We recommend increasing your offer to €80.00."
       )
       expect(notice).toBeInTheDocument()
     })
@@ -226,7 +226,7 @@ describe("PriceOptions", () => {
       expect(selected).toHaveTextContent("Offer amount missing or invalid.")
     })
     it("correctly rounds the values and displays the currency symbol", () => {
-      expect(radios[0]).toHaveTextContent("A$99.00") // Exact price
+      expect(radios[0]).toHaveTextContent("A$99.00") // List price
       expect(radios[1]).toHaveTextContent("A$89.00") // %90 would be A$89.10
       expect(radios[2]).toHaveTextContent("A$79.00") // %80 would be A$79.20
     })


### PR DESCRIPTION
The type of this PR is: Fix
This PR solves: [NX-3116](https://artsyproduct.atlassian.net/browse/NX-3116)

Copy changes for Exact price and Warning message.
Exact price is now changed to: List price
Added margin top for Warning message.

<img width="749" alt="Screenshot 2022-03-28 at 16 01 34" src="https://user-images.githubusercontent.com/17580625/160415455-c98c44a1-1151-4f52-9462-86567197c1a2.png">

