### PR TITLE
fix: breaking artwork test

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkLightbox.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkLightbox.tsx
@@ -24,7 +24,7 @@ const ArtworkLightbox: React.FC<ArtworkLightboxProps> = ({
   ...rest
 }) => {
   const images = compact(artwork.images)
-  const hasGeometry = !!images[0].resized?.width
+  const hasGeometry = !!images[0]?.resized?.width
 
   const { resized, fallback, placeholder, isDefault } = images[activeIndex]
   const image = hasGeometry ? resized : fallback


### PR DESCRIPTION
The type of this PR is: **Bugfix**


This PR addresses an issue breaking integrity tests related to the `Artwork` page. This was coupled with two new errors popping up in sentry ([one](https://sentry.io/organizations/artsynet/issues/2340820754/?project=159064), [two](https://sentry.io/organizations/artsynet/issues/2301113459/?project=159064)). The first was resolved by #10153. This addresses the second. 

This seems to be related to the work on #9870. @laurabeth, @jonallured - Not sure if this is enough to resolve the issue or if this surfaced a bug requiring additional work?

[Slack thread](https://artsy.slack.com/archives/C02BC3HEJ/p1653428106310039)