### PR TITLE
fix: no shipping info when price on request

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -95,15 +95,14 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
     )
   }
 
-  renderEditionSet(
-    editionSet: EditionSet,
-    includeSelectOption: boolean,
-    editionSelectableOnInquireable: boolean
-  ) {
+  renderEditionSet(editionSet: EditionSet) {
+    const {
+      is_offerable: isOfferable,
+      is_acquireable: isAcquireable,
+      is_inquireable: isInquireable,
+    } = this.props.artwork
     const editionEcommerceAvailable =
-      editionSet?.is_acquireable ||
-      editionSet?.is_offerable ||
-      editionSelectableOnInquireable
+      editionSet?.is_acquireable || editionSet?.is_offerable || isInquireable
 
     const editionFragment = (
       <Flex justifyContent="space-between" flex={1}>
@@ -114,7 +113,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
         </Text>
       </Flex>
     )
-    if (includeSelectOption) {
+    if (!!(isOfferable || isAcquireable || isInquireable)) {
       return (
         <Row>
           <Radio
@@ -133,22 +132,13 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
     }
   }
 
-  renderEditionSets(
-    includeSelectOption: boolean,
-    editionSelectableOnInquireable: boolean
-  ) {
+  renderEditionSets() {
     const editionSets = this.props.artwork.edition_sets
 
     const editionSetsFragment = editionSets?.map((editionSet, index) => {
       return (
         <React.Fragment key={editionSet?.id}>
-          <Box py={2}>
-            {this.renderEditionSet(
-              editionSet,
-              includeSelectOption,
-              editionSelectableOnInquireable
-            )}
-          </Box>
+          <Box py={2}>{this.renderEditionSet(editionSet)}</Box>
           {index !== editionSets.length - 1 && <Separator />}
         </React.Fragment>
       )
@@ -410,10 +400,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
             )
           ) : (
             <>
-              {this.renderEditionSets(
-                artworkEcommerceAvailable || !!isInquireable,
-                !!isInquireable
-              )}
+              {this.renderEditionSets()}
 
               {selectedEditionSet && (
                 <>

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -381,11 +381,8 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
       selectedEditionSet,
     } = this.state
 
-    const editionSelectableOnInquireable = !!artwork.is_inquireable
     const artworkEcommerceAvailable = !!(
-      artwork.is_acquireable ||
-      artwork.is_offerable ||
-      editionSelectableOnInquireable
+      artwork.is_acquireable || artwork.is_offerable
     )
 
     if (!artwork.sale_message && !isInquireable) {
@@ -414,8 +411,8 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
           ) : (
             <>
               {this.renderEditionSets(
-                artworkEcommerceAvailable,
-                editionSelectableOnInquireable
+                artworkEcommerceAvailable || !!isInquireable,
+                !!isInquireable
               )}
 
               {selectedEditionSet && (
@@ -427,7 +424,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
             </>
           )}
 
-          {artworkEcommerceAvailable &&
+          {(artworkEcommerceAvailable || !!isInquireable) &&
             (artwork.shippingOrigin || artwork.shippingInfo) && (
               <Spacer mt={1} />
             )}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR solves [NX-3106]

### Description

It Fixes one issue given price on request, we were displaying shipping info when we don't want in this case.

Before
<img width="1746" alt="Screenshot 2022-03-11 at 16 34 23" src="https://user-images.githubusercontent.com/15792853/162410399-0d2a6e66-18b1-409d-bbc5-17be679bb8bf.png">

After
<img width="1765" alt="Screenshot 2022-04-08 at 11 00 14" src="https://user-images.githubusercontent.com/15792853/162410290-f737d058-8f07-4a17-907d-e56d7556fd13.png">





[NX-3106]: https://artsyproduct.atlassian.net/browse/NX-3106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ