### PR TITLE
NX-3136 Handle edition sets modal for Purchase from inquiry

### DIFF
--- a/src/v2/Apps/Conversation/Components/ConfirmArtworkModal.tsx
+++ b/src/v2/Apps/Conversation/Components/ConfirmArtworkModal.tsx
@@ -52,7 +52,7 @@ export const ConfirmArtworkModal: React.FC<ConfirmArtworkModalProps> = ({
       title="Select edition set"
       footer={
         <Flex flexGrow={1}>
-          <Button variant="secondaryOutline" flexGrow={1} onClick={closeModal}>
+          <Button variant="secondaryOutline" width="100%" onClick={closeModal}>
             Cancel
           </Button>
           <Spacer m={1} />
@@ -67,7 +67,9 @@ export const ConfirmArtworkModal: React.FC<ConfirmArtworkModalProps> = ({
                 context_owner_type: OwnerType.conversation,
               })
             }
-          />
+          >
+            Confirm
+          </ConfirmArtworkButtonFragmentContainer>
         </Flex>
       }
     >

--- a/src/v2/Apps/Conversation/Components/ConversationCTA.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationCTA.tsx
@@ -78,6 +78,7 @@ export const ConversationCTA: React.FC<ConversationCTAProps> = ({
           <Flex flexDirection="row">
             {isCBNEnabled && isAcquireable && (
               <PurchaseOnInquiryButtonFragmentContainer
+                openInquiryModal={() => openInquiryModal()}
                 conversation={conversation}
               />
             )}

--- a/src/v2/Apps/Conversation/Components/MakeOfferOnInquiryButton.tsx
+++ b/src/v2/Apps/Conversation/Components/MakeOfferOnInquiryButton.tsx
@@ -43,6 +43,7 @@ export const MakeOfferOnInquiryButton: React.FC<MakeOfferOnInquiryButtonProps> =
         <Button
           size="medium"
           variant={variant}
+          width="100%"
           onClick={() => {
             tracking.trackEvent(tappedMakeOfferEvent)
             openInquiryModal()

--- a/src/v2/Apps/Conversation/Components/PurchaseOnInquiryButton.tsx
+++ b/src/v2/Apps/Conversation/Components/PurchaseOnInquiryButton.tsx
@@ -4,12 +4,15 @@ import { PurchaseOnInquiryButton_conversation } from "v2/__generated__/PurchaseO
 import { ConfirmArtworkButtonFragmentContainer } from "./ConfirmArtworkButton"
 import { useTracking } from "react-tracking"
 import { TappedBuyNow, ActionType, OwnerType } from "@artsy/cohesion"
+import { Button } from "@artsy/palette"
 
 export interface PurchaseOnInquiryButtonProps {
+  openInquiryModal: () => void
   conversation: PurchaseOnInquiryButton_conversation
 }
 
 export const PurchaseOnInquiryButton: React.FC<PurchaseOnInquiryButtonProps> = ({
+  openInquiryModal,
   conversation,
 }) => {
   const tracking = useTracking()
@@ -30,7 +33,20 @@ export const PurchaseOnInquiryButton: React.FC<PurchaseOnInquiryButtonProps> = (
     impulse_conversation_id: conversationID,
   }
 
-  return isUniqueArtwork ? (
+  return !isUniqueArtwork ? (
+    // Opens a modal window to select an edition set on non-unique artworks
+    <Button
+      size="medium"
+      width="100%"
+      onClick={() => {
+        tracking.trackEvent(tappedPurchaseEvent)
+        openInquiryModal()
+      }}
+    >
+      Purchase
+    </Button>
+  ) : (
+    // Creates an order and redirects to the checkout flow
     <ConfirmArtworkButtonFragmentContainer
       artwork={artwork}
       conversationID={conversationID}
@@ -40,7 +56,7 @@ export const PurchaseOnInquiryButton: React.FC<PurchaseOnInquiryButtonProps> = (
     >
       Purchase
     </ConfirmArtworkButtonFragmentContainer>
-  ) : null
+  )
 }
 
 export const PurchaseOnInquiryButtonFragmentContainer = createFragmentContainer(


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [NX-3136]

### Description

- Replicate functionality from MakeOfferOnInquiryButton into PurchaseOnInquiryButton to choose edition set
- Add "Confirm" as ConfirmArtworkButton `children` since it extends from ButtonProps now, and it's a required prop.

<!-- Implementation description -->
cc @artsy/negotiate-devs 