### PR TITLE
[WIP] feat(ArtworkFilter): Make filter URL driven so that browser back buttons preserve previous selections 

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -140,7 +140,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
       const filtersHaveUpdated = !isEqual(currentFilter, previousFilter)
 
       if (filtersHaveUpdated) {
-        fetchResults()
+        // fetchResults()
 
         // If user is not logged-in, show auth modal, but only if it was never shown before.
         if (!user && !authShownForFiltering) {

--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
@@ -4,7 +4,6 @@ import {
   ArtworkFilterContextProvider,
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
-import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { Match, RouterState, withRouter } from "found"
 import * as React from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
@@ -39,7 +38,6 @@ const ArtistSeriesArtworksFilter: React.FC<ArtistSeriesArtworksFilterProps> = pr
         { value: "-year", text: "Artwork year (desc.)" },
         { value: "year", text: "Artwork year (asc.)" },
       ]}
-      onChange={updateUrl}
     >
       <BaseArtworkFilter
         relay={relay}

--- a/src/v2/Apps/Auction/auctionRoutes.tsx
+++ b/src/v2/Apps/Auction/auctionRoutes.tsx
@@ -83,6 +83,8 @@ export const auctionRoutes: AppRouteConfig[] = [
           ...initialFilterState,
           ...getArtworkFilterInputArgs(props.context.user),
           saleID: params.slug,
+          // TODO: might fix
+          // sort: "sale_position",
           // FIXME: Understand why this is needed to view lots in `the-artist-is-present-a-benefit-auction-for-ukraine` while logged out
           priceRange: "*-*",
         },

--- a/src/v2/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collect/index.tsx
@@ -117,30 +117,7 @@ export const CollectApp: React.FC<CollectAppProps> = ({
               { text: "Artwork year (desc.)", value: "-year" },
               { text: "Artwork year (asc.)", value: "year" },
             ]}
-            onChange={filters => {
-              const url = buildUrlForCollectApp(filters)
-
-              if (typeof window !== "undefined") {
-                window.history.replaceState({}, "", url)
-              }
-
-              /**
-             * FIXME: Ideally we route using our router, but are running into
-             * synchronization issues between router state and URL bar state.
-             *
-             * See below example as an illustration:
-             *
-              const newLocation = router.createLocation(url)
-
-              router.replace({
-                ...newLocation,
-                state: {
-                  scrollTo: "#jump--artworkFilter"
-                },
-              })
-            *
-            */
-            }}
+            getUrlForFilterParams={buildUrlForCollectApp}
           />
         </Box>
       </FrameWithRecentlyViewed>

--- a/src/v2/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
@@ -6,6 +6,7 @@ import {
   Counts,
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { usePathnameComplete } from "v2/Utils/Hooks/usePathnameComplete"
 import { useRouter } from "v2/System/Router/useRouter"
 import { CollectionArtworksFilter_collection } from "v2/__generated__/CollectionArtworksFilter_collection.graphql"
@@ -80,6 +81,7 @@ export const CollectionArtworksFilter: React.FC<CollectionArtworksFilterProps> =
       ]}
       counts={counts}
       aggregations={aggregations}
+      onChange={updateUrl}
     >
       <BaseArtworkFilter
         relay={relay}

--- a/src/v2/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
@@ -6,7 +6,6 @@ import {
   Counts,
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
-import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { usePathnameComplete } from "v2/Utils/Hooks/usePathnameComplete"
 import { useRouter } from "v2/System/Router/useRouter"
 import { CollectionArtworksFilter_collection } from "v2/__generated__/CollectionArtworksFilter_collection.graphql"
@@ -81,7 +80,6 @@ export const CollectionArtworksFilter: React.FC<CollectionArtworksFilterProps> =
       ]}
       counts={counts}
       aggregations={aggregations}
-      onChange={updateUrl}
     >
       <BaseArtworkFilter
         relay={relay}

--- a/src/v2/Apps/Collect/Utils/urlBuilder.ts
+++ b/src/v2/Apps/Collect/Utils/urlBuilder.ts
@@ -1,8 +1,5 @@
 import { ArtworkFilters } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
-import {
-  paramsToSnakeCase,
-  removeDefaultValues,
-} from "v2/Components/ArtworkFilter/Utils/urlBuilder"
+import { removeDefaultValues } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import qs from "qs"
 
 export const buildUrlForCollectApp = (state: ArtworkFilters): string => {

--- a/src/v2/Apps/Collect/Utils/urlBuilder.ts
+++ b/src/v2/Apps/Collect/Utils/urlBuilder.ts
@@ -19,5 +19,5 @@ const buildCollectUrlFragmentFromState = (state: ArtworkFilters): string => {
     return emptyOrSpecificMedium
   }
 
-  return `${emptyOrSpecificMedium}?${qs.stringify(paramsToSnakeCase(params))}`
+  return `${emptyOrSpecificMedium}?${qs.stringify(params)}`
 }

--- a/src/v2/Apps/Collect/collectRoutes.tsx
+++ b/src/v2/Apps/Collect/collectRoutes.tsx
@@ -129,13 +129,15 @@ function initializeVariablesWithFilterState(params, props) {
     first: 30,
   }
 
-  return {
+  const filterState = {
     input,
     aggregations,
     slug: collectionSlug,
     sort: "-decayed_merch",
     shouldFetchCounts: !!props.context.user,
   }
+
+  return filterState
 }
 
 function getArtworkFilterQuery() {

--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -5,7 +5,6 @@ import {
   Counts,
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
-import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import * as React from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { MediumFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter"

--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -74,10 +74,8 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
         { text: "Artwork year (desc.)", value: "-year" },
         { text: "Artwork year (asc.)", value: "year" },
       ]}
-      onChange={updateUrl}
       aggregations={
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-        sidebarAggregations.aggregations as SharedArtworkFilterContextProps["aggregations"]
+        sidebarAggregations?.aggregations as SharedArtworkFilterContextProps["aggregations"]
       }
     >
       <BaseArtworkFilter mt={6} relay={relay} viewer={fair} Filters={Filters} />

--- a/src/v2/Apps/Gene/Components/GeneArtworkFilter.tsx
+++ b/src/v2/Apps/Gene/Components/GeneArtworkFilter.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createRefetchContainer, RelayRefetchProp, graphql } from "react-relay"
 import { useRouter } from "v2/System/Router/useRouter"
 import { BaseArtworkFilter } from "v2/Components/ArtworkFilter"
@@ -25,7 +25,6 @@ const GeneArtworkFilter: React.FC<GeneArtworkFilterProps> = ({
   return (
     <ArtworkFilterContextProvider
       filters={match && match.location.query}
-      onChange={updateUrl}
       sortOptions={[
         { text: "Default", value: "-decayed_merch" },
         { text: "Price (desc.)", value: "-has_price,-prices" },

--- a/src/v2/Apps/Partner/Routes/Works/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Works/index.tsx
@@ -36,7 +36,6 @@ export const Artworks: React.FC<PartnerArtworkFilterProps> = ({
         { text: "Artwork year (desc.)", value: "-year" },
         { text: "Artwork year (asc.)", value: "year" },
       ]}
-      onChange={updateUrl}
       aggregations={
         sidebar?.aggregations as SharedArtworkFilterContextProps["aggregations"]
       }

--- a/src/v2/Apps/Search/Routes/SearchResultsArtworks.tsx
+++ b/src/v2/Apps/Search/Routes/SearchResultsArtworks.tsx
@@ -24,7 +24,6 @@ export const SearchResultsArtworksRoute: React.FC<SearchResultsRouteProps> = pro
       mt={4}
       viewer={viewer}
       filters={match.location.query}
-      onChange={updateUrl}
       ZeroState={ZeroState}
       aggregations={
         sidebar?.aggregations as SharedArtworkFilterContextProps["aggregations"]

--- a/src/v2/Apps/Show/Components/ShowArtworks.tsx
+++ b/src/v2/Apps/Show/Components/ShowArtworks.tsx
@@ -6,7 +6,7 @@ import {
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
-import * as React from "react";
+import * as React from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { BoxProps } from "@artsy/palette"
 import { useRouter } from "v2/System/Router/useRouter"
@@ -50,7 +50,6 @@ const ShowArtworksFilter: React.FC<ShowArtworksFilterProps> = props => {
         { text: "Artwork year (desc.)", value: "-year" },
         { text: "Artwork year (asc.)", value: "year" },
       ]}
-      onChange={updateUrl}
       aggregations={aggregations}
       counts={counts}
     >

--- a/src/v2/Apps/Tag/Components/TagArtworkFilter.tsx
+++ b/src/v2/Apps/Tag/Components/TagArtworkFilter.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createRefetchContainer, RelayRefetchProp, graphql } from "react-relay"
 import { useRouter } from "v2/System/Router/useRouter"
 import { BaseArtworkFilter } from "v2/Components/ArtworkFilter"
@@ -22,7 +22,6 @@ const TagArtworkFilter: React.FC<TagArtworkFilterProps> = ({ tag, relay }) => {
   return (
     <ArtworkFilterContextProvider
       filters={match && match.location.query}
-      onChange={updateUrl}
       sortOptions={[
         { text: "Default", value: "-decayed_merch" },
         { text: "Price (desc.)", value: "-has_price,-prices" },

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -1,4 +1,4 @@
-import { Spacer, useThemeConfig } from "@artsy/palette"
+import { Box, Spacer, Spinner, useThemeConfig } from "@artsy/palette"
 import * as React from "react"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 import { ArtworkFilterArtworkGrid_filtered_artworks } from "v2/__generated__/ArtworkFilterArtworkGrid_filtered_artworks.graphql"
@@ -6,10 +6,10 @@ import { useSystemContext } from "v2/System"
 import { useTracking } from "v2/System/Analytics/useTracking"
 import ArtworkGrid from "v2/Components/ArtworkGrid"
 import { PaginationFragmentContainer as Pagination } from "v2/Components/Pagination"
-import { LoadingArea } from "../LoadingArea"
 import { useArtworkFilterContext } from "./ArtworkFilterContext"
 import { ContextModule, clickedMainArtworkGrid } from "@artsy/cohesion"
 import { useAnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
+import { Sticky } from "../Sticky"
 
 interface ArtworkFilterArtworkGridProps {
   columnCount: number[]
@@ -62,7 +62,6 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
 
   return (
     <>
-      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <LoadingArea isLoading={props.isLoading}>
         <ArtworkGrid
           artworks={props.filtered_artworks}
@@ -101,6 +100,25 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
         />
       </LoadingArea>
     </>
+  )
+}
+
+const LoadingArea: React.FC<{ isLoading?: boolean }> = ({
+  isLoading,
+  children,
+}) => {
+  return (
+    <Box position="relative">
+      {isLoading && (
+        <Sticky>
+          <Box height={300} width="100%" position="absolute">
+            <Spinner />
+          </Box>
+        </Sticky>
+      )}
+
+      <Box opacity={isLoading ? 0.1 : 1}>{children}</Box>
+    </Box>
   )
 }
 

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -1,14 +1,17 @@
-import { isArray, omit } from "lodash"
-import { useContext, useReducer, useState } from "react"
+import { debounce, isArray, isEqual, omit, pick } from "lodash"
+import { useContext, useEffect, useReducer, useState } from "react"
 import * as React from "react"
 import useDeepCompareEffect from "use-deep-compare-effect"
 import { SortOptions } from "../SortFilter"
 import { hasFilters } from "./Utils/hasFilters"
 import { isDefaultFilter } from "./Utils/isDefaultFilter"
 import { rangeToTuple } from "./Utils/rangeToTuple"
-import { paramsToCamelCase } from "./Utils/urlBuilder"
+import { paramsToCamelCase, removeDefaultValues } from "./Utils/urlBuilder"
 import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { DEFAULT_METRIC, Metric } from "./Utils/metrics"
+import { useRouter } from "v2/System/Router/useRouter"
+import { getInitialFilterState } from "./Utils/getInitialFilterState"
+import qs from "qs"
 
 /**
  * Initial filter state
@@ -177,14 +180,17 @@ export enum SelectedFiltersCountsLabels {
   waysToBuy = "waysToBuy",
 }
 
-// TODO: merge or make a generic base of `ArtworkFilterContextProps` and `AuctionResultsFilterContextProps`.
-// Possibly just extend `BaseFilterContext` and make the former ones into `BaseFilterContext<ArtworkFilters>`
-// and `BaseFilterContext<AuctionResultFilters>`.
+// TODO: merge or make a generic base of `ArtworkFilterContextProps` and
+// `AuctionResultsFilterContextProps`. Possibly just extend `BaseFilterContext`
+// and make the former ones into `BaseFilterContext<ArtworkFilters>` and
+// `BaseFilterContext<AuctionResultFilters>`.
 export interface ArtworkFilterContextProps {
-  /** The current artwork filter state (which determines the network request and the url querystring) */
+  // The current artwork filter state (which determines the network request and
+  // the url querystring)
   filters?: ArtworkFiltersState
 
-  /** Interim filter state, to be manipulated before being applied to the current filter state */
+  // Interim filter state, to be manipulated before being applied to the current
+  // filter state
   stagedFilters?: ArtworkFiltersState
 
   /** Getter for the appropriate source of truth to render in the filter UI */
@@ -277,6 +283,8 @@ export const ArtworkFilterContextProvider: React.FC<
   sortOptions,
   ZeroState,
 }) => {
+  const { router, match } = useRouter()
+
   const initialFilterState = {
     ...initialArtworkFilterState,
     sort: sortOptions?.[0].value ?? initialArtworkFilterState.sort,
@@ -289,6 +297,10 @@ export const ArtworkFilterContextProvider: React.FC<
   )
 
   const [stagedArtworkFilterState, stage] = useReducer(artworkFilterReducer, {})
+  const [routerArtworkFilterState, dispatchToRouter] = useReducer(
+    artworkFilterReducer,
+    initialFilterState
+  )
 
   // TODO: Consolidate this into additional reducer
   const [artworkCounts, setCounts] = useState(counts)
@@ -298,9 +310,21 @@ export const ArtworkFilterContextProvider: React.FC<
 
   useDeepCompareEffect(() => {
     if (onChange) {
-      onChange(omit(artworkFilterState, ["reset"]))
+      // onChange(omit(artworkFilterState, ["reset"]))
     }
   }, [artworkFilterState])
+
+  useDeepCompareEffect(() => {
+    pushChangeToRouter(routerArtworkFilterState)
+  }, [routerArtworkFilterState])
+
+  useDeepCompareEffect(() => {
+    const action: ArtworkFiltersAction = {
+      type: "SET_FILTERS",
+      payload: match.location.query,
+    }
+    dispatch(action)
+  }, [match.location.query])
 
   // If in staged mode, return the staged filters for UI display
   const currentlySelectedFilters = () => {
@@ -312,12 +336,32 @@ export const ArtworkFilterContextProvider: React.FC<
   // If in staged mode, manipulate the staged version of filter state
   // instead of "real" one
   const dispatchOrStage = (action: ArtworkFiltersAction) => {
-    shouldStageFilterChanges ? stage(action) : dispatch(action)
+    // shouldStageFilterChanges ? stage(action) : dispatch(action)
+    shouldStageFilterChanges ? stage(action) : dispatchToRouter(action)
   }
 
   const currentlySelectedFiltersCounts = getSelectedFiltersCounts(
     currentlySelectedFilters()
   )
+
+  const pushChangeToRouter = state => {
+    const url =
+      window.location.pathname +
+      "?" +
+      qs.stringify(getInitialFilterState(removeDefaultValues(state)))
+    const newLocation = router.createLocation(url)
+    console.log(newLocation)
+
+    // return
+    router.push({
+      ...newLocation,
+      state: {
+        scrollTo: "#jump--artworkFilter",
+        ignoreScrollBehavior: true,
+        hidePageLoader: true,
+      },
+    })
+  }
 
   const artworkFilterContext = {
     mountedContext: true,

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -1,4 +1,4 @@
-import { isArray } from "lodash"
+import { isArray, isEqual } from "lodash"
 import { useContext, useReducer, useState } from "react"
 import * as React from "react"
 import useDeepCompareEffect from "use-deep-compare-effect"
@@ -287,6 +287,7 @@ export const ArtworkFilterContextProvider: React.FC<
 }) => {
   const { router, match } = useRouter()
 
+  // console.log(sortOptions?.[0].value, initialArtworkFilterState.sort)
   const initialFilterState = {
     ...initialArtworkFilterState,
     sort: sortOptions?.[0].value ?? initialArtworkFilterState.sort,
@@ -309,9 +310,6 @@ export const ArtworkFilterContextProvider: React.FC<
     artworkFilterReducer,
     initialFilterState
   )
-
-  // debugger
-
   const [stagedArtworkFilterState, stage] = useReducer(artworkFilterReducer, {})
 
   // TODO: Consolidate this into additional reducer
@@ -339,21 +337,6 @@ export const ArtworkFilterContextProvider: React.FC<
   const currentlySelectedFiltersCounts = getSelectedFiltersCounts(
     currentlySelectedFilters()
   )
-
-  const pushChangeToRouter = state => {
-    const url = getUrlForFilterParams(state)
-    console.log(url)
-    const newLocation = router.createLocation(url)
-
-    router.push({
-      ...newLocation,
-      state: {
-        scrollTo: "#jump--artworkFilter",
-        ignoreScrollBehavior: true,
-        isArtworkFilter: true,
-      },
-    })
-  }
 
   const artworkFilterContext = {
     mountedContext: true,
@@ -440,6 +423,20 @@ export const ArtworkFilterContextProvider: React.FC<
       const { force } = opts
       force ? dispatch(action) : dispatchOrStage(action)
     },
+  }
+
+  const pushChangeToRouter = state => {
+    const url = getUrlForFilterParams(state)
+    const newLocation = router.createLocation(url)
+
+    router.push({
+      ...newLocation,
+      state: {
+        scrollTo: "#jump--artworkFilter",
+        ignoreScrollBehavior: true,
+        isArtworkFilter: true,
+      },
+    })
   }
 
   // 1) When the state of the router artwork filter changes, push the change

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtworkSortFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtworkSortFilter.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { SortFilter } from "v2/Components/SortFilter"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 

--- a/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
@@ -44,7 +44,8 @@ export const buildUrl = (
   const params = removeDefaultValues(state, {
     defaultValues: options?.defaultValues,
   })
-  const queryString = qs.stringify(paramsToSnakeCase(params))
+
+  const queryString = qs.stringify(params)
 
   let pathname = options?.pathname
   if (!pathname && typeof window !== "undefined") {
@@ -57,21 +58,13 @@ export const buildUrl = (
   return url
 }
 
-export const updateUrl = (state: ArtworkFilters, options?: BuildUrlOptions) => {
-  const url = buildUrl(state, { defaultValues: options?.defaultValues })
-
-  if (typeof window !== "undefined") {
-    window.history.replaceState({}, "", url)
-  }
-}
-
 export const getUrlForFilterParams = (
   state: ArtworkFilters,
   options?: BuildUrlOptions
 ) => {
   const url = buildUrl(state, { defaultValues: options?.defaultValues })
-  console.log(url)
-  return `${window.location.pathname}?${url}`
+  return url
+  // return `${window.location.pathname}?${url}`
 }
 
 export const removeDefaultValues = (
@@ -88,4 +81,13 @@ export const removeDefaultValues = (
     },
     {}
   )
+}
+
+// OLD, can delete
+export const updateUrl = (state: ArtworkFilters, options?: BuildUrlOptions) => {
+  const url = buildUrl(state, { defaultValues: options?.defaultValues })
+
+  if (typeof window !== "undefined") {
+    window.history.replaceState({}, "", url)
+  }
 }

--- a/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
@@ -1,6 +1,6 @@
 import { ArtworkFilters } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { isDefaultFilter } from "v2/Components/ArtworkFilter/Utils/isDefaultFilter"
-import { camelCase, snakeCase } from "lodash"
+import { camelCase, omit, snakeCase } from "lodash"
 import qs from "qs"
 
 // Utility method to convert keys of a hash into snake case.
@@ -62,6 +62,16 @@ export const getUrlForFilterParams = (
   state: ArtworkFilters,
   options?: BuildUrlOptions
 ) => {
+  // DO we need this:
+  // const refetchVariables = {
+  //   input: {
+  //     first: 30,
+  //     ...relayRefetchInputVariables,
+  //     ...allowedFilters(filterContext.filters),
+  //     keyword: filterContext.filters!.term,
+  //   },
+  //   ...relayVariables,
+  // }
   const url = buildUrl(state, { defaultValues: options?.defaultValues })
   return url
   // return `${window.location.pathname}?${url}`
@@ -71,16 +81,20 @@ export const removeDefaultValues = (
   state: ArtworkFilters,
   options?: BuildUrlOptions
 ) => {
-  return Object.entries(state).reduce(
-    (acc, [key, value]: [keyof ArtworkFilters, any]) => {
-      if (isDefaultFilter(key, value, options?.defaultValues)) {
-        return acc
-      } else {
-        return { ...acc, [key]: value }
-      }
-    },
-    {}
+  const values = omit(
+    Object.entries(state).reduce(
+      (acc, [key, value]: [keyof ArtworkFilters, any]) => {
+        if (isDefaultFilter(key, value, options?.defaultValues)) {
+          return acc
+        } else {
+          return { ...acc, [key]: value }
+        }
+      },
+      {}
+    ),
+    ["reset"]
   )
+  return values
 }
 
 // OLD, can delete

--- a/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
@@ -65,6 +65,15 @@ export const updateUrl = (state: ArtworkFilters, options?: BuildUrlOptions) => {
   }
 }
 
+export const getUrlForFilterParams = (
+  state: ArtworkFilters,
+  options?: BuildUrlOptions
+) => {
+  const url = buildUrl(state, { defaultValues: options?.defaultValues })
+  console.log(url)
+  return `${window.location.pathname}?${url}`
+}
+
 export const removeDefaultValues = (
   state: ArtworkFilters,
   options?: BuildUrlOptions

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -46,6 +46,7 @@ import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvi
 import { getTotalSelectedFiltersCount } from "./Utils/getTotalSelectedFiltersCount"
 import { SavedSearchEntity } from "../SavedSearchAlert/types"
 import { SavedSearchAlertArtworkGridFilterPills } from "../SavedSearchAlert/Components/SavedSearchAlertArtworkGridFilterPills"
+import { useRouter } from "v2/System/Router/useRouter"
 
 interface ArtworkFilterProps extends SharedArtworkFilterContextProps, BoxProps {
   enableCreateAlert?: boolean
@@ -70,6 +71,7 @@ export const ArtworkFilter: React.FC<ArtworkFilterProps> = ({
   aggregations,
   counts,
   filters,
+  getUrlForFilterParams,
   onChange,
   onFilterClick,
   sortOptions,
@@ -82,6 +84,7 @@ export const ArtworkFilter: React.FC<ArtworkFilterProps> = ({
       aggregations={aggregations}
       counts={counts}
       filters={filters}
+      getUrlForFilterParams={getUrlForFilterParams}
       sortOptions={sortOptions}
       onFilterClick={onFilterClick}
       onChange={onChange}
@@ -108,6 +111,7 @@ export const BaseArtworkFilter: React.FC<
   savedSearchEntity,
   ...rest
 }) => {
+  const { match } = useRouter()
   const tracking = useTracking()
   const {
     contextPageOwnerId,
@@ -122,6 +126,8 @@ export const BaseArtworkFilter: React.FC<
   const appliedFiltersTotalCount = getTotalSelectedFiltersCount(
     filterContext.selectedFiltersCounts
   )
+
+  const isLoading = match.location?.state?.isArtworkFilter && isFetching
 
   /**
    * Check to see if the mobile action sheet is present and prevent scrolling
@@ -288,7 +294,7 @@ export const BaseArtworkFilter: React.FC<
 
           <ArtworkFilterArtworkGrid
             filtered_artworks={viewer.filtered_artworks!}
-            isLoading={isFetching}
+            isLoading={isLoading}
             offset={offset}
             columnCount={[2, 2, 2, 3]}
           />
@@ -335,7 +341,7 @@ export const BaseArtworkFilter: React.FC<
             {children || (
               <ArtworkFilterArtworkGrid
                 filtered_artworks={viewer.filtered_artworks!}
-                isLoading={isFetching}
+                isLoading={isLoading}
                 offset={offset}
                 columnCount={[2, 2, 2, 3]}
               />

--- a/src/v2/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
+++ b/src/v2/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
@@ -1,31 +1,42 @@
-import { Clickable, Message } from "@artsy/palette"
-import * as React from "react";
+import { Box, Clickable, Message } from "@artsy/palette"
+import * as React from "react"
 import styled from "styled-components"
+import { Sticky } from "../Sticky"
 
 interface ArtworkGridEmptyStateProps {
   onClearFilters?: () => void
 }
 
 export const ArtworkGridEmptyState: React.FC<ArtworkGridEmptyStateProps> = props => (
-  <Message width="100%">
-    <>
-      There aren't any works available that meet the following criteria at this
-      time.
-    </>
-    {props.onClearFilters && (
-      <>
-        {" "}
-        Change your filter criteria to view more works.{" "}
-        <ResetFilterLink
-          textDecoration="underline"
-          onClick={props.onClearFilters}
-        >
-          Clear all filters
-        </ResetFilterLink>
-        .
-      </>
-    )}
-  </Message>
+  <Box width="100%">
+    <Sticky>
+      {({ stuck }) => {
+        return (
+          <Box pt={stuck ? 1 : 0}>
+            <Message width="100%">
+              <>
+                There aren't any works available that meet the following
+                criteria at this time.
+              </>
+              {props.onClearFilters && (
+                <>
+                  {" "}
+                  Change your filter criteria to view more works.{" "}
+                  <ResetFilterLink
+                    textDecoration="underline"
+                    onClick={props.onClearFilters}
+                  >
+                    Clear all filters
+                  </ResetFilterLink>
+                  .
+                </>
+              )}
+            </Message>
+          </Box>
+        )
+      }}
+    </Sticky>
+  </Box>
 )
 
 export const ResetFilterLink = styled(Clickable)``

--- a/src/v2/System/Router/RenderStatus.tsx
+++ b/src/v2/System/Router/RenderStatus.tsx
@@ -13,8 +13,14 @@ import { HttpError } from "found"
 
 const logger = createLogger("Artsy/Router/Utils/RenderStatus")
 
-export const RenderPending = () => {
+export const RenderPending = props => {
   const { isFetching, setFetching } = useSystemContext()
+
+  const hidePageLoaderFromRouterState =
+    props.location?.state?.hidePageLoader ?? false
+
+  // const hidePageLoaderFromRouterState =
+  // match.location?.state?.hidePageLoader ?? false
 
   /**
    * First, set fetching to ensure that components that are listening for this
@@ -31,18 +37,20 @@ export const RenderPending = () => {
       <>
         <Renderer>{null}</Renderer>
 
-        <PageLoader
-          className="reactionPageLoader" // positional styling comes from Force body.styl
-          showBackground={false}
-          step={10} // speed of progress bar, randomized between 1/x to simulate variable progress
-          style={{
-            borderTop: "1px solid white",
-            position: "fixed",
-            left: 0,
-            top: -5,
-            zIndex: 1000,
-          }}
-        />
+        {!hidePageLoaderFromRouterState && (
+          <PageLoader
+            className="reactionPageLoader" // positional styling comes from Force body.styl
+            showBackground={false}
+            step={10} // speed of progress bar, randomized between 1/x to simulate variable progress
+            style={{
+              borderTop: "1px solid white",
+              position: "fixed",
+              left: 0,
+              top: -5,
+              zIndex: 1000,
+            }}
+          />
+        )}
 
         <NetworkTimeout />
       </>

--- a/src/v2/System/Router/RenderStatus.tsx
+++ b/src/v2/System/Router/RenderStatus.tsx
@@ -16,11 +16,8 @@ const logger = createLogger("Artsy/Router/Utils/RenderStatus")
 export const RenderPending = props => {
   const { isFetching, setFetching } = useSystemContext()
 
-  const hidePageLoaderFromRouterState =
-    props.location?.state?.hidePageLoader ?? false
-
-  // const hidePageLoaderFromRouterState =
-  // match.location?.state?.hidePageLoader ?? false
+  // Artwork filter has its own loading behavior, so supress top loader bar
+  const isArtworkFilter = props.location?.state?.isArtworkFilter ?? false
 
   /**
    * First, set fetching to ensure that components that are listening for this
@@ -37,7 +34,7 @@ export const RenderPending = props => {
       <>
         <Renderer>{null}</Renderer>
 
-        {!hidePageLoaderFromRouterState && (
+        {!isArtworkFilter && (
           <PageLoader
             className="reactionPageLoader" // positional styling comes from Force body.styl
             showBackground={false}

--- a/src/v2/System/Router/Utils/shouldUpdateScroll.tsx
+++ b/src/v2/System/Router/Utils/shouldUpdateScroll.tsx
@@ -29,6 +29,15 @@ export function shouldUpdateScroll(prevRenderArgs, currentRenderArgs) {
   const { routes } = currentRenderArgs
 
   try {
+    // When using router.push one can pass additional state along, which we
+    // grab here. (This is currently being used in the ArtworkFilter.)
+    const ignoreScrollBehaviorFromRouterState =
+      currentRenderArgs.location?.state?.ignoreScrollBehavior ?? false
+
+    if (ignoreScrollBehaviorFromRouterState) {
+      return false
+    }
+
     // If true, don't reset scroll position on route change, no matter what
     if (routes?.some(route => route.ignoreScrollBehavior)) {
       return false


### PR DESCRIPTION
### Status:
Putting this down for a bit because there are a good number of issues as expressed between the different filters present on different pages. 
- Auction filter is slightly different than rest, so all update props would need to be made consistent across different surface 
- Need to consolidate all of the different URL formatting functions as those are different across different surfaces (meaning: the url as its formatted and pushed to the url bar, which then updates state) 
- Other misc qa issues. 

I will PR the other changes in this PR that deal with random UX issues. 

The type of this PR is: **Feature**

This PR solves [GRO-824]

### Description

This updates our Artwork filter so that we can drive via the back / forward buttons on the browser. Previously when a user made a selection and then hit the back button it would take them away from their previous selection, versus pushing it into the browsers history stack. This fixes that. 

Also fixes a bunch of random UX issues like the page loader post filter select being stuck at the top of the page rather than in the viewport, and the zerostate doing the same. Now they will stay within the users scroll position eliminating confusion. 


[GRO-824]: https://artsyproduct.atlassian.net/browse/GRO-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ