### PR TITLE
[ENHANCEMENT]: AlicanAkyuz/TX-403/UI-improvements-checkout-flow

### DIFF
--- a/src/v2/Apps/Order/Components/BankDebitDetails.tsx
+++ b/src/v2/Apps/Order/Components/BankDebitDetails.tsx
@@ -9,7 +9,7 @@ export const BankDebitDetails = ({
   textColor?: string
 }) => (
   <Flex alignItems="center">
-    <InstitutionIcon fill="black60" />
+    <InstitutionIcon fill="green100" />
     <Spacer ml={0.5} />
     <Text
       size={responsive ? ["2", "3"] : "3"}

--- a/src/v2/Apps/Order/Components/PaymentMethodSummaryItem.tsx
+++ b/src/v2/Apps/Order/Components/PaymentMethodSummaryItem.tsx
@@ -11,12 +11,12 @@ import { WireTransferDetails } from "./WireTransferDetails"
 export const PaymentMethodSummaryItem = ({
   order: { creditCard, paymentMethod },
   textColor = "black100",
-  currentStep,
+  withDescription = true,
   ...others
 }: {
   order: PaymentMethodSummaryItem_order
   textColor?: string
-  currentStep?: string
+  withDescription?: boolean
 } & StepSummaryItemProps) => {
   const cardInfoWithTextColor = {
     ...creditCard!,
@@ -30,7 +30,7 @@ export const PaymentMethodSummaryItem = ({
       case "US_BANK_ACCOUNT":
         return <BankDebitDetails {...cardInfoWithTextColor} />
       case "WIRE_TRANSFER":
-        return <WireTransferDetails currentStep={currentStep} />
+        return <WireTransferDetails withDescription={withDescription} />
       default:
         null
     }

--- a/src/v2/Apps/Order/Components/PaymentMethodSummaryItem.tsx
+++ b/src/v2/Apps/Order/Components/PaymentMethodSummaryItem.tsx
@@ -11,10 +11,12 @@ import { WireTransferDetails } from "./WireTransferDetails"
 export const PaymentMethodSummaryItem = ({
   order: { creditCard, paymentMethod },
   textColor = "black100",
+  currentStep,
   ...others
 }: {
   order: PaymentMethodSummaryItem_order
   textColor?: string
+  currentStep?: string
 } & StepSummaryItemProps) => {
   const cardInfoWithTextColor = {
     ...creditCard!,
@@ -28,7 +30,7 @@ export const PaymentMethodSummaryItem = ({
       case "US_BANK_ACCOUNT":
         return <BankDebitDetails {...cardInfoWithTextColor} />
       case "WIRE_TRANSFER":
-        return <WireTransferDetails />
+        return <WireTransferDetails currentStep={currentStep} />
       default:
         null
     }

--- a/src/v2/Apps/Order/Components/WireTransferDetails.tsx
+++ b/src/v2/Apps/Order/Components/WireTransferDetails.tsx
@@ -3,7 +3,7 @@ import { Flex, InstitutionIcon, Text } from "@artsy/palette"
 export const WireTransferDetails = ({
   responsive = true,
   textColor = "black100",
-  withDescription,
+  withDescription = true,
 }: {
   responsive?: boolean
   textColor?: string

--- a/src/v2/Apps/Order/Components/WireTransferDetails.tsx
+++ b/src/v2/Apps/Order/Components/WireTransferDetails.tsx
@@ -3,13 +3,15 @@ import { Flex, InstitutionIcon, Text } from "@artsy/palette"
 export const WireTransferDetails = ({
   responsive = true,
   textColor = "black100",
+  currentStep,
 }: {
   responsive?: boolean
   textColor?: string
+  currentStep?: string
 }) => (
   <Flex flexDirection="column">
     <Flex alignItems="center">
-      <InstitutionIcon fill="black60" width="25px" />
+      <InstitutionIcon fill="green100" width="25px" />
       <Text
         size={responsive ? ["2", "3"] : "3"}
         color={textColor}
@@ -18,14 +20,16 @@ export const WireTransferDetails = ({
         Wire transfer
       </Text>
     </Flex>
-    <Flex flexDirection="column" mt={0.5} ml={4}>
-      <Text color="black60" variant="sm" fontSize={13}>
-        • To pay by wire transfer, complete checkout and one of our support
-        specialists will reach out with next steps.
-      </Text>
-      <Text color="black60" variant="sm" fontSize={13}>
-        • Your bank may charge a fee for the transaction.
-      </Text>
-    </Flex>
+    {currentStep !== "status" && (
+      <Flex flexDirection="column" mt={0.5} ml={4}>
+        <Text color="black60" fontSize={13}>
+          • To pay by wire transfer, complete checkout and a member of the Artsy
+          team will contact you with next steps by email.
+        </Text>
+        <Text color="black60" fontSize={13}>
+          • Your bank may charge a fee for the transaction.
+        </Text>
+      </Flex>
+    )}
   </Flex>
 )

--- a/src/v2/Apps/Order/Components/WireTransferDetails.tsx
+++ b/src/v2/Apps/Order/Components/WireTransferDetails.tsx
@@ -3,11 +3,11 @@ import { Flex, InstitutionIcon, Text } from "@artsy/palette"
 export const WireTransferDetails = ({
   responsive = true,
   textColor = "black100",
-  currentStep,
+  withDescription,
 }: {
   responsive?: boolean
   textColor?: string
-  currentStep?: string
+  withDescription?: boolean
 }) => (
   <Flex flexDirection="column">
     <Flex alignItems="center">
@@ -20,7 +20,7 @@ export const WireTransferDetails = ({
         Wire transfer
       </Text>
     </Flex>
-    {currentStep !== "status" && (
+    {withDescription && (
       <Flex flexDirection="column" mt={0.5} ml={4}>
         <Text color="black60" fontSize={13}>
           • To pay by wire transfer, complete checkout and a member of the Artsy

--- a/src/v2/Apps/Order/Components/__tests__/WireTransferDetails.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/WireTransferDetails.jest.tsx
@@ -1,0 +1,34 @@
+import { screen } from "@testing-library/react"
+import { render } from "@testing-library/react"
+import { WireTransferDetails } from "../WireTransferDetails"
+
+describe("WireTransferDetails", () => {
+  it("renders a title", () => {
+    render(<WireTransferDetails />)
+    expect(screen.queryByText("Wire transfer")).toBeInTheDocument()
+  })
+
+  it("renders 2 description texts when no props passed", () => {
+    render(<WireTransferDetails />)
+    expect(
+      screen.queryByText("• Your bank may charge a fee for the transaction.")
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        "• To pay by wire transfer, complete checkout and a member of the Artsy team will contact you with next steps by email."
+      )
+    ).toBeInTheDocument()
+  })
+
+  it("does not render description texts when withDescription dictates otherwise", () => {
+    render(<WireTransferDetails withDescription={false} />)
+    expect(
+      screen.queryByText("• Your bank may charge a fee for the transaction.")
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        "• To pay by wire transfer, complete checkout and a member of the Artsy team will contact you with next steps by email."
+      )
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/v2/Apps/Order/Components/__tests__/WireTransferDetails.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/WireTransferDetails.jest.tsx
@@ -1,5 +1,4 @@
-import { screen } from "@testing-library/react"
-import { render } from "@testing-library/react"
+import { screen, render } from "@testing-library/react"
 import { WireTransferDetails } from "../WireTransferDetails"
 
 describe("WireTransferDetails", () => {

--- a/src/v2/Apps/Order/Components/__tests__/WireTransferDetails.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/WireTransferDetails.jest.tsx
@@ -19,7 +19,7 @@ describe("WireTransferDetails", () => {
     ).toBeInTheDocument()
   })
 
-  it("does not render description texts when withDescription dictates otherwise", () => {
+  it("does not render description texts when withDescription dictates so", () => {
     render(<WireTransferDetails withDescription={false} />)
     expect(
       screen.queryByText("• Your bank may charge a fee for the transaction.")

--- a/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -136,8 +136,8 @@ export const PaymentContent: FC<Props> = props => {
       {/* Wire transfer */}
       <Collapse open={paymentMethod === "WIRE_TRANSFER"}>
         <Text color="black60" variant="sm">
-          • To pay by wire transfer, complete checkout and one of our support
-          specialists will reach out with next steps.
+          • To pay by wire transfer, complete checkout and a member of the Artsy
+          team will contact you with next steps by email.
         </Text>
         <Text color="black60" variant="sm">
           • Your bank may charge a fee for the transaction.
@@ -189,7 +189,7 @@ const getAvailablePaymentMethods = (
       value={paymentMethod}
       label={
         <>
-          <CreditCardIcon type="Unknown" fill="black60" />
+          <CreditCardIcon type="Unknown" fill="black100" />
           <Text ml={1}>Credit card</Text>
         </>
       }
@@ -203,7 +203,7 @@ const getAvailablePaymentMethods = (
         value={(paymentMethod = "WIRE_TRANSFER")}
         label={
           <>
-            <InstitutionIcon fill="black60" />
+            <InstitutionIcon fill="green100" />
             <Text ml={1}>Wire transfer</Text>
           </>
         }
@@ -218,7 +218,7 @@ const getAvailablePaymentMethods = (
         value={(paymentMethod = "US_BANK_ACCOUNT")}
         label={
           <>
-            <InstitutionIcon fill="black60" />
+            <InstitutionIcon fill="green100" />
             <Text ml={1}>Bank transfer (US bank account)</Text>
           </>
         }

--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -398,7 +398,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
               <PaymentMethodSummaryItem
                 order={order}
                 onChange={onChangePayment}
-                title="Payment"
+                title="Payment method"
               />
               <ShippingArtaSummaryItemFragmentContainer
                 order={order}

--- a/src/v2/Apps/Order/Routes/Status/index.tsx
+++ b/src/v2/Apps/Order/Routes/Status/index.tsx
@@ -127,7 +127,11 @@ export class StatusRoute extends Component<StatusProps> {
                     <Flex flexDirection="column">
                       <Flex flexDirection="column">
                         <StyledShippingSummaryItem order={order} />
-                        <PaymentMethodSummaryItem order={order} />
+                        <PaymentMethodSummaryItem
+                          order={order}
+                          currentStep="status"
+                          title="Payment method"
+                        />
                       </Flex>
                     </Flex>
                   )

--- a/src/v2/Apps/Order/Routes/Status/index.tsx
+++ b/src/v2/Apps/Order/Routes/Status/index.tsx
@@ -129,7 +129,7 @@ export class StatusRoute extends Component<StatusProps> {
                         <StyledShippingSummaryItem order={order} />
                         <PaymentMethodSummaryItem
                           order={order}
-                          currentStep="status"
+                          withDescription={false}
                           title="Payment method"
                         />
                       </Flex>


### PR DESCRIPTION
The type of this PR is: **Enhancement**

This PR solves [TX-403]

### Description
This PR improves the checkout flow UI, namely: 

- The copy for wire transfer payment method is updated to "To pay by wire transfer, complete checkout and a member of the Artsy team will contact you with next steps by email." in Payment and Review steps. 
- The copy is removed from the confirmation step.
- The icon colours for wire and bank transfer orders are updated to _green100_
- The copy "Payment" is updated to "Payment method' in Review and Confirmation steps. 

Note: to make the CreditCardIcon darker, we'll need to update it on Palette as there seems to be no type or color that we can pass to it to make it darker.

#### Video 
https://user-images.githubusercontent.com/42584148/173025150-02633b95-5241-4cdd-8022-a79e1277f451.mov

[TX-403]: https://artsyproduct.atlassian.net/browse/TX-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ