### PR TITLE
feat(FX-4027): Add keyword filter to artist page's artwork grid

### DIFF
--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -20,21 +20,7 @@ import {
   useFeatureVariant,
   useTrackFeatureVariant,
 } from "v2/System/useFeatureFlag"
-import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
-import { ColorFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter"
-import { MediumFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter"
-import { PriceRangeFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter"
-import { SizeFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter"
-import { TimePeriodFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter"
-import { WaysToBuyFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter"
-import { AttributionClassFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
-import { ArtworkLocationFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter"
-import { ArtistNationalityFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter"
-import { MaterialsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MaterialsFilter"
-import { PartnersFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
-import { ArtistsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter"
-import { KeywordFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
-import { useFeatureFlag } from "v2/System/useFeatureFlag"
+import { ArtistArtworkFilters } from "./ArtistArtworkFilters"
 
 interface ArtistArtworkFilterProps {
   aggregations: SharedArtworkFilterContextProps["aggregations"]
@@ -42,13 +28,11 @@ interface ArtistArtworkFilterProps {
   me: ArtistArtworkFilter_me | null
   relay: RelayRefetchProp
   match?: Match
-  user?: User
-  relayEnvironment?: RelayModernEnvironment
 }
 
 const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
   const { match } = useRouter()
-  const { relay, aggregations, artist, me, user, relayEnvironment } = props
+  const { relay, aggregations, artist, me } = props
   const { filtered_artworks } = artist
   const hasFilter = filtered_artworks && filtered_artworks.id
   const trendingSortVariant = useFeatureVariant(
@@ -58,8 +42,6 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
     experimentName: "trending-sort-for-artist-artwork-grids",
     variantName: trendingSortVariant?.name!,
   })
-
-  const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
 
   useEffect(() => {
     trackFeatureVariant()
@@ -94,24 +76,6 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
     trendingSortVariant
   )
 
-  const Filters = (
-    <>
-      {showKeywordFilter && <KeywordFilter />}
-      <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
-      <AttributionClassFilter expanded />
-      <MediumFilter expanded />
-      <PriceRangeFilter expanded />
-      <SizeFilter expanded />
-      <WaysToBuyFilter expanded />
-      <MaterialsFilter />
-      <ArtistNationalityFilter />
-      <ArtworkLocationFilter />
-      <TimePeriodFilter />
-      <ColorFilter />
-      <PartnersFilter />
-    </>
-  )
-
   return (
     <ArtworkFilterContextProvider
       aggregations={aggregations}
@@ -131,7 +95,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
       <BaseArtworkFilter
         relay={relay}
         viewer={artist}
-        Filters={Filters}
+        Filters={<ArtistArtworkFilters relayEnvironment={relay.environment} />}
         relayVariables={{
           aggregations: ["TOTAL"],
         }}

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -34,6 +34,7 @@ import { MaterialsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/Mate
 import { PartnersFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
 import { ArtistsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter"
 import { KeywordFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
+import { useFeatureFlag } from "v2/System/useFeatureFlag"
 
 interface ArtistArtworkFilterProps {
   aggregations: SharedArtworkFilterContextProps["aggregations"]
@@ -57,6 +58,8 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
     experimentName: "trending-sort-for-artist-artwork-grids",
     variantName: trendingSortVariant?.name!,
   })
+
+  const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
 
   useEffect(() => {
     trackFeatureVariant()
@@ -93,7 +96,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
 
   const Filters = (
     <>
-      <KeywordFilter />
+      {showKeywordFilter && <KeywordFilter />}
       <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
       <AttributionClassFilter expanded />
       <MediumFilter expanded />

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -20,6 +20,20 @@ import {
   useFeatureVariant,
   useTrackFeatureVariant,
 } from "v2/System/useFeatureFlag"
+import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
+import { ColorFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter"
+import { MediumFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter"
+import { PriceRangeFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter"
+import { SizeFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter"
+import { TimePeriodFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter"
+import { WaysToBuyFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter"
+import { AttributionClassFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
+import { ArtworkLocationFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter"
+import { ArtistNationalityFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter"
+import { MaterialsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MaterialsFilter"
+import { PartnersFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
+import { ArtistsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter"
+import { KeywordFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
 
 interface ArtistArtworkFilterProps {
   aggregations: SharedArtworkFilterContextProps["aggregations"]
@@ -27,11 +41,13 @@ interface ArtistArtworkFilterProps {
   me: ArtistArtworkFilter_me | null
   relay: RelayRefetchProp
   match?: Match
+  user?: User
+  relayEnvironment?: RelayModernEnvironment
 }
 
 const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
   const { match } = useRouter()
-  const { relay, aggregations, artist, me } = props
+  const { relay, aggregations, artist, me, user, relayEnvironment } = props
   const { filtered_artworks } = artist
   const hasFilter = filtered_artworks && filtered_artworks.id
   const trendingSortVariant = useFeatureVariant(
@@ -75,6 +91,24 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
     trendingSortVariant
   )
 
+  const Filters = (
+    <>
+      <KeywordFilter />
+      <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
+      <AttributionClassFilter expanded />
+      <MediumFilter expanded />
+      <PriceRangeFilter expanded />
+      <SizeFilter expanded />
+      <WaysToBuyFilter expanded />
+      <MaterialsFilter />
+      <ArtistNationalityFilter />
+      <ArtworkLocationFilter />
+      <TimePeriodFilter />
+      <ColorFilter />
+      <PartnersFilter />
+    </>
+  )
+
   return (
     <ArtworkFilterContextProvider
       aggregations={aggregations}
@@ -94,6 +128,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
       <BaseArtworkFilter
         relay={relay}
         viewer={artist}
+        Filters={Filters}
         relayVariables={{
           aggregations: ["TOTAL"],
         }}

--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -1,0 +1,45 @@
+import { ColorFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter"
+import { MediumFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter"
+import { PriceRangeFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter"
+import { SizeFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter"
+import { TimePeriodFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter"
+import { WaysToBuyFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter"
+import { AttributionClassFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
+import { ArtworkLocationFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter"
+import { ArtistNationalityFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter"
+import { MaterialsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MaterialsFilter"
+import { PartnersFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
+import { ArtistsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter"
+import { KeywordFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
+import { useFeatureFlag } from "v2/System/useFeatureFlag"
+import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
+import { useSystemContext } from "v2/System"
+
+interface ArtistArtworkFiltersProps {
+  relayEnvironment?: RelayModernEnvironment
+}
+
+export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props => {
+  const { relayEnvironment } = props
+  const { user } = useSystemContext()
+
+  const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
+
+  return (
+    <>
+      {showKeywordFilter && <KeywordFilter />}
+      <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
+      <AttributionClassFilter expanded />
+      <MediumFilter expanded />
+      <PriceRangeFilter expanded />
+      <SizeFilter expanded />
+      <WaysToBuyFilter expanded />
+      <MaterialsFilter />
+      <ArtistNationalityFilter />
+      <ArtworkLocationFilter />
+      <TimePeriodFilter />
+      <ColorFilter />
+      <PartnersFilter />
+    </>
+  )
+}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -23,7 +23,6 @@ export const initialArtworkFilterState: ArtworkFilters = {
   partnerIDs: [],
   additionalGeneIDs: [],
   colors: [],
-  keyword: undefined,
   locationCities: [],
   artistNationalities: [],
   materialsTerms: [],

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -23,6 +23,7 @@ export const initialArtworkFilterState: ArtworkFilters = {
   partnerIDs: [],
   additionalGeneIDs: [],
   colors: [],
+  keyword: undefined,
   locationCities: [],
   artistNationalities: [],
   materialsTerms: [],
@@ -472,6 +473,7 @@ const artworkFilterReducer = (
       const stringFilterTypes: Array<keyof ArtworkFilters> = [
         "color",
         "height",
+        "keyword",
         "medium",
         "partnerID",
         "priceRange",

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -20,6 +20,7 @@ export const initialArtworkFilterState: ArtworkFilters = {
   sort: "-decayed_merch",
   artistIDs: [],
   attributionClass: [],
+  keyword: undefined,
   partnerIDs: [],
   additionalGeneIDs: [],
   colors: [],

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -643,6 +643,12 @@ export const getSelectedFiltersCounts = (
         }
         break
       }
+      case paramName === FilterParamName.keyword: {
+        if (paramValue?.length) {
+          counts[paramName] = 1
+        }
+        break
+      }
 
       default: {
         counts[paramName] = 1

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
@@ -7,40 +7,43 @@ import { useArtworkFilterContext } from "../ArtworkFilterContext"
 const DEBOUNCE_DELAY = 300
 
 export const KeywordFilter: React.FC = () => {
-  const filterContext = useArtworkFilterContext()
+  const { filters, setFilter } = useArtworkFilterContext()
+  const { keyword } = filters ?? {}
 
-  const [keyword, setKeyword] = useState(filterContext.filters!.keyword)
+  const [value, setValue] = useState(keyword)
 
   const updateKeywordFilter = (text: string) => {
-    let textOrUndefined = text.length === 0 ? undefined : text
-    filterContext.setFilter("keyword", textOrUndefined)
+    const textOrUndefined = text.length === 0 ? undefined : text
+    setFilter("keyword", textOrUndefined)
   }
 
   const handleDebounce = useMemo(
     () => debounce(updateKeywordFilter, DEBOUNCE_DELAY),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 
   const handleChangeText = text => {
-    setKeyword(text)
+    setValue(text)
     handleDebounce(text)
   }
 
   // Stop the invocation of the debounced function after unmounting
   useEffect(() => {
     return () => handleDebounce.cancel()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {
-    if (filterContext.filters!.keyword === undefined) {
-      setKeyword("")
+    if (keyword === undefined) {
+      setValue("")
     }
-  }, [filterContext.filters!.keyword])
+  }, [keyword, setValue])
 
   return (
     <FilterExpandable label="Keyword Search" expanded={true}>
       <LabeledInput
-        value={keyword}
+        value={value}
         placeholder="Enter a search term"
         onChange={event => handleChangeText(event.currentTarget.value)}
         type="text"

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
@@ -2,15 +2,11 @@ import { LabeledInput, MagnifyingGlassIcon } from "@artsy/palette"
 import { FilterExpandable } from "./FilterExpandable"
 import React, { useEffect, useMemo } from "react"
 import { debounce } from "lodash"
-import {
-  useCurrentlySelectedFilters,
-  useArtworkFilterContext,
-} from "../ArtworkFilterContext"
+import { useArtworkFilterContext } from "../ArtworkFilterContext"
 
-const DEBOUNCE_DELAY = 100
+const DEBOUNCE_DELAY = 300
 
 export const KeywordFilter: React.FC = () => {
-  const { keyword = [] } = useCurrentlySelectedFilters()
   const filterContext = useArtworkFilterContext()
 
   const updateKeywordFilter = (text: string) => {
@@ -31,7 +27,7 @@ export const KeywordFilter: React.FC = () => {
   return (
     <FilterExpandable label="Keyword Search" expanded={true}>
       <LabeledInput
-        value={keyword}
+        defaultValue={filterContext.filters!.keyword}
         placeholder="Enter a search term"
         onChange={event => handleChangeText(event.currentTarget.value)}
         type="text"

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
@@ -1,6 +1,6 @@
 import { LabeledInput, MagnifyingGlassIcon } from "@artsy/palette"
 import { FilterExpandable } from "./FilterExpandable"
-import React, { useEffect, useMemo } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import { debounce } from "lodash"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 
@@ -9,29 +9,43 @@ const DEBOUNCE_DELAY = 300
 export const KeywordFilter: React.FC = () => {
   const filterContext = useArtworkFilterContext()
 
+  const [keyword, setKeyword] = useState(filterContext.filters!.keyword)
+
   const updateKeywordFilter = (text: string) => {
-    let textOrUndefined = !text ? undefined : text
+    let textOrUndefined = text.length === 0 ? undefined : text
     filterContext.setFilter("keyword", textOrUndefined)
   }
 
-  const handleChangeText = useMemo(
+  const handleDebounce = useMemo(
     () => debounce(updateKeywordFilter, DEBOUNCE_DELAY),
-    [filterContext]
+    []
   )
+
+  const handleChangeText = text => {
+    setKeyword(text)
+    handleDebounce(text)
+  }
 
   // Stop the invocation of the debounced function after unmounting
   useEffect(() => {
-    return () => handleChangeText.cancel()
+    return () => handleDebounce.cancel()
   }, [])
+
+  useEffect(() => {
+    if (filterContext.filters!.keyword === undefined) {
+      setKeyword("")
+    }
+  }, [filterContext.filters!.keyword])
 
   return (
     <FilterExpandable label="Keyword Search" expanded={true}>
       <LabeledInput
-        defaultValue={filterContext.filters!.keyword}
+        value={keyword}
         placeholder="Enter a search term"
         onChange={event => handleChangeText(event.currentTarget.value)}
         type="text"
         label={<MagnifyingGlassIcon />}
+        data-testid="keywordSearchInput"
       />
     </FilterExpandable>
   )

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
@@ -1,20 +1,27 @@
 import { LabeledInput, MagnifyingGlassIcon } from "@artsy/palette"
 import { FilterExpandable } from "./FilterExpandable"
-import React, { useEffect, useMemo, useState } from "react"
+import React, { useRef, useEffect, useMemo, useState } from "react"
 import { debounce } from "lodash"
-import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import {
+  useCurrentlySelectedFilters,
+  useArtworkFilterContext,
+} from "../ArtworkFilterContext"
 
 const DEBOUNCE_DELAY = 300
 
 export const KeywordFilter: React.FC = () => {
-  const { filters, setFilter } = useArtworkFilterContext()
-  const { keyword } = filters ?? {}
+  const { setFilter } = useArtworkFilterContext()
+
+  const setFilterRef = useRef(setFilter)
+  setFilterRef.current = setFilter
+
+  const { keyword } = useCurrentlySelectedFilters()
 
   const [value, setValue] = useState(keyword)
 
   const updateKeywordFilter = (text: string) => {
     const textOrUndefined = text.length === 0 ? undefined : text
-    setFilter("keyword", textOrUndefined)
+    setFilterRef.current("keyword", textOrUndefined)
   }
 
   const handleDebounce = useMemo(

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
@@ -1,0 +1,42 @@
+import { LabeledInput, MagnifyingGlassIcon } from "@artsy/palette"
+import { FilterExpandable } from "./FilterExpandable"
+import React, { useEffect, useMemo } from "react"
+import { debounce } from "lodash"
+import {
+  useCurrentlySelectedFilters,
+  useArtworkFilterContext,
+} from "../ArtworkFilterContext"
+
+const DEBOUNCE_DELAY = 100
+
+export const KeywordFilter: React.FC = () => {
+  const { keyword = [] } = useCurrentlySelectedFilters()
+  const filterContext = useArtworkFilterContext()
+
+  const updateKeywordFilter = (text: string) => {
+    let textOrUndefined = !text ? undefined : text
+    filterContext.setFilter("keyword", textOrUndefined)
+  }
+
+  const handleChangeText = useMemo(
+    () => debounce(updateKeywordFilter, DEBOUNCE_DELAY),
+    [filterContext]
+  )
+
+  // Stop the invocation of the debounced function after unmounting
+  useEffect(() => {
+    return () => handleChangeText.cancel()
+  }, [])
+
+  return (
+    <FilterExpandable label="Keyword Search" expanded={true}>
+      <LabeledInput
+        value={keyword}
+        placeholder="Enter a search term"
+        onChange={event => handleChangeText(event.currentTarget.value)}
+        type="text"
+        label={<MagnifyingGlassIcon />}
+      />
+    </FilterExpandable>
+  )
+}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
@@ -48,7 +48,7 @@ export const KeywordFilter: React.FC = () => {
   }, [keyword, setValue])
 
   return (
-    <FilterExpandable label="Keyword Search" expanded={true}>
+    <FilterExpandable label="Keyword Search" expanded>
       <LabeledInput
         value={value}
         placeholder="Enter a search term"

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/KeywordFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/KeywordFilter.jest.tsx
@@ -1,0 +1,100 @@
+import React, { ReactElement } from "react"
+import {
+  render as originalRender,
+  RenderOptions,
+  screen,
+  fireEvent,
+} from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import {
+  ArtworkFilterContextProps,
+  ArtworkFilterContextProvider,
+  useArtworkFilterContext,
+} from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+
+import { KeywordFilter } from "../KeywordFilter"
+
+jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
+  __internal__useMatchMedia: () => ({}),
+}))
+
+jest.mock("lodash/debounce", () => jest.fn(e => e))
+
+const render = (ui: ReactElement, options: RenderOptions = {}) =>
+  originalRender(ui, { wrapper: Wrapper, ...options })
+
+const Wrapper: React.FC = ({ children }) => {
+  return (
+    <ArtworkFilterContextProvider>
+      <ClearAllButton />
+      {children}
+      <ArtworkFilterContextInspector />
+    </ArtworkFilterContextProvider>
+  )
+}
+
+const ClearAllButton: React.FC = () => {
+  const artworkFilterContext = useArtworkFilterContext()
+
+  return (
+    <button onClick={() => artworkFilterContext.resetFilters()}>
+      Clear all
+    </button>
+  )
+}
+
+const ArtworkFilterContextInspector: React.FC = () => {
+  const artworkFilterContext = useArtworkFilterContext()
+
+  return (
+    <aside data-testid="artwork-filter-context-inspector">
+      {JSON.stringify(artworkFilterContext, null, 2)}
+    </aside>
+  )
+}
+
+const currentContext = (): ArtworkFilterContextProps => {
+  let contextInspector: HTMLElement
+  try {
+    contextInspector = screen.getByTestId("artwork-filter-context-inspector")
+  } catch (error) {
+    if (error.name === "TestingLibraryElementError")
+      throw new Error(
+        `The currentContext() helper function requires an <ArtworkFilterContextInspector /> to be mounted in the current DOM.`
+      )
+  }
+  return JSON.parse(contextInspector!.textContent!)
+}
+
+describe("KeywordFilter", () => {
+  it("updates context on filter change", () => {
+    render(<KeywordFilter />)
+    expect(screen.getByText("Keyword Search")).toBeInTheDocument()
+
+    userEvent.type(screen.getByTestId("keywordSearchInput"), "Chopper")
+    expect(currentContext().filters?.keyword).toEqual("Chopper")
+
+    fireEvent.change(screen.getByTestId("keywordSearchInput"), {
+      target: { value: "" },
+    })
+    expect(currentContext().filters?.keyword).toEqual(undefined)
+  })
+
+  it("clears local input state after Clear All", () => {
+    render(<KeywordFilter />)
+
+    userEvent.type(screen.getByTestId("keywordSearchInput"), "Chopper")
+    expect(currentContext().filters?.keyword).toEqual("Chopper")
+    expect(
+      (screen.getByTestId("keywordSearchInput") as HTMLInputElement).value
+    ).toEqual("Chopper")
+
+    userEvent.click(screen.getByText("Clear all"))
+
+    expect(currentContext().filters?.keyword).toEqual(undefined)
+    expect(
+      (screen.getByTestId("keywordSearchInput") as HTMLInputElement).value
+    ).toEqual("")
+  })
+})

--- a/src/v2/Components/ArtworkFilter/Utils/isDefaultFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/isDefaultFilter.tsx
@@ -6,6 +6,10 @@ export const isDefaultFilter: (
   value: any,
   defaultValues?: Partial<ArtworkFilters>
 ) => boolean = (name, value, defaultValues = {}) => {
+  if (name === "keyword" && !value) {
+    return true
+  }
+
   if (!value) {
     return false
   }

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -13,6 +13,7 @@ import { initialArtworkFilterState } from "../ArtworkFilterContext"
 import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
 import { SavedSearchEntity } from "v2/Components/SavedSearchAlert/types"
 import { OwnerType } from "@artsy/cohesion"
+import { omit } from "lodash"
 
 jest.unmock("react-relay")
 jest.mock("v2/System/Analytics/useTracking")
@@ -138,11 +139,16 @@ describe("ArtworkFilter", () => {
 
       const { current, changed } = trackEvent.mock.calls[0][0]
 
-      expect(JSON.parse(current)).toMatchObject({
-        ...initialArtworkFilterState,
-        ...filters,
-        acquireable: true,
-      })
+      expect(JSON.parse(current)).toMatchObject(
+        omit(
+          {
+            ...initialArtworkFilterState,
+            ...filters,
+            acquireable: true,
+          },
+          "keyword"
+        )
+      )
 
       expect(JSON.parse(changed)).toMatchObject({
         acquireable: true,

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -198,7 +198,7 @@ export const BaseArtworkFilter: React.FC<
         first: 30,
         ...relayRefetchInputVariables,
         ...allowedFilters(filterContext.filters),
-        keyword: filterContext.filters!.term,
+        keyword: filterContext.filters!.term || filterContext.filters!.keyword,
       },
       ...relayVariables,
     }


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR solves [FX-4027]

### Description

As a collector
When I visit the artist page’s artwork grid
I see a new keyword filter
And when I enter a keyword
the grid is filtered down to match that query

I've created a feature toggle in Unleash, it's called `artist-artwork-grid-keyword-search` and currently enabled for development and staging

### Demo

* [Demo app](https://artwork-grid-keyword-filter.artsy.net)
* [Banksy grid](https://artwork-grid-keyword-filter.artsy.net/artist/banksy/works-for-sale?sort=-default_trending_score)

https://user-images.githubusercontent.com/3934579/175893281-c8b0e340-644b-4087-9d80-0496e926e4dd.mp4

[FX-4027]: https://artsyproduct.atlassian.net/browse/FX-4027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ