### PR TITLE
chore: update copy for timing banner for cascading auction

### DIFF
--- a/src/v2/Apps/Auction/Components/AuctionDetails/SaleDetailTimer.tsx
+++ b/src/v2/Apps/Auction/Components/AuctionDetails/SaleDetailTimer.tsx
@@ -65,22 +65,22 @@ export const getTimerCopy = (time, hasStarted, lotsAreClosing) => {
   // Lots haven't yet closed
   else {
     // 1 hour or less
-    if (parsedDays < 1 && parsedHours < 1 && parsedHours < 1) {
-      copy = `${parsedMinutes}m ${parsedSeconds}s Until Bidding Ends`
+    if (parsedDays < 1 && parsedHours < 1) {
+      copy = `${parsedMinutes}m ${parsedSeconds}s`
       color = "red100"
     }
-    // More than 24 hours until close
+    // More than 24 hours
     else if (parsedDays >= 1) {
-      copy = `${parsedDays + 1} Day${
-        parsedDays >= 1 ? "s" : ""
-      } Until Bidding Ends`
+      copy = `${parsedDays + 1} Day${parsedDays >= 1 ? "s" : ""}`
     }
 
     // 1-24 hours until close
     else if (parsedDays < 1 && parsedHours >= 1) {
-      copy = `${parsedHours}h ${parsedMinutes}m Until Bidding Ends`
+      copy = `${parsedHours}h ${parsedMinutes}m`
       color = "red100"
     }
+
+    copy += " Until Lots Start Closing"
   }
 
   return { copy, color }

--- a/src/v2/Apps/Auction/Components/AuctionDetails/__tests__/SaleDetailTimer.jest.tsx
+++ b/src/v2/Apps/Auction/Components/AuctionDetails/__tests__/SaleDetailTimer.jest.tsx
@@ -8,7 +8,7 @@ describe("getTimerCopy", () => {
       const hasEnded = false
       it("formats the timer correctly", () => {
         expect(getTimerCopy(time, hasStarted, hasEnded).copy).toEqual(
-          "2 Days Until Bidding Ends"
+          "2 Days Until Lots Start Closing"
         )
         expect(getTimerCopy(time, hasStarted, hasEnded).color).toEqual(
           "blue100"
@@ -22,7 +22,7 @@ describe("getTimerCopy", () => {
       const hasEnded = false
       it("formats the timer correctly", () => {
         expect(getTimerCopy(time, hasStarted, hasEnded).copy).toEqual(
-          "23h 33m Until Bidding Ends"
+          "23h 33m Until Lots Start Closing"
         )
         expect(getTimerCopy(time, hasStarted, hasEnded).color).toEqual("red100")
       })
@@ -34,7 +34,7 @@ describe("getTimerCopy", () => {
       const hasEnded = false
       it("formats the timer correctly", () => {
         expect(getTimerCopy(time, hasStarted, hasEnded).copy).toEqual(
-          "58m 23s Until Bidding Ends"
+          "58m 23s Until Lots Start Closing"
         )
         expect(getTimerCopy(time, hasStarted, hasEnded).color).toEqual("red100")
       })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR solves [BID-313]

### Description

Changes copy from 'Until Bidding Ends' -> 'Until Lots Start Closing' , which is more accurate. This component is sort of generically named (`SaleDetailTimer`), so I was afraid that perhaps I was inadvertently changing copy for other use cases, but it looks like the fragment container is only used for cascading (https://github.com/artsy/force/blob/40606892068e96bda00397f5f5426ee32c45d142/src/v2/Apps/Auction/Components/AuctionDetails/AuctionDetails.tsx#L51-L53)

[BID-313]: https://artsyproduct.atlassian.net/browse/BID-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ