### PR TITLE
refactor: add alert to verify email after update

### DIFF
--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
@@ -78,7 +78,7 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
               sendToast({
                 variant: "alert",
                 message:
-                  "Please confirm your new email for this update to take effect.",
+                  "Please confirm your new email for this update to take effect",
               })
             }
 

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
@@ -67,9 +67,16 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
               },
             })
 
+            // If the email was updated, inform the user that they will need to
+            // confirm the new email address before we will update it.
+            const message =
+              email == me.email
+                ? "Information updated succesfully"
+                : "Information updated succesfully. Please confirm your new email for this update to take effect."
+
             sendToast({
               variant: "success",
-              message: "Information updated successfully",
+              message,
             })
 
             const updatedMe = updateMyUserProfile?.me

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
@@ -69,7 +69,7 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
 
             sendToast({
               variant: "success",
-              message: "Information updated succesfully",
+              message: "Information updated successfully",
             })
 
             // If the email was updated, inform the user that they will need to

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
@@ -67,17 +67,20 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
               },
             })
 
-            // If the email was updated, inform the user that they will need to
-            // confirm the new email address before we will update it.
-            const message =
-              email == me.email
-                ? "Information updated succesfully"
-                : "Information updated succesfully. Please confirm your new email for this update to take effect."
-
             sendToast({
               variant: "success",
-              message,
+              message: "Information updated succesfully",
             })
+
+            // If the email was updated, inform the user that they will need to
+            // confirm the new email address before we will update it.
+            if (email !== me.email) {
+              sendToast({
+                variant: "alert",
+                message:
+                  "Please confirm your new email for this update to take effect.",
+              })
+            }
 
             const updatedMe = updateMyUserProfile?.me
 


### PR DESCRIPTION
The type of this PR is: **Enhancement**

This PR solves [PLATFORM-4179]

### Description

This PR adds an alert message after a user updates their email instructing them to verify their email address. It supports the backend changes being made as part of this [ticket](https://artsyproduct.atlassian.net/browse/PLATFORM-4178), and will not be merged until that work is complete. 

#### Considerations

I don't love the two toasts, but I felt it made the action require more clear to the user. If people feel strongly, I'm happy to revert to the alternative approach shown below, with the action required message being part of the success toast message. 

Current Approach:
<img width="2144" alt="Screen Shot 2022-05-24 at 4 14 15 PM" src="https://user-images.githubusercontent.com/38149304/170126948-8661166c-0ba0-4a53-8aa2-f07fd9f7096c.png">


Alternative Approach:
<img width="1998" alt="Screen Shot 2022-05-24 at 4 14 51 PM" src="https://user-images.githubusercontent.com/38149304/170126963-1a48fa4c-af81-49ad-818f-1aea912f7242.png">

### Follow-up
Update [related integrity test.](https://github.com/artsy/integrity/blob/5dac98724c8500498156d8f491fceea16a5fbd53/cypress/integration/velocity/authentication/userAccount.spec.ts#L36)


[PLATFORM-4179]: https://artsyproduct.atlassian.net/browse/PLATFORM-4179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ