### PR TITLE
fix(NX-3128): avoid to inject an extra separator on artwork badges

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/index.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/index.tsx
@@ -21,7 +21,6 @@ import { useTimer } from "v2/Utils/Hooks/useTimer"
 import { ArtworkSidebarBiddingClosedMessageFragmentContainer } from "./ArtworkSidebarBiddingClosedMessage"
 import { lotIsClosed } from "v2/Apps/Artwork/Utils/lotIsClosed"
 import {
-  shouldRenderAuthenticityCertificate,
   shouldRenderBuyerGuaranteeAndSecurePayment,
   shouldRenderVerifiedSeller,
 } from "../../Utils/badges"
@@ -47,7 +46,6 @@ export const ArtworkSidebar: React.FC<ArtworkSidebarProps> = ({
   const startAt = sale?.startAt
 
   const shouldRenderArtworkBadges =
-    shouldRenderAuthenticityCertificate(artwork) ||
     shouldRenderVerifiedSeller(artwork) ||
     shouldRenderBuyerGuaranteeAndSecurePayment(artwork)
 


### PR DESCRIPTION



The type of this PR is: **Bugfix/Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [NX-3128]

### Description

WHAT: There is a double line below the Contact Gallery button, only for a few use cases.

WHY: The AuthenticityCertificate component [was moved out of the artwork badges zone](https://github.com/artsy/force/pull/10193), but `shouldRenderAuthenticityCertificate` was still defining if `shouldRenderArtworkBadges`.

| Before | After |
| --- | --- |
| <img width="414" alt="image" src="https://user-images.githubusercontent.com/265560/172621851-cd1e1af5-b4cd-409d-819f-af357c218f78.png"> | <img width="419" alt="image" src="https://user-images.githubusercontent.com/265560/172622004-a7acbb80-50db-4e18-8b87-bbe880ac6878.png"> |


cc @artsy/negotiate-devs 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NX-3128]: https://artsyproduct.atlassian.net/browse/NX-3128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ