### PR TITLE
feat(FX-3965): add finds under 1000 in artwork links tab

### DIFF
--- a/src/v2/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
@@ -44,8 +44,11 @@ describe("NavBarSubMenu", () => {
     expect(linkMenuItems.at(2).text()).toContain("Finds Under $2500")
     expect(linkMenuItems.at(2).prop("href")).toEqual("/gene/finds-under-2500")
 
-    expect(linkMenuItems.at(3).text()).toContain("The Collectibles Shop")
-    expect(linkMenuItems.at(3).prop("href")).toEqual(
+    expect(linkMenuItems.at(3).text()).toContain("Finds Under $1000")
+    expect(linkMenuItems.at(3).prop("href")).toEqual("/gene/finds-under-1000")
+
+    expect(linkMenuItems.at(4).text()).toContain("The Collectibles Shop")
+    expect(linkMenuItems.at(4).prop("href")).toEqual(
       "/gene/the-collectibles-shop"
     )
 

--- a/src/v2/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
@@ -52,8 +52,8 @@ describe("NavBarSubMenu", () => {
       "/gene/the-collectibles-shop"
     )
 
-    expect(linkMenuItems.at(4).text()).toContain("View All Artworks")
-    expect(linkMenuItems.at(4).prop("href")).toEqual("/collect")
+    expect(linkMenuItems.at(5).text()).toContain("View All Artworks")
+    expect(linkMenuItems.at(5).prop("href")).toEqual("/collect")
   })
 
   it("doesn't render artists letter nav inside artworks dropdown", () => {

--- a/src/v2/Components/NavBar/menuData.ts
+++ b/src/v2/Components/NavBar/menuData.ts
@@ -163,6 +163,10 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
         href: "/gene/finds-under-2500",
       },
       {
+        text: "Finds Under $1000",
+        href: "/gene/finds-under-1000",
+      },
+      {
         text: "The Collectibles Shop",
         href: "/gene/the-collectibles-shop",
       },


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-3965]

### Description

Adds `Finds Under ＄1000` -> `/gene/finds-under-1000` to Artworks Navigation tab

|Screenshots||
|---|---|
|<img width="400" alt="Screenshot 2022-05-16 at 19 27 10" src="https://user-images.githubusercontent.com/21178754/168649789-75f51407-d05c-41fc-a0a3-424afd578e9e.png">|<img width="500" alt="Screenshot 2022-05-16 at 19 26 57" src="https://user-images.githubusercontent.com/21178754/168649795-bec90506-024d-4fb7-84d0-02a4d5f9bd5a.png">|

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-3965]: https://artsyproduct.atlassian.net/browse/FX-3965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ