### PR TITLE
feat: move websockets into a proper context, and use in the ArtworkApp

### DIFF
--- a/src/v2/Apps/Artwork/ArtworkApp.tsx
+++ b/src/v2/Apps/Artwork/ArtworkApp.tsx
@@ -29,6 +29,7 @@ import { Media } from "v2/Utils/Responsive"
 import { UseRecordArtworkView } from "./useRecordArtworkView"
 import { Router, Match } from "found"
 import { CascadingEndTimesBanner } from "../Auction/Components/AuctionDetails/CascadingEndTimesBanner"
+import { WebsocketContextProvider } from "v2/System/WebsocketContext"
 
 export interface Props {
   artwork: ArtworkApp_artwork
@@ -237,7 +238,7 @@ export class ArtworkApp extends React.Component<Props> {
 
 const TrackingWrappedArtworkApp: React.FC<Props> = props => {
   const {
-    artwork: { internalID },
+    artwork: { internalID, sale },
   } = props
   const {
     match: {
@@ -251,6 +252,8 @@ const TrackingWrappedArtworkApp: React.FC<Props> = props => {
   const referrer = state && state.previousHref
   const { isComplete } = useRouteComplete()
 
+  const websocketEnabled = !!sale?.extendedBiddingIntervalMinutes
+
   return (
     <AnalyticsContext.Provider
       value={{
@@ -259,12 +262,20 @@ const TrackingWrappedArtworkApp: React.FC<Props> = props => {
         contextPageOwnerType,
       }}
     >
-      <ArtworkApp
-        {...props}
-        routerPathname={pathname}
-        referrer={referrer}
-        shouldTrackPageView={isComplete}
-      />
+      <WebsocketContextProvider
+        channelInfo={{
+          channel: "SalesChannel",
+          sale_id: sale?.internalID,
+        }}
+        enabled={websocketEnabled}
+      >
+        <ArtworkApp
+          {...props}
+          routerPathname={pathname}
+          referrer={referrer}
+          shouldTrackPageView={isComplete}
+        />
+      </WebsocketContextProvider>
     </AnalyticsContext.Provider>
   )
 }

--- a/src/v2/System/WebsocketContext.tsx
+++ b/src/v2/System/WebsocketContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, useEffect, useState } from "react"
+import { getENV } from "v2/Utils/getENV"
+
+interface ReceivedData {
+  [key: string]: string
+}
+
+interface WebsocketContextProps {
+  data: ReceivedData
+}
+
+interface WebsocketContextProviderProps {
+  enabled: boolean
+  channelInfo: {
+    channel: string
+    [id: string]: string | undefined
+  }
+}
+
+const initialValues = {
+  data: {} as ReceivedData,
+}
+
+const WebsocketContext = createContext<WebsocketContextProps>(initialValues)
+
+export const WebsocketContextProvider: React.FC<WebsocketContextProviderProps> = ({
+  channelInfo,
+  enabled,
+  children,
+}) => {
+  const [receivedData, setReceivedData] = useState(initialValues)
+
+  useEffect(() => {
+    if (!enabled) return
+    const actionCable = require("actioncable")
+    const cable = actionCable.createConsumer(getENV("GRAVITY_WEBSOCKET_URL"))
+    cable.subscriptions.create(
+      {
+        ...channelInfo,
+      },
+      {
+        received: data => {
+          setReceivedData({ data })
+        },
+      }
+    )
+  }, [])
+
+  return (
+    <WebsocketContext.Provider value={receivedData}>
+      {children}
+    </WebsocketContext.Provider>
+  )
+}
+
+export const useWebsocketContext = () => {
+  const websocketContext = useContext(WebsocketContext) ?? {}
+  return websocketContext
+}


### PR DESCRIPTION
Rather than the naive approach of each component initializing their own `actioncable` object _and_ subscription , we really should be using one (per tree).

Artwork app - should have one place that sets up a subscription to the sale channel (if an extended bidding auction work), and injects the received data into the context.

We'd like to use this in the auction app, and so the same applies as above.

Seems to work well w/ mocktioning locally but ofc want to test on staging.