### PR TITLE
fix(artwork alerts): update copy for CTA

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
@@ -97,7 +97,7 @@ export const CreateArtworkAlertSection: React.FC<CreateArtworkAlertSectionProps>
         justifyContent="space-between"
       >
         <Text variant="xs" mr={2}>
-          Be notified when a similar piece is available
+          Be notified when a similar work is available
         </Text>
         <SavedSearchCreateAlertButton
           entity={entity}

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebar.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebar.jest.tsx
@@ -80,7 +80,7 @@ describe("ArtworkSidebar", () => {
 
     expect(screen.queryByText(/Create Alert/i)).toBeInTheDocument()
     expect(
-      screen.queryByText(/Be notified when a similar piece is available/i)
+      screen.queryByText(/Be notified when a similar work is available/i)
     ).toBeInTheDocument()
   })
 
@@ -89,7 +89,7 @@ describe("ArtworkSidebar", () => {
 
     expect(screen.queryByText(/Create Alert/i)).not.toBeInTheDocument()
     expect(
-      screen.queryByText(/Be notified when a similar piece is available/i)
+      screen.queryByText(/Be notified when a similar work is available/i)
     ).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR solves [FX-3908]

### Description

Tiny change to artwork alerts CTA (`similar piece` → `similar work`), in order to be more consistent with Artsy's copyediting standards. 