### PR TITLE
chore(FX-3927): update copy when no artworks available by an artist

### DIFF
--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -78,9 +78,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
         enableCreateAlert
         savedSearchEntity={savedSearchEntity}
       >
-        {artist.counts!.artworks === 0 && (
-          <ZeroState artist={artist} isFollowed={artist.isFollowed} />
-        )}
+        {artist.counts!.artworks === 0 && <ZeroState />}
       </BaseArtworkFilter>
     </ArtworkFilterContextProvider>
   )

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -14,6 +14,7 @@ import { useRouter } from "v2/System/Router/useRouter"
 import { SavedSearchEntity } from "v2/Components/SavedSearchAlert/types"
 import { getSupportedMetric } from "v2/Components/ArtworkFilter/Utils/metrics"
 import { OwnerType } from "@artsy/cohesion"
+import { ZeroState } from "./ZeroState"
 
 interface ArtistArtworkFilterProps {
   aggregations: SharedArtworkFilterContextProps["aggregations"]
@@ -67,6 +68,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
         { value: "-year", text: "Artwork year (desc.)" },
         { value: "year", text: "Artwork year (asc.)" },
       ]}
+      ZeroState={ZeroState}
     >
       <BaseArtworkFilter
         relay={relay}

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -10,7 +10,6 @@ import {
 import { Match } from "found"
 import * as React from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
-import { ZeroState } from "./ZeroState"
 import { useRouter } from "v2/System/Router/useRouter"
 import { SavedSearchEntity } from "v2/Components/SavedSearchAlert/types"
 import { getSupportedMetric } from "v2/Components/ArtworkFilter/Utils/metrics"
@@ -77,9 +76,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
         }}
         enableCreateAlert
         savedSearchEntity={savedSearchEntity}
-      >
-        {artist.counts!.artworks === 0 && <ZeroState />}
-      </BaseArtworkFilter>
+      />
     </ArtworkFilterContextProvider>
   )
 }

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
@@ -1,31 +1,12 @@
-import { ContextModule } from "@artsy/cohesion"
-import { Clickable, Flex, Message, Text } from "@artsy/palette"
-import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "v2/Components/FollowButton/FollowArtistButton"
+import { Message, Text } from "@artsy/palette"
 
 export const ZeroState = props => {
-  const { isFollowed, artist } = props
-
   return (
     <Message>
-      There aren’t any works available by the artist at this time.{" "}
-      {!isFollowed && (
-        <Flex>
-          <FollowArtistButton
-            artist={artist}
-            contextModule={ContextModule.worksForSaleRail}
-            render={({ name }) => {
-              return (
-                <Clickable cursor="pointer" textDecoration="underline">
-                  <Text>Follow {name}</Text>
-                </Clickable>
-              )
-            }}
-          />{" "}
-          <Text pl={0.5}>
-            to receive notifications when new works are added.
-          </Text>
-        </Flex>
-      )}
+      <Text>No works available by the artist at this time</Text>
+      <Text textColor="black60">
+        Create an Alert to receive notifications when new works are added
+      </Text>
     </Message>
   )
 }

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
@@ -1,7 +1,17 @@
 import { Box, Message, Text } from "@artsy/palette"
+import { isEmpty } from "lodash"
+import { useArtworkFilterContext } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+import { ArtworkGridEmptyState } from "v2/Components/ArtworkGrid/ArtworkGridEmptyState"
 import { Sticky } from "v2/Components/Sticky"
 
 export const ZeroState: React.FC = () => {
+  const { selectedFiltersCounts, resetFilters } = useArtworkFilterContext()
+  const hasAppliedFilters = !isEmpty(selectedFiltersCounts)
+
+  if (hasAppliedFilters) {
+    return <ArtworkGridEmptyState onClearFilters={resetFilters} />
+  }
+
   return (
     <Box width="100%" my={1}>
       <Sticky>

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
@@ -1,6 +1,6 @@
 import { Message, Text } from "@artsy/palette"
 
-export const ZeroState = props => {
+export const ZeroState: React.FC = () => {
   return (
     <Message>
       <Text>No works available by the artist at this time</Text>

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
@@ -1,12 +1,24 @@
-import { Message, Text } from "@artsy/palette"
+import { Box, Message, Text } from "@artsy/palette"
+import { Sticky } from "v2/Components/Sticky"
 
 export const ZeroState: React.FC = () => {
   return (
-    <Message>
-      <Text>No works available by the artist at this time</Text>
-      <Text textColor="black60">
-        Create an Alert to receive notifications when new works are added
-      </Text>
-    </Message>
+    <Box width="100%" my={1}>
+      <Sticky>
+        {({ stuck }) => {
+          return (
+            <Box pt={stuck ? 1 : 0}>
+              <Message>
+                <Text>No works available by the artist at this time</Text>
+                <Text textColor="black60">
+                  Create an Alert to receive notifications when new works are
+                  added
+                </Text>
+              </Message>
+            </Box>
+          )
+        }}
+      </Sticky>
+    </Box>
   )
 }

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -64,7 +64,7 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
     context.setFilter("page", page)
   }
 
-  const isArtistPage = match.location.pathname.includes("/artist/")
+  const isArtistPage = match.location.pathname?.includes("/artist/")
 
   const hasAppliedFilters = !isEmpty(context?.selectedFiltersCounts)
 

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -10,10 +10,6 @@ import { useArtworkFilterContext } from "./ArtworkFilterContext"
 import { ContextModule, clickedMainArtworkGrid } from "@artsy/cohesion"
 import { useAnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
 import { Sticky } from "../Sticky"
-import { isEmpty } from "lodash"
-import { ArtworkGridEmptyState } from "../ArtworkGrid/ArtworkGridEmptyState"
-import { ZeroState } from "v2/Apps/Artist/Routes/WorksForSale/Components/ZeroState"
-import { useRouter } from "v2/System/Router/useRouter"
 
 interface ArtworkFilterArtworkGridProps {
   columnCount: number[]
@@ -26,7 +22,6 @@ interface ArtworkFilterArtworkGridProps {
 const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props => {
   const { user } = useSystemContext()
   const { trackEvent } = useTracking()
-  const { match } = useRouter()
   const {
     contextPageOwnerType,
     contextPageOwnerSlug,
@@ -64,10 +59,6 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
     context.setFilter("page", page)
   }
 
-  const isArtistPage = match.location.pathname?.includes("/artist/")
-
-  const hasAppliedFilters = !isEmpty(context?.selectedFiltersCounts)
-
   return (
     <>
       <LoadingArea isLoading={props.isLoading}>
@@ -78,17 +69,7 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
           itemMargin={40}
           user={user}
           onClearFilters={context.resetFilters}
-          emptyStateComponent={
-            isArtistPage ? (
-              !!hasAppliedFilters ? (
-                <ArtworkGridEmptyState onClearFilters={context.resetFilters} />
-              ) : (
-                <ZeroState />
-              )
-            ) : (
-              context.ZeroState && <context.ZeroState />
-            )
-          }
+          emptyStateComponent={context.ZeroState && <context.ZeroState />}
           onBrickClick={(artwork, artworkIndex) => {
             trackEvent(
               clickedMainArtworkGrid({

--- a/src/v2/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/v2/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -2,7 +2,7 @@ import { AuthContextModule, ContextModule } from "@artsy/cohesion"
 import { Column, Flex, GridColumns } from "@artsy/palette"
 import { ArtworkGrid_artworks } from "v2/__generated__/ArtworkGrid_artworks.graphql"
 import { ArtworkGridEmptyState } from "v2/Components/ArtworkGrid/ArtworkGridEmptyState"
-import { isEqual } from "lodash"
+import { isEmpty, isEqual } from "lodash"
 import memoizeOnce from "memoize-one"
 import { ReactNode } from "react"
 import * as React from "react"
@@ -232,7 +232,7 @@ export class ArtworkGridContainer extends React.Component<
       emptyStateComponent,
     } = this.props
 
-    const hasArtworks = artworks && artworks.edges && artworks.edges.length > 0
+    const hasArtworks = !isEmpty(artworks?.edges)
     let artworkGrids
 
     if (isAuctionArtwork) {

--- a/src/v2/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
+++ b/src/v2/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
@@ -15,8 +15,8 @@ export const ArtworkGridEmptyState: React.FC<ArtworkGridEmptyStateProps> = props
           <Box pt={stuck ? 1 : 0}>
             <Message width="100%">
               <>
-                There aren't any works available that meet the following
-                criteria at this time.
+                {`There aren't any works available that meet the following
+                criteria at this time. `}
               </>
               {props.onClearFilters && (
                 <>


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-3927]

### Description

[Review app](https://empty-artist-artworks.artsy.net/)

We want to display the same messages on mWeb and Desktop.  More specifically:

- No filters applied: [this copy](https://www.figma.com/file/zG9cduJdOaTQAw886QcOwn/Filters?node-id=3914%3A33534) on desktop / mWeb

- Filters applied: the already existing copy on mWeb but on both desktop/mWeb:
 `There aren't any works available that meet the following criteria at this time. Change your filter criteria to view more works. Clear all filters.` 
 where the clear all filters will be a clickable underlined text that clears the applied filters.

#### Screenshots

##### Desktop

|No filters applied|Filters applied|
|---|---|
|Before||
|<img width="1792" alt="Screenshot 2022-05-19 at 11 58 36" src="https://user-images.githubusercontent.com/21178754/169267396-77577492-74eb-4b86-92e7-0d86d28e6673.png">|<img width="1792" alt="Screenshot 2022-05-19 at 11 58 30" src="https://user-images.githubusercontent.com/21178754/169267389-41bf3dee-90a9-491c-9793-8af34a8eb742.png">|
|After||
|<img width="1792" alt="Screenshot 2022-05-19 at 11 58 54" src="https://user-images.githubusercontent.com/21178754/169267379-d87b0716-8483-42e5-8888-47f36c1cd214.png">|<img width="414" alt="Screenshot 2022-05-19 at 11 48 35" src="https://user-images.githubusercontent.com/21178754/169266729-2dbbec65-c831-4919-aee0-5fb7ea0469bd.png">|

##### mWeb

|No filters applied|Filters applied|
|---|---|
|Before||
|<img width="433" alt="Screenshot 2022-05-19 at 11 54 43" src="https://user-images.githubusercontent.com/21178754/169266536-962e2f15-16c0-43c3-9956-632e739f2c76.png">|<img width="434" alt="Screenshot 2022-05-19 at 11 54 53" src="https://user-images.githubusercontent.com/21178754/169266528-a9f77fa4-68f5-43d2-809e-e8efb3919da4.png">|
|After||
|<img width="421" alt="Screenshot 2022-05-19 at 11 48 44" src="https://user-images.githubusercontent.com/21178754/169266719-7ac1aad0-843d-45f4-94d6-2cc088b0a6ab.png">|<img width="414" alt="Screenshot 2022-05-19 at 11 48 35" src="https://user-images.githubusercontent.com/21178754/169266729-2dbbec65-c831-4919-aee0-5fb7ea0469bd.png">|


<!-- Implementation description -->

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-3927]: https://artsyproduct.atlassian.net/browse/FX-3927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ