### PR TITLE
feat(FX-4041): Add active filter pills to partner page's artwork grid

### DIFF
--- a/src/v2/Apps/Partner/Routes/Works/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Works/index.tsx
@@ -10,6 +10,7 @@ import {
 import { BaseArtworkFilter } from "v2/Components/ArtworkFilter"
 import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { Match, RouterState, withRouter } from "found"
+import { ActiveFilterPills } from "v2/Components/SavedSearchAlert/Components/ActiveFilterPills"
 
 interface PartnerArtworkFilterProps {
   partner: Works_partner
@@ -42,7 +43,12 @@ export const Artworks: React.FC<PartnerArtworkFilterProps> = ({
       }
       counts={sidebar?.counts as Counts}
     >
-      <BaseArtworkFilter relay={relay} offset={200} viewer={partner} />
+      <BaseArtworkFilter
+        relay={relay}
+        offset={200}
+        viewer={partner}
+        renderFilterPills={() => <ActiveFilterPills />}
+      />
     </ArtworkFilterContextProvider>
   )
 }

--- a/src/v2/Apps/Partner/Routes/Works/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Works/index.tsx
@@ -47,7 +47,7 @@ export const Artworks: React.FC<PartnerArtworkFilterProps> = ({
         relay={relay}
         offset={200}
         viewer={partner}
-        renderFilterPills={() => <ActiveFilterPills />}
+        FilterPills={<ActiveFilterPills />}
       />
     </ArtworkFilterContextProvider>
   )

--- a/src/v2/Components/ArtworkFilter/Utils/__tests__/filterArtistSlugsByAggregation.jest.ts
+++ b/src/v2/Components/ArtworkFilter/Utils/__tests__/filterArtistSlugsByAggregation.jest.ts
@@ -1,0 +1,90 @@
+import { Aggregations } from "../../ArtworkFilterContext"
+import { filterArtistSlugsByAggregation } from "../filterArtistSlugsByAggregation"
+
+describe("filterArtistSlugsByAggregation", () => {
+  it("should return slugs only for those artists who are in ARTIST aggregation", () => {
+    const result = filterArtistSlugsByAggregation(
+      mockedArtistSlugs,
+      mockedAggregations
+    )
+
+    expect(result).toEqual(["kaws", "banksy"])
+  })
+
+  it("should return empty array when there is no ARTIST aggregation", () => {
+    const aggregations: Aggregations = [
+      {
+        slice: "MEDIUM",
+        counts: [
+          {
+            name: "Prints",
+            value: "prints",
+            count: 212,
+          },
+        ],
+      },
+    ]
+    const result = filterArtistSlugsByAggregation(
+      mockedArtistSlugs,
+      aggregations
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it("should return empty array when there are no aggregation elements", () => {
+    const aggregations: Aggregations = [
+      {
+        slice: "ARTIST",
+        counts: [],
+      },
+    ]
+    const result = filterArtistSlugsByAggregation(
+      mockedArtistSlugs,
+      aggregations
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it("should return empty array when list of artist slugs is empty", () => {
+    const result = filterArtistSlugsByAggregation([], mockedAggregations)
+
+    expect(result).toEqual([])
+  })
+
+  it("should return empty array if there are no matches with aggregation elements", () => {
+    const artistSlugs = ["max-ernst", "zhao-zhao"]
+    const result = filterArtistSlugsByAggregation(
+      artistSlugs,
+      mockedAggregations
+    )
+
+    expect(result).toEqual([])
+  })
+})
+
+const mockedArtistSlugs = ["kaws", "banksy", "max-ernst"]
+
+const mockedAggregations: Aggregations = [
+  {
+    slice: "ARTIST",
+    counts: [
+      {
+        name: "Banksy",
+        value: "banksy",
+        count: 20,
+      },
+      {
+        name: "Damien Hirst",
+        value: "damien-hirst",
+        count: 18,
+      },
+      {
+        name: "KAWS",
+        value: "kaws",
+        count: 10,
+      },
+    ],
+  },
+]

--- a/src/v2/Components/ArtworkFilter/Utils/filterArtistSlugsByAggregation.ts
+++ b/src/v2/Components/ArtworkFilter/Utils/filterArtistSlugsByAggregation.ts
@@ -1,0 +1,15 @@
+import { Aggregations } from "../ArtworkFilterContext"
+
+export const filterArtistSlugsByAggregation = (
+  slugs: string[],
+  aggregations: Aggregations
+) => {
+  const aggregation = aggregations.find(agg => agg.slice === "ARTIST")
+  const artists = aggregation?.counts ?? []
+  const artistAggregationSlugs = artists.map(artist => artist.value)
+  const artistSlugs = slugs.filter(slug =>
+    artistAggregationSlugs.includes(slug)
+  )
+
+  return artistSlugs
+}

--- a/src/v2/Components/ArtworkFilter/Utils/usePrepareFiltersForPills.ts
+++ b/src/v2/Components/ArtworkFilter/Utils/usePrepareFiltersForPills.ts
@@ -1,0 +1,42 @@
+import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { filterArtistSlugsByAggregation } from "./filterArtistSlugsByAggregation"
+
+export const usePrepareFiltersForPills = () => {
+  const {
+    filters,
+    aggregations,
+    followedArtists = [],
+  } = useArtworkFilterContext()
+  let preparedFilters = filters ?? {}
+  const { artistIDs = [] } = preparedFilters
+
+  // Display all the followed artists that can be extracted from ARTIST aggregation
+  // when "Artists I Follow" is selected
+  if (preparedFilters?.includeArtworksByFollowedArtists) {
+    const followedArtistSlugs = followedArtists.map(artist => artist.slug)
+    const artistSlugs = filterArtistSlugsByAggregation(
+      followedArtistSlugs,
+      aggregations ?? []
+    )
+
+    preparedFilters = {
+      ...preparedFilters,
+      artistIDs: artistSlugs,
+    }
+  }
+
+  // Display only those artists who are present in ARTIST aggregation
+  if (artistIDs.length > 0) {
+    const artistSlugs = filterArtistSlugsByAggregation(
+      artistIDs,
+      aggregations ?? []
+    )
+
+    preparedFilters = {
+      ...preparedFilters,
+      artistIDs: artistSlugs,
+    }
+  }
+
+  return preparedFilters
+}

--- a/src/v2/Components/SavedSearchAlert/Components/ActiveFilterPills.tsx
+++ b/src/v2/Components/SavedSearchAlert/Components/ActiveFilterPills.tsx
@@ -10,6 +10,7 @@ import { SavedSearchAlertPills } from "./SavedSearchAlertPills"
 import { FilterPill } from "../types"
 import { getAllowedSearchCriteria } from "../Utils/savedSearchCriteria"
 import { DEFAULT_METRIC } from "v2/Components/ArtworkFilter/Utils/metrics"
+import { usePrepareFiltersForPills } from "v2/Components/ArtworkFilter/Utils/usePrepareFiltersForPills"
 
 interface ActiveFilterPillsProps {
   defaultPills?: FilterPill[]
@@ -17,7 +18,8 @@ interface ActiveFilterPillsProps {
 
 export const ActiveFilterPills: React.FC<ActiveFilterPillsProps> = props => {
   const { defaultPills = [] } = props
-  const { filters, aggregations, setFilter } = useArtworkFilterContext()
+  const { aggregations, setFilter } = useArtworkFilterContext()
+  const filters = usePrepareFiltersForPills()
   const criteria = getAllowedSearchCriteria(filters ?? {})
   const metric = filters?.metric ?? DEFAULT_METRIC
   const filterPills = extractPillsFromCriteria({
@@ -41,6 +43,10 @@ export const ActiveFilterPills: React.FC<ActiveFilterPillsProps> = props => {
     }
 
     setFilter(pill.field as keyof ArtworkFilters, filterValue)
+
+    if (pill.field === "artistIDs") {
+      setFilter("includeArtworksByFollowedArtists", false)
+    }
   }
 
   return <SavedSearchAlertPills items={pills} onDeletePress={removePill} />

--- a/src/v2/Components/SavedSearchAlert/Components/ArtworkGridFilterPills.tsx
+++ b/src/v2/Components/SavedSearchAlert/Components/ArtworkGridFilterPills.tsx
@@ -12,7 +12,11 @@ export const ArtworkGridFilterPills: React.FC<ArtworkGridFilterPillsProps> = pro
   const { FilterPills, CreateAlertButton } = props
 
   return (
-    <Flex flexWrap="wrap" mx={-PILL_HORIZONTAL_MARGIN_SIZE}>
+    <Flex
+      flexWrap="wrap"
+      mx={-PILL_HORIZONTAL_MARGIN_SIZE}
+      data-testid="artworkGridFilterPills"
+    >
       {FilterPills}
       {CreateAlertButton}
     </Flex>

--- a/src/v2/Components/SavedSearchAlert/Components/DefaultCreateAlertButton.tsx
+++ b/src/v2/Components/SavedSearchAlert/Components/DefaultCreateAlertButton.tsx
@@ -6,6 +6,7 @@ import { SavedSearchCreateAlertButton } from "./SavedSearchCreateAlertButton"
 import { DEFAULT_METRIC } from "v2/Components/ArtworkFilter/Utils/metrics"
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { AuthModalOptions } from "v2/Utils/openAuthModal"
+import { usePrepareFiltersForPills } from "v2/Components/ArtworkFilter/Utils/usePrepareFiltersForPills"
 
 const PILL_HORIZONTAL_MARGIN_SIZE = 0.5
 
@@ -15,7 +16,8 @@ interface ArtworkGridFilterPillsProps {
 
 export const DefaultCreateAlertButton: React.FC<ArtworkGridFilterPillsProps> = props => {
   const { savedSearchEntity } = props
-  const { filters, aggregations } = useArtworkFilterContext()
+  const { aggregations } = useArtworkFilterContext()
+  const filters = usePrepareFiltersForPills()
   const criteria = getSearchCriteriaFromFilters(
     savedSearchEntity,
     filters ?? {}

--- a/src/v2/Components/SavedSearchAlert/Components/__tests__/ArtworkGridFilterPills.jest.tsx
+++ b/src/v2/Components/SavedSearchAlert/Components/__tests__/ArtworkGridFilterPills.jest.tsx
@@ -1,8 +1,10 @@
 import { OwnerType } from "@artsy/cohesion"
 import { render, screen, fireEvent } from "@testing-library/react"
 import {
+  Aggregations,
   ArtworkFilterContextProvider,
   ArtworkFiltersState,
+  FollowedArtists,
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import {
@@ -95,5 +97,71 @@ describe("ArtworkGridFilterPills", () => {
     fireEvent.click(screen.getByText("Banksy"))
 
     expect(screen.getByText("Banksy")).toBeInTheDocument()
+  })
+
+  it("display followed artist pills when 'Artists I Follow' is selected", () => {
+    const aggregations: Aggregations = [
+      {
+        slice: "ARTIST",
+        counts: [
+          {
+            name: "Damien Hirst",
+            value: "damien-hirst",
+            count: 20,
+          },
+          {
+            name: "KAWS",
+            value: "kaws",
+            count: 10,
+          },
+        ],
+      },
+    ]
+    const followedArtists: FollowedArtists = [
+      {
+        slug: "kaws",
+        internalID: "kaws-internal-id",
+      },
+      {
+        slug: "damien-hirst",
+        internalID: "damien-hirst-internal-id",
+      },
+    ]
+
+    renderPills({
+      filters: {
+        includeArtworksByFollowedArtists: true,
+      },
+      followedArtists,
+      aggregations,
+    })
+
+    expect(screen.getByText("Damien Hirst")).toBeInTheDocument()
+    expect(screen.getByText("KAWS")).toBeInTheDocument()
+  })
+
+  it("should display only those artists who are present in ARTIST aggregation", () => {
+    const aggregations: Aggregations = [
+      {
+        slice: "ARTIST",
+        counts: [
+          {
+            name: "KAWS",
+            value: "kaws",
+            count: 10,
+          },
+        ],
+      },
+    ]
+
+    renderPills({
+      filters: {
+        artistIDs: ["kaws", "banksy"],
+      },
+      aggregations,
+    })
+
+    expect(screen.queryByText("KAWS")).toBeInTheDocument()
+    expect(screen.queryByText("banksy")).not.toBeInTheDocument()
   })
 })

--- a/src/v2/Components/SavedSearchAlert/constants.ts
+++ b/src/v2/Components/SavedSearchAlert/constants.ts
@@ -5,6 +5,8 @@ export const shouldExtractValueNamesFromAggregation = [
   "materialsTerms",
   "additionalGeneIDs",
   "partnerIDs",
+  "artistIDs",
+  "artistNationalities",
 ]
 
 export const aggregationNameFromFilter: Record<string, Slice> = {
@@ -12,6 +14,8 @@ export const aggregationNameFromFilter: Record<string, Slice> = {
   materialsTerms: "MATERIALS_TERMS",
   additionalGeneIDs: "MEDIUM",
   partnerIDs: "PARTNER",
+  artistIDs: "ARTIST",
+  artistNationalities: "ARTIST_NATIONALITY",
 }
 
 export const allowedSearchCriteriaKeys = [

--- a/src/v2/Components/SavedSearchAlert/constants.ts
+++ b/src/v2/Components/SavedSearchAlert/constants.ts
@@ -36,4 +36,5 @@ export const allowedSearchCriteriaKeys = [
   "sizes",
   "height",
   "width",
+  "artistNationalities",
 ]

--- a/src/v2/__generated__/WorksTL_Query.graphql.ts
+++ b/src/v2/__generated__/WorksTL_Query.graphql.ts
@@ -1,0 +1,1351 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type WorksTL_QueryVariables = {
+    partnerId: string;
+};
+export type WorksTL_QueryResponse = {
+    readonly partner: {
+        readonly " $fragmentRefs": FragmentRefs<"Works_partner">;
+    } | null;
+};
+export type WorksTL_Query = {
+    readonly response: WorksTL_QueryResponse;
+    readonly variables: WorksTL_QueryVariables;
+};
+
+
+
+/*
+query WorksTL_Query(
+  $partnerId: String!
+) {
+  partner(id: $partnerId) {
+    ...Works_partner
+    id
+  }
+}
+
+fragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {
+  id
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  pageCursors {
+    ...Pagination_pageCursors
+  }
+  edges {
+    node {
+      id
+    }
+  }
+  ...ArtworkGrid_artworks
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
+  __isArtworkConnectionInterface: __typename
+  edges {
+    __typename
+    node {
+      id
+      slug
+      href
+      internalID
+      image {
+        aspect_ratio: aspectRatio
+      }
+      ...GridItem_artwork
+      ...FlatGridItem_artwork
+    }
+    ... on Node {
+      __isNode: __typename
+      id
+    }
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    endAt
+    cascadingEndTimeIntervalMinutes
+    extendedBiddingIntervalMinutes
+    startAt
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    lotID
+    lotLabel
+    endAt
+    extendedBiddingEndAt
+    formattedEndDateTime
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+  ...NewSaveButton_artwork
+  ...HoverDetails_artwork
+}
+
+fragment FlatGridItem_artwork on Artwork {
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  sale {
+    extendedBiddingPeriodMinutes
+    extendedBiddingIntervalMinutes
+    startAt
+    id
+  }
+  saleArtwork {
+    endAt
+    extendedBiddingEndAt
+    lotID
+    id
+  }
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    resized(width: 445, version: ["normalized", "larger", "large"]) {
+      src
+      srcSet
+      width
+      height
+    }
+  }
+  artistNames
+  href
+  is_saved: isSaved
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  artistNames
+  href
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+
+fragment HoverDetails_artwork on Artwork {
+  internalID
+  attributionClass {
+    name
+    id
+  }
+  mediumType {
+    filterGene {
+      name
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  href
+}
+
+fragment NewSaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment Works_partner on Partner {
+  slug
+  internalID
+  sidebar: filterArtworksConnection(first: 1) {
+    aggregations {
+      slice
+      counts {
+        name
+        value
+        count
+      }
+    }
+    id
+  }
+  filtered_artworks: filterArtworksConnection(first: 30) {
+    id
+    counts {
+      total(format: "0,0")
+    }
+    ...ArtworkFilterArtworkGrid_filtered_artworks
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "partnerId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "partnerId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "page",
+  "storageKey": null
+},
+v8 = [
+  (v6/*: any*/),
+  (v7/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "isCurrent",
+    "storageKey": null
+  }
+],
+v9 = [
+  (v5/*: any*/)
+],
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v11 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lotID",
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "extendedBiddingEndAt",
+  "storageKey": null
+},
+v15 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v16 = [
+  (v4/*: any*/),
+  (v5/*: any*/)
+],
+v17 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Partner"
+},
+v18 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FilterArtworksConnection"
+},
+v19 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v20 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FormattedNumber"
+},
+v21 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v22 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v23 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v24 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v25 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "SaleArtwork"
+},
+v26 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Boolean"
+},
+v27 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+},
+v28 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "PageCursor"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "WorksTL_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Works_partner"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "WorksTL_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "alias": "sidebar",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtworksAggregationResults",
+                "kind": "LinkedField",
+                "name": "aggregations",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slice",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "kind": "LinkedField",
+                    "name": "counts",
+                    "plural": true,
+                    "selections": [
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "value",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "count",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:1)"
+          },
+          {
+            "alias": "filtered_artworks",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 30
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "format",
+                        "value": "0,0"
+                      }
+                    ],
+                    "kind": "ScalarField",
+                    "name": "total",
+                    "storageKey": "total(format:\"0,0\")"
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageCursors",
+                "kind": "LinkedField",
+                "name": "pageCursors",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "around",
+                    "plural": true,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "first",
+                    "plural": false,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "last",
+                    "plural": false,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "previous",
+                    "plural": false,
+                    "selections": [
+                      (v6/*: any*/),
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": (v9/*: any*/),
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v10/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "aspect_ratio",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "aspectRatio",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "placeholder",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "large"
+                                  }
+                                ],
+                                "kind": "ScalarField",
+                                "name": "url",
+                                "storageKey": "url(version:\"large\")"
+                              },
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": [
+                                      "normalized",
+                                      "larger",
+                                      "large"
+                                    ]
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 445
+                                  }
+                                ],
+                                "concreteType": "ResizedImageUrl",
+                                "kind": "LinkedField",
+                                "name": "resized",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "src",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "srcSet",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "width",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "height",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:445)"
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "title",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "image_title",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "imageTitle",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "artistNames",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "date",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "sale_message",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "saleMessage",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "cultural_maker",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "culturalMaker",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": (v11/*: any*/),
+                            "concreteType": "Artist",
+                            "kind": "LinkedField",
+                            "name": "artists",
+                            "plural": true,
+                            "selections": [
+                              (v5/*: any*/),
+                              (v10/*: any*/),
+                              (v4/*: any*/)
+                            ],
+                            "storageKey": "artists(shallow:true)"
+                          },
+                          {
+                            "alias": "collecting_institution",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "collectingInstitution",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": (v11/*: any*/),
+                            "concreteType": "Partner",
+                            "kind": "LinkedField",
+                            "name": "partner",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              (v10/*: any*/),
+                              (v5/*: any*/)
+                            ],
+                            "storageKey": "partner(shallow:true)"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Sale",
+                            "kind": "LinkedField",
+                            "name": "sale",
+                            "plural": false,
+                            "selections": [
+                              (v12/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "cascadingEndTimeIntervalMinutes",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "extendedBiddingIntervalMinutes",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "startAt",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_auction",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isAuction",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_closed",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isClosed",
+                                "storageKey": null
+                              },
+                              (v5/*: any*/),
+                              {
+                                "alias": "is_preview",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isPreview",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "display_timely_at",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "displayTimelyAt",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "extendedBiddingPeriodMinutes",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "sale_artwork",
+                            "args": null,
+                            "concreteType": "SaleArtwork",
+                            "kind": "LinkedField",
+                            "name": "saleArtwork",
+                            "plural": false,
+                            "selections": [
+                              (v13/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "lotLabel",
+                                "storageKey": null
+                              },
+                              (v12/*: any*/),
+                              (v14/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "formattedEndDateTime",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "SaleArtworkCounts",
+                                "kind": "LinkedField",
+                                "name": "counts",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "bidder_positions",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "bidderPositions",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "highest_bid",
+                                "args": null,
+                                "concreteType": "SaleArtworkHighestBid",
+                                "kind": "LinkedField",
+                                "name": "highestBid",
+                                "plural": false,
+                                "selections": (v15/*: any*/),
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "opening_bid",
+                                "args": null,
+                                "concreteType": "SaleArtworkOpeningBid",
+                                "kind": "LinkedField",
+                                "name": "openingBid",
+                                "plural": false,
+                                "selections": (v15/*: any*/),
+                                "storageKey": null
+                              },
+                              (v5/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_saved",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isSaved",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "AttributionClass",
+                            "kind": "LinkedField",
+                            "name": "attributionClass",
+                            "plural": false,
+                            "selections": (v16/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkMedium",
+                            "kind": "LinkedField",
+                            "name": "mediumType",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Gene",
+                                "kind": "LinkedField",
+                                "name": "filterGene",
+                                "plural": false,
+                                "selections": (v16/*: any*/),
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_biddable",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isBiddable",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtwork",
+                            "kind": "LinkedField",
+                            "name": "saleArtwork",
+                            "plural": false,
+                            "selections": [
+                              (v12/*: any*/),
+                              (v14/*: any*/),
+                              (v13/*: any*/),
+                              (v5/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": (v9/*: any*/),
+                        "type": "Node",
+                        "abstractKey": "__isNode"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "ArtworkConnectionInterface",
+                "abstractKey": "__isArtworkConnectionInterface"
+              }
+            ],
+            "storageKey": "filterArtworksConnection(first:30)"
+          },
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "4a4cac6efbc72b986ca8df53b4fa300b",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "partner": (v17/*: any*/),
+        "partner.filtered_artworks": (v18/*: any*/),
+        "partner.filtered_artworks.__isArtworkConnectionInterface": (v19/*: any*/),
+        "partner.filtered_artworks.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FilterArtworksCounts"
+        },
+        "partner.filtered_artworks.counts.total": (v20/*: any*/),
+        "partner.filtered_artworks.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArtworkEdgeInterface"
+        },
+        "partner.filtered_artworks.edges.__isNode": (v19/*: any*/),
+        "partner.filtered_artworks.edges.__typename": (v19/*: any*/),
+        "partner.filtered_artworks.edges.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "partner.filtered_artworks.edges.node.artistNames": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.artists": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Artist"
+        },
+        "partner.filtered_artworks.edges.node.artists.href": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.artists.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.artists.name": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.attributionClass": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AttributionClass"
+        },
+        "partner.filtered_artworks.edges.node.attributionClass.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.attributionClass.name": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.collecting_institution": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.cultural_maker": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.date": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.href": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "partner.filtered_artworks.edges.node.image.aspect_ratio": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Float"
+        },
+        "partner.filtered_artworks.edges.node.image.placeholder": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ResizedImageUrl"
+        },
+        "partner.filtered_artworks.edges.node.image.resized.height": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized.src": (v19/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized.srcSet": (v19/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized.width": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.image.url": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.image_title": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.internalID": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.is_biddable": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.is_saved": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.mediumType": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkMedium"
+        },
+        "partner.filtered_artworks.edges.node.mediumType.filterGene": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Gene"
+        },
+        "partner.filtered_artworks.edges.node.mediumType.filterGene.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.mediumType.filterGene.name": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.partner": (v17/*: any*/),
+        "partner.filtered_artworks.edges.node.partner.href": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.partner.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.partner.name": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "partner.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.display_timely_at": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.endAt": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.is_auction": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.is_closed": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.is_preview": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.startAt": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork": (v25/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.endAt": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.lotID": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork": (v25/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkCounts"
+        },
+        "partner.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v20/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.endAt": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.highest_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkHighestBid"
+        },
+        "partner.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.lotID": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.lotLabel": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.opening_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkOpeningBid"
+        },
+        "partner.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_message": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.slug": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.title": (v22/*: any*/),
+        "partner.filtered_artworks.id": (v21/*: any*/),
+        "partner.filtered_artworks.pageCursors": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "PageCursors"
+        },
+        "partner.filtered_artworks.pageCursors.around": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "PageCursor"
+        },
+        "partner.filtered_artworks.pageCursors.around.cursor": (v19/*: any*/),
+        "partner.filtered_artworks.pageCursors.around.isCurrent": (v26/*: any*/),
+        "partner.filtered_artworks.pageCursors.around.page": (v27/*: any*/),
+        "partner.filtered_artworks.pageCursors.first": (v28/*: any*/),
+        "partner.filtered_artworks.pageCursors.first.cursor": (v19/*: any*/),
+        "partner.filtered_artworks.pageCursors.first.isCurrent": (v26/*: any*/),
+        "partner.filtered_artworks.pageCursors.first.page": (v27/*: any*/),
+        "partner.filtered_artworks.pageCursors.last": (v28/*: any*/),
+        "partner.filtered_artworks.pageCursors.last.cursor": (v19/*: any*/),
+        "partner.filtered_artworks.pageCursors.last.isCurrent": (v26/*: any*/),
+        "partner.filtered_artworks.pageCursors.last.page": (v27/*: any*/),
+        "partner.filtered_artworks.pageCursors.previous": (v28/*: any*/),
+        "partner.filtered_artworks.pageCursors.previous.cursor": (v19/*: any*/),
+        "partner.filtered_artworks.pageCursors.previous.page": (v27/*: any*/),
+        "partner.filtered_artworks.pageInfo": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "PageInfo"
+        },
+        "partner.filtered_artworks.pageInfo.endCursor": (v22/*: any*/),
+        "partner.filtered_artworks.pageInfo.hasNextPage": (v26/*: any*/),
+        "partner.id": (v21/*: any*/),
+        "partner.internalID": (v21/*: any*/),
+        "partner.sidebar": (v18/*: any*/),
+        "partner.sidebar.aggregations": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArtworksAggregationResults"
+        },
+        "partner.sidebar.aggregations.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "AggregationCount"
+        },
+        "partner.sidebar.aggregations.counts.count": (v27/*: any*/),
+        "partner.sidebar.aggregations.counts.name": (v19/*: any*/),
+        "partner.sidebar.aggregations.counts.value": (v19/*: any*/),
+        "partner.sidebar.aggregations.slice": {
+          "enumValues": [
+            "ARTIST",
+            "ARTIST_NATIONALITY",
+            "ATTRIBUTION_CLASS",
+            "COLOR",
+            "DIMENSION_RANGE",
+            "FOLLOWED_ARTISTS",
+            "GALLERY",
+            "INSTITUTION",
+            "LOCATION_CITY",
+            "MAJOR_PERIOD",
+            "MATERIALS_TERMS",
+            "MEDIUM",
+            "MERCHANDISABLE_ARTISTS",
+            "PARTNER",
+            "PARTNER_CITY",
+            "PERIOD",
+            "PRICE_RANGE",
+            "SIMPLE_PRICE_HISTOGRAM",
+            "TOTAL"
+          ],
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkAggregation"
+        },
+        "partner.sidebar.id": (v21/*: any*/),
+        "partner.slug": (v21/*: any*/)
+      }
+    },
+    "name": "WorksTL_Query",
+    "operationKind": "query",
+    "text": "query WorksTL_Query(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) {\n    ...Works_partner\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Works_partner on Partner {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '975d274a3ab31f3cbdae54ea7803711c';
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR solves [FX-4041]

Review app: https://selected-filters-for-partner.artsy.net

### Context
We’ve added active filter pills to the artist page’s artworks grid a while ago, which is also where the “Create alert” control lives. We’d like to first expand these active filter pills to other grids before we also support alert creation on those surfaces.

![image](https://user-images.githubusercontent.com/3513494/174100198-a94b25aa-039d-46f4-8444-4d2ff7ca8ee5.png)

### Acceptance Criteria
* As a collector
* When I visit a partner’s artwork grid
* And I enable at least one filter
* Then I should see my active filters represented as pills above the artwork grid
* And "Create Alert" button should **NOT** be displayed

#### Quick links
* [Aicon Gallery](https://selected-filters-for-partner.artsy.net/partner/aicon-gallery/works)
* [Paragon](https://selected-filters-for-partner.artsy.net/partner/paragon/works)
* [Galerie Denise René](https://selected-filters-for-partner.artsy.net/partner/galerie-denise-rene/works)

### Demo


<!-- Implementation description -->


[FX-4041]: https://artsyproduct.atlassian.net/browse/FX-4041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ