### PR TITLE
fix: removes offset; removes double focus

### DIFF
--- a/src/v2/Apps/ArtAppraisals/ArtAppraisalsApp.tsx
+++ b/src/v2/Apps/ArtAppraisals/ArtAppraisalsApp.tsx
@@ -38,7 +38,7 @@ const Header: React.FC = () => {
     <FullBleedHeader src="https://files.artsy.net/images/appraisals-header-image.png">
       <Flex
         position="absolute"
-        top={-7}
+        top={0}
         left={0}
         width="100%"
         height="100%"
@@ -63,9 +63,13 @@ const Header: React.FC = () => {
 
             <Spacer mt={4} />
 
-            <a href="mailto:simon.wills@artsymail.com">
-              <Button>Request an Appraisal</Button>
-            </a>
+            <Button
+              // @ts-ignore
+              as="a"
+              href="mailto:simon.wills@artsymail.com"
+            >
+              Request an Appraisal
+            </Button>
           </Column>
         </GridColumns>
       </Flex>


### PR DESCRIPTION
This is actually centered. I think you were trying to offset for the line-height of the headline text. Which I don't think we should do.

Also minor fix: don't wrap buttons in links. It creates a double tabstop and an empty button.