### PR TITLE
chore: add ability to pass context module prop for Details and Metadata components

### DIFF
--- a/src/v2/Components/Artwork/Details.tsx
+++ b/src/v2/Components/Artwork/Details.tsx
@@ -15,7 +15,7 @@ import { useArtworkGridContext } from "../ArtworkGrid/ArtworkGridContext"
 import { useTimer } from "v2/Utils/Hooks/useTimer"
 import { HoverDetailsFragmentContainer } from "./HoverDetails"
 
-import { ContextModule } from "@artsy/cohesion"
+import { AuthContextModule } from "@artsy/cohesion"
 import { NewSaveButtonFragmentContainer } from "./SaveButton"
 import { getSaleOrLotTimerInfo } from "v2/Utils/getSaleOrLotTimerInfo"
 import { useState } from "react"
@@ -29,6 +29,7 @@ interface DetailsProps {
   hidePartnerName?: boolean
   isHovered?: boolean
   shouldShowHoverSaveButton?: boolean
+  contextModule?: AuthContextModule
 }
 
 const ConditionalLink: React.FC<
@@ -216,6 +217,7 @@ export const Details: React.FC<DetailsProps> = ({
   hideSaleInfo,
   isHovered,
   shouldShowHoverSaveButton,
+  contextModule,
   ...rest
 }) => {
   const { isAuctionArtwork } = useArtworkGridContext()
@@ -241,7 +243,7 @@ export const Details: React.FC<DetailsProps> = ({
         {!hideArtistName && <ArtistLine {...rest} />}
         {shouldShowHoverSaveButton && (
           <NewSaveButtonFragmentContainer
-            contextModule={ContextModule.artworkGrid}
+            contextModule={contextModule!}
             artwork={rest.artwork}
           />
         )}

--- a/src/v2/Components/Artwork/GridItem.tsx
+++ b/src/v2/Components/Artwork/GridItem.tsx
@@ -117,6 +117,7 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
         artwork={artwork}
         isHovered={isHovered}
         shouldShowHoverSaveButton={!!shouldShowHoverSaveButton}
+        contextModule={contextModule || ContextModule.artworkGrid}
       />
     </div>
   )

--- a/src/v2/Components/Artwork/Metadata.tsx
+++ b/src/v2/Components/Artwork/Metadata.tsx
@@ -4,6 +4,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { DetailsFragmentContainer as Details } from "./Details"
 import { BoxProps } from "@artsy/palette"
 import { RouterLink } from "v2/System/Router/RouterLink"
+import { AuthContextModule } from "@artsy/cohesion"
 
 export interface MetadataProps
   extends BoxProps,
@@ -15,6 +16,7 @@ export interface MetadataProps
   hideSaleInfo?: boolean
   isHovered?: boolean
   shouldShowHoverSaveButton?: boolean
+  contextModule?: AuthContextModule
 }
 
 export const Metadata: React.FC<MetadataProps> = ({
@@ -26,6 +28,7 @@ export const Metadata: React.FC<MetadataProps> = ({
   hideSaleInfo,
   isHovered,
   shouldShowHoverSaveButton,
+  contextModule,
   ...rest
 }) => {
   return (
@@ -45,6 +48,7 @@ export const Metadata: React.FC<MetadataProps> = ({
         hideArtistName={hideArtistName}
         isHovered={isHovered}
         shouldShowHoverSaveButton={shouldShowHoverSaveButton}
+        contextModule={contextModule}
       />
     </RouterLink>
   )


### PR DESCRIPTION
The type of this PR is: **Enhancement**


### Description
Added the ability to pass the `contextModule` prop, the value of which is used for the "save" button

<!-- Implementation description -->
