### PR TITLE
feat: do not send segment event for disabled variant views

### DIFF
--- a/src/v2/System/__tests__/useFeatureFlag.jest.tsx
+++ b/src/v2/System/__tests__/useFeatureFlag.jest.tsx
@@ -113,7 +113,7 @@ describe("useTrackFeatureVariantView", () => {
     )
   })
 
-  it("does not call tracking funciton if the variantName is disabled", () => {
+  it("does not call the tracking function if the variantName is disabled", () => {
     const { trackFeatureVariant } = useTrackFeatureVariant({
       experimentName: "cool-experiment",
       variantName: "disabled",

--- a/src/v2/System/__tests__/useFeatureFlag.jest.tsx
+++ b/src/v2/System/__tests__/useFeatureFlag.jest.tsx
@@ -78,7 +78,7 @@ describe("useFeatureVariant", () => {
   })
 })
 
-describe("useTrackVariantView", () => {
+describe("useTrackFeatureVariantView", () => {
   const analytics = window.analytics
 
   beforeEach(() => {
@@ -111,6 +111,17 @@ describe("useTrackVariantView", () => {
         variant_name: "experiment",
       }
     )
+  })
+
+  it("does not call tracking funciton if the variantName is disabled", () => {
+    const { trackFeatureVariant } = useTrackFeatureVariant({
+      experimentName: "cool-experiment",
+      variantName: "disabled",
+    })
+
+    trackFeatureVariant()
+
+    expect(window?.analytics?.track).toHaveBeenCalledTimes(0)
   })
 })
 

--- a/src/v2/System/useFeatureFlag.tsx
+++ b/src/v2/System/useFeatureFlag.tsx
@@ -64,7 +64,7 @@ export function useTrackFeatureVariant({
 
     const trackFeatureView = shouldTrack(experimentName, variantName)
 
-    if (trackFeatureView) {
+    if (trackFeatureView && variantName !== "disabled") {
       // HACK: We are using window.analytics.track over trackEvent from useTracking because
       // the trackEvent wasn't behaving as expected, it was never firing the event and
       // moving to using the solution below fixed the issue.


### PR DESCRIPTION
The type of this PR is: Enhancement

### Description

This PR adds a guard against sending segment events when the `variantName` equals `disabled`. This prevents us from sending useless data to segment, as all we care about are `control` or `experiment` views. 



co-authored with: @ovasdi 