### PR TITLE
fix: ignore touch devices for MagnifyImage component

### DIFF
--- a/src/v2/Components/MagnifyImage.tsx
+++ b/src/v2/Components/MagnifyImage.tsx
@@ -1,6 +1,7 @@
 import { Image as BaseImage, ImageProps, Box } from "@artsy/palette"
 import { useRef, useState } from "react"
 import styled from "styled-components"
+import { isTouch } from "v2/Utils/device"
 
 type Position = number | null
 
@@ -32,12 +33,20 @@ export const MagnifyImage: React.FC<MagnifyImageProps> = ({
   })
 
   const onMouseOver = () => {
+    if (isTouch) {
+      return
+    }
+
     timeoutRef.current = setTimeout(() => {
       setZoomed(true)
     }, ENTER_TIMEOUT_DELAY)
   }
 
   const onMouseOut = () => {
+    if (isTouch) {
+      return
+    }
+
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current)
     }
@@ -46,7 +55,7 @@ export const MagnifyImage: React.FC<MagnifyImageProps> = ({
   }
 
   const onMouseMove = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    if (!containerRef.current) {
+    if (!containerRef.current || isTouch) {
       return
     }
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

[Notion card](https://www.notion.so/artsy/Mobile-web-When-I-tap-an-image-it-zooms-before-navigating-b0f4b0821b3f45b6a20acedf1f7b505c)

<!-- Bugfix/Feature/Enhancement/Documentation -->

### Description
When user tap an image (MagnifyImage component), it zooms before navigating

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/164474100-430de80b-8e86-4443-8280-b36e49344703.mp4

#### After
https://user-images.githubusercontent.com/3513494/164473964-1b72a850-f4fa-4dca-9cfb-8e233e972d5a.mp4

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ