### PR TITLE
fix(auth): Fix redirect to existing page on signup

### DIFF
--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -241,6 +241,7 @@ export const NavBar: React.FC = track(
                           mode: ModalType.signup,
                           intent: Intent.signup,
                           contextModule: ContextModule.header,
+                          redirectTo: window.location.href,
                         })
                       }}
                     >

--- a/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -121,6 +121,7 @@ describe("NavBar", () => {
         contextModule: "header",
         intent: "signup",
         mode: "signup",
+        redirectTo: "http://localhost/",
       })
     })
   })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR solves [GRO-1002]

### Description

This fixes an issue where the user isn't redirected back to the existing page on sign up, and instead is redirected to home. Now the user is redirected to the current url.


[GRO-1002]: https://artsyproduct.atlassian.net/browse/GRO-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ