### PR TITLE
feat(onboarding): adds animated welcome panel

### DIFF
--- a/src/v2/Apps/Onboarding/Components/OnboardingSplitLayout.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingSplitLayout.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from "@artsy/palette"
+import { ArtsyLogoIcon, Box, Flex } from "@artsy/palette"
 import { FC } from "react"
 
 interface OnboardingSplitLayoutProps {
@@ -12,8 +12,15 @@ export const OnboardingSplitLayout: FC<OnboardingSplitLayoutProps> = ({
 }) => {
   return (
     <Flex height="100%">
-      <Box display={["none", "block"]} bg="black100" flexBasis="50%">
+      <Box
+        display={["none", "block"]}
+        bg="black100"
+        flexBasis="50%"
+        position="relative"
+      >
         {left}
+
+        <ArtsyLogoIcon fill="white100" position="absolute" top={2} left={2} />
       </Box>
 
       <Flex flexBasis={["100%", "50%"]}>{right}</Flex>

--- a/src/v2/Apps/Onboarding/Components/OnboardingWelcomeAnimatedPanel.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingWelcomeAnimatedPanel.tsx
@@ -1,0 +1,98 @@
+import { Box, Flex, Image, ResponsiveBox } from "@artsy/palette"
+import { FC } from "react"
+import styled, { keyframes } from "styled-components"
+
+export const OnboardingWelcomeAnimatedPanel: FC = () => {
+  return (
+    <Box
+      width="100%"
+      height="100%"
+      position="relative"
+      overflow="hidden"
+      style={{ pointerEvents: "none", userSelect: "none" }}
+    >
+      <Flex
+        bg="black100"
+        position="absolute"
+        top={0}
+        left={0}
+        style={{
+          transform: "rotate(33.33deg) translate(10px, -25%)",
+          transformOrigin: "top left",
+        }}
+      >
+        {[...new Array(3)].map((_, col) => {
+          const Component = col % 2 === 0 ? Up : Down
+
+          return (
+            <Component
+              key={col}
+              color="white"
+              width={250}
+              ml={col === 0 ? 0 : 2}
+            >
+              {[...new Array(6)].map((_, row) => (
+                <ResponsiveBox
+                  key={row}
+                  aspectWidth={3}
+                  aspectHeight={4}
+                  maxWidth="100%"
+                  bg="black60"
+                  mt={2}
+                >
+                  <Image
+                    src={`https://picsum.photos/seed/${col}:${row}/300/400`}
+                    srcSet={`https://picsum.photos/seed/${col}:${row}/300/400 1x, https://picsum.photos/seed/${col}:${row}/600/800 2x`}
+                    width="100%"
+                    height="100%"
+                    alt=""
+                  />
+                </ResponsiveBox>
+              ))}
+
+              {/* Should be a copy of the previous images. We transform these 50% for a seamless loop */}
+              {[...new Array(6)].map((_, row) => (
+                <ResponsiveBox
+                  key={`${row}--copy`}
+                  aspectWidth={3}
+                  aspectHeight={4}
+                  maxWidth="100%"
+                  bg="black60"
+                  mt={2}
+                >
+                  <Image
+                    src={`https://picsum.photos/seed/${col}:${row}/300/400`}
+                    srcSet={`https://picsum.photos/seed/${col}:${row}/300/400 1x, https://picsum.photos/seed/${col}:${row}/600/800 2x`}
+                    width="100%"
+                    height="100%"
+                    alt=""
+                  />
+                </ResponsiveBox>
+              ))}
+            </Component>
+          )
+        })}
+      </Flex>
+    </Box>
+  )
+}
+
+const DURATION = "60s"
+
+const up = keyframes`
+  0% { transform: translateY(0%) }
+  100% { transform: translateY(-50%); }
+`
+
+const Up = styled(Box)`
+  animation: ${up} ${DURATION} linear infinite;
+`
+
+const down = keyframes`
+  0% { transform: translateY(-50%) }
+  100% { transform: translateY(0%); }
+`
+
+const Down = styled(Box)`
+  animation: ${down} ${DURATION} linear infinite;
+`

--- a/src/v2/Apps/Onboarding/Views/OnboardingWelcome.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingWelcome.tsx
@@ -2,6 +2,7 @@ import { Flex, Text, Spacer, Button, Box } from "@artsy/palette"
 import { useSystemContext } from "v2/System"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { OnboardingSplitLayout } from "../Components/OnboardingSplitLayout"
+import { OnboardingWelcomeAnimatedPanel } from "../Components/OnboardingWelcomeAnimatedPanel"
 import { useOnboardingContext } from "../useOnboardingContext"
 
 export const OnboardingWelcome = () => {
@@ -10,7 +11,7 @@ export const OnboardingWelcome = () => {
 
   return (
     <OnboardingSplitLayout
-      left={<div>TODO: Animated panel</div>}
+      left={<OnboardingWelcomeAnimatedPanel />}
       right={
         <Flex flexDirection="column" justifyContent="space-between" p={4}>
           {/* Vertically centers next Box */}


### PR DESCRIPTION
This blocks in the animation on the opening welcome panel. We won't have assets until they are approved on Monday — so some placeholders.

https://user-images.githubusercontent.com/112297/175394154-034c1613-72f7-4e84-9572-d3c2c9312b17.mov
