### PR TITLE
feat: add data-test props for collections page

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collections/Components/CollectionsCategory.tsx
+++ b/src/v2/Apps/Collect/Routes/Collections/Components/CollectionsCategory.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import * as React from "react"
 import {
   Box,
   Button,
@@ -46,7 +45,7 @@ export const CollectionsCategory: React.FC<CollectionsCategoryProps> = ({
         </>
       )}
 
-      <GridColumns>
+      <GridColumns data-test="collections-category-list">
         {sortedCollections.map((collection, i) => {
           return (
             <Column

--- a/src/v2/Apps/Collect/Routes/Collections/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collections/index.tsx
@@ -1,13 +1,12 @@
-import { Column, GridColumns, Join, Spacer, Text } from "@artsy/palette"
+import { Box, Column, GridColumns, Join, Spacer, Text } from "@artsy/palette"
 import { Collections_marketingCategories } from "v2/__generated__/Collections_marketingCategories.graphql"
 import { FrameWithRecentlyViewed } from "v2/Components/FrameWithRecentlyViewed"
 import { BreadCrumbList } from "v2/Components/Seo"
-import * as React from "react";
 import { Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
-import { data as sd } from "sharify"
 import { CollectionsCategoryFragmentContainer } from "./Components/CollectionsCategory"
 import { RouterLink } from "v2/System/Router/RouterLink"
+import { getENV } from "v2/Utils/getENV"
 
 interface CollectionsAppProps {
   marketingCategories: Collections_marketingCategories
@@ -23,7 +22,7 @@ export const CollectionsApp: React.FC<CollectionsAppProps> = ({
   return (
     <>
       <Title>Collections | Artsy</Title>
-      <Meta property="og:url" content={`${sd.APP_URL}/collections`} />
+      <Meta property="og:url" content={`${getENV("APP_URL")}/collections`} />
       <Meta name="description" content={META_DESCRIPTION} />
       <Meta property="og:description" content={META_DESCRIPTION} />
       <Meta property="twitter:description" content={META_DESCRIPTION} />
@@ -44,16 +43,18 @@ export const CollectionsApp: React.FC<CollectionsAppProps> = ({
           </Column>
         </GridColumns>
 
-        <Join separator={<Spacer mt={6} />}>
-          {sorted.map((category, i) => {
-            return (
-              <CollectionsCategoryFragmentContainer
-                key={category.name + i}
-                category={category}
-              />
-            )
-          })}
-        </Join>
+        <Box data-test="collections-list">
+          <Join separator={<Spacer mt={6} />}>
+            {sorted.map((category, i) => {
+              return (
+                <CollectionsCategoryFragmentContainer
+                  key={category.name + i}
+                  category={category}
+                />
+              )
+            })}
+          </Join>
+        </Box>
       </FrameWithRecentlyViewed>
     </>
   )


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-3907]

### Description

In FX we decided to add two test cases in integrity for collections.

You can see the Integrity PR [here](https://github.com/artsy/integrity/pull/333)

This PR adds:
- added `data-test` properties in order to be able to select the elements that we want to test.
- refactored `sd` -> to use `getENV` in one file due to eslint errors.
- removed redundant react import

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-3907]: https://artsyproduct.atlassian.net/browse/FX-3907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ