### PR TITLE
fix(FX-4020): Jumping state for "Notable Works" rail on artwork page

### DIFF
--- a/src/v2/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
@@ -65,7 +65,6 @@ const ArtistNotableWorksRail: React.FC<ArtistNotableWorksRailProps> = ({
             <ShelfArtworkFragmentContainer
               artwork={node}
               contextModule={ContextModule.topWorksRail}
-              hideArtistName
               hidePartnerName
               key={index}
               showExtended={false}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR solves [FX-4020]

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/172820004-bd4dcfa0-a70e-4c8b-a360-5f84b21e0400.mp4

#### After
https://user-images.githubusercontent.com/3513494/172820189-3cca0c8c-2d0b-45c8-a8bd-c42c637f2c3e.mp4

cc: @dzucconi 

<!-- Implementation description -->


[FX-4020]: https://artsyproduct.atlassian.net/browse/FX-4020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ