### PR TITLE
feat(onboarding): adds staggered fade transition between views

### DIFF
--- a/src/v2/Apps/Onboarding/Components/OnboardingWelcomeAnimatedPanel.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingWelcomeAnimatedPanel.tsx
@@ -1,81 +1,84 @@
 import { Box, Flex, Image, ResponsiveBox } from "@artsy/palette"
-import { FC } from "react"
+import { forwardRef } from "react"
 import styled, { keyframes } from "styled-components"
 
-export const OnboardingWelcomeAnimatedPanel: FC = () => {
-  return (
-    <Box
-      width="100%"
-      height="100%"
-      position="relative"
-      overflow="hidden"
-      style={{ pointerEvents: "none", userSelect: "none" }}
-    >
-      <Flex
-        bg="black100"
-        position="absolute"
-        top={0}
-        left={0}
-        style={{
-          transform: "rotate(33.33deg) translate(10px, -25%)",
-          transformOrigin: "top left",
-        }}
+export const OnboardingWelcomeAnimatedPanel = forwardRef(
+  (_props, forwardedRef) => {
+    return (
+      <Box
+        ref={forwardedRef as any}
+        width="100%"
+        height="100%"
+        position="relative"
+        overflow="hidden"
+        style={{ pointerEvents: "none", userSelect: "none" }}
       >
-        {[...new Array(3)].map((_, col) => {
-          const Component = col % 2 === 0 ? Up : Down
+        <Flex
+          bg="black100"
+          position="absolute"
+          top={0}
+          left={0}
+          style={{
+            transform: "rotate(33.33deg) translate(10px, -25%)",
+            transformOrigin: "top left",
+          }}
+        >
+          {[...new Array(3)].map((_, col) => {
+            const Component = col % 2 === 0 ? Down : Up
 
-          return (
-            <Component
-              key={col}
-              color="white"
-              width={250}
-              ml={col === 0 ? 0 : 2}
-            >
-              {[...new Array(6)].map((_, row) => (
-                <ResponsiveBox
-                  key={row}
-                  aspectWidth={3}
-                  aspectHeight={4}
-                  maxWidth="100%"
-                  bg="black60"
-                  mt={2}
-                >
-                  <Image
-                    src={`https://picsum.photos/seed/${col}:${row}/300/400`}
-                    srcSet={`https://picsum.photos/seed/${col}:${row}/300/400 1x, https://picsum.photos/seed/${col}:${row}/600/800 2x`}
-                    width="100%"
-                    height="100%"
-                    alt=""
-                  />
-                </ResponsiveBox>
-              ))}
+            return (
+              <Component
+                key={col}
+                color="white"
+                width={250}
+                ml={col === 0 ? 0 : 2}
+              >
+                {[...new Array(6)].map((_, row) => (
+                  <ResponsiveBox
+                    key={row}
+                    aspectWidth={3}
+                    aspectHeight={4}
+                    maxWidth="100%"
+                    bg="black60"
+                    mt={2}
+                  >
+                    <Image
+                      src={`https://picsum.photos/seed/${col}:${row}/300/400`}
+                      srcSet={`https://picsum.photos/seed/${col}:${row}/300/400 1x, https://picsum.photos/seed/${col}:${row}/600/800 2x`}
+                      width="100%"
+                      height="100%"
+                      alt=""
+                    />
+                  </ResponsiveBox>
+                ))}
 
-              {/* Should be a copy of the previous images. We transform these 50% for a seamless loop */}
-              {[...new Array(6)].map((_, row) => (
-                <ResponsiveBox
-                  key={`${row}--copy`}
-                  aspectWidth={3}
-                  aspectHeight={4}
-                  maxWidth="100%"
-                  bg="black60"
-                  mt={2}
-                >
-                  <Image
-                    src={`https://picsum.photos/seed/${col}:${row}/300/400`}
-                    srcSet={`https://picsum.photos/seed/${col}:${row}/300/400 1x, https://picsum.photos/seed/${col}:${row}/600/800 2x`}
-                    width="100%"
-                    height="100%"
-                    alt=""
-                  />
-                </ResponsiveBox>
-              ))}
-            </Component>
-          )
-        })}
-      </Flex>
-    </Box>
-  )
-}
+                {/* Should be a copy of the previous images. We transform these 50% for a seamless loop */}
+                {[...new Array(6)].map((_, row) => (
+                  <ResponsiveBox
+                    key={`${row}--copy`}
+                    aspectWidth={3}
+                    aspectHeight={4}
+                    maxWidth="100%"
+                    bg="black60"
+                    mt={2}
+                  >
+                    <Image
+                      src={`https://picsum.photos/seed/${col}:${row}/300/400`}
+                      srcSet={`https://picsum.photos/seed/${col}:${row}/300/400 1x, https://picsum.photos/seed/${col}:${row}/600/800 2x`}
+                      width="100%"
+                      height="100%"
+                      alt=""
+                    />
+                  </ResponsiveBox>
+                ))}
+              </Component>
+            )
+          })}
+        </Flex>
+      </Box>
+    )
+  }
+)
 
 const DURATION = "60s"
 

--- a/src/v2/Apps/Onboarding/Hooks/useOnboardingFadeTransition.tsx
+++ b/src/v2/Apps/Onboarding/Hooks/useOnboardingFadeTransition.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from "react"
+import { useFadeTransition } from "v2/Utils/Hooks/useFadeTransition"
+import { wait } from "v2/Utils/wait"
+
+interface UseOnboardingFadeTransition {
+  next(): void
+}
+
+export const useOnboardingFadeTransition = ({
+  next,
+}: UseOnboardingFadeTransition) => {
+  const { register, transition, mode, status } = useFadeTransition({
+    initialStatus: "Out",
+  })
+
+  useEffect(() => {
+    const init = async () => {
+      await wait(100)
+      transition("In")
+    }
+
+    init()
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleNext = async () => {
+    await transition("Out")
+    await wait(100)
+    next()
+  }
+
+  return {
+    register,
+    handleNext,
+    loading: status === "In" && mode === "Transitioning",
+  }
+}

--- a/src/v2/Apps/Onboarding/Views/OnboardingQuestionOne.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingQuestionOne.tsx
@@ -6,14 +6,21 @@ import {
   OPTION_NO_IM_JUST_STARTING_OUT,
   OPTION_YES_I_LOVE_COLLECTING_ART,
 } from "../config"
+import { useOnboardingFadeTransition } from "../Hooks/useOnboardingFadeTransition"
 import { useOnboardingContext } from "../useOnboardingContext"
 
 export const OnboardingQuestionOne: FC = () => {
   const { next, dispatch, state } = useOnboardingContext()
+  const { register, loading, handleNext } = useOnboardingFadeTransition({
+    next,
+  })
 
   return (
     <OnboardingSplitLayout
-      left={<div>TODO: Image</div>}
+      left={
+        // TODO: Replace with image
+        <Box ref={register(0)} width="100%" height="100%" bg="black60" />
+      }
       right={
         <Flex
           flexDirection="column"
@@ -24,11 +31,13 @@ export const OnboardingQuestionOne: FC = () => {
           <OnboardingProgress />
 
           <Box width="100%">
-            <Text variant="lg-display">Have you bought art before?</Text>
+            <Text variant="lg-display" ref={register(1)}>
+              Have you bought art before?
+            </Text>
 
             <Spacer mt={4} />
 
-            <Box>
+            <Box ref={register(2)}>
               <Join separator={<Spacer mt={2} />}>
                 {QUESTION_1.map(option => {
                   return (
@@ -48,7 +57,12 @@ export const OnboardingQuestionOne: FC = () => {
             </Box>
           </Box>
 
-          <Button disabled={!state.questionOne} onClick={next} width="100%">
+          <Button
+            disabled={!state.questionOne || loading}
+            loading={loading}
+            onClick={handleNext}
+            width="100%"
+          >
             Next
           </Button>
         </Flex>

--- a/src/v2/Apps/Onboarding/Views/OnboardingQuestionThree.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingQuestionThree.tsx
@@ -12,10 +12,14 @@ import {
   OPTION_KEEP_TRACK_OF_ART,
   OPTION_TOP_AUCTION_LOTS,
 } from "../config"
+import { useOnboardingFadeTransition } from "../Hooks/useOnboardingFadeTransition"
 import { useOnboardingContext } from "../useOnboardingContext"
 
 export const OnboardingQuestionThree: FC = () => {
   const { state, dispatch, next } = useOnboardingContext()
+  const { register, loading, handleNext } = useOnboardingFadeTransition({
+    next,
+  })
 
   const options = useMemo(() => {
     switch (true) {
@@ -54,7 +58,10 @@ export const OnboardingQuestionThree: FC = () => {
 
   return (
     <OnboardingSplitLayout
-      left={<div>TODO: Image</div>}
+      left={
+        // TODO: Replace with image
+        <Box ref={register(0)} width="100%" height="100%" bg="black60" />
+      }
       right={
         <Flex
           flexDirection="column"
@@ -65,16 +72,18 @@ export const OnboardingQuestionThree: FC = () => {
           <OnboardingProgress />
 
           <Box width="100%">
-            <Text variant="lg-display">
+            <Text variant="lg-display" ref={register(1)}>
               Where would you like to dive in first?
             </Text>
 
             <Spacer mt={1} />
 
-            <Text variant="sm-display">Choose one to start exploring.</Text>
+            <Text variant="sm-display" ref={register(2)}>
+              Choose one to start exploring.
+            </Text>
           </Box>
 
-          <Box>
+          <Box ref={register(3)}>
             <Join separator={<Spacer mt={2} />}>
               {options.map(option => {
                 return (
@@ -93,8 +102,9 @@ export const OnboardingQuestionThree: FC = () => {
           </Box>
 
           <Button
-            disabled={state.questionThree === null}
-            onClick={next}
+            disabled={state.questionThree === null || loading}
+            loading={loading}
+            onClick={handleNext}
             width="100%"
           >
             Next

--- a/src/v2/Apps/Onboarding/Views/OnboardingQuestionTwo.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingQuestionTwo.tsx
@@ -8,14 +8,21 @@ import {
   OPTION_FINDING_GREAT_INVESTMENTS,
   OPTION_KEEP_TRACK_OF_ART,
 } from "../config"
+import { useOnboardingFadeTransition } from "../Hooks/useOnboardingFadeTransition"
 import { useOnboardingContext } from "../useOnboardingContext"
 
 export const OnboardingQuestionTwo: FC = () => {
   const { state, dispatch, next } = useOnboardingContext()
+  const { register, loading, handleNext } = useOnboardingFadeTransition({
+    next,
+  })
 
   return (
     <OnboardingSplitLayout
-      left={<div>TODO: Image</div>}
+      left={
+        // TODO: Replace with image
+        <Box ref={register(0)} width="100%" height="100%" bg="black60" />
+      }
       right={
         <Flex
           flexDirection="column"
@@ -26,16 +33,18 @@ export const OnboardingQuestionTwo: FC = () => {
           <OnboardingProgress />
 
           <Box width="100%">
-            <Text variant="lg-display">
+            <Text variant="lg-display" ref={register(1)}>
               What do you love most about exploring art?
             </Text>
 
             <Spacer mt={1} />
 
-            <Text variant="sm-display">Choose as many as you like.</Text>
+            <Text variant="sm-display" ref={register(2)}>
+              Choose as many as you like.
+            </Text>
           </Box>
 
-          <Box>
+          <Box ref={register(3)}>
             <Join separator={<Spacer mt={2} />}>
               {QUESTION_2.map(option => {
                 return (
@@ -54,8 +63,9 @@ export const OnboardingQuestionTwo: FC = () => {
           </Box>
 
           <Button
-            disabled={state.questionTwo.length === 0}
-            onClick={next}
+            disabled={state.questionTwo.length === 0 || loading}
+            loading={loading}
+            onClick={handleNext}
             width="100%"
           >
             Next

--- a/src/v2/Apps/Onboarding/Views/OnboardingWelcome.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingWelcome.tsx
@@ -3,33 +3,44 @@ import { useSystemContext } from "v2/System"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { OnboardingSplitLayout } from "../Components/OnboardingSplitLayout"
 import { OnboardingWelcomeAnimatedPanel } from "../Components/OnboardingWelcomeAnimatedPanel"
+import { useOnboardingFadeTransition } from "../Hooks/useOnboardingFadeTransition"
 import { useOnboardingContext } from "../useOnboardingContext"
 
 export const OnboardingWelcome = () => {
   const { user } = useSystemContext()
   const { next } = useOnboardingContext()
+  const { register, handleNext, loading } = useOnboardingFadeTransition({
+    next,
+  })
 
   return (
     <OnboardingSplitLayout
-      left={<OnboardingWelcomeAnimatedPanel />}
+      left={<OnboardingWelcomeAnimatedPanel ref={register(0)} />}
       right={
         <Flex flexDirection="column" justifyContent="space-between" p={4}>
           {/* Vertically centers next Box */}
           <Box />
 
           <Box width="100%">
-            <Text variant={["xl", "xxl"]}>Welcome to Artsy, {user?.name}.</Text>
+            <Text ref={register(1)} variant={["xl", "xxl"]}>
+              Welcome to Artsy, {user?.name}.
+            </Text>
 
             <Spacer mt={4} />
 
-            <Text variant="lg-display">
+            <Text variant="lg-display" ref={register(2)}>
               Ready to find art you love? Start building your profile and tailor
               Artsy to your tastes.
             </Text>
           </Box>
 
           <Box width="100%">
-            <Button onClick={next} width="100%">
+            <Button
+              disabled={loading}
+              loading={loading}
+              onClick={handleNext}
+              width="100%"
+            >
               Get started
             </Button>
 

--- a/src/v2/Utils/Hooks/__tests__/useFadeTransition.jest.tsx
+++ b/src/v2/Utils/Hooks/__tests__/useFadeTransition.jest.tsx
@@ -1,0 +1,63 @@
+import { render } from "@testing-library/react"
+import { renderHook } from "@testing-library/react-hooks"
+import { useFadeTransition } from "../useFadeTransition"
+
+jest.mock("../../wait", () => ({
+  wait: () => Promise.resolve(),
+}))
+
+describe("useFadeTransition", () => {
+  it("sets some defaults", () => {
+    const { result } = renderHook(() => useFadeTransition())
+
+    expect(result.current.mode).toEqual("Resting")
+    expect(result.current.status).toEqual("In")
+  })
+
+  it("registers elements", () => {
+    const { result } = renderHook(() => useFadeTransition())
+
+    const Example = () => {
+      return (
+        <div>
+          <div ref={result.current.register(0)}>one</div>
+          <div ref={result.current.register(2)}>three</div>
+          <div ref={result.current.register(1)}>two</div>
+        </div>
+      )
+    }
+
+    render(<Example />)
+
+    expect(
+      result.current.refs.current.map(ref => ref.current!.innerHTML)
+    ).toEqual(["one", "two", "three"])
+  })
+
+  it("transitions elements", async () => {
+    const { result } = renderHook(() => useFadeTransition({ duration: 250 }))
+
+    const Example = () => {
+      return (
+        <div>
+          <div ref={result.current.register(0)}>one</div>
+          <div ref={result.current.register(2)}>three</div>
+          <div ref={result.current.register(1)}>two</div>
+        </div>
+      )
+    }
+
+    render(<Example />)
+
+    await result.current.transition("Out")
+
+    const styles = result.current.refs.current.map(ref => ref.current!.style)
+
+    expect(styles.map(style => style.opacity)).toEqual(["0", "0", "0"])
+    expect(styles.map(style => style.transition)).toEqual([
+      "opacity 250ms",
+      "opacity 250ms",
+      "opacity 250ms",
+    ])
+  })
+})

--- a/src/v2/Utils/Hooks/useFadeTransition.story.tsx
+++ b/src/v2/Utils/Hooks/useFadeTransition.story.tsx
@@ -1,0 +1,75 @@
+import { Button, Text } from "@artsy/palette"
+import { useState } from "react"
+import { States } from "storybook-states"
+import { UseFadeTransition, useFadeTransition } from "./useFadeTransition"
+
+export default {
+  title: "Hooks/useFadeTransition",
+}
+
+export const Default = () => {
+  return (
+    <States<UseFadeTransition>
+      states={[{}, { initialStatus: "Out", duration: 1000 }]}
+    >
+      <Demo />
+    </States>
+  )
+}
+
+const Demo = (props: UseFadeTransition) => {
+  const { register, transition, mode, status } = useFadeTransition(props)
+
+  const [counter, setCounter] = useState(1)
+
+  const handleTransition = async () => {
+    await transition()
+
+    console.log("Done")
+  }
+
+  return (
+    <>
+      <Button onClick={handleTransition} size="small">
+        Transition
+      </Button>
+
+      <Button
+        size="small"
+        ml={1}
+        onClick={() => setCounter(prevRenders => prevRenders + 1)}
+        variant="secondaryBlack"
+      >
+        Increment Counter
+      </Button>
+
+      <Text variant="xs" bg="black5" px={1} py={0.5} mt={2} color="black60">
+        {JSON.stringify({ counter, mode, status }, null, 2)}
+      </Text>
+
+      <Text variant="sm" ref={register(1)} mt={1}>
+        Fade first
+      </Text>
+
+      <Text variant="sm" ref={register(2)}>
+        Fade second
+      </Text>
+
+      <Text variant="sm" ref={register(4)}>
+        Fade <strong>fourth</strong>
+      </Text>
+
+      <Text variant="sm" ref={register(3)}>
+        Fade third
+      </Text>
+
+      <Text variant="sm" ref={register(6)}>
+        Fade <strong>sixth</strong>
+      </Text>
+
+      <Text variant="sm" ref={register(5)}>
+        Fade fifth
+      </Text>
+    </>
+  )
+}

--- a/src/v2/Utils/Hooks/useFadeTransition.tsx
+++ b/src/v2/Utils/Hooks/useFadeTransition.tsx
@@ -1,0 +1,81 @@
+import { compact } from "lodash"
+import { createRef, RefObject, useCallback, useEffect, useRef } from "react"
+import { wait } from "../wait"
+import { useMode } from "./useMode"
+
+export interface UseFadeTransition {
+  /** Duration of transition in milliseconds */
+  duration?: number
+  /**
+   * If set to `"Out"` all registered elements will
+   * initially have their opacities set to 0
+   * */
+  initialStatus?: "In" | "Out"
+}
+
+export const useFadeTransition = ({
+  duration = 500,
+  initialStatus = "In",
+}: UseFadeTransition = {}) => {
+  const [status, setStatus] = useMode<"In" | "Out">(initialStatus)
+  const [mode, setMode] = useMode<"Resting" | "Transitioning">("Resting")
+
+  // If the `initialStatus` is `"Out"` make sure els are initially hidden
+  useEffect(() => {
+    if (status === "In") return
+
+    const els = compact(refs.current.map(ref => ref.current))
+
+    els.forEach(el => {
+      el.style.opacity = "0"
+    })
+  }, [status])
+
+  const refs = useRef<RefObject<HTMLElement>[]>([])
+
+  /**
+   * @param index The index of the element to register.
+   * Transitions will execute in the order specified by the indexes.
+   * @returns A ref to the element.
+   */
+  const register = useCallback((index: number) => {
+    const ref = createRef<HTMLElement>()
+    refs.current[index] = ref
+    return ref as any // Cast as `any` to get around outdated styled-components typing
+  }, [])
+
+  /**
+   * @returns A promise that resolves when the transition is complete.
+   */
+  const transition = useCallback(
+    async (toStatus?: "In" | "Out") => {
+      if (mode === "Transitioning") return
+
+      setMode("Transitioning")
+
+      const fromStatus = toStatus ? { In: "Out", Out: "In" }[toStatus] : null
+      const els = compact(refs.current.map(ref => ref.current))
+
+      await els.reduce((promise, el) => {
+        return promise.then(() => {
+          el.style.transition = `opacity ${duration}ms`
+          el.style.opacity = (fromStatus ?? status) === "In" ? "0" : "1"
+
+          return wait(duration / 3)
+        })
+      }, Promise.resolve())
+
+      setStatus((fromStatus ?? status) === "In" ? "Out" : "In")
+      setMode("Resting")
+    },
+    [duration, mode, setMode, setStatus, status]
+  )
+
+  return {
+    refs,
+    register,
+    transition,
+    mode,
+    status,
+  }
+}


### PR DESCRIPTION
The goal with this PR was to implement a method for doing the staggered fade transitions without having to muddy up the components with complex and repetitive styling.

The solution I arrived at with cda564a26bc3013d67e094d6314480eb58b5653f is a very simple hook that allows one to `register` elements in a specific order. Then returns a function to `transition` them in that order. We could make this hook much more generic to support different types of transitions; like transforms — not necessary at this time.

https://user-images.githubusercontent.com/112297/175652649-823d2968-10e9-454f-a7e1-5e29006377e5.mov

