### PR TITLE
test: update some signup redirect specs

### DIFF
--- a/src/v2/Components/FollowButton/__tests__/FollowArtistButton.jest.tsx
+++ b/src/v2/Components/FollowButton/__tests__/FollowArtistButton.jest.tsx
@@ -82,7 +82,6 @@ describe("FollowArtistButton", () => {
         copy: "Sign up to follow Damon Zucconi",
         intent: "followArtist",
         mode: "signup",
-        redirectTo: "http://localhost/",
       })
     })
 

--- a/src/v2/Components/FollowButton/__tests__/FollowProfileButton.jest.tsx
+++ b/src/v2/Components/FollowButton/__tests__/FollowProfileButton.jest.tsx
@@ -70,6 +70,7 @@ describe("FollowProfileButton", () => {
         copy: "Sign up to follow Salon 94",
         intent: "followPartner",
         mode: "signup",
+        redirectTo: "http://localhost/",
       })
     })
 


### PR DESCRIPTION
I have no clue what's correct, this just updates the specs to match https://github.com/artsy/force/pull/10020 (which seemed to be hastily merged by Peril 'merge on green' before Circle ran).