### PR TITLE
chore(FX-3972): track analytics for Trending Sort A/B test

### DIFF
--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -16,7 +16,10 @@ import { SavedSearchEntity } from "v2/Components/SavedSearchAlert/types"
 import { getSupportedMetric } from "v2/Components/ArtworkFilter/Utils/metrics"
 import { OwnerType } from "@artsy/cohesion"
 import { ZeroState } from "./ZeroState"
-import { useFeatureVariant } from "v2/System/useFeatureFlag"
+import {
+  useFeatureVariant,
+  useTrackFeatureVariant,
+} from "v2/System/useFeatureFlag"
 
 interface ArtistArtworkFilterProps {
   aggregations: SharedArtworkFilterContextProps["aggregations"]
@@ -34,6 +37,14 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
   const trendingSortVariant = useFeatureVariant(
     "trending-sort-for-artist-artwork-grids"
   )
+  const { trackFeatureVariant } = useTrackFeatureVariant({
+    experimentName: "trending-sort-for-artist-artwork-grids",
+    variantName: trendingSortVariant?.name!,
+  })
+
+  React.useEffect(() => {
+    trackFeatureVariant()
+  })
 
   if (!hasFilter) {
     return null

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -9,7 +9,7 @@ import {
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { getDefaultSort } from "v2/Apps/Artist/Routes/WorksForSale/Utils/getDefaultSort"
 import { Match } from "found"
-import * as React from "react"
+import { useEffect } from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { useRouter } from "v2/System/Router/useRouter"
 import { SavedSearchEntity } from "v2/Components/SavedSearchAlert/types"
@@ -42,7 +42,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
     variantName: trendingSortVariant?.name!,
   })
 
-  React.useEffect(() => {
+  useEffect(() => {
     trackFeatureVariant()
   })
 


### PR DESCRIPTION
The type of this PR is: **Chore**

Related PR #10186

This PR solves [FX-3972]

Unleash flag: [trending-sort-for-artist-artwork-grids](https://unleash.artsy.net/projects/default/features/trending-sort-for-artist-artwork-grids)

### Description
* Experiment name: `trending-sort-for-artist-artwork-grids`
* Variant names: `control` and `experiment`

<!-- Implementation description -->


[FX-3972]: https://artsyproduct.atlassian.net/browse/FX-3972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ