### PR TITLE
feat(press): adds press2 app

### DIFF
--- a/src/v2/Apps/Page/Components/PageHTML.tsx
+++ b/src/v2/Apps/Page/Components/PageHTML.tsx
@@ -28,7 +28,6 @@ export const PageHTML = styled(Box)`
   h2,
   h3 {
     margin: ${themeGet("space.2")} auto;
-    text-align: center;
   }
 
   h1 {

--- a/src/v2/Apps/Page/PageApp.tsx
+++ b/src/v2/Apps/Page/PageApp.tsx
@@ -43,8 +43,8 @@ const PageApp: FC<PageAppProps> = ({ page }) => {
 
       <Spacer mt={4} />
 
-      <GridColumns>
-        <Column span={[12, 8, 6]} start={[1, 3, 4]}>
+      <GridColumns gridRowGap={4}>
+        <Column span={8} start={3}>
           <PageHTML dangerouslySetInnerHTML={{ __html: page.content }} />
         </Column>
       </GridColumns>

--- a/src/v2/Apps/Press/PressApp.tsx
+++ b/src/v2/Apps/Press/PressApp.tsx
@@ -1,0 +1,60 @@
+import { Text, Spacer, GridColumns, Column } from "@artsy/palette"
+import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { MetaTags } from "v2/Components/MetaTags"
+import { RouteTab, RouteTabs } from "v2/Components/RouteTabs"
+import { PressApp_page } from "v2/__generated__/PressApp_page.graphql"
+import { PageHTML } from "../Page/Components/PageHTML"
+
+interface PressAppProps {
+  page: PressApp_page
+}
+
+const PressApp: FC<PressAppProps> = ({ page }) => {
+  if (!page.content) return null
+
+  return (
+    <>
+      <MetaTags title={`${page.name} | Artsy`} />
+
+      <Spacer mt={4} />
+
+      <Text variant="xl">Artsy Press</Text>
+
+      <Text variant="xl" color="black60">
+        Contact{" "}
+        <a href="mailto:press@artsy.net" style={{ textDecoration: "none" }}>
+          press@artsy.net
+        </a>
+      </Text>
+
+      <Spacer mt={4} />
+
+      <RouteTabs fill>
+        <RouteTab to="/press2/in-the-media">Artsy in the Media</RouteTab>
+
+        <RouteTab to="/press2/press-releases">
+          News &amp; Press Releases
+        </RouteTab>
+      </RouteTabs>
+
+      <Spacer mt={4} />
+
+      <GridColumns gridRowGap={4}>
+        <Column span={8} start={3}>
+          <PageHTML dangerouslySetInnerHTML={{ __html: page.content }} />
+        </Column>
+      </GridColumns>
+    </>
+  )
+}
+
+export const PressAppFragmentContainer = createFragmentContainer(PressApp, {
+  page: graphql`
+    fragment PressApp_page on Page {
+      internalID
+      name
+      content(format: HTML)
+    }
+  `,
+})

--- a/src/v2/Apps/Press/pressRoutes.tsx
+++ b/src/v2/Apps/Press/pressRoutes.tsx
@@ -1,0 +1,43 @@
+import loadable from "@loadable/component"
+import { graphql } from "react-relay"
+import { AppRouteConfig } from "v2/System/Router/Route"
+
+const PressApp = loadable(
+  () => import(/* webpackChunkName: "pressBundle" */ "./PressApp"),
+  {
+    resolveComponent: component => component.PressAppFragmentContainer,
+  }
+)
+
+export const pressRoutes: AppRouteConfig[] = [
+  {
+    path: "/press2/in-the-media",
+
+    getComponent: () => PressApp,
+    onClientSideRender: () => {
+      PressApp.preload()
+    },
+    query: graphql`
+      query pressRoutes_InTheMediaQuery {
+        page(id: "in-the-media") @principalField {
+          ...PressApp_page
+        }
+      }
+    `,
+  },
+  {
+    path: "/press2/press-releases",
+
+    getComponent: () => PressApp,
+    onClientSideRender: () => {
+      PressApp.preload()
+    },
+    query: graphql`
+      query pressRoutes_PressReleasesQuery {
+        page(id: "news-and-press-releases") @principalField {
+          ...PressApp_page
+        }
+      }
+    `,
+  },
+]

--- a/src/v2/__generated__/PressApp_page.graphql.ts
+++ b/src/v2/__generated__/PressApp_page.graphql.ts
@@ -1,0 +1,59 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PressApp_page = {
+    readonly internalID: string;
+    readonly name: string;
+    readonly content: string | null;
+    readonly " $refType": "PressApp_page";
+};
+export type PressApp_page$data = PressApp_page;
+export type PressApp_page$key = {
+    readonly " $data"?: PressApp_page$data;
+    readonly " $fragmentRefs": FragmentRefs<"PressApp_page">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "PressApp_page",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "HTML"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "content",
+      "storageKey": "content(format:\"HTML\")"
+    }
+  ],
+  "type": "Page",
+  "abstractKey": null
+};
+(node as any).hash = 'a889683a5e7ce6942841f8852f8c6bd5';
+export default node;

--- a/src/v2/__generated__/pressRoutes_InTheMediaQuery.graphql.ts
+++ b/src/v2/__generated__/pressRoutes_InTheMediaQuery.graphql.ts
@@ -1,0 +1,134 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type pressRoutes_InTheMediaQueryVariables = {};
+export type pressRoutes_InTheMediaQueryResponse = {
+    readonly page: {
+        readonly " $fragmentRefs": FragmentRefs<"PressApp_page">;
+    };
+};
+export type pressRoutes_InTheMediaQuery = {
+    readonly response: pressRoutes_InTheMediaQueryResponse;
+    readonly variables: pressRoutes_InTheMediaQueryVariables;
+};
+
+
+
+/*
+query pressRoutes_InTheMediaQuery {
+  page(id: "in-the-media") @principalField {
+    ...PressApp_page
+    id
+  }
+}
+
+fragment PressApp_page on Page {
+  internalID
+  name
+  content(format: HTML)
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "in-the-media"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "pressRoutes_InTheMediaQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Page",
+        "kind": "LinkedField",
+        "name": "page",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "PressApp_page"
+          }
+        ],
+        "storageKey": "page(id:\"in-the-media\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "pressRoutes_InTheMediaQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Page",
+        "kind": "LinkedField",
+        "name": "page",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "HTML"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "content",
+            "storageKey": "content(format:\"HTML\")"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "page(id:\"in-the-media\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "3e95c4e8ef398018892fe07275c8c961",
+    "id": null,
+    "metadata": {},
+    "name": "pressRoutes_InTheMediaQuery",
+    "operationKind": "query",
+    "text": "query pressRoutes_InTheMediaQuery {\n  page(id: \"in-the-media\") @principalField {\n    ...PressApp_page\n    id\n  }\n}\n\nfragment PressApp_page on Page {\n  internalID\n  name\n  content(format: HTML)\n}\n"
+  }
+};
+})();
+(node as any).hash = '375038273fedb117d441bffae18b23a5';
+export default node;

--- a/src/v2/__generated__/pressRoutes_PressReleasesQuery.graphql.ts
+++ b/src/v2/__generated__/pressRoutes_PressReleasesQuery.graphql.ts
@@ -1,0 +1,134 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type pressRoutes_PressReleasesQueryVariables = {};
+export type pressRoutes_PressReleasesQueryResponse = {
+    readonly page: {
+        readonly " $fragmentRefs": FragmentRefs<"PressApp_page">;
+    };
+};
+export type pressRoutes_PressReleasesQuery = {
+    readonly response: pressRoutes_PressReleasesQueryResponse;
+    readonly variables: pressRoutes_PressReleasesQueryVariables;
+};
+
+
+
+/*
+query pressRoutes_PressReleasesQuery {
+  page(id: "news-and-press-releases") @principalField {
+    ...PressApp_page
+    id
+  }
+}
+
+fragment PressApp_page on Page {
+  internalID
+  name
+  content(format: HTML)
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "news-and-press-releases"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "pressRoutes_PressReleasesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Page",
+        "kind": "LinkedField",
+        "name": "page",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "PressApp_page"
+          }
+        ],
+        "storageKey": "page(id:\"news-and-press-releases\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "pressRoutes_PressReleasesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Page",
+        "kind": "LinkedField",
+        "name": "page",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "HTML"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "content",
+            "storageKey": "content(format:\"HTML\")"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "page(id:\"news-and-press-releases\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ad8db60858a7e0158a8acb4cffdbecdf",
+    "id": null,
+    "metadata": {},
+    "name": "pressRoutes_PressReleasesQuery",
+    "operationKind": "query",
+    "text": "query pressRoutes_PressReleasesQuery {\n  page(id: \"news-and-press-releases\") @principalField {\n    ...PressApp_page\n    id\n  }\n}\n\nfragment PressApp_page on Page {\n  internalID\n  name\n  content(format: HTML)\n}\n"
+  }
+};
+})();
+(node as any).hash = '61a3ee7d1b971c6f537512f2539921f0';
+export default node;

--- a/src/v2/routes.tsx
+++ b/src/v2/routes.tsx
@@ -33,6 +33,7 @@ import { pageRoutes } from "v2/Apps/Page/pageRoutes"
 import { partnerRoutes } from "v2/Apps/Partner/partnerRoutes"
 import { partnersRoutes } from "v2/Apps/Partners/partnersRoutes"
 import { preferencesRoutes } from "./Apps/Preferences/preferencesRoutes"
+import { pressRoutes } from "./Apps/Press/pressRoutes"
 import { priceDatabaseRoutes } from "./Apps/PriceDatabase/priceDatabaseRoutes"
 import { searchRoutes } from "v2/Apps/Search/searchRoutes"
 import { settingsRoutes } from "v2/Apps/Settings/settingsRoutes"
@@ -76,6 +77,7 @@ export function getAppRoutes(): AppRouteConfig[] {
     { routes: partnerRoutes },
     { routes: partnersRoutes },
     { routes: preferencesRoutes },
+    { routes: pressRoutes },
     { routes: priceDatabaseRoutes },
     { routes: searchRoutes },
     { routes: settingsRoutes },


### PR DESCRIPTION
Adds the press2 app. These pages are backed by two Markdown pages managed in Torque:

https://admin.artsy.net/page/in-the-media
https://admin.artsy.net/page/news-and-press-releases

Which I made by converting the JSON blobs from the JSON pages into Markdown.

https://artsy-force-production.s3.amazonaws.com/json/in-the-media.json
https://artsy-force-production.s3.amazonaws.com/json/press-releases.json

https://user-images.githubusercontent.com/112297/164546873-7fa75ba6-78f5-42ee-9194-68c2d0843e37.mov


