### PR TITLE
refactor: useFeatureVariant

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -12,12 +12,6 @@ import { MaterialsFilter } from "./MaterialsFilter"
 import { PartnersFilter } from "./PartnersFilter"
 import { ArtistsFilter } from "./ArtistsFilter"
 import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
-import {
-  useFeatureVariant,
-  useTrackVariantView,
-} from "v2/System/useFeatureFlag"
-import { useAnalyticsContext } from "v2/System"
-import { OwnerType } from "@artsy/cohesion"
 
 interface ArtworkFiltersProps {
   user?: User

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -27,28 +27,6 @@ interface ArtworkFiltersProps {
 // Some filters will be rendered only if there is the necessary data in aggregations (for example, ArtistsFilter)
 export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
   const { user, relayEnvironment } = props
-  const {
-    contextPageOwnerId,
-    contextPageOwnerSlug,
-    contextPageOwnerType,
-  } = useAnalyticsContext()
-
-  const isArtistPage = contextPageOwnerType === OwnerType.artist
-
-  const variant = useFeatureVariant("filters-expanded-experiment")
-
-  useTrackVariantView({
-    experimentName: "filters-expanded-experiment",
-    variantName: variant?.name!,
-    contextOwnerId: contextPageOwnerId,
-    contextOwnerSlug: contextPageOwnerSlug,
-    contextOwnerType: contextPageOwnerType!,
-    shouldTrackExperiment: isArtistPage,
-  })
-
-  const isExpanded =
-    isArtistPage && variant?.name === "experiment" && !!variant?.enabled
-  const expandedProp = { ...(isExpanded && { expanded: isExpanded }) }
 
   return (
     <>
@@ -58,12 +36,12 @@ export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
       <PriceRangeFilter expanded />
       <SizeFilter expanded />
       <WaysToBuyFilter expanded />
-      <MaterialsFilter {...expandedProp} />
-      <ArtistNationalityFilter {...expandedProp} />
-      <ArtworkLocationFilter {...expandedProp} />
-      <TimePeriodFilter {...expandedProp} />
-      <ColorFilter {...expandedProp} />
-      <PartnersFilter {...expandedProp} />
+      <MaterialsFilter />
+      <ArtistNationalityFilter />
+      <ArtworkLocationFilter />
+      <TimePeriodFilter />
+      <ColorFilter />
+      <PartnersFilter />
     </>
   )
 }

--- a/src/v2/System/__tests__/useFeatureFlag.jest.tsx
+++ b/src/v2/System/__tests__/useFeatureFlag.jest.tsx
@@ -92,7 +92,7 @@ describe("useTrackVariantView", () => {
     window.analytics = analytics
   })
 
-  it("does something", () => {
+  it("calls the tracking function with the correct payload", () => {
     const { trackVariantView } = useTrackVariantView({
       experimentName: "cool-experiment",
       variantName: "experiment",

--- a/src/v2/System/__tests__/useFeatureFlag.jest.tsx
+++ b/src/v2/System/__tests__/useFeatureFlag.jest.tsx
@@ -1,45 +1,47 @@
-import { useFeatureFlag, useFeatureVariant } from "../useFeatureFlag"
+import {
+  useFeatureFlag,
+  useFeatureVariant,
+  useTrackVariantView,
+  shouldTrack,
+} from "../useFeatureFlag"
 import { useSystemContext } from "v2/System/useSystemContext"
-import { useTracking } from "react-tracking"
 
 jest.mock("v2/System/useSystemContext")
-
-const mockUseSystemContext = useSystemContext as jest.Mock
-let mockFeatureFlags
-let trackEvent
+jest.mock("v2/System/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      location: {
+        pathname: "/artist/daniel-arsham",
+      },
+    },
+  }),
+}))
 
 beforeAll(() => {
-  trackEvent = jest.fn()
-  ;(useTracking as jest.Mock).mockImplementation(() => {
+  ;(useSystemContext as jest.Mock).mockImplementation(() => {
     return {
-      trackEvent,
-    }
-  })
-
-  mockFeatureFlags = {
-    featureFlags: {
-      "feature-a": {
-        flagEnabled: true,
-        variant: {
-          enabled: true,
-          name: "variant-a",
-          payload: {
-            type: "string",
-            value: "my payload",
+      featureFlags: {
+        "feature-a": {
+          flagEnabled: true,
+          variant: {
+            enabled: true,
+            name: "variant-a",
+            payload: {
+              type: "string",
+              value: "my payload",
+            },
+          },
+        },
+        "feature-b": {
+          flagEnabled: false,
+          variant: {
+            enabled: false,
+            name: "disabled",
           },
         },
       },
-      "feature-b": {
-        flagEnabled: false,
-        variant: {
-          enabled: false,
-          name: "disabled",
-        },
-      },
-    },
-  }
-
-  mockUseSystemContext.mockImplementation(() => mockFeatureFlags)
+    }
+  })
 })
 
 describe("useFeatureFlag", () => {
@@ -73,5 +75,58 @@ describe("useFeatureVariant", () => {
   it("returns false when the variant isn't present", () => {
     const variant = useFeatureVariant("feature-x")
     expect(variant).toBe(null)
+  })
+})
+
+describe("useTrackVariantView", () => {
+  const analytics = window.analytics
+
+  beforeEach(() => {
+    window.analytics = {
+      track: jest.fn(),
+    } as any
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    window.analytics = analytics
+  })
+
+  it("does something", () => {
+    const { trackVariantView } = useTrackVariantView({
+      experimentName: "cool-experiment",
+      variantName: "experiment",
+    })
+
+    trackVariantView()
+
+    expect(window?.analytics?.track).toHaveBeenLastCalledWith(
+      "experimentViewed",
+      {
+        context_owner_slug: "daniel-arsham",
+        context_owner_type: "artist",
+        experiment_name: "cool-experiment",
+        payload: undefined,
+        service: "unleash",
+        variant_name: "experiment",
+      }
+    )
+  })
+})
+
+describe("shouldTrack", () => {
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  it("returns true if the experiment has not been viewed", () => {
+    const track = shouldTrack("coolFeature", "variantName")
+    expect(track).toEqual(true)
+  })
+
+  it("returns false if the experiment has been viewed", () => {
+    shouldTrack("coolFeature", "variantName")
+    const track = shouldTrack("coolFeature", "variantName")
+    expect(track).toEqual(false)
   })
 })

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -56,9 +56,7 @@ export function useTrackVariantView({
 
   const trackVariantView = () => {
     // HACK: Temporary hack while we refactor useAnalyticsContext
-    // to update upon page navigation. Currently it requires a
-    // context provider to be manually added as a parent component,
-    // which doesn't support components used accross various pageTypes
+    // to update upon page navigation.
     const path = router.match.location.pathname
     const pageParts = path.split("/")
     const pageSlug = pageParts[2]
@@ -67,6 +65,9 @@ export function useTrackVariantView({
     const trackFeatureView = shouldTrack(experimentName, variantName)
 
     if (trackFeatureView) {
+      // HACK: We are using window.analytics.track over trackEvent from useTracking because
+      // the trackEvent wasn't behaving as expected, it was never firing the event and
+      // moving to using the solution below fixed the issue.
       window?.analytics?.track(ActionType.experimentViewed, {
         service: "unleash",
         experiment_name: experimentName,


### PR DESCRIPTION
The type of this PR is: Enhancement

This PR solves [PLATFORM-4059]

### Description

This PR aims to make s number of improvements to the `useFeatureVariant` function and address tracking-related issues [discovered while QA'ing the first implementation](https://github.com/artsy/force/pull/9679). 

1. Reduce `useFeatureVariant`'s parameters to `experimentName`,  `variantName`,  and `payload` (optional). Analytics data no longer is being passed in and is handled within the function itself using  `useRouter` to get the pathname and parse out the `PageType` and `PageSlug`. 
2. Return out a callback, `trackVariantView` instead of passing in a `boolean` to the `shouldTrackExperiment`, enabling developers to conditionally make a tracking call in the component being tested.
3. Improved test coverage

Done with @damassi.


[PLATFORM-4059]: https://artsyproduct.atlassian.net/browse/PLATFORM-4059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ