### PR TITLE
feat: Temporarily suppress logged out hero GRO-1025

### DIFF
--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -1,7 +1,8 @@
 import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
 
 describe("Home", () => {
-  it("/", () => {
+  // add this back in once we revert the suppression
+  it.skip("/", () => {
     visitWithStatusRetries("/")
     cy.get("h1").should("contain", "Collect art by the world’s leading artists")
   })

--- a/src/v2/Apps/Home/Components/HomeHeroUnits/HomeHeroUnits.tsx
+++ b/src/v2/Apps/Home/Components/HomeHeroUnits/HomeHeroUnits.tsx
@@ -16,6 +16,8 @@ interface HomeHeroUnitsProps {
 }
 
 const HomeHeroUnits: React.FC<HomeHeroUnitsProps> = ({ homePage }) => {
+  // TODO: Remove after SSS sale ends
+  const skipHomeHero = true
   const { isLoggedIn } = useSystemContext()
 
   const heroUnits = [
@@ -29,6 +31,8 @@ const HomeHeroUnits: React.FC<HomeHeroUnitsProps> = ({ homePage }) => {
         // If logged out, the first hero unit is static and
         // needs to be rendered without the fragment container
         if (!isLoggedIn && i === 0) {
+          if (skipHomeHero) return
+
           return (
             <HomeHeroUnit
               key={i}


### PR DESCRIPTION
We have a contract with a partner about how the carousel on the homepage behaves - it was supposed to always show an ad for a particular auction but we forgot about the signed out user. This PR does the absolutely bare minimum to suppress that item because I believe once that sale ends we'll want to revert. Looks like this:

<img width="1244" alt="Screen Shot 2022-05-12 at 1 16 16 PM" src="https://user-images.githubusercontent.com/79799/168142406-cb09f7ea-df06-4ec4-909c-bc542772b650.png">


https://artsyproduct.atlassian.net/browse/GRO-1025

/cc @artsy/grow-devs