### PR TITLE
fix[cookie-consent]: add bottom margin to checkout flow

### DIFF
--- a/src/v2/Apps/Order/OrderApp.tsx
+++ b/src/v2/Apps/Order/OrderApp.tsx
@@ -170,7 +170,7 @@ export { OrderAppWithRouter as OrderApp }
 const SafeAreaContainer = styled(Box)`
   padding: env(safe-area-inset-top) env(safe-area-inset-right)
     env(safe-area-inset-bottom) env(safe-area-inset-left);
-  margin-bottom: 75px;
+  margin-bottom: 200px;
 `
 
 graphql`

--- a/src/v2/Apps/Order/OrderApp.tsx
+++ b/src/v2/Apps/Order/OrderApp.tsx
@@ -14,11 +14,11 @@ import { Elements } from "@stripe/react-stripe-js"
 import styled from "styled-components"
 import { get } from "v2/Utils/get"
 import { ConnectedModalDialog } from "./Dialogs"
-import { data as sd } from "sharify"
 import { ZendeskWrapper } from "v2/Components/ZendeskWrapper"
 import { HorizontalPadding } from "../Components/HorizontalPadding"
 import { AppContainer } from "../Components/AppContainer"
 import { isExceededZendeskThreshold } from "v2/Utils/isExceededZendeskThreshold"
+import { getENV } from "v2/Utils/getENV"
 
 export interface OrderAppProps extends RouterState {
   params: {
@@ -96,7 +96,7 @@ class OrderApp extends Component<OrderAppProps, {}> {
 
     if (typeof window !== "undefined" && window.zEmbed) return
 
-    return <ZendeskWrapper zdKey={sd.ZENDESK_KEY} />
+    return <ZendeskWrapper zdKey={getENV("ZENDESK_KEY")} />
   }
 
   render() {
@@ -117,7 +117,7 @@ class OrderApp extends Component<OrderAppProps, {}> {
       )
     }
 
-    const stripePromise = loadStripe(sd.STRIPE_PUBLISHABLE_KEY)
+    const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
 
     const isModal = !!this.props.match?.location.query.isModal
 


### PR DESCRIPTION
The type of this PR is: **bugfix**

### Description

Currently, if a user has not accepted cookies and views an order page, they will be unable to see the "continue" button at the bottom of the screen and are unable to scroll it into view.

While we figure out a better long-term solution, this PR adds more margin to the container so that users can at least scroll the button into view and not get stuck.

Before:
![before](https://user-images.githubusercontent.com/5361806/164713908-87ae15c7-8943-4756-a3da-4b2b3f201189.gif)

After:
![after](https://user-images.githubusercontent.com/5361806/164713872-25ba8497-eddc-4ad3-be1d-177bdec9b840.gif)

After + user has accepted cookies:
![after-accepting-cookies](https://user-images.githubusercontent.com/5361806/164713860-2cff1124-e0eb-4707-8fce-9b0dc462ae66.gif)

