### PR TITLE
chore(footer): swap out assets

### DIFF
--- a/src/v2/Components/DownloadAppBadges/DownloadAppBadge.tsx
+++ b/src/v2/Components/DownloadAppBadges/DownloadAppBadge.tsx
@@ -13,10 +13,10 @@ import { Device } from "v2/Utils/Hooks/useDeviceDetection"
 // - Can be lazyloaded
 
 const DOWNLOAD_IOS_APP_BADGE =
-  "https://files.artsy.net/images/download-ios-app.svg"
+  "https://files.artsy.net/images/App Download_iOS-1656079682156.png"
 
 const DOWNLOAD_ANDROID_APP_BADGE =
-  "https://files.artsy.net/images/download-android-app.svg"
+  "https://files.artsy.net/images/App Download_Google Play-1656079682114.png"
 
 interface DownloadAppBadgeProps extends LinkProps {
   contextModule: ContextModule

--- a/src/v2/Components/Footer/FooterDownloadAppBanner.tsx
+++ b/src/v2/Components/Footer/FooterDownloadAppBanner.tsx
@@ -18,7 +18,7 @@ const DESKTOP_COVER_IMAGE = resized(
 )
 
 const MOBILE_COVER_IMAGE = resized(
-  "https://files.artsy.net/images/App%20Download%20Banner_1200x2440_1x-1656078790066.png",
+  "https://files.artsy.net/images/App Download Banner_1200x2440_2x-1656078840527.png",
   { width: 725, quality: 50 }
 )
 

--- a/src/v2/Components/Footer/FooterDownloadAppBanner.tsx
+++ b/src/v2/Components/Footer/FooterDownloadAppBanner.tsx
@@ -13,12 +13,12 @@ import { Media } from "v2/Utils/Responsive"
 import { DownloadAppBadges } from "../DownloadAppBadges/DownloadAppBadges"
 
 const DESKTOP_COVER_IMAGE = resized(
-  "https://files.artsy.net/images/artsy_app-download-footer_2x_max.jpg",
+  "https://files.artsy.net/images/App Download Banner_1200x2440_2x-1656078840527.png",
   { width: 1220, quality: 50 }
 )
 
 const MOBILE_COVER_IMAGE = resized(
-  "https://files.artsy.net/images/artsy_app-download-footer_2x_max.jpg",
+  "https://files.artsy.net/images/App%20Download%20Banner_1200x2440_1x-1656078790066.png",
   { width: 725, quality: 50 }
 )
 


### PR DESCRIPTION
The type of this PR is: **CHORE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-994]

### Description

<!-- Implementation description -->
- Upload assets through tools.artsy.net
- Swap out asset addresses in both `FooterDownloadAppBanner` and `DownloadAppBadge`

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-994]: https://artsyproduct.atlassian.net/browse/GRO-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ