### PR TITLE
fix(auction): Link conditions of sale

### DIFF
--- a/src/v2/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
+++ b/src/v2/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
@@ -1,5 +1,6 @@
 import { Checkbox, Spacer, Text } from "@artsy/palette"
 import { useFormContext } from "v2/Apps/Auction/Hooks/useFormContext"
+import { RouterLink } from "v2/System/Router/RouterLink"
 
 export const ConditionsOfSaleCheckbox: React.FC = () => {
   const {
@@ -21,7 +22,15 @@ export const ConditionsOfSaleCheckbox: React.FC = () => {
     <>
       <Checkbox selected={values.agreeToTerms} onSelect={handleCheckboxSelect}>
         <Text variant="md" ml={0.5}>
-          Agree to Conditions of Sale
+          Agree to{" "}
+          <RouterLink
+            display="inline"
+            color="black100"
+            to="/conditions-of-sale"
+            target="_blank"
+          >
+            Conditions of Sale
+          </RouterLink>
         </Text>
       </Checkbox>
 

--- a/src/v2/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
+++ b/src/v2/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
@@ -58,4 +58,9 @@ describe("ConditionsOfSaleCheckbox", () => {
     expect(setFieldTouched).toHaveBeenCalledWith("agreeToTerms")
     expect(setFieldValue).toHaveBeenCalledWith("agreeToTerms", true)
   })
+
+  it("links out to conditions of sale", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.html()).toContain('href="/conditions-of-sale"')
+  })
 })

--- a/src/v2/Apps/Auction/Routes/AuctionConfirmRegistrationRoute.tsx
+++ b/src/v2/Apps/Auction/Routes/AuctionConfirmRegistrationRoute.tsx
@@ -23,7 +23,6 @@ import {
   confirmRegistrationValidationSchemas,
 } from "v2/Apps/Auction/Components/Form/Utils"
 import { useEffect } from "react"
-import { RouterLink } from "v2/System/Router/RouterLink"
 import { redirectToSaleHome } from "./AuctionRegistrationRoute"
 import { useUpdateMyUserProfile } from "v2/Utils/Hooks/Mutations/useUpdateMyUserProfile"
 
@@ -179,12 +178,7 @@ const ConditionsOfSaleMessage: React.FC<{ additionalText?: string }> = ({
   return (
     <Text variant="md">
       Welcome back. To complete your registration, please confirm that you agree
-      to the{" "}
-      <Text variant="md" display="inline">
-        <RouterLink color="black100" to="/conditions-of-sale" target="_blank">
-          Conditions of Sale
-        </RouterLink>
-      </Text>
+      to the Conditions of Sale
       {additionalText}
     </Text>
   )


### PR DESCRIPTION
The type of this PR is: **Bugfix**

### Description

Fixes missing conditions of sale link on register page (it only appeared on register screen for users with a CC on file).

 
<img width="382" alt="Screen Shot 2022-05-03 at 5 37 08 PM" src="https://user-images.githubusercontent.com/236943/166608699-0843577a-aea1-40bb-8e6b-7eae63765a20.png">

