### PR TITLE
Disable submit button on review step until Stripe is ready

### DIFF
--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -362,6 +362,18 @@ export const ReviewRoute: FC<ReviewProps> = props => {
   const { order, isCommittingMutation, isEigen, stripe } = props
   const submittable = !!stripe
 
+  const SubmitButton: FC = () => (
+    <Button
+      variant="primaryBlack"
+      width="100%"
+      loading={isCommittingMutation}
+      disabled={!submittable}
+      onClick={onSubmit}
+    >
+      Submit
+    </Button>
+  )
+
   return (
     <Box data-test="orderReview">
       <OrderStepper
@@ -378,15 +390,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
               </Message>
               {isEigen && (
                 <>
-                  <Button
-                    variant="primaryBlack"
-                    width="100%"
-                    loading={isCommittingMutation}
-                    disabled={!submittable}
-                    onClick={() => onSubmit()}
-                  >
-                    Submit
-                  </Button>
+                  <SubmitButton />
                   <ConditionsOfSaleDisclaimer paddingY={2} textAlign="start" />
                 </>
               )}
@@ -411,15 +415,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
             <Media greaterThan="xs">
               <ItemReview lineItem={order?.lineItems?.edges?.[0]?.node!} />
               <Spacer mb={2} />
-              <Button
-                variant="primaryBlack"
-                width="100%"
-                loading={isCommittingMutation}
-                disabled={!submittable}
-                onClick={() => onSubmit()}
-              >
-                Submit
-              </Button>
+              <SubmitButton />
               <Spacer mb={2} />
               <ConditionsOfSaleDisclaimer textAlign="center" />
             </Media>
@@ -440,15 +436,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
             />
             <Spacer mb={[2, 4]} />
             <Media at="xs">
-              <Button
-                variant="primaryBlack"
-                width="100%"
-                loading={isCommittingMutation}
-                disabled={!submittable}
-                onClick={() => onSubmit()}
-              >
-                Submit
-              </Button>
+              <SubmitButton />
               <Spacer mb={2} />
               <ConditionsOfSaleDisclaimer />
             </Media>

--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -359,7 +359,8 @@ export const ReviewRoute: FC<ReviewProps> = props => {
     props.router.push(`/orders/${props.order.internalID}/shipping`)
   }
 
-  const { order, isCommittingMutation, isEigen } = props
+  const { order, isCommittingMutation, isEigen, stripe } = props
+  const submittable = !!stripe
 
   return (
     <Box data-test="orderReview">
@@ -381,6 +382,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
                     variant="primaryBlack"
                     width="100%"
                     loading={isCommittingMutation}
+                    disabled={!submittable}
                     onClick={() => onSubmit()}
                   >
                     Submit
@@ -413,6 +415,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
                 variant="primaryBlack"
                 width="100%"
                 loading={isCommittingMutation}
+                disabled={!submittable}
                 onClick={() => onSubmit()}
               >
                 Submit
@@ -441,6 +444,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
                 variant="primaryBlack"
                 width="100%"
                 loading={isCommittingMutation}
+                disabled={!submittable}
                 onClick={() => onSubmit()}
               >
                 Submit

--- a/src/v2/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -45,19 +45,19 @@ jest.mock("v2/System/Analytics/useTracking")
 jest.mock("@stripe/stripe-js", () => {
   let mock = null
   return {
-    loadStripe: () => {
+    loadStripe: jest.fn(() => {
       if (mock === null) {
         // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         mock = mockStripe()
       }
       return mock
-    },
+    }),
     _mockStripe: () => mock,
     // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     _mockReset: () => (mock = mockStripe()),
   }
 })
-const { _mockStripe } = require("@stripe/stripe-js")
+const { loadStripe, _mockStripe } = require("@stripe/stripe-js")
 
 const mockShowErrorDialog = jest.fn()
 jest.mock("v2/Apps/Order/Dialogs", () => ({
@@ -139,6 +139,15 @@ describe("Review", () => {
 
       expect(mockCommitMutation).toHaveBeenCalledTimes(1)
       expect(pushMock).toBeCalledWith("/orders/1234/status")
+    })
+
+    it("disables the submit button when props.stripe is not present", () => {
+      loadStripe.mockReturnValueOnce(null)
+      const wrapper = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      const page = new ReviewTestPage(wrapper)
+      expect(page.submitButton.props().disabled).toBeTruthy()
     })
 
     it("takes the user back to the /shipping view", () => {


### PR DESCRIPTION
The type of this PR is: **Enhancement**

This PR solves [TX-421].

### Description

Roughly since https://github.com/artsy/force/pull/10320, we started to see flaky Integrity failures on the [SCA scenarios](https://artsy.slack.com/archives/C02JHHHKP5K/p1655809767938599). It seems like `props.stripe` was `null` when submitting the form, and presumably Cypress was clicking the submit button too fast, before stripe is loaded (hopefully this doesn't impact real users).

This PR disables the submit button until stripe is ready and the page re-renders. We'll need to update Integrity to make sure it waits until the button is actionable.

It's still unclear to me what exactly caused this behavioral change.

![Screen Shot 2022-06-17 at 4 05 52 PM](https://user-images.githubusercontent.com/796573/175143788-2e7d7aa5-40a6-491d-ab3c-577ae446cbf6.png)

