### PR TITLE
fix: dont reask for credit card info during bidding

### DIFF
--- a/src/v2/Apps/Auction/Routes/Bid/AuctionBidRoute.tsx
+++ b/src/v2/Apps/Auction/Routes/Bid/AuctionBidRoute.tsx
@@ -256,7 +256,7 @@ const computeProps = ({
 
   const requiresCheckbox = !bidder
   const requiresPaymentInformation =
-    requiresCheckbox || !me.hasQualifiedCreditCards
+    requiresCheckbox && !me.hasQualifiedCreditCards
 
   const {
     validationSchemaForRegisteredUsers,

--- a/src/v2/Apps/Auction/Routes/Bid/__tests__/AuctionBidRoute.jest.tsx
+++ b/src/v2/Apps/Auction/Routes/Bid/__tests__/AuctionBidRoute.jest.tsx
@@ -191,6 +191,20 @@ describe("AuctionBidRoute", () => {
     expect(wrapper.find("ErrorStatus")).toHaveLength(1)
   })
 
+  it("doesn't ask for credit card info if user has one on file", () => {
+    const wrapper = getWrapper({
+      Sale: () => ({
+        bidder: null,
+      }),
+      Me: () => ({
+        hasQualifiedCreditCards: true,
+      }),
+    })
+
+    expect(wrapper.find("AddressFormWithCreditCard")).toHaveLength(0)
+    expect(wrapper.find("ConditionsOfSaleCheckbox")).toHaveLength(1)
+  })
+
   it("submits bid", async () => {
     const spy = jest.fn()
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR solves [BID-292]

### Description

The following scenario was observed:
  - user is not registered for an auction, and enters the bid flow
  - they are asked to register ('agree to conditions of sale', placing the bid will create the bidder)
  - they are asked to input a CC always, even if they already had one on file

The desired behavior:
  - if a CC is on file, the registration inlined during bidding should just be the conditions of sale checkbox
  - if there is no CC on file, preserve current behavior (CC form)

After taking a careful look, it seems like a logic bug with `&&` vs `||`.

With these changes, here's how it now looks if you are not registered to bid, but have a CC on file:
![Screen Shot 2022-04-05 at 4 50 17 PM](https://user-images.githubusercontent.com/1457859/161848214-301b73d0-24af-40d8-896a-bbf912bd8a5c.png)



[BID-292]: https://artsyproduct.atlassian.net/browse/BID-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ