### PR TITLE
enhancement(FX-4016): Add new hover behavior to artwork cards in ArtworkShelf

### DIFF
--- a/src/v2/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
@@ -65,7 +65,6 @@ const ArtistNotableWorksRail: React.FC<ArtistNotableWorksRailProps> = ({
             <ShelfArtworkFragmentContainer
               artwork={node}
               contextModule={ContextModule.topWorksRail}
-              hidePartnerName
               key={index}
               showExtended={false}
               showMetadata

--- a/src/v2/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
@@ -60,7 +60,6 @@ const ArtistWorksForSaleRail: React.FC<ArtistWorksForSaleRailProps> = ({
               <ShelfArtworkFragmentContainer
                 artwork={node}
                 contextModule={ContextModule.worksForSaleRail}
-                hidePartnerName
                 key={index}
                 showExtended={false}
                 showMetadata

--- a/src/v2/Apps/Auctions/Components/AuctionArtworksRail.tsx
+++ b/src/v2/Apps/Auctions/Components/AuctionArtworksRail.tsx
@@ -68,7 +68,6 @@ export const AuctionArtworksRail: React.FC<AuctionArtworksRailProps> = ({
               artwork={node}
               key={node.slug}
               contextModule={contextModule}
-              hidePartnerName
               lazyLoad
               onClick={() => {
                 trackEvent(

--- a/src/v2/Apps/Auctions/Components/StandoutLotsRail.tsx
+++ b/src/v2/Apps/Auctions/Components/StandoutLotsRail.tsx
@@ -36,7 +36,6 @@ const StandoutLotsRail: React.FC<StandoutLotsRailProps> = ({ viewer }) => {
                 artwork={artwork}
                 key={artwork.slug}
                 contextModule={contextModule}
-                hidePartnerName
                 lazyLoad
                 onClick={() => {
                   trackEvent(

--- a/src/v2/Apps/Auctions/Components/TrendingLotsRail.tsx
+++ b/src/v2/Apps/Auctions/Components/TrendingLotsRail.tsx
@@ -37,7 +37,6 @@ const TrendingLotsRail: React.FC<TrendingLotsRailProps> = ({ viewer }) => {
               artwork={node}
               key={node.slug}
               contextModule={contextModule}
-              hidePartnerName
               lazyLoad
               onClick={() => {
                 trackEvent(

--- a/src/v2/Apps/Auctions/Components/WorksByArtistsYouFollowRail.tsx
+++ b/src/v2/Apps/Auctions/Components/WorksByArtistsYouFollowRail.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useAnalyticsContext } from "v2/System"
 import { WorksByArtistsYouFollowRail_viewer } from "v2/__generated__/WorksByArtistsYouFollowRail_viewer.graphql"

--- a/src/v2/Apps/Auctions/Components/WorksByArtistsYouFollowRail.tsx
+++ b/src/v2/Apps/Auctions/Components/WorksByArtistsYouFollowRail.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useAnalyticsContext } from "v2/System"
 import { WorksByArtistsYouFollowRail_viewer } from "v2/__generated__/WorksByArtistsYouFollowRail_viewer.graphql"
@@ -39,7 +39,6 @@ const WorksByArtistsYouFollowRail: React.FC<WorksByArtistsYouFollowRailProps> = 
               artwork={node}
               key={node.slug}
               contextModule={contextModule}
-              hidePartnerName
               lazyLoad
               onClick={() => {
                 trackEvent(

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/SoldRecentlyOnArtsy.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/SoldRecentlyOnArtsy.tsx
@@ -68,7 +68,6 @@ export const SoldRecentlyOnArtsy: React.FC<SoldRecentlyOnArtsyProps> = ({
                   <ShelfArtworkFragmentContainer
                     artwork={artwork!}
                     key={artwork!.internalID}
-                    hidePartnerName
                     hideSaleInfo
                     lazyLoad
                     // @ts-ignore

--- a/src/v2/Apps/Fair/Components/FairBoothRail/FairBoothRailArtworks.tsx
+++ b/src/v2/Apps/Fair/Components/FairBoothRail/FairBoothRailArtworks.tsx
@@ -62,7 +62,6 @@ const FairBoothRailArtworks: React.FC<FairBoothRailArtworksProps> = ({
             key={artwork.internalID}
             contextModule={ContextModule.fairRail}
             artwork={artwork}
-            hidePartnerName
             lazyLoad
             onClick={() =>
               tracking.trackEvent(

--- a/src/v2/Apps/Home/Components/HomeAuctionLotsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeAuctionLotsRail.tsx
@@ -60,7 +60,6 @@ const HomeAuctionLotsRail: React.FC<HomeAuctionLotsRailProps> = ({
               artwork={artwork}
               key={artwork.slug}
               contextModule={ContextModule.auctionLots}
-              hidePartnerName
               lazyLoad
               onClick={() => {
                 const trackingEvent: ClickedArtworkGroup = {

--- a/src/v2/Apps/Home/Components/HomeRecentlyViewedRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeRecentlyViewedRail.tsx
@@ -47,7 +47,6 @@ const HomeRecentlyViewedRail: React.FC<HomeRecentlyViewedRailProps> = ({
             key={index}
             // TODO: Add home type to cohesion once we have tracking
             contextModule={null as any}
-            hidePartnerName
             lazyLoad
             onClick={() => {
               const trackingEvent: ClickedArtworkGroup = {

--- a/src/v2/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
@@ -47,7 +47,6 @@ const HomeWorksByArtistsYouFollowRail: React.FC<HomeWorksByArtistsYouFollowRailP
             key={index}
             // TODO: Add home type to cohesion once we have tracking
             contextModule={null as any}
-            hidePartnerName
             lazyLoad
             onClick={() => {
               const trackingEvent: ClickedArtworkGroup = {

--- a/src/v2/Components/Artwork/Details.tsx
+++ b/src/v2/Components/Artwork/Details.tsx
@@ -43,7 +43,7 @@ const ConditionalLink: React.FC<
 const ArtistLine: React.FC<DetailsProps> = ({
   artwork: { cultural_maker, artists },
   includeLinks,
-  shouldShowHoverSaveButton,
+  showSaveButton,
 }) => {
   const tokens = useThemeConfig({
     v2: {
@@ -63,7 +63,7 @@ const ArtistLine: React.FC<DetailsProps> = ({
   }
 
   if (!artists?.length) {
-    if (shouldShowHoverSaveButton) {
+    if (showSaveButton) {
       return (
         <Text variant={tokens.variant} overflowEllipsis>
           Artist Unavailable
@@ -249,7 +249,9 @@ export const Details: React.FC<DetailsProps> = ({
         </Flex>
       )}
       <Flex flexDirection="row" justifyContent="space-between">
-        {!hideArtistName && <ArtistLine {...rest} />}
+        {!hideArtistName && (
+          <ArtistLine showSaveButton={showSaveButton} {...rest} />
+        )}
         {showSaveButton && (
           <NewSaveButtonFragmentContainer
             contextModule={contextModule!}

--- a/src/v2/Components/Artwork/Details.tsx
+++ b/src/v2/Components/Artwork/Details.tsx
@@ -43,6 +43,7 @@ const ConditionalLink: React.FC<
 const ArtistLine: React.FC<DetailsProps> = ({
   artwork: { cultural_maker, artists },
   includeLinks,
+  shouldShowHoverSaveButton,
 }) => {
   const tokens = useThemeConfig({
     v2: {
@@ -62,6 +63,14 @@ const ArtistLine: React.FC<DetailsProps> = ({
   }
 
   if (!artists?.length) {
+    if (shouldShowHoverSaveButton) {
+      return (
+        <Text variant={tokens.variant} overflowEllipsis>
+          Artist Unavailable
+        </Text>
+      )
+    }
+
     return null
   }
 

--- a/src/v2/Components/Artwork/ShelfArtwork.tsx
+++ b/src/v2/Components/Artwork/ShelfArtwork.tsx
@@ -7,6 +7,7 @@ import { AuthContextModule } from "@artsy/cohesion"
 import styled from "styled-components"
 import { Image, Flex } from "@artsy/palette"
 import { Media } from "v2/Utils/Responsive"
+import { useHoverMetadata } from "./useHoverMetadata"
 
 /**
  * The max height for an image in the carousel
@@ -19,8 +20,6 @@ export const IMG_HEIGHT = {
 interface ShelfArtworkProps {
   artwork: ShelfArtwork_artwork
   contextModule?: AuthContextModule
-  hideArtistName?: boolean
-  hidePartnerName?: boolean
   hideSaleInfo?: boolean
   lazyLoad?: boolean
   showExtended?: boolean
@@ -31,16 +30,21 @@ interface ShelfArtworkProps {
 const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
   artwork,
   contextModule,
-  hideArtistName,
-  hidePartnerName,
   hideSaleInfo,
   lazyLoad,
   onClick,
   showExtended,
   showMetadata = true,
 }) => {
+  const { isHovered, onMouseEnter, onMouseLeave } = useHoverMetadata()
+
   return (
-    <div data-test="artworkShelfArtwork" data-testid="ShelfArtwork">
+    <div
+      data-test="artworkShelfArtwork"
+      data-testid="ShelfArtwork"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
       <RouterLink
         to={artwork?.href}
         display="block"
@@ -63,10 +67,10 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
         <Metadata
           artwork={artwork}
           extended={showExtended}
-          hidePartnerName={hidePartnerName}
-          hideArtistName={hideArtistName}
           hideSaleInfo={hideSaleInfo}
           maxWidth={artwork.image?.resized?.width}
+          contextModule={contextModule}
+          isHovered={isHovered}
           showSaveButton
         />
       )}

--- a/src/v2/Components/Artwork/ShelfArtwork.tsx
+++ b/src/v2/Components/Artwork/ShelfArtwork.tsx
@@ -69,8 +69,8 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
           extended={showExtended}
           hideSaleInfo={hideSaleInfo}
           maxWidth={artwork.image?.resized?.width}
-          contextModule={contextModule}
           isHovered={isHovered}
+          contextModule={contextModule}
           showSaveButton
         />
       )}


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR solves [FX-4016]

Related PR for `GridItem` component #9741

Reverted initial PR: #10234

### Description
We added new hover behavior to swap in information on Rarity and Medium Type on artwork cards in the artwork grid. This ticket covers adding the same hover behavior to the artworks cards found on the ArtworkShelf component, supporting most artwork rails on [artsy.net](http://artsy.net/)

> **Note**
> We also want to start rendering the gallery name on these cards as well. This will give us the same vertical space to render the pills within.

### Acceptance Criteria
* Always display artist name, artwork title, gallery name/partner, price
* Display the rarity and medium type pills when hovering over an artwork card in an artwork rail
* No changes to existing behaviour on artwork grid artwork item (default ‘heart’ unselected empty state; when selected ‘heart’ blue state)

### Not in Scope
* Any artwork rails that do not rely on the `ShelfArtwork` component
* The image zoom behavior

### Demo
#### [Artist page](https://hover-effect-for-shelf-artwork.artsy.net/artist/banksy) / "Works For Sale" rail

| Before  | After |
| ------------- | ------------- |
| <img width="1904" alt="before-1" src="https://user-images.githubusercontent.com/3513494/172672024-37aed285-13bc-4c91-973c-a36d4b8fd451.png"> | <img width="1904" alt="after-1" src="https://user-images.githubusercontent.com/3513494/172672064-bb46f20d-5255-4dab-9a5d-6eaf3f758557.png"> |

#### [Auctions page](https://hover-effect-for-shelf-artwork.artsy.net/auctions) / "Current Auctions" or "Upcoming" or "Past" rails

| Before  | After |
| ------------- | ------------- |
| <img width="1897" alt="before-2" src="https://user-images.githubusercontent.com/3513494/172673274-d5ae8c4a-e311-44de-9017-24d252c850e9.png"> | <img width="1897" alt="after-2" src="https://user-images.githubusercontent.com/3513494/172673338-16dbe646-e332-48ef-af4e-f331ed6ef518.png"> |


#### [Auctions page](https://hover-effect-for-shelf-artwork.artsy.net/auctions) / "Current Highlights" rail

| Before  | After |
| ------------- | ------------- |
| <img width="1905" alt="before-3" src="https://user-images.githubusercontent.com/3513494/172673765-ac1d21ef-af2c-43d4-b641-f6f51a95a164.png"> | <img width="1905" alt="after-3" src="https://user-images.githubusercontent.com/3513494/172673823-64aeab4b-41ba-4251-aab7-897537e0eafe.png"> |

#### [Auctions page](https://hover-effect-for-shelf-artwork.artsy.net/auctions) / "Trending Lots" rail

| Before  | After |
| ------------- | ------------- |
| <img width="1902" alt="before-4" src="https://user-images.githubusercontent.com/3513494/172674132-6c90303e-9ef0-472f-81ec-20884744878e.png"> | <img width="1902" alt="after-4" src="https://user-images.githubusercontent.com/3513494/172674183-e907b187-23fb-42bf-baf3-489b37a08082.png"> |

#### [Auctions page](https://hover-effect-for-shelf-artwork.artsy.net/auctions) / "Works For You" rail (_not displayed in the review app)_

| Before  | After |
| ------------- | ------------- |
| <img width="1898" alt="before-5" src="https://user-images.githubusercontent.com/3513494/172674446-d67ee618-8344-406a-89e7-228c09ac4cfd.png"> | <img width="1898" alt="after-5" src="https://user-images.githubusercontent.com/3513494/172674512-52ef0980-6557-4f0d-98aa-980809291c1f.png"> |

#### [Consign or Sell page](https://hover-effect-for-shelf-artwork.artsy.net/sell) / "Sold Recently on Artsy" rail

| Before  | After |
| ------------- | ------------- |
| <img width="1896" alt="before-6" src="https://user-images.githubusercontent.com/3513494/172675216-7347cdd3-e6e3-4947-a048-d6e52f0a3e7d.png"> | <img width="1896" alt="after-6" src="https://user-images.githubusercontent.com/3513494/172675270-d6ba97a5-1add-4e56-8221-1a7e7730c388.png"> |

#### [Fair page](https://hover-effect-for-shelf-artwork.artsy.net/fair/art-brussels-2022) / "Booths" rails (_not displayed in the review app)_

| Before  | After |
| ------------- | ------------- |
| <img width="1897" alt="before-7" src="https://user-images.githubusercontent.com/3513494/172675647-231d8186-192f-4357-9d20-9cd980147fae.png"> | <img width="1897" alt="after-7" src="https://user-images.githubusercontent.com/3513494/172675691-72781f3a-65ce-4258-abef-a44948279452.png"> |

#### [Home page](https://hover-effect-for-shelf-artwork.artsy.net/) / "Auction Lots" rail

| Before  | After |
| ------------- | ------------- |
| <img width="1894" alt="before-8" src="https://user-images.githubusercontent.com/3513494/172676081-86b23eaf-1f7d-4c88-b305-9f2f3053d008.png"> | <img width="1894" alt="after-8" src="https://user-images.githubusercontent.com/3513494/172676172-aff0a2ba-bb74-48a6-8385-8a68284925e6.png"> |

#### [Artist page](https://hover-effect-for-shelf-artwork.artsy.net/artist/banksy) / "Notable Works" rail

| Before  | After |
| ------------- | ------------- |
| <img width="1901" alt="before-9" src="https://user-images.githubusercontent.com/3513494/172676573-90490768-0fbb-47e9-9192-0a7cf506edd2.png"> | <img width="1901" alt="after-9" src="https://user-images.githubusercontent.com/3513494/172676637-43a92b1c-587a-45dd-b1c2-9e66c412e378.png"> |

<!-- Implementation description -->

[FX-4016]: https://artsyproduct.atlassian.net/browse/FX-4016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ