### PR TITLE
fix(NX-3130): add a margin to the tertiary button to avoid clashing

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPartnerInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPartnerInfo.tsx
@@ -14,10 +14,15 @@ import { RouterLink } from "v2/System/Router/RouterLink"
 import { useInquiry } from "v2/Components/Inquiry/useInquiry"
 import { useFeatureFlag } from "v2/System/useFeatureFlag"
 import { AnalyticsSchema, useTracking } from "v2/System/Analytics"
+import styled from "styled-components"
 
 export interface ArtworkSidebarPartnerInfoProps {
   artwork: ArtworkSidebarPartnerInfo_artwork
 }
+
+const PartnerContainer = styled(Box)`
+  word-break: break-word;
+`
 
 export const ArtworkSidebarPartnerInfo: FC<ArtworkSidebarPartnerInfoProps> = ({
   artwork,
@@ -87,7 +92,7 @@ export const ArtworkSidebarPartnerInfo: FC<ArtworkSidebarPartnerInfoProps> = ({
     <>
       <Separator my={2} />
       <Flex justifyContent="space-between">
-        <Box>
+        <PartnerContainer>
           {renderPartnerName()}
           {locationNames && locationNames.length > 0 && (
             <Flex mt={1}>
@@ -99,7 +104,7 @@ export const ArtworkSidebarPartnerInfo: FC<ArtworkSidebarPartnerInfoProps> = ({
               </Flex>
             </Flex>
           )}
-        </Box>
+        </PartnerContainer>
 
         {shouldRenderInquiryButton && (
           <Button
@@ -107,6 +112,7 @@ export const ArtworkSidebarPartnerInfo: FC<ArtworkSidebarPartnerInfoProps> = ({
             size="small"
             borderColor="black30"
             onClick={handleInquiry}
+            ml={1}
           >
             Contact Gallery
           </Button>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [NX-3130]

### Description

<!-- Implementation description -->
Small improvement to the tertiary button "Contact Gallery" clashing with the partner title.

Before:

<img width="346" alt="image" src="https://user-images.githubusercontent.com/265560/165749459-37bd6091-7a36-4d8f-8d2b-f87348b72899.png">

After:

<img width="351" alt="image" src="https://user-images.githubusercontent.com/265560/165749564-56218b43-ff34-417c-a7d4-fd0032bf101d.png">

cc @artsy/negotiate-devs 

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NX-3130]: https://artsyproduct.atlassian.net/browse/NX-3130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ