### PR TITLE
feat(artwork-filter): Making loading/zero states sticky

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -1,4 +1,4 @@
-import { Spacer, useThemeConfig } from "@artsy/palette"
+import { Box, Spacer, Spinner, useThemeConfig } from "@artsy/palette"
 import * as React from "react"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 import { ArtworkFilterArtworkGrid_filtered_artworks } from "v2/__generated__/ArtworkFilterArtworkGrid_filtered_artworks.graphql"
@@ -6,10 +6,10 @@ import { useSystemContext } from "v2/System"
 import { useTracking } from "v2/System/Analytics/useTracking"
 import ArtworkGrid from "v2/Components/ArtworkGrid"
 import { PaginationFragmentContainer as Pagination } from "v2/Components/Pagination"
-import { LoadingArea } from "../LoadingArea"
 import { useArtworkFilterContext } from "./ArtworkFilterContext"
 import { ContextModule, clickedMainArtworkGrid } from "@artsy/cohesion"
 import { useAnalyticsContext } from "v2/System/Analytics/AnalyticsContext"
+import { Sticky } from "../Sticky"
 
 interface ArtworkFilterArtworkGridProps {
   columnCount: number[]
@@ -62,7 +62,6 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
 
   return (
     <>
-      {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <LoadingArea isLoading={props.isLoading}>
         <ArtworkGrid
           artworks={props.filtered_artworks}
@@ -127,3 +126,22 @@ export const ArtworkFilterArtworkGridRefetchContainer = createFragmentContainer(
     `,
   }
 )
+
+const LoadingArea: React.FC<{ isLoading?: boolean }> = ({
+  isLoading,
+  children,
+}) => {
+  return (
+    <Box position="relative">
+      {isLoading && (
+        <Sticky>
+          <Box height={300} width="100%" position="absolute">
+            <Spinner />
+          </Box>
+        </Sticky>
+      )}
+
+      <Box opacity={isLoading ? 0.1 : 1}>{children}</Box>
+    </Box>
+  )
+}

--- a/src/v2/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
+++ b/src/v2/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
@@ -1,5 +1,6 @@
-import { Clickable, Message } from "@artsy/palette"
-import * as React from "react";
+import { Sticky } from "../Sticky"
+import { Box, Clickable, Message } from "@artsy/palette"
+import * as React from "react"
 import styled from "styled-components"
 
 interface ArtworkGridEmptyStateProps {
@@ -7,25 +8,34 @@ interface ArtworkGridEmptyStateProps {
 }
 
 export const ArtworkGridEmptyState: React.FC<ArtworkGridEmptyStateProps> = props => (
-  <Message width="100%">
-    <>
-      There aren't any works available that meet the following criteria at this
-      time.
-    </>
-    {props.onClearFilters && (
-      <>
-        {" "}
-        Change your filter criteria to view more works.{" "}
-        <ResetFilterLink
-          textDecoration="underline"
-          onClick={props.onClearFilters}
-        >
-          Clear all filters
-        </ResetFilterLink>
-        .
-      </>
-    )}
-  </Message>
+  <Box width="100%" my={1}>
+    <Sticky>
+      {({ stuck }) => {
+        return (
+          <Box pt={stuck ? 1 : 0}>
+            <Message width="100%">
+              <>
+                There aren't any works available that meet the following
+                criteria at this time.
+              </>
+              {props.onClearFilters && (
+                <>
+                  Change your filter criteria to view more works.{" "}
+                  <ResetFilterLink
+                    textDecoration="underline"
+                    onClick={props.onClearFilters}
+                  >
+                    Clear all filters
+                  </ResetFilterLink>
+                  .
+                </>
+              )}
+            </Message>
+          </Box>
+        )
+      }}
+    </Sticky>
+  </Box>
 )
 
 export const ResetFilterLink = styled(Clickable)``

--- a/src/v2/Components/ArtworkGrid/__tests__/ArtworkGrid.jest.tsx
+++ b/src/v2/Components/ArtworkGrid/__tests__/ArtworkGrid.jest.tsx
@@ -20,6 +20,9 @@ import {
 
 jest.unmock("react-relay")
 global.clearInterval = jest.fn()
+jest.mock("v2/Components/Sticky", () => ({
+  Sticky: ({ children }) => children({ stuck: false }),
+}))
 
 const TestContainer = createFragmentContainer(
   ({


### PR DESCRIPTION
The type of this PR is: **Feature**

### Description

This updates our artwork filter so that the zero state / loading indicator is sticky, preserving the position in the users viewport even if they've scrolled down. (It was confusing to click a filter and to see nothing happen, especially if there are no results and on mobile.)
 
![filter](https://user-images.githubusercontent.com/236943/168136039-0c48107a-86cc-4011-a278-893ad0175ee6.gif)

cc @artsy/grow-devs 