### PR TITLE
fix(NX-3190): fix bug on CBN flow for edition sets

### DIFF
--- a/src/v2/Apps/Conversation/Components/ConfirmArtworkButton.tsx
+++ b/src/v2/Apps/Conversation/Components/ConfirmArtworkButton.tsx
@@ -33,7 +33,6 @@ export const ConfirmArtworkButton: React.FC<ConfirmArtworkButtonProps> = ({
   onClick,
 }) => {
   const [isCommittingMutation, setIsCommittingMutation] = useState(false)
-
   const commitMutation = createsOfferOrder ? MakeInquiryOffer : MakeInquiryOrder
   const onMutationError = (error: Error) => {
     logger.error(error)

--- a/src/v2/Apps/Conversation/Components/ConfirmArtworkModal.tsx
+++ b/src/v2/Apps/Conversation/Components/ConfirmArtworkModal.tsx
@@ -22,6 +22,7 @@ export interface ConfirmArtworkModalProps {
   conversationID: string
   show: boolean
   closeModal: () => void
+  createsOfferOrder: boolean
 }
 
 export const ConfirmArtworkModal: React.FC<ConfirmArtworkModalProps> = ({
@@ -29,6 +30,7 @@ export const ConfirmArtworkModal: React.FC<ConfirmArtworkModalProps> = ({
   conversationID,
   show,
   closeModal,
+  createsOfferOrder,
 }) => {
   const { editionSets, isEdition } = { ...artwork }
 
@@ -67,6 +69,7 @@ export const ConfirmArtworkModal: React.FC<ConfirmArtworkModalProps> = ({
                 context_owner_type: OwnerType.conversation,
               })
             }
+            createsOfferOrder={createsOfferOrder}
           >
             Confirm
           </ConfirmArtworkButtonFragmentContainer>
@@ -114,6 +117,7 @@ export const ConfirmArtworkModalQueryRenderer: React.FC<{
   conversationID: string
   show: boolean
   closeModal: () => void
+  createsOfferOrder: boolean
 }> = ({ artworkID, ...rest }) => {
   const { relayEnvironment } = useSystemContext()
   if (!artworkID) return null

--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -51,7 +51,6 @@ const Loading: React.FC = () => (
 
 const Conversation: React.FC<ConversationProps> = props => {
   const { conversation, relay, showDetails, setShowDetails } = props
-
   const liveArtwork = conversation?.items?.[0]?.liveArtwork
   const artwork = liveArtwork?.__typename === "Artwork" ? liveArtwork : null
   const isCBNEnabled = useFeatureFlag("conversational-buy-now")
@@ -63,6 +62,8 @@ const Conversation: React.FC<ConversationProps> = props => {
   const [showConfirmArtworkModal, setShowConfirmArtworkModal] = useState<
     boolean
   >(false)
+
+  const [createsOfferOrder, setCreatesOfferOrder] = useState<boolean>(true)
 
   const inquiryItemBox = compact(conversation.items).map((i, idx) => {
     const isValidType =
@@ -259,7 +260,10 @@ const Conversation: React.FC<ConversationProps> = props => {
           conversation={conversation}
           refetch={props.refetch}
           environment={relay.environment}
-          openInquiryModal={() => setShowConfirmArtworkModal(true)}
+          openInquiryModal={({ createsOfferOrder }) => {
+            setShowConfirmArtworkModal(true)
+            setCreatesOfferOrder(createsOfferOrder)
+          }}
           openOrderModal={() => setShowOrderModal(true)}
         />
       </NoScrollFlex>
@@ -269,6 +273,7 @@ const Conversation: React.FC<ConversationProps> = props => {
           conversationID={conversation.internalID!}
           show={showConfirmArtworkModal}
           closeModal={() => setShowConfirmArtworkModal(false)}
+          createsOfferOrder={createsOfferOrder}
         />
       )}
       {isActionable && (

--- a/src/v2/Apps/Conversation/Components/ConversationCTA.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationCTA.tsx
@@ -19,7 +19,7 @@ import { themeGet } from "@styled-system/theme-get"
 
 interface ConversationCTAProps {
   conversation: ConversationCTA_conversation
-  openInquiryModal: () => void
+  openInquiryModal: ({ createsOfferOrder: boolean }) => void
   openOrderModal: () => void
 }
 
@@ -78,13 +78,17 @@ export const ConversationCTA: React.FC<ConversationCTAProps> = ({
           <Flex flexDirection="row">
             {isCBNEnabled && isAcquireable && (
               <PurchaseOnInquiryButtonFragmentContainer
-                openInquiryModal={() => openInquiryModal()}
+                openInquiryModal={() =>
+                  openInquiryModal({ createsOfferOrder: false })
+                }
                 conversation={conversation}
               />
             )}
             {(isOfferableFromInquiry || (isCBNEnabled && isOfferable)) && (
               <MakeOfferOnInquiryButtonFragmentContainer
-                openInquiryModal={() => openInquiryModal()}
+                openInquiryModal={() =>
+                  openInquiryModal({ createsOfferOrder: true })
+                }
                 conversation={conversation}
               />
             )}

--- a/src/v2/Apps/Conversation/Components/OrderModal.tsx
+++ b/src/v2/Apps/Conversation/Components/OrderModal.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react"
 import { Modal, ModalWidth } from "@artsy/palette"
 import styled from "styled-components"
 

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -58,7 +58,7 @@ interface ReplyProps {
   environment: Environment
   onScroll: () => void
   refetch: RelayRefetchProp["refetch"]
-  openInquiryModal: () => void
+  openInquiryModal: ({ createsOfferOrder: boolean }) => void
   openOrderModal: () => void
 }
 
@@ -137,7 +137,9 @@ export const Reply: React.FC<ReplyProps> = props => {
       <Flex zIndex={[null, 2]} flexDirection="column" background="white">
         <ConversationCTAFragmentContainer
           conversation={conversation}
-          openInquiryModal={() => openInquiryModal()}
+          openInquiryModal={({ createsOfferOrder }) =>
+            openInquiryModal({ createsOfferOrder })
+          }
           openOrderModal={() => openOrderModal()}
         />
         <StyledFlex p={1}>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [NX-3190]

### Description

<!-- Implementation description -->


This fix is needed because otherwise Conversational Buy Now Flow for artworks containing more than 1 edition set would lead to "Make Offer" flow instead of "Buy Now".

The solution here consists of passing the param between different components so we can control if an order is an offer or purchase. We understand this is not the ideal solution, this is a quick fix so we can release the feature tomorrow. We'll work separately on a proper refactor to avoid the prop drilling ([NX-3208]).

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NX-3190]: https://artsyproduct.atlassian.net/browse/NX-3190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NX-3208]: https://artsyproduct.atlassian.net/browse/NX-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ