### PR TITLE
feat(FX-3972): send trending sort for artist artwork grids based on Unleash flag

### DIFF
--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -15,6 +15,7 @@ import { SavedSearchEntity } from "v2/Components/SavedSearchAlert/types"
 import { getSupportedMetric } from "v2/Components/ArtworkFilter/Utils/metrics"
 import { OwnerType } from "@artsy/cohesion"
 import { ZeroState } from "./ZeroState"
+import { useFeatureFlag } from "v2/System/useFeatureFlag"
 
 interface ArtistArtworkFilterProps {
   aggregations: SharedArtworkFilterContextProps["aggregations"]
@@ -26,6 +27,9 @@ interface ArtistArtworkFilterProps {
 
 const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
   const { match } = useRouter()
+  const isTrendingSortEnabled = useFeatureFlag(
+    "force-trending-sort-for-artists"
+  )
   const { relay, aggregations, artist, me } = props
   const { filtered_artworks } = artist
   const hasFilter = filtered_artworks && filtered_artworks.id
@@ -60,7 +64,11 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
       counts={artist.counts as Counts}
       filters={filters}
       sortOptions={[
-        { value: "-decayed_merch", text: "Default" },
+        {
+          // TODO: Clarify trending sort value
+          value: isTrendingSortEnabled ? "trending_score" : "-decayed_merch",
+          text: "Default",
+        },
         { value: "-has_price,-prices", text: "Price (desc.)" },
         { value: "-has_price,prices", text: "Price (asc.)" },
         { value: "-partner_updated_at", text: "Recently updated" },

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
@@ -10,10 +10,16 @@ export function getWorksForSaleRouteVariables(
   // renders (such as tabbing back to this route in your browser) will not.
   const initialFilterState = getInitialFilterState(location?.query ?? {})
   const newPriceFilterFlag = featureFlags["new_price_filter"]
+  const trendingSortFlag = featureFlags["force-trending-sort-for-artists"]
 
   const filterParams = {
     sort: "-decayed_merch",
     ...initialFilterState,
+  }
+
+  if (trendingSortFlag?.flagEnabled) {
+    // TODO: Clarify sort value
+    filterParams.sort = "trending_score"
   }
 
   const aggregations = [


### PR DESCRIPTION
The type of this PR is: **Expirement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-3972]

### Description
When a user is viewing an artist artwork grid with the “default” sort option enabled, we want to have the option to either send `-decayed_merch` (our current default sort) or our new `trending_score` (TODO: Clarify this moment) sort parameter to Gravity. We want to be able to change this behavior based on an Unleash feature flag. This will first allow us to add specific Artsy users to the “view trending score-boosted sort” group, so that we can do a qualitative review of the updated grids with stakeholders.

### Acceptance criteria
- [x] Feature flag in Unleash is created
- [x] When the flag is true AND the user is viewing an artist works for sale page, send the new trending score sort param in the fetch for `filteredArtworksConnection`
- [x] When it is `false`, maintain the existing behavior (sending `-decayed_merch`)
- [ ] Correctly track analytics

Then later, we can launch by updating the feature flag to show to all users (or to a portion of users for an A/B test if desired)

<!-- Implementation description -->
