### PR TITLE
fix(standards): replace setImmediate with setTimeout

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -247,7 +247,7 @@
         "filename": "src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx",
         "hashed_secret": "d62b42cc21382044595c7c5131b0f28e8588ae62",
         "is_verified": false,
-        "line_number": 41
+        "line_number": 40
       }
     ],
     "src/v2/Apps/__tests__/Fixtures/Artwork/ArtistInfo.ts": [
@@ -601,5 +601,5 @@
       }
     ]
   },
-  "generated_at": "2022-05-31T17:47:11Z"
+  "generated_at": "2022-06-03T18:13:26Z"
 }

--- a/package.json
+++ b/package.json
@@ -231,7 +231,6 @@
     "styled-system": "5.1.5",
     "stylus": "0.54.5",
     "superagent": "3.8.3",
-    "timers-browserify": "2.0.12",
     "tti-polyfill": "0.2.2",
     "typeahead.js": "0.10.5",
     "underscore": "1.12.1",

--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -47,7 +47,6 @@ import { KeywordFilter } from "./Components/KeywordFilter"
 import { MarketStatsQueryRenderer } from "./Components/MarketStats"
 import { SortSelect } from "./Components/SortSelect"
 import { TableSidebar } from "./Components/TableSidebar"
-import { setImmediate } from "timers"
 
 const logger = createLogger("ArtistAuctionResults.tsx")
 
@@ -206,7 +205,10 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
     if (!scrollToMarketSignals) return
 
     // Scroll to auction results if the market signals section is not visible
-    setImmediate(visible ? scrollToMarketSignalsTop : scrollToAuctionResultsTop)
+    setTimeout(
+      visible ? scrollToMarketSignalsTop : scrollToAuctionResultsTop,
+      0
+    )
   }
 
   return (

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -14,7 +14,6 @@ import { MarketStatsQuery } from "v2/__generated__/MarketStatsQuery.graphql"
 import { MarketStats_priceInsightsConnection } from "v2/__generated__/MarketStats_priceInsightsConnection.graphql"
 import { MarketStatsInfoButton } from "./MarketStatsInfoButton"
 import { MarketStatsPlaceholder } from "./MarketStatsPlaceholder"
-import { setImmediate } from "timers"
 
 interface MarketStatsProps {
   priceInsightsConnection: MarketStats_priceInsightsConnection
@@ -241,7 +240,7 @@ export const MarketStatsQueryRenderer: React.FC<{
   const onRender = (visible: boolean) => {
     if (hasRendered) return
 
-    setImmediate(() => setHasRendered(true))
+    setTimeout(() => setHasRendered(true), 0)
     onRendered?.(visible)
   }
 

--- a/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -27,7 +27,6 @@ import { MockPayloadGenerator } from "relay-test-utils"
 
 describe("AuctionResults", () => {
   // @ts-ignore
-  window.setImmediate = jest.fn()
   let breakpoint
   const trackEvent = jest.fn()
   const mockOpenAuthModal = openAuthModal as jest.Mock

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -10,7 +10,6 @@ import { ViewingRoomApp_LoggedOutTest_QueryRawResponse } from "v2/__generated__/
 import { Breakpoint } from "@artsy/palette"
 import { mockLocation } from "v2/DevTools/mockLocation"
 
-jest.useFakeTimers()
 jest.unmock("react-relay")
 jest.mock("v2/System/Router/useRouter", () => ({
   useIsRouteActive: () => false,

--- a/src/v2/DevTools/__tests__/renderUntil.jest.tsx
+++ b/src/v2/DevTools/__tests__/renderUntil.jest.tsx
@@ -1,6 +1,5 @@
 import { mount } from "enzyme"
 import * as React from "react"
-import { setImmediate } from "timers"
 import { Responsive } from "v2/Utils/Responsive"
 import { MockBoot } from "../MockBoot"
 import { renderUntil } from "../renderUntil"
@@ -16,9 +15,9 @@ class Component extends React.Component {
         data: "Loading",
       },
       () =>
-        setImmediate(() => {
+        setTimeout(() => {
           this.setState({ data: "ohai" })
-        })
+        }, 0)
     )
   }
 

--- a/src/v2/DevTools/enzyme+renderUntil.d.ts
+++ b/src/v2/DevTools/enzyme+renderUntil.d.ts
@@ -1,5 +1,5 @@
 import { ReactWrapper } from "enzyme"
-import * as React from "react";
+import * as React from "react"
 
 declare module "enzyme" {
   export type RenderUntilPredicate<P, S, C> = (
@@ -29,9 +29,9 @@ declare module "enzyme" {
 
         // After mounting and the initial render, trigger another render with data.
         componentDidMount() {
-          setImmediate(() => {
+          setTimeout(() => {
             this.setState({ data: "ohai" })
-          })
+          }, 0)
         }
 
         render() {

--- a/src/v2/DevTools/renderUntil.tsx
+++ b/src/v2/DevTools/renderUntil.tsx
@@ -1,6 +1,5 @@
 import { ReactWrapper, RenderUntilPredicate, mount } from "enzyme"
 import * as React from "react"
-import { setImmediate } from "timers"
 
 function renderUntil<
   P = {},
@@ -17,7 +16,7 @@ function renderUntil<
       if (predicate(this)) {
         resolve(this)
       } else {
-        setImmediate(() => {
+        setTimeout(() => {
           /**
            * Except for after the initial render, we need to make sure the
            * tree gets re-rendered to reflect any changes caused by props or
@@ -25,7 +24,7 @@ function renderUntil<
            */
           this.update()
           wait()
-        })
+        }, 0)
       }
     }
     /**

--- a/src/v2/System/Router/RenderStatus.tsx
+++ b/src/v2/System/Router/RenderStatus.tsx
@@ -10,7 +10,6 @@ import { PageLoader } from "./PageLoader"
 import { AppShell } from "v2/Apps/Components/AppShell"
 import { getENV } from "v2/Utils/getENV"
 import { HttpError } from "found"
-import { setImmediate } from "timers"
 
 const logger = createLogger("Artsy/Router/Utils/RenderStatus")
 
@@ -24,7 +23,7 @@ export const RenderPending = () => {
    * duration of the fetch.
    */
   if (!isFetching) {
-    setImmediate(() => setFetching?.(true))
+    setTimeout(() => setFetching?.(true), 0)
   }
 
   if (isFetching) {
@@ -55,7 +54,7 @@ export const RenderReady = (props: { elements: React.ReactNode }) => {
   const { isFetching, setFetching } = useSystemContext()
 
   if (isFetching) {
-    setImmediate(() => setFetching?.(false))
+    setTimeout(() => setFetching?.(false), 0)
   }
 
   if (!isFetching) {
@@ -77,7 +76,7 @@ export const RenderError: React.FC<{
   const { isFetching, setFetching } = useSystemContext()
 
   if (isFetching) {
-    setImmediate(() => setFetching?.(false))
+    setTimeout(() => setFetching?.(false), 0)
   }
 
   const message =

--- a/src/v2/System/__tests__/SystemContext.jest.tsx
+++ b/src/v2/System/__tests__/SystemContext.jest.tsx
@@ -2,7 +2,6 @@ import { SystemContextProps } from "v2/System"
 import * as Artsy from "v2/System"
 import { render } from "enzyme"
 import * as React from "react"
-import { setImmediate } from "timers"
 
 jest.mock("v2/System/Relay/createRelaySSREnvironment", () => ({
   createRelaySSREnvironment: config => ({
@@ -56,7 +55,7 @@ describe("Artsy context", () => {
               "setUser",
               "user",
             ])
-            setImmediate(done)
+            setTimeout(done, 0)
             return <div />
           }}
         </Artsy.SystemContextConsumer>

--- a/src/v2/Utils/Hooks/useRouteComplete.ts
+++ b/src/v2/Utils/Hooks/useRouteComplete.ts
@@ -1,7 +1,6 @@
 import { useSystemContext } from "v2/System/SystemContext"
 import { useEffect, useState } from "react"
 import { usePrevious } from "v2/Utils/Hooks/usePrevious"
-import { setImmediate } from "timers"
 
 /**
  * Checks to see if a route was previously fetching and has completed.
@@ -20,9 +19,9 @@ export const useRouteComplete = ({
 
       // Wait till after the next tick to set to false, to give react tree
       // ability to execute related tracking handlers
-      setImmediate(() => {
+      setTimeout(() => {
         setIsComplete(false)
-      })
+      }, 0)
     }
   }, [isFetching, onComplete, prevFetching])
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21352,7 +21352,7 @@ timed-out@^4.0.0:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
-timers-browserify@2.0.12, timers-browserify@^2.0.12:
+timers-browserify@^2.0.12:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.12.tgz#44a45c11fbf407f34f97bccd1577c652361b00ee"
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This replaces our non-standard use of `setImmediate` with `setTimeout`. It turns out that `setImmediate` is a [non-standard browser function](https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate) and `setTimeout, 0` does the exact same thing. 

Related: 
- https://github.com/artsy/force/pull/10203
- https://github.com/artsy/force/pull/10198
