### PR TITLE
feat(FX-4025): Add active filter pills to other (non-artist) artwork grids

### DIFF
--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
@@ -8,6 +8,7 @@ import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { Match, RouterState, withRouter } from "found"
 import * as React from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
+import { ActiveFilterPills } from "v2/Components/SavedSearchAlert/Components/ActiveFilterPills"
 
 interface ArtistSeriesArtworksFilterProps {
   artistSeries: ArtistSeriesArtworksFilter_artistSeries
@@ -50,6 +51,7 @@ const ArtistSeriesArtworksFilter: React.FC<
           aggregations: ["TOTAL"],
           first: 20,
         }}
+        FilterPillsSection={<ActiveFilterPills />}
       />
     </ArtworkFilterContextProvider>
   )

--- a/src/v2/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/v2/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -11,6 +11,7 @@ import { PriceRangeFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/Pri
 import { ArtworkGridContextProvider } from "v2/Components/ArtworkGrid/ArtworkGridContext"
 import { useSystemContext } from "v2/System"
 import { AuctionArtworkFilter_viewer } from "v2/__generated__/AuctionArtworkFilter_viewer.graphql"
+import { ActiveFilterPills } from "v2/Components/SavedSearchAlert/Components/ActiveFilterPills"
 
 interface AuctionArtworkFilterProps {
   relay: RelayRefetchProp
@@ -53,6 +54,7 @@ const AuctionArtworkFilter: React.FC<AuctionArtworkFilterProps> = ({
             <MediumFilter expanded />
           </>
         }
+        FilterPillsSection={<ActiveFilterPills />}
       />
     </ArtworkGridContextProvider>
   )

--- a/src/v2/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collect/index.tsx
@@ -22,6 +22,9 @@ import {
   Counts,
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+import { ActiveFilterPills } from "v2/Components/SavedSearchAlert/Components/ActiveFilterPills"
+import { FilterPill } from "v2/Components/SavedSearchAlert/types"
+import { hardcodedMediums } from "v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter"
 
 export interface CollectAppProps {
   match: Match
@@ -45,8 +48,24 @@ export const CollectApp: React.FC<CollectAppProps> = ({
   })
 
   let canonicalHref
+  let defaultPills: FilterPill[] = []
+
   if (medium) {
     canonicalHref = `${getENV("APP_URL")}/collect/${medium}`
+    const hardcodedMedium = hardcodedMediums.find(
+      entity => entity.value === medium
+    )
+
+    if (hardcodedMedium) {
+      defaultPills = [
+        {
+          isDefault: true,
+          value: hardcodedMedium.value,
+          displayValue: hardcodedMedium.name,
+          field: "additionalGeneIDs",
+        },
+      ]
+    }
   } else if (color) {
     canonicalHref = `${getENV("APP_URL")}/collect/color/${color}`
   } else {
@@ -141,6 +160,9 @@ export const CollectApp: React.FC<CollectAppProps> = ({
             *
             */
             }}
+            FilterPillsSection={
+              <ActiveFilterPills defaultPills={defaultPills} />
+            }
           />
         </Box>
       </FrameWithRecentlyViewed>

--- a/src/v2/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
@@ -23,6 +23,7 @@ import { MaterialsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/Mate
 import { PartnersFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
 import { ArtistsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter"
 import { __internal__useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { ActiveFilterPills } from "v2/Components/SavedSearchAlert/Components/ActiveFilterPills"
 
 interface CollectionArtworksFilterProps {
   relay: RelayRefetchProp
@@ -91,6 +92,7 @@ export const CollectionArtworksFilter: React.FC<CollectionArtworksFilterProps> =
         relayVariables={{
           slug,
         }}
+        FilterPillsSection={<ActiveFilterPills />}
       />
     </ArtworkFilterContextProvider>
   )

--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -21,6 +21,7 @@ import { ArtistNationalityFilter } from "v2/Components/ArtworkFilter/ArtworkFilt
 import { MaterialsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MaterialsFilter"
 import { ArtworkLocationFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter"
 import { SizeFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter"
+import { ActiveFilterPills } from "v2/Components/SavedSearchAlert/Components/ActiveFilterPills"
 
 interface FairArtworksFilterProps {
   fair: FairArtworks_fair
@@ -80,7 +81,13 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
         sidebarAggregations.aggregations as SharedArtworkFilterContextProps["aggregations"]
       }
     >
-      <BaseArtworkFilter mt={6} relay={relay} viewer={fair} Filters={Filters} />
+      <BaseArtworkFilter
+        mt={6}
+        relay={relay}
+        viewer={fair}
+        Filters={Filters}
+        FilterPillsSection={<ActiveFilterPills />}
+      />
     </ArtworkFilterContextProvider>
   )
 }

--- a/src/v2/Apps/Gene/Components/GeneArtworkFilter.tsx
+++ b/src/v2/Apps/Gene/Components/GeneArtworkFilter.tsx
@@ -9,6 +9,7 @@ import {
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { GeneArtworkFilter_gene } from "v2/__generated__/GeneArtworkFilter_gene.graphql"
+import { ActiveFilterPills } from "v2/Components/SavedSearchAlert/Components/ActiveFilterPills"
 
 interface GeneArtworkFilterProps {
   gene: GeneArtworkFilter_gene
@@ -40,7 +41,11 @@ const GeneArtworkFilter: React.FC<GeneArtworkFilterProps> = ({
       }
       counts={sidebar?.counts as Counts}
     >
-      <BaseArtworkFilter relay={relay} viewer={gene} />
+      <BaseArtworkFilter
+        relay={relay}
+        viewer={gene}
+        FilterPillsSection={<ActiveFilterPills />}
+      />
     </ArtworkFilterContextProvider>
   )
 }

--- a/src/v2/Apps/Search/Routes/SearchResultsArtworks.tsx
+++ b/src/v2/Apps/Search/Routes/SearchResultsArtworks.tsx
@@ -9,6 +9,7 @@ import {
   Counts,
   SharedArtworkFilterContextProps,
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+import { ActiveFilterPills } from "v2/Components/SavedSearchAlert/Components/ActiveFilterPills"
 
 interface SearchResultsRouteProps {
   viewer: SearchResultsArtworks_viewer
@@ -39,6 +40,7 @@ export const SearchResultsArtworksRoute: React.FC<SearchResultsRouteProps> = pro
         { value: "-year", text: "Artwork year (desc.)" },
         { value: "year", text: "Artwork year (asc.)" },
       ]}
+      FilterPillsSection={<ActiveFilterPills />}
     />
   )
 }

--- a/src/v2/Apps/Show/Components/ShowArtworks.tsx
+++ b/src/v2/Apps/Show/Components/ShowArtworks.tsx
@@ -11,6 +11,7 @@ import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { BoxProps } from "@artsy/palette"
 import { useRouter } from "v2/System/Router/useRouter"
 import { omit } from "lodash"
+import { ActiveFilterPills } from "v2/Components/SavedSearchAlert/Components/ActiveFilterPills"
 
 interface ShowArtworksFilterProps extends BoxProps {
   show: ShowArtworks_show
@@ -61,6 +62,7 @@ const ShowArtworksFilter: React.FC<ShowArtworksFilterProps> = props => {
         relayVariables={{
           aggregations: ["TOTAL"],
         }}
+        FilterPillsSection={<ActiveFilterPills />}
         {...rest}
       />
     </ArtworkFilterContextProvider>

--- a/src/v2/Apps/Tag/Components/TagArtworkFilter.tsx
+++ b/src/v2/Apps/Tag/Components/TagArtworkFilter.tsx
@@ -9,6 +9,7 @@ import {
 } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { TagArtworkFilter_tag } from "v2/__generated__/TagArtworkFilter_tag.graphql"
+import { ActiveFilterPills } from "v2/Components/SavedSearchAlert/Components/ActiveFilterPills"
 
 interface TagArtworkFilterProps {
   tag: TagArtworkFilter_tag
@@ -37,7 +38,11 @@ const TagArtworkFilter: React.FC<TagArtworkFilterProps> = ({ tag, relay }) => {
         sidebar?.aggregations as SharedArtworkFilterContextProps["aggregations"]
       }
     >
-      <BaseArtworkFilter relay={relay} viewer={tag} />
+      <BaseArtworkFilter
+        relay={relay}
+        viewer={tag}
+        FilterPillsSection={<ActiveFilterPills />}
+      />
     </ArtworkFilterContextProvider>
   )
 }

--- a/src/v2/Components/SavedSearchAlert/Utils/__tests__/extractPills.jest.ts
+++ b/src/v2/Components/SavedSearchAlert/Utils/__tests__/extractPills.jest.ts
@@ -1,3 +1,4 @@
+import { Aggregations } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import {
   SavedSearchDefaultCriteria,
   SearchCriteriaAttributes,
@@ -5,7 +6,63 @@ import {
 import {
   extractPillsFromDefaultCriteria,
   excludeDefaultCriteria,
+  extractPillFromAggregation,
 } from "../extractPills"
+
+describe("extractPillFromAggregation", () => {
+  it("returns pills", () => {
+    const result = extractPillFromAggregation(
+      {
+        paramName: "materialsTerms",
+        paramValue: ["acrylic", "canvas"],
+      },
+      mockedAggregations
+    )
+
+    const pills = [
+      { displayValue: "Acrylic", value: "acrylic", field: "materialsTerms" },
+      { displayValue: "Canvas", value: "canvas", field: "materialsTerms" },
+    ]
+
+    expect(result).toEqual(pills)
+  })
+
+  it("returns empty array when couldn't get aggregation by param name", () => {
+    const result = extractPillFromAggregation(
+      {
+        paramName: "materialsTerms",
+        paramValue: ["acrylic", "canvas"],
+      },
+      []
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it("returns pills extracted from hardcoded aggregation values for additionalGeneIDs", () => {
+    const result = extractPillFromAggregation(
+      {
+        paramName: "additionalGeneIDs",
+        paramValue: ["painting", "sculpture", "nft"],
+      },
+      []
+    )
+
+    expect(result).toEqual([
+      {
+        displayValue: "Painting",
+        value: "painting",
+        field: "additionalGeneIDs",
+      },
+      {
+        displayValue: "Sculpture",
+        value: "sculpture",
+        field: "additionalGeneIDs",
+      },
+      { displayValue: "NFT", value: "nft", field: "additionalGeneIDs" },
+    ])
+  })
+})
 
 describe("extractPillsFromDefaultCriteria", () => {
   it("should return nothing", () => {
@@ -193,3 +250,26 @@ const criteria: SearchCriteriaAttributes = {
   offerable: true,
   sizes: ["SMALL"],
 }
+
+const mockedAggregations: Aggregations = [
+  {
+    slice: "MATERIALS_TERMS",
+    counts: [
+      {
+        count: 44,
+        name: "Acrylic",
+        value: "acrylic",
+      },
+      {
+        count: 30,
+        name: "Canvas",
+        value: "canvas",
+      },
+      {
+        count: 26,
+        name: "Metal",
+        value: "metal",
+      },
+    ],
+  },
+]

--- a/src/v2/Components/SavedSearchAlert/Utils/extractPills.ts
+++ b/src/v2/Components/SavedSearchAlert/Utils/extractPills.ts
@@ -38,7 +38,10 @@ export const extractPillFromAggregation = (
   let aggregationValues = aggregation?.counts
 
   // Use hardcoded medium values for some grids (e.g. fair, collect grids)
-  if (paramName === "additionalGeneIDs" && !aggregation) {
+  if (
+    paramName === "additionalGeneIDs" &&
+    (aggregation?.counts ?? []).length === 0
+  ) {
     aggregationValues = hardcodedMediums as Aggregation["counts"]
   }
 

--- a/src/v2/Components/SavedSearchAlert/Utils/extractPills.ts
+++ b/src/v2/Components/SavedSearchAlert/Utils/extractPills.ts
@@ -1,7 +1,11 @@
 import { compact, difference, find, flatten, keyBy } from "lodash"
-import { Aggregations } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+import {
+  Aggregation,
+  Aggregations,
+} from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { checkboxValues } from "v2/Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
 import { COLOR_OPTIONS } from "v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter"
+import { hardcodedMediums } from "v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter"
 import {
   getPredefinedSizesByMetric,
   parseRange,
@@ -31,18 +35,25 @@ export const extractPillFromAggregation = (
 ) => {
   const { paramName, paramValue } = filter
   const aggregation = aggregationForFilter(paramName, aggregations)
+  let aggregationValues = aggregation?.counts
 
-  if (aggregation) {
-    const aggregationByValue = keyBy(aggregation.counts, "value")
-
-    return (paramValue as string[]).map(value => ({
-      value,
-      displayValue: aggregationByValue[value]?.name ?? "",
-      field: paramName,
-    }))
+  // TODO: Add test case
+  // Use hardcoded medium values
+  if (paramName === "additionalGeneIDs" && !aggregation) {
+    aggregationValues = hardcodedMediums as Aggregation["counts"]
   }
 
-  return []
+  if (!aggregationValues) {
+    return []
+  }
+
+  const aggregationByValue = keyBy(aggregationValues, "value")
+
+  return (paramValue as string[]).map(value => ({
+    value,
+    displayValue: aggregationByValue[value]?.name ?? "",
+    field: paramName,
+  }))
 }
 
 export const extractSizeLabel = ({

--- a/src/v2/Components/SavedSearchAlert/Utils/extractPills.ts
+++ b/src/v2/Components/SavedSearchAlert/Utils/extractPills.ts
@@ -37,8 +37,7 @@ export const extractPillFromAggregation = (
   const aggregation = aggregationForFilter(paramName, aggregations)
   let aggregationValues = aggregation?.counts
 
-  // TODO: Add test case
-  // Use hardcoded medium values
+  // Use hardcoded medium values for some grids (e.g. fair, collect grids)
   if (paramName === "additionalGeneIDs" && !aggregation) {
     aggregationValues = hardcodedMediums as Aggregation["counts"]
   }


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR solves [FX-4025]

Review app: https://pills-for-other-grids.artsy.net/

Investigation and faced problems: [Spike Document](https://www.notion.so/artsy/Spike-Add-saved-search-alerts-to-other-artwork-grids-a57a04ac02654861915f6f7d3f2edb4a)

### Added support for grids
* [Auctions](https://pills-for-other-grids.artsy.net/auction/artsy-x-seoul-auction-contemporary-icons)
* [Show](https://pills-for-other-grids.artsy.net/show/charlie-smith-london-papyrophilia)
* [Tag](https://pills-for-other-grids.artsy.net/tag/cowboy)
* [Artist Series](https://pills-for-other-grids.artsy.net/artist-series/hiroshi-sugimoto-seascapes)
* [Gene](https://pills-for-other-grids.artsy.net/gene/ukiyo-e)
* [Fair](https://pills-for-other-grids.artsy.net/fair/art-cologne-2020/artworks)
* [Collection](https://pills-for-other-grids.artsy.net/collection/contemporary)
* [Search Results](https://pills-for-other-grids.artsy.net/search?term=sculpture)
* Collect
  * [Default collect page](https://pills-for-other-grids.artsy.net/collect)
  * [Collect page with selected medium value by default](https://pills-for-other-grids.artsy.net/collect/sculpture)

### Description

<!-- Implementation description -->


[FX-4025]: https://artsyproduct.atlassian.net/browse/FX-4025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ