### PR TITLE
ci(slack-notifications): remove practice-web

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ jobs:
       - image: cimg/node:14.19
     parameters:
       # find channel ID at the botton of channel details view (slack app) or by right clicking on channel, and copying the link. The ID will be visible at the end of that URL.
-      practice_web:
-        type: string
-        default: C2TQ4PT8R
       dev:
         type: string
         default: C02BC3HEJ
@@ -40,7 +37,7 @@ jobs:
           command: node scripts/validateSchemas.js production
       - slack/notify:
           event: fail
-          channel: "<< parameters.practice_web >>, << parameters.dev >>"
+          channel: "<< parameters.dev >>"
           custom: |
             {
               "blocks": [


### PR DESCRIPTION
The type of this PR is: **CI**

### Description

This removes practice-web from out-of-sync MP slack pings since we now have that notification going directly to #dev 
