### PR TITLE
feat(PX-5031): Support EU/NO/GB/CH checkout out flows with artsy shipping

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "dependencies": {
     "@artsy/backbone-mixins": "3.0.0",
     "@artsy/cohesion": "4.55.0",
+    "@artsy/commerce_helpers": "artsy/commerce_helpers",
     "@artsy/eigen-web-association": "^1.5.3",
     "@artsy/express-reloadable": "^1.7.0",
     "@artsy/fresnel": "3.5.0",

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -182,12 +182,10 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
 
   isArtsyShipping = () => {
     const addresses = this.getAddressList()
-    const processWithArtsyShippingDomestic = !!this.getOrderArtwork()
-      ?.processWithArtsyShippingDomestic
-    const artsyShippingInternational = !!this.getOrderArtwork()
-      ?.artsyShippingInternational
-
     const artwork = this.getOrderArtwork()
+    const processWithArtsyShippingDomestic = !!artwork?.processWithArtsyShippingDomestic
+    const artsyShippingInternational = !!artwork?.artsyShippingInternational
+
     const shippingCountry = this.isCreateNewAddress()
       ? this.state.address.country
       : addresses &&

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -47,6 +47,7 @@ import {
 } from "v2/Components/AddressForm"
 import { Router } from "found"
 import { Component } from "react"
+import { COUNTRIES_IN_EUROPEAN_UNION } from "@artsy/commerce_helpers"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 import createLogger from "v2/Utils/logger"
 import { Media } from "v2/Utils/Responsive"
@@ -186,6 +187,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
     const artsyShippingInternational = !!this.getOrderArtwork()
       ?.artsyShippingInternational
 
+    const artwork = this.getOrderArtwork()
     const shippingCountry = this.isCreateNewAddress()
       ? this.state.address.country
       : addresses &&
@@ -193,11 +195,16 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
           address => address?.node?.internalID == this.state.selectedAddressID
         )?.node?.country
 
+    const isDomesticOrder =
+      (COUNTRIES_IN_EUROPEAN_UNION.includes(shippingCountry) &&
+        COUNTRIES_IN_EUROPEAN_UNION.includes(artwork?.shippingCountry)) ||
+      artwork?.shippingCountry == shippingCountry
+    const isInternationalOrder = !isDomesticOrder
+
     return (
       this.state.shippingOption === "SHIP" &&
-      ((processWithArtsyShippingDomestic && shippingCountry === "US") ||
-        (artsyShippingInternational && shippingCountry !== "US"))
-      // we are only allowing US based Artsy Shipping for now
+      ((processWithArtsyShippingDomestic && isDomesticOrder) ||
+        (artsyShippingInternational && isInternationalOrder))
     )
   }
 

--- a/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -3,9 +3,11 @@ import { cloneDeep } from "lodash"
 
 import {
   UntouchedBuyOrder,
-  UntouchedBuyOrderWithArtaEnabled,
-  UntouchedBuyOrderWithArtsyShippingInternational,
   UntouchedOfferOrder,
+  UntouchedBuyOrderWithArtsyShippingDomesticFromGermany,
+  UntouchedBuyOrderWithArtsyShippingDomesticFromUS,
+  UntouchedBuyOrderWithArtsyShippingInternationalFromGermany,
+  UntouchedBuyOrderWithArtsyShippingInternationalFromUS,
 } from "v2/Apps/__tests__/Fixtures/Order"
 import {
   fillAddressForm,
@@ -63,16 +65,32 @@ const testOrder: ShippingTestQueryRawResponse["order"] = {
   id: "1234",
 }
 
-const ArtaEnabledTestOrder: ShippingTestQueryRawResponse["order"] = {
-  ...UntouchedBuyOrderWithArtaEnabled,
+const ArtsyShippingDomesticFromUSOrder: ShippingTestQueryRawResponse["order"] = {
+  ...UntouchedBuyOrderWithArtsyShippingDomesticFromUS,
   __typename: "CommerceBuyOrder",
   mode: "BUY",
   internalID: "1234",
   id: "1234",
 }
 
-const ArtsyShippingInternationalTestOrder: ShippingTestQueryRawResponse["order"] = {
-  ...UntouchedBuyOrderWithArtsyShippingInternational,
+const ArtsyShippingInternationalFromUSTestOrder: ShippingTestQueryRawResponse["order"] = {
+  ...UntouchedBuyOrderWithArtsyShippingInternationalFromUS,
+  __typename: "CommerceBuyOrder",
+  mode: "BUY",
+  internalID: "1234",
+  id: "1234",
+}
+
+const ArtsyShippingDomesticFromGermanyOrder: ShippingTestQueryRawResponse["order"] = {
+  ...UntouchedBuyOrderWithArtsyShippingDomesticFromGermany,
+  __typename: "CommerceBuyOrder",
+  mode: "BUY",
+  internalID: "1234",
+  id: "1234",
+}
+
+const ArtsyShippingInternationalFromGermanyOrder: ShippingTestQueryRawResponse["order"] = {
+  ...UntouchedBuyOrderWithArtsyShippingInternationalFromGermany,
   __typename: "CommerceBuyOrder",
   mode: "BUY",
   internalID: "1234",
@@ -375,14 +393,14 @@ describe("Shipping", () => {
       })
     })
 
-    describe("ARTA shipping", () => {
+    describe("Artsy domestic shipping", () => {
       let page
 
       beforeEach(async () => {
         page = await buildPage({
           mockData: {
             order: {
-              ...ArtaEnabledTestOrder,
+              ...ArtsyShippingDomesticFromUSOrder,
             },
           },
         })
@@ -894,7 +912,7 @@ describe("Shipping", () => {
         mockData: {
           me: collectorWithDefaultAddressInEurope,
           order: {
-            ...ArtaEnabledTestOrder,
+            ...ArtsyShippingDomesticFromUSOrder,
           },
         },
       })
@@ -904,284 +922,395 @@ describe("Shipping", () => {
     })
 
     describe("Artsy shipping international", () => {
-      it("commits set shipping mutation if address in Europe", async () => {
-        const collectorWithDefaultAddressInEurope = cloneDeep(testMe) as any
-        collectorWithDefaultAddressInEurope.addressConnection.edges[0].node.isDefault = true
-        collectorWithDefaultAddressInEurope.addressConnection.edges[1].node.isDefault = false
+      describe("when artwork is located in the US", () => {
+        describe("when collector is located in EU", () => {
+          const collectorWithDefaultAddressInEurope = cloneDeep(testMe) as any
+          beforeEach(async () => {
+            // sets collector's default address to a Spain address
+            collectorWithDefaultAddressInEurope.addressConnection.edges[0].node.isDefault = true
+            // US address
+            collectorWithDefaultAddressInEurope.addressConnection.edges[1].node.isDefault = false
+          })
 
-        page = await buildPage({
-          mockData: {
-            me: collectorWithDefaultAddressInEurope,
-            order: {
-              ...ArtsyShippingInternationalTestOrder,
-            },
-          },
+          it("commits the set shipping mutation", async () => {
+            page = await buildPage({
+              mockData: {
+                me: collectorWithDefaultAddressInEurope,
+                order: {
+                  ...ArtsyShippingInternationalFromUSTestOrder,
+                },
+              },
+            })
+            await page.update()
+
+            expect(mutations.mockFetch).toHaveBeenCalled()
+          })
         })
-        await page.update()
 
-        expect(mutations.mockFetch).toHaveBeenCalled()
+        describe("when collector is located in US", () => {
+          it("does not commit set shipping mutation", async () => {
+            page = await buildPage({
+              mockData: {
+                me: testMe,
+                order: {
+                  ...ArtsyShippingInternationalFromUSTestOrder,
+                },
+              },
+            })
+            await page.update()
+
+            expect(mutations.mockFetch).not.toHaveBeenCalled()
+          })
+        })
       })
 
-      it("does not commit set shipping mutation if address in US", async () => {
-        page = await buildPage({
-          mockData: {
-            me: testMe,
-            order: {
-              ...ArtsyShippingInternationalTestOrder,
-            },
-          },
-        })
-        await page.update()
+      describe("when artwork is located in the Germany", () => {
+        describe("when collector is located in EU", () => {
+          const collectorWithDefaultAddressInEurope = cloneDeep(testMe) as any
 
-        expect(mutations.mockFetch).not.toHaveBeenCalled()
+          beforeEach(async () => {
+            // sets collector's default address to a Spain address
+            collectorWithDefaultAddressInEurope.addressConnection.edges[0].node.isDefault = true
+            // US address
+            collectorWithDefaultAddressInEurope.addressConnection.edges[1].node.isDefault = false
+          })
+
+          it("does not commit set shipping mutation", async () => {
+            page = await buildPage({
+              mockData: {
+                me: collectorWithDefaultAddressInEurope,
+                order: {
+                  ...ArtsyShippingInternationalFromGermanyOrder,
+                },
+              },
+            })
+            await page.update()
+            expect(mutations.mockFetch).not.toHaveBeenCalled()
+          })
+        })
+
+        describe("when collector is located in US", () => {
+          it("does commit set shipping mutation", async () => {
+            page = await buildPage({
+              mockData: {
+                me: testMe,
+                order: {
+                  ...ArtsyShippingInternationalFromGermanyOrder,
+                },
+              },
+            })
+            await page.update()
+            expect(mutations.mockFetch).toHaveBeenCalled()
+          })
+        })
       })
     })
 
-    describe("ARTA shipping", () => {
-      beforeEach(async () => {
-        mutations.useResultsOnce(settingOrderArtaShipmentSuccess)
+    describe("Artsy shipping domestic", () => {
+      describe("when artwork is located in Germany", () => {
+        describe("when collector is located in EU", () => {
+          const collectorWithDefaultAddressInEurope = cloneDeep(testMe) as any
 
-        page = await buildPage({
-          mockData: {
-            me: testMe,
-            order: {
-              ...ArtaEnabledTestOrder,
-            },
-          },
-        })
-      })
+          beforeEach(async () => {
+            // sets collector's default address to a Spain address
+            collectorWithDefaultAddressInEurope.addressConnection.edges[0].node.isDefault = true
+            // US address
+            collectorWithDefaultAddressInEurope.addressConnection.edges[1].node.isDefault = false
+          })
 
-      it("commits set shipping mutation if default collector address in USA", async () => {
-        expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
-        expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
-          "SetShippingMutation"
-        )
-
-        expect(mutations.lastFetchVariables).toMatchInlineSnapshot(`
-          Object {
-            "input": Object {
-              "fulfillmentType": "SHIP_ARTA",
-              "id": "1234",
-              "phoneNumber": "422-424-4242",
-              "shipping": Object {
-                "addressLine1": "401 Broadway",
-                "addressLine2": "Floor 25",
-                "city": "New York",
-                "country": "US",
-                "name": "Test Name",
-                "phoneNumber": "422-424-4242",
-                "postalCode": "10013",
-                "region": "NY",
+          it("does commit set shipping mutation", async () => {
+            page = await buildPage({
+              mockData: {
+                me: collectorWithDefaultAddressInEurope,
+                order: {
+                  ...ArtsyShippingDomesticFromGermanyOrder,
+                },
               },
-            },
-          }
-        `)
-      })
-
-      it("shows shipping quotes after set shipping mutation commited", async () => {
-        expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
-        expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
-          "SetShippingMutation"
-        )
-
-        expect(page.find(ShippingRoute).state().shippingQuotes).toHaveLength(5)
-      })
-
-      it("default selects the first quote and submit button is enabled", async () => {
-        expect(page.find(ShippingRoute).state().shippingQuoteId).toEqual(
-          "4a8f8080-23d3-4c0e-9811-7a41a9df6933"
-        )
-
-        expect(page.submitButton.props().disabled).toBeFalsy()
-      })
-
-      it("submit button enabled if shipping quote is selected", async () => {
-        page.find(`[data-test="shipping-quotes"]`).last().simulate("click")
-
-        expect(page.find(ShippingRoute).state().shippingQuoteId).toEqual(
-          "1eb3ba19-643b-4101-b113-2eb4ef7e30b6"
-        )
-
-        expect(page.submitButton.props().disabled).toBeFalsy()
-      })
-
-      it("does not show shipping quotes if address in Europe", async () => {
-        const collectorWithDefaultAddressInEurope = cloneDeep(testMe) as any
-        collectorWithDefaultAddressInEurope.addressConnection.edges[0].node.isDefault = true
-        collectorWithDefaultAddressInEurope.addressConnection.edges[1].node.isDefault = false
-
-        page = await buildPage({
-          mockData: {
-            me: collectorWithDefaultAddressInEurope,
-            order: {
-              ...ArtaEnabledTestOrder,
-            },
-          },
-        })
-        await page.update()
-
-        expect(page.find(`[data-test="shipping-quotes"]`)).toHaveLength(0)
-      })
-
-      it("commites selectShippingOption mutation with correct input", async () => {
-        page.find(`[data-test="shipping-quotes"]`).last().simulate("click")
-
-        await page.clickSubmit()
-
-        expect(mutations.lastFetchVariables).toMatchInlineSnapshot(`
-          Object {
-            "input": Object {
-              "id": "1234",
-              "selectedShippingQuoteId": "1eb3ba19-643b-4101-b113-2eb4ef7e30b6",
-            },
-          }
-        `)
-      })
-
-      it("routes to payment screen after selectShippingOption mutation completes", async () => {
-        page.find(`[data-test="shipping-quotes"]`).last().simulate("click")
-
-        await page.clickSubmit()
-
-        expect(mutations.mockFetch).toHaveBeenCalledTimes(2)
-        expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
-          "SetShippingMutation"
-        )
-
-        expect(routes.mockPushRoute).toHaveBeenCalledWith(
-          "/orders/1234/payment"
-        )
-      })
-
-      it("reload shipping quotes after selected address edited", async () => {
-        page
-          .find(`[data-test="editAddressInShipping"]`)
-          .last()
-          .simulate("click")
-        const inputs = page.find("AddressModal").find("input")
-        inputs.forEach(input => {
-          input.instance().value = `Test input '${input.props().name}'`
-          input.simulate("change")
-        })
-        const countrySelect = page.find("AddressModal").find("select").first()
-        countrySelect.instance().value = `US`
-        countrySelect.simulate("change")
-
-        mutations.useResultsOnce({
-          updateUserAddress: {
-            userAddressOrErrors: {
-              internalID: "2",
-              id: "addressID2",
-              isDefault: true,
-              addressLine1: "Test input 'addressLine1'",
-              addressLine2: "Test input 'addressLine2'",
-              city: "Test input 'city'",
-              country: "US",
-              name: "Test input 'name'",
-              phoneNumber: "Test input 'phoneNumber'",
-              postalCode: "Test input 'postalCode'",
-              region: "Test input 'region'",
-            },
-          },
+            })
+            await page.update()
+            expect(mutations.mockFetch).toHaveBeenCalled()
+          })
         })
 
-        const form = page.find("form").first()
-        form.props().onSubmit()
-
-        await page.update()
-
-        expect(mutations.mockFetch.mock.calls[1][0].name).toEqual(
-          "UpdateUserAddressMutation"
-        )
-        expect(mutations.mockFetch.mock.calls[2][0].name).toEqual(
-          "SetShippingMutation"
-        )
-
-        expect(mutations.mockFetch).toHaveBeenCalledTimes(3)
-        expect(mutations.mockFetch.mock.calls[1][1]).toMatchInlineSnapshot(`
-          Object {
-            "input": Object {
-              "attributes": Object {
-                "addressLine1": "Test input 'addressLine1'",
-                "addressLine2": "Test input 'addressLine2'",
-                "addressLine3": "",
-                "city": "Test input 'city'",
-                "country": "US",
-                "name": "Test input 'name'",
-                "phoneNumber": "422-424-4242",
-                "postalCode": "Test input 'postalCode'",
-                "region": "Test input 'region'",
+        describe("when collector is located in US", () => {
+          it("does not commit set shipping mutation", async () => {
+            page = await buildPage({
+              mockData: {
+                me: testMe,
+                order: {
+                  ...ArtsyShippingDomesticFromGermanyOrder,
+                },
               },
-              "userAddressID": "2",
-            },
-          }
-        `)
+            })
+            await page.update()
+            expect(mutations.mockFetch).not.toHaveBeenCalled()
+          })
+        })
       })
 
-      it("does not reload shipping quotes after edit not selected address", async () => {
-        expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
-          "SetShippingMutation"
-        )
+      describe("when artwork is located in US", () => {
+        describe("when collector is located in EU", () => {
+          let collectorWithDefaultAddressInEurope
+          beforeEach(async () => {
+            const collectorWithDefaultAddressInEurope = cloneDeep(testMe) as any
+            // sets collector's default address to a Spain address
+            collectorWithDefaultAddressInEurope.addressConnection.edges[0].node.isDefault = true
+            // US collector address
+            collectorWithDefaultAddressInEurope.addressConnection.edges[1].node.isDefault = false
+          })
 
-        page
-          .find(`[data-test="editAddressInShipping"]`)
-          .first()
-          .simulate("click")
-        const inputs = page.find("AddressModal").find("input")
-        inputs.forEach(input => {
-          input.instance().value = `Test input '${input.props().name}'`
-          input.simulate("change")
-        })
-        const countrySelect = page.find("AddressModal").find("select").first()
-        countrySelect.instance().value = `US`
-        countrySelect.simulate("change")
-
-        mutations.useResultsOnce({
-          updateUserAddress: {
-            userAddressOrErrors: {
-              internalID: "1",
-              id: "addressID1",
-              isDefault: false,
-              addressLine1: "Test input 'addressLine1'",
-              addressLine2: "Test input 'addressLine2'",
-              city: "Test input 'city'",
-              country: "US",
-              name: "Test input 'name'",
-              phoneNumber: "Test input 'phoneNumber'",
-              postalCode: "Test input 'postalCode'",
-              region: "Test input 'region'",
-            },
-          },
-        })
-
-        const form = page.find("form").first()
-        form.props().onSubmit()
-
-        await page.update()
-
-        expect(mutations.mockFetch.mock.calls[1][0].name).toEqual(
-          "UpdateUserAddressMutation"
-        )
-
-        expect(mutations.mockFetch).toHaveBeenCalledTimes(2)
-        expect(mutations.mockFetch.mock.calls[1][1]).toMatchInlineSnapshot(`
-          Object {
-            "input": Object {
-              "attributes": Object {
-                "addressLine1": "Test input 'addressLine1'",
-                "addressLine2": "Test input 'addressLine2'",
-                "addressLine3": "",
-                "city": "Test input 'city'",
-                "country": "US",
-                "name": "Test input 'name'",
-                "phoneNumber": "555-555-5555",
-                "postalCode": "Test input 'postalCode'",
-                "region": "Test input 'region'",
+          it("does not show shipping quotes", async () => {
+            page = await buildPage({
+              mockData: {
+                me: collectorWithDefaultAddressInEurope,
+                order: {
+                  ...ArtsyShippingDomesticFromUSOrder,
+                },
               },
-              "userAddressID": "1",
-            },
-          }
-        `)
+            })
+            await page.update()
+
+            expect(page.find(`[data-test="shipping-quotes"]`)).toHaveLength(0)
+          })
+        })
+
+        describe("when collector is located in US", () => {
+          beforeEach(async () => {
+            mutations.useResultsOnce(settingOrderArtaShipmentSuccess)
+
+            page = await buildPage({
+              mockData: {
+                me: testMe,
+                order: {
+                  ...ArtsyShippingDomesticFromUSOrder,
+                },
+              },
+            })
+          })
+
+          it("commits set shipping mutation", async () => {
+            expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
+            expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
+              "SetShippingMutation"
+            )
+
+            expect(mutations.lastFetchVariables).toMatchInlineSnapshot(`
+              Object {
+                "input": Object {
+                  "fulfillmentType": "SHIP_ARTA",
+                  "id": "1234",
+                  "phoneNumber": "422-424-4242",
+                  "shipping": Object {
+                    "addressLine1": "401 Broadway",
+                    "addressLine2": "Floor 25",
+                    "city": "New York",
+                    "country": "US",
+                    "name": "Test Name",
+                    "phoneNumber": "422-424-4242",
+                    "postalCode": "10013",
+                    "region": "NY",
+                  },
+                },
+              }
+            `)
+          })
+
+          it("shows shipping quotes after set shipping mutation commited", async () => {
+            expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
+            expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
+              "SetShippingMutation"
+            )
+
+            expect(
+              page.find(ShippingRoute).state().shippingQuotes
+            ).toHaveLength(5)
+          })
+
+          it("default selects the first quote and submit button is enabled", async () => {
+            expect(page.find(ShippingRoute).state().shippingQuoteId).toEqual(
+              "4a8f8080-23d3-4c0e-9811-7a41a9df6933"
+            )
+
+            expect(page.submitButton.props().disabled).toBeFalsy()
+          })
+
+          it("submit button enabled if shipping quote is selected", async () => {
+            page.find(`[data-test="shipping-quotes"]`).last().simulate("click")
+
+            expect(page.find(ShippingRoute).state().shippingQuoteId).toEqual(
+              "1eb3ba19-643b-4101-b113-2eb4ef7e30b6"
+            )
+
+            expect(page.submitButton.props().disabled).toBeFalsy()
+          })
+
+          it("commites selectShippingOption mutation with correct input", async () => {
+            page.find(`[data-test="shipping-quotes"]`).last().simulate("click")
+
+            await page.clickSubmit()
+
+            expect(mutations.lastFetchVariables).toMatchInlineSnapshot(`
+              Object {
+                "input": Object {
+                  "id": "1234",
+                  "selectedShippingQuoteId": "1eb3ba19-643b-4101-b113-2eb4ef7e30b6",
+                },
+              }
+            `)
+          })
+
+          it("routes to payment screen after selectShippingOption mutation completes", async () => {
+            page.find(`[data-test="shipping-quotes"]`).last().simulate("click")
+
+            await page.clickSubmit()
+
+            expect(mutations.mockFetch).toHaveBeenCalledTimes(2)
+            expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
+              "SetShippingMutation"
+            )
+
+            expect(routes.mockPushRoute).toHaveBeenCalledWith(
+              "/orders/1234/payment"
+            )
+          })
+
+          it("reload shipping quotes after selected address edited", async () => {
+            page
+              .find(`[data-test="editAddressInShipping"]`)
+              .last()
+              .simulate("click")
+            const inputs = page.find("AddressModal").find("input")
+            inputs.forEach(input => {
+              input.instance().value = `Test input '${input.props().name}'`
+              input.simulate("change")
+            })
+            const countrySelect = page
+              .find("AddressModal")
+              .find("select")
+              .first()
+            countrySelect.instance().value = `US`
+            countrySelect.simulate("change")
+
+            mutations.useResultsOnce({
+              updateUserAddress: {
+                userAddressOrErrors: {
+                  internalID: "2",
+                  id: "addressID2",
+                  isDefault: true,
+                  addressLine1: "Test input 'addressLine1'",
+                  addressLine2: "Test input 'addressLine2'",
+                  city: "Test input 'city'",
+                  country: "US",
+                  name: "Test input 'name'",
+                  phoneNumber: "Test input 'phoneNumber'",
+                  postalCode: "Test input 'postalCode'",
+                  region: "Test input 'region'",
+                },
+              },
+            })
+
+            const form = page.find("form").first()
+            form.props().onSubmit()
+
+            await page.update()
+
+            expect(mutations.mockFetch.mock.calls[1][0].name).toEqual(
+              "UpdateUserAddressMutation"
+            )
+            expect(mutations.mockFetch.mock.calls[2][0].name).toEqual(
+              "SetShippingMutation"
+            )
+
+            expect(mutations.mockFetch).toHaveBeenCalledTimes(3)
+            expect(mutations.mockFetch.mock.calls[1][1]).toMatchInlineSnapshot(`
+              Object {
+                "input": Object {
+                  "attributes": Object {
+                    "addressLine1": "Test input 'addressLine1'",
+                    "addressLine2": "Test input 'addressLine2'",
+                    "addressLine3": "",
+                    "city": "Test input 'city'",
+                    "country": "US",
+                    "name": "Test input 'name'",
+                    "phoneNumber": "422-424-4242",
+                    "postalCode": "Test input 'postalCode'",
+                    "region": "Test input 'region'",
+                  },
+                  "userAddressID": "2",
+                },
+              }
+            `)
+          })
+
+          it("does not reload shipping quotes after edit not selected address", async () => {
+            expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
+              "SetShippingMutation"
+            )
+
+            page
+              .find(`[data-test="editAddressInShipping"]`)
+              .first()
+              .simulate("click")
+            const inputs = page.find("AddressModal").find("input")
+            inputs.forEach(input => {
+              input.instance().value = `Test input '${input.props().name}'`
+              input.simulate("change")
+            })
+            const countrySelect = page
+              .find("AddressModal")
+              .find("select")
+              .first()
+            countrySelect.instance().value = `US`
+            countrySelect.simulate("change")
+
+            mutations.useResultsOnce({
+              updateUserAddress: {
+                userAddressOrErrors: {
+                  internalID: "1",
+                  id: "addressID1",
+                  isDefault: false,
+                  addressLine1: "Test input 'addressLine1'",
+                  addressLine2: "Test input 'addressLine2'",
+                  city: "Test input 'city'",
+                  country: "US",
+                  name: "Test input 'name'",
+                  phoneNumber: "Test input 'phoneNumber'",
+                  postalCode: "Test input 'postalCode'",
+                  region: "Test input 'region'",
+                },
+              },
+            })
+
+            const form = page.find("form").first()
+            form.props().onSubmit()
+
+            await page.update()
+
+            expect(mutations.mockFetch.mock.calls[1][0].name).toEqual(
+              "UpdateUserAddressMutation"
+            )
+
+            expect(mutations.mockFetch).toHaveBeenCalledTimes(2)
+            expect(mutations.mockFetch.mock.calls[1][1]).toMatchInlineSnapshot(`
+              Object {
+                "input": Object {
+                  "attributes": Object {
+                    "addressLine1": "Test input 'addressLine1'",
+                    "addressLine2": "Test input 'addressLine2'",
+                    "addressLine3": "",
+                    "city": "Test input 'city'",
+                    "country": "US",
+                    "name": "Test input 'name'",
+                    "phoneNumber": "555-555-5555",
+                    "postalCode": "Test input 'postalCode'",
+                    "region": "Test input 'region'",
+                  },
+                  "userAddressID": "1",
+                },
+              }
+            `)
+          })
+        })
       })
     })
 

--- a/src/v2/Apps/__tests__/Fixtures/Order.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Order.ts
@@ -91,6 +91,12 @@ const OrderArtworkNodeWithoutShipping = {
   isEdition: false,
 }
 
+const artworkFromGermany = {
+  ...OrderArtworkNodeWithoutShipping,
+  priceCurrency: "EUR",
+  shippingCountry: "DE",
+}
+
 const OrderArtworkVersionNode = {
   artworkVersion: {
     id: "02393",
@@ -125,41 +131,38 @@ const OrderArtworkNode = {
   },
 }
 
-const ArtsyShippingDomesticOrderArtworkNode = {
+const ArtsyShippingDomesticFromUSArtworkNode = {
   artwork: {
     ...OrderArtworkNodeWithoutShipping,
     shippingOrigin: "New York, NY",
     processWithArtsyShippingDomestic: true,
     artsyShippingInternational: false,
-    domesticShippingFee: {
-      minor: 10000,
-      major: 100,
-      display: "$100",
-    },
-    internationalShippingFee: {
-      minor: 10000,
-      major: 100,
-      display: "$100",
-    },
+  },
+}
+const ArtsyShippingDomesticFromGermanyArtworkNode = {
+  artwork: {
+    ...artworkFromGermany,
+    shippingOrigin: "Berlin, DE",
+    processWithArtsyShippingDomestic: true,
+    artsyShippingInternational: false,
   },
 }
 
-const ArtstyShippingInternationalOrderArtworkNode = {
+const ArtstyShippingInternationalFromUSArtworkNode = {
   artwork: {
     ...OrderArtworkNodeWithoutShipping,
     shippingOrigin: "New York, NY",
     processWithArtsyShippingDomestic: false,
     artsyShippingInternational: true,
-    domesticShippingFee: {
-      minor: 10000,
-      major: 100,
-      display: "$100",
-    },
-    internationalShippingFee: {
-      minor: 10000,
-      major: 100,
-      display: "$100",
-    },
+  },
+}
+
+const ArtsyShippingInternationalFromGermanyArtworkNode = {
+  artwork: {
+    ...artworkFromGermany,
+    shippingOrigin: "Berlin, DE",
+    processWithArtsyShippingDomestic: false,
+    artsyShippingInternational: true,
   },
 }
 
@@ -341,7 +344,7 @@ export const UntouchedBuyOrder = {
   source: "artwork_page",
 } as const
 
-export const UntouchedBuyOrderWithArtaEnabled = {
+export const UntouchedBuyOrderWithArtsyShippingDomesticFromUS = {
   ...UntouchedBuyOrder,
   __typename: "CommerceBuyOrder",
   lineItems: {
@@ -352,7 +355,7 @@ export const UntouchedBuyOrderWithArtaEnabled = {
           id: "line-item-node-id",
           selectedShippingQuote: null,
           shippingQuoteOptions: null,
-          ...ArtsyShippingDomesticOrderArtworkNode,
+          ...ArtsyShippingDomesticFromUSArtworkNode,
           ...OrderArtworkVersionNode,
           ...OrderArtworkOrEditionSetkNode_Artwork,
           ...EmptyFulfillmentsNode,
@@ -363,7 +366,7 @@ export const UntouchedBuyOrderWithArtaEnabled = {
   },
 } as const
 
-export const UntouchedBuyOrderWithArtsyShippingInternational = {
+export const UntouchedBuyOrderWithArtsyShippingInternationalFromUS = {
   ...UntouchedBuyOrder,
   __typename: "CommerceBuyOrder",
   lineItems: {
@@ -374,7 +377,51 @@ export const UntouchedBuyOrderWithArtsyShippingInternational = {
           id: "line-item-node-id",
           selectedShippingQuote: null,
           shippingQuoteOptions: null,
-          ...ArtstyShippingInternationalOrderArtworkNode,
+          ...ArtstyShippingInternationalFromUSArtworkNode,
+          ...OrderArtworkVersionNode,
+          ...OrderArtworkOrEditionSetkNode_Artwork,
+          ...EmptyFulfillmentsNode,
+          ...ArtaShipmentNode,
+        },
+      },
+    ],
+  },
+} as const
+
+export const UntouchedBuyOrderWithArtsyShippingDomesticFromGermany = {
+  ...UntouchedBuyOrder,
+  __typename: "CommerceBuyOrder",
+  lineItems: {
+    edges: [
+      {
+        node: {
+          editionSetId: null,
+          id: "line-item-node-id",
+          selectedShippingQuote: null,
+          shippingQuoteOptions: null,
+          ...ArtsyShippingDomesticFromGermanyArtworkNode,
+          ...OrderArtworkVersionNode,
+          ...OrderArtworkOrEditionSetkNode_Artwork,
+          ...EmptyFulfillmentsNode,
+          ...ArtaShipmentNode,
+        },
+      },
+    ],
+  },
+} as const
+
+export const UntouchedBuyOrderWithArtsyShippingInternationalFromGermany = {
+  ...UntouchedBuyOrder,
+  __typename: "CommerceBuyOrder",
+  lineItems: {
+    edges: [
+      {
+        node: {
+          editionSetId: null,
+          id: "line-item-node-id",
+          selectedShippingQuote: null,
+          shippingQuoteOptions: null,
+          ...ArtsyShippingInternationalFromGermanyArtworkNode,
           ...OrderArtworkVersionNode,
           ...OrderArtworkOrEditionSetkNode_Artwork,
           ...EmptyFulfillmentsNode,
@@ -458,7 +505,7 @@ export const UntouchedBuyOrderWithShippingQuotes = {
               },
             ],
           },
-          ...ArtsyShippingDomesticOrderArtworkNode,
+          ...ArtsyShippingDomesticFromUSArtworkNode,
           ...OrderArtworkVersionNode,
           ...OrderArtworkOrEditionSetkNode_Artwork,
           ...EmptyFulfillmentsNode,
@@ -552,7 +599,7 @@ export const UntouchedBuyOrderWithSelectedShippingQuote = {
               },
             ],
           },
-          ...ArtsyShippingDomesticOrderArtworkNode,
+          ...ArtsyShippingDomesticFromUSArtworkNode,
           ...OrderArtworkOrEditionSetkNode_Artwork,
           ...OrderArtworkFulfillmentsNode,
           ...ArtaShipmentNode,

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,10 @@
   dependencies:
     core-js "3"
 
+"@artsy/commerce_helpers@artsy/commerce_helpers":
+  version "0.1.0"
+  resolved "https://codeload.github.com/artsy/commerce_helpers/tar.gz/65c8cd03480bf9030d853e2d114f8bcf6de969a7"
+
 "@artsy/detect-responsive-traits@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@artsy/detect-responsive-traits/-/detect-responsive-traits-0.1.0.tgz#f7ae5041893b859ff9f6bc305fd318d2f5132745"


### PR DESCRIPTION
Expands force side logic to include more countries into artsy shipping

pairing with @oxaudo 

TO DOs:
- [x] handling for GB/UK/NO/CH
- [x] Fixing and adding more specs
- [x] Refactor, refactor, refactor

Addressing: https://artsyproduct.atlassian.net/browse/PX-5031


The type of this PR is: Feature

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PX-5031]

### Description
Expands force logic to allow for EU/UK/CH/NO domestic and international artsy shipping

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PX-5031]: https://artsyproduct.atlassian.net/browse/PX-5031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ