### PR TITLE
chore: keep followed artists inside `ArtworkFilterContext`

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -156,6 +156,11 @@ export interface Counts {
   followedArtists?: number
 }
 
+export type FollowedArtists = Array<{
+  slug: string
+  internalID: string
+}>
+
 export type SelectedFiltersCounts = {
   [Name in FilterParamName | "waysToBuy"]: number
 }
@@ -201,6 +206,9 @@ export interface ArtworkFilterContextProps {
   aggregations?: Aggregations
   counts?: Counts
   setCounts?: (counts: Counts) => void
+
+  followedArtists?: FollowedArtists
+  setFollowedArtists?: (artists: FollowedArtists) => void
 
   // Handlers
   onFilterClick?: (
@@ -259,6 +267,7 @@ export type SharedArtworkFilterContextProps = Pick<
   | "sortOptions"
   | "onFilterClick"
   | "ZeroState"
+  | "followedArtists"
 > & {
   onChange?: (filterState) => void
 }
@@ -272,6 +281,7 @@ export const ArtworkFilterContextProvider: React.FC<
   children,
   counts = {},
   filters = {},
+  followedArtists: _followedArtists = [],
   onChange = updateUrl,
   onFilterClick,
   sortOptions,
@@ -294,6 +304,9 @@ export const ArtworkFilterContextProvider: React.FC<
   const [artworkCounts, setCounts] = useState(counts)
   const [shouldStageFilterChanges, setShouldStageFilterChanges] = useState(
     false
+  )
+  const [followedArtists, setFollowedArtists] = useState<FollowedArtists>(
+    _followedArtists
   )
 
   useDeepCompareEffect(() => {
@@ -336,6 +349,8 @@ export const ArtworkFilterContextProvider: React.FC<
     aggregations,
     counts: artworkCounts,
     setCounts,
+    followedArtists,
+    setFollowedArtists,
 
     // Components
     ZeroState,

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react"
+import { FC, useEffect } from "react"
 import * as React from "react"
 import { sortBy } from "lodash"
 import { Checkbox, CheckboxProps, Flex, useThemeConfig } from "@artsy/palette"
@@ -7,10 +7,7 @@ import {
   useArtworkFilterContext,
   useCurrentlySelectedFilters,
 } from "../ArtworkFilterContext"
-import {
-  FollowedArtistList,
-  fetchFollowedArtists,
-} from "../Utils/fetchFollowedArtists"
+import { fetchFollowedArtists } from "../Utils/fetchFollowedArtists"
 import { FilterExpandable } from "./FilterExpandable"
 import { ShowMore } from "./ShowMore"
 import { useFilterLabelCountByKey } from "../Utils/useFilterLabelCountByKey"
@@ -84,14 +81,18 @@ const ArtistItem: React.FC<
 
 export const ArtistsFilter: FC<ArtistsFilterProps> = ({ expanded, fairID }) => {
   const { relayEnvironment, user } = useSystemContext()
-  const { aggregations, ...filterContext } = useArtworkFilterContext()
+  const {
+    aggregations,
+    followedArtists = [],
+    setFollowedArtists,
+    ...filterContext
+  } = useArtworkFilterContext()
   const artists = aggregations?.find(agg => agg.slice === "ARTIST")
   const {
     artistIDs = [],
     includeArtworksByFollowedArtists,
   } = useCurrentlySelectedFilters()
 
-  const [followedArtists, setFollowedArtists] = useState<FollowedArtistList>([])
   const followedArtistSlugs = followedArtists.map(({ slug }) => slug)
 
   const filtersCount = useFilterLabelCountByKey(
@@ -107,7 +108,7 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({ expanded, fairID }) => {
   useEffect(() => {
     if (artists?.counts && relayEnvironment && user) {
       fetchFollowedArtists({ relayEnvironment, fairID }).then(data => {
-        setFollowedArtists(data)
+        setFollowedArtists!(data)
       })
     }
 

--- a/src/v2/Components/ArtworkFilter/Utils/fetchFollowedArtists.ts
+++ b/src/v2/Components/ArtworkFilter/Utils/fetchFollowedArtists.ts
@@ -3,11 +3,7 @@ import { graphql } from "react-relay"
 import { fetchFollowedArtistsByFairIdQuery } from "v2/__generated__/fetchFollowedArtistsByFairIdQuery.graphql"
 import { fetchFollowedArtistsRawQuery } from "v2/__generated__/fetchFollowedArtistsRawQuery.graphql"
 import { compact, isString } from "lodash"
-
-export type FollowedArtistList = Array<{
-  slug: string
-  internalID: string
-}>
+import { FollowedArtists } from "../ArtworkFilterContext"
 
 graphql`
   fragment fetchFollowedArtists_response on FollowArtistConnection {
@@ -58,7 +54,7 @@ interface Args extends FetchFollowedArtistsArgs {
 
 export async function fetchFollowedArtists(
   args: Args
-): Promise<FollowedArtistList> {
+): Promise<FollowedArtists> {
   const { relayEnvironment, ...props } = args
 
   const query = isString(props.fairID) ? queryByFairId : rawQuery


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

### Description
These changes are necessary for the [FX-4041](https://artsyproduct.atlassian.net/browse/FX-4041) task so that artist pills can be displayed correctly when the "Artists I Follow" option has been selected (now the followed artists are stored [inside the component](https://github.com/artsy/force/blob/main/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx#L94) and for this reason we do not have access to them)

#### Demo of how it will work
https://user-images.githubusercontent.com/3513494/173886558-4a3d74dc-cbff-4da0-8a6b-74f3b54ed851.mp4

<!-- Implementation description -->
