### PR TITLE
Gkartalis/fx 3930/update navigation links

### DIFF
--- a/src/v2/Components/NavBar/menuData.ts
+++ b/src/v2/Components/NavBar/menuData.ts
@@ -32,34 +32,34 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
     title: "Artists",
     links: [
       {
-        text: "Trending on Artsy",
-        href: "/collection/highlights-this-month",
+        text: "Trending This Week",
+        href: "/gene/trending-this-week",
       },
       {
-        text: "The Artsy Vanguard Artists",
-        href: "/collection/artsy-vanguard-artists",
+        text: "Black Painters On Our Radar",
+        href: "/gene/black-painters-on-our-radar",
       },
       {
-        text: "Limited-Edition Prints by Leading Artists",
-        href: "/collection/limited-edition-prints-trending-artists",
+        text: "Our Top Auction Lots",
+        href: "/gene/our-top-auction-lots",
         dividerBelow: true,
       },
       {
-        text: "New From",
+        text: "Curator's Picks",
         menu: {
-          title: "New From",
+          title: "Curator's Picks",
           links: [
             {
-              text: "Emerging Artists",
-              href: "/collection/new-from-emerging-artists",
+              text: "Artists On The Rise",
+              href: "/gene/artists-on-the-rise",
             },
             {
-              text: "Established Artists",
-              href: "/collection/new-from-established-artists",
+              text: "Emerging Photographers to Watch",
+              href: "/gene/emerging-photographers-to-watch",
             },
             {
-              text: "Street Artists",
-              href: "/collection/street-art-highlights",
+              text: "Street Art Now",
+              href: "/gene/street-art-now-1",
             },
           ],
         },

--- a/src/v2/Components/NavBar/menuData.ts
+++ b/src/v2/Components/NavBar/menuData.ts
@@ -155,16 +155,16 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
         href: "/gene/trove",
       },
       {
-        text: "Highlights at Auction This Week",
-        href: "/collection/auction-highlights",
+        text: "Iconic Prints",
+        href: "/gene/iconic-prints",
       },
       {
-        text: "Highlights at Fairs This Week",
-        href: "/collection/art-fair-highlights",
+        text: "Finds Under $2500",
+        href: "/gene/finds-under-2500",
       },
       {
-        text: "New in Figurative Painting",
-        href: "/collection/emerging-figurative-painting",
+        text: "The Collectibles Shop",
+        href: "/gene/the-collectibles-shop",
       },
       {
         text: "Price",


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-3930]

### Description

Updated the links under artworks and artists navigation tabs to be like the screenshots below.

check the [review-app here](https://updated-tab-navigation-links.artsy.net/)

Artworks Tab 
| Before | After | 
|---|---|
|![Screenshot 2022-05-04 at 11 42 22](https://user-images.githubusercontent.com/21178754/166658438-aed1280d-eb5b-45b8-aefa-d90f0405cc03.png)|![Screenshot 2022-05-04 at 11 40 58](https://user-images.githubusercontent.com/21178754/166658445-c2856ee1-cb30-4c70-9649-621397a3fe36.png)|

Artists Tab 
| Before | After | 
|---|---|
|![Screenshot 2022-05-04 at 11 42 16](https://user-images.githubusercontent.com/21178754/166658443-262d9df2-f1d3-4cbf-ad63-7cbb21e8c82e.png)|![Screenshot 2022-05-04 at 11 40 49](https://user-images.githubusercontent.com/21178754/166658447-b9b4752d-b9bc-4b83-a4a1-85aa7aa3a159.png)|

<!-- Implementation description -->
