### PR TITLE
fix(rss): fixes order of variables for news query

### DIFF
--- a/src/desktop/apps/rss/queries/news.js
+++ b/src/desktop/apps/rss/queries/news.js
@@ -1,21 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import { data as sd } from "sharify"
 
-export const news = `
-  query RSSNewsQuery {
-    articles(
-      published: true,
-      channel_id: "${sd.ARTSY_EDITORIAL_CHANNEL}",
-      sort: "-published_at",
-      exclude_google_news: false,
-      limit: 50
-    ) {
-      ${articleBody}
-    }
-  }
-  ${sectionFragments}
-`
-
 const articleBody = `
   id
   title
@@ -214,4 +199,19 @@ const sectionFragments = `
     width
     height
   }
+`
+
+export const news = `
+  query RSSNewsQuery {
+    articles(
+      published: true,
+      channel_id: "${sd.ARTSY_EDITORIAL_CHANNEL}",
+      sort: "-published_at",
+      exclude_google_news: false,
+      limit: 50
+    ) {
+      ${articleBody}
+    }
+  }
+  ${sectionFragments}
 `


### PR DESCRIPTION
I deleted some stuff in this file and in doing so re-ordered and broke the query. A rare `.js` file.