### PR TITLE
feat: let CI always use hokusai beta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
             }
 
   create_or_update_review_app:
-    executor: hokusai/deploy
+    executor: hokusai/beta
     parameters:
       artsy_docker_host:
         type: string
@@ -310,6 +310,7 @@ workflows:
       - artsy-remote-docker/buildkit-build:
           <<: *not_staging_or_release
           context: hokusai
+          executor: hokusai/beta
           name: builder-image-build
           pre-steps:
             - run:
@@ -318,6 +319,7 @@ workflows:
       - artsy-remote-docker/buildkit-push:
           <<: *not_staging_or_release
           context: hokusai
+          executor: hokusai/beta
           name: builder-image-push
           requires:
             - builder-image-build
@@ -329,6 +331,7 @@ workflows:
       - artsy-remote-docker/buildkit-build:
           <<: *not_staging_or_release
           context: hokusai
+          executor: hokusai/beta
           name: electron-runner-image-build
           requires:
             - builder-image-build
@@ -339,6 +342,7 @@ workflows:
       - artsy-remote-docker/buildkit-push:
           <<: *not_staging_or_release
           context: hokusai
+          executor: hokusai/beta
           name: electron-runner-image-push
           requires:
             - electron-runner-image-build
@@ -393,6 +397,7 @@ workflows:
       - artsy-remote-docker/buildkit-build:
           <<: *only_main
           context: hokusai
+          executor: hokusai/beta
           name: production-image-build
           requires:
             - builder-image-build
@@ -400,6 +405,7 @@ workflows:
       - artsy-remote-docker/buildkit-push:
           <<: *only_main
           context: hokusai
+          executor: hokusai/beta
           name: production-image-push
           requires:
             - mocha
@@ -414,6 +420,7 @@ workflows:
           <<: *only_main
           name: deploy-staging
           project-name: force
+          executor: hokusai/beta
           requires:
             - production-image-push
           post-steps:
@@ -455,6 +462,7 @@ workflows:
       # Production
       - hokusai/deploy-production:
           <<: *only_release
+          executor: hokusai/beta
           name: deploy-production
           requires:
             - horizon/block
@@ -468,6 +476,7 @@ workflows:
 
       - create_or_update_review_app:
           context: hokusai
+          executor: hokusai/beta
           filters:
             branches:
               only: /^review-app-.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,7 +476,6 @@ workflows:
 
       - create_or_update_review_app:
           context: hokusai
-          executor: hokusai/beta
           filters:
             branches:
               only: /^review-app-.*/


### PR DESCRIPTION
Every Hokusai release is preceded by a [beta release](https://github.com/artsy/hokusai#distributing-hokusai) which has to be tested against a representative project. We had [designated Gravity](https://github.com/artsy/gravity/pull/15211) as such a project, but it [appears](https://artsy.slack.com/archives/CP9P4KR35/p1650901922885489) that Force is a better candiate!

So how about we put Force on hokusai beta (and relieve Gravity)?