### PR TITLE
[WIP- dont merge][GRO-1061] Render active_secondary_market as badge on artist page

### DIFF
--- a/src/v2/Components/ArtistInsight.tsx
+++ b/src/v2/Components/ArtistInsight.tsx
@@ -1,4 +1,4 @@
-import { BlueChipIcon, Box, Flex, Link, Sans, Text } from "@artsy/palette"
+import { BlueChipIcon, Box, Flex, Text } from "@artsy/palette"
 import { track } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
 import * as React from "react"

--- a/src/v2/Components/ArtistInsight.tsx
+++ b/src/v2/Components/ArtistInsight.tsx
@@ -1,38 +1,13 @@
-import { Box, Flex, Link, Sans, Text } from "@artsy/palette"
+import { BlueChipIcon, Box, Flex, Link, Sans, Text } from "@artsy/palette"
 import { track } from "v2/System/Analytics"
 import * as Schema from "v2/System/Analytics/Schema"
-import * as React from "react";
-
-import {
-  AuctionIcon,
-  BlueChipIcon,
-  BookIcon,
-  FairIcon,
-  GroupIcon,
-  MuseumIcon,
-  SoloIcon,
-  TopEmergingIcon,
-  TopEstablishedIcon,
-} from "@artsy/palette"
+import * as React from "react"
 
 interface ArtistInsightProps {
   type: string
   label: string
   value?: string
   entities?: ReadonlyArray<string>
-  themeVersion?: any // FIXME
-}
-
-const ICON_MAPPING = {
-  HIGH_AUCTION: AuctionIcon,
-  SOLO_SHOW: SoloIcon,
-  GROUP_SHOW: GroupIcon,
-  BIENNIAL: FairIcon,
-  REVIEWED: BookIcon,
-  COLLECTED: MuseumIcon,
-  BLUE_CHIP: BlueChipIcon,
-  TOP_ESTABLISHED: TopEstablishedIcon,
-  TOP_EMERGING: TopEmergingIcon,
 }
 
 @track<ArtistInsightProps>(props => ({
@@ -53,40 +28,23 @@ export class ArtistInsight extends React.Component<ArtistInsightProps> {
     this.setState({ expanded: true })
   }
 
-  getTextByTheme() {
-    if (this.props.themeVersion === "v3") {
-      return props => (
-        <Text variant="sm" {...props}>
-          {props.children}
-        </Text>
-      )
-    } else {
-      return props => (
-        <Sans size="2" {...props}>
-          {props.children}
-        </Sans>
-      )
-    }
-  }
-
   renderEntities() {
     const { entities } = this.props
-    const TextWrapper = this.getTextByTheme()
 
     if (!entities || entities.length < 1) {
       return null
     } else if (this.state.expanded) {
       return (
-        <TextWrapper verticalAlign="top" color="black60">
+        <Text variant="sm" verticalAlign="top" color="black60">
           {entities.join(", ")}.
-        </TextWrapper>
+        </Text>
       )
     } else {
       return (
-        <TextWrapper verticalAlign="top" color="black60" textAlign="left">
-          {entities[0]}
+        <Text variant="sm" verticalAlign="top" color="black60" textAlign="left">
+          {/* {entities[0]} */}
 
-          {entities.length > 1 && (
+          {/* {entities.length > 1 && (
             <>
               , and{" "}
               <Link onClick={this.handleExpand.bind(this)}>
@@ -94,50 +52,31 @@ export class ArtistInsight extends React.Component<ArtistInsightProps> {
                 &nbsp;more
               </Link>
             </>
-          )}
-        </TextWrapper>
+          )} */}
+        </Text>
       )
     }
   }
 
-  renderIcon(insightType) {
-    const Component = ICON_MAPPING[insightType]
-
-    return <Component />
-  }
-
   render() {
-    const { label, type, value, entities } = this.props
-    const TextWrapper = this.getTextByTheme()
+    const { label, value, entities } = this.props
 
     if (!(value || (entities && entities.length > 0))) {
       return null
     }
 
     return (
-      <Flex
-        mt={1}
-        width={
-          this.props.themeVersion === "v3"
-            ? ["100%", "100%", "100%", "100%", "50%"]
-            : "100%"
-        }
-        position="relative"
-      >
-        <Flex
-          pr={1}
-          top={this.props.themeVersion === "v2" ? 0 : "3px"}
-          position="relative"
-        >
-          {this.renderIcon(type)}
-        </Flex>
-        <Flex flexDirection="column" pr={2}>
-          <Box>
-            <TextWrapper>{label}</TextWrapper>
-            {value && <TextWrapper color="black60">{value}</TextWrapper>}
-            {this.renderEntities()}
-          </Box>
-        </Flex>
+      <Flex mt={1} width={["100%", "100%", "100%", "100%", "50%"]}>
+        <BlueChipIcon mr={2} />
+        <Box>
+          <Text variant="sm">{label}</Text>
+          {value && (
+            <Text variant="sm" color="black60">
+              {value}
+            </Text>
+          )}
+          {this.renderEntities()}
+        </Box>
       </Flex>
     )
   }

--- a/src/v2/Components/SelectedCareerAchievements.tsx
+++ b/src/v2/Components/SelectedCareerAchievements.tsx
@@ -1,15 +1,6 @@
-import {
-  BorderBox,
-  Box,
-  Flex,
-  Spacer,
-  useThemeConfig,
-  Text,
-} from "@artsy/palette"
+import { Box, Flex, Spacer, Text } from "@artsy/palette"
 import { SelectedCareerAchievements_artist } from "v2/__generated__/SelectedCareerAchievements_artist.graphql"
-
 import { ArtistInsight } from "v2/Components/ArtistInsight"
-import { ArtistInsightsModal } from "v2/Components/ArtistInsightsModal"
 import { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SpaceProps } from "styled-system"
@@ -19,7 +10,6 @@ import { highestCategory, hasSections } from "./ArtistMarketInsights"
 
 export interface SelectedCareerAchievementsProps extends SpaceProps {
   artist: SelectedCareerAchievements_artist
-  themeVersion?: string
   onlyCareerHighlights?: boolean
 }
 
@@ -37,15 +27,11 @@ const CATEGORY_LABEL_MAP = {
 export class SelectedCareerAchievements extends Component<
   SelectedCareerAchievementsProps
 > {
-  state = {
-    showModal: false,
-  }
-
   defaultProps: {
     onlyCareerHighlights: false
   }
 
-  renderAuctionHighlight() {
+  highAuctionRecord() {
     if (
       !this.props.artist.auctionResultsConnection ||
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
@@ -65,11 +51,11 @@ export class SelectedCareerAchievements extends Component<
         type="HIGH_AUCTION"
         label="High auction record"
         value={display}
-        themeVersion={this.props.themeVersion}
       />
     )
   }
-  renderGalleryRepresentation() {
+
+  blueChipRepresentation() {
     const { highlights } = this.props.artist
     // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const { partnersConnection } = highlights
@@ -88,20 +74,33 @@ export class SelectedCareerAchievements extends Component<
           type={type}
           label={label}
           value={CATEGORY_LABEL_MAP[highCategory]}
-          themeVersion={this.props.themeVersion}
         />
       )
     }
   }
 
-  renderInsight(insight) {
+  activeSecondaryMarket() {
+    const isActiveSecondaryMarket = true
+
+    if (isActiveSecondaryMarket) {
+      return (
+        <ArtistInsight
+          key="ACTIVE_SECONDARY_MARKET"
+          type="ACTIVE_SECONDARY_MARKET"
+          label="Active Secondary Market"
+          value="Recent auction results in the Artsy Price Database."
+        />
+      )
+    }
+  }
+
+  careerHighlight(insight) {
     return (
       <ArtistInsight
         key={insight.type}
         type={insight.type}
         label={insight.label}
         entities={insight.entities}
-        themeVersion={this.props.themeVersion}
       />
     )
   }
@@ -122,36 +121,6 @@ export class SelectedCareerAchievements extends Component<
       )
     }
 
-    if (this.props.themeVersion === "v2") {
-      return (
-        <>
-          <ArtistInsightsModal />
-          <Spacer mb={2} />
-
-          <BorderBox pt={1}>
-            <Flex flexDirection="column" alignItems="left" width="100%">
-              <Flex
-                flexDirection="column"
-                flexWrap="wrap"
-                justifyContent="space-between"
-              >
-                {this.renderGalleryRepresentation()}
-                {this.renderAuctionHighlight()}
-
-                {/*  @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
-                {this.props.artist.insights.map(insight => {
-                  return this.renderInsight(insight)
-                })}
-              </Flex>
-            </Flex>
-          </BorderBox>
-
-          {this.props.children}
-        </>
-      )
-    }
-
-    // V3 theme
     return (
       <Box {...this.props}>
         {this.props.onlyCareerHighlights ? (
@@ -161,7 +130,7 @@ export class SelectedCareerAchievements extends Component<
             </Text>
             <Flex flexWrap="wrap" pr={2}>
               {this.props.artist?.insights?.map(insight => {
-                return this.renderInsight(insight)
+                return this.careerHighlight(insight)
               })}
             </Flex>
 
@@ -173,8 +142,9 @@ export class SelectedCareerAchievements extends Component<
           </>
         ) : (
           <Flex flexDirection="column">
-            {this.renderGalleryRepresentation()}
-            {this.renderAuctionHighlight()}
+            {this.activeSecondaryMarket()}
+            {this.blueChipRepresentation()}
+            {this.highAuctionRecord()}
           </Flex>
         )}
       </Box>
@@ -184,18 +154,7 @@ export class SelectedCareerAchievements extends Component<
 
 export const SelectedCareerAchievementsFragmentContainer = createFragmentContainer(
   (props: SelectedCareerAchievementsProps) => {
-    const tokens = useThemeConfig({
-      v2: {
-        version: "v2",
-      },
-      v3: {
-        version: "v3",
-      },
-    })
-
-    return (
-      <SelectedCareerAchievements {...props} themeVersion={tokens.version} />
-    )
+    return <SelectedCareerAchievements {...props} />
   },
   {
     artist: graphql`


### PR DESCRIPTION
The type of this PR is: feat

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1061]

### Description

This PR is to add` active_secondary_market` as a new badge on the Artist page. I am currently in the process of refactoring some older code so... WIP.

TBD
- [ ] change `SelectedCareerAchievements` from class component to functional components 
- [ ] Rework/transform `ArtistInsights` component to render career highlights w/o icons and artist badges with icons (OR separate them out into diff components OR inline them elsewhere)
- [ ] Refactor `SelectedCareerAchievements` spec and include new testing for rendering artist badges
- [ ] Create new component for rendering artist badge blue pills that are buttons

