### PR TITLE
feat(cookie-consent): Sync OneTrust cookie on server

### DIFF
--- a/src/lib/analytics/segmentOneTrustIntegration/__tests__/getOneTrustConsent.jest.ts
+++ b/src/lib/analytics/segmentOneTrustIntegration/__tests__/getOneTrustConsent.jest.ts
@@ -4,6 +4,7 @@ import { oneTrustReady } from "../oneTrustReady"
 
 jest.mock("../delay")
 jest.mock("../oneTrustReady")
+jest.mock("../setServerSideCookie")
 
 describe("getOneTrustConsent", () => {
   const delayMock = delay as jest.Mock

--- a/src/lib/analytics/segmentOneTrustIntegration/getOneTrustConsent.ts
+++ b/src/lib/analytics/segmentOneTrustIntegration/getOneTrustConsent.ts
@@ -1,5 +1,6 @@
 import { delay } from "./delay"
 import { oneTrustReady } from "./oneTrustReady"
+import { setServerSideCookie } from "./setServerSideCookie"
 
 export async function getOneTrustConsent() {
   let attempts = 0
@@ -12,6 +13,8 @@ export async function getOneTrustConsent() {
   }
 
   if (oneTrustReady()) {
+    setServerSideCookie()
+
     // OneTrust stores consent in window.OnetrustActiveGroups.
     return window.OnetrustActiveGroups
   } else {

--- a/src/lib/analytics/segmentOneTrustIntegration/setServerSideCookie.ts
+++ b/src/lib/analytics/segmentOneTrustIntegration/setServerSideCookie.ts
@@ -1,0 +1,12 @@
+import cookies from "cookies-js"
+
+export function setServerSideCookie() {
+  const OptanonAlertBoxClosed = encodeURIComponent(
+    cookies.get("OptanonAlertBoxClosed")
+  )
+  const OptanonConsent = encodeURIComponent(cookies.get("OptanonConsent"))
+
+  fetch(
+    `/set-tracking-preferences?OptanonAlertBoxClosed=${OptanonAlertBoxClosed}&OptanonConsent=${OptanonConsent}`
+  )
+}

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -43,6 +43,27 @@ app.get(
   }
 )
 
+// Experiment with overwriting OneTrust consent cookie with server-side version
+// to get around Safari's 7 day limit for client-side cookies.
+app.get("/set-tracking-preferences", (req, res) => {
+  const { OptanonAlertBoxClosed, OptanonConsent } = req.query
+
+  const cookieConfig = {
+    maxAge: 1000 * 60 * 60 * 24 * 365,
+    httpOnly: false,
+    secure: true,
+  }
+
+  if (OptanonAlertBoxClosed !== "undefined") {
+    res.cookie("OptanonAlertBoxClosed", OptanonAlertBoxClosed, cookieConfig)
+  }
+  if (OptanonConsent) {
+    res.cookie("OptanonConsent", OptanonConsent, cookieConfig)
+  }
+
+  res.send("[Force] Consent cookie set.")
+})
+
 // This export form is required for express-reloadable
 // TODO: Remove when no longer needed for hot reloading
 module.exports = app


### PR DESCRIPTION
The type of this PR is: **Feature**

### Description

This updates our OneTrust cookie consent flow by syncing the client-side cookie on the server via `secure: true`, which should satisfy Apple's requirements around ITP and get around resetting after 7 days. 

Note the checkmarks in the rows highlighted below; that means `secure: true`, set from the server and overwriting the client cookie set by OneTrust.

<img width="415" alt="Screen Shot 2022-06-09 at 1 23 59 PM" src="https://user-images.githubusercontent.com/236943/172938374-2fb80110-53a3-41c4-bfa4-5597fab00418.png">

<img width="539" alt="Screen Shot 2022-06-09 at 1 24 04 PM" src="https://user-images.githubusercontent.com/236943/172938407-7f235881-5f00-4bac-b29f-7ad1c166a0f3.png">

Opening for discussion. 

