### PR TITLE
feat(FX-3997): Expand New 'Save' Styling to ShelfArtwork component

### DIFF
--- a/src/v2/Components/Artwork/ShelfArtwork.tsx
+++ b/src/v2/Components/Artwork/ShelfArtwork.tsx
@@ -8,6 +8,7 @@ import { AuthContextModule } from "@artsy/cohesion"
 import styled from "styled-components"
 import { Image, Flex } from "@artsy/palette"
 import { Media } from "v2/Utils/Responsive"
+import { useHoverMetadata } from "./useHoverMetadata"
 
 /**
  * The max height for an image in the carousel
@@ -43,17 +44,22 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
   const { containerProps, isSaveButtonVisible } = useSaveButton({
     isSaved: !!artwork.is_saved,
   })
+  const { isHovered, isHoverEffectEnabled } = useHoverMetadata()
+
+  const shouldShowHoverSaveButton =
+    isHoverEffectEnabled && (!!artwork.is_saved || isSaveButtonVisible)
 
   return (
-    <>
+    <div
+      {...containerProps}
+      data-test="artworkShelfArtwork"
+      data-testid="ShelfArtwork"
+    >
       <RouterLink
         to={artwork?.href}
         display="block"
         textDecoration="none"
         onClick={onClick}
-        data-test="artworkShelfArtwork"
-        data-testid="ShelfArtwork"
-        {...containerProps}
       >
         <ResponsiveContainer artwork={artwork}>
           <Image
@@ -65,14 +71,16 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
             style={{ objectFit: "contain", display: "block" }}
           />
 
-          <Media greaterThan="sm">
-            {isSaveButtonVisible && (
-              <SaveButtonFragmentContainer
-                contextModule={contextModule!}
-                artwork={artwork}
-              />
-            )}
-          </Media>
+          {!isHoverEffectEnabled && (
+            <Media greaterThan="sm">
+              {isSaveButtonVisible && (
+                <SaveButtonFragmentContainer
+                  contextModule={contextModule!}
+                  artwork={artwork}
+                />
+              )}
+            </Media>
+          )}
         </ResponsiveContainer>
       </RouterLink>
 
@@ -80,13 +88,15 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
         <Metadata
           artwork={artwork}
           extended={showExtended}
+          isHovered={isHovered}
           hidePartnerName={hidePartnerName}
           hideArtistName={hideArtistName}
           hideSaleInfo={hideSaleInfo}
           maxWidth={artwork.image?.resized?.width}
+          shouldShowHoverSaveButton={!!shouldShowHoverSaveButton}
         />
       )}
-    </>
+    </div>
   )
 }
 

--- a/src/v2/Components/Artwork/ShelfArtwork.tsx
+++ b/src/v2/Components/Artwork/ShelfArtwork.tsx
@@ -8,7 +8,7 @@ import { AuthContextModule } from "@artsy/cohesion"
 import styled from "styled-components"
 import { Image, Flex } from "@artsy/palette"
 import { Media } from "v2/Utils/Responsive"
-import { useHoverMetadata } from "./useHoverMetadata"
+import { useFeatureFlag } from "v2/System/useFeatureFlag"
 
 /**
  * The max height for an image in the carousel
@@ -44,7 +44,9 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
   const { containerProps, isSaveButtonVisible } = useSaveButton({
     isSaved: !!artwork.is_saved,
   })
-  const { isHovered, isHoverEffectEnabled } = useHoverMetadata()
+  const isHoverEffectEnabled = useFeatureFlag(
+    "force-enable-hover-effect-for-artwork-item"
+  )
 
   const shouldShowHoverSaveButton =
     isHoverEffectEnabled && (!!artwork.is_saved || isSaveButtonVisible)
@@ -88,7 +90,6 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
         <Metadata
           artwork={artwork}
           extended={showExtended}
-          isHovered={isHovered}
           hidePartnerName={hidePartnerName}
           hideArtistName={hideArtistName}
           hideSaleInfo={hideSaleInfo}


### PR DESCRIPTION
Co-authored-by: Dima Tretyak (Dzmitry Tratsiak) <itretyak@ya.ru>

The type of this PR is: **feature**

This PR solves [FX-3997](https://artsyproduct.atlassian.net/browse/FX-3997)

Review app: https://shelf-artwork-save-button.artsy.net/

## Description

Updates the pages which do not have the quick-view functionality to have the new Save button.

## Demo

### Before

https://user-images.githubusercontent.com/3934579/172379667-91c3b3c5-f479-4681-9991-ad13f7a59d89.mp4

### After 

https://user-images.githubusercontent.com/3934579/172379684-74d499b1-5bf7-48a1-9bef-870d7108c424.mp4
