### PR TITLE
fix:correct spelling of accommodate on lot page

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/LotTimer.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/LotTimer.tsx
@@ -76,7 +76,7 @@ export const LotTimer: React.FC<LotTimerProps> = ({ saleArtwork }) => {
         <>
           <Spacer mt={1} />
           <Text variant="xs" color={"black60"}>
-            *Closure times may be extended to accomodate last minute bids
+            *Closure times may be extended to accommodate last minute bids
           </Text>
         </>
       )}

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/LotTimer.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/LotTimer.jest.tsx
@@ -23,7 +23,7 @@ describe("extendedBiddingInfoCopy", () => {
       const wrapper = mount(<LotTimer saleArtwork={saleArtwork} />)
       const text = wrapper.text()
       expect(text).toContain(
-        "*Closure times may be extended to accomodate last minute bids"
+        "*Closure times may be extended to accommodate last minute bids"
       )
     })
     describe("a bid has extended the auction", () => {
@@ -100,7 +100,7 @@ describe("extendedBiddingInfoCopy", () => {
       const wrapper = mount(<LotTimer saleArtwork={saleArtwork} />)
       const text = wrapper.text()
       expect(text).not.toContain(
-        "*Closure times may be extended to accomodate last minute bids"
+        "*Closure times may be extended to accommodate last minute bids"
       )
     })
   })


### PR DESCRIPTION
The type of this PR is: FIX

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [BID-409]

### Description

Fixes a typo on the lot page.

<img width="630" alt="Screen Shot 2022-06-22 at 3 08 16 PM" src="https://user-images.githubusercontent.com/19369/175118230-452152f9-8d87-411d-bc89-60548e86ad61.png">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BID-409]: https://artsyproduct.atlassian.net/browse/BID-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ