### PR TITLE
fix: update web association, add missing auth endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "dependencies": {
     "@artsy/backbone-mixins": "3.0.0",
     "@artsy/cohesion": "4.46.0",
-    "@artsy/eigen-web-association": "1.3.0",
+    "@artsy/eigen-web-association": "1.5.0",
     "@artsy/express-reloadable": "1.6.0",
     "@artsy/fresnel": "3.5.0",
     "@artsy/gemup": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,10 +44,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/detect-responsive-traits/-/detect-responsive-traits-0.1.0.tgz#f7ae5041893b859ff9f6bc305fd318d2f5132745"
   integrity sha512-cdHMDcGpYuItSBvelAWEWxWipVGw/8Yzk7YoMvO+qWjZsHJtIF2hACtL5QFQxcf9K3j/eTXNSFlPmfZAe9Byew==
 
-"@artsy/eigen-web-association@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@artsy/eigen-web-association/-/eigen-web-association-1.3.0.tgz#9181452dcdf4a159a2d368ae04e98f850b536f3b"
-  integrity sha512-vRDublbvMdhfFsQrzeUmIHOIFlW12Suq/ZQU83Bp4Faiad0hcQWyDjv4MppD+r2c7Y0gr9YdD4oa9+3TAIMt0A==
+"@artsy/eigen-web-association@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@artsy/eigen-web-association/-/eigen-web-association-1.5.0.tgz#6edc462382001906ee6455aa8fed6ba8b987130b"
+  integrity sha512-kIGhH4uSfxSO7XnWXKcXHXpDjxGN76JgvItsADAiPjP1AfyJtIYw+HyZzjt03hcF2sk3uDiElTRhW+1zvLAxtA==
   dependencies:
     express "^4.15.0"
 


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->



### Description

<!-- Implementation description -->

Updates eigen-web-association to latest version which has additional auth related endpoints to prevent deep linking during auth flows.

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ