### PR TITLE
feat: require password for account deletion, if account has password

### DIFF
--- a/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
@@ -14,6 +14,8 @@ import { RouterLink } from "v2/System/Router/RouterLink"
 import { Formik, Form } from "formik"
 import { useDeleteAccount } from "./useDeleteAccount"
 import { logout } from "v2/Utils/auth"
+import { PasswordInput } from "@artsy/palette"
+import { password } from "v2/Components/Authentication/Validators"
 
 export const DeleteAccountRoute: FC = () => {
   const { sendToast } = useToasts()
@@ -31,16 +33,18 @@ export const DeleteAccountRoute: FC = () => {
           initialValues={{
             explanation: "",
             confirmation: false,
+            password: "",
           }}
           validationSchema={Yup.object().shape({
             explanation: Yup.string().min(1).required(),
             confirmation: Yup.boolean().oneOf([true]),
+            password: password,
           })}
-          onSubmit={async ({ explanation }) => {
+          onSubmit={async ({ explanation, password }) => {
             try {
               await submitMutation({
                 variables: {
-                  input: { explanation, url: window.location.href },
+                  input: { explanation, password, url: window.location.href },
                 },
                 rejectIf: res => {
                   return res.deleteMyAccountMutation?.userAccountOrError
@@ -66,7 +70,7 @@ export const DeleteAccountRoute: FC = () => {
             }
           }}
         >
-          {({ isSubmitting, values, isValid, setFieldValue }) => {
+          {({ errors, isSubmitting, values, isValid, setFieldValue }) => {
             return (
               <Form>
                 <Checkbox
@@ -87,6 +91,18 @@ export const DeleteAccountRoute: FC = () => {
                   required
                   onChange={({ value }) => {
                     setFieldValue("explanation", value)
+                  }}
+                />
+
+                <PasswordInput
+                  name="password"
+                  mt={2}
+                  title="Password"
+                  error={errors.password}
+                  placeholder="Enter your password"
+                  value={values.password}
+                  onChange={({ value }) => {
+                    setFieldValue("password", value)
                   }}
                 />
 

--- a/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
@@ -16,11 +16,11 @@ import { useDeleteAccount } from "./useDeleteAccount"
 import { logout } from "v2/Utils/auth"
 import { PasswordInput } from "@artsy/palette"
 import { password } from "v2/Components/Authentication/Validators"
-import { SettingsDeleteAccountRoute_me } from "v2/__generated__/SettingsDeleteAccountRoute_me.graphql"
+import { DeleteAccountRoute_me } from "v2/__generated__/DeleteAccountRoute_me.graphql"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface DeleteAccountRouteProps {
-  me: SettingsDeleteAccountRoute_me
+  me: DeleteAccountRoute_me
 }
 
 export const DeleteAccountRoute: FC<DeleteAccountRouteProps> = ({
@@ -150,11 +150,11 @@ export const DeleteAccountRoute: FC<DeleteAccountRouteProps> = ({
   )
 }
 
-export const SettingsDeleteAccountRouteFragmentContainer = createFragmentContainer(
+export const DeleteAccountRouteFragmentContainer = createFragmentContainer(
   DeleteAccountRoute,
   {
     me: graphql`
-      fragment SettingsDeleteAccountRoute_me on Me {
+      fragment DeleteAccountRoute_me on Me {
         hasPassword
       }
     `,

--- a/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
@@ -16,8 +16,16 @@ import { useDeleteAccount } from "./useDeleteAccount"
 import { logout } from "v2/Utils/auth"
 import { PasswordInput } from "@artsy/palette"
 import { password } from "v2/Components/Authentication/Validators"
+import { SettingsDeleteAccountRoute_me } from "v2/__generated__/SettingsDeleteAccountRoute_me.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
 
-export const DeleteAccountRoute: FC = () => {
+interface DeleteAccountRouteProps {
+  me: SettingsDeleteAccountRoute_me
+}
+
+export const DeleteAccountRoute: FC<DeleteAccountRouteProps> = ({
+  me: { hasPassword },
+}) => {
   const { sendToast } = useToasts()
   const { submitMutation } = useDeleteAccount()
 
@@ -72,6 +80,7 @@ export const DeleteAccountRoute: FC = () => {
         >
           {({
             errors,
+            handleBlur,
             handleChange,
             isSubmitting,
             isValid,
@@ -102,15 +111,19 @@ export const DeleteAccountRoute: FC = () => {
                   }}
                 />
 
-                <PasswordInput
-                  name="password"
-                  mt={2}
-                  title="Password"
-                  error={touched.password && errors.password}
-                  placeholder="Enter your password"
-                  value={values.password}
-                  onChange={handleChange}
-                />
+                {hasPassword && (
+                  <PasswordInput
+                    name="password"
+                    mt={2}
+                    title="Password"
+                    error={touched.password && errors.password}
+                    //error={errors.password}
+                    placeholder="Enter your password"
+                    value={values.password}
+                    onBlur={handleBlur}
+                    onChange={handleChange}
+                  />
+                )}
 
                 <Button
                   mt={4}
@@ -136,3 +149,14 @@ export const DeleteAccountRoute: FC = () => {
     </GridColumns>
   )
 }
+
+export const SettingsDeleteAccountRouteFragmentContainer = createFragmentContainer(
+  DeleteAccountRoute,
+  {
+    me: graphql`
+      fragment SettingsDeleteAccountRoute_me on Me {
+        hasPassword
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
@@ -41,7 +41,7 @@ export const DeleteAccountRoute: FC<DeleteAccountRouteProps> = ({
           initialValues={{
             confirmation: false,
             explanation: "",
-            hasPassword: hasPassword,
+            hasPassword,
             password: "",
           }}
           validationSchema={Yup.object().shape({

--- a/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
@@ -3,21 +3,21 @@ import {
   Checkbox,
   Column,
   GridColumns,
+  PasswordInput,
   Separator,
   Text,
   TextArea,
   useToasts,
 } from "@artsy/palette"
 import * as Yup from "yup"
+import { password } from "v2/Components/Authentication/Validators"
 import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { DeleteAccountRoute_me } from "v2/__generated__/DeleteAccountRoute_me.graphql"
+import { useDeleteAccount } from "./useDeleteAccount"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { Formik, Form } from "formik"
-import { useDeleteAccount } from "./useDeleteAccount"
 import { logout } from "v2/Utils/auth"
-import { PasswordInput } from "@artsy/palette"
-import { password } from "v2/Components/Authentication/Validators"
-import { DeleteAccountRoute_me } from "v2/__generated__/DeleteAccountRoute_me.graphql"
-import { createFragmentContainer, graphql } from "react-relay"
 
 interface DeleteAccountRouteProps {
   me: DeleteAccountRoute_me
@@ -113,15 +113,15 @@ export const DeleteAccountRoute: FC<DeleteAccountRouteProps> = ({
 
                 {hasPassword && (
                   <PasswordInput
-                    name="password"
-                    mt={2}
-                    title="Password"
                     error={touched.password && errors.password}
-                    //error={errors.password}
-                    placeholder="Enter your password"
-                    value={values.password}
+                    mt={2}
+                    name="password"
                     onBlur={handleBlur}
                     onChange={handleChange}
+                    placeholder="Enter your password"
+                    required
+                    title="Password"
+                    value={values.password}
                   />
                 )}
 

--- a/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
@@ -70,7 +70,15 @@ export const DeleteAccountRoute: FC = () => {
             }
           }}
         >
-          {({ errors, isSubmitting, values, isValid, setFieldValue }) => {
+          {({
+            errors,
+            handleChange,
+            isSubmitting,
+            isValid,
+            setFieldValue,
+            touched,
+            values,
+          }) => {
             return (
               <Form>
                 <Checkbox
@@ -98,12 +106,10 @@ export const DeleteAccountRoute: FC = () => {
                   name="password"
                   mt={2}
                   title="Password"
-                  error={errors.password}
+                  error={touched.password && errors.password}
                   placeholder="Enter your password"
                   value={values.password}
-                  onChange={({ value }) => {
-                    setFieldValue("password", value)
-                  }}
+                  onChange={handleChange}
                 />
 
                 <Button

--- a/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
+++ b/src/v2/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
@@ -39,14 +39,19 @@ export const DeleteAccountRoute: FC<DeleteAccountRouteProps> = ({
         <Formik
           validateOnMount
           initialValues={{
-            explanation: "",
             confirmation: false,
+            explanation: "",
+            hasPassword: hasPassword,
             password: "",
           }}
           validationSchema={Yup.object().shape({
             explanation: Yup.string().min(1).required(),
             confirmation: Yup.boolean().oneOf([true]),
-            password: password,
+            hasPassword: Yup.boolean(),
+            password: password.when("hasPassword", {
+              is: true,
+              otherwise: field => field.notRequired(),
+            }),
           })}
           onSubmit={async ({ explanation, password }) => {
             try {

--- a/src/v2/Apps/Settings/settingsRoutes.tsx
+++ b/src/v2/Apps/Settings/settingsRoutes.tsx
@@ -233,6 +233,13 @@ export const settingsRoutes: AppRouteConfig[] = [
           DeleteAccountRoute.preload()
         },
         onServerSideRender: handleServerSideRender,
+        query: graphql`
+          query settingsRoutes_SettingsDeleteAccountRouteQuery {
+            me {
+              ...SettingsDeleteAccountRoute_me
+            }
+          }
+        `,
       },
       {
         path: "shipping",

--- a/src/v2/Apps/Settings/settingsRoutes.tsx
+++ b/src/v2/Apps/Settings/settingsRoutes.tsx
@@ -83,7 +83,8 @@ const DeleteAccountRoute = loadable(
       /* webpackChunkName: "settingsBundle" */ "./Routes/DeleteAccount/DeleteAccountRoute"
     ),
   {
-    resolveComponent: component => component.DeleteAccountRoute,
+    resolveComponent: component =>
+      component.DeleteAccountRouteFragmentContainer,
   }
 )
 

--- a/src/v2/Apps/Settings/settingsRoutes.tsx
+++ b/src/v2/Apps/Settings/settingsRoutes.tsx
@@ -234,9 +234,9 @@ export const settingsRoutes: AppRouteConfig[] = [
         },
         onServerSideRender: handleServerSideRender,
         query: graphql`
-          query settingsRoutes_SettingsDeleteAccountRouteQuery {
+          query settingsRoutes_DeleteAccountRouteQuery {
             me {
-              ...SettingsDeleteAccountRoute_me
+              ...DeleteAccountRoute_me
             }
           }
         `,

--- a/src/v2/__generated__/DeleteAccountRoute_me.graphql.ts
+++ b/src/v2/__generated__/DeleteAccountRoute_me.graphql.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type DeleteAccountRoute_me = {
+    readonly hasPassword: boolean;
+    readonly " $refType": "DeleteAccountRoute_me";
+};
+export type DeleteAccountRoute_me$data = DeleteAccountRoute_me;
+export type DeleteAccountRoute_me$key = {
+    readonly " $data"?: DeleteAccountRoute_me$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"DeleteAccountRoute_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "DeleteAccountRoute_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasPassword",
+      "storageKey": null
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+(node as any).hash = '681e2f7a259aacdf29b4588bada18aa4';
+export default node;

--- a/src/v2/__generated__/settingsRoutes_DeleteAccountRouteQuery.graphql.ts
+++ b/src/v2/__generated__/settingsRoutes_DeleteAccountRouteQuery.graphql.ts
@@ -1,0 +1,103 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type settingsRoutes_DeleteAccountRouteQueryVariables = {};
+export type settingsRoutes_DeleteAccountRouteQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"DeleteAccountRoute_me">;
+    } | null;
+};
+export type settingsRoutes_DeleteAccountRouteQuery = {
+    readonly response: settingsRoutes_DeleteAccountRouteQueryResponse;
+    readonly variables: settingsRoutes_DeleteAccountRouteQueryVariables;
+};
+
+
+
+/*
+query settingsRoutes_DeleteAccountRouteQuery {
+  me {
+    ...DeleteAccountRoute_me
+    id
+  }
+}
+
+fragment DeleteAccountRoute_me on Me {
+  hasPassword
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "settingsRoutes_DeleteAccountRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "DeleteAccountRoute_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "settingsRoutes_DeleteAccountRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hasPassword",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1838aefbc22504b484439724d1b52b4e",
+    "id": null,
+    "metadata": {},
+    "name": "settingsRoutes_DeleteAccountRouteQuery",
+    "operationKind": "query",
+    "text": "query settingsRoutes_DeleteAccountRouteQuery {\n  me {\n    ...DeleteAccountRoute_me\n    id\n  }\n}\n\nfragment DeleteAccountRoute_me on Me {\n  hasPassword\n}\n"
+  }
+};
+(node as any).hash = 'c54bb2421e59e40f01d0a70e9f8bca56';
+export default node;


### PR DESCRIPTION
The type of this PR is: Enhancement
This PR solves [PLATFORM-4147]

Thanks to @damassi , @ovasdi , @jacobherrington for their help with this task.

## Description

Update `/settings/delete` page so it presents two alternative views:
- When `hasPassword` is true (the case of non-social accounts), display a `PASSWORD` field required for form submission. Password must be correct for deletion to succeed.
- When `hasPassword` is false (Google/Facebook/Apple accounts), no `PASSWORD` field.

Related PRs and Slack threads:
https://github.com/artsy/metaphysics/pull/4057 (MP accept password)
https://github.com/artsy/gravity/pull/15289 (Gravity accept password)
https://github.com/artsy/integrity/pull/337 (Update test for non-social account deletion)
https://artsy.slack.com/archives/C9XJKPY9W/p1652992094634549

## Demonstration
## Non-Social
![non_social](https://user-images.githubusercontent.com/63004951/169570828-560c7b08-3c05-43bb-9739-29a34478dbcf.gif)
## Social
![social](https://user-images.githubusercontent.com/63004951/169591868-b5b0533f-33dc-4d40-a896-508e026d9b19.gif)



[PLATFORM-4147]: https://artsyproduct.atlassian.net/browse/PLATFORM-4147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ