### PR TITLE
feat: Add lot countdown timer + progress bar in bid modal

### DIFF
--- a/src/v2/Apps/Auction/Routes/Bid/AuctionBidRoute.tsx
+++ b/src/v2/Apps/Auction/Routes/Bid/AuctionBidRoute.tsx
@@ -21,6 +21,7 @@ import {
 import { useAuctionTracking } from "v2/Apps/Auction/Hooks/useAuctionTracking"
 import { CreditCardInputProvider } from "v2/Components/CreditCardInput"
 import { ErrorStatus } from "../../Components/Form/ErrorStatus"
+import { ArtworkSidebarAuctionTimerFragmentContainer } from "v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionTimer"
 
 interface AuctionBidRouteProps {
   artwork: AuctionBidRoute_artwork
@@ -110,6 +111,9 @@ const AuctionBidRoute: React.FC<AuctionBidRouteProps> = ({
                 <AuctionLotInfoFragmentContainer
                   saleArtwork={artwork.saleArtwork!}
                 />
+                <ArtworkSidebarAuctionTimerFragmentContainer
+                  artwork={artwork}
+                />
 
                 <Text variant="lg-display">Set Your Max Bid</Text>
 
@@ -176,6 +180,7 @@ export const AuctionBidRouteFragmentContainer = createRefetchContainer(
       fragment AuctionBidRoute_artwork on Artwork {
         slug
         internalID
+        ...ArtworkSidebarAuctionTimer_artwork
         saleArtwork {
           ...AuctionLotInfo_saleArtwork
             @arguments(imageWidth: 150, imageHeight: 150)

--- a/src/v2/Apps/Auction/Routes/Bid/__tests__/AuctionBidRoute.jest.tsx
+++ b/src/v2/Apps/Auction/Routes/Bid/__tests__/AuctionBidRoute.jest.tsx
@@ -241,7 +241,7 @@ describe("AuctionBidRoute", () => {
     ;(wrapper.find("Select").props() as any).onSelect("1000")
 
     expect(spy).toHaveBeenCalledWith({
-      bidderID: "<Bidder-mock-id-7>",
+      bidderID: "<Bidder-mock-id-6>",
       maxBid: "1000",
     })
 

--- a/src/v2/__generated__/AuctionBidRouteQuery.graphql.ts
+++ b/src/v2/__generated__/AuctionBidRouteQuery.graphql.ts
@@ -45,9 +45,26 @@ query AuctionBidRouteQuery(
   }
 }
 
+fragment ArtworkSidebarAuctionTimer_artwork on Artwork {
+  internalID
+  sale {
+    cascadingEndTimeIntervalMinutes
+    isClosed
+    ...AuctionTimer_sale
+    startAt
+    id
+  }
+  saleArtwork {
+    ...LotTimer_saleArtwork
+    endAt
+    id
+  }
+}
+
 fragment AuctionBidRoute_artwork on Artwork {
   slug
   internalID
+  ...ArtworkSidebarAuctionTimer_artwork
   saleArtwork {
     ...AuctionLotInfo_saleArtwork_1WWOz5
     minimumNextBid {
@@ -110,6 +127,25 @@ fragment AuctionLotInfo_saleArtwork_1WWOz5 on SaleArtwork {
     id
   }
 }
+
+fragment AuctionTimer_sale on Sale {
+  liveStartAt
+  endAt
+}
+
+fragment LotTimer_saleArtwork on SaleArtwork {
+  endAt
+  formattedStartDateTime
+  extendedBiddingEndAt
+  lotID
+  sale {
+    startAt
+    extendedBiddingPeriodMinutes
+    extendedBiddingIntervalMinutes
+    internalID
+    id
+  }
+}
 */
 
 const node: ConcreteRequest = (function(){
@@ -157,17 +193,31 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "display",
+  "name": "endAt",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "startAt",
   "storageKey": null
 },
 v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "display",
+  "storageKey": null
+},
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -252,11 +302,129 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "Sale",
+            "kind": "LinkedField",
+            "name": "sale",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cascadingEndTimeIntervalMinutes",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isClosed",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "liveStartAt",
+                "storageKey": null
+              },
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "SaleArtwork",
             "kind": "LinkedField",
             "name": "saleArtwork",
             "plural": false,
             "selections": [
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "formattedStartDateTime",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "extendedBiddingEndAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "lotID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Sale",
+                "kind": "LinkedField",
+                "name": "sale",
+                "plural": false,
+                "selections": [
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "extendedBiddingPeriodMinutes",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "extendedBiddingIntervalMinutes",
+                    "storageKey": null
+                  },
+                  (v4/*: any*/),
+                  (v7/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Bidder",
+                    "kind": "LinkedField",
+                    "name": "bidder",
+                    "plural": false,
+                    "selections": [
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v3/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Bidder",
+                    "kind": "LinkedField",
+                    "name": "registrationStatus",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "qualifiedForBidding",
+                        "storageKey": null
+                      },
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v7/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -290,7 +458,7 @@ return {
                 "name": "currentBid",
                 "plural": false,
                 "selections": [
-                  (v5/*: any*/)
+                  (v8/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -405,7 +573,7 @@ return {
                     "storageKey": null
                   },
                   (v3/*: any*/),
-                  (v6/*: any*/)
+                  (v7/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -417,7 +585,7 @@ return {
                 "name": "minimumNextBid",
                 "plural": false,
                 "selections": [
-                  (v7/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -435,61 +603,15 @@ return {
                 "name": "increments",
                 "plural": true,
                 "selections": [
-                  (v7/*: any*/),
-                  (v5/*: any*/)
+                  (v9/*: any*/),
+                  (v8/*: any*/)
                 ],
                 "storageKey": "increments(useMyMaxBid:true)"
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Sale",
-                "kind": "LinkedField",
-                "name": "sale",
-                "plural": false,
-                "selections": [
-                  (v4/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Bidder",
-                    "kind": "LinkedField",
-                    "name": "bidder",
-                    "plural": false,
-                    "selections": [
-                      (v6/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  (v3/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Bidder",
-                    "kind": "LinkedField",
-                    "name": "registrationStatus",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "qualifiedForBidding",
-                        "storageKey": null
-                      },
-                      (v6/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  (v6/*: any*/)
-                ],
-                "storageKey": null
-              },
-              (v6/*: any*/)
+              }
             ],
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       },
@@ -509,7 +631,7 @@ return {
             "name": "hasQualifiedCreditCards",
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       },
@@ -523,19 +645,19 @@ return {
         "selections": [
           (v4/*: any*/),
           (v3/*: any*/),
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "15066008a94a0a30f937674386afb4e4",
+    "cacheID": "4c8a2432c0d89fecf70bd29066c132b3",
     "id": null,
     "metadata": {},
     "name": "AuctionBidRouteQuery",
     "operationKind": "query",
-    "text": "query AuctionBidRouteQuery(\n  $artworkID: String!\n  $saleID: String!\n) {\n  artwork(id: $artworkID) {\n    ...AuctionBidRoute_artwork\n    id\n  }\n  me {\n    ...AuctionBidRoute_me\n    id\n  }\n  sale(id: $saleID) {\n    ...AuctionBidRoute_sale\n    id\n  }\n}\n\nfragment AuctionBidRoute_artwork on Artwork {\n  slug\n  internalID\n  saleArtwork {\n    ...AuctionLotInfo_saleArtwork_1WWOz5\n    minimumNextBid {\n      cents\n    }\n    increments(useMyMaxBid: true) {\n      cents\n      display\n    }\n    sale {\n      internalID\n      bidder {\n        id\n      }\n      slug\n      registrationStatus {\n        qualifiedForBidding\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment AuctionBidRoute_me on Me {\n  internalID\n  hasQualifiedCreditCards\n}\n\nfragment AuctionBidRoute_sale on Sale {\n  internalID\n  slug\n}\n\nfragment AuctionLotInfo_saleArtwork_1WWOz5 on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  currentBid {\n    display\n  }\n  formattedEndDateTime\n  artwork {\n    internalID\n    date\n    title\n    image {\n      resized(width: 150, height: 150, version: \"medium\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    imageUrl\n    artistNames\n    slug\n    id\n  }\n}\n"
+    "text": "query AuctionBidRouteQuery(\n  $artworkID: String!\n  $saleID: String!\n) {\n  artwork(id: $artworkID) {\n    ...AuctionBidRoute_artwork\n    id\n  }\n  me {\n    ...AuctionBidRoute_me\n    id\n  }\n  sale(id: $saleID) {\n    ...AuctionBidRoute_sale\n    id\n  }\n}\n\nfragment ArtworkSidebarAuctionTimer_artwork on Artwork {\n  internalID\n  sale {\n    cascadingEndTimeIntervalMinutes\n    isClosed\n    ...AuctionTimer_sale\n    startAt\n    id\n  }\n  saleArtwork {\n    ...LotTimer_saleArtwork\n    endAt\n    id\n  }\n}\n\nfragment AuctionBidRoute_artwork on Artwork {\n  slug\n  internalID\n  ...ArtworkSidebarAuctionTimer_artwork\n  saleArtwork {\n    ...AuctionLotInfo_saleArtwork_1WWOz5\n    minimumNextBid {\n      cents\n    }\n    increments(useMyMaxBid: true) {\n      cents\n      display\n    }\n    sale {\n      internalID\n      bidder {\n        id\n      }\n      slug\n      registrationStatus {\n        qualifiedForBidding\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment AuctionBidRoute_me on Me {\n  internalID\n  hasQualifiedCreditCards\n}\n\nfragment AuctionBidRoute_sale on Sale {\n  internalID\n  slug\n}\n\nfragment AuctionLotInfo_saleArtwork_1WWOz5 on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  currentBid {\n    display\n  }\n  formattedEndDateTime\n  artwork {\n    internalID\n    date\n    title\n    image {\n      resized(width: 150, height: 150, version: \"medium\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    imageUrl\n    artistNames\n    slug\n    id\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  liveStartAt\n  endAt\n}\n\nfragment LotTimer_saleArtwork on SaleArtwork {\n  endAt\n  formattedStartDateTime\n  extendedBiddingEndAt\n  lotID\n  sale {\n    startAt\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    internalID\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/AuctionBidRouteTestQuery.graphql.ts
+++ b/src/v2/__generated__/AuctionBidRouteTestQuery.graphql.ts
@@ -39,9 +39,26 @@ query AuctionBidRouteTestQuery {
   }
 }
 
+fragment ArtworkSidebarAuctionTimer_artwork on Artwork {
+  internalID
+  sale {
+    cascadingEndTimeIntervalMinutes
+    isClosed
+    ...AuctionTimer_sale
+    startAt
+    id
+  }
+  saleArtwork {
+    ...LotTimer_saleArtwork
+    endAt
+    id
+  }
+}
+
 fragment AuctionBidRoute_artwork on Artwork {
   slug
   internalID
+  ...ArtworkSidebarAuctionTimer_artwork
   saleArtwork {
     ...AuctionLotInfo_saleArtwork_1WWOz5
     minimumNextBid {
@@ -104,6 +121,25 @@ fragment AuctionLotInfo_saleArtwork_1WWOz5 on SaleArtwork {
     id
   }
 }
+
+fragment AuctionTimer_sale on Sale {
+  liveStartAt
+  endAt
+}
+
+fragment LotTimer_saleArtwork on SaleArtwork {
+  endAt
+  formattedStartDateTime
+  extendedBiddingEndAt
+  lotID
+  sale {
+    startAt
+    extendedBiddingPeriodMinutes
+    extendedBiddingIntervalMinutes
+    internalID
+    id
+  }
+}
 */
 
 const node: ConcreteRequest = (function(){
@@ -132,76 +168,90 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "display",
+  "name": "endAt",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "startAt",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cents",
+  "name": "id",
   "storageKey": null
 },
 v6 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Artwork"
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "display",
+  "storageKey": null
 },
 v7 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "ID"
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cents",
+  "storageKey": null
 },
 v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "String"
+  "type": "Artwork"
 },
 v9 = {
   "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Int"
-},
-v10 = {
-  "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "String"
+  "type": "ID"
 },
-v11 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Float"
-},
-v12 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Sale"
 },
+v11 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v12 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
 v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Bidder"
+  "type": "Boolean"
 },
 v14 = {
   "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v15 = {
+  "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Boolean"
+  "type": "Float"
+},
+v16 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Bidder"
 };
 return {
   "fragment": {
@@ -281,11 +331,129 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "Sale",
+            "kind": "LinkedField",
+            "name": "sale",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cascadingEndTimeIntervalMinutes",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isClosed",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "liveStartAt",
+                "storageKey": null
+              },
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "SaleArtwork",
             "kind": "LinkedField",
             "name": "saleArtwork",
             "plural": false,
             "selections": [
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "formattedStartDateTime",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "extendedBiddingEndAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "lotID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Sale",
+                "kind": "LinkedField",
+                "name": "sale",
+                "plural": false,
+                "selections": [
+                  (v4/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "extendedBiddingPeriodMinutes",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "extendedBiddingIntervalMinutes",
+                    "storageKey": null
+                  },
+                  (v2/*: any*/),
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Bidder",
+                    "kind": "LinkedField",
+                    "name": "bidder",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v1/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Bidder",
+                    "kind": "LinkedField",
+                    "name": "registrationStatus",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "qualifiedForBidding",
+                        "storageKey": null
+                      },
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -319,7 +487,7 @@ return {
                 "name": "currentBid",
                 "plural": false,
                 "selections": [
-                  (v3/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -434,7 +602,7 @@ return {
                     "storageKey": null
                   },
                   (v1/*: any*/),
-                  (v4/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -446,7 +614,7 @@ return {
                 "name": "minimumNextBid",
                 "plural": false,
                 "selections": [
-                  (v5/*: any*/)
+                  (v7/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -464,61 +632,15 @@ return {
                 "name": "increments",
                 "plural": true,
                 "selections": [
-                  (v5/*: any*/),
-                  (v3/*: any*/)
+                  (v7/*: any*/),
+                  (v6/*: any*/)
                 ],
                 "storageKey": "increments(useMyMaxBid:true)"
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Sale",
-                "kind": "LinkedField",
-                "name": "sale",
-                "plural": false,
-                "selections": [
-                  (v2/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Bidder",
-                    "kind": "LinkedField",
-                    "name": "bidder",
-                    "plural": false,
-                    "selections": [
-                      (v4/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  (v1/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Bidder",
-                    "kind": "LinkedField",
-                    "name": "registrationStatus",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "qualifiedForBidding",
-                        "storageKey": null
-                      },
-                      (v4/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  (v4/*: any*/)
-                ],
-                "storageKey": null
-              },
-              (v4/*: any*/)
+              }
             ],
             "storageKey": null
           },
-          (v4/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "artwork(id:\"foo\")"
       },
@@ -538,7 +660,7 @@ return {
             "name": "hasQualifiedCreditCards",
             "storageKey": null
           },
-          (v4/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       },
@@ -552,30 +674,37 @@ return {
         "selections": [
           (v2/*: any*/),
           (v1/*: any*/),
-          (v4/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "sale(id:\"foo\")"
       }
     ]
   },
   "params": {
-    "cacheID": "a15223260af92c38a35a19016265f1e1",
+    "cacheID": "dcb39735a2da5e868ac90142ba00cdb8",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "artwork": (v6/*: any*/),
-        "artwork.id": (v7/*: any*/),
-        "artwork.internalID": (v7/*: any*/),
+        "artwork": (v8/*: any*/),
+        "artwork.id": (v9/*: any*/),
+        "artwork.internalID": (v9/*: any*/),
+        "artwork.sale": (v10/*: any*/),
+        "artwork.sale.cascadingEndTimeIntervalMinutes": (v11/*: any*/),
+        "artwork.sale.endAt": (v12/*: any*/),
+        "artwork.sale.id": (v9/*: any*/),
+        "artwork.sale.isClosed": (v13/*: any*/),
+        "artwork.sale.liveStartAt": (v12/*: any*/),
+        "artwork.sale.startAt": (v12/*: any*/),
         "artwork.saleArtwork": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtwork"
         },
-        "artwork.saleArtwork.artwork": (v6/*: any*/),
-        "artwork.saleArtwork.artwork.artistNames": (v8/*: any*/),
-        "artwork.saleArtwork.artwork.date": (v8/*: any*/),
-        "artwork.saleArtwork.artwork.id": (v7/*: any*/),
+        "artwork.saleArtwork.artwork": (v8/*: any*/),
+        "artwork.saleArtwork.artwork.artistNames": (v12/*: any*/),
+        "artwork.saleArtwork.artwork.date": (v12/*: any*/),
+        "artwork.saleArtwork.artwork.id": (v9/*: any*/),
         "artwork.saleArtwork.artwork.image": {
           "enumValues": null,
           "nullable": true,
@@ -588,14 +717,14 @@ return {
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "artwork.saleArtwork.artwork.image.resized.height": (v9/*: any*/),
-        "artwork.saleArtwork.artwork.image.resized.src": (v10/*: any*/),
-        "artwork.saleArtwork.artwork.image.resized.srcSet": (v10/*: any*/),
-        "artwork.saleArtwork.artwork.image.resized.width": (v9/*: any*/),
-        "artwork.saleArtwork.artwork.imageUrl": (v8/*: any*/),
-        "artwork.saleArtwork.artwork.internalID": (v7/*: any*/),
-        "artwork.saleArtwork.artwork.slug": (v7/*: any*/),
-        "artwork.saleArtwork.artwork.title": (v8/*: any*/),
+        "artwork.saleArtwork.artwork.image.resized.height": (v11/*: any*/),
+        "artwork.saleArtwork.artwork.image.resized.src": (v14/*: any*/),
+        "artwork.saleArtwork.artwork.image.resized.srcSet": (v14/*: any*/),
+        "artwork.saleArtwork.artwork.image.resized.width": (v11/*: any*/),
+        "artwork.saleArtwork.artwork.imageUrl": (v12/*: any*/),
+        "artwork.saleArtwork.artwork.internalID": (v9/*: any*/),
+        "artwork.saleArtwork.artwork.slug": (v9/*: any*/),
+        "artwork.saleArtwork.artwork.title": (v12/*: any*/),
         "artwork.saleArtwork.counts": {
           "enumValues": null,
           "nullable": true,
@@ -614,53 +743,60 @@ return {
           "plural": false,
           "type": "SaleArtworkCurrentBid"
         },
-        "artwork.saleArtwork.currentBid.display": (v8/*: any*/),
-        "artwork.saleArtwork.formattedEndDateTime": (v8/*: any*/),
-        "artwork.saleArtwork.id": (v7/*: any*/),
+        "artwork.saleArtwork.currentBid.display": (v12/*: any*/),
+        "artwork.saleArtwork.endAt": (v12/*: any*/),
+        "artwork.saleArtwork.extendedBiddingEndAt": (v12/*: any*/),
+        "artwork.saleArtwork.formattedEndDateTime": (v12/*: any*/),
+        "artwork.saleArtwork.formattedStartDateTime": (v12/*: any*/),
+        "artwork.saleArtwork.id": (v9/*: any*/),
         "artwork.saleArtwork.increments": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "BidIncrementsFormatted"
         },
-        "artwork.saleArtwork.increments.cents": (v11/*: any*/),
-        "artwork.saleArtwork.increments.display": (v8/*: any*/),
-        "artwork.saleArtwork.lotLabel": (v8/*: any*/),
+        "artwork.saleArtwork.increments.cents": (v15/*: any*/),
+        "artwork.saleArtwork.increments.display": (v12/*: any*/),
+        "artwork.saleArtwork.lotID": (v12/*: any*/),
+        "artwork.saleArtwork.lotLabel": (v12/*: any*/),
         "artwork.saleArtwork.minimumNextBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkMinimumNextBid"
         },
-        "artwork.saleArtwork.minimumNextBid.cents": (v11/*: any*/),
-        "artwork.saleArtwork.sale": (v12/*: any*/),
-        "artwork.saleArtwork.sale.bidder": (v13/*: any*/),
-        "artwork.saleArtwork.sale.bidder.id": (v7/*: any*/),
-        "artwork.saleArtwork.sale.id": (v7/*: any*/),
-        "artwork.saleArtwork.sale.internalID": (v7/*: any*/),
-        "artwork.saleArtwork.sale.registrationStatus": (v13/*: any*/),
-        "artwork.saleArtwork.sale.registrationStatus.id": (v7/*: any*/),
-        "artwork.saleArtwork.sale.registrationStatus.qualifiedForBidding": (v14/*: any*/),
-        "artwork.saleArtwork.sale.slug": (v7/*: any*/),
-        "artwork.slug": (v7/*: any*/),
+        "artwork.saleArtwork.minimumNextBid.cents": (v15/*: any*/),
+        "artwork.saleArtwork.sale": (v10/*: any*/),
+        "artwork.saleArtwork.sale.bidder": (v16/*: any*/),
+        "artwork.saleArtwork.sale.bidder.id": (v9/*: any*/),
+        "artwork.saleArtwork.sale.extendedBiddingIntervalMinutes": (v11/*: any*/),
+        "artwork.saleArtwork.sale.extendedBiddingPeriodMinutes": (v11/*: any*/),
+        "artwork.saleArtwork.sale.id": (v9/*: any*/),
+        "artwork.saleArtwork.sale.internalID": (v9/*: any*/),
+        "artwork.saleArtwork.sale.registrationStatus": (v16/*: any*/),
+        "artwork.saleArtwork.sale.registrationStatus.id": (v9/*: any*/),
+        "artwork.saleArtwork.sale.registrationStatus.qualifiedForBidding": (v13/*: any*/),
+        "artwork.saleArtwork.sale.slug": (v9/*: any*/),
+        "artwork.saleArtwork.sale.startAt": (v12/*: any*/),
+        "artwork.slug": (v9/*: any*/),
         "me": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Me"
         },
-        "me.hasQualifiedCreditCards": (v14/*: any*/),
-        "me.id": (v7/*: any*/),
-        "me.internalID": (v7/*: any*/),
-        "sale": (v12/*: any*/),
-        "sale.id": (v7/*: any*/),
-        "sale.internalID": (v7/*: any*/),
-        "sale.slug": (v7/*: any*/)
+        "me.hasQualifiedCreditCards": (v13/*: any*/),
+        "me.id": (v9/*: any*/),
+        "me.internalID": (v9/*: any*/),
+        "sale": (v10/*: any*/),
+        "sale.id": (v9/*: any*/),
+        "sale.internalID": (v9/*: any*/),
+        "sale.slug": (v9/*: any*/)
       }
     },
     "name": "AuctionBidRouteTestQuery",
     "operationKind": "query",
-    "text": "query AuctionBidRouteTestQuery {\n  artwork(id: \"foo\") {\n    ...AuctionBidRoute_artwork\n    id\n  }\n  me {\n    ...AuctionBidRoute_me\n    id\n  }\n  sale(id: \"foo\") {\n    ...AuctionBidRoute_sale\n    id\n  }\n}\n\nfragment AuctionBidRoute_artwork on Artwork {\n  slug\n  internalID\n  saleArtwork {\n    ...AuctionLotInfo_saleArtwork_1WWOz5\n    minimumNextBid {\n      cents\n    }\n    increments(useMyMaxBid: true) {\n      cents\n      display\n    }\n    sale {\n      internalID\n      bidder {\n        id\n      }\n      slug\n      registrationStatus {\n        qualifiedForBidding\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment AuctionBidRoute_me on Me {\n  internalID\n  hasQualifiedCreditCards\n}\n\nfragment AuctionBidRoute_sale on Sale {\n  internalID\n  slug\n}\n\nfragment AuctionLotInfo_saleArtwork_1WWOz5 on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  currentBid {\n    display\n  }\n  formattedEndDateTime\n  artwork {\n    internalID\n    date\n    title\n    image {\n      resized(width: 150, height: 150, version: \"medium\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    imageUrl\n    artistNames\n    slug\n    id\n  }\n}\n"
+    "text": "query AuctionBidRouteTestQuery {\n  artwork(id: \"foo\") {\n    ...AuctionBidRoute_artwork\n    id\n  }\n  me {\n    ...AuctionBidRoute_me\n    id\n  }\n  sale(id: \"foo\") {\n    ...AuctionBidRoute_sale\n    id\n  }\n}\n\nfragment ArtworkSidebarAuctionTimer_artwork on Artwork {\n  internalID\n  sale {\n    cascadingEndTimeIntervalMinutes\n    isClosed\n    ...AuctionTimer_sale\n    startAt\n    id\n  }\n  saleArtwork {\n    ...LotTimer_saleArtwork\n    endAt\n    id\n  }\n}\n\nfragment AuctionBidRoute_artwork on Artwork {\n  slug\n  internalID\n  ...ArtworkSidebarAuctionTimer_artwork\n  saleArtwork {\n    ...AuctionLotInfo_saleArtwork_1WWOz5\n    minimumNextBid {\n      cents\n    }\n    increments(useMyMaxBid: true) {\n      cents\n      display\n    }\n    sale {\n      internalID\n      bidder {\n        id\n      }\n      slug\n      registrationStatus {\n        qualifiedForBidding\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment AuctionBidRoute_me on Me {\n  internalID\n  hasQualifiedCreditCards\n}\n\nfragment AuctionBidRoute_sale on Sale {\n  internalID\n  slug\n}\n\nfragment AuctionLotInfo_saleArtwork_1WWOz5 on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  currentBid {\n    display\n  }\n  formattedEndDateTime\n  artwork {\n    internalID\n    date\n    title\n    image {\n      resized(width: 150, height: 150, version: \"medium\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    imageUrl\n    artistNames\n    slug\n    id\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  liveStartAt\n  endAt\n}\n\nfragment LotTimer_saleArtwork on SaleArtwork {\n  endAt\n  formattedStartDateTime\n  extendedBiddingEndAt\n  lotID\n  sale {\n    startAt\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    internalID\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/AuctionBidRoute_artwork.graphql.ts
+++ b/src/v2/__generated__/AuctionBidRoute_artwork.graphql.ts
@@ -27,6 +27,7 @@ export type AuctionBidRoute_artwork = {
         } | null;
         readonly " $fragmentRefs": FragmentRefs<"AuctionLotInfo_saleArtwork">;
     } | null;
+    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarAuctionTimer_artwork">;
     readonly " $refType": "AuctionBidRoute_artwork";
 };
 export type AuctionBidRoute_artwork$data = AuctionBidRoute_artwork;
@@ -179,11 +180,16 @@ return {
         }
       ],
       "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ArtworkSidebarAuctionTimer_artwork"
     }
   ],
   "type": "Artwork",
   "abstractKey": null
 };
 })();
-(node as any).hash = '1890c5d4be005fc2e66f11a538c56460';
+(node as any).hash = '9cd2d727e0d0c0dbb8242519d05ac7cd';
 export default node;

--- a/src/v2/__generated__/auctionRoutes_BidRouteQuery.graphql.ts
+++ b/src/v2/__generated__/auctionRoutes_BidRouteQuery.graphql.ts
@@ -45,9 +45,26 @@ query auctionRoutes_BidRouteQuery(
   }
 }
 
+fragment ArtworkSidebarAuctionTimer_artwork on Artwork {
+  internalID
+  sale {
+    cascadingEndTimeIntervalMinutes
+    isClosed
+    ...AuctionTimer_sale
+    startAt
+    id
+  }
+  saleArtwork {
+    ...LotTimer_saleArtwork
+    endAt
+    id
+  }
+}
+
 fragment AuctionBidRoute_artwork on Artwork {
   slug
   internalID
+  ...ArtworkSidebarAuctionTimer_artwork
   saleArtwork {
     ...AuctionLotInfo_saleArtwork_1WWOz5
     minimumNextBid {
@@ -110,6 +127,25 @@ fragment AuctionLotInfo_saleArtwork_1WWOz5 on SaleArtwork {
     id
   }
 }
+
+fragment AuctionTimer_sale on Sale {
+  liveStartAt
+  endAt
+}
+
+fragment LotTimer_saleArtwork on SaleArtwork {
+  endAt
+  formattedStartDateTime
+  extendedBiddingEndAt
+  lotID
+  sale {
+    startAt
+    extendedBiddingPeriodMinutes
+    extendedBiddingIntervalMinutes
+    internalID
+    id
+  }
+}
 */
 
 const node: ConcreteRequest = (function(){
@@ -162,10 +198,24 @@ v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "display",
+  "name": "endAt",
   "storageKey": null
 },
 v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "startAt",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "display",
+  "storageKey": null
+},
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -270,11 +320,129 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "Sale",
+            "kind": "LinkedField",
+            "name": "sale",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cascadingEndTimeIntervalMinutes",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isClosed",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "liveStartAt",
+                "storageKey": null
+              },
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v6/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "SaleArtwork",
             "kind": "LinkedField",
             "name": "saleArtwork",
             "plural": false,
             "selections": [
+              (v7/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "formattedStartDateTime",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "extendedBiddingEndAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "lotID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Sale",
+                "kind": "LinkedField",
+                "name": "sale",
+                "plural": false,
+                "selections": [
+                  (v8/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "extendedBiddingPeriodMinutes",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "extendedBiddingIntervalMinutes",
+                    "storageKey": null
+                  },
+                  (v4/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Bidder",
+                    "kind": "LinkedField",
+                    "name": "bidder",
+                    "plural": false,
+                    "selections": [
+                      (v6/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Bidder",
+                    "kind": "LinkedField",
+                    "name": "registrationStatus",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "qualifiedForBidding",
+                        "storageKey": null
+                      },
+                      (v6/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -308,7 +476,7 @@ return {
                 "name": "currentBid",
                 "plural": false,
                 "selections": [
-                  (v7/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -435,7 +603,7 @@ return {
                 "name": "minimumNextBid",
                 "plural": false,
                 "selections": [
-                  (v8/*: any*/)
+                  (v10/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -453,57 +621,11 @@ return {
                 "name": "increments",
                 "plural": true,
                 "selections": [
-                  (v8/*: any*/),
-                  (v7/*: any*/)
+                  (v10/*: any*/),
+                  (v9/*: any*/)
                 ],
                 "storageKey": "increments(useMyMaxBid:true)"
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Sale",
-                "kind": "LinkedField",
-                "name": "sale",
-                "plural": false,
-                "selections": [
-                  (v4/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Bidder",
-                    "kind": "LinkedField",
-                    "name": "bidder",
-                    "plural": false,
-                    "selections": [
-                      (v6/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  (v5/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Bidder",
-                    "kind": "LinkedField",
-                    "name": "registrationStatus",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "qualifiedForBidding",
-                        "storageKey": null
-                      },
-                      (v6/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  (v6/*: any*/)
-                ],
-                "storageKey": null
-              },
-              (v6/*: any*/)
+              }
             ],
             "storageKey": null
           },
@@ -534,12 +656,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "28ee8cf80184595581fa16841bc06fd4",
+    "cacheID": "8c06287d22d2d2e371eeb470ed2b9f44",
     "id": null,
     "metadata": {},
     "name": "auctionRoutes_BidRouteQuery",
     "operationKind": "query",
-    "text": "query auctionRoutes_BidRouteQuery(\n  $slug: String!\n  $artworkSlug: String!\n) {\n  sale(id: $slug) @principalField {\n    ...AuctionBidRoute_sale\n    id\n  }\n  artwork(id: $artworkSlug) {\n    ...AuctionBidRoute_artwork\n    id\n  }\n  me {\n    ...AuctionBidRoute_me\n    id\n  }\n}\n\nfragment AuctionBidRoute_artwork on Artwork {\n  slug\n  internalID\n  saleArtwork {\n    ...AuctionLotInfo_saleArtwork_1WWOz5\n    minimumNextBid {\n      cents\n    }\n    increments(useMyMaxBid: true) {\n      cents\n      display\n    }\n    sale {\n      internalID\n      bidder {\n        id\n      }\n      slug\n      registrationStatus {\n        qualifiedForBidding\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment AuctionBidRoute_me on Me {\n  internalID\n  hasQualifiedCreditCards\n}\n\nfragment AuctionBidRoute_sale on Sale {\n  internalID\n  slug\n}\n\nfragment AuctionLotInfo_saleArtwork_1WWOz5 on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  currentBid {\n    display\n  }\n  formattedEndDateTime\n  artwork {\n    internalID\n    date\n    title\n    image {\n      resized(width: 150, height: 150, version: \"medium\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    imageUrl\n    artistNames\n    slug\n    id\n  }\n}\n"
+    "text": "query auctionRoutes_BidRouteQuery(\n  $slug: String!\n  $artworkSlug: String!\n) {\n  sale(id: $slug) @principalField {\n    ...AuctionBidRoute_sale\n    id\n  }\n  artwork(id: $artworkSlug) {\n    ...AuctionBidRoute_artwork\n    id\n  }\n  me {\n    ...AuctionBidRoute_me\n    id\n  }\n}\n\nfragment ArtworkSidebarAuctionTimer_artwork on Artwork {\n  internalID\n  sale {\n    cascadingEndTimeIntervalMinutes\n    isClosed\n    ...AuctionTimer_sale\n    startAt\n    id\n  }\n  saleArtwork {\n    ...LotTimer_saleArtwork\n    endAt\n    id\n  }\n}\n\nfragment AuctionBidRoute_artwork on Artwork {\n  slug\n  internalID\n  ...ArtworkSidebarAuctionTimer_artwork\n  saleArtwork {\n    ...AuctionLotInfo_saleArtwork_1WWOz5\n    minimumNextBid {\n      cents\n    }\n    increments(useMyMaxBid: true) {\n      cents\n      display\n    }\n    sale {\n      internalID\n      bidder {\n        id\n      }\n      slug\n      registrationStatus {\n        qualifiedForBidding\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment AuctionBidRoute_me on Me {\n  internalID\n  hasQualifiedCreditCards\n}\n\nfragment AuctionBidRoute_sale on Sale {\n  internalID\n  slug\n}\n\nfragment AuctionLotInfo_saleArtwork_1WWOz5 on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  currentBid {\n    display\n  }\n  formattedEndDateTime\n  artwork {\n    internalID\n    date\n    title\n    image {\n      resized(width: 150, height: 150, version: \"medium\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    imageUrl\n    artistNames\n    slug\n    id\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  liveStartAt\n  endAt\n}\n\nfragment LotTimer_saleArtwork on SaleArtwork {\n  endAt\n  formattedStartDateTime\n  extendedBiddingEndAt\n  lotID\n  sale {\n    startAt\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    internalID\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR solves [BID-388]

### Description

This re-uses the artwork page countdown and progress bar in the bid modal. It's a bit rough, but works as expected!

Looks like:

![Screen Shot 2022-06-08 at 2 21 34 PM](https://user-images.githubusercontent.com/1457859/172689127-b590e98c-91f4-49b6-9cc5-a5a01572f703.png)

The footnote about closure times adjusting is popcorn-bidding specific.

I have an open question to design about fitting this data in a bit more smoothly but in the meantime, we decided to roll with it.

[BID-388]: https://artsyproduct.atlassian.net/browse/BID-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ