### PR TITLE
fix: sanitising untrusted redirect url

### DIFF
--- a/src/v2/Apps/Authentication/Server/checkForRedirect.ts
+++ b/src/v2/Apps/Authentication/Server/checkForRedirect.ts
@@ -17,8 +17,6 @@ export const checkForRedirect = ({ req, res }) => {
     newRedirect = "/"
   } else if (!!redirectTo) {
     newRedirect = sanitizeRedirect(redirectTo)
-  } else {
-    newRedirect = redirectTo
   }
 
   res.locals.sd.AUTHENTICATION_REDIRECT_TO = newRedirect

--- a/src/v2/Apps/Authentication/Server/checkForRedirect.ts
+++ b/src/v2/Apps/Authentication/Server/checkForRedirect.ts
@@ -15,8 +15,10 @@ export const checkForRedirect = ({ req, res }) => {
   let newRedirect
   if (redirectTo === ("/reset_password" || "/user/delete")) {
     newRedirect = "/"
-  } else {
+  } else if (!!redirectTo) {
     newRedirect = sanitizeRedirect(redirectTo)
+  } else {
+    newRedirect = redirectTo
   }
 
   res.locals.sd.AUTHENTICATION_REDIRECT_TO = newRedirect

--- a/src/v2/Apps/Authentication/Server/checkForRedirect.ts
+++ b/src/v2/Apps/Authentication/Server/checkForRedirect.ts
@@ -1,3 +1,4 @@
+import sanitizeRedirect from "lib/passport/sanitize-redirect"
 import { isStaticAuthRoute } from "./isStaticAuthRoute"
 
 export const checkForRedirect = ({ req, res }) => {
@@ -15,7 +16,7 @@ export const checkForRedirect = ({ req, res }) => {
   if (redirectTo === ("/reset_password" || "/user/delete")) {
     newRedirect = "/"
   } else {
-    newRedirect = redirectTo
+    newRedirect = sanitizeRedirect(redirectTo)
   }
 
   res.locals.sd.AUTHENTICATION_REDIRECT_TO = newRedirect

--- a/src/v2/Components/Authentication/FormSwitcher.tsx
+++ b/src/v2/Components/Authentication/FormSwitcher.tsx
@@ -15,6 +15,7 @@ import {
   ModalType,
   SubmitHandler,
 } from "./Types"
+import sanitizeRedirect from "lib/passport/sanitize-redirect"
 
 export interface FormSwitcherProps {
   error?: string
@@ -146,7 +147,9 @@ export class FormSwitcher extends Component<FormSwitcherProps, State> {
       },
       options.redirectTo || options["redirect-to"]
         ? {
-            "redirect-to": options.redirectTo || options["redirect-to"],
+            "redirect-to": sanitizeRedirect(
+              options.redirectTo || options["redirect-to"]
+            ),
           }
         : null,
       options.intent


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PLATFORM-4011]

### Description

<!-- Implementation description -->

This closes a potentially malicious loophole where an Artsy URL could be used to redirect a collector off the website as the untrusted input for the `redirect-to` param was not sanitised.

OWASP [suggests](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html) a number of ways to deal with this issue, however it appears that we already have this code [implemented in Artsy](https://github.com/artsy/force/blob/a5702128800ff5dfd4b2f2ea55708a98ef27d2ab/src/lib/passport/lib/app/sanitize_redirect.js#L29), but we were not using it in this instance. In addition to this, we also have a great test suite setup, even including a URL which [does not contain a protocol](https://github.com/artsy/force/blob/a5702128800ff5dfd4b2f2ea55708a98ef27d2ab/src/lib/passport/test/app/sanitize_redirect.test.js#L60) which was used as an example in this bounty submission.

As part of this PR, I have attempted to find other instances of where we use the unsanitised `redirect-to` parameters.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLATFORM-4011]: https://artsyproduct.atlassian.net/browse/PLATFORM-4011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ