### PR TITLE
chore(FX-3882): update offsets for updated price filter (with histogram)

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilterNew.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilterNew.tsx
@@ -109,7 +109,7 @@ export const PriceRangeFilterNew: FC<PriceRangeFilterNewProps> = ({
           />
         </Box>
 
-        <Spacer mx={2} />
+        <Spacer mr={2} />
 
         <Box flex={1}>
           <Text variant="xs" mb={0.5}>
@@ -127,7 +127,7 @@ export const PriceRangeFilterNew: FC<PriceRangeFilterNewProps> = ({
         </Box>
       </Flex>
 
-      <Box mt={4} mx={`${RANGE_DOT_SIZE / 2}px`}>
+      <Box mt={2} mx={`${RANGE_DOT_SIZE / 2}px`}>
         {bars.length > 0 ? (
           <Histogram
             bars={bars}
@@ -135,7 +135,7 @@ export const PriceRangeFilterNew: FC<PriceRangeFilterNewProps> = ({
           />
         ) : null}
 
-        <Spacer mb={4} />
+        <Spacer mb={2} />
 
         <Range
           min={defaultMinValue}
@@ -150,7 +150,7 @@ export const PriceRangeFilterNew: FC<PriceRangeFilterNewProps> = ({
           ]}
         />
 
-        <Flex justifyContent="space-between" mt={2}>
+        <Flex justifyContent="space-between" mt={1}>
           <Text variant="xs" color="black60">
             ${defaultMinValue}
           </Text>


### PR DESCRIPTION
The type of this PR is: **Enhancement**

This PR solves [FX-3882]

Review app [link](https://update-offsets-for-price-filter.artsy.net/artist/banksy/works-for-sale)

### Acceptance Criteria
* Spacing between min and max boxes is `20px`
* Spacing between graph and max/min is `20px`
* Spacing between bar and graph is `20px`
* Spacing between slider and price points is `10px`

### Demo
| Before        | After           |
| ------------- |:-------------:|
| <img width="472" alt="price-before" src="https://user-images.githubusercontent.com/3513494/162427340-1e95f0e7-fc73-4442-9c86-7b14ccd2ac2a.png"> | <img width="472" alt="price-after" src="https://user-images.githubusercontent.com/3513494/162427350-a3cb8fa3-4355-404d-9500-ed8a231c93ef.png"> |

<!-- Implementation description -->


[FX-3882]: https://artsyproduct.atlassian.net/browse/FX-3882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ