### PR TITLE
docs: Document setting scope params [ci skip]

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -66,6 +66,7 @@ To add a new provider, you'll need to accomplish the following tasks:
   provider](https://www.passportjs.org/packages/)
 - Add any required keys or tokens from the provider to Force
 - Configure the strategy in `src/lib/passport/lib/passport/index.js`
+  - Ensure you have set any necessary scope params in `src/lib/passport/lib/passport/lifecycle.js` or [this could be you](https://github.com/artsy/force/pull/9851)!
 - Write the callback function for your provider in
   `src/lib/passport/lib/passport/callbacks.js`
 - Add routes for your provider to `src/lib/passport/lib/passport/index.js`


### PR DESCRIPTION
The type of this PR is: **Documentation**

### Description

I thought this was being done in another place while adding Google auth to Force, but later realized it wasn't working how I thought, so I am leaving a note for the next person 😄 
