### PR TITLE
feat: Enable NOSF for single editions with listed price

### DIFF
--- a/src/v2/Apps/Order/Routes/Offer/index.tsx
+++ b/src/v2/Apps/Order/Routes/Offer/index.tsx
@@ -155,7 +155,14 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
     const listPriceCents = this.props.order.totalListPriceCents
     const artworkPrice = artwork?.price
     const isInquiryCheckout = !artwork?.isPriceRange && !artwork?.price
-    const isEdition = artwork?.isEdition
+    const hasPrice =
+      (artwork?.listPrice?.__typename === "Money" &&
+        artwork?.listPrice?.major) ||
+      (artwork?.listPrice?.__typename === "PriceRange" &&
+        artwork?.listPrice?.maxPrice?.major &&
+        artwork?.listPrice?.minPrice?.major)
+    const showPriceOptions =
+      (artwork?.editionSets?.length ?? 0) < 2 && !!hasPrice
     const isPriceHidden = isNil(artworkPrice) || artworkPrice === ""
     const isRangeOffer = getOfferItemFromOrder(this.props.order.lineItems)
       ?.displayPriceRange
@@ -163,7 +170,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
     if (
       !isPriceHidden &&
       !isRangeOffer &&
-      (isInquiryCheckout || isEdition) &&
+      (isInquiryCheckout || !showPriceOptions) &&
       !lowSpeedBumpEncountered &&
       offerValue * 100 < listPriceCents * 0.8
     ) {
@@ -223,7 +230,14 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
 
     const artwork = this.props.order.lineItems?.edges?.[0]?.node?.artwork
     const isInquiryCheckout = !artwork?.isPriceRange && !artwork?.price
-    const isEdition = artwork?.isEdition
+    const hasPrice =
+      (artwork?.listPrice?.__typename === "Money" &&
+        artwork?.listPrice?.major) ||
+      (artwork?.listPrice?.__typename === "PriceRange" &&
+        artwork?.listPrice?.maxPrice?.major &&
+        artwork?.listPrice?.minPrice?.major)
+    const showPriceOptions =
+      (artwork?.editionSets?.length ?? 0) < 2 && !!hasPrice
 
     return (
       <>
@@ -235,7 +249,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
               style={isCommittingMutation ? { pointerEvents: "none" } : {}}
               id="offer-page-left-column"
             >
-              {(isInquiryCheckout || isEdition) && (
+              {(isInquiryCheckout || !showPriceOptions) && (
                 <>
                   <Flex flexDirection="column">
                     <OfferInput
@@ -250,7 +264,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
                   {priceNote}
                 </>
               )}
-              {!isInquiryCheckout && !isEdition && (
+              {!isInquiryCheckout && showPriceOptions && (
                 <>
                   <Text variant="lg-display" color="black80" mt={2}>
                     Select an Option
@@ -366,7 +380,23 @@ export const OfferFragmentContainer = createFragmentContainer(
                 slug
                 price
                 isPriceRange
-                isEdition
+                listPrice {
+                  __typename
+                  ... on Money {
+                    major
+                  }
+                  ... on PriceRange {
+                    maxPrice {
+                      major
+                    }
+                    minPrice {
+                      major
+                    }
+                  }
+                }
+                editionSets {
+                  internalID
+                }
                 ...PriceOptions_artwork
               }
               artworkOrEditionSet {

--- a/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
@@ -4,7 +4,9 @@ import {
   UntouchedOfferOrder,
   UntouchedOfferOrderInPounds,
   UntouchedOfferOrderWithRange,
-  UntouchedOfferOrderEditionSet,
+  UntouchedOfferOrderMultipleEditionSets,
+  UntouchedOfferOrderSingleEditionSet,
+  UntouchedOfferOrderSingleEditionSetNoPrice,
   UntouchedOfferOrderPriceHidden,
 } from "../../../__tests__/Fixtures/Order"
 import {
@@ -103,7 +105,7 @@ describe("Offer InitialMutation", () => {
   })
 
   describe("the page layout", () => {
-    it("has 4 price options", () => {
+    it("has 4 price options - unique artwork", () => {
       let wrapper = getWrapper({
         CommerceOrder: () => testOffer,
       })
@@ -114,6 +116,38 @@ describe("Offer InitialMutation", () => {
       const container = page.find("div#offer-page-left-column")
       expect(container.text()).toContain("List price: US$16,000")
       expect(page.text()).toContain("All offers are binding")
+    })
+    it("has price options - single edition with price", () => {
+      let wrapper = getWrapper({
+        CommerceOrder: () => ({
+          ...UntouchedOfferOrderSingleEditionSet,
+          internalID: "1234",
+        }),
+      })
+      let page = new OrderAppTestPage(wrapper)
+
+      expect(page.priceOptions).toHaveLength(1)
+      expect(page.priceOptions.find("BorderedRadio")).toHaveLength(4)
+    })
+    it("doesn't have price options - single edition without price", () => {
+      let wrapper = getWrapper({
+        CommerceOrder: () => ({
+          ...UntouchedOfferOrderSingleEditionSetNoPrice,
+          internalID: "1234",
+        }),
+      })
+      let page = new OrderAppTestPage(wrapper)
+      expect(page.find("PriceOptions").exists()).toBeFalsy()
+    })
+    it("doesn't have price options - multiple editions", () => {
+      let wrapper = getWrapper({
+        CommerceOrder: () => ({
+          ...UntouchedOfferOrderMultipleEditionSets,
+          internalID: "1234",
+        }),
+      })
+      let page = new OrderAppTestPage(wrapper)
+      expect(page.find("PriceOptions").exists()).toBeFalsy()
     })
 
     it("can receive input, which updates the transaction summary", async () => {
@@ -372,7 +406,7 @@ describe("Offer InitialMutation", () => {
       it("shows if the offer amount is too small", async () => {
         let wrapper = getWrapper({
           CommerceOrder: () => ({
-            ...UntouchedOfferOrderEditionSet,
+            ...UntouchedOfferOrderMultipleEditionSets,
             internalID: "1234",
           }),
         })

--- a/src/v2/Apps/__tests__/Fixtures/Order.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Order.ts
@@ -88,7 +88,7 @@ const OrderArtworkNodeWithoutShipping = {
   slug: "artworkId",
   title: "Gramercy Park South",
   isPriceRange: false,
-  isEdition: false,
+  editionSets: null,
 }
 
 const OrderArtworkVersionNode = {
@@ -761,7 +761,7 @@ export const UntouchedOfferOrderWithRange = {
           shippingQuoteOptions: null,
           artwork: {
             ...OrderArtworkNode.artwork,
-            isEdition: true,
+            editionSets: [{ internalID: "1" }, { internalID: "2" }],
           },
           ...OrderArtworkVersionNode,
           ...OfferArtworkOrEditionSetNode_Range,

--- a/src/v2/Apps/__tests__/Fixtures/Order.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Order.ts
@@ -640,7 +640,7 @@ export const UntouchedOfferOrder = {
   totalListPriceCents: 1600000,
 } as const
 
-export const UntouchedOfferOrderEditionSet = {
+export const UntouchedOfferOrderSingleEditionSet = {
   ...UntouchedOfferOrder,
   lineItems: {
     edges: [
@@ -653,12 +653,44 @@ export const UntouchedOfferOrderEditionSet = {
           __isCommerceOrder: "CommerceOfferOrder",
           artwork: {
             ...OrderArtworkNode.artwork,
-            isEdition: true,
+            editionSets: [{ internalID: "1" }],
           },
           ...OrderArtworkVersionNode,
           ...OfferArtworkOrEditionSetNode_EditionSet,
           ...OrderArtworkFulfillmentsNode,
           ...ArtaShipmentNode,
+        },
+      },
+    ],
+  },
+}
+
+export const UntouchedOfferOrderSingleEditionSetNoPrice = {
+  ...UntouchedOfferOrderSingleEditionSet,
+  lineItems: {
+    edges: [
+      {
+        node: {
+          artwork: {
+            ...OrderArtworkNode.artwork,
+            listPrice: null,
+          },
+        },
+      },
+    ],
+  },
+}
+
+export const UntouchedOfferOrderMultipleEditionSets = {
+  ...UntouchedOfferOrderSingleEditionSet,
+  lineItems: {
+    edges: [
+      {
+        node: {
+          artwork: {
+            ...OrderArtworkNode.artwork,
+            editionSets: [{ internalID: "1" }, { internalID: "2" }],
+          },
         },
       },
     ],

--- a/src/v2/__generated__/OfferTestQuery.graphql.ts
+++ b/src/v2/__generated__/OfferTestQuery.graphql.ts
@@ -29,8 +29,6 @@ export type OfferTestQueryRawResponse = {
                         readonly slug: string;
                         readonly price: string | null;
                         readonly isPriceRange: boolean | null;
-                        readonly isEdition: boolean | null;
-                        readonly priceCurrency: string | null;
                         readonly listPrice: ({
                             readonly __typename: "Money";
                             readonly major: number;
@@ -45,6 +43,11 @@ export type OfferTestQueryRawResponse = {
                         } | {
                             readonly __typename: string;
                         }) | null;
+                        readonly editionSets: ReadonlyArray<({
+                            readonly internalID: string;
+                            readonly id: string;
+                        }) | null> | null;
+                        readonly priceCurrency: string | null;
                         readonly id: string;
                         readonly date: string | null;
                         readonly shippingOrigin: string | null;
@@ -153,8 +156,6 @@ export type OfferTestQueryRawResponse = {
                         readonly slug: string;
                         readonly price: string | null;
                         readonly isPriceRange: boolean | null;
-                        readonly isEdition: boolean | null;
-                        readonly priceCurrency: string | null;
                         readonly listPrice: ({
                             readonly __typename: "Money";
                             readonly major: number;
@@ -169,6 +170,11 @@ export type OfferTestQueryRawResponse = {
                         } | {
                             readonly __typename: string;
                         }) | null;
+                        readonly editionSets: ReadonlyArray<({
+                            readonly internalID: string;
+                            readonly id: string;
+                        }) | null> | null;
+                        readonly priceCurrency: string | null;
                         readonly id: string;
                         readonly date: string | null;
                         readonly shippingOrigin: string | null;
@@ -321,7 +327,24 @@ fragment Offer_order on CommerceOrder {
           slug
           price
           isPriceRange
-          isEdition
+          listPrice {
+            __typename
+            ... on Money {
+              major
+            }
+            ... on PriceRange {
+              maxPrice {
+                major
+              }
+              minPrice {
+                major
+              }
+            }
+          }
+          editionSets {
+            internalID
+            id
+          }
           ...PriceOptions_artwork
           id
         }
@@ -785,20 +808,6 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "kind": "ScalarField",
-                            "name": "isEdition",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "priceCurrency",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
                             "concreteType": null,
                             "kind": "LinkedField",
                             "name": "listPrice",
@@ -839,6 +848,26 @@ return {
                                 "abstractKey": null
                               }
                             ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "EditionSet",
+                            "kind": "LinkedField",
+                            "name": "editionSets",
+                            "plural": true,
+                            "selections": [
+                              (v2/*: any*/),
+                              (v5/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "priceCurrency",
                             "storageKey": null
                           },
                           (v5/*: any*/),
@@ -1086,7 +1115,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1052e177b64006d105cc78ee51202393",
+    "cacheID": "4b4af10315680018bcc27311df518810",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1148,8 +1177,15 @@ return {
           "type": "Artwork"
         },
         "order.lineItems.edges.node.artwork.date": (v17/*: any*/),
+        "order.lineItems.edges.node.artwork.editionSets": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "EditionSet"
+        },
+        "order.lineItems.edges.node.artwork.editionSets.id": (v18/*: any*/),
+        "order.lineItems.edges.node.artwork.editionSets.internalID": (v18/*: any*/),
         "order.lineItems.edges.node.artwork.id": (v18/*: any*/),
-        "order.lineItems.edges.node.artwork.isEdition": (v23/*: any*/),
         "order.lineItems.edges.node.artwork.isPriceRange": (v23/*: any*/),
         "order.lineItems.edges.node.artwork.listPrice": {
           "enumValues": null,
@@ -1272,7 +1308,7 @@ return {
     },
     "name": "OfferTestQuery",
     "operationKind": "query",
-    "text": "query OfferTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Offer_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  currencyCode\n  mode\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          date\n          shippingOrigin\n          id\n        }\n        artworkVersion {\n          artistNames\n          title\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Offer_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  state\n  totalListPriceCents\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          price\n          isPriceRange\n          isEdition\n          ...PriceOptions_artwork\n          id\n        }\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n            displayPriceRange\n          }\n          ... on EditionSet {\n            price\n            displayPriceRange\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    isInquiryOrder\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...PriceOptions_order\n}\n\nfragment PriceOptions_artwork on Artwork {\n  priceCurrency\n  isPriceRange\n  listPrice {\n    __typename\n    ... on Money {\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        major\n      }\n      minPrice {\n        major\n      }\n    }\n  }\n}\n\nfragment PriceOptions_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
+    "text": "query OfferTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Offer_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  currencyCode\n  mode\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          date\n          shippingOrigin\n          id\n        }\n        artworkVersion {\n          artistNames\n          title\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Offer_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  state\n  totalListPriceCents\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          price\n          isPriceRange\n          listPrice {\n            __typename\n            ... on Money {\n              major\n            }\n            ... on PriceRange {\n              maxPrice {\n                major\n              }\n              minPrice {\n                major\n              }\n            }\n          }\n          editionSets {\n            internalID\n            id\n          }\n          ...PriceOptions_artwork\n          id\n        }\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n            displayPriceRange\n          }\n          ... on EditionSet {\n            price\n            displayPriceRange\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    isInquiryOrder\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...PriceOptions_order\n}\n\nfragment PriceOptions_artwork on Artwork {\n  priceCurrency\n  isPriceRange\n  listPrice {\n    __typename\n    ... on Money {\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        major\n      }\n      minPrice {\n        major\n      }\n    }\n  }\n}\n\nfragment PriceOptions_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/Offer_order.graphql.ts
+++ b/src/v2/__generated__/Offer_order.graphql.ts
@@ -19,7 +19,25 @@ export type Offer_order = {
                     readonly slug: string;
                     readonly price: string | null;
                     readonly isPriceRange: boolean | null;
-                    readonly isEdition: boolean | null;
+                    readonly listPrice: ({
+                        readonly __typename: "Money";
+                        readonly major: number;
+                    } | {
+                        readonly __typename: "PriceRange";
+                        readonly maxPrice: {
+                            readonly major: number;
+                        } | null;
+                        readonly minPrice: {
+                            readonly major: number;
+                        } | null;
+                    } | {
+                        /*This will never be '%other', but we need some
+                        value in case none of the concrete values match.*/
+                        readonly __typename: "%other";
+                    }) | null;
+                    readonly editionSets: ReadonlyArray<{
+                        readonly internalID: string;
+                    } | null> | null;
                     readonly " $fragmentRefs": FragmentRefs<"PriceOptions_artwork">;
                 } | null;
                 readonly artworkOrEditionSet: ({
@@ -55,11 +73,34 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "price",
   "storageKey": null
 },
-v1 = [
-  (v0/*: any*/),
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "major",
+    "storageKey": null
+  }
+],
+v4 = [
+  (v1/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -74,13 +115,7 @@ return {
   "metadata": null,
   "name": "Offer_order",
   "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "internalID",
-      "storageKey": null
-    },
+    (v0/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -148,7 +183,7 @@ return {
                       "name": "slug",
                       "storageKey": null
                     },
-                    (v0/*: any*/),
+                    (v1/*: any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -159,8 +194,58 @@ return {
                     {
                       "alias": null,
                       "args": null,
-                      "kind": "ScalarField",
-                      "name": "isEdition",
+                      "concreteType": null,
+                      "kind": "LinkedField",
+                      "name": "listPrice",
+                      "plural": false,
+                      "selections": [
+                        (v2/*: any*/),
+                        {
+                          "kind": "InlineFragment",
+                          "selections": (v3/*: any*/),
+                          "type": "Money",
+                          "abstractKey": null
+                        },
+                        {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "Money",
+                              "kind": "LinkedField",
+                              "name": "maxPrice",
+                              "plural": false,
+                              "selections": (v3/*: any*/),
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "Money",
+                              "kind": "LinkedField",
+                              "name": "minPrice",
+                              "plural": false,
+                              "selections": (v3/*: any*/),
+                              "storageKey": null
+                            }
+                          ],
+                          "type": "PriceRange",
+                          "abstractKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "EditionSet",
+                      "kind": "LinkedField",
+                      "name": "editionSets",
+                      "plural": true,
+                      "selections": [
+                        (v0/*: any*/)
+                      ],
                       "storageKey": null
                     },
                     {
@@ -179,22 +264,16 @@ return {
                   "name": "artworkOrEditionSet",
                   "plural": false,
                   "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "__typename",
-                      "storageKey": null
-                    },
+                    (v2/*: any*/),
                     {
                       "kind": "InlineFragment",
-                      "selections": (v1/*: any*/),
+                      "selections": (v4/*: any*/),
                       "type": "Artwork",
                       "abstractKey": null
                     },
                     {
                       "kind": "InlineFragment",
-                      "selections": (v1/*: any*/),
+                      "selections": (v4/*: any*/),
                       "type": "EditionSet",
                       "abstractKey": null
                     }
@@ -244,5 +323,5 @@ return {
   "abstractKey": "__isCommerceOrder"
 };
 })();
-(node as any).hash = 'ea62ca9d92afba9e622a857060399ea7';
+(node as any).hash = 'a1867bbac372e425b11e65589e96fc5a';
 export default node;

--- a/src/v2/__generated__/orderRoutes_OfferQuery.graphql.ts
+++ b/src/v2/__generated__/orderRoutes_OfferQuery.graphql.ts
@@ -99,7 +99,24 @@ fragment Offer_order on CommerceOrder {
           slug
           price
           isPriceRange
-          isEdition
+          listPrice {
+            __typename
+            ... on Money {
+              major
+            }
+            ... on PriceRange {
+              maxPrice {
+                major
+              }
+              minPrice {
+                major
+              }
+            }
+          }
+          editionSets {
+            internalID
+            id
+          }
           ...PriceOptions_artwork
           id
         }
@@ -507,20 +524,6 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "kind": "ScalarField",
-                            "name": "isEdition",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "priceCurrency",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
                             "concreteType": null,
                             "kind": "LinkedField",
                             "name": "listPrice",
@@ -561,6 +564,26 @@ return {
                                 "abstractKey": null
                               }
                             ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "EditionSet",
+                            "kind": "LinkedField",
+                            "name": "editionSets",
+                            "plural": true,
+                            "selections": [
+                              (v3/*: any*/),
+                              (v6/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "priceCurrency",
                             "storageKey": null
                           },
                           (v6/*: any*/),
@@ -808,12 +831,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "388f65f48dc29e63705f949fdab13fd5",
+    "cacheID": "e8582c1f072181f357a597fb2a941808",
     "id": null,
     "metadata": {},
     "name": "orderRoutes_OfferQuery",
     "operationKind": "query",
-    "text": "query orderRoutes_OfferQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Offer_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  currencyCode\n  mode\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          date\n          shippingOrigin\n          id\n        }\n        artworkVersion {\n          artistNames\n          title\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Offer_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  state\n  totalListPriceCents\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          price\n          isPriceRange\n          isEdition\n          ...PriceOptions_artwork\n          id\n        }\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n            displayPriceRange\n          }\n          ... on EditionSet {\n            price\n            displayPriceRange\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    isInquiryOrder\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...PriceOptions_order\n}\n\nfragment PriceOptions_artwork on Artwork {\n  priceCurrency\n  isPriceRange\n  listPrice {\n    __typename\n    ... on Money {\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        major\n      }\n      minPrice {\n        major\n      }\n    }\n  }\n}\n\nfragment PriceOptions_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
+    "text": "query orderRoutes_OfferQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Offer_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  currencyCode\n  mode\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          date\n          shippingOrigin\n          id\n        }\n        artworkVersion {\n          artistNames\n          title\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Offer_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  state\n  totalListPriceCents\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          price\n          isPriceRange\n          listPrice {\n            __typename\n            ... on Money {\n              major\n            }\n            ... on PriceRange {\n              maxPrice {\n                major\n              }\n              minPrice {\n                major\n              }\n            }\n          }\n          editionSets {\n            internalID\n            id\n          }\n          ...PriceOptions_artwork\n          id\n        }\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n            displayPriceRange\n          }\n          ... on EditionSet {\n            price\n            displayPriceRange\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    isInquiryOrder\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...PriceOptions_order\n}\n\nfragment PriceOptions_artwork on Artwork {\n  priceCurrency\n  isPriceRange\n  listPrice {\n    __typename\n    ... on Money {\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        major\n      }\n      minPrice {\n        major\n      }\n    }\n  }\n}\n\nfragment PriceOptions_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: Feature

This PR solves [NX-3064]

### Description
This PR enables the New Offer Submission Flow on single editioned artworks with a listed price.
![nosf-edition](https://user-images.githubusercontent.com/7117670/175499122-c17410d1-8603-43fa-acb3-69d7839ae9a1.gif)

We can continue enhancing the scope of NSFW with future work, after a clearer path forward with editions.

Based on work done by @tam-kis 
cc @artsy/negotiate-devs 


[NX-3064]: https://artsyproduct.atlassian.net/browse/NX-3064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ