### PR TITLE
chore: removed swa unleash flag (SWA-349)

### DIFF
--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
@@ -6,13 +6,11 @@ import { DownloadApps } from "./Components/DownloadApps"
 import { AnalyticsSchema, useSystemContext, useTracking } from "v2/System"
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { useRouter } from "v2/System/Router/useRouter"
-import { useFeatureFlag } from "v2/System/useFeatureFlag"
 
 export const ThankYou: React.FC = () => {
   const { user, isLoggedIn } = useSystemContext()
   const { match } = useRouter()
   const { trackEvent } = useTracking()
-  const isSWAMCEnabled = useFeatureFlag("swa_my_collection")
 
   const trackSubmitAnotherWorkClick = () =>
     trackEvent({
@@ -26,7 +24,7 @@ export const ThankYou: React.FC = () => {
 
   return (
     <>
-      {isSWAMCEnabled && isLoggedIn ? (
+      {isLoggedIn ? (
         <>
           <Text variant="xxl" mt={4}>
             Your artwork has been submitted

--- a/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYou.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYou.jest.tsx
@@ -46,15 +46,10 @@ describe("ThankYou page", () => {
     })
   })
 
-  describe("when ff enabled and user is logged in", () => {
+  describe("when user is logged in", () => {
     beforeEach(() => {
       ;(useSystemContext as jest.Mock).mockImplementation(() => {
         return {
-          featureFlags: {
-            swa_my_collection: {
-              flagEnabled: true,
-            },
-          },
           isLoggedIn: true,
         }
       })
@@ -86,50 +81,11 @@ describe("ThankYou page", () => {
     })
   })
 
-  describe("when ff enabled or disabled and user is not logged in", () => {
+  describe("when user is not logged in", () => {
     beforeEach(() => {
       ;(useSystemContext as jest.Mock).mockImplementation(() => {
         return {
           isLoggedIn: false,
-        }
-      })
-    })
-    it("renders correctly", () => {
-      const wrapper = mount(<ThankYou />)
-      const text = wrapper.text()
-
-      expect(text).toContain("Thank you for submitting a work")
-      expect(text).toContain(
-        "We’ll email you within 1–3 business days to let you know the status of your submission."
-      )
-      expect(text).toContain(
-        "In the meantime, feel free to submit another work—and benefit from Artsy’s low fees, informed pricing, and multiple selling options."
-      )
-
-      expect(
-        wrapper.find("button[data-test-id='submit-another-work']").text()
-      ).toContain("Submit Another Work")
-
-      expect(
-        wrapper.find("button[data-test-id='go-to-artsy-homepage']").text()
-      ).toContain("Back to Artsy Homepage")
-
-      expect(text).toContain("View My Collection on the Artsy App")
-
-      expect(wrapper.find("SoldRecentlyQueryRenderer").length).toBe(1)
-      expect(wrapper.find("FAQ").length).toBe(1)
-    })
-  })
-
-  describe("when ff disabled", () => {
-    beforeEach(() => {
-      ;(useSystemContext as jest.Mock).mockImplementation(() => {
-        return {
-          featureFlags: {
-            swa_my_collection: {
-              flagEnabled: false,
-            },
-          },
         }
       })
     })


### PR DESCRIPTION
The type of this PR is: Chore

This PR solves [SWA-349]

Removes the `swa_my_collection` Unleash feature flag from logic that displays different confirmation screens at the end of the SWA flow.

[SWA-349]: https://artsyproduct.atlassian.net/browse/SWA-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ