### PR TITLE
enhancement: return 404 when identity verification does not exist

### DIFF
--- a/src/v2/Apps/IdentityVerification/IdentityVerificationApp/index.tsx
+++ b/src/v2/Apps/IdentityVerification/IdentityVerificationApp/index.tsx
@@ -18,6 +18,7 @@ import { CompletePassed } from "./CompletePassed"
 import { CompleteWatchlistHit } from "./CompleteWatchlistHit"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { MetaTags } from "v2/Components/MetaTags"
+import { HttpError } from "found"
 
 const logger = createLogger("IdentityVerificationApp.tsx")
 
@@ -36,6 +37,9 @@ const IdentityVerificationApp: React.FC<Props> = ({
   const { trackEvent } = useTracking()
 
   const alternateComponent = useMemo(() => {
+    if (!identityVerification) {
+      throw new HttpError(404)
+    }
     if (identityVerification.state === "failed") {
       return <CompleteFailed />
     }

--- a/src/v2/Apps/IdentityVerification/__tests__/IdentityVerificationApp.jest.tsx
+++ b/src/v2/Apps/IdentityVerification/__tests__/IdentityVerificationApp.jest.tsx
@@ -44,7 +44,7 @@ const setupTestEnv = () => {
 }
 
 describe("IdentityVerification route", () => {
-  describe("for signed-in user", () => {
+  describe("for a visitor", () => {
     describe("unactionable end states", () => {
       it("renders a message about an identity verification that is `passed`", async () => {
         const env = setupTestEnv()

--- a/src/v2/Apps/IdentityVerification/__tests__/IdentityVerificationApp.jest.tsx
+++ b/src/v2/Apps/IdentityVerification/__tests__/IdentityVerificationApp.jest.tsx
@@ -8,12 +8,14 @@ import { IdentityVerificationAppQueryResponseFixture } from "../__fixtures__/rou
 import { IdentityVerificationAppFragmentContainer } from "../IdentityVerificationApp"
 import { IdentityVerificationAppTestPage } from "./Utils/IdentityVerificationAppTestPage"
 import { mockLocation } from "v2/DevTools/mockLocation"
+import { HttpError } from "found"
 
 jest.unmock("react-relay")
 jest.unmock("react-tracking")
 jest.mock("v2/Utils/Events", () => ({
   postEvent: jest.fn(),
 }))
+jest.mock("found")
 
 const mockPostEvent = require("v2/Utils/Events").postEvent as jest.Mock
 
@@ -47,16 +49,14 @@ describe("IdentityVerification route", () => {
   describe("for a visitor", () => {
     describe("unactionable end states", () => {
       it("returns a 404 when the identity verification is not found", async () => {
+        const mockHttpError = HttpError as jest.Mock
         const env = setupTestEnv()
-        try {
-          await env.buildPage({
-            mockData: deepMerge(IdentityVerificationAppQueryResponseFixture, {
-              identityVerification: null,
-            }),
-          })
-        } catch (error) {
-          console.log("ERROR", error)
-        }
+        await env.buildPage({
+          mockData: deepMerge(IdentityVerificationAppQueryResponseFixture, {
+            identityVerification: null,
+          }),
+        })
+        expect(mockHttpError).toHaveBeenCalledWith(404)
       })
 
       it("renders a message about an identity verification that is `passed`", async () => {

--- a/src/v2/Apps/IdentityVerification/__tests__/IdentityVerificationApp.jest.tsx
+++ b/src/v2/Apps/IdentityVerification/__tests__/IdentityVerificationApp.jest.tsx
@@ -46,6 +46,19 @@ const setupTestEnv = () => {
 describe("IdentityVerification route", () => {
   describe("for a visitor", () => {
     describe("unactionable end states", () => {
+      it("returns a 404 when the identity verification is not found", async () => {
+        const env = setupTestEnv()
+        try {
+          await env.buildPage({
+            mockData: deepMerge(IdentityVerificationAppQueryResponseFixture, {
+              identityVerification: null,
+            }),
+          })
+        } catch (error) {
+          console.log("ERROR", error)
+        }
+      })
+
       it("renders a message about an identity verification that is `passed`", async () => {
         const env = setupTestEnv()
 


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PLATFORM-4165](https://artsyproduct.atlassian.net/browse/PLATFORM-4165)

### Description

<!-- Implementation description -->

This is a followup to https://github.com/artsy/force/pull/10263. After removing [this logic](https://github.com/artsy/force/pull/10263/files#diff-5e4ebdf40b75b0a9dac5f65a77a5e245dff68b03561e90c7259fefecc403bd2dL39) and the [wrong-owner component](https://github.com/artsy/force/pull/10263/files#diff-5e8cbe37fe55c565db5dfb15eaa537c04376af52e84c62af9370006930c54bf6L11) I introduced a regression and so now when requesting an identity verification that does not exist the client throws a _500 internal server error_ whereas before we rendered a _wrong-owner_ component. 

To address this regression I thought it would be good to return a _404_ when an identity verification is not found.

Before https://github.com/artsy/force/pull/10263:
<img width="720" alt="Screen Shot 2022-06-10 at 11 19 19 AM" src="https://user-images.githubusercontent.com/29984068/173130804-0030dfa1-92c9-4da4-bb44-24193e30ee6d.png">

Now:
<img width="515" alt="Screen Shot 2022-06-10 at 2 20 31 PM" src="https://user-images.githubusercontent.com/29984068/173127519-e4ec093e-62db-4864-9417-c1fd1de01a06.png">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ