### PR TITLE
fix: "Works for You" page does not display correctly in Firefox

### DIFF
--- a/src/v2/Apps/WorksForYou/WorksForYouApp.tsx
+++ b/src/v2/Apps/WorksForYou/WorksForYouApp.tsx
@@ -90,7 +90,12 @@ const WorksForYouApp: React.FC<WorksForYouProps> = ({
             />
           </Column>
 
-          <Column span={9}>
+          <Column
+            span={9}
+            // Fix for issue in Firefox where contents overflow container.
+            // Safe to remove once artwork masonry uses CSS grid.
+            width="100%"
+          >
             <GridColumns mt={0.5}>
               <Column span={9}>
                 <Text variant="sm-display" fontWeight="medium">


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR solves [FX-4017]

Similar PR #8004

Review app: https://works-for-you-page.artsy.net/works-for-you

### Description
Artworks break out of container and overlap the footer if you open the ["Works For You"](https://www.artsy.net/works-for-you) page in Firefox

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/172888470-73a4a6ca-91f5-4a75-a8bb-a79be474aaa3.mp4

#### After
https://user-images.githubusercontent.com/3513494/172888583-34267262-583f-4453-9989-a1ccbc4af9ca.mp4

<!-- Implementation description -->


[FX-4017]: https://artsyproduct.atlassian.net/browse/FX-4017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ