### PR TITLE
fix: revert yarn/node orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
   hokusai: artsy/hokusai@volatile
   horizon: artsy/release@volatile
   slack: circleci/slack@4.9.3
-  yarn: artsy/yarn@volatile
+  yarn: artsy/yarn@6.1.0
 
 jobs:
   run_deepcrawl_automator:


### PR DESCRIPTION
bumped these orbs version to latest in https://github.com/artsy/force/pull/9947, not realizing they carry node version. undo.