### PR TITLE
fix(FX-3804): Incorrect behavior for Artists filter

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -43,6 +43,7 @@ const ArtistItem: React.FC<
   const toggleArtistSelection = (selected, slug) => {
     let updatedValues = artistIDs
 
+    // Move followed artists to the explicit `artistIDs` list
     if (isFollowedArtistCheckboxSelected) {
       updatedValues = [...artistIDs, ...followedArtistSlugs]
     }

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -43,19 +43,17 @@ const ArtistItem: React.FC<
   const toggleArtistSelection = (selected, slug) => {
     let updatedValues = artistIDs
 
+    if (isFollowedArtistCheckboxSelected) {
+      updatedValues = [...artistIDs, ...followedArtistSlugs]
+    }
+
     if (selected) {
       updatedValues = [...updatedValues, slug]
     } else {
-      // When an artist is de-selected, if it is a followed artist _and_ that filter
-      // is also checked, we want to de-select it as well, and move remaining followed
-      // artists to the explicit `artistIDs` list.
-      if (followedArtistSlugs.includes(slug)) {
-        setFilter("includeArtworksByFollowedArtists", false)
-        updatedValues = [...updatedValues, ...followedArtistSlugs]
-      }
-
       updatedValues = updatedValues.filter(item => item !== slug)
     }
+
+    setFilter("includeArtworksByFollowedArtists", false)
     setFilter("artistIDs", updatedValues)
   }
 
@@ -132,9 +130,10 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({ expanded, fairID }) => {
         <Checkbox
           disabled={!followedArtistArtworkCount}
           selected={isFollowedArtistCheckboxSelected}
-          onSelect={value =>
+          onSelect={value => {
             filterContext.setFilter("includeArtworksByFollowedArtists", value)
-          }
+            filterContext.setFilter("artistIDs", [])
+          }}
           my={tokens.my}
         >
           Artists I follow ({followedArtistArtworkCount})


### PR DESCRIPTION
The type of this PR is: **Bugfix/Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR solves [FX-3804]

Review app: [artists-filter](https://artists-filter.artsy.net/collect)

### Description
#### Steps to Reproduce
* Go to [Collect page](https://www.artsy.net/collect)
* Select the artist you follow in Artists filter (e.g. if you follow Banksy, you need to check Banksy)
* Unselect this artist
* **_current outcome_**: All the artists you follow will be selected.
* **_expected outcome_**: Previously selected artist will be unselected

### Changes in this PR
* Fixes for the problem described above
* Some improvements for `Artists I follow` (you can find more context in [this slack thread](https://artsy.slack.com/archives/C9SATFLUU/p1649779628853899))

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/162975587-198733ad-7e85-4b4b-932a-740e8e352829.mp4

#### After
https://user-images.githubusercontent.com/3513494/162975620-1cf5601b-8164-494e-962b-24382f341301.mp4

##### Updated logic of `Artists I follow`
https://user-images.githubusercontent.com/3513494/163189482-78f52864-1d3f-487f-a53f-0000b441f583.mp4

<!-- Implementation description -->


[FX-3804]: https://artsyproduct.atlassian.net/browse/FX-3804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ