### PR TITLE
GRO-1003: Update general secondary market seller support email to sell@artsy.net

### DIFF
--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ContactUs.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ContactUs.tsx
@@ -12,7 +12,7 @@ export const ContactUs: React.FC = () => {
             Questions? Speak to an Artsy Specialist
           </Text>
 
-          <Text data-testid="contactUsBody" variant="sm" mb={4}>
+          <Text variant="sm" mb={4}>
             Email us at <a href="mailto:sell@artsy.net">sell@artsy.net</a> or
             call <a href="tel:!1-646-797-3423">+1-646-797-3423</a> for more
             information on how Artsy can sell your artwork.

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ContactUs.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ContactUs.tsx
@@ -1,5 +1,5 @@
 import { Button, FullBleed, Text } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 
@@ -13,8 +13,8 @@ export const ContactUs: React.FC = () => {
           </Text>
 
           <Text variant="sm" mb={4}>
-            Email us at <a href="mailto:consign@artsy.net">consign@artsy.net</a>{" "}
-            or call <a href="tel:!1-646-797-3423">+1-646-797-3423</a> for more
+            Email us at <a href="mailto:sell@artsy.net">sell@artsy.net</a> or
+            call <a href="tel:!1-646-797-3423">+1-646-797-3423</a> for more
             information on how Artsy can sell your artwork.
           </Text>
 
@@ -22,7 +22,7 @@ export const ContactUs: React.FC = () => {
             variant="secondaryOutline"
             // @ts-ignore
             as="a"
-            href="mailto:consign@artsy.net"
+            href="mailto:sell@artsy.net"
           >
             Send an email
           </Button>

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ContactUs.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/ContactUs.tsx
@@ -12,7 +12,7 @@ export const ContactUs: React.FC = () => {
             Questions? Speak to an Artsy Specialist
           </Text>
 
-          <Text variant="sm" mb={4}>
+          <Text data-testid="contactUsBody" variant="sm" mb={4}>
             Email us at <a href="mailto:sell@artsy.net">sell@artsy.net</a> or
             call <a href="tel:!1-646-797-3423">+1-646-797-3423</a> for more
             information on how Artsy can sell your artwork.

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/FAQ.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/FAQ.tsx
@@ -125,8 +125,8 @@ export const FAQ: React.FC = () => {
       value: (
         <TextItem>
           To edit your existing submissions or add further details, please
-          contact consign@artsy.net with the subject line “Edit my submission”
-          and one of our specialists will assist you. In the body of your email,
+          contact sell@artsy.net with the subject line “Edit my submission” and
+          one of our specialists will assist you. In the body of your email,
           please include the submission ID number, which can be found in the
           email receipt you received from Artsy.
         </TextItem>
@@ -137,7 +137,7 @@ export const FAQ: React.FC = () => {
       value: (
         <TextItem>
           You can contact an Artsy specialist at any time by emailing
-          consign@artsy.net.
+          sell@artsy.net.
         </TextItem>
       ),
     },

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/ContactUs.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/ContactUs.jest.tsx
@@ -1,8 +1,7 @@
 import { ContactUs } from "../ContactUs"
 import { MockBoot } from "v2/DevTools"
 import { Breakpoint } from "@artsy/palette"
-import { render, screen, within } from "@testing-library/react"
-import { debug } from "console"
+import { render, screen } from "@testing-library/react"
 
 jest.mock("react-tracking")
 

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/ContactUs.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/ContactUs.jest.tsx
@@ -6,7 +6,7 @@ import { render, screen } from "@testing-library/react"
 jest.mock("react-tracking")
 
 describe("ContactUs", () => {
-  const getWrapper = (breakpoint = "md") => {
+  const renderContactUs = (breakpoint = "md") => {
     return render(
       <MockBoot breakpoint={breakpoint as Breakpoint}>
         <ContactUs />
@@ -14,13 +14,13 @@ describe("ContactUs", () => {
     )
   }
 
-  it("contains correct email in body with, correct email link and phone number", () => {
-    getWrapper()
-    // console.log("*****************************")
-    // const text = screen.getByTestId("contactUsBody")
-    // debug(text)
-    // expect(within(text).getByText("Email us at")).toBeInTheDocument()
-    expect(screen.getByText("sell@artsy.net")).toBeInTheDocument()
-    expect(screen.getByText("+1-646-797-3423")).toBeInTheDocument()
+  it.each([
+    /(Email us at)/g,
+    /(sell@artsy.net)/g,
+    /(\+1-646-797-3423)/g,
+    /(information on how Artsy can sell your artwork\.)/g,
+  ])("text body contains %s", (text: RegExp) => {
+    renderContactUs()
+    expect(screen.getByText(text)).toBeInTheDocument()
   })
 })

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/ContactUs.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/ContactUs.jest.tsx
@@ -1,32 +1,27 @@
-import { mount } from "enzyme"
 import { ContactUs } from "../ContactUs"
 import { MockBoot } from "v2/DevTools"
 import { Breakpoint } from "@artsy/palette"
+import { render, screen, within } from "@testing-library/react"
+import { debug } from "console"
 
 jest.mock("react-tracking")
 
 describe("ContactUs", () => {
   const getWrapper = (breakpoint = "md") => {
-    return mount(
+    return render(
       <MockBoot breakpoint={breakpoint as Breakpoint}>
         <ContactUs />
       </MockBoot>
     )
   }
 
-  it("contains correct email in body", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.text()).toContain(
-      "Email us at sell@artsy.net or call +1-646-797-3423 for more information on how Artsy can sell your artwork."
-    ) // pull text minus divs
-  })
-
-  it("has correct email link", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.find("a").first().props().href).toBe("mailto:sell@artsy.net")
-    const wrapperMobile = getWrapper("xs")
-    expect(wrapperMobile.find("a").first().props().href).toBe(
-      "mailto:sell@artsy.net"
-    )
+  it("contains correct email in body with, correct email link and phone number", () => {
+    getWrapper()
+    // console.log("*****************************")
+    // const text = screen.getByTestId("contactUsBody")
+    // debug(text)
+    // expect(within(text).getByText("Email us at")).toBeInTheDocument()
+    expect(screen.getByText("sell@artsy.net")).toBeInTheDocument()
+    expect(screen.getByText("+1-646-797-3423")).toBeInTheDocument()
   })
 })

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/ContactUs.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/ContactUs.jest.tsx
@@ -17,18 +17,16 @@ describe("ContactUs", () => {
   it("contains correct email in body", () => {
     const wrapper = getWrapper()
     expect(wrapper.text()).toContain(
-      "Email us at consign@artsy.net or call +1-646-797-3423 for more information on how Artsy can sell your artwork."
+      "Email us at sell@artsy.net or call +1-646-797-3423 for more information on how Artsy can sell your artwork."
     ) // pull text minus divs
   })
 
   it("has correct email link", () => {
     const wrapper = getWrapper()
-    expect(wrapper.find("a").first().props().href).toBe(
-      "mailto:consign@artsy.net"
-    )
+    expect(wrapper.find("a").first().props().href).toBe("mailto:sell@artsy.net")
     const wrapperMobile = getWrapper("xs")
     expect(wrapperMobile.find("a").first().props().href).toBe(
-      "mailto:consign@artsy.net"
+      "mailto:sell@artsy.net"
     )
   })
 })

--- a/src/v2/Apps/Consign/Routes/Offer/Components/StickyFooter.tsx
+++ b/src/v2/Apps/Consign/Routes/Offer/Components/StickyFooter.tsx
@@ -1,6 +1,7 @@
-import * as React from "react";
+import * as React from "react"
 
-import { Flex, Link, Sans, Spacer } from "@artsy/palette"
+import { Flex, Link, Text, Spacer } from "@artsy/palette"
+import { RouterLink } from "v2/System/Router/RouterLink"
 
 export const StickyFooter: React.FC = () => {
   return (
@@ -16,9 +17,10 @@ export const StickyFooter: React.FC = () => {
       justifyContent="center"
       backgroundColor="white100"
     >
-      <Sans size="2" color="black60">
-        Need help? <Link href="mailto:consign@artsy.net">Ask a question</Link>.
-      </Sans>
+      <Text variant="xs" color="black60">
+        Need help?{" "}
+        <RouterLink to="mailto: sell@artsy.net">Ask a question</RouterLink>.
+      </Text>
       <Spacer mb={2} />
     </Flex>
   )

--- a/src/v2/Apps/Consign/Routes/Offer/Components/StickyFooter.tsx
+++ b/src/v2/Apps/Consign/Routes/Offer/Components/StickyFooter.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { Flex, Link, Text, Spacer } from "@artsy/palette"
+import { Flex, Text, Spacer } from "@artsy/palette"
 import { RouterLink } from "v2/System/Router/RouterLink"
 
 export const StickyFooter: React.FC = () => {


### PR DESCRIPTION
The type of this PR is: Enhancement

This PR solves [GRO-1003]

### Description
This is in support of the need to update any use of the old consignments email addresses, so that the team can use the new email address, [sell@artsy.net](mailto:sell@artsy.net) across all surfaces.


[GRO-1003]: https://artsyproduct.atlassian.net/browse/GRO-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ