### PR TITLE
chore(FX-4005): display "Saved" label when artwork is saved

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -24,6 +24,7 @@ import {
   Spacer,
   Text,
   Popover,
+  TextProps,
 } from "@artsy/palette"
 import { userIsAdmin, userIsTeam } from "v2/Utils/user"
 import { themeGet } from "@styled-system/theme-get"
@@ -311,10 +312,17 @@ interface UtilButtonProps {
   download?: string
   selected?: boolean
   label?: string
+  longestLabel?: string
   Icon?: React.ReactNode
   Component?: typeof UtilButtonButton | typeof UtilButtonLink
   onClick?: () => void
 }
+
+type UtilButtonInnerTextProps = Pick<
+  UtilButtonProps,
+  "label" | "longestLabel"
+> &
+  TextProps
 
 export const UtilButton: React.ForwardRefExoticComponent<
   UtilButtonProps & {
@@ -325,6 +333,7 @@ export const UtilButton: React.ForwardRefExoticComponent<
     {
       href,
       label,
+      longestLabel,
       name,
       onClick,
       Icon,
@@ -377,15 +386,39 @@ export const UtilButton: React.ForwardRefExoticComponent<
           <ActionIcon {...rest} fill="currentColor" />
         </Flex>
 
-        {label && (
-          <Text variant="xs" lineHeight={1}>
-            {label}
-          </Text>
-        )}
+        <UtilButtonInnerText
+          label={label}
+          longestLabel={longestLabel}
+          variant="xs"
+          lineHeight={1}
+        />
       </Component>
     )
   }
 )
+
+const UtilButtonInnerText: React.FC<UtilButtonInnerTextProps> = ({
+  label,
+  longestLabel,
+  ...rest
+}) => {
+  if (!label) {
+    return null
+  }
+
+  if (longestLabel) {
+    return (
+      <Box position="relative">
+        <VisibleText {...rest}>{label}</VisibleText>
+        <HiddenText aria-hidden="true" {...rest}>
+          {longestLabel}
+        </HiddenText>
+      </Box>
+    )
+  }
+
+  return <Text {...rest}>{label}</Text>
+}
 
 const utilButtonMixin = css`
   display: flex;
@@ -412,6 +445,18 @@ const Container = styled(Flex)`
   user-select: none;
   justify-content: center;
   align-items: center;
+`
+
+const VisibleText = styled(Text)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`
+
+const HiddenText = styled(Text)`
+  opacity: 0;
+  pointer-events: none;
 `
 
 ArtworkActionsFragmentContainer.displayName = "ArtworkActions"

--- a/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -420,13 +420,26 @@ const UtilButtonInnerText: React.FC<UtilButtonInnerTextProps> = ({
   return <Text {...rest}>{label}</Text>
 }
 
+const VisibleText = styled(Text)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`
+
+const HiddenText = styled(Text)`
+  opacity: 0;
+  pointer-events: none;
+`
+
 const utilButtonMixin = css`
   display: flex;
   align-items: center;
   justify-content: center;
   color: ${themeGet("colors.black100")};
 
-  &:hover {
+  &:hover,
+  &:hover ${VisibleText} {
     color: ${themeGet("colors.blue100")};
     text-decoration: underline;
   }
@@ -445,18 +458,6 @@ const Container = styled(Flex)`
   user-select: none;
   justify-content: center;
   align-items: center;
-`
-
-const VisibleText = styled(Text)`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-`
-
-const HiddenText = styled(Text)`
-  opacity: 0;
-  pointer-events: none;
 `
 
 ArtworkActionsFragmentContainer.displayName = "ArtworkActions"

--- a/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
@@ -47,6 +47,7 @@ const ArtworkActionsSaveButton: React.FC<ArtworkActionsSaveButtonProps> = ({
         name="heart"
         Icon={isSaved ? FilledIcon : HeartIcon}
         label={isSaved ? "Saved" : "Save"}
+        longestLabel="Saved"
         onClick={handleSave}
       />
     )

--- a/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
@@ -5,7 +5,7 @@ import {
   HeartFillIcon,
   HeartIcon,
 } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSaveArtwork } from "v2/Components/Artwork/SaveButton/useSaveArtwork"
 import { ArtworkActionsSaveButton_artwork } from "v2/__generated__/ArtworkActionsSaveButton_artwork.graphql"
@@ -46,7 +46,7 @@ const ArtworkActionsSaveButton: React.FC<ArtworkActionsSaveButtonProps> = ({
       <UtilButton
         name="heart"
         Icon={isSaved ? FilledIcon : HeartIcon}
-        label="Save"
+        label={isSaved ? "Saved" : "Save"}
         onClick={handleSave}
       />
     )


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4005]

Review app: https://saved-label-on-artwork-page.artsy.net/artwork/banksy-flower-thrower-13

### Acceptance Criteria
* Given a collector
* And I am on an artwork page
* And the artwork is not yet saved
* When I click the save control
* The control text changes to “Saved”
* And "Saved" label should not shift other buttons to the right

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/171868173-d3d666dd-2250-4c55-be65-6c5faf8e570e.mp4

#### After

https://user-images.githubusercontent.com/3513494/171868236-6ebf6433-4eba-4fcb-a55b-f7812eac700b.mp4



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-4005]: https://artsyproduct.atlassian.net/browse/FX-4005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ