### PR TITLE
slack notify dev when validate_production_schema fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,14 @@ jobs:
 
   validate_production_schema:
     executor: node/build
+    parameters:
+      # find channel ID at the botton of channel details view (slack app) or by right clicking on channel, and copying the link. The ID will be visible at the end of that URL.
+      practice_web:
+        type: string
+        default: C2TQ4PT8R
+      dev:
+        type: string
+        default: C02BC3HEJ
     steps:
       - yarn/setup
       - run:
@@ -32,6 +40,7 @@ jobs:
           command: node scripts/validateSchemas.js production
       - slack/notify:
           event: fail
+          channel: "<< parameters.practice_web >>, << parameters.dev >>"
           custom: |
             {
               "blocks": [
@@ -413,12 +422,6 @@ workflows:
           requires:
             - horizon/block
             - validate_production_schema
-          post-steps:
-            # notify: practice-web, dev
-            - slack/notify:
-                event: fail
-                channel: "C2TQ4PT8R, C02BC3HEJ"
-                template: basic_fail_1
 
       # Other
       - run_deepcrawl_automator:


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

Specify slack channels in the `validate_production_schema` job instead of _post-steps_ to deliver notifications to both channels.

In my [testing](https://github.com/artsy/force/commit/5fa8cd717dd8e9e9d04215c635429d5002f13377), the post-step would not trigger a slack/notify if one of the required jobs fails and sends a slack notification.

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ