### PR TITLE
chore: truncate text for last pill

### DIFF
--- a/src/v2/Components/Artwork/HoverDetails.tsx
+++ b/src/v2/Components/Artwork/HoverDetails.tsx
@@ -27,11 +27,22 @@ const HoverDetails: FC<HoverDetailsProps> = ({ artwork }) => {
   return (
     <HoverContainer>
       <Join separator={<Spacer mr={0.5} />}>
-        {pills.map(pill => (
-          <Pill key={pill.id} variant="filter" disabled>
-            {pill.label}
-          </Pill>
-        ))}
+        {pills.map((pill, index) => {
+          // Truncate text for last pill
+          if (index === pills.length - 1) {
+            return (
+              <TruncatedTextPill key={pill.id} variant="filter" disabled>
+                {pill.label}
+              </TruncatedTextPill>
+            )
+          }
+
+          return (
+            <Pill key={pill.id} variant="filter" disabled>
+              {pill.label}
+            </Pill>
+          )
+        })}
       </Join>
     </HoverContainer>
   )
@@ -45,6 +56,13 @@ const HoverContainer = styled(Box)`
   display: flex;
   align-items: center;
   background-color: ${themeGet("colors.white100")};
+`
+
+const TruncatedTextPill = styled(Pill)`
+  overflow: hidden;
+  min-width: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `
 
 export const HoverDetailsFragmentContainer = createFragmentContainer(


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->


### Description
We have to truncate the text for the second pill when hovering. Otherwise, there may be a situation when the contents of these pills exceed the width of the parent container and there is such a visual bug

![Image 2022-06-09 13-31-35](https://user-images.githubusercontent.com/3513494/172827104-8e390806-5932-4c50-b306-c782edf2f539.png)

The result of how it will look after the text for the second pill is truncated
<img width="963" alt="image" src="https://user-images.githubusercontent.com/3513494/172826994-61482ff2-5ea4-45bf-a9cf-0b9de9556221.png">


<!-- Implementation description -->
