### PR TITLE
feat: zoom in on image when hovering on artwork grid item

### DIFF
--- a/src/v2/Components/Artwork/ArtworkImage.tsx
+++ b/src/v2/Components/Artwork/ArtworkImage.tsx
@@ -18,6 +18,8 @@ const defaultPositions: Positions = {
   y: null,
 }
 const ENTER_TIMEOUT_DELAY = 200
+const SCALE = 1.75
+const SCALE_DURATION = 0.15
 
 export const ArtworkImage: React.FC<ArtworkImageProps> = ({
   shouldZoomOnHover,
@@ -79,8 +81,8 @@ const ZoomScrollImage: React.FC<ImageProps> = props => {
         style={{
           ...props.style,
           transformOrigin: getTransformOrigin(positions),
-          transition: "transform 0.2s ease-out",
-          transform: zoomed ? `scale(1.5)` : `scale(1.0)`,
+          transition: `transform ${SCALE_DURATION}s ease-out`,
+          transform: zoomed ? `scale(${SCALE})` : `scale(1.0)`,
         }}
       />
     </Box>

--- a/src/v2/Components/Artwork/ArtworkImage.tsx
+++ b/src/v2/Components/Artwork/ArtworkImage.tsx
@@ -1,8 +1,21 @@
 import { Image as BaseImage, ImageProps, Box } from "@artsy/palette"
+import { useRef, useState } from "react"
 import styled from "styled-components"
 
 interface ArtworkImageProps extends ImageProps {
   shouldZoomOnHover?: boolean
+}
+
+type Position = number | null
+
+interface Positions {
+  x: Position
+  y: Position
+}
+
+const defaultPositions: Positions = {
+  x: null,
+  y: null,
 }
 
 export const ArtworkImage: React.FC<ArtworkImageProps> = ({
@@ -10,14 +23,60 @@ export const ArtworkImage: React.FC<ArtworkImageProps> = ({
   ...rest
 }) => {
   if (shouldZoomOnHover) {
-    return (
-      <Box overflow="hidden">
-        <ZoomImage {...rest} />
-      </Box>
-    )
+    return <ZoomScrollImage {...rest} />
   }
 
   return <Image {...rest} />
+}
+
+const ZoomScrollImage: React.FC<ImageProps> = props => {
+  const [zoomed, setZoomed] = useState(false)
+  const [positions, setPositions] = useState<Positions>(defaultPositions)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  const onMouseOver = () => {
+    setZoomed(true)
+  }
+
+  const onMouseOut = () => {
+    setZoomed(false)
+  }
+
+  const onMouseMove = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    if (!containerRef.current) {
+      return
+    }
+
+    const containerRect = containerRef.current.getBoundingClientRect()
+    const x = e.clientX - containerRect.left
+    const y = e.clientY - containerRect.top
+
+    setPositions({
+      x,
+      y,
+    })
+  }
+
+  return (
+    <Box
+      position="relative"
+      overflow="hidden"
+      onMouseOver={onMouseOver}
+      onMouseOut={onMouseOut}
+      onMouseMove={onMouseMove}
+      ref={containerRef as any}
+    >
+      <Image
+        {...props}
+        style={{
+          ...props.style,
+          transformOrigin: getTransformOrigin(positions),
+          transition: "transform 0.2s ease-out",
+          transform: zoomed ? `scale(1.5)` : `scale(1.0)`,
+        }}
+      />
+    </Box>
+  )
 }
 
 const Image = styled(BaseImage)`
@@ -26,10 +85,10 @@ const Image = styled(BaseImage)`
   height: 100%;
 `
 
-const ZoomImage = styled(Image)`
-  transition: transform 0.2s;
-
-  &:hover {
-    transform: scale(1.1);
+const getTransformOrigin = (positions: Positions) => {
+  if (positions.x === null && positions.y === null) {
+    return "center center"
   }
-`
+
+  return `${positions.x}px ${positions.y}px`
+}

--- a/src/v2/Components/Artwork/ArtworkImage.tsx
+++ b/src/v2/Components/Artwork/ArtworkImage.tsx
@@ -1,92 +1,20 @@
-import { Image as BaseImage, ImageProps, Box } from "@artsy/palette"
-import { useRef, useState } from "react"
+import { Image as BaseImage, ImageProps } from "@artsy/palette"
 import styled from "styled-components"
+import { MagnifyImage } from "../MagnifyImage"
 
 interface ArtworkImageProps extends ImageProps {
   shouldZoomOnHover?: boolean
 }
-
-type Position = number | null
-
-interface Positions {
-  x: Position
-  y: Position
-}
-
-const defaultPositions: Positions = {
-  x: null,
-  y: null,
-}
-const ENTER_TIMEOUT_DELAY = 200
-const SCALE = 1.75
-const SCALE_DURATION = 0.15
 
 export const ArtworkImage: React.FC<ArtworkImageProps> = ({
   shouldZoomOnHover,
   ...rest
 }) => {
   if (shouldZoomOnHover) {
-    return <ZoomScrollImage {...rest} />
+    return <MagnifyImage {...rest} />
   }
 
   return <Image {...rest} />
-}
-
-const ZoomScrollImage: React.FC<ImageProps> = props => {
-  const [zoomed, setZoomed] = useState(false)
-  const [positions, setPositions] = useState<Positions>(defaultPositions)
-  const containerRef = useRef<HTMLDivElement | null>(null)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const onMouseOver = () => {
-    timeoutRef.current = setTimeout(() => {
-      setZoomed(true)
-    }, ENTER_TIMEOUT_DELAY)
-  }
-
-  const onMouseOut = () => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-    }
-
-    setZoomed(false)
-  }
-
-  const onMouseMove = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    if (!containerRef.current) {
-      return
-    }
-
-    const containerRect = containerRef.current.getBoundingClientRect()
-    const x = e.clientX - containerRect.left
-    const y = e.clientY - containerRect.top
-
-    setPositions({
-      x,
-      y,
-    })
-  }
-
-  return (
-    <Box
-      position="relative"
-      overflow="hidden"
-      onMouseOver={onMouseOver}
-      onMouseOut={onMouseOut}
-      onMouseMove={onMouseMove}
-      ref={containerRef as any}
-    >
-      <Image
-        {...props}
-        style={{
-          ...props.style,
-          transformOrigin: getTransformOrigin(positions),
-          transition: `transform ${SCALE_DURATION}s ease-out`,
-          transform: zoomed ? `scale(${SCALE})` : `scale(1.0)`,
-        }}
-      />
-    </Box>
-  )
 }
 
 const Image = styled(BaseImage)`
@@ -94,11 +22,3 @@ const Image = styled(BaseImage)`
   width: 100%;
   height: 100%;
 `
-
-const getTransformOrigin = (positions: Positions) => {
-  if (positions.x === null && positions.y === null) {
-    return "center center"
-  }
-
-  return `${positions.x}px ${positions.y}px`
-}

--- a/src/v2/Components/Artwork/ArtworkImage.tsx
+++ b/src/v2/Components/Artwork/ArtworkImage.tsx
@@ -1,5 +1,6 @@
 import { Image as BaseImage, ImageProps, Box } from "@artsy/palette"
-import { useRef, useState } from "react"
+import { debounce } from "lodash"
+import { useRef, useState, useMemo } from "react"
 import styled from "styled-components"
 
 interface ArtworkImageProps extends ImageProps {
@@ -17,6 +18,7 @@ const defaultPositions: Positions = {
   x: null,
   y: null,
 }
+const MOUSE_ENTER_DEBOUNCE_TIME = 200
 
 export const ArtworkImage: React.FC<ArtworkImageProps> = ({
   shouldZoomOnHover,
@@ -34,12 +36,17 @@ const ZoomScrollImage: React.FC<ImageProps> = props => {
   const [positions, setPositions] = useState<Positions>(defaultPositions)
   const containerRef = useRef<HTMLDivElement | null>(null)
 
-  const onMouseOver = () => {
-    setZoomed(true)
-  }
+  const onMouseOver = useMemo(
+    () =>
+      debounce(() => {
+        setZoomed(true)
+      }, MOUSE_ENTER_DEBOUNCE_TIME),
+    []
+  )
 
   const onMouseOut = () => {
     setZoomed(false)
+    onMouseOver.cancel()
   }
 
   const onMouseMove = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {

--- a/src/v2/Components/Artwork/ArtworkImage.tsx
+++ b/src/v2/Components/Artwork/ArtworkImage.tsx
@@ -1,6 +1,5 @@
 import { Image as BaseImage, ImageProps, Box } from "@artsy/palette"
-import { debounce } from "lodash"
-import { useRef, useState, useMemo } from "react"
+import { useRef, useState } from "react"
 import styled from "styled-components"
 
 interface ArtworkImageProps extends ImageProps {
@@ -18,7 +17,7 @@ const defaultPositions: Positions = {
   x: null,
   y: null,
 }
-const MOUSE_ENTER_DEBOUNCE_TIME = 200
+const ENTER_TIMEOUT_DELAY = 200
 
 export const ArtworkImage: React.FC<ArtworkImageProps> = ({
   shouldZoomOnHover,
@@ -35,18 +34,20 @@ const ZoomScrollImage: React.FC<ImageProps> = props => {
   const [zoomed, setZoomed] = useState(false)
   const [positions, setPositions] = useState<Positions>(defaultPositions)
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const onMouseOver = useMemo(
-    () =>
-      debounce(() => {
-        setZoomed(true)
-      }, MOUSE_ENTER_DEBOUNCE_TIME),
-    []
-  )
+  const onMouseOver = () => {
+    timeoutRef.current = setTimeout(() => {
+      setZoomed(true)
+    }, ENTER_TIMEOUT_DELAY)
+  }
 
   const onMouseOut = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+    }
+
     setZoomed(false)
-    onMouseOver.cancel()
   }
 
   const onMouseMove = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {

--- a/src/v2/Components/Artwork/ArtworkImage.tsx
+++ b/src/v2/Components/Artwork/ArtworkImage.tsx
@@ -1,0 +1,35 @@
+import { Image as BaseImage, ImageProps, Box } from "@artsy/palette"
+import styled from "styled-components"
+
+interface ArtworkImageProps extends ImageProps {
+  shouldZoomOnHover?: boolean
+}
+
+export const ArtworkImage: React.FC<ArtworkImageProps> = ({
+  shouldZoomOnHover,
+  ...rest
+}) => {
+  if (shouldZoomOnHover) {
+    return (
+      <Box overflow="hidden">
+        <ZoomImage {...rest} />
+      </Box>
+    )
+  }
+
+  return <Image {...rest} />
+}
+
+const Image = styled(BaseImage)`
+  display: block;
+  width: 100%;
+  height: 100%;
+`
+
+const ZoomImage = styled(Image)`
+  transition: transform 0.2s;
+
+  &:hover {
+    transform: scale(1.1);
+  }
+`

--- a/src/v2/Components/Artwork/GridItem.tsx
+++ b/src/v2/Components/Artwork/GridItem.tsx
@@ -1,5 +1,5 @@
 import { AuthContextModule, ContextModule } from "@artsy/cohesion"
-import { Image as BaseImage, Box } from "@artsy/palette"
+import { Box } from "@artsy/palette"
 import { GridItem_artwork } from "v2/__generated__/GridItem_artwork.graphql"
 import { useSystemContext } from "v2/System"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -11,6 +11,7 @@ import { SaveButtonFragmentContainer, useSaveButton } from "./SaveButton"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { cropped, resized } from "v2/Utils/resized"
 import { useHoverMetadata } from "./useHoverMetadata"
+import { ArtworkImage } from "./ArtworkImage"
 
 interface ArtworkGridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   artwork: GridItem_artwork
@@ -32,7 +33,12 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
   const { containerProps, isSaveButtonVisible } = useSaveButton({
     isSaved: !!artwork.is_saved,
   })
-  const { isHovered, onMouseEnter, onMouseLeave } = useHoverMetadata()
+  const {
+    isHovered,
+    isHoverEffectEnabled,
+    onMouseEnter,
+    onMouseLeave,
+  } = useHoverMetadata()
 
   const aspectRatio = artwork.image?.aspect_ratio ?? 1
   const width = 445
@@ -83,13 +89,14 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
           onClick={handleClick}
           aria-label={`${artwork.title} by ${artwork.artistNames}`}
         >
-          <Image
+          <ArtworkImage
             title={artwork.title ?? undefined}
             alt={artwork.image_title ?? ""}
             src={src}
             srcSet={srcSet}
             lazyLoad={lazyLoad}
             preventRightClick={!isTeam}
+            shouldZoomOnHover={!!isHoverEffectEnabled}
           />
         </Link>
 
@@ -119,12 +126,6 @@ const Link = styled(RouterLink)`
   right: 0;
   bottom: 0;
   left: 0;
-`
-
-const Image = styled(BaseImage)`
-  display: block;
-  width: 100%;
-  height: 100%;
 `
 
 export const ArtworkGridItemFragmentContainer = createFragmentContainer(

--- a/src/v2/Components/MagnifyImage.tsx
+++ b/src/v2/Components/MagnifyImage.tsx
@@ -71,6 +71,7 @@ export const MagnifyImage: React.FC<MagnifyImageProps> = ({
     >
       <Image
         {...rest}
+        title={undefined} // don't display a tooltip when hovering over the image
         style={{
           ...rest.style,
           transformOrigin: getTransformOrigin(positions),

--- a/src/v2/Components/MagnifyImage.tsx
+++ b/src/v2/Components/MagnifyImage.tsx
@@ -1,0 +1,97 @@
+import { Image as BaseImage, ImageProps, Box } from "@artsy/palette"
+import { useRef, useState } from "react"
+import styled from "styled-components"
+
+type Position = number | null
+
+interface Positions {
+  x: Position
+  y: Position
+}
+
+interface MagnifyImageProps extends ImageProps {
+  scale?: number
+  scaleDuration?: number
+}
+
+const ENTER_TIMEOUT_DELAY = 200
+const DEFAULT_SCALE = 1.75
+const DEFAULT_SCALE_DURATION = 0.15
+
+export const MagnifyImage: React.FC<MagnifyImageProps> = ({
+  scale = DEFAULT_SCALE,
+  scaleDuration = DEFAULT_SCALE_DURATION,
+  ...rest
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [zoomed, setZoomed] = useState(false)
+  const [positions, setPositions] = useState<Positions>({
+    x: null,
+    y: null,
+  })
+
+  const onMouseOver = () => {
+    timeoutRef.current = setTimeout(() => {
+      setZoomed(true)
+    }, ENTER_TIMEOUT_DELAY)
+  }
+
+  const onMouseOut = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+    }
+
+    setZoomed(false)
+  }
+
+  const onMouseMove = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    if (!containerRef.current) {
+      return
+    }
+
+    const containerRect = containerRef.current.getBoundingClientRect()
+    const x = e.clientX - containerRect.left
+    const y = e.clientY - containerRect.top
+
+    setPositions({
+      x,
+      y,
+    })
+  }
+
+  return (
+    <Box
+      position="relative"
+      overflow="hidden"
+      onMouseOver={onMouseOver}
+      onMouseOut={onMouseOut}
+      onMouseMove={onMouseMove}
+      ref={containerRef as any}
+    >
+      <Image
+        {...rest}
+        style={{
+          ...rest.style,
+          transformOrigin: getTransformOrigin(positions),
+          transition: `transform ${scaleDuration}s ease-out`,
+          transform: zoomed ? `scale(${scale})` : `scale(1.0)`,
+        }}
+      />
+    </Box>
+  )
+}
+
+const Image = styled(BaseImage)`
+  display: block;
+  width: 100%;
+  height: 100%;
+`
+
+const getTransformOrigin = (positions: Positions) => {
+  if (positions.x === null && positions.y === null) {
+    return "center center"
+  }
+
+  return `${positions.x}px ${positions.y}px`
+}

--- a/src/v2/Components/MagnifyImage.tsx
+++ b/src/v2/Components/MagnifyImage.tsx
@@ -14,7 +14,7 @@ interface MagnifyImageProps extends ImageProps {
   scaleDuration?: number
 }
 
-const ENTER_TIMEOUT_DELAY = 200
+const ENTER_TIMEOUT_DELAY = 300
 const DEFAULT_SCALE = 1.75
 const DEFAULT_SCALE_DURATION = 0.15
 
@@ -75,7 +75,7 @@ export const MagnifyImage: React.FC<MagnifyImageProps> = ({
         style={{
           ...rest.style,
           transformOrigin: getTransformOrigin(positions),
-          transition: `transform ${scaleDuration}s ease-out`,
+          transition: `transform ${scaleDuration}s ease, transform-origin 100ms ease`,
           transform: zoomed ? `scale(${scale})` : `scale(1.0)`,
         }}
       />


### PR DESCRIPTION
The type of this PR is: **Feature**
This PR solves [FX-3849]
Slack thread with discussion: [Link](https://artsy.slack.com/archives/C9SATFLUU/p1648554470666829)
Review app: [Link](https://zoom-scroll-when-hovering.artsy.net/artist/banksy/works-for-sale)

### Description
As a collector, I’d like to zoom in into the primary image so I can see more detail.

### Acceptance Criteria
* Given I am on the artwork grid
* And I am hovering on an artwork grid item
* And the artwork does not have an alternate image available
* Then I should see a zoomed in view of the image

### Some notes
* Alternative metadata is displayed when hovering only for `GridItem` component
* Changes are hidden under [Unleash flag](https://unleash.artsy.net/projects/default/features2/force-enable-hover-effect-for-artwork-item) and will be available only for staging environment

### Demo
https://user-images.githubusercontent.com/3513494/161061391-46540ff3-c447-4998-a200-725d3a15b70e.mp4

<!-- Implementation description -->

[FX-3849]: https://artsyproduct.atlassian.net/browse/FX-3849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ