### PR TITLE
fix(FX-4043): Alert Management page pills styling after palette upgrade

### DIFF
--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -13,16 +13,11 @@ import {
 } from "@artsy/palette"
 import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import styled from "styled-components"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { SavedSearchAlertListItem_item } from "v2/__generated__/SavedSearchAlertListItem_item.graphql"
 import { EditAlertEntity } from "../types"
 
 export type SavedSearchAlertListItemVariant = "active" | "inactive"
-
-const AlertPill = styled(Pill)<{ active: boolean }>`
-  pointer-events: none;
-`
 
 interface SavedSearchAlertListItemProps {
   item: SavedSearchAlertListItem_item
@@ -101,15 +96,15 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
         <Column span={[12, 8]}>
           {isExpanded &&
             item.labels.map(label => (
-              <AlertPill
+              <Pill
                 key={label.displayValue}
                 variant="filter"
-                active
+                disabled
                 mr={1}
                 mb={1}
               >
                 {label.displayValue}
-              </AlertPill>
+              </Pill>
             ))}
         </Column>
       </GridColumns>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR solves [FX-4043]

### Description

After the upgrade of palette to v3.1 the pill design in the alert management page broke, this pr addresses that.

> ⚠️ ⚠️ This PR doesn't address the other layout issues. I will follow up with design to create tickets and sync for the rest of the layout issues ⚠️ ⚠️ 

#### Web

|Before|After|
|---|---|
|<img width="1792" alt="Screenshot 2022-06-16 at 12 28 10" src="https://user-images.githubusercontent.com/21178754/174040173-2d1dafe2-7813-48c0-aa33-4d3ed949a4f0.png">|<img width="1792" alt="Screenshot 2022-06-16 at 12 29 32" src="https://user-images.githubusercontent.com/21178754/174040160-1a0f2248-f632-4d92-aaf7-71184e186070.png">|

#### Mobile

|Before|After|
|---|---|
|<img width="420" alt="Screenshot 2022-06-16 at 12 30 50" src="https://user-images.githubusercontent.com/21178754/174040147-72dcc6e4-022d-43b3-80bb-5aa145d68ccd.png">|<img width="416" alt="Screenshot 2022-06-16 at 12 29 57" src="https://user-images.githubusercontent.com/21178754/174040155-d8ba74e6-87e9-44cf-ae53-e8e295da3059.png">|


<!-- Implementation description -->


[FX-4043]: https://artsyproduct.atlassian.net/browse/FX-4043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ