### PR TITLE
fix: remove Authy reference in favour of Google Authenticator

### DIFF
--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -155,7 +155,15 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = ({
             >
               1Password
             </a>{" "}
-            or Google Authenticator.
+            or{" "}
+            <a
+              href="https://support.google.com/accounts/answer/1066447"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Google Authenticator
+            </a>
+            .
           </Text>
         </Box>
 

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -155,15 +155,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = ({
             >
               1Password
             </a>{" "}
-            or{" "}
-            <a
-              href="https://authy.com/features"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Authy
-            </a>
-            .
+            or Google Authenticator.
           </Text>
         </Box>
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PLATFORM-3979]

### Description

Due to Authy being no longer [actively developed](https://www.twilio.com/docs/verify/authy-vs-verify) we would prefer to recommend Google Authenticator to collectors instead.

~~Currently, this also removes a hyperlink as there doesn't appear to be a "nice" hyperlink for Google Authenticator for all users. There are links, but they are to the Apple or Google play stores, which doesn't cover all users.~~

A [hyperlink](https://support.google.com/accounts/answer/1066447?hl=en&co=GENIE.Platform%3DAndroid&oco=0) has been added to help collectors know exactly where to download Google Authenticator for both Android and iOS.

<!-- Implementation description -->

#### Before
<img width="1151" alt="Screenshot 2022-04-05 at 12 42 05" src="https://user-images.githubusercontent.com/6280410/161738713-203552fb-5b97-4026-9f07-2b81a87c9195.png">


#### After
<img width="1155" alt="Screenshot 2022-04-06 at 11 52 21" src="https://user-images.githubusercontent.com/6280410/161948903-78322104-0487-411e-8fac-a4ad1ba3f7e0.png">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLATFORM-3979]: https://artsyproduct.atlassian.net/browse/PLATFORM-3979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ