### PR TITLE
chore(FX-4007): replace hover to click on rightmost navigation bar elements

### DIFF
--- a/src/v2/Components/NavBar/NavBarLoggedInActions.tsx
+++ b/src/v2/Components/NavBar/NavBarLoggedInActions.tsx
@@ -1,7 +1,7 @@
 import { useContext } from "react"
 import * as React from "react"
 import { NavBarNotificationsQueryRenderer, NavBarUserMenu } from "./Menus"
-import { AnalyticsSchema, SystemContext, useTracking } from "v2/System"
+import { SystemContext } from "v2/System"
 import {
   BellIcon,
   Dropdown,
@@ -24,19 +24,13 @@ import {
 } from "./helpers"
 import styled from "styled-components"
 import { themeGet } from "@styled-system/theme-get"
-import {
-  NavBarItemButton,
-  NavBarItemLink,
-  NavBarItemUnfocusableAnchor,
-} from "./NavBarItem"
+import { NavBarItemButton, NavBarItemLink } from "./NavBarItem"
 import { Z } from "v2/Apps/Components/constants"
 
 /** Displays action icons for logged in users such as inbox, profile, and notifications */
 export const NavBarLoggedInActions: React.FC<Partial<
   NavBarLoggedInActionsQueryResponse
 >> = ({ me }) => {
-  const { trackEvent } = useTracking()
-
   const hasUnreadNotifications =
     (me?.unreadNotificationsCount ?? 0) > 0 || getNotificationCount() > 0
   const hasUnreadConversations =
@@ -52,6 +46,7 @@ export const NavBarLoggedInActions: React.FC<Partial<
         dropdown={<NavBarNotificationsQueryRenderer />}
         placement="bottom-end"
         offset={0}
+        openDropdownByClick
       >
         {({ anchorRef, anchorProps, visible }) => (
           <NavBarItemButton
@@ -59,18 +54,6 @@ export const NavBarLoggedInActions: React.FC<Partial<
             active={visible}
             {...anchorProps}
           >
-            <NavBarItemUnfocusableAnchor
-              href="/works-for-you"
-              onClick={() => {
-                trackEvent({
-                  action_type: AnalyticsSchema.ActionType.Click,
-                  subject: AnalyticsSchema.Subject.NotificationBell,
-                  new_notification_count: getNotificationCount(),
-                  destination_path: "/works-for-you",
-                })
-              }}
-            />
-
             <BellIcon
               title="Notifications"
               // @ts-ignore
@@ -101,6 +84,7 @@ export const NavBarLoggedInActions: React.FC<Partial<
         dropdown={<NavBarUserMenu />}
         placement="bottom-end"
         offset={0}
+        openDropdownByClick
       >
         {({ anchorRef, anchorProps, visible }) => (
           <NavBarItemButton

--- a/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
@@ -30,29 +30,6 @@ describe("NavBarTracking", () => {
     jest.clearAllMocks()
   })
 
-  describe("NavBar", () => {
-    it("tracks NavBar notification badge clicks", () => {
-      const wrapper = mount(
-        <Wrapper>
-          <NavBar />
-        </Wrapper>
-      )
-
-      wrapper
-        .find("a")
-        .find({ href: "/works-for-you" })
-        .first()
-        .simulate("click")
-
-      expect(trackEvent).toBeCalledWith({
-        action_type: AnalyticsSchema.ActionType.Click,
-        subject: AnalyticsSchema.Subject.NotificationBell,
-        destination_path: "/works-for-you",
-        new_notification_count: 0,
-      })
-    })
-  })
-
   describe("NavBarUserMenu", () => {
     it("tracks NavBarUserMenu clicks", () => {
       const wrapper = mount(


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR solves [FX-4007]

Related Palette PR: artsy/palette#1180

Review app: https://replace-hover-on-click.artsy.net/

### Description
Right now you can hover over the activity bell or the profile icon to see menus appear. We’d like to remove the hover effect and instead show/hide the menus on click

### Acceptance Criteria
* Menu should be opened/hided by click instead of hover
* Clicking outside of the menu should cause the menu to hide

<!-- Implementation description -->


[FX-4007]: https://artsyproduct.atlassian.net/browse/FX-4007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ