### PR TITLE
test: remove old relay test tools part I

### DIFF
--- a/src/v2/Apps/Order/Routes/Accept/index.tsx
+++ b/src/v2/Apps/Order/Routes/Accept/index.tsx
@@ -88,7 +88,6 @@ export class Accept extends Component<AcceptProps & StripeProps> {
     try {
       const orderOrError = (await this.acceptOffer()).commerceBuyerAcceptOffer
         ?.orderOrError
-
       if (!orderOrError?.error) {
         this.props.router.push(`/orders/${this.props.order.internalID}/status`)
         return
@@ -334,7 +333,9 @@ export class Accept extends Component<AcceptProps & StripeProps> {
 }
 
 export const AcceptFragmentContainer = createFragmentContainer(
-  createStripeWrapper(injectCommitMutation(injectDialog(Accept)) as any),
+  createStripeWrapper<AcceptProps>(
+    injectCommitMutation(injectDialog(Accept)) as any
+  ),
   {
     order: graphql`
       fragment Accept_order on CommerceOrder {

--- a/src/v2/Apps/Order/Routes/__tests__/Accept.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Accept.jest.tsx
@@ -1,13 +1,11 @@
-import { AcceptTestQueryRawResponse } from "v2/__generated__/AcceptTestQuery.graphql"
 import {
   Buyer,
   OfferOrderWithShippingDetails,
   OfferWithTotals,
   Offers,
 } from "v2/Apps/__tests__/Fixtures/Order"
-import { createTestEnv } from "v2/DevTools/createTestEnv"
 import { DateTime } from "luxon"
-import { graphql } from "react-relay"
+import { graphql, commitMutation as _commitMutation } from "react-relay"
 import {
   acceptOfferFailed,
   acceptOfferInsufficientInventoryFailure,
@@ -15,13 +13,16 @@ import {
   acceptOfferPaymentFailedInsufficientFunds,
   acceptOfferPaymentRequiresAction,
   acceptOfferSuccess,
-  fixFailedPaymentSuccess,
 } from "../__fixtures__/MutationResults"
 import { AcceptFragmentContainer } from "../Accept"
 import { OrderAppTestPage } from "./Utils/OrderAppTestPage"
 import { mockLocation } from "v2/DevTools/mockLocation"
 import { useTracking } from "v2/System"
 import { mockStripe } from "v2/DevTools/mockStripe"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { Router } from "found"
+import { MockBoot } from "v2/DevTools"
+import { ConnectedModalDialog } from "v2/Apps/Order/Dialogs"
 
 jest.unmock("react-relay")
 
@@ -31,17 +32,15 @@ const NOW = "2018-12-05T13:47:16.446Z"
 require("v2/Utils/getCurrentTimeAsIsoString").__setCurrentTime(NOW)
 
 jest.mock("@stripe/stripe-js", () => {
-  let mock = null
+  let mock: ReturnType<typeof mockStripe> | null = null
   return {
     loadStripe: () => {
       if (mock === null) {
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         mock = mockStripe()
       }
       return mock
     },
     _mockStripe: () => mock,
-    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     _mockReset: () => (mock = mockStripe()),
   }
 })
@@ -63,6 +62,33 @@ const testOrder = {
 }
 
 describe("Accept seller offer", () => {
+  const pushMock: jest.Mock<Router["push"]> = jest.fn()
+  const commitMutation = jest.fn()
+  let isCommittingMutation = false
+
+  const { getWrapper } = setupTestWrapper({
+    Component: (props: any) => (
+      <MockBoot>
+        <AcceptFragmentContainer
+          router={{ push: pushMock } as any}
+          route={{ onTransition: jest.fn }}
+          order={props.order}
+          dialog={{} as any}
+          isCommittingMutation={isCommittingMutation}
+          commitMutation={commitMutation}
+        />
+        <ConnectedModalDialog />
+      </MockBoot>
+    ),
+    query: graphql`
+      query AcceptTestQuery @raw_response_type @relay_test_operation {
+        order: commerceOrder(id: "test-id") {
+          ...Accept_order
+        }
+      }
+    `,
+  })
+
   beforeAll(() => {
     ;(useTracking as jest.Mock).mockImplementation(() => ({
       trackEvent: jest.fn(),
@@ -73,97 +99,54 @@ describe("Accept seller offer", () => {
     mockLocation()
   })
 
-  const { mutations, buildPage, routes } = createTestEnv({
-    Component: AcceptFragmentContainer,
-    query: graphql`
-      query AcceptTestQuery @raw_response_type @relay_test_operation {
-        order: commerceOrder(id: "") {
-          ...Accept_order
-        }
-      }
-    `,
-    defaultData: {
-      order: testOrder,
-      system: {
-        time: {
-          unix: 222,
-        },
-      },
-    } as AcceptTestQueryRawResponse,
-    defaultMutationResults: {
-      ...acceptOfferSuccess,
-      ...fixFailedPaymentSuccess,
-    },
-    TestPage: OrderAppTestPage,
+  afterEach(() => {
+    pushMock.mockReset()
+    commitMutation.mockReset()
+    isCommittingMutation = false
   })
 
   describe("with default data", () => {
-    let page: OrderAppTestPage
     beforeAll(async () => {
       global.setInterval = jest.fn()
-      page = await buildPage({
-        mockData: {
-          order: {
-            ...testOrder,
-            stateExpiresAt: DateTime.fromISO(NOW)
-              .plus({ days: 1, hours: 4, minutes: 22, seconds: 59 })
-              .toString(),
-          },
-        },
-      })
     })
 
     afterAll(() => {
       global.setInterval = realSetInterval
     })
 
-    it("shows the countdown timer", async () => {
-      expect(page.countdownTimer.text()).toContain("01d 04h 22m 59s left")
-    })
+    it("renders", async () => {
+      let wrapper = getWrapper({
+        CommerceOrder: () => ({
+          ...testOrder,
+          stateExpiresAt: DateTime.fromISO(NOW)
+            .plus({ days: 1, hours: 4, minutes: 22, seconds: 59 })
+            .toString(),
+        }),
+      })
+      let page = new OrderAppTestPage(wrapper)
 
-    it("Shows the stepper", async () => {
+      expect(page.countdownTimer.text()).toContain("01d 04h 22m 59s left")
       expect(page.orderStepper.text()).toMatchInlineSnapshot(
         `"CheckRespondNavigate rightReview"`
       )
       expect(page.orderStepperCurrentStep).toBe(`Review`)
-    })
-
-    it("shows the transaction summary", async () => {
       expect(page.transactionSummary.text()).toMatch(
         "Accept seller's offerChange"
       )
       expect(page.transactionSummary.text()).toMatch(
         "Seller's offerUS$sellers.offer"
       )
-    })
-
-    it("shows the artwork summary", async () => {
       expect(page.artworkSummary.text()).toMatch(
         "Lisa BreslowGramercy Park South"
       )
-    })
-
-    it("shows the shipping details", async () => {
       expect(page.shippingSummary.text()).toMatch(
         "Ship toLockedJoelle Van Dyne401 Broadway"
       )
-    })
-
-    it("shows the payment details", async () => {
       expect(page.paymentSummary.text()).toMatchInlineSnapshot(
         `"Lockedvisa•••• 4444   Exp 03/21"`
       )
-    })
-
-    it("shows buyer guarentee", () => {
       expect(page.buyerGuarantee.length).toBe(1)
-    })
-
-    it("shows the submit button", async () => {
       expect(page.submitButton.text()).toBe("Submit")
-    })
-
-    it("Shows the conditions of sale disclaimer.", async () => {
       expect(page.conditionsOfSaleDisclaimer.text()).toMatchInlineSnapshot(
         `"By clicking Submit, I agree to Artsy’s Conditions of Sale."`
       )
@@ -171,10 +154,8 @@ describe("Accept seller offer", () => {
   })
 
   describe("mutation", () => {
-    let page: OrderAppTestPage
     beforeEach(async () => {
       global.setInterval = jest.fn()
-      page = await buildPage()
     })
 
     afterEach(() => {
@@ -182,27 +163,48 @@ describe("Accept seller offer", () => {
     })
 
     it("routes to status page after mutation completes", async () => {
+      commitMutation.mockReturnValue(acceptOfferSuccess)
+      let wrapper = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      let page = new OrderAppTestPage(wrapper)
+
       await page.clickSubmit()
-      expect(routes.mockPushRoute).toHaveBeenCalledWith(
+      expect(pushMock).toHaveBeenCalledWith(
         `/orders/${testOrder.internalID}/status`
       )
     })
 
-    it("shows the button spinner while loading the mutation", async () => {
-      await page.expectButtonSpinnerWhenSubmitting()
+    it("shows the button spinner while loading the mutation", () => {
+      isCommittingMutation = true
+      let wrapper = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      let page = new OrderAppTestPage(wrapper)
+
+      expect(page.isLoading()).toBeTruthy()
     })
 
     it("shows an error modal when there is an error from the server", async () => {
-      mutations.useResultsOnce(acceptOfferFailed)
+      commitMutation.mockReturnValue(acceptOfferFailed)
+      let wrapper = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      let page = new OrderAppTestPage(wrapper)
+
       await page.clickSubmit()
       await page.expectAndDismissDefaultErrorDialog()
     })
 
     it("commits fixFailedPayment mutation with Gravity credit card id", async () => {
-      mutations.useResultsOnce(acceptOfferPaymentRequiresAction)
-      await page.clickSubmit()
+      commitMutation.mockReturnValue(acceptOfferPaymentRequiresAction)
+      let wrapper = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      let page = new OrderAppTestPage(wrapper)
 
-      expect(mutations.lastFetchVariables).toMatchObject({
+      await page.clickSubmit()
+      expect(commitMutation.mock.calls[1][0].variables).toMatchObject({
         input: {
           creditCardId: "creditCardId",
           offerId: "myoffer-id",
@@ -211,31 +213,46 @@ describe("Accept seller offer", () => {
     })
 
     it("shows an error modal if there is a capture_failed error", async () => {
-      mutations.useResultsOnce(acceptOfferPaymentFailed)
+      commitMutation.mockReturnValue(acceptOfferPaymentFailed)
+      let wrapper = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      let page = new OrderAppTestPage(wrapper)
+
       await page.clickSubmit()
       await page.expectAndDismissErrorDialogMatching(
         "Charge failed",
         "Payment authorization has been declined. Please contact your card provider, then press “Submit” again. Alternatively, use a new card."
       )
-      expect(routes.mockPushRoute).toHaveBeenCalledWith(
+      expect(pushMock).toHaveBeenCalledWith(
         `/orders/${testOrder.internalID}/payment/new`
       )
     })
 
     it("shows an error modal if there is a capture_failed error with insufficient_funds", async () => {
-      mutations.useResultsOnce(acceptOfferPaymentFailedInsufficientFunds)
+      commitMutation.mockReturnValue(acceptOfferPaymentFailedInsufficientFunds)
+      let wrapper = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      let page = new OrderAppTestPage(wrapper)
+
       await page.clickSubmit()
       await page.expectAndDismissErrorDialogMatching(
         "Insufficient funds",
         "There aren’t enough funds available on the card you provided. Please use a new card. Alternatively, contact your card provider, then press “Submit” again."
       )
-      expect(routes.mockPushRoute).toHaveBeenCalledWith(
+      expect(pushMock).toHaveBeenCalledWith(
         `/orders/${testOrder.internalID}/payment/new`
       )
     })
 
     it("shows an error modal and routes the user to the artist page if there is insufficient inventory", async () => {
-      mutations.useResultsOnce(acceptOfferInsufficientInventoryFailure)
+      commitMutation.mockReturnValue(acceptOfferInsufficientInventoryFailure)
+      let wrapper = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      let page = new OrderAppTestPage(wrapper)
+
       await page.clickSubmit()
       await page.expectAndDismissErrorDialogMatching(
         "Not available",

--- a/src/v2/Apps/Order/Routes/__tests__/Utils/OrderAppTestPage.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Utils/OrderAppTestPage.tsx
@@ -1,5 +1,6 @@
 import { BorderedRadio, Button } from "@artsy/palette"
 import { Stepper } from "@artsy/palette"
+import { ReactWrapper } from "enzyme"
 import { ArtworkSummaryItemFragmentContainer } from "v2/Apps/Order/Components/ArtworkSummaryItem"
 import { BuyerGuarantee } from "v2/Apps/Order/Components/BuyerGuarantee"
 import { ConditionsOfSaleDisclaimer } from "v2/Apps/Order/Components/ConditionsOfSaleDisclaimer"
@@ -16,6 +17,9 @@ import { RootTestPage, expectOne } from "v2/DevTools/RootTestPage"
 
 export class OrderAppTestPage extends RootTestPage {
   /** COMPONENT SELECTORS **/
+  constructor(wrapper?: ReactWrapper) {
+    super(wrapper)
+  }
 
   get orderStepper() {
     return expectOne(this.root.find(OrderStepper))
@@ -74,6 +78,10 @@ export class OrderAppTestPage extends RootTestPage {
     return expectOne(this.find(PriceOptions))
   }
 
+  isLoading() {
+    return this.submitButton.props().loading
+  }
+
   /** PAGE ACTIONS **/
 
   async clickSubmit() {
@@ -106,6 +114,7 @@ export class OrderAppTestPage extends RootTestPage {
   }
 
   /*** COMMON ASSERTIONS ***/
+
   async expectNoModal() {
     const modal = this.modalDialog.find(ModalButton)
     expect(modal.length).toBe(0)

--- a/src/v2/DevTools/RootTestPage.tsx
+++ b/src/v2/DevTools/RootTestPage.tsx
@@ -13,6 +13,13 @@ export class RootTestPage {
   // these three properties get hydrated by createTestEnv
   readonly root: ReactWrapper
 
+  constructor(wrapper?: ReactWrapper) {
+    if (wrapper) {
+      // @ts-ignore
+      this.root = wrapper
+    }
+  }
+
   async update() {
     await flushPromiseQueue()
     this.root.update()


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR enhances the morale

### Description

Removes the old createTestEnv which works but is a high-level abstraction not needed thanks to the Relay testing tools we have. This is also one attempt to unblock the Relay 13 upgrade which has failing tests in special with `createTestEnv` and they're very hard to debug and find the issue.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ