### PR TITLE
fix: disable text highlighting within range slider UI

### DIFF
--- a/src/v2/Components/Range.tsx
+++ b/src/v2/Components/Range.tsx
@@ -15,6 +15,7 @@ const StyledRange = styled(RCRange)`
   height: ${RANGE_DOT_SIZE}px;
   width: 100%;
   touch-action: none;
+  user-select: none;
 
   .rc-slider-rail {
     width: 100%;


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR solves [FX-3995]

### Description

Fixes a minor issue where a user may inadvertently highlight a selection which includes the range slider UI, which is visually noisy and not really meaningful


## Before

https://user-images.githubusercontent.com/140521/171226922-f381deb8-4072-4fb6-956c-21f6f96e4fc9.MP4


## After

Note that some text remains selectable, consistent with other parts of the filter UI.

https://user-images.githubusercontent.com/140521/171226924-cb42ffe9-269e-48fe-ad4e-40b040345cdb.MP4





[FX-3995]: https://artsyproduct.atlassian.net/browse/FX-3995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ