### PR TITLE
chore: display error if user tries to edit an alert that has already been deleted

### DIFF
--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -5,6 +5,7 @@ import {
   Flex,
   Input,
   Join,
+  Message,
   Spacer,
   Text,
 } from "@artsy/palette"
@@ -256,7 +257,7 @@ const SavedSearchAlertEditFormContainer: React.FC<SavedSearchAlertEditFormProps>
   } = props
   const { savedSearch } = me
   const aggregations = artworksConnection?.aggregations as Aggregations
-  const criteria = getAllowedSearchCriteria(savedSearch as any)
+  const criteria = getAllowedSearchCriteria((savedSearch as any) ?? {})
   const entity: SavedSearchEntity = {
     placeholder: artist.name ?? "",
     artists: [
@@ -281,6 +282,16 @@ const SavedSearchAlertEditFormContainer: React.FC<SavedSearchAlertEditFormProps>
   if (shouldFetchLabelsFromMetaphysics) {
     labels = (savedSearch?.labels as LabelEntity[]) ?? []
     pills = convertLabelsToPills(labels)
+  }
+
+  if (savedSearch === null) {
+    return (
+      <Box>
+        <Message variant="error" title="Edit action cannot be performed">
+          This alert has been deleted in another tab or mobile app
+        </Message>
+      </Box>
+    )
   }
 
   return (

--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/__tests__/SavedSearchAlertEditForm.jest.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/__tests__/SavedSearchAlertEditForm.jest.tsx
@@ -159,6 +159,23 @@ describe("SavedSearchAlertEditForm", () => {
     `)
   })
 
+  it("should display error message when user tries to edit a deleted alert", () => {
+    renderWithRelay({
+      Artist: () => artistMocked,
+      FilterArtworksConnection: () => filterArtworksConnectionMocked,
+      Me: () => ({
+        ...meMocked,
+        savedSearch: null,
+      }),
+    })
+
+    const title = "Edit action cannot be performed"
+    const message = "This alert has been deleted in another tab or mobile app"
+
+    expect(screen.getByText(title)).toBeInTheDocument()
+    expect(screen.getByText(message)).toBeInTheDocument()
+  })
+
   describe("Save Alert button", () => {
     it("should be disabled by default", () => {
       renderWithRelay({


### PR DESCRIPTION
The type of this PR is: **Chore**

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/173057225-e27df6c7-0a75-4418-8364-281d53f212d3.mp4

#### After
https://user-images.githubusercontent.com/3513494/173057268-13f2e556-e7e3-41af-b697-85fdf3b86351.mp4

<!-- Implementation description -->
