### PR TITLE
feat(NX-3052): Modify the UI of the edition selection modal

### DIFF
--- a/src/v2/Apps/Conversation/Components/CollapsibleArtworkDetails.tsx
+++ b/src/v2/Apps/Conversation/Components/CollapsibleArtworkDetails.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Expandable, Flex, Image, Text } from "@artsy/palette"
 import styled from "styled-components"
@@ -56,7 +56,7 @@ export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps>
       <Expandable
         pb={1}
         label={
-          <Flex alignItems="center" mt={1} mx={2} pb={1}>
+          <Flex py={1}>
             {!!artwork.image && (
               <Image
                 width={artwork.image.resized?.width}
@@ -77,7 +77,6 @@ export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps>
       >
         <Flex
           flexDirection="column"
-          ml={2}
           pr={2}
           maxHeight="230px"
           overflowY="scroll"

--- a/src/v2/Apps/Conversation/Components/ConfirmArtworkModal.tsx
+++ b/src/v2/Apps/Conversation/Components/ConfirmArtworkModal.tsx
@@ -1,15 +1,7 @@
 import { useState } from "react"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import {
-  Button,
-  Flex,
-  Message,
-  Modal,
-  Separator,
-  Spacer,
-  Text,
-} from "@artsy/palette"
+import { Button, Flex, ModalDialog, Separator, Spacer } from "@artsy/palette"
 import { useSystemContext } from "v2/System"
 import { renderWithLoadProgress } from "v2/System/Relay/renderWithLoadProgress"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
@@ -52,17 +44,16 @@ export const ConfirmArtworkModal: React.FC<ConfirmArtworkModalProps> = ({
     }
   }
 
-  return (
-    <Modal
-      show={show}
+  return show ? (
+    <ModalDialog
       onClose={closeModal}
-      title="Confirm Artwork"
-      FixedButton={
+      title="Select edition set"
+      footer={
         <Flex flexGrow={1}>
           <Button variant="secondaryOutline" flexGrow={1} onClick={closeModal}>
             Cancel
           </Button>
-          <Spacer m={2} />
+          <Spacer m={1} />
           <ConfirmArtworkButtonFragmentContainer
             artwork={artwork}
             disabled={!!isEdition && !selectedEdition}
@@ -72,17 +63,10 @@ export const ConfirmArtworkModal: React.FC<ConfirmArtworkModalProps> = ({
         </Flex>
       }
     >
-      <Text color="black60" variant="md" mb={2}>
-        Make sure the artwork below matches the intended work you’re making an
-        offer on.
-      </Text>
       <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
-      <Separator />
+      <Separator mb={2} />
       {!!isEdition && editionSets?.length && (
         <Flex flexDirection="column">
-          <Text mx={2} mt={2} mb={1}>
-            Which edition are you interested in?
-          </Text>
           {editionSets?.map(edition => (
             <EditionSelectBoxFragmentContainer
               edition={edition!}
@@ -93,12 +77,8 @@ export const ConfirmArtworkModal: React.FC<ConfirmArtworkModalProps> = ({
           ))}
         </Flex>
       )}
-      <Message mt={2} mx={2}>
-        Making an offer doesn’t guarantee you the work, as the seller might be
-        receiving competing offers.
-      </Message>
-    </Modal>
-  )
+    </ModalDialog>
+  ) : null
 }
 
 export const ConfirmArtworkModalFragmentContainer = createFragmentContainer(

--- a/src/v2/Apps/Conversation/Components/EditionSelectBox.tsx
+++ b/src/v2/Apps/Conversation/Components/EditionSelectBox.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { Box, BorderBox, Flex, Text, Radio } from "@artsy/palette"
+import { Box, Flex, Text, BorderedRadio } from "@artsy/palette"
 import styled from "styled-components"
 import { themeGet } from "@styled-system/theme-get"
 
@@ -28,16 +28,13 @@ export const EditionSelectBox: React.FC<Props> = ({
   const isOfferable = !!edition.isOfferableFromInquiry
 
   return (
-    <BorderBox
-      onClick={() => {
+    <BorderedRadio
+      onSelect={() => {
         onSelect(edition.internalID, isOfferable)
       }}
-      mx={2}
-      mb={1}
-      flexDirection="row"
-      alignItems="start"
+      disabled={!isOfferable}
+      selected={selected}
     >
-      <Radio disabled={!isOfferable} selected={selected} />
       <Flex flexGrow={1} flexDirection="column">
         <Text color={isOfferable ? "black100" : "black30"}>
           {edition.dimensions?.in}
@@ -57,7 +54,7 @@ export const EditionSelectBox: React.FC<Props> = ({
           <Text>Unavailable</Text>
         </Flex>
       )}
-    </BorderBox>
+    </BorderedRadio>
   )
 }
 

--- a/src/v2/Apps/Conversation/Components/__tests__/ConfirmArtwork.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/ConfirmArtwork.jest.tsx
@@ -1,7 +1,7 @@
 import { ConfirmArtworkModalFragmentContainer } from "../ConfirmArtworkModal"
 import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
-import { screen, fireEvent } from "@testing-library/react"
+import { screen, fireEvent, waitFor } from "@testing-library/react"
 
 jest.mock("@artsy/palette", () => {
   return {
@@ -13,7 +13,9 @@ jest.mock("@artsy/palette", () => {
 jest.unmock("react-relay")
 
 const { renderWithRelay } = setupTestWrapperTL({
-  Component: ConfirmArtworkModalFragmentContainer,
+  Component: (props: any) => (
+    <ConfirmArtworkModalFragmentContainer show={true} {...props} />
+  ),
   query: graphql`
     query ConfirmArtworkModal_Test_Query @relay_test_operation {
       artwork(id: "xxx") {
@@ -24,17 +26,20 @@ const { renderWithRelay } = setupTestWrapperTL({
 })
 
 describe("ConfirmArtworkModal", () => {
-  it("renders the correct artwork details", () => {
+  it("renders the correct artwork details", async () => {
     renderWithRelay({
       Artwork: () => ({
         title: "Test Artwork",
         date: "1967",
       }),
     })
-    expect(screen.getByText("Test Artwork, 1967")).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Artwork, 1967")).toBeInTheDocument()
+    })
   })
 
-  it("has expandable details and correctly parses labels", () => {
+  it("has expandable details and correctly parses labels", async () => {
     renderWithRelay({
       Artwork: () => ({
         certificateOfAuthenticity: { details: "test" },
@@ -45,13 +50,17 @@ describe("ConfirmArtworkModal", () => {
       }),
     })
 
-    expect(screen.queryAllByText("Certificate of Authenticity")).toStrictEqual(
-      []
-    )
-    fireEvent.click(screen.getByRole("button"))
+    await waitFor(() => {
+      expect(
+        screen.queryAllByText("Certificate of Authenticity")
+      ).toStrictEqual([])
+      fireEvent.click(screen.getByText("Reveal more"))
 
-    expect(screen.getByText("Certificate of Authenticity")).toBeInTheDocument()
-    expect(screen.getByText("33 x 33 in 33 x 33 cm")).toBeInTheDocument()
+      expect(
+        screen.getByText("Certificate of Authenticity")
+      ).toBeInTheDocument()
+      expect(screen.getByText("33 x 33 in 33 x 33 cm")).toBeInTheDocument()
+    })
   })
 })
 
@@ -120,53 +129,63 @@ describe("Artwork editions", () => {
     }),
   }
 
-  it("An Edition renders correctly", () => {
+  it("An Edition renders correctly", async () => {
     renderWithRelay(mockSingleEdition)
 
-    expect(screen.queryAllByRole("radio")[0]).toBeInTheDocument()
-    expect(screen.getByText("27 3/5 × 9 4/5 × 13 4/5 in")).toBeInTheDocument()
-    expect(screen.getByText("70 × 25 × 35 cm")).toBeInTheDocument()
-    expect(screen.getByText("Edition of 50")).toBeInTheDocument()
-    expect(screen.getByText("$100")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryAllByRole("radio")[0]).toBeInTheDocument()
+      expect(screen.getByText("27 3/5 × 9 4/5 × 13 4/5 in")).toBeInTheDocument()
+      expect(screen.getByText("70 × 25 × 35 cm")).toBeInTheDocument()
+      expect(screen.getByText("Edition of 50")).toBeInTheDocument()
+      expect(screen.getByText("$100")).toBeInTheDocument()
+    })
   })
 
-  it("One edition is always selected", () => {
+  it("One edition is always selected", async () => {
     renderWithRelay(mockSingleEdition)
 
-    expect(screen.getByRole("radio")).toBeChecked()
+    await waitFor(() => {
+      expect(screen.getByRole("radio")).toBeChecked()
+    })
   })
 
-  it("Display edititon as disabled when it is not available", () => {
+  it("Display edititon as disabled when it is not available", async () => {
     renderWithRelay(unavailableEdition)
 
-    // eslint-disable-next-line jest-dom/prefer-enabled-disabled
-    expect(screen.getByRole("radio")).toHaveAttribute("disabled")
-    expect(screen.getByText("Unavailable")).toBeInTheDocument()
+    await waitFor(() => {
+      // eslint-disable-next-line jest-dom/prefer-enabled-disabled
+      expect(screen.getByRole("radio")).toHaveAttribute("disabled")
+      expect(screen.getByText("Unavailable")).toBeInTheDocument()
+    })
   })
 
-  it("Display 'Contact for price' if a price not set in listPrice", () => {
+  it("Display 'Contact for price' if a price not set in listPrice", async () => {
     renderWithRelay(nullListPriceEdition)
 
-    expect(screen.getByText("Contact for price")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText("Contact for price")).toBeInTheDocument()
+    })
   })
 
-  it("Can select editions", () => {
+  it("Can select editions", async () => {
     renderWithRelay(mockEditions)
 
-    const radios = screen.getAllByRole("radio")
-    expect(radios).toHaveLength(2)
+    await waitFor(() => {
+      const radios = screen.getAllByRole("radio")
+      expect(radios).toHaveLength(2)
 
-    const editions = screen.getAllByText(/test-edition-[12]/)
-    expect(editions).toHaveLength(2)
-    expect(editions[0]).toHaveTextContent("test-edition-1")
-    expect(editions[1]).toHaveTextContent("test-edition-2")
+      const editions = screen.getAllByText(/test-edition-[12]/)
+      expect(editions).toHaveLength(2)
+      expect(editions[0]).toHaveTextContent("test-edition-1")
+      expect(editions[1]).toHaveTextContent("test-edition-2")
 
-    fireEvent.click(editions[0])
-    expect(radios[0]).toBeChecked()
-    expect(radios[1]).not.toBeChecked()
+      fireEvent.click(editions[0])
+      expect(radios[0]).toBeChecked()
+      expect(radios[1]).not.toBeChecked()
 
-    fireEvent.click(editions[1])
-    expect(radios[0]).not.toBeChecked()
-    expect(radios[1]).toBeChecked()
+      fireEvent.click(editions[1])
+      expect(radios[0]).not.toBeChecked()
+      expect(radios[1]).toBeChecked()
+    })
   })
 })


### PR DESCRIPTION
The type of this PR is: Enhancement

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [NX-3052]

### Description

Remove some texts, fix elements alignment, upgrade deprecated Palette components, update tests to wait for DialogModal to open.

Before:
<img alt="image" src="https://user-images.githubusercontent.com/265560/160871670-f48589a4-1f1b-4c70-bab6-e527d86d900f.png">

After:
<img alt="image" src="https://user-images.githubusercontent.com/265560/160871421-1e66b3ce-28b6-43fa-ac9a-ad8b84cb17c2.png">


cc @artsy/negotiate-devs 

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NX-3052]: https://artsyproduct.atlassian.net/browse/NX-3052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ