### PR TITLE
ci: spruce up "Validate Production Schema" CI job failure Slack notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,50 @@ jobs:
               "blocks": [
                 {
                   "type": "section",
-                  "fields": [
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *Deployment Failed* :warning:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Hey there! :wave:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A Force production deployment failed <$CIRCLE_BUILD_URL|on CircleCI> because its local Metaphysics GraphQL schema is incompatible with Metaphysics' production environment."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "No worries though! Force deploys are usually unblocked by first deploying Metaphysics with a Deploy PR <https://github.com/artsy/metaphysics/compare/release...staging?expand=1|here on GitHub>."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "As soon as Metaphysics' production environment is up-to-date, you can \"Rerun worflow from failed\" on the <$CIRCLE_BUILD_URL| CircleCI build page> to continue this Force deployment. :+1:"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
                     {
-                      "type": "plain_text",
-                      "text": "A Force production deploy was attempted and failed due to the local Metaphysics GraphQL schema not being compatible with Metaphysics production. To fix, start a deploy here: https://github.com/artsy/metaphysics/compare/release...staging?expand=1"
+                      "type": "image",
+                      "image_url": "https://assets.brandfolder.com/otz5mn-bw4j2w-6jzqo8/original/circle-logo-badge-black.png",
+                      "alt_text": "CircleCI logo"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "<$CIRCLE_BUILD_URL|$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME@$CIRCLE_BRANCH (#$CIRCLE_BUILD_NUM)> — $CIRCLE_JOB"
                     }
                   ]
                 }


### PR DESCRIPTION
The type of this PR is: **Enhancement**

### Description

We're already using the [slack/notify orb](https://github.com/CircleCI-Public/slack-orb) which supports custom templates written for Slack's [Block Kit](https://api.slack.com/block-kit) UI framework.

This commit takes further advantage of the framework to format links and break up the notification content into a few sections.

You can view an example notification in Slack's Block Kit Builder [here][example].

[example]: https://app.slack.com/block-kit-builder/T02531TU5#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22:warning:%20*Deployment%20Failed*%20:warning:%22%7D%7D,%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22Hey%20there!%20:wave:%22%7D%7D,%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22A%20Force%20production%20deployment%20failed%20%3Chttps://circleci.com/gh/artsy/force/227214%7Con%20CircleCI%3E%20because%20its%20local%20Metaphysics%20GraphQL%20schema%20is%20incompatible%20with%20Metaphysics'%20production%20environment.%22%7D%7D,%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22No%20worries%20though!%20Force%20deploys%20are%20usually%20unblocked%20by%20first%20deploying%20Metaphysics%20with%20a%20Deploy%20PR%20%3Chttps://github.com/artsy/metaphysics/compare/release...staging?expand=1%7Chere%20on%20GitHub%3E.%22%7D%7D,%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22As%20soon%20as%20Metaphysics'%20production%20environment%20is%20up-to-date,%20you%20can%20%5C%22Rerun%20worflow%20from%20failed%5C%22%20on%20the%20%3Chttps://circleci.com/gh/artsy/force/227214%7C%20CircleCI%20build%20page%3E%20to%20continue%20this%20Force%20deployment.%20:+1:%22%7D%7D,%7B%22type%22:%22context%22,%22elements%22:%5B%7B%22type%22:%22image%22,%22image_url%22:%22https://assets.brandfolder.com/otz5mn-bw4j2w-6jzqo8/original/circle-logo-badge-black.png%22,%22alt_text%22:%22CircleCI%20logo%22%7D,%7B%22type%22:%22mrkdwn%22,%22text%22:%22%3Chttps://circleci.com/gh/artsy/force/227214%7Cartsy/force@release%20(#227214)%3E%20%E2%80%94%20validate_production_schema%22%7D%5D%7D%5D%7D

**Light Example**

<img width="505" alt="Screen Shot 2022-04-01 at 01 06 25" src="https://user-images.githubusercontent.com/123595/161164245-ff017748-4acd-448e-b37d-0335855b82db.png">

**Dark Example**

<img width="493" alt="Screen Shot 2022-04-01 at 01 06 31" src="https://user-images.githubusercontent.com/123595/161164252-541a9674-5a61-4fad-a04e-7d9ec5f398a9.png">


