### PR TITLE
feat(artist): bundle split artist/overview page

### DIFF
--- a/src/v2/Apps/Artist/Routes/Overview/ArtistOverviewRoute.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/ArtistOverviewRoute.tsx
@@ -2,15 +2,64 @@ import { Join, Spacer } from "@artsy/palette"
 import * as React from "react"
 import { Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
-import { ArtistIconicCollectionsRailQueryRenderer } from "v2/Apps/Artist/Routes/Overview/Components/ArtistIconicCollectionsRail"
-import { ArtistNotableWorksRailQueryRenderer } from "v2/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail"
-import { ArtistWorksForSaleRailQueryRenderer } from "./Components/ArtistWorksForSaleRail"
-import { ArtistCurrentShowsRailQueryRenderer } from "./Components/ArtistCurrentShowsRail"
-import { ArtistCurrentArticlesRailQueryRenderer } from "./Components/ArtistCurrentArticlesRail"
-import { ArtistCareerHighlightsQueryRenderer } from "./Components/ArtistCareerHighlights"
-import { ArtistRelatedArtistsRailQueryRenderer } from "./Components/ArtistRelatedArtistsRail"
-import { ArtistSellWithArtsyQueryRenderer } from "./Components/ArtistSellWithArtsy"
 import { computeTitle } from "../../Utils/computeTitle"
+import loadable from "@loadable/component"
+
+const ArtistIconicCollectionsRailQueryRenderer = loadable(
+  () => import("./Components/ArtistIconicCollectionsRail"),
+  {
+    resolveComponent: component =>
+      component.ArtistIconicCollectionsRailQueryRenderer,
+  }
+)
+const ArtistNotableWorksRailQueryRenderer = loadable(
+  () => import("./Components/ArtistNotableWorksRail"),
+  {
+    resolveComponent: component =>
+      component.ArtistNotableWorksRailQueryRenderer,
+  }
+)
+const ArtistWorksForSaleRailQueryRenderer = loadable(
+  () => import("./Components/ArtistWorksForSaleRail"),
+  {
+    resolveComponent: component =>
+      component.ArtistWorksForSaleRailQueryRenderer,
+  }
+)
+const ArtistCurrentShowsRailQueryRenderer = loadable(
+  () => import("./Components/ArtistCurrentShowsRail"),
+  {
+    resolveComponent: component =>
+      component.ArtistCurrentShowsRailQueryRenderer,
+  }
+)
+const ArtistCurrentArticlesRailQueryRenderer = loadable(
+  () => import("./Components/ArtistCurrentArticlesRail"),
+  {
+    resolveComponent: component =>
+      component.ArtistCurrentArticlesRailQueryRenderer,
+  }
+)
+const ArtistCareerHighlightsQueryRenderer = loadable(
+  () => import("./Components/ArtistCareerHighlights"),
+  {
+    resolveComponent: component =>
+      component.ArtistCareerHighlightsQueryRenderer,
+  }
+)
+const ArtistRelatedArtistsRailQueryRenderer = loadable(
+  () => import("./Components/ArtistRelatedArtistsRail"),
+  {
+    resolveComponent: component =>
+      component.ArtistRelatedArtistsRailQueryRenderer,
+  }
+)
+const ArtistSellWithArtsyQueryRenderer = loadable(
+  () => import("./Components/ArtistSellWithArtsy"),
+  {
+    resolveComponent: component => component.ArtistSellWithArtsyQueryRenderer,
+  }
+)
 
 interface ArtistOverviewRouteProps {
   artist: any


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR solves [GRO-925]

### Description

This bundle splits all of the lazy loaded queryrenderers on /artist/id/overview, which reduces the size of the main artist page chunk: 

<img width="504" alt="Screen Shot 2022-05-13 at 3 55 41 PM" src="https://user-images.githubusercontent.com/236943/168399300-df073e02-e2fe-479a-a181-6bc2f69c712c.png">

cc @artsy/grow-devs 



[GRO-925]: https://artsyproduct.atlassian.net/browse/GRO-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ