### PR TITLE
feat: added price histogram to the artist series page

### DIFF
--- a/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
+++ b/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
@@ -33,8 +33,10 @@ export const artistSeriesRoutes: AppRouteConfig[] = [
   },
 ]
 
-function initializeVariablesWithFilterState({ slug }, props) {
-  const initialFilterState = getInitialFilterState(props.location?.query ?? {})
+function initializeVariablesWithFilterState({ slug }, { context, location }) {
+  const initialFilterState = getInitialFilterState(location?.query ?? {})
+  const { featureFlags = {} } = context
+  const newPriceFilterFlag = featureFlags["new_price_filter"]
 
   const aggregations = [
     "MEDIUM",
@@ -44,6 +46,11 @@ function initializeVariablesWithFilterState({ slug }, props) {
     "LOCATION_CITY",
     "MATERIALS_TERMS",
   ]
+
+  // Fetch histogram data for price filter
+  if (newPriceFilterFlag?.flagEnabled) {
+    aggregations.push("SIMPLE_PRICE_HISTOGRAM")
+  }
 
   const input = {
     sort: "-decayed_merch",


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Feature -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-3835]

### Description

<!-- Implementation description -->

This PR adds the price histogram on to the artist series page. This is controlled by the `new_price_filter` unleash feature toggle which can be found [here](https://unleash.artsy.net/projects/default/features2/new_price_filter)


### Image

This is how it looks on my local machine
![Screenshot 2022-03-28 at 18 09 59](https://user-images.githubusercontent.com/6280410/160441787-7ae55057-e7dc-4325-9ac8-b5c7ab225f73.png)



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-3835]: https://artsyproduct.atlassian.net/browse/FX-3835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ