### PR TITLE
feat: re-enable new color filtering palette

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
+++ b/src/v2/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
@@ -5,8 +5,7 @@ describe("getMetadata", () => {
     it("formats medium types", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
         medium: "painting",
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-        color: null,
+        color: undefined,
       })
       expect(title).toBe("Paintings - For Sale on Artsy")
       expect(breadcrumbTitle).toBe("Paintings")
@@ -18,8 +17,7 @@ describe("getMetadata", () => {
     it("falls back to fallback meta if medium is invalid", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
         medium: "foo" as any,
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-        color: null,
+        color: undefined,
       })
       expect(title).toBe("Collect | Artsy")
       expect(breadcrumbTitle).toBe("Collect")
@@ -32,8 +30,7 @@ describe("getMetadata", () => {
   describe("color", () => {
     it("formats color types", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-        medium: null,
+        medium: undefined,
         color: "red",
       })
 
@@ -46,8 +43,7 @@ describe("getMetadata", () => {
 
     it("falls back to fallback meta if medium is invalid", () => {
       const { title, breadcrumbTitle, description } = getMetadata({
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-        medium: null,
+        medium: undefined,
         color: "foo" as any,
       })
       expect(title).toBe("Collect | Artsy")
@@ -60,10 +56,8 @@ describe("getMetadata", () => {
 
   it("formats default types", () => {
     const { title, breadcrumbTitle, description } = getMetadata({
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      medium: null,
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      color: null,
+      medium: undefined,
+      color: undefined,
     })
 
     expect(title).toBe("Collect | Artsy")

--- a/src/v2/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
+++ b/src/v2/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
@@ -15,21 +15,18 @@ export type Medium =
 
 export type Color =
   | "black-and-white"
-  | "darkblue"
-  | "darkgreen"
-  | "darkviolet"
-  | "gold"
-  | "lightblue"
-  | "lightgreen"
+  | "blue"
+  | "gray"
+  | "green"
   | "orange"
   | "pink"
+  | "purple"
   | "red"
-  | "violet"
   | "yellow"
 
 interface Props {
-  medium: Medium
-  color: Color
+  medium: Medium | undefined
+  color: Color | undefined
 }
 
 export function getMetadata({ medium, color }: Props) {
@@ -108,23 +105,14 @@ export function getMetadata({ medium, color }: Props) {
       case "black-and-white":
         title = "Black and White Art"
         break
-      case "darkblue":
-        title = "Blue Art"
-        break
-      case "darkgreen":
-        title = "Dark Green Art"
-        break
-      case "darkviolet":
-        title = "Dark Violet Art"
-        break
-      case "gold":
-        title = "Gold Art"
-        break
-      case "lightblue":
-        title = "Light Blue Art"
-        break
-      case "lightgreen":
+      case "green":
         title = "Green Art"
+        break
+      case "gray":
+        title = "Gray Art"
+        break
+      case "blue":
+        title = "Blue Art"
         break
       case "orange":
         title = "Orange Art"
@@ -135,8 +123,8 @@ export function getMetadata({ medium, color }: Props) {
       case "red":
         title = "Red Art"
         break
-      case "violet":
-        title = "Violet Art"
+      case "purple":
+        title = "Purple Art"
         break
       case "yellow":
         title = "Yellow Art"

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -21,19 +21,15 @@ import { useFilterLabelCountByKey } from "../Utils/useFilterLabelCountByKey"
 import { sortResults } from "./Utils/sortResults"
 
 export const COLOR_OPTIONS = [
+  { hex: "#BB392D", value: "red", name: "Red" },
+  { hex: "#EA6B1F", value: "orange", name: "Orange" },
+  { hex: "#E2B929", value: "yellow", name: "Yellow" },
+  { hex: "#00674A", value: "green", name: "Green" },
+  { hex: "#0A1AB4", value: "blue", name: "Blue" },
+  { hex: "#7B3D91", value: "purple", name: "Purple" },
   { hex: "#ffffff", value: "black-and-white", name: "Black and White" },
-  { hex: "#ff0000", value: "red", name: "Red" },
-  { hex: "#fbe854", value: "yellow", name: "Yellow" },
-  { hex: "#f7923a", value: "orange", name: "Orange" },
-  { hex: "#fb81cd", value: "pink", name: "Pink" },
-  { hex: "#b82c83", value: "violet", name: "Violet" },
-  { hex: "#daa520", value: "gold", name: "Gold" },
-  { hex: "#f1572c", value: "darkorange", name: "Dark Orange" },
-  { hex: "#217c44", value: "darkgreen", name: "Dark Green" },
-  { hex: "#0a1ab4", value: "darkblue", name: "Dark Blue" },
-  { hex: "#642b7f", value: "darkviolet", name: "Dark Violet" },
-  { hex: "#bccc46", value: "lightgreen", name: "Light Green" },
-  { hex: "#c2d5f1", value: "lightblue", name: "Light Blue" },
+  { hex: "#C2C2C2", value: "gray", name: "Gray" },
+  { hex: "#E1ADCD", value: "pink", name: "Pink" },
 ]
 
 type ColorOption = typeof COLOR_OPTIONS[number]

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
@@ -38,7 +38,7 @@ describe("ColorFilter", () => {
 
     wrapper.find("Checkbox").first().simulate("click")
 
-    expect(context.filters.colors).toEqual(["black-and-white"])
+    expect(context.filters.colors).toEqual(["red"])
   })
 
   it("selects multiple colors when clicked", () => {
@@ -49,7 +49,7 @@ describe("ColorFilter", () => {
     wrapper.find("Checkbox").first().simulate("click")
     wrapper.find("Checkbox").last().simulate("click")
 
-    expect(context.filters.colors).toEqual(["black-and-white", "violet"])
+    expect(context.filters.colors).toEqual(["red", "purple"])
   })
 
   it("unselects a selected a color when clicked", () => {
@@ -60,11 +60,11 @@ describe("ColorFilter", () => {
     wrapper.find("Checkbox").first().simulate("click")
     wrapper.find("Checkbox").last().simulate("click")
 
-    expect(context.filters.colors).toEqual(["black-and-white", "violet"])
+    expect(context.filters.colors).toEqual(["red", "purple"])
 
     wrapper.find("Checkbox").first().simulate("click")
 
-    expect(context.filters.colors).toEqual(["violet"])
+    expect(context.filters.colors).toEqual(["purple"])
   })
 
   describe("the `expanded` prop", () => {


### PR DESCRIPTION
~Blocked by https://github.com/artsy/gravity/pull/15407 + a full artwork reindex, but otherwise ready for review~ all good now 👍🏽 

The type of this PR is: **Feature**

This PR solves [FX-4001]

### Description

This reverts the revert in 2b25e68979007aa2698e4e43e08dae82f34e1128, in order to re-enable the updated color filtering UIs, with an updated palette of color swatches to choose from.

(Eventually we'll PR a change to _drop_ support for the _old_ colors).

[FX-4001]: https://artsyproduct.atlassian.net/browse/FX-4001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ