### PR TITLE
chore: failure of validate schemas only sent to #dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ jobs:
       - image: cimg/node:14.19
     parameters:
       # find channel ID at the botton of channel details view (slack app) or by right clicking on channel, and copying the link. The ID will be visible at the end of that URL.
-      practice_web:
-        type: string
-        default: C2TQ4PT8R
       dev:
         type: string
         default: C02BC3HEJ
@@ -40,7 +37,7 @@ jobs:
           command: node scripts/validateSchemas.js production
       - slack/notify:
           event: fail
-          channel: "<< parameters.practice_web >>, << parameters.dev >>"
+          channel: "<< parameters.dev >>"
           custom: |
             {
               "blocks": [


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

As notifications of failed validate production schema are now being sent to #dev, we no longer need those notifications to surface in #practice-web.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ