### PR TITLE
fix: Editioned artworks were wrongfully being marked as unavailable

### DIFF
--- a/src/v2/Apps/Conversation/Components/EditionSelectBox.tsx
+++ b/src/v2/Apps/Conversation/Components/EditionSelectBox.tsx
@@ -25,7 +25,7 @@ export const EditionSelectBox: React.FC<Props> = ({
   selected,
   onSelect,
 }) => {
-  const isOfferable = !!edition.isOfferableFromInquiry
+  const isOfferable = !!edition.isOfferableFromInquiry || !!edition.isOfferable
 
   return (
     <BorderedRadio
@@ -66,6 +66,7 @@ export const EditionSelectBoxFragmentContainer = createFragmentContainer(
         internalID
         editionOf
         isOfferableFromInquiry
+        isOfferable
         listPrice {
           ... on Money {
             display

--- a/src/v2/__generated__/ConfirmArtworkModalQuery.graphql.ts
+++ b/src/v2/__generated__/ConfirmArtworkModalQuery.graphql.ts
@@ -89,6 +89,7 @@ fragment EditionSelectBox_edition on EditionSet {
   internalID
   editionOf
   isOfferableFromInquiry
+  isOfferable
   listPrice {
     __typename
     ... on Money {
@@ -430,6 +431,13 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "kind": "ScalarField",
+                "name": "isOfferable",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "concreteType": null,
                 "kind": "LinkedField",
                 "name": "listPrice",
@@ -481,12 +489,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "69939648cc2405a8fd51fea3f19588d5",
+    "cacheID": "70d7e347a770d9e3323200388db46054",
     "id": null,
     "metadata": {},
     "name": "ConfirmArtworkModalQuery",
     "operationKind": "query",
-    "text": "query ConfirmArtworkModalQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ConfirmArtworkModal_artwork\n    id\n  }\n}\n\nfragment CollapsibleArtworkDetails_artwork on Artwork {\n  image {\n    resized(width: 40, height: 40) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  internalID\n  title\n  date\n  saleMessage\n  attributionClass {\n    name\n    id\n  }\n  category\n  manufacturer\n  publisher\n  medium\n  conditionDescription {\n    details\n  }\n  certificateOfAuthenticity {\n    details\n  }\n  framed {\n    details\n  }\n  dimensions {\n    in\n    cm\n  }\n  signatureInfo {\n    details\n  }\n  artistNames\n}\n\nfragment ConfirmArtworkButton_artwork on Artwork {\n  internalID\n}\n\nfragment ConfirmArtworkModal_artwork on Artwork {\n  ...CollapsibleArtworkDetails_artwork\n  ...ConfirmArtworkButton_artwork\n  internalID\n  isEdition\n  editionSets {\n    internalID\n    ...EditionSelectBox_edition\n    id\n  }\n}\n\nfragment EditionSelectBox_edition on EditionSet {\n  internalID\n  editionOf\n  isOfferableFromInquiry\n  listPrice {\n    __typename\n    ... on Money {\n      display\n    }\n    ... on PriceRange {\n      display\n    }\n  }\n  dimensions {\n    cm\n    in\n  }\n}\n"
+    "text": "query ConfirmArtworkModalQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ConfirmArtworkModal_artwork\n    id\n  }\n}\n\nfragment CollapsibleArtworkDetails_artwork on Artwork {\n  image {\n    resized(width: 40, height: 40) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  internalID\n  title\n  date\n  saleMessage\n  attributionClass {\n    name\n    id\n  }\n  category\n  manufacturer\n  publisher\n  medium\n  conditionDescription {\n    details\n  }\n  certificateOfAuthenticity {\n    details\n  }\n  framed {\n    details\n  }\n  dimensions {\n    in\n    cm\n  }\n  signatureInfo {\n    details\n  }\n  artistNames\n}\n\nfragment ConfirmArtworkButton_artwork on Artwork {\n  internalID\n}\n\nfragment ConfirmArtworkModal_artwork on Artwork {\n  ...CollapsibleArtworkDetails_artwork\n  ...ConfirmArtworkButton_artwork\n  internalID\n  isEdition\n  editionSets {\n    internalID\n    ...EditionSelectBox_edition\n    id\n  }\n}\n\nfragment EditionSelectBox_edition on EditionSet {\n  internalID\n  editionOf\n  isOfferableFromInquiry\n  isOfferable\n  listPrice {\n    __typename\n    ... on Money {\n      display\n    }\n    ... on PriceRange {\n      display\n    }\n  }\n  dimensions {\n    cm\n    in\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ConfirmArtworkModal_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ConfirmArtworkModal_Test_Query.graphql.ts
@@ -85,6 +85,7 @@ fragment EditionSelectBox_edition on EditionSet {
   internalID
   editionOf
   isOfferableFromInquiry
+  isOfferable
   listPrice {
     __typename
     ... on Money {
@@ -461,6 +462,13 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "kind": "ScalarField",
+                "name": "isOfferable",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "concreteType": null,
                 "kind": "LinkedField",
                 "name": "listPrice",
@@ -512,7 +520,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4eee81aeba0a29e602f93477efdbf4ea",
+    "cacheID": "6166702866245cd74ec299b4604ad400",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -552,6 +560,7 @@ return {
         "artwork.editionSets.editionOf": (v7/*: any*/),
         "artwork.editionSets.id": (v8/*: any*/),
         "artwork.editionSets.internalID": (v8/*: any*/),
+        "artwork.editionSets.isOfferable": (v11/*: any*/),
         "artwork.editionSets.isOfferableFromInquiry": (v11/*: any*/),
         "artwork.editionSets.listPrice": {
           "enumValues": null,
@@ -593,7 +602,7 @@ return {
     },
     "name": "ConfirmArtworkModal_Test_Query",
     "operationKind": "query",
-    "text": "query ConfirmArtworkModal_Test_Query {\n  artwork(id: \"xxx\") {\n    ...ConfirmArtworkModal_artwork\n    id\n  }\n}\n\nfragment CollapsibleArtworkDetails_artwork on Artwork {\n  image {\n    resized(width: 40, height: 40) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  internalID\n  title\n  date\n  saleMessage\n  attributionClass {\n    name\n    id\n  }\n  category\n  manufacturer\n  publisher\n  medium\n  conditionDescription {\n    details\n  }\n  certificateOfAuthenticity {\n    details\n  }\n  framed {\n    details\n  }\n  dimensions {\n    in\n    cm\n  }\n  signatureInfo {\n    details\n  }\n  artistNames\n}\n\nfragment ConfirmArtworkButton_artwork on Artwork {\n  internalID\n}\n\nfragment ConfirmArtworkModal_artwork on Artwork {\n  ...CollapsibleArtworkDetails_artwork\n  ...ConfirmArtworkButton_artwork\n  internalID\n  isEdition\n  editionSets {\n    internalID\n    ...EditionSelectBox_edition\n    id\n  }\n}\n\nfragment EditionSelectBox_edition on EditionSet {\n  internalID\n  editionOf\n  isOfferableFromInquiry\n  listPrice {\n    __typename\n    ... on Money {\n      display\n    }\n    ... on PriceRange {\n      display\n    }\n  }\n  dimensions {\n    cm\n    in\n  }\n}\n"
+    "text": "query ConfirmArtworkModal_Test_Query {\n  artwork(id: \"xxx\") {\n    ...ConfirmArtworkModal_artwork\n    id\n  }\n}\n\nfragment CollapsibleArtworkDetails_artwork on Artwork {\n  image {\n    resized(width: 40, height: 40) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  internalID\n  title\n  date\n  saleMessage\n  attributionClass {\n    name\n    id\n  }\n  category\n  manufacturer\n  publisher\n  medium\n  conditionDescription {\n    details\n  }\n  certificateOfAuthenticity {\n    details\n  }\n  framed {\n    details\n  }\n  dimensions {\n    in\n    cm\n  }\n  signatureInfo {\n    details\n  }\n  artistNames\n}\n\nfragment ConfirmArtworkButton_artwork on Artwork {\n  internalID\n}\n\nfragment ConfirmArtworkModal_artwork on Artwork {\n  ...CollapsibleArtworkDetails_artwork\n  ...ConfirmArtworkButton_artwork\n  internalID\n  isEdition\n  editionSets {\n    internalID\n    ...EditionSelectBox_edition\n    id\n  }\n}\n\nfragment EditionSelectBox_edition on EditionSet {\n  internalID\n  editionOf\n  isOfferableFromInquiry\n  isOfferable\n  listPrice {\n    __typename\n    ... on Money {\n      display\n    }\n    ... on PriceRange {\n      display\n    }\n  }\n  dimensions {\n    cm\n    in\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/EditionSelectBox_edition.graphql.ts
+++ b/src/v2/__generated__/EditionSelectBox_edition.graphql.ts
@@ -8,6 +8,7 @@ export type EditionSelectBox_edition = {
     readonly internalID: string;
     readonly editionOf: string | null;
     readonly isOfferableFromInquiry: boolean | null;
+    readonly isOfferable: boolean | null;
     readonly listPrice: {
         readonly display?: string | null | undefined;
     } | null;
@@ -65,6 +66,13 @@ return {
     {
       "alias": null,
       "args": null,
+      "kind": "ScalarField",
+      "name": "isOfferable",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": null,
       "kind": "LinkedField",
       "name": "listPrice",
@@ -115,5 +123,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'bed44602aa3d225b35cb8b5a9aa189a0';
+(node as any).hash = 'b31cac2e039131114a5188f46251511e';
 export default node;


### PR DESCRIPTION
The type of this PR is Bugfix.

This PR solves [NX-3172]

### Description
Edition selection modal displayed editions as unavailable unless explicitly marked as `isOfferableFromInquiry`.  Since the release of MOOAEA, this should've considered both `isOfferableFromInquiry` and `isOfferable`.

Reported by @chr-tatu 
cc @artsy/negotiate-devs 
