### PR TITLE
GROW-919: Added New for You page title and header copy

### DIFF
--- a/src/v2/Apps/NewForYou/NewForYouApp.tsx
+++ b/src/v2/Apps/NewForYou/NewForYouApp.tsx
@@ -1,6 +1,8 @@
 import React, { FC, useEffect } from "react"
+import { MetaTags } from "v2/Components/MetaTags"
 import { useRouter } from "v2/System/Router/useRouter"
 import { useFeatureFlag } from "v2/System/useFeatureFlag"
+import { Column, GridColumns, Spacer, Text } from "@artsy/palette"
 
 export const NewForYouApp: FC = () => {
   const featureFlagEnabled = useFeatureFlag("new_for_you")
@@ -12,5 +14,23 @@ export const NewForYouApp: FC = () => {
     }
   })
 
-  return <>NewForYouApp</>
+  return (
+    <>
+      <Spacer mt={2} />
+      <MetaTags title="New For You" />
+      <GridColumns>
+        <Column span={6}>
+          <Text variant="xl" mt={4}>
+            New Works For You
+          </Text>
+        </Column>
+        <Column span={6}>
+          <Text variant={"md"} mt={6}>
+            Description Here Explaining Stuff
+          </Text>
+        </Column>
+      </GridColumns>
+      <Spacer mt={4} />
+    </>
+  )
 }

--- a/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
+++ b/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
@@ -20,6 +20,6 @@ describe("NewForYouApp", () => {
         </SystemContextProvider>
       </MockBoot>
     )
-    expect(screen.getByText("NewForYouApp")).toBeInTheDocument()
+    expect(screen.getByText("New Works For You")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
The type of this PR is: Feature development

This PR solves [GRO-919]

Figma Designs: https://www.figma.com/file/HwAhS7iZKrvZLs6lNx5g4z/New-for-You?node-id=53%3A11944

### Description
We need to create a new page, /new-for-you so that users can find affinity recommendations all in one place on web.  This puts in the New Works For You page title and header copy.

New Layout:
<img width="1789" alt="Screen Shot 2022-05-05 at 1 26 48 PM" src="https://user-images.githubusercontent.com/30025439/167020913-3c673fa9-144a-491d-8158-702e0cbd2118.png">



[GRO-919]: https://artsyproduct.atlassian.net/browse/GRO-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ