### PR TITLE
[GRO-944] universally remove subtitles from Rails at smaller screen widths

### DIFF
--- a/src/v2/Components/Rail/RailHeader.tsx
+++ b/src/v2/Components/Rail/RailHeader.tsx
@@ -59,9 +59,11 @@ export const RailHeader: React.FC<RailHeaderProps> = ({
         </Text>
 
         {subTitle && (
-          <Text as="h3" variant="lg" color="black60" lineClamp={2}>
-            {subTitle}
-          </Text>
+          <Box display={["none", "block"]}>
+            <Text as="h3" variant="lg" color="black60" lineClamp={2}>
+              {subTitle}
+            </Text>
+          </Box>
         )}
       </Box>
 


### PR DESCRIPTION
The type of this PR is: feat

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-944]

### Description

<!-- Implementation description -->
Design noticed that the Home Trove Rail mweb cuts off the text at the ellipsis when viewing on mobile screens so I added this to all Rails for consistency.

<img width="607" alt="Screen Shot 2022-04-11 at 5 28 47 PM" src="https://user-images.githubusercontent.com/23108927/162843705-6a5aeb65-28f8-4562-a70f-fb19361b0e08.png">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-944]: https://artsyproduct.atlassian.net/browse/GRO-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ