### PR TITLE
bugfix(artwork-lightbox): make lightbox safer

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkLightbox.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkLightbox.tsx
@@ -23,14 +23,17 @@ const ArtworkLightbox: React.FC<ArtworkLightboxProps> = ({
   onClick,
   ...rest
 }) => {
+  const { user } = useSystemContext()
+  const isTeam = userIsTeam(user)
   const images = compact(artwork.images)
   const hasGeometry = !!images[0]?.resized?.width
 
+  if (!images?.[activeIndex]) {
+    return null
+  }
+
   const { resized, fallback, placeholder, isDefault } = images[activeIndex]
   const image = hasGeometry ? resized : fallback
-
-  const { user } = useSystemContext()
-  const isTeam = userIsTeam(user)
 
   if (!image) {
     return null

--- a/src/v2/Apps/Artwork/Components/__tests__/ArtworkLightbox.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/__tests__/ArtworkLightbox.jest.tsx
@@ -1,0 +1,38 @@
+import { graphql } from "react-relay"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { ArtworkLightboxFragmentContainer } from "../ArtworkLightbox"
+
+jest.unmock("react-relay")
+jest.mock("react-head", () => ({
+  Link: () => null,
+}))
+
+describe("ArtworkLightbox", () => {
+  const setup = (
+    passedProps: { activeIndex: number | null } = { activeIndex: 0 }
+  ) => {
+    const { getWrapper } = setupTestWrapper({
+      Component: (props: any) => (
+        <ArtworkLightboxFragmentContainer {...props} {...passedProps} />
+      ),
+      query: graphql`
+        query ArtworkLightboxTestQuery {
+          artwork(id: "foo") {
+            ...ArtworkLightbox_artwork
+          }
+        }
+      `,
+    })
+    return { getWrapper }
+  }
+
+  it("does not error out if activeIndex is undefined", () => {
+    const wrapper = setup({ activeIndex: null }).getWrapper()
+    expect(wrapper.html()).toBeFalsy()
+  })
+
+  it("renders correctly", () => {
+    const wrapper = setup().getWrapper()
+    expect(wrapper.find("Image").length).toBeTruthy()
+  })
+})

--- a/src/v2/__generated__/ArtworkLightboxTestQuery.graphql.ts
+++ b/src/v2/__generated__/ArtworkLightboxTestQuery.graphql.ts
@@ -1,0 +1,233 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtworkLightboxTestQueryVariables = {};
+export type ArtworkLightboxTestQueryResponse = {
+    readonly artwork: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtworkLightbox_artwork">;
+    } | null;
+};
+export type ArtworkLightboxTestQuery = {
+    readonly response: ArtworkLightboxTestQueryResponse;
+    readonly variables: ArtworkLightboxTestQueryVariables;
+};
+
+
+
+/*
+query ArtworkLightboxTestQuery {
+  artwork(id: "foo") {
+    ...ArtworkLightbox_artwork
+    id
+  }
+}
+
+fragment ArtworkLightbox_artwork on Artwork {
+  formattedMetadata
+  images {
+    isDefault
+    placeholder: url(version: ["small", "medium"])
+    fallback: cropped(width: 800, height: 800, version: ["normalized", "larger", "large"]) {
+      width
+      height
+      src
+      srcSet
+    }
+    resized(width: 800, height: 800, version: ["normalized", "larger", "large"]) {
+      width
+      height
+      src
+      srcSet
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "foo"
+  }
+],
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "height",
+    "value": 800
+  },
+  {
+    "kind": "Literal",
+    "name": "version",
+    "value": [
+      "normalized",
+      "larger",
+      "large"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 800
+  }
+],
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "src",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtworkLightboxTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtworkLightbox_artwork"
+          }
+        ],
+        "storageKey": "artwork(id:\"foo\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtworkLightboxTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "formattedMetadata",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "images",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isDefault",
+                "storageKey": null
+              },
+              {
+                "alias": "placeholder",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": [
+                      "small",
+                      "medium"
+                    ]
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:[\"small\",\"medium\"])"
+              },
+              {
+                "alias": "fallback",
+                "args": (v1/*: any*/),
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": (v2/*: any*/),
+                "storageKey": "cropped(height:800,version:[\"normalized\",\"larger\",\"large\"],width:800)"
+              },
+              {
+                "alias": null,
+                "args": (v1/*: any*/),
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v2/*: any*/),
+                "storageKey": "resized(height:800,version:[\"normalized\",\"larger\",\"large\"],width:800)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "artwork(id:\"foo\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1881fd1429fafc312bdf03cbbd454d80",
+    "id": null,
+    "metadata": {},
+    "name": "ArtworkLightboxTestQuery",
+    "operationKind": "query",
+    "text": "query ArtworkLightboxTestQuery {\n  artwork(id: \"foo\") {\n    ...ArtworkLightbox_artwork\n    id\n  }\n}\n\nfragment ArtworkLightbox_artwork on Artwork {\n  formattedMetadata\n  images {\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    fallback: cropped(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'd89c107ad8a376c89f12778bd9f949f3';
+export default node;


### PR DESCRIPTION
The type of this PR is: **Bugfix**

### Description

This makes the ArtworkLightbox a bit safer with a guard, and adds a test. 

Repo steps:
- on staging, log out
- visit https://staging.artsy.net/artwork/628e9618880cda000d5fb82e
- should get 500 error, due to server-side render pass failing [around here](https://github.com/artsy/force/blob/main/src/v2/Apps/Artwork/Components/ArtworkLightbox.tsx#L29)
- Does _not_ fail on localhost

@laurabeth / @dzucconi - when y'all get a sec please investigate why `activeIndex` might be null as that's what seems to be leading to this error. Nothing jumps immediately out. 


See [this thread](https://artsy.slack.com/archives/C02BC3HEJ/p1653428106310039) for more info. 