### PR TITLE
[WIP] feat(ArtworkFilter): Make filter URL driven so that browser back buttons preserve previous selections

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collect/index.tsx
@@ -38,7 +38,7 @@ export const CollectApp: React.FC<CollectAppProps> = ({
   match: { location, params },
   viewer,
 }) => {
-  const { router } = useRouter()
+  const { router, match } = useRouter()
   const medium = params?.medium as Medium
   const color = params?.color as Color
   const { description, breadcrumbTitle, title } = getMetadata({
@@ -134,6 +134,8 @@ export const CollectApp: React.FC<CollectAppProps> = ({
                *
                */
               const newLocation = router.createLocation(url)
+
+              // console.log(match)
 
               router.push({
                 ...newLocation,

--- a/src/v2/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collect/index.tsx
@@ -22,6 +22,7 @@ import {
   Counts,
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+import { useRouter } from "v2/System/Router/useRouter"
 
 export interface CollectAppProps {
   match: Match
@@ -37,6 +38,7 @@ export const CollectApp: React.FC<CollectAppProps> = ({
   match: { location, params },
   viewer,
 }) => {
+  const { router } = useRouter()
   const medium = params?.medium as Medium
   const color = params?.color as Color
   const { description, breadcrumbTitle, title } = getMetadata({
@@ -120,26 +122,27 @@ export const CollectApp: React.FC<CollectAppProps> = ({
             onChange={filters => {
               const url = buildUrlForCollectApp(filters)
 
-              if (typeof window !== "undefined") {
-                window.history.replaceState({}, "", url)
-              }
+              // if (typeof window !== "undefined") {
+              //   window.history.pushState({}, "", url)
+              // }
 
               /**
-             * FIXME: Ideally we route using our router, but are running into
-             * synchronization issues between router state and URL bar state.
-             *
-             * See below example as an illustration:
-             *
+               * FIXME: Ideally we route using our router, but are running into
+               * synchronization issues between router state and URL bar state.
+               *
+               * See below example as an illustration:
+               *
+               */
               const newLocation = router.createLocation(url)
 
-              router.replace({
+              router.push({
                 ...newLocation,
                 state: {
-                  scrollTo: "#jump--artworkFilter"
+                  scrollTo: "#jump--artworkFilter",
+                  ignoreScrollBehavior: true,
+                  hidePageLoader: true,
                 },
               })
-            *
-            */
             }}
           />
         </Box>

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -1,4 +1,4 @@
-import { Spacer, useThemeConfig } from "@artsy/palette"
+import { Box, Spacer, Spinner, useThemeConfig } from "@artsy/palette"
 import * as React from "react"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 import { ArtworkFilterArtworkGrid_filtered_artworks } from "v2/__generated__/ArtworkFilterArtworkGrid_filtered_artworks.graphql"
@@ -6,10 +6,10 @@ import { useSystemContext } from "v2/System"
 import { useTracking } from "v2/System/Analytics/useTracking"
 import ArtworkGrid from "v2/Components/ArtworkGrid"
 import { PaginationFragmentContainer as Pagination } from "v2/Components/Pagination"
-import { LoadingArea } from "../LoadingArea"
 import { useArtworkFilterContext } from "./ArtworkFilterContext"
 import { ContextModule, clickedMainArtworkGrid } from "@artsy/cohesion"
 import { useAnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
+import { Sticky } from "../Sticky"
 
 interface ArtworkFilterArtworkGridProps {
   columnCount: number[]
@@ -62,7 +62,6 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
 
   return (
     <>
-      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <LoadingArea isLoading={props.isLoading}>
         <ArtworkGrid
           artworks={props.filtered_artworks}
@@ -127,3 +126,22 @@ export const ArtworkFilterArtworkGridRefetchContainer = createFragmentContainer(
     `,
   }
 )
+
+const LoadingArea: React.FC<{ isLoading?: boolean }> = ({
+  isLoading,
+  children,
+}) => {
+  return (
+    <Box position="relative">
+      {isLoading && (
+        <Sticky>
+          <Box height={300} width="100%" position="absolute">
+            <Spinner />
+          </Box>
+        </Sticky>
+      )}
+
+      <Box opacity={isLoading ? 0.1 : 1}>{children}</Box>
+    </Box>
+  )
+}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -9,6 +9,8 @@ import { rangeToTuple } from "./Utils/rangeToTuple"
 import { paramsToCamelCase } from "./Utils/urlBuilder"
 import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { DEFAULT_METRIC, Metric } from "./Utils/metrics"
+import { useRouter } from "v2/System/Router/useRouter"
+import { getInitialFilterState } from "./Utils/getInitialFilterState"
 
 /**
  * Initial filter state
@@ -280,6 +282,8 @@ export const ArtworkFilterContextProvider: React.FC<
   sortOptions,
   ZeroState,
 }) => {
+  const { router, match } = useRouter()
+
   const initialFilterState = {
     ...initialArtworkFilterState,
     sort: sortOptions?.[0].value ?? initialArtworkFilterState.sort,
@@ -408,6 +412,11 @@ export const ArtworkFilterContextProvider: React.FC<
       force ? dispatch(action) : dispatchOrStage(action)
     },
   }
+
+  useDeepCompareEffect(() => {
+    const updatedStateFromURL = getInitialFilterState(location.query)
+    // artworkFilterContext.setFilters(updatedStateFromURL ?? {})
+  }, [match.location.query])
 
   return (
     <ArtworkFilterContext.Provider value={artworkFilterContext}>

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -177,14 +177,17 @@ export enum SelectedFiltersCountsLabels {
   waysToBuy = "waysToBuy",
 }
 
-// TODO: merge or make a generic base of `ArtworkFilterContextProps` and `AuctionResultsFilterContextProps`.
-// Possibly just extend `BaseFilterContext` and make the former ones into `BaseFilterContext<ArtworkFilters>`
-// and `BaseFilterContext<AuctionResultFilters>`.
+// TODO: merge or make a generic base of `ArtworkFilterContextProps` and
+// `AuctionResultsFilterContextProps`. Possibly just extend `BaseFilterContext`
+// and make the former ones into `BaseFilterContext<ArtworkFilters>` and
+// `BaseFilterContext<AuctionResultFilters>`.
 export interface ArtworkFilterContextProps {
-  /** The current artwork filter state (which determines the network request and the url querystring) */
+  // The current artwork filter state (which determines the network request and
+  // the url querystring)
   filters?: ArtworkFiltersState
 
-  /** Interim filter state, to be manipulated before being applied to the current filter state */
+  // Interim filter state, to be manipulated before being applied to the current
+  // filter state
   stagedFilters?: ArtworkFiltersState
 
   /** Getter for the appropriate source of truth to render in the filter UI */

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtworkSortFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtworkSortFilter.tsx
@@ -6,7 +6,7 @@ export const ArtworkSortFilter: React.FC = () => {
   const context = useArtworkFilterContext()
   const { sortOptions, filters } = context
 
-  console.log(filters.sort)
+  // console.log(filters.sort)
 
   return (
     <SortFilter

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtworkSortFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtworkSortFilter.tsx
@@ -1,10 +1,12 @@
-import * as React from "react";
+import * as React from "react"
 import { SortFilter } from "v2/Components/SortFilter"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 
 export const ArtworkSortFilter: React.FC = () => {
   const context = useArtworkFilterContext()
   const { sortOptions, filters } = context
+
+  console.log(filters.sort)
 
   return (
     <SortFilter

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -114,7 +114,7 @@ export const BaseArtworkFilter: React.FC<
     contextPageOwnerSlug,
     contextPageOwnerType,
   } = useAnalyticsContext()
-  // const [isFetching, toggleFetching] = useState(false)
+  const [_isFetching, toggleFetching] = useState(false)
   const [showMobileActionSheet, toggleMobileActionSheet] = useState(false)
   const filterContext = useArtworkFilterContext()
   const previousFilters = usePrevious(filterContext.filters)
@@ -149,7 +149,9 @@ export const BaseArtworkFilter: React.FC<
         const filtersHaveUpdated = !isEqual(currentFilter, previousFilter)
 
         if (filtersHaveUpdated) {
-          fetchResults()
+          // TODO: Remove this function once we're certain route-based updates
+          // are working as expected.
+          // fetchResultsViaRelayRefetch()
 
           if (filterKey === "page") {
             const pageTrackingParams: ClickedChangePage = {
@@ -186,8 +188,10 @@ export const BaseArtworkFilter: React.FC<
     )
   }, [filterContext.filters])
 
-  function fetchResults() {
-    // toggleFetching(true)
+  // TODO: Remove this once we're certain that route-based updates are working
+  // as expected.
+  function fetchResultsViaRelayRefetch() {
+    toggleFetching(true)
 
     const refetchVariables = {
       input: {
@@ -199,13 +203,13 @@ export const BaseArtworkFilter: React.FC<
       ...relayVariables,
     }
 
-    // relay.refetch(refetchVariables, null, error => {
-    //   if (error) {
-    //     console.error(error)
-    //   }
+    relay.refetch(refetchVariables, null, error => {
+      if (error) {
+        console.error(error)
+      }
 
-    //   toggleFetching(false)
-    // })
+      toggleFetching(false)
+    })
   }
 
   if (!viewer?.filtered_artworks) {

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -46,6 +46,8 @@ import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvi
 import { getTotalSelectedFiltersCount } from "./Utils/getTotalSelectedFiltersCount"
 import { SavedSearchEntity } from "../SavedSearchAlert/types"
 import { SavedSearchAlertArtworkGridFilterPills } from "../SavedSearchAlert/Components/SavedSearchAlertArtworkGridFilterPills"
+import { useRouter } from "v2/System/Router/useRouter"
+import { getInitialFilterState } from "./Utils/getInitialFilterState"
 
 interface ArtworkFilterProps extends SharedArtworkFilterContextProps, BoxProps {
   enableCreateAlert?: boolean
@@ -108,6 +110,7 @@ export const BaseArtworkFilter: React.FC<
   savedSearchEntity,
   ...rest
 }) => {
+  const { router, match } = useRouter()
   const tracking = useTracking()
   const {
     contextPageOwnerId,

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -28,7 +28,6 @@ import {
   GridColumns,
   Spacer,
   Text,
-  useThemeConfig,
 } from "@artsy/palette"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { ArtworkQueryFilter } from "./ArtworkQueryFilter"
@@ -115,11 +114,11 @@ export const BaseArtworkFilter: React.FC<
     contextPageOwnerSlug,
     contextPageOwnerType,
   } = useAnalyticsContext()
-  const [isFetching, toggleFetching] = useState(false)
+  // const [isFetching, toggleFetching] = useState(false)
   const [showMobileActionSheet, toggleMobileActionSheet] = useState(false)
   const filterContext = useArtworkFilterContext()
   const previousFilters = usePrevious(filterContext.filters)
-  const { user } = useSystemContext()
+  const { user, isFetching } = useSystemContext()
   const appliedFiltersTotalCount = getTotalSelectedFiltersCount(
     filterContext.selectedFiltersCounts
   )
@@ -187,21 +186,8 @@ export const BaseArtworkFilter: React.FC<
     )
   }, [filterContext.filters])
 
-  const tokens = useThemeConfig({
-    v2: {
-      version: "v2",
-      mt: [0, 0.5],
-      pr: [0, 2],
-    },
-    v3: {
-      version: "v3",
-      mt: undefined,
-      pr: undefined,
-    },
-  })
-
   function fetchResults() {
-    toggleFetching(true)
+    // toggleFetching(true)
 
     const refetchVariables = {
       input: {
@@ -213,13 +199,13 @@ export const BaseArtworkFilter: React.FC<
       ...relayVariables,
     }
 
-    relay.refetch(refetchVariables, null, error => {
-      if (error) {
-        console.error(error)
-      }
+    // relay.refetch(refetchVariables, null, error => {
+    //   if (error) {
+    //     console.error(error)
+    //   }
 
-      toggleFetching(false)
-    })
+    //   toggleFetching(false)
+    // })
   }
 
   if (!viewer?.filtered_artworks) {
@@ -227,7 +213,7 @@ export const BaseArtworkFilter: React.FC<
   }
 
   return (
-    <Box mt={tokens.mt} {...rest}>
+    <Box {...rest}>
       <Box id="jump--artworkFilter" />
 
       {/* Mobile Artwork Filter */}
@@ -307,18 +293,16 @@ export const BaseArtworkFilter: React.FC<
 
       {/* Desktop Artwork Filter */}
       <Media greaterThan="xs">
-        {tokens.version === "v3" && (
-          <Flex justifyContent="space-between" alignItems="center" mb={4}>
-            <Text variant="xs" textTransform="uppercase">
-              Filter by
-            </Text>
+        <Flex justifyContent="space-between" alignItems="center" mb={4}>
+          <Text variant="xs" textTransform="uppercase">
+            Filter by
+          </Text>
 
-            <ArtworkSortFilter />
-          </Flex>
-        )}
+          <ArtworkSortFilter />
+        </Flex>
 
         <GridColumns>
-          <Column span={3} pr={tokens.pr}>
+          <Column span={3}>
             {Filters ? (
               Filters
             ) : (
@@ -335,12 +319,6 @@ export const BaseArtworkFilter: React.FC<
             // Safe to remove once artwork masonry uses CSS grid.
             width="100%"
           >
-            {tokens.version === "v2" && (
-              <Box mb={2} pt={2} borderTop="1px solid" borderTopColor="black10">
-                <ArtworkSortFilter />
-              </Box>
-            )}
-
             {enableCreateAlert && savedSearchEntity && (
               <>
                 <SavedSearchAlertArtworkGridFilterPills
@@ -397,8 +375,6 @@ export const ArtworkFilterQueryRenderer = ({ keyword = "andy warhol" }) => {
     >
       <SystemQueryRenderer<ArtworkFilterQueryType>
         environment={relayEnvironment}
-        // FIXME: Passing a variable to `query` shouldn't error out in linter
-        /* tslint:disable:relay-operation-generics */
         query={ArtworkQueryFilter}
         variables={{
           keyword,

--- a/src/v2/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
+++ b/src/v2/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
@@ -1,31 +1,42 @@
-import { Clickable, Message } from "@artsy/palette"
-import * as React from "react";
+import { Box, Clickable, Message } from "@artsy/palette"
+import * as React from "react"
 import styled from "styled-components"
+import { Sticky } from "../Sticky"
 
 interface ArtworkGridEmptyStateProps {
   onClearFilters?: () => void
 }
 
 export const ArtworkGridEmptyState: React.FC<ArtworkGridEmptyStateProps> = props => (
-  <Message width="100%">
-    <>
-      There aren't any works available that meet the following criteria at this
-      time.
-    </>
-    {props.onClearFilters && (
-      <>
-        {" "}
-        Change your filter criteria to view more works.{" "}
-        <ResetFilterLink
-          textDecoration="underline"
-          onClick={props.onClearFilters}
-        >
-          Clear all filters
-        </ResetFilterLink>
-        .
-      </>
-    )}
-  </Message>
+  <Box width="100%">
+    <Sticky>
+      {({ stuck }) => {
+        return (
+          <Box pt={stuck ? 1 : 0}>
+            <Message width="100%">
+              <>
+                There aren't any works available that meet the following
+                criteria at this time.
+              </>
+              {props.onClearFilters && (
+                <>
+                  {" "}
+                  Change your filter criteria to view more works.{" "}
+                  <ResetFilterLink
+                    textDecoration="underline"
+                    onClick={props.onClearFilters}
+                  >
+                    Clear all filters
+                  </ResetFilterLink>
+                  .
+                </>
+              )}
+            </Message>
+          </Box>
+        )
+      }}
+    </Sticky>
+  </Box>
 )
 
 export const ResetFilterLink = styled(Clickable)``

--- a/src/v2/Components/LoadingArea.tsx
+++ b/src/v2/Components/LoadingArea.tsx
@@ -1,5 +1,5 @@
 import Spinner from "v2/Components/Spinner"
-import { ReactNode, SFC } from "react";
+import { ReactNode, SFC } from "react"
 import styled from "styled-components"
 
 export interface LoadingAreaState {

--- a/src/v2/System/Router/RenderStatus.tsx
+++ b/src/v2/System/Router/RenderStatus.tsx
@@ -17,6 +17,7 @@ export const RenderPending = () => {
   const { match } = useRouter()
   const { isFetching, setFetching } = useSystemContext()
 
+  // One can set this by passing argument to router.push `state`
   const hidePageLoaderFromRouterState =
     match.location?.state?.hidePageLoader ?? false
 

--- a/src/v2/System/Router/RenderStatus.tsx
+++ b/src/v2/System/Router/RenderStatus.tsx
@@ -9,12 +9,16 @@ import { NetworkTimeout } from "./NetworkTimeout"
 import { PageLoader } from "./PageLoader"
 import { AppShell } from "v2/Apps/Components/AppShell"
 import { getENV } from "v2/Utils/getENV"
-import { HttpError } from "found"
+import { HttpError, useRouter } from "found"
 
 const logger = createLogger("Artsy/Router/Utils/RenderStatus")
 
 export const RenderPending = () => {
+  const { match } = useRouter()
   const { isFetching, setFetching } = useSystemContext()
+
+  const hidePageLoaderFromRouterState =
+    match.location?.state?.hidePageLoader ?? false
 
   /**
    * First, set fetching to ensure that components that are listening for this
@@ -31,18 +35,20 @@ export const RenderPending = () => {
       <>
         <Renderer>{null}</Renderer>
 
-        <PageLoader
-          className="reactionPageLoader" // positional styling comes from Force body.styl
-          showBackground={false}
-          step={10} // speed of progress bar, randomized between 1/x to simulate variable progress
-          style={{
-            borderTop: "1px solid white",
-            position: "fixed",
-            left: 0,
-            top: -5,
-            zIndex: 1000,
-          }}
-        />
+        {!hidePageLoaderFromRouterState && (
+          <PageLoader
+            className="reactionPageLoader" // positional styling comes from Force body.styl
+            showBackground={false}
+            step={10} // speed of progress bar, randomized between 1/x to simulate variable progress
+            style={{
+              borderTop: "1px solid white",
+              position: "fixed",
+              left: 0,
+              top: -5,
+              zIndex: 1000,
+            }}
+          />
+        )}
 
         <NetworkTimeout />
       </>

--- a/src/v2/System/Router/Utils/shouldUpdateScroll.tsx
+++ b/src/v2/System/Router/Utils/shouldUpdateScroll.tsx
@@ -29,6 +29,15 @@ export function shouldUpdateScroll(prevRenderArgs, currentRenderArgs) {
   const { routes } = currentRenderArgs
 
   try {
+    // When using router.push one can pass additional state along, which we
+    // grab here. (This is currently being used in the ArtworkFilter.)
+    const ignoreScrollBehaviorFromRouterState =
+      currentRenderArgs.location?.state?.ignoreScrollBehavior ?? false
+
+    if (ignoreScrollBehaviorFromRouterState) {
+      return false
+    }
+
     // If true, don't reset scroll position on route change, no matter what
     if (routes?.some(route => route.ignoreScrollBehavior)) {
       return false


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR solves [GRO-824]

### Description

This updates our Artwork filter so that we can drive via the back / forward buttons on the browser. Previously when a user made a selection and then hit the back button it would take them away from their previous selection, versus pushing it into the browsers history stack. This fixes that. 

Also fixes a bunch of random UX issues like the page loader post filter select being stuck at the top of the page rather than in the viewport, and the zerostate doing the same. Now they will stay within the users scroll position eliminating confusion. 


[GRO-824]: https://artsyproduct.atlassian.net/browse/GRO-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ