### PR TITLE
chore(FX-3980): add comma on links

### DIFF
--- a/src/v2/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
@@ -41,10 +41,10 @@ describe("NavBarSubMenu", () => {
     expect(linkMenuItems.at(1).text()).toContain("Iconic Prints")
     expect(linkMenuItems.at(1).prop("href")).toEqual("/gene/iconic-prints")
 
-    expect(linkMenuItems.at(2).text()).toContain("Finds Under $2500")
+    expect(linkMenuItems.at(2).text()).toContain("Finds Under $2,500")
     expect(linkMenuItems.at(2).prop("href")).toEqual("/gene/finds-under-2500")
 
-    expect(linkMenuItems.at(3).text()).toContain("Finds Under $1000")
+    expect(linkMenuItems.at(3).text()).toContain("Finds Under $1,000")
     expect(linkMenuItems.at(3).prop("href")).toEqual("/gene/finds-under-1000")
 
     expect(linkMenuItems.at(4).text()).toContain("The Collectibles Shop")

--- a/src/v2/Components/NavBar/menuData.ts
+++ b/src/v2/Components/NavBar/menuData.ts
@@ -159,11 +159,11 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
         href: "/gene/iconic-prints",
       },
       {
-        text: "Finds Under $2500",
+        text: "Finds Under $2,500",
         href: "/gene/finds-under-2500",
       },
       {
-        text: "Finds Under $1000",
+        text: "Finds Under $1,000",
         href: "/gene/finds-under-1000",
       },
       {


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-3980]

### Description

Adds a comma `,` to the artwork navlink titles 
- `Finds Under $2,500`
- `Finds Under $1,000`

[Slack thread](https://artsy.slack.com/archives/C9SATFLUU/p1652797512421009?thread_ts=1652785037.842789&cid=C9SATFLUU) where it was reported.
|Screenshots||
|---|---|
|Before|After|
|Desktop||
|<img width="620" alt="Screenshot 2022-05-17 at 17 36 21" src="https://user-images.githubusercontent.com/21178754/168851379-95c93959-d11e-43cd-a257-8088930b0a30.png">|<img width="450" alt="Screenshot 2022-05-17 at 17 35 02" src="https://user-images.githubusercontent.com/21178754/168851069-38ed5b8c-453b-4d3f-9408-98f0d2ecdfee.png">|
|Mobile||
|<img width="424" alt="Screenshot 2022-05-17 at 17 36 31" src="https://user-images.githubusercontent.com/21178754/168851371-fd4a16af-7653-4aa8-a405-f3439fcfff2e.png">|<img width="413" alt="Screenshot 2022-05-17 at 17 35 17" src="https://user-images.githubusercontent.com/21178754/168851062-b9096919-4cde-4d0c-86ac-cce4ad9d0f78.png">|

<!-- Implementation description -->
