### PR TITLE
fix(auction): Restore old urls for older versions of Eigen

### DIFF
--- a/src/v2/Apps/Auction/auctionRoutes.tsx
+++ b/src/v2/Apps/Auction/auctionRoutes.tsx
@@ -159,7 +159,7 @@ export const auctionRoutes: AppRouteConfig[] = [
     ],
   },
   {
-    path: "/auction-faq2",
+    path: "/auction-faq",
     getComponent: () => AuctionFAQRoute,
     query: graphql`
       query auctionRoutes_AuctionFAQRouteQuery {
@@ -168,6 +168,27 @@ export const auctionRoutes: AppRouteConfig[] = [
         }
       }
     `,
+  },
+  {
+    // Legacy redirect for old Eigen clients
+    path: "/auction-registration/:slug?",
+    children: [
+      new Redirect({
+        from: "/",
+        to: "/auction/:slug/register",
+      }) as any,
+    ],
+  },
+
+  {
+    // Legacy redirect for old Eigen clients
+    path: "/auction/:slug/buyers-premium",
+    children: [
+      new Redirect({
+        from: "/",
+        to: "/auction-faq",
+      }) as any,
+    ],
   },
   {
     // Redirect from the old route to the new one


### PR DESCRIPTION
The type of this PR is: **Bugfix**

### Description

Following the thread [here](https://artsy.slack.com/archives/C01ADJNCS5D/p1649788140435499) it turns out some old Eigen versions are relying on urls that no longer exist after the /auction/id rebuild. This restores those URLs:

- /auction-registration/<sale-slug>: redirects to /sale/id/register
- /auction-faq: promotes /auction-faq2 to /auction-faq
- /auction/<sale-slug>/buyers-premium: redirects to /auction-faq (since that page contains buyer premium information
