### PR TITLE
feat(TX-295): ACH payment page redesign

### DIFF
--- a/src/v2/Apps/Order/Components/__mocks__/BankDebitProvider.tsx
+++ b/src/v2/Apps/Order/Components/__mocks__/BankDebitProvider.tsx
@@ -1,0 +1,5 @@
+import { createElement } from "react"
+
+export const BankDebitProvider = () => {
+  return createElement("div")
+}

--- a/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -1,13 +1,11 @@
 import { FC, RefObject, useState } from "react"
 import {
-  Button,
   Flex,
   Spacer,
   BorderedRadio,
   RadioGroup,
   Text,
   Collapse,
-  Clickable,
 } from "@artsy/palette"
 import {
   PaymentPicker,
@@ -38,23 +36,7 @@ export const PaymentContent: FC<Props> = props => {
     order,
     paymentPicker,
   } = props
-  const [stepOneComplete, setStepOneComplete] = useState(false)
-  const [paymentMethodSelection, setPaymentMethodSelection] = useState("")
-  const [paymentMethod, setPaymentMethod] = useState("")
-
-  const paymentMethodLabel = (paymentMethod: string) => {
-    switch (paymentMethod) {
-      case "credit_card":
-        return "Credit card"
-      case "bank_debit":
-        return "Bank transfer (US bank account)"
-    }
-  }
-
-  const handlePaymentMethodSave = paymentMethodSelection => {
-    setPaymentMethod(paymentMethodSelection)
-    setStepOneComplete(true)
-  }
+  const [paymentMethod, setPaymentMethod] = useState("bank_debit")
 
   return (
     <div>
@@ -62,71 +44,50 @@ export const PaymentContent: FC<Props> = props => {
         flexDirection="column"
         style={isLoading ? { pointerEvents: "none" } : {}}
       >
-        {/* Step One Payment Menthod */}
-        <Flex flexDirection="row" justifyContent="space-between">
-          <Flex flexDirection="column">
-            <Text variant="xs">Step 1 of 2</Text>
-            <Text variant="lg">Payment Method</Text>
-            <Text color="black60">
-              {paymentMethod && paymentMethodLabel(paymentMethod)}
-            </Text>
-          </Flex>
-          {paymentMethod && (
-            <Clickable
-              textDecoration="underline"
-              onClick={() => setStepOneComplete(false)}
-            >
-              <Text variant="xs">Change</Text>
-            </Clickable>
-          )}
-        </Flex>
-        <Collapse open={!stepOneComplete}>
-          <Spacer mb={4} />
-          <RadioGroup
-            onSelect={val => {
-              setPaymentMethodSelection(val)
-            }}
-          >
-            <BorderedRadio value="credit_card" label="Credit Card" />
-            <BorderedRadio value="bank_debit" label="Bank Transfer" />
-          </RadioGroup>
-          <Spacer mb={4} />
-          <Button
-            onClick={() => handlePaymentMethodSave(paymentMethodSelection)}
-            variant="primaryBlack"
-            width="100%"
-          >
-            Save and Continue
-          </Button>
-        </Collapse>
-        <Spacer mb={4} />
-        {/* Step Two Payment Details */}
-        <Text color={stepOneComplete ? "black100" : "black30"} variant="xs">
-          Step 2 of 2
-        </Text>
-        <Text color={stepOneComplete ? "black100" : "black30"} variant="lg">
-          Payment Details
-        </Text>
         <Spacer mb={2} />
-        {paymentMethod && paymentMethod === "credit_card" && (
-          <Collapse open={stepOneComplete}>
-            <PaymentPickerFragmentContainer
-              commitMutation={commitMutation}
-              me={me}
-              order={order}
-              innerRef={paymentPicker}
-            />
-            <Spacer mb={4} />
-            <Media greaterThan="xs">
-              <ContinueButton onClick={onContinue} loading={isLoading} />
-            </Media>
-          </Collapse>
-        )}
-        {paymentMethod && paymentMethod === "bank_debit" && (
-          <Collapse open={stepOneComplete}>
-            <BankDebitProvider order={order} />
-          </Collapse>
-        )}
+        <Text variant="lg">Payment method</Text>
+        <Spacer mb={2} />
+        <RadioGroup
+          onSelect={val => {
+            setPaymentMethod(val)
+          }}
+          defaultValue={paymentMethod}
+        >
+          <BorderedRadio
+            value="bank_debit"
+            label="Bank transfer (US bank account)"
+          />
+          <BorderedRadio value="credit_card" label="Credit card" />
+        </RadioGroup>
+        <Spacer mb={4} />
+        <Text variant="lg">Payment details</Text>
+        <Spacer mb={2} />
+        <Collapse open={paymentMethod === "credit_card"}>
+          <PaymentPickerFragmentContainer
+            commitMutation={commitMutation}
+            me={me}
+            order={order}
+            innerRef={paymentPicker}
+          />
+          <Spacer mb={4} />
+          <Media greaterThan="xs">
+            <ContinueButton onClick={onContinue} loading={isLoading} />
+          </Media>
+        </Collapse>
+        <Collapse open={paymentMethod === "bank_debit"}>
+          <Text color="black60" variant="sm">
+            • Bank transfer is powered by Stripe.
+          </Text>
+          <Text color="black60" variant="sm">
+            • Search for your bank institution or select from the options below.
+          </Text>
+          <Text color="black60" variant="sm">
+            • If you can not find your bank, please check your spelling or
+            choose another payment method.
+          </Text>
+          <Spacer mb={2} />
+          <BankDebitProvider order={order} />
+        </Collapse>
       </Flex>
     </div>
   )

--- a/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from "@artsy/palette"
+import { Checkbox, Collapse } from "@artsy/palette"
 import { PaymentTestQueryRawResponse } from "v2/__generated__/PaymentTestQuery.graphql"
 import {
   BuyOrderWithShippingDetails,
@@ -243,15 +243,21 @@ describe("Payment", () => {
     it("renders credit card element when credit card is chosen as payment method", async () => {
       const env = setupTestEnv()
       const page = await env.buildPage()
-      page.selectPaymentMethod(0)
-      expect(page.find(PaymentPickerFragmentContainer).length).toBe(1)
+      page.selectPaymentMethod(1)
+      const creditCardCollapse = page.find(PaymentPickerFragmentContainer).closest(Collapse)
+      expect(creditCardCollapse.first().props().open).toBe(true)
+      const bankDebitCollapse = page.find(BankDebitProvider).closest(Collapse)
+      expect(bankDebitCollapse.first().props().open).toBe(false)
     })
 
     it("renders bank element when bank transfer is chosen as payment method", async () => {
       const env = setupTestEnv()
       const page = await env.buildPage()
-      page.selectPaymentMethod(1)
-      expect(page.find(BankDebitProvider).length).toBe(1)
+      page.selectPaymentMethod(0)
+      const creditCardCollapse = page.find(PaymentPickerFragmentContainer).closest(Collapse)
+      expect(creditCardCollapse.first().props().open).toBe(false)
+      const bankDebitCollapse = page.find(BankDebitProvider).closest(Collapse)
+      expect(bankDebitCollapse.first().props().open).toBe(true)
     })
   })
 })

--- a/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -259,5 +259,9 @@ describe("Payment", () => {
       const bankDebitCollapse = page.find(BankDebitProvider).closest(Collapse)
       expect(bankDebitCollapse.first().props().open).toBe(true)
     })
+
+    // Ran in to the error when following `createTestEnv`
+    // Invariant Violation: commitMutation: expected "environment" to be an instance of "RelayModernEnvironment"
+    it.todo("creates a bank debit setup")
   })
 })

--- a/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -113,12 +113,14 @@ describe("Payment", () => {
   })
 
 
+  // eslint-disable-next-line jest/expect-expect
   it("shows the button spinner while loading the mutation", async () => {
     const env = setupTestEnv()
     const page = await env.buildPage()
     await page.expectButtonSpinnerWhenSubmitting()
   })
 
+  // eslint-disable-next-line jest/expect-expect
   it("shows the default error modal when the payment picker throws an error", async () => {
     paymentPickerMock.useThrownError()
     const env = setupTestEnv()
@@ -127,6 +129,7 @@ describe("Payment", () => {
     await page.expectAndDismissDefaultErrorDialog()
   })
 
+  // eslint-disable-next-line jest/expect-expect
   it("shows a custom error modal with when the payment picker returns a normal error", async () => {
     paymentPickerMock.useErrorResult()
     const env = setupTestEnv()
@@ -138,6 +141,7 @@ describe("Payment", () => {
     )
   })
 
+  // eslint-disable-next-line jest/expect-expect
   it("shows an error modal with the title 'An internal error occurred' and the default message when the payment picker returns an error with the type 'internal_error'", async () => {
     paymentPickerMock.useInternalErrorResult()
     const env = setupTestEnv()
@@ -169,6 +173,7 @@ describe("Payment", () => {
     expect(env.routes.mockPushRoute).toHaveBeenCalledWith("/orders/1234/review")
   })
 
+  // eslint-disable-next-line jest/expect-expect
   it("shows an error modal when there is an error in SetOrderPaymentPayload", async () => {
     const env = setupTestEnv()
     const page = await env.buildPage()
@@ -177,6 +182,7 @@ describe("Payment", () => {
     await page.expectAndDismissDefaultErrorDialog()
   })
 
+  // eslint-disable-next-line jest/expect-expect
   it("shows an error modal when there is a network error", async () => {
     const env = setupTestEnv()
     const page = await env.buildPage()

--- a/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -209,21 +209,19 @@ describe("Payment", () => {
 
     it("renders selection of payment methods", async () => {
       const page = await buildPage()
-      expect(page.text()).toContain("Credit Card")
-      expect(page.text()).toContain("Bank Transfer")
+      expect(page.text()).toContain("Credit card")
+      expect(page.text()).toContain("Bank transfer")
     })
 
     it("renders credit card element when credit card is chosen as payment method", async () => {
       const page = await buildPage()
       page.selectPaymentMethod(0)
-      expect(page.text()).toContain("Credit card")
       expect(page.find(PaymentPickerFragmentContainer).length).toBe(1)
     })
 
-    it("renders bank element when bank transfer is chosen as payment mehod", async () => {
+    it("renders bank element when bank transfer is chosen as payment method", async () => {
       const page = await buildPage()
       page.selectPaymentMethod(1)
-      expect(page.text()).toContain("Bank transfer")
       expect(page.find(BankDebitProvider).length).toBe(1)
     })
   })

--- a/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -32,6 +32,14 @@ jest.mock(
     return require("../../Components/__mocks__/PaymentPicker")
   }
 )
+jest.mock(
+  "v2/Components/BankDebitForm/BankDebitProvider",
+  // not sure why this is neccessary :(
+  // should just work without this extra argument
+  () => {
+    return require("../../Components/__mocks__/BankDebitProvider")
+  }
+)
 jest.mock("v2/System/useSystemContext")
 
 const testOrder: PaymentTestQueryRawResponse["order"] = {

--- a/src/v2/Apps/Order/Routes/__tests__/Utils/OrderAppTestPage.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Utils/OrderAppTestPage.tsx
@@ -102,7 +102,6 @@ export class OrderAppTestPage extends RootTestPage {
 
   async selectPaymentMethod(option: number) {
     this.find(BorderedRadio).at(option).simulate("click")
-    this.find(Button).simulate("click")
     await this.update()
   }
 

--- a/src/v2/Components/BankDebitForm/BankDebitForm.tsx
+++ b/src/v2/Components/BankDebitForm/BankDebitForm.tsx
@@ -21,12 +21,6 @@ export const BankDebitForm: FC = () => {
       elements,
       confirmParams: {
         return_url: "https://staging.artsy.net/",
-        payment_method_data: {
-          billing_details: {
-            name: user.name,
-            email: user.email,
-          },
-        },
       },
     })
 
@@ -41,14 +35,7 @@ export const BankDebitForm: FC = () => {
         {isPaymentElementLoading && <Box height={300}></Box>}
         <PaymentElement
           onReady={() => setIsPaymentElementLoading(false)}
-          options={{
-            fields: {
-              billingDetails: {
-                name: "never",
-                email: "never",
-              },
-            },
-          }}
+          onChange={event => console.log("event", event)}
         />
         <Spacer mt={2} />
         <Button disabled={!stripe} variant="primaryBlack" width="100%">


### PR DESCRIPTION
The type of this PR is: Feature
<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-295]

### Description

Updates payment transaction step design to remove the two-step process in favor of a more simple implementation.  (behind stripe_ACH feature flag)

This does not include some of the smaller details of the Figma design, as I want to get the new logic out first as it could affect future development. 

### Recording 

https://user-images.githubusercontent.com/50849237/165928682-421819c9-1ba9-4300-97b5-d35d9736b5cd.mov




[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-295]: https://artsyproduct.atlassian.net/browse/TX-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ