### PR TITLE
fix: fill width/height for MagnifyImage container

### DIFF
--- a/src/v2/Components/MagnifyImage.tsx
+++ b/src/v2/Components/MagnifyImage.tsx
@@ -67,6 +67,8 @@ export const MagnifyImage: React.FC<MagnifyImageProps> = ({
       onMouseOver={onMouseOver}
       onMouseOut={onMouseOut}
       onMouseMove={onMouseMove}
+      width="100%"
+      height="100%"
       ref={containerRef as any}
     >
       <Image


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

### Demo
#### Before
<img width="1886" alt="before" src="https://user-images.githubusercontent.com/3513494/164445145-6a0e56f3-8a2c-4842-b1a5-75fcd16b89be.png">

#### After
<img width="1886" alt="after" src="https://user-images.githubusercontent.com/3513494/164445159-ca50c3c0-7c9f-4e46-b917-6f26f0313e02.png">


<!-- Implementation description -->
