### PR TITLE
feature(NewForYou): implement artwork grid w/ artworksForUser query

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -11681,6 +11681,16 @@ type Query {
     width: String
   ): FilterArtworksConnection
 
+  # A connection of artworks for a user.
+  artworksForUser(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+    userId: String
+  ): ArtworkConnection
+
   # An auction result
   auctionResult(
     # The ID of the auction result
@@ -14997,6 +15007,16 @@ type Viewer {
     tagID: String
     width: String
   ): FilterArtworksConnection
+
+  # A connection of artworks for a user.
+  artworksForUser(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+    userId: String
+  ): ArtworkConnection
 
   # An auction result
   auctionResult(

--- a/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
+++ b/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
@@ -3,9 +3,7 @@ import React, { FC, Fragment } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import ArtworkGridItemFragmentContainer from "v2/Components/Artwork/GridItem"
 import { Masonry } from "v2/Components/Masonry"
-import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { extractNodes } from "v2/Utils/extractNodes"
-import { NewForYouArtworksGridQuery } from "v2/__generated__/NewForYouArtworksGridQuery.graphql"
 import { NewForYouArtworksGrid_viewer } from "v2/__generated__/NewForYouArtworksGrid_viewer.graphql"
 
 interface NewForYouArtworksGridProps {
@@ -15,8 +13,7 @@ interface NewForYouArtworksGridProps {
 export const NewForYouArtworksGrid: FC<NewForYouArtworksGridProps> = ({
   viewer,
 }) => {
-  const { artworksForUser } = viewer
-  const artworks = extractNodes(artworksForUser)
+  const artworks = extractNodes(viewer.artworksForUser)
 
   return (
     <Masonry columnCount={[2, 3, 4]}>
@@ -33,37 +30,12 @@ export const NewForYouArtworksGrid: FC<NewForYouArtworksGridProps> = ({
   )
 }
 
-export const NewForYouArtworksGridQueryRenderer: React.FC = () => {
-  return (
-    <SystemQueryRenderer<NewForYouArtworksGridQuery>
-      query={graphql`
-        query NewForYouArtworksGridQuery {
-          viewer {
-            ...NewForYouArtworksGrid_viewer
-          }
-        }
-      `}
-      render={({ props, error }) => {
-        if (error) {
-          console.error(error)
-          return null
-        }
-        if (!props?.viewer) {
-          return null
-        }
-        return <NewForYouArtworksGridFragmentContainer viewer={props.viewer} />
-      }}
-    />
-  )
-}
-
 export const NewForYouArtworksGridFragmentContainer = createFragmentContainer(
   NewForYouArtworksGrid,
   {
     viewer: graphql`
       fragment NewForYouArtworksGrid_viewer on Viewer {
         artworksForUser {
-          totalCount
           edges {
             node {
               internalID

--- a/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
+++ b/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
@@ -1,6 +1,10 @@
-import { Spacer } from "@artsy/palette"
+import { Box, Button, Spacer } from "@artsy/palette"
 import React, { FC, Fragment } from "react"
-import { createFragmentContainer, graphql } from "react-relay"
+import {
+  createPaginationContainer,
+  graphql,
+  RelayPaginationProp,
+} from "react-relay"
 import ArtworkGridItemFragmentContainer from "v2/Components/Artwork/GridItem"
 import { Masonry } from "v2/Components/Masonry"
 import { extractNodes } from "v2/Utils/extractNodes"
@@ -8,40 +12,99 @@ import { NewForYouArtworksGrid_viewer } from "v2/__generated__/NewForYouArtworks
 
 interface NewForYouArtworksGridProps {
   viewer: NewForYouArtworksGrid_viewer
+  relay: RelayPaginationProp
 }
 
 export const NewForYouArtworksGrid: FC<NewForYouArtworksGridProps> = ({
   viewer,
+  relay,
 }) => {
+  const [loading, setLoading] = React.useState(false)
   const artworks = extractNodes(viewer.artworksForUser)
 
+  const loadMore = () => {
+    if (!relay.hasMore() || relay.isLoading()) return
+
+    setLoading(true)
+
+    relay.loadMore(25, err => {
+      if (err) console.error(err)
+
+      setTimeout(() => {
+        setLoading(false)
+      }, 2500)
+    })
+  }
+
   return (
-    <Masonry columnCount={[2, 3, 4]}>
-      {artworks?.length > 0 &&
-        artworks.map(artwork => {
-          return (
-            <Fragment key={artwork.internalID}>
-              <ArtworkGridItemFragmentContainer artwork={artwork} />
-              <Spacer mt={4} />
-            </Fragment>
-          )
-        })}
-    </Masonry>
+    <>
+      <Masonry columnCount={[2, 3, 4]}>
+        {artworks?.length > 0 &&
+          artworks.map(artwork => {
+            return (
+              <Fragment key={artwork.internalID}>
+                <ArtworkGridItemFragmentContainer artwork={artwork} />
+                <Spacer mt={4} />
+              </Fragment>
+            )
+          })}
+      </Masonry>
+      {relay.hasMore() && (
+        <Box textAlign="center" mt={4}>
+          <Button onClick={loadMore} loading={loading}>
+            Show More
+          </Button>
+        </Box>
+      )}
+    </>
   )
 }
 
-export const NewForYouArtworksGridFragmentContainer = createFragmentContainer(
+export const NewForYouArtworksGridFragmentContainer = createPaginationContainer(
   NewForYouArtworksGrid,
   {
     viewer: graphql`
-      fragment NewForYouArtworksGrid_viewer on Viewer {
-        artworksForUser {
+      fragment NewForYouArtworksGrid_viewer on Viewer
+        @argumentDefinitions(
+          count: { type: "Int", defaultValue: 10 }
+          cursor: { type: "String" }
+        ) {
+        artworksForUser(first: $count, after: $cursor)
+          @connection(key: "NewForYouArtworksGrid_artworksForUser") {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
           edges {
             node {
               internalID
               ...GridItem_artwork
             }
           }
+        }
+      }
+    `,
+  },
+  {
+    direction: "forward",
+    getFragmentVariables(prevVars, totalCount) {
+      return {
+        ...prevVars,
+        count: totalCount,
+      }
+    },
+    getVariables(_props, { count, cursor }, fragmentVariables) {
+      return {
+        ...fragmentVariables,
+        count,
+        cursor,
+      }
+    },
+    query: graphql`
+      query NewForYouArtworksGridQuery($count: Int!, $cursor: String) {
+        viewer {
+          ...NewForYouArtworksGrid_viewer
+            @arguments(count: $count, cursor: $cursor)
         }
       }
     `,

--- a/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
+++ b/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Spacer } from "@artsy/palette"
+import { Box, Button, Spacer, Text } from "@artsy/palette"
 import React, { FC, Fragment } from "react"
 import {
   createPaginationContainer,
@@ -38,9 +38,9 @@ export const NewForYouArtworksGrid: FC<NewForYouArtworksGridProps> = ({
 
   return (
     <>
-      <Masonry columnCount={[2, 3, 4]}>
-        {artworks?.length > 0 &&
-          artworks.map(artwork => {
+      {artworks?.length > 0 ? (
+        <Masonry columnCount={[2, 3, 4]}>
+          {artworks.map(artwork => {
             return (
               <Fragment key={artwork.internalID}>
                 <ArtworkGridItemFragmentContainer artwork={artwork} />
@@ -48,7 +48,12 @@ export const NewForYouArtworksGrid: FC<NewForYouArtworksGridProps> = ({
               </Fragment>
             )
           })}
-      </Masonry>
+        </Masonry>
+      ) : (
+        <Text variant="lg" mt={4} color="black60">
+          Nothing yet.
+        </Text>
+      )}
       {relay.hasMore() && (
         <Box textAlign="center" mt={4}>
           <Button onClick={loadMore} loading={loading}>

--- a/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
+++ b/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
@@ -1,0 +1,77 @@
+import { Spacer } from "@artsy/palette"
+import React, { FC, Fragment } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import ArtworkGridItemFragmentContainer from "v2/Components/Artwork/GridItem"
+import { Masonry } from "v2/Components/Masonry"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { extractNodes } from "v2/Utils/extractNodes"
+import { NewForYouArtworksGridQuery } from "v2/__generated__/NewForYouArtworksGridQuery.graphql"
+import { NewForYouArtworksGrid_viewer } from "v2/__generated__/NewForYouArtworksGrid_viewer.graphql"
+
+interface NewForYouArtworksGridProps {
+  viewer: NewForYouArtworksGrid_viewer
+}
+
+export const NewForYouArtworksGrid: FC<NewForYouArtworksGridProps> = ({
+  viewer,
+}) => {
+  const { artworksForUser } = viewer
+  const artworks = extractNodes(artworksForUser)
+
+  return (
+    <Masonry columnCount={[2, 3, 4]}>
+      {artworks?.length > 0 &&
+        artworks.map(artwork => {
+          return (
+            <Fragment key={artwork.internalID}>
+              <ArtworkGridItemFragmentContainer artwork={artwork} />
+              <Spacer mt={4} />
+            </Fragment>
+          )
+        })}
+    </Masonry>
+  )
+}
+
+export const NewForYouArtworksGridQueryRenderer: React.FC = () => {
+  return (
+    <SystemQueryRenderer<NewForYouArtworksGridQuery>
+      query={graphql`
+        query NewForYouArtworksGridQuery {
+          viewer {
+            ...NewForYouArtworksGrid_viewer
+          }
+        }
+      `}
+      render={({ props, error }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+        if (!props?.viewer) {
+          return null
+        }
+        return <NewForYouArtworksGridFragmentContainer viewer={props.viewer} />
+      }}
+    />
+  )
+}
+
+export const NewForYouArtworksGridFragmentContainer = createFragmentContainer(
+  NewForYouArtworksGrid,
+  {
+    viewer: graphql`
+      fragment NewForYouArtworksGrid_viewer on Viewer {
+        artworksForUser {
+          totalCount
+          edges {
+            node {
+              internalID
+              ...GridItem_artwork
+            }
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/NewForYou/NewForYouApp.tsx
+++ b/src/v2/Apps/NewForYou/NewForYouApp.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react"
 import { MetaTags } from "v2/Components/MetaTags"
-import { Column, GridColumns, Spacer, Text } from "@artsy/palette"
+import { Spacer, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { NewForYouApp_viewer } from "v2/__generated__/NewForYouApp_viewer.graphql"
 import { NewForYouArtworksGridFragmentContainer } from "v2/Apps/NewForYou/Components/NewForYouArtworksGrid"
@@ -14,18 +14,9 @@ export const NewForYouApp: FC<NewForYouAppProps> = ({ viewer }) => {
     <>
       <Spacer mt={2} />
       <MetaTags title="New For You" />
-      <GridColumns>
-        <Column span={6}>
-          <Text variant="xl" mt={4}>
-            New Works For You
-          </Text>
-        </Column>
-        <Column span={6}>
-          <Text variant={"md"} mt={6}>
-            Description Here Explaining Stuff
-          </Text>
-        </Column>
-      </GridColumns>
+      <Text variant="xl" mt={4}>
+        New Works For You
+      </Text>
       <Spacer mt={4} />
       {viewer && <NewForYouArtworksGridFragmentContainer viewer={viewer} />}
     </>

--- a/src/v2/Apps/NewForYou/NewForYouApp.tsx
+++ b/src/v2/Apps/NewForYou/NewForYouApp.tsx
@@ -1,10 +1,15 @@
 import React, { FC } from "react"
-
 import { MetaTags } from "v2/Components/MetaTags"
 import { Column, GridColumns, Spacer, Text } from "@artsy/palette"
-import { NewForYouArtworksGridQueryRenderer } from "v2/Apps/NewForYou/Components/NewForYouArtworksGrid"
+import { createFragmentContainer, graphql } from "react-relay"
+import { NewForYouApp_viewer } from "v2/__generated__/NewForYouApp_viewer.graphql"
+import { NewForYouArtworksGridFragmentContainer } from "v2/Apps/NewForYou/Components/NewForYouArtworksGrid"
 
-export const NewForYouApp: FC = () => {
+interface NewForYouAppProps {
+  viewer: NewForYouApp_viewer
+}
+
+export const NewForYouApp: FC<NewForYouAppProps> = ({ viewer }) => {
   return (
     <>
       <Spacer mt={2} />
@@ -22,7 +27,18 @@ export const NewForYouApp: FC = () => {
         </Column>
       </GridColumns>
       <Spacer mt={4} />
-      <NewForYouArtworksGridQueryRenderer />
+      {viewer && <NewForYouArtworksGridFragmentContainer viewer={viewer} />}
     </>
   )
 }
+
+export const NewForYouAppFragmentContainer = createFragmentContainer(
+  NewForYouApp,
+  {
+    viewer: graphql`
+      fragment NewForYouApp_viewer on Viewer {
+        ...NewForYouArtworksGrid_viewer
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/NewForYou/NewForYouApp.tsx
+++ b/src/v2/Apps/NewForYou/NewForYouApp.tsx
@@ -1,19 +1,10 @@
-import React, { FC, useEffect } from "react"
+import React, { FC } from "react"
+
 import { MetaTags } from "v2/Components/MetaTags"
-import { useRouter } from "v2/System/Router/useRouter"
-import { useFeatureFlag } from "v2/System/useFeatureFlag"
 import { Column, GridColumns, Spacer, Text } from "@artsy/palette"
+import { NewForYouArtworksGridQueryRenderer } from "v2/Apps/NewForYou/Components/NewForYouArtworksGrid"
 
 export const NewForYouApp: FC = () => {
-  const featureFlagEnabled = useFeatureFlag("new_for_you")
-  const { router } = useRouter()
-
-  useEffect(() => {
-    if (!featureFlagEnabled) {
-      router.replace("/")
-    }
-  })
-
   return (
     <>
       <Spacer mt={2} />
@@ -31,6 +22,7 @@ export const NewForYouApp: FC = () => {
         </Column>
       </GridColumns>
       <Spacer mt={4} />
+      <NewForYouArtworksGridQueryRenderer />
     </>
   )
 }

--- a/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
+++ b/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
@@ -2,6 +2,7 @@ import { MockBoot } from "v2/DevTools"
 import { render, screen } from "@testing-library/react"
 import { NewForYouApp } from "../NewForYouApp"
 import { SystemContextProvider } from "v2/System"
+import { NewForYouApp_artworks } from "v2/__generated__/NewForYouApp_artworks.graphql"
 
 jest.mock("v2/System/Router/useRouter", () => ({
   useRouter: () => ({
@@ -16,7 +17,13 @@ describe("NewForYouApp", () => {
     render(
       <MockBoot breakpoint="lg">
         <SystemContextProvider>
-          <NewForYouApp />
+          <NewForYouApp
+            artworks={
+              [
+                { title: "Test Title", internalID: "test-artwork-slug" },
+              ] as NewForYouApp_artworks[]
+            }
+          />
         </SystemContextProvider>
       </MockBoot>
     )

--- a/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
+++ b/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
@@ -1,23 +1,42 @@
-import { MockBoot } from "v2/DevTools"
-import { render, screen } from "@testing-library/react"
-// import { NewForYouApp } from "../NewForYouApp"
-import { SystemContextProvider } from "v2/System"
+import { screen } from "@testing-library/react"
+import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
+import { graphql } from "relay-runtime"
+import { NewForYouAppFragmentContainer } from "../NewForYouApp"
 
-jest.mock("v2/System/Router/useRouter", () => ({
-  useRouter: () => ({
-    router: {
-      replace: jest.fn(),
-    },
-  }),
+jest.unmock("react-relay")
+jest.mock("v2/Components/MetaTags", () => ({
+  MetaTags: () => "MetaTags",
 }))
+jest.mock("v2/System/Router/useRouter", () => ({
+  useRouter: jest.fn(),
+}))
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: NewForYouAppFragmentContainer,
+  query: graphql`
+    query NewForYouApp_test_Query @relay_test_operation {
+      viewer: viewer {
+        ...NewForYouArtworksGrid_viewer
+      }
+    }
+  `,
+})
 
 describe("NewForYouApp", () => {
   it("renders", () => {
-    render(
-      <MockBoot breakpoint="lg">
-        <SystemContextProvider>{/* <NewForYouApp /> */}</SystemContextProvider>
-      </MockBoot>
-    )
+    renderWithRelay()
+
+    expect(screen.getByText("MetaTags")).toBeInTheDocument()
     expect(screen.getByText("New Works For You")).toBeInTheDocument()
+  })
+
+  it("shows expected no-results messaging", () => {
+    renderWithRelay({
+      Viewer: () => ({
+        artworksForUser: null,
+      }),
+    })
+
+    expect(screen.getByText("Nothing yet.")).toBeInTheDocument()
   })
 })

--- a/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
+++ b/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
@@ -1,6 +1,6 @@
 import { MockBoot } from "v2/DevTools"
 import { render, screen } from "@testing-library/react"
-import { NewForYouApp } from "../NewForYouApp"
+// import { NewForYouApp } from "../NewForYouApp"
 import { SystemContextProvider } from "v2/System"
 
 jest.mock("v2/System/Router/useRouter", () => ({
@@ -15,9 +15,7 @@ describe("NewForYouApp", () => {
   it("renders", () => {
     render(
       <MockBoot breakpoint="lg">
-        <SystemContextProvider>
-          <NewForYouApp />
-        </SystemContextProvider>
+        <SystemContextProvider>{/* <NewForYouApp /> */}</SystemContextProvider>
       </MockBoot>
     )
     expect(screen.getByText("New Works For You")).toBeInTheDocument()

--- a/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
+++ b/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
@@ -2,7 +2,6 @@ import { MockBoot } from "v2/DevTools"
 import { render, screen } from "@testing-library/react"
 import { NewForYouApp } from "../NewForYouApp"
 import { SystemContextProvider } from "v2/System"
-import { NewForYouApp_artworks } from "v2/__generated__/NewForYouApp_artworks.graphql"
 
 jest.mock("v2/System/Router/useRouter", () => ({
   useRouter: () => ({
@@ -17,13 +16,7 @@ describe("NewForYouApp", () => {
     render(
       <MockBoot breakpoint="lg">
         <SystemContextProvider>
-          <NewForYouApp
-            artworks={
-              [
-                { title: "Test Title", internalID: "test-artwork-slug" },
-              ] as NewForYouApp_artworks[]
-            }
-          />
+          <NewForYouApp />
         </SystemContextProvider>
       </MockBoot>
     )

--- a/src/v2/Apps/NewForYou/newForYouRoutes.tsx
+++ b/src/v2/Apps/NewForYou/newForYouRoutes.tsx
@@ -1,5 +1,10 @@
-import { NewForYouApp } from "./NewForYouApp"
 import { AppRouteConfig } from "v2/System/Router/Route"
+import { graphql } from "relay-runtime"
+import loadable from "@loadable/component"
+
+const NewForYouApp = loadable(() => import("./NewForYouApp"), {
+  resolveComponent: component => component.NewForYouAppFragmentContainer,
+})
 
 export const newForYouRoutes: AppRouteConfig[] = [
   {
@@ -10,5 +15,15 @@ export const newForYouRoutes: AppRouteConfig[] = [
         res.redirect("/")
       }
     },
+    onClientSideRender: () => {
+      NewForYouApp.preload()
+    },
+    query: graphql`
+      query newForYouRoutes_TopLevelQuery {
+        viewer {
+          ...NewForYouApp_viewer
+        }
+      }
+    `,
   },
 ]

--- a/src/v2/Apps/NewForYou/newForYouRoutes.tsx
+++ b/src/v2/Apps/NewForYou/newForYouRoutes.tsx
@@ -6,7 +6,7 @@ export const newForYouRoutes: AppRouteConfig[] = [
     path: "/new-for-you",
     getComponent: () => NewForYouApp,
     onServerSideRender: ({ req, res }) => {
-      if (!req.user) {
+      if (!res.locals.sd.FEATURE_FLAGS.new_for_you || !req.user) {
         res.redirect("/")
       }
     },

--- a/src/v2/__generated__/NewForYouApp_test_Query.graphql.ts
+++ b/src/v2/__generated__/NewForYouApp_test_Query.graphql.ts
@@ -1,0 +1,910 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type NewForYouApp_test_QueryVariables = {};
+export type NewForYouApp_test_QueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"NewForYouArtworksGrid_viewer">;
+    } | null;
+};
+export type NewForYouApp_test_Query = {
+    readonly response: NewForYouApp_test_QueryResponse;
+    readonly variables: NewForYouApp_test_QueryVariables;
+};
+
+
+
+/*
+query NewForYouApp_test_Query {
+  viewer {
+    ...NewForYouArtworksGrid_viewer
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    endAt
+    cascadingEndTimeIntervalMinutes
+    extendedBiddingIntervalMinutes
+    startAt
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    lotLabel
+    endAt
+    extendedBiddingEndAt
+    formattedEndDateTime
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+  ...NewSaveButton_artwork
+  ...HoverDetails_artwork
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  artistNames
+  href
+  is_saved: isSaved
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+
+fragment HoverDetails_artwork on Artwork {
+  internalID
+  attributionClass {
+    name
+    id
+  }
+  mediumType {
+    filterGene {
+      name
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment NewForYouArtworksGrid_viewer on Viewer {
+  artworksForUser(first: 10) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    edges {
+      node {
+        internalID
+        ...GridItem_artwork
+        id
+        __typename
+      }
+      cursor
+    }
+  }
+}
+
+fragment NewSaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v7 = [
+  (v4/*: any*/),
+  (v3/*: any*/)
+],
+v8 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v9 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v10 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v11 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v12 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NewForYouApp_test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "NewForYouArtworksGrid_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "NewForYouApp_test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "ArtworkConnection",
+            "kind": "LinkedField",
+            "name": "artworksForUser",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtworkEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "image_title",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "imageTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "placeholder",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large"
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:\"large\")"
+                          },
+                          {
+                            "alias": "aspect_ratio",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "artistNames",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/),
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v3/*: any*/),
+                          (v1/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v1/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "type",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "cascadingEndTimeIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "startAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/),
+                          {
+                            "alias": "is_live_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isLiveOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_preview",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isPreview",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "display_timely_at",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "displayTimelyAt",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotLabel",
+                            "storageKey": null
+                          },
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingEndAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "formattedEndDateTime",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v6/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v6/*: any*/),
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "AttributionClass",
+                        "kind": "LinkedField",
+                        "name": "attributionClass",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkMedium",
+                        "kind": "LinkedField",
+                        "name": "mediumType",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Gene",
+                            "kind": "LinkedField",
+                            "name": "filterGene",
+                            "plural": false,
+                            "selections": (v7/*: any*/),
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_inquireable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isInquireable",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_biddable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isBiddable",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "artworksForUser(first:10)"
+          },
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "filters": null,
+            "handle": "connection",
+            "key": "NewForYouArtworksGrid_artworksForUser",
+            "kind": "LinkedHandle",
+            "name": "artworksForUser"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d4888ac96ec9cf6a66192b39f5210adb",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "viewer": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Viewer"
+        },
+        "viewer.artworksForUser": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkConnection"
+        },
+        "viewer.artworksForUser.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArtworkEdge"
+        },
+        "viewer.artworksForUser.edges.cursor": (v8/*: any*/),
+        "viewer.artworksForUser.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "viewer.artworksForUser.edges.node.__typename": (v8/*: any*/),
+        "viewer.artworksForUser.edges.node.artistNames": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.artists": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Artist"
+        },
+        "viewer.artworksForUser.edges.node.artists.href": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.artists.id": (v10/*: any*/),
+        "viewer.artworksForUser.edges.node.artists.name": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.attributionClass": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AttributionClass"
+        },
+        "viewer.artworksForUser.edges.node.attributionClass.id": (v10/*: any*/),
+        "viewer.artworksForUser.edges.node.attributionClass.name": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.collecting_institution": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.cultural_maker": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.date": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.href": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.id": (v10/*: any*/),
+        "viewer.artworksForUser.edges.node.image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "viewer.artworksForUser.edges.node.image.aspect_ratio": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Float"
+        },
+        "viewer.artworksForUser.edges.node.image.placeholder": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.image.url": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.image_title": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.internalID": (v10/*: any*/),
+        "viewer.artworksForUser.edges.node.is_biddable": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.is_inquireable": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.is_saved": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.mediumType": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkMedium"
+        },
+        "viewer.artworksForUser.edges.node.mediumType.filterGene": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Gene"
+        },
+        "viewer.artworksForUser.edges.node.mediumType.filterGene.id": (v10/*: any*/),
+        "viewer.artworksForUser.edges.node.mediumType.filterGene.name": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "viewer.artworksForUser.edges.node.partner.href": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.partner.id": (v10/*: any*/),
+        "viewer.artworksForUser.edges.node.partner.name": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.partner.type": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "viewer.artworksForUser.edges.node.sale.cascadingEndTimeIntervalMinutes": (v12/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.display_timely_at": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.endAt": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.extendedBiddingIntervalMinutes": (v12/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.id": (v10/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.is_auction": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.is_closed": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.is_live_open": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.is_open": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.is_preview": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.startAt": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtwork"
+        },
+        "viewer.artworksForUser.edges.node.sale_artwork.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkCounts"
+        },
+        "viewer.artworksForUser.edges.node.sale_artwork.counts.bidder_positions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FormattedNumber"
+        },
+        "viewer.artworksForUser.edges.node.sale_artwork.endAt": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.extendedBiddingEndAt": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.formattedEndDateTime": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.highest_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkHighestBid"
+        },
+        "viewer.artworksForUser.edges.node.sale_artwork.highest_bid.display": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.id": (v10/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.lotLabel": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.opening_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkOpeningBid"
+        },
+        "viewer.artworksForUser.edges.node.sale_artwork.opening_bid.display": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_message": (v9/*: any*/),
+        "viewer.artworksForUser.edges.node.slug": (v10/*: any*/),
+        "viewer.artworksForUser.edges.node.title": (v9/*: any*/),
+        "viewer.artworksForUser.pageInfo": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "PageInfo"
+        },
+        "viewer.artworksForUser.pageInfo.endCursor": (v9/*: any*/),
+        "viewer.artworksForUser.pageInfo.hasNextPage": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Boolean"
+        }
+      }
+    },
+    "name": "NewForYouApp_test_Query",
+    "operationKind": "query",
+    "text": "query NewForYouApp_test_Query {\n  viewer {\n    ...NewForYouArtworksGrid_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment NewForYouArtworksGrid_viewer on Viewer {\n  artworksForUser(first: 10) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+  }
+};
+})();
+(node as any).hash = 'eb7c817ecb03a4142ac6901239ce42de';
+export default node;

--- a/src/v2/__generated__/NewForYouApp_viewer.graphql.ts
+++ b/src/v2/__generated__/NewForYouApp_viewer.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type NewForYouApp_viewer = {
+    readonly " $fragmentRefs": FragmentRefs<"NewForYouArtworksGrid_viewer">;
+    readonly " $refType": "NewForYouApp_viewer";
+};
+export type NewForYouApp_viewer$data = NewForYouApp_viewer;
+export type NewForYouApp_viewer$key = {
+    readonly " $data"?: NewForYouApp_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"NewForYouApp_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "NewForYouApp_viewer",
+  "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "NewForYouArtworksGrid_viewer"
+    }
+  ],
+  "type": "Viewer",
+  "abstractKey": null
+};
+(node as any).hash = 'c0853067c5df9e2c4f11fa5787d41abb';
+export default node;

--- a/src/v2/__generated__/NewForYouArtworksGridQuery.graphql.ts
+++ b/src/v2/__generated__/NewForYouArtworksGridQuery.graphql.ts
@@ -4,23 +4,29 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type newForYouRoutes_TopLevelQueryVariables = {};
-export type newForYouRoutes_TopLevelQueryResponse = {
+export type NewForYouArtworksGridQueryVariables = {
+    count: number;
+    cursor?: string | null;
+};
+export type NewForYouArtworksGridQueryResponse = {
     readonly viewer: {
-        readonly " $fragmentRefs": FragmentRefs<"NewForYouApp_viewer">;
+        readonly " $fragmentRefs": FragmentRefs<"NewForYouArtworksGrid_viewer">;
     } | null;
 };
-export type newForYouRoutes_TopLevelQuery = {
-    readonly response: newForYouRoutes_TopLevelQueryResponse;
-    readonly variables: newForYouRoutes_TopLevelQueryVariables;
+export type NewForYouArtworksGridQuery = {
+    readonly response: NewForYouArtworksGridQueryResponse;
+    readonly variables: NewForYouArtworksGridQueryVariables;
 };
 
 
 
 /*
-query newForYouRoutes_TopLevelQuery {
+query NewForYouArtworksGridQuery(
+  $count: Int!
+  $cursor: String
+) {
   viewer {
-    ...NewForYouApp_viewer
+    ...NewForYouArtworksGrid_viewer_1G22uz
   }
 }
 
@@ -145,12 +151,8 @@ fragment Metadata_artwork on Artwork {
   href
 }
 
-fragment NewForYouApp_viewer on Viewer {
-  ...NewForYouArtworksGrid_viewer
-}
-
-fragment NewForYouArtworksGrid_viewer on Viewer {
-  artworksForUser(first: 10) {
+fragment NewForYouArtworksGrid_viewer_1G22uz on Viewer {
+  artworksForUser(first: $count, after: $cursor) {
     pageInfo {
       hasNextPage
       endCursor
@@ -187,47 +189,64 @@ fragment SaveButton_artwork on Artwork {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "kind": "Literal",
-    "name": "first",
-    "value": 10
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "count"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "cursor"
   }
 ],
-v1 = {
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "cursor"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "count"
+  }
+],
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -236,16 +255,16 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v8 = [
+  (v5/*: any*/),
+  (v4/*: any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "newForYouRoutes_TopLevelQuery",
+    "name": "NewForYouArtworksGridQuery",
     "selections": [
       {
         "alias": null,
@@ -256,9 +275,20 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": null,
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "count",
+                "variableName": "count"
+              },
+              {
+                "kind": "Variable",
+                "name": "cursor",
+                "variableName": "cursor"
+              }
+            ],
             "kind": "FragmentSpread",
-            "name": "NewForYouApp_viewer"
+            "name": "NewForYouArtworksGrid_viewer"
           }
         ],
         "storageKey": null
@@ -269,9 +299,9 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "newForYouRoutes_TopLevelQuery",
+    "name": "NewForYouArtworksGridQuery",
     "selections": [
       {
         "alias": null,
@@ -283,7 +313,7 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": (v0/*: any*/),
+            "args": (v1/*: any*/),
             "concreteType": "ArtworkConnection",
             "kind": "LinkedField",
             "name": "artworksForUser",
@@ -396,7 +426,7 @@ return {
                         "name": "artistNames",
                         "storageKey": null
                       },
-                      (v1/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -427,15 +457,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v3/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v1/*: any*/),
-                          (v4/*: any*/)
+                          (v4/*: any*/),
+                          (v2/*: any*/),
+                          (v5/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -448,15 +478,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v3/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
+                          (v5/*: any*/),
+                          (v2/*: any*/),
                           (v4/*: any*/),
-                          (v1/*: any*/),
-                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -475,7 +505,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -511,7 +541,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": "is_live_open",
                             "args": null,
@@ -558,7 +588,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -598,7 +628,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v7/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -608,14 +638,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v7/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -630,7 +660,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v8/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -648,7 +678,7 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -689,11 +719,11 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "artworksForUser(first:10)"
+            "storageKey": null
           },
           {
             "alias": null,
-            "args": (v0/*: any*/),
+            "args": (v1/*: any*/),
             "filters": null,
             "handle": "connection",
             "key": "NewForYouArtworksGrid_artworksForUser",
@@ -706,14 +736,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3df2e56dc176f51c1a5a523e48e798cc",
+    "cacheID": "5af005bc2010a4dca9d368efc4eb5a19",
     "id": null,
     "metadata": {},
-    "name": "newForYouRoutes_TopLevelQuery",
+    "name": "NewForYouArtworksGridQuery",
     "operationKind": "query",
-    "text": "query newForYouRoutes_TopLevelQuery {\n  viewer {\n    ...NewForYouApp_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment NewForYouApp_viewer on Viewer {\n  ...NewForYouArtworksGrid_viewer\n}\n\nfragment NewForYouArtworksGrid_viewer on Viewer {\n  artworksForUser(first: 10) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query NewForYouArtworksGridQuery(\n  $count: Int!\n  $cursor: String\n) {\n  viewer {\n    ...NewForYouArtworksGrid_viewer_1G22uz\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment NewForYouArtworksGrid_viewer_1G22uz on Viewer {\n  artworksForUser(first: $count, after: $cursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();
-(node as any).hash = '2bf8c321e0fdb3e3a81f9441c60048dd';
+(node as any).hash = '0def2d54d6d6282c6bc2db6c0ecf924c';
 export default node;

--- a/src/v2/__generated__/NewForYouArtworksGridQuery.graphql.ts
+++ b/src/v2/__generated__/NewForYouArtworksGridQuery.graphql.ts
@@ -1,0 +1,662 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type NewForYouArtworksGridQueryVariables = {};
+export type NewForYouArtworksGridQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"NewForYouArtworksGrid_viewer">;
+    } | null;
+};
+export type NewForYouArtworksGridQuery = {
+    readonly response: NewForYouArtworksGridQueryResponse;
+    readonly variables: NewForYouArtworksGridQueryVariables;
+};
+
+
+
+/*
+query NewForYouArtworksGridQuery {
+  viewer {
+    ...NewForYouArtworksGrid_viewer
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    endAt
+    cascadingEndTimeIntervalMinutes
+    extendedBiddingIntervalMinutes
+    startAt
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    lotLabel
+    endAt
+    extendedBiddingEndAt
+    formattedEndDateTime
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+  ...NewSaveButton_artwork
+  ...HoverDetails_artwork
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  artistNames
+  href
+  is_saved: isSaved
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+
+fragment HoverDetails_artwork on Artwork {
+  internalID
+  attributionClass {
+    name
+    id
+  }
+  mediumType {
+    filterGene {
+      name
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment NewForYouArtworksGrid_viewer on Viewer {
+  artworksForUser {
+    totalCount
+    edges {
+      node {
+        internalID
+        ...GridItem_artwork
+        id
+      }
+    }
+  }
+}
+
+fragment NewSaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NewForYouArtworksGridQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "NewForYouArtworksGrid_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "NewForYouArtworksGridQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkConnection",
+            "kind": "LinkedField",
+            "name": "artworksForUser",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalCount",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtworkEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "image_title",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "imageTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "placeholder",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large"
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:\"large\")"
+                          },
+                          {
+                            "alias": "aspect_ratio",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "artistNames",
+                        "storageKey": null
+                      },
+                      (v0/*: any*/),
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v1/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v0/*: any*/),
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v1/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          (v0/*: any*/),
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "type",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "cascadingEndTimeIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "startAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/),
+                          {
+                            "alias": "is_live_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isLiveOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_preview",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isPreview",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "display_timely_at",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "displayTimelyAt",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotLabel",
+                            "storageKey": null
+                          },
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingEndAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "formattedEndDateTime",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "AttributionClass",
+                        "kind": "LinkedField",
+                        "name": "attributionClass",
+                        "plural": false,
+                        "selections": (v6/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkMedium",
+                        "kind": "LinkedField",
+                        "name": "mediumType",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Gene",
+                            "kind": "LinkedField",
+                            "name": "filterGene",
+                            "plural": false,
+                            "selections": (v6/*: any*/),
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_inquireable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isInquireable",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_biddable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isBiddable",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "4daf95eb5e990a729abfe1020115665f",
+    "id": null,
+    "metadata": {},
+    "name": "NewForYouArtworksGridQuery",
+    "operationKind": "query",
+    "text": "query NewForYouArtworksGridQuery {\n  viewer {\n    ...NewForYouArtworksGrid_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment NewForYouArtworksGrid_viewer on Viewer {\n  artworksForUser {\n    totalCount\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+  }
+};
+})();
+(node as any).hash = '1b7838fedb5e6b5cca15dcfb80e495a1';
+export default node;

--- a/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
+++ b/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
@@ -6,7 +6,6 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type NewForYouArtworksGrid_viewer = {
     readonly artworksForUser: {
-        readonly totalCount: number | null;
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly internalID: string;
@@ -38,13 +37,6 @@ const node: ReaderFragment = {
       "name": "artworksForUser",
       "plural": false,
       "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "totalCount",
-          "storageKey": null
-        },
         {
           "alias": null,
           "args": null,
@@ -86,5 +78,5 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = '82a8783da944097a170edcae481b52ce';
+(node as any).hash = '4ffdb71dbc24cb22eff3a467fc003e03';
 export default node;

--- a/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
+++ b/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
@@ -1,0 +1,90 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type NewForYouArtworksGrid_viewer = {
+    readonly artworksForUser: {
+        readonly totalCount: number | null;
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly " $fragmentRefs": FragmentRefs<"GridItem_artwork">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "NewForYouArtworksGrid_viewer";
+};
+export type NewForYouArtworksGrid_viewer$data = NewForYouArtworksGrid_viewer;
+export type NewForYouArtworksGrid_viewer$key = {
+    readonly " $data"?: NewForYouArtworksGrid_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"NewForYouArtworksGrid_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "NewForYouArtworksGrid_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArtworkConnection",
+      "kind": "LinkedField",
+      "name": "artworksForUser",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworkEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "GridItem_artwork"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Viewer",
+  "abstractKey": null
+};
+(node as any).hash = '82a8783da944097a170edcae481b52ce';
+export default node;

--- a/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
+++ b/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
@@ -6,6 +6,10 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type NewForYouArtworksGrid_viewer = {
     readonly artworksForUser: {
+        readonly pageInfo: {
+            readonly hasNextPage: boolean;
+            readonly endCursor: string | null;
+        };
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly internalID: string;
@@ -24,19 +28,66 @@ export type NewForYouArtworksGrid_viewer$key = {
 
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "defaultValue": 10,
+      "kind": "LocalArgument",
+      "name": "count"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "cursor"
+    }
+  ],
   "kind": "Fragment",
-  "metadata": null,
+  "metadata": {
+    "connection": [
+      {
+        "count": "count",
+        "cursor": "cursor",
+        "direction": "forward",
+        "path": [
+          "artworksForUser"
+        ]
+      }
+    ]
+  },
   "name": "NewForYouArtworksGrid_viewer",
   "selections": [
     {
-      "alias": null,
+      "alias": "artworksForUser",
       "args": null,
       "concreteType": "ArtworkConnection",
       "kind": "LinkedField",
-      "name": "artworksForUser",
+      "name": "__NewForYouArtworksGrid_artworksForUser_connection",
       "plural": false,
       "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
         {
           "alias": null,
           "args": null,
@@ -61,11 +112,25 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                },
+                {
                   "args": null,
                   "kind": "FragmentSpread",
                   "name": "GridItem_artwork"
                 }
               ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
               "storageKey": null
             }
           ],
@@ -78,5 +143,5 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = '4ffdb71dbc24cb22eff3a467fc003e03';
+(node as any).hash = '36a784e610d0d444d3d90784111a6e3f';
 export default node;

--- a/src/v2/__generated__/newForYouRoutes_TopLevelQuery.graphql.ts
+++ b/src/v2/__generated__/newForYouRoutes_TopLevelQuery.graphql.ts
@@ -4,23 +4,23 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type NewForYouArtworksGridQueryVariables = {};
-export type NewForYouArtworksGridQueryResponse = {
+export type newForYouRoutes_TopLevelQueryVariables = {};
+export type newForYouRoutes_TopLevelQueryResponse = {
     readonly viewer: {
-        readonly " $fragmentRefs": FragmentRefs<"NewForYouArtworksGrid_viewer">;
+        readonly " $fragmentRefs": FragmentRefs<"NewForYouApp_viewer">;
     } | null;
 };
-export type NewForYouArtworksGridQuery = {
-    readonly response: NewForYouArtworksGridQueryResponse;
-    readonly variables: NewForYouArtworksGridQueryVariables;
+export type newForYouRoutes_TopLevelQuery = {
+    readonly response: newForYouRoutes_TopLevelQueryResponse;
+    readonly variables: newForYouRoutes_TopLevelQueryVariables;
 };
 
 
 
 /*
-query NewForYouArtworksGridQuery {
+query newForYouRoutes_TopLevelQuery {
   viewer {
-    ...NewForYouArtworksGrid_viewer
+    ...NewForYouApp_viewer
   }
 }
 
@@ -145,9 +145,12 @@ fragment Metadata_artwork on Artwork {
   href
 }
 
+fragment NewForYouApp_viewer on Viewer {
+  ...NewForYouArtworksGrid_viewer
+}
+
 fragment NewForYouArtworksGrid_viewer on Viewer {
   artworksForUser {
-    totalCount
     edges {
       node {
         internalID
@@ -229,7 +232,7 @@ return {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "NewForYouArtworksGridQuery",
+    "name": "newForYouRoutes_TopLevelQuery",
     "selections": [
       {
         "alias": null,
@@ -242,7 +245,7 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "NewForYouArtworksGrid_viewer"
+            "name": "NewForYouApp_viewer"
           }
         ],
         "storageKey": null
@@ -255,7 +258,7 @@ return {
   "operation": {
     "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "NewForYouArtworksGridQuery",
+    "name": "newForYouRoutes_TopLevelQuery",
     "selections": [
       {
         "alias": null,
@@ -273,13 +276,6 @@ return {
             "name": "artworksForUser",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "totalCount",
-                "storageKey": null
-              },
               {
                 "alias": null,
                 "args": null,
@@ -649,14 +645,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4daf95eb5e990a729abfe1020115665f",
+    "cacheID": "85f9c8ed8b005670305047b570e8e51d",
     "id": null,
     "metadata": {},
-    "name": "NewForYouArtworksGridQuery",
+    "name": "newForYouRoutes_TopLevelQuery",
     "operationKind": "query",
-    "text": "query NewForYouArtworksGridQuery {\n  viewer {\n    ...NewForYouArtworksGrid_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment NewForYouArtworksGrid_viewer on Viewer {\n  artworksForUser {\n    totalCount\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query newForYouRoutes_TopLevelQuery {\n  viewer {\n    ...NewForYouApp_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment NewForYouApp_viewer on Viewer {\n  ...NewForYouArtworksGrid_viewer\n}\n\nfragment NewForYouArtworksGrid_viewer on Viewer {\n  artworksForUser {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();
-(node as any).hash = '1b7838fedb5e6b5cca15dcfb80e495a1';
+(node as any).hash = '2bf8c321e0fdb3e3a81f9441c60048dd';
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-918] & [GRO-920]

### Description

Add the new for you grid structure & associated query (which will fetch backfill artworks if the user has none). 
Backfill work is in flight, per @jonallured.

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-918]: https://artsyproduct.atlassian.net/browse/GRO-918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-920]: https://artsyproduct.atlassian.net/browse/GRO-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ