### PR TITLE
fix(auction): prevents overflowing text from breaking out of column in Firefox

### DIFF
--- a/src/v2/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/v2/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -178,7 +178,7 @@ export class ArtworkGridContainer extends React.Component<
       <GridColumns width="100%">
         {nodes.map(artwork => {
           return (
-            <Column span={[6, 4]} key={artwork.internalID}>
+            <Column span={[6, 4]} key={artwork.internalID} minWidth={0}>
               <FlatGridItemFragmentContainer artwork={artwork} />
             </Column>
           )


### PR DESCRIPTION
Some interaction between `white-space: nowrap` and CSS grid: https://bugzilla.mozilla.org/show_bug.cgi?id=1528030