### PR TITLE
fix: drop cypress base image to last working version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
 
   smoke-test-on-live-env:
     docker:
-      - image: cypress/base:16.14.2
+      - image: cypress/base:16.14.0
         environment:
           TERM: xterm
     working_directory: ~/app


### PR DESCRIPTION
This PR reverts the renovate bump of cypress's docker base image from `16.4.0` to `16.4.2`. This appears to be causing `smoke-test-on-live-env` to failed with a `error Couldn't find the binary git`. Failure in CI [here](https://app.circleci.com/pipelines/github/artsy/force/29307/workflows/9ac6ed93-196c-4851-bb86-f41ba2e22699/jobs/228659?invite=true#step-102-56).

Slack discussion [here](https://artsy.slack.com/archives/CA8SANW3W/p1649428139745399).

This PR aims to get CI green again while we look into the other related issues: the root cause of the error, and why Horizon merged the PR with failing checks. 


