### PR TITLE
feat(GRO-943): /jobs2

### DIFF
--- a/src/v2/Apps/Jobs/JobsApp.tsx
+++ b/src/v2/Apps/Jobs/JobsApp.tsx
@@ -1,0 +1,113 @@
+import { Column, GridColumns, Separator, Spacer, Text } from "@artsy/palette"
+import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { CellArticleFragmentContainer } from "v2/Components/Cells/CellArticle"
+import { MetaTags } from "v2/Components/MetaTags"
+import { RouterLink } from "v2/System/Router/RouterLink"
+import { extractNodes } from "v2/Utils/extractNodes"
+import { JobsApp_viewer } from "v2/__generated__/JobsApp_viewer.graphql"
+
+interface JobsAppProps {
+  viewer: JobsApp_viewer
+}
+
+const JobsApp: FC<JobsAppProps> = ({ viewer }) => {
+  const articles = extractNodes(viewer.articlesConnection)
+
+  return (
+    <>
+      <MetaTags
+        title="Jobs | Artsy"
+        description="Artsy is redefining the way the world discovers art. Our mission is to make all the world’s art accessible to anyone with an Internet connection. Reaching that goal starts with our people, and so we dedicate serious time and energy to find excellent new team members as passionate about our product as we are. Want to help us? We’d love to hear from you."
+        pathname="jobs"
+      />
+
+      <Spacer mt={4} />
+
+      <GridColumns gridRowGap={4}>
+        <Column span={6}>
+          <Text variant="xl">Join Our Team</Text>
+        </Column>
+
+        <Column span={6}>
+          <Text variant="sm">
+            Artsy is redefining the way the world discovers art. Our mission is
+            to expand the art market to support more artists and art in the
+            world. Reaching that goal starts with our people. We dedicate an
+            extraordinary amount of time and energy to finding world-class
+            talent to join the Artsy Team. Want to join us? We’d love to hear
+            from you.
+          </Text>
+
+          <Spacer mt={2} />
+
+          <Text variant="sm">
+            <RouterLink to="/article/artsy-jobs-life-artsy">
+              Life at Artsy
+            </RouterLink>
+
+            <br />
+
+            <RouterLink to="/article/artsy-jobs-engineering">
+              Artsy Engineering
+            </RouterLink>
+          </Text>
+
+          <Separator my={2} />
+
+          <Text variant="sm">
+            Check us out on:{" "}
+            <a
+              href="http://www.glassdoor.com/Overview/Working-at-Artsy-EI_IE793485.11,16.htm"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Glassdoor
+            </a>
+            {" | "}
+            <a
+              href="https://angel.co/artsy"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              AngelList
+            </a>
+            {" | "}
+            <a
+              href="https://www.linkedin.com/company/artsyinc?trk=top_nav_home"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              LinkedIn
+            </a>
+          </Text>
+        </Column>
+
+        {articles.map(article => (
+          <Column span={3} key={article.internalID}>
+            <CellArticleFragmentContainer
+              article={article}
+              mode="GRID"
+              displayByline={false}
+            />
+          </Column>
+        ))}
+      </GridColumns>
+    </>
+  )
+}
+
+export const JobsAppFragmentContainer = createFragmentContainer(JobsApp, {
+  viewer: graphql`
+    fragment JobsApp_viewer on Viewer {
+      articlesConnection(channelId: "578eb73cb5989e6f98f779a1", first: 50) {
+        edges {
+          node {
+            internalID
+            ...CellArticle_article
+          }
+        }
+      }
+    }
+  `,
+})

--- a/src/v2/Apps/Jobs/jobsRoutes.tsx
+++ b/src/v2/Apps/Jobs/jobsRoutes.tsx
@@ -1,0 +1,27 @@
+import loadable from "@loadable/component"
+import { graphql } from "react-relay"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const JobsApp = loadable(
+  () => import(/* webpackChunkName: "jobsBundle" */ "./JobsApp"),
+  {
+    resolveComponent: component => component.JobsAppFragmentContainer,
+  }
+)
+
+export const jobsRoutes: AppRouteConfig[] = [
+  {
+    path: "/jobs2",
+    getComponent: () => JobsApp,
+    onClientSideRender: () => {
+      JobsApp.preload()
+    },
+    query: graphql`
+      query jobsRoutes_JobsQuery {
+        viewer {
+          ...JobsApp_viewer
+        }
+      }
+    `,
+  },
+]

--- a/src/v2/Apps/Page/pageRoutes.tsx
+++ b/src/v2/Apps/Page/pageRoutes.tsx
@@ -3,7 +3,7 @@ import { graphql } from "react-relay"
 import { AppRouteConfig } from "v2/System/Router/Route"
 
 const PageApp = loadable(
-  () => import(/* webpackChunkName: "buyerBundle" */ "./PageApp"),
+  () => import(/* webpackChunkName: "pageBundle" */ "./PageApp"),
   {
     resolveComponent: component => component.PageAppFragmentContainer,
   }

--- a/src/v2/Components/Cells/CellArticle.tsx
+++ b/src/v2/Components/Cells/CellArticle.tsx
@@ -16,9 +16,15 @@ export interface CellArticleProps extends Omit<RouterLinkProps, "to"> {
   article: CellArticle_article
   /** Defaults to `"RAIL"` */
   mode?: "GRID" | "RAIL"
+  displayByline?: boolean
 }
 
-const CellArticle: FC<CellArticleProps> = ({ article, mode, ...rest }) => {
+const CellArticle: FC<CellArticleProps> = ({
+  article,
+  mode,
+  displayByline = true,
+  ...rest
+}) => {
   const width = mode === "GRID" ? "100%" : DEFAULT_CELL_WIDTH
   const image = article.thumbnailImage?.cropped
 
@@ -56,9 +62,11 @@ const CellArticle: FC<CellArticleProps> = ({ article, mode, ...rest }) => {
         {article.thumbnailTitle ?? article.title}
       </Text>
 
-      <Text variant="md" mt={0.5} lineClamp={1}>
-        By {article.byline}
-      </Text>
+      {displayByline && (
+        <Text variant="md" mt={0.5} lineClamp={1}>
+          By {article.byline}
+        </Text>
+      )}
 
       <Text variant="md" color="black60" mt={0.5}>
         {article.publishedAt}

--- a/src/v2/__generated__/JobsApp_viewer.graphql.ts
+++ b/src/v2/__generated__/JobsApp_viewer.graphql.ts
@@ -1,0 +1,93 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type JobsApp_viewer = {
+    readonly articlesConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly " $fragmentRefs": FragmentRefs<"CellArticle_article">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "JobsApp_viewer";
+};
+export type JobsApp_viewer$data = JobsApp_viewer;
+export type JobsApp_viewer$key = {
+    readonly " $data"?: JobsApp_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"JobsApp_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "JobsApp_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "channelId",
+          "value": "578eb73cb5989e6f98f779a1"
+        },
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 50
+        }
+      ],
+      "concreteType": "ArticleConnection",
+      "kind": "LinkedField",
+      "name": "articlesConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArticleEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Article",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "CellArticle_article"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "articlesConnection(channelId:\"578eb73cb5989e6f98f779a1\",first:50)"
+    }
+  ],
+  "type": "Viewer",
+  "abstractKey": null
+};
+(node as any).hash = '8aac205979127838257b0420969f1c1d';
+export default node;

--- a/src/v2/__generated__/jobsRoutes_JobsQuery.graphql.ts
+++ b/src/v2/__generated__/jobsRoutes_JobsQuery.graphql.ts
@@ -1,0 +1,280 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type jobsRoutes_JobsQueryVariables = {};
+export type jobsRoutes_JobsQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"JobsApp_viewer">;
+    } | null;
+};
+export type jobsRoutes_JobsQuery = {
+    readonly response: jobsRoutes_JobsQueryResponse;
+    readonly variables: jobsRoutes_JobsQueryVariables;
+};
+
+
+
+/*
+query jobsRoutes_JobsQuery {
+  viewer {
+    ...JobsApp_viewer
+  }
+}
+
+fragment CellArticle_article on Article {
+  vertical
+  title
+  thumbnailTitle
+  byline
+  href
+  publishedAt(format: "MMM D, YYYY")
+  thumbnailImage {
+    cropped(width: 445, height: 334) {
+      width
+      height
+      src
+      srcSet
+    }
+  }
+}
+
+fragment JobsApp_viewer on Viewer {
+  articlesConnection(channelId: "578eb73cb5989e6f98f779a1", first: 50) {
+    edges {
+      node {
+        internalID
+        ...CellArticle_article
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "jobsRoutes_JobsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "JobsApp_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "jobsRoutes_JobsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "channelId",
+                "value": "578eb73cb5989e6f98f779a1"
+              },
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 50
+              }
+            ],
+            "concreteType": "ArticleConnection",
+            "kind": "LinkedField",
+            "name": "articlesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArticleEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Article",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "vertical",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "thumbnailTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "byline",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "format",
+                            "value": "MMM D, YYYY"
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "publishedAt",
+                        "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "thumbnailImage",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 334
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 445
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "width",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "height",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "cropped(height:334,width:445)"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "articlesConnection(channelId:\"578eb73cb5989e6f98f779a1\",first:50)"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "6240031517188f8272b496172ab0889e",
+    "id": null,
+    "metadata": {},
+    "name": "jobsRoutes_JobsQuery",
+    "operationKind": "query",
+    "text": "query jobsRoutes_JobsQuery {\n  viewer {\n    ...JobsApp_viewer\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment JobsApp_viewer on Viewer {\n  articlesConnection(channelId: \"578eb73cb5989e6f98f779a1\", first: 50) {\n    edges {\n      node {\n        internalID\n        ...CellArticle_article\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+(node as any).hash = '12575517b4d2656d8cc49a592a3d093a';
+export default node;

--- a/src/v2/routes.tsx
+++ b/src/v2/routes.tsx
@@ -26,6 +26,7 @@ import { featureRoutes } from "v2/Apps/Feature/featureRoutes"
 import { geneRoutes } from "v2/Apps/Gene/geneRoutes"
 import { homeRoutes } from "v2/Apps/Home/homeRoutes"
 import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identityVerificationRoutes"
+import { jobsRoutes } from "v2/Apps/Jobs/jobsRoutes"
 import { meetTheSpecialistsRoutes } from "v2/Apps/MeetTheSpecialists/meetTheSpecialistsRoutes"
 import { orderRoutes } from "v2/Apps/Order/orderRoutes"
 import { pageRoutes } from "v2/Apps/Page/pageRoutes"
@@ -68,6 +69,7 @@ export function getAppRoutes(): AppRouteConfig[] {
     { routes: geneRoutes },
     { routes: homeRoutes },
     { routes: identityVerificationRoutes },
+    { routes: jobsRoutes },
     { routes: meetTheSpecialistsRoutes },
     { routes: orderRoutes },
     { routes: pageRoutes },


### PR DESCRIPTION
This PR (potentially) solves [GRO-943]

This just sets up a new jobs page under /jobs2. We should run this by the relevant stakeholders since we're dropping the grouping. We _could_ also display this as a flat list with descriptions etc like it is currently. Here I'm just using the article cell components since they are articles and it was quick/easy/consistent.


![](https://static.damonzucconi.com/_capture/ROwTPHrW.png)

[GRO-943]: https://artsyproduct.atlassian.net/browse/GRO-943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ