### PR TITLE
feat(colors): add brown color filter option

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -28,6 +28,7 @@ export const COLOR_OPTIONS = [
   { hex: "#0A1AB4", value: "blue", name: "Blue" },
   { hex: "#7B3D91", value: "purple", name: "Purple" },
   { hex: "#ffffff", value: "black-and-white", name: "Black and White" },
+  { hex: "#7B5927", value: "brown", name: "Brown" },
   { hex: "#C2C2C2", value: "gray", name: "Gray" },
   { hex: "#E1ADCD", value: "pink", name: "Pink" },
 ]

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
@@ -31,6 +31,17 @@ describe("ColorFilter", () => {
     expect(wrapper.find("Checkbox")).toHaveLength(6)
   })
 
+  it("renders all the colors when 'Show more' is clicked", () => {
+    const wrapper = getWrapper()
+
+    wrapper
+      .findWhere(t => t.text() === "Show more")
+      .first()
+      .simulate("click")
+
+    expect(wrapper.find("Checkbox")).toHaveLength(10)
+  })
+
   it("selects a color when clicked", () => {
     const wrapper = getWrapper()
 


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-3779]

### Description

Simply adds a new color filtering option for **brown**.

This will begin to appear in the filtering UI as soon as this PR is deployed, so this should probably wait until we've actually indexed brown for all artworks (see: https://github.com/artsy/gravity/pull/15433)

|Desktop|mWeb|
|---|---|
|<img alt="brown desktop" src="https://user-images.githubusercontent.com/140521/172861191-4f2485f2-422a-4950-a247-7aad4dabeced.png">|<img alt="brown mweb" src="https://user-images.githubusercontent.com/140521/172861653-ca530677-c260-4ca5-9e61-3d798b88a7a3.png">|






[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-3779]: https://artsyproduct.atlassian.net/browse/FX-3779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ