### PR TITLE
fix: removes google retargeting script

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkMeta.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkMeta.tsx
@@ -40,47 +40,6 @@ export class ArtworkMeta extends Component<ArtworkMetaProps> {
     )
   }
 
-  renderGoogleAdSnippet() {
-    const { artwork, googleAdId: fromPropsGoogleAdId } = this.props
-    const { GOOGLE_ADWORDS_ID: fromSharifyGoogleAdId } = sd
-    const { isInAuction, isAcquireable, internalID } = artwork
-    if (!isInAuction && !isAcquireable) return
-
-    // TODO: Investigate always being able to select from sharify.
-    const googleAdId = fromSharifyGoogleAdId || fromPropsGoogleAdId
-    if (!googleAdId) return
-
-    const script = `
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', "${googleAdId}");
-      gtag('event', 'page_view', {
-        'send_to': "${googleAdId}",
-        'dynx_itemid': "${internalID}"
-      });`
-
-    // The below might be a useful guard if scripts start to be evaluated twice.
-    // const isServer = typeof window === "undefined"
-    // if (!isServer) return
-
-    return (
-      <>
-        <Meta
-          tag="script"
-          type="text/javascript"
-          async
-          src={`https://www.googletagmanager.com/gtag/js?id=${googleAdId}`}
-        />
-        <Meta
-          tag="script"
-          type="text/javascript"
-          dangerouslySetInnerHTML={{ __html: script }}
-        />
-      </>
-    )
-  }
-
   get isInquiryArtwork() {
     const { isAcquireable, isInquireable, isOfferable } = this.props.artwork
     return isInquireable && !isAcquireable && !isOfferable
@@ -110,7 +69,6 @@ export class ArtworkMeta extends Component<ArtworkMetaProps> {
 
         <SeoDataForArtwork artwork={artwork} />
         {this.renderImageMetaTags()}
-        {this.renderGoogleAdSnippet()}
       </>
     )
   }


### PR DESCRIPTION
Whether it's with how this script is loaded, or something in the content of this script — something about this include is causing the DOM to be manipulated outside of React, which is causing an error on route changes.

Removing it completely for now. Will re-add using our `useLoadScript` hook.