### PR TITLE
feat: Manually trigger Braze IAM GRO-895

### DIFF
--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -16,6 +16,7 @@ import { useAuthIntent } from "v2/Utils/Hooks/useAuthIntent"
 import { AppToasts } from "./AppToasts"
 import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 import { useProductionEnvironmentWarning } from "v2/Utils/Hooks/useProductionEnvironmentWarning"
+import { useBrazeInAppMessage } from "v2/Utils/Hooks/useBrazeInAppMessage"
 import { useAuthValidation } from "v2/Utils/Hooks/useAuthValidation"
 import { Z } from "./constants"
 import {
@@ -78,6 +79,7 @@ export const AppShell: React.FC<AppShellProps> = props => {
 
   useNetworkOfflineMonitor()
   useProductionEnvironmentWarning()
+  useBrazeInAppMessage()
 
   return (
     <Flex

--- a/src/v2/Utils/Hooks/__tests__/useBrazeInAppMessage.jest.ts
+++ b/src/v2/Utils/Hooks/__tests__/useBrazeInAppMessage.jest.ts
@@ -1,0 +1,42 @@
+import { isMatchingRoute } from "../useBrazeInAppMessage"
+
+describe("isMatchingRoute", () => {
+  const validRoutes = [
+    "/",
+    "/art-fairs",
+    "/article/best-art-in-the-world",
+    "/articles",
+    "/artist/andy-warhol",
+    "/artists",
+    "/auctions",
+    "/collect",
+    "/collection/trove",
+    "/fair/outside-tent-thingy",
+    "/galleries",
+    "/gene/works-on-paper",
+    "/partner/abc-gallery",
+    "/show/only-blue-paintings",
+    "/shows",
+    "/viewing-room/for-your-eyes-only",
+    "/viewing-rooms",
+  ]
+
+  it("returns true for valid routes", () => {
+    const validResults = validRoutes.map(route => isMatchingRoute(route))
+    expect(validResults.length).toEqual(validResults.length)
+  })
+
+  const invalidRoutes = [
+    "/artist/andy-warhol/works-for-sale",
+    "/auction/fancy-prints-2022",
+    "/categories",
+    "/collections",
+    "/login",
+    "/sell",
+  ]
+
+  it("returns false for invalid routes", () => {
+    const invalidResults = invalidRoutes.map(route => !isMatchingRoute(route))
+    expect(invalidResults.length).toEqual(invalidResults.length)
+  })
+})

--- a/src/v2/Utils/Hooks/useBrazeInAppMessage.ts
+++ b/src/v2/Utils/Hooks/useBrazeInAppMessage.ts
@@ -1,0 +1,60 @@
+import { useEffect } from "react"
+import { pathToRegexp } from "path-to-regexp"
+import { useRouter } from "v2/System/Router/useRouter"
+
+const allowedPatterns = [
+  "/",
+  "/art-fairs",
+  "/article/:slug",
+  "/articles",
+  "/artist/:slug,",
+  "/artists",
+  "/auctions",
+  "/collect",
+  "/collection/:slug",
+  "/fair/:slug",
+  "/galleries",
+  "/gene/:slug",
+  "/partner/:slug",
+  "/show/:slug",
+  "/shows",
+  "/viewing-room/:slug",
+  "/viewing-rooms",
+].map(path => pathToRegexp(path))
+
+export const isMatchingRoute = (pathname): boolean => {
+  return allowedPatterns.some(pattern => pattern.test(pathname))
+}
+
+// adapted from here:
+// https://segment.com/docs/connections/destinations/catalog/braze/#other-features
+
+export const useBrazeInAppMessage = () => {
+  const { match } = useRouter()
+  const pathname = match.location.pathname
+
+  useEffect(() => {
+    // @ts-ignore
+    const { analytics, appboy } = window
+
+    if (!analytics || !appboy || !pathname) return
+
+    let subscriptionId
+
+    analytics.ready(() => {
+      subscriptionId = appboy.subscribeToNewInAppMessages(inAppMessages => {
+        if (inAppMessages.length < 1 || !isMatchingRoute(pathname))
+          return inAppMessages
+
+        appboy.display.showInAppMessage(inAppMessages[0])
+        return inAppMessages.slice(1)
+      })
+    })
+
+    return () => {
+      if (!subscriptionId) return
+
+      appboy.removeSubscription(subscriptionId)
+    }
+  })
+}


### PR DESCRIPTION
This PR adds a new trick to our app shell: conditionally showing Braze In App Messages! I got some advice from @dzucconi here:

https://artsy.slack.com/archives/C01ADJNCS5D/p1655829978286369

And the approach we sorta settled on was: add a hook to the app shell and adapt the code that Segment suggests with an allow list of routes. Here's that code from the Segment docs:

https://segment.com/docs/connections/destinations/catalog/braze/#other-features

Overall the flow is:

* add a ready handler to window.analytics
* add a subscription to window.appboy with a handler
* when that handler fires, decide if the IAM should be shown

In terms of testing what we have here is I extracted a function that wraps the regex checks and that's what I'm testing. The async nature of this code resisted any further testing.

Note: this does NOT address Eigen - that's been broken off into a separate Jira ticket.

https://artsyproduct.atlassian.net/browse/GRO-895

/cc @artsy/grow-devs @kathytafel 