### PR TITLE
feat(onboarding): animates progress bar

### DIFF
--- a/src/v2/Apps/Onboarding/Components/OnboardingProgress.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingProgress.tsx
@@ -1,9 +1,30 @@
 import { ProgressBar } from "@artsy/palette"
 import { FC } from "react"
+import { useDebouncedValue } from "v2/Utils/Hooks/useDebounce"
 import { useOnboardingContext } from "../useOnboardingContext"
 
-export const OnboardingProgress: FC = () => {
-  const { progress } = useOnboardingContext()
+interface OnboardingProgressProps {
+  preview?: boolean
+}
 
-  return <ProgressBar my={0} percentComplete={progress} />
+export const OnboardingProgress: FC<OnboardingProgressProps> = ({
+  preview = false,
+}) => {
+  const { progress, workflowEngine } = useOnboardingContext()
+
+  const nextProgress = progress + 100 / workflowEngine.total()
+
+  const { debouncedValue: debouncedProgress } = useDebouncedValue({
+    value: preview ? nextProgress : progress,
+    delay: 250,
+  })
+
+  return (
+    <ProgressBar
+      width="100%"
+      my={0}
+      transition="transform 250ms"
+      percentComplete={debouncedProgress}
+    />
+  )
 }

--- a/src/v2/Apps/Onboarding/Views/OnboardingQuestionOne.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingQuestionOne.tsx
@@ -28,7 +28,7 @@ export const OnboardingQuestionOne: FC = () => {
           justifyContent="space-between"
           width="100%"
         >
-          <OnboardingProgress />
+          <OnboardingProgress preview={loading} />
 
           <Box width="100%">
             <Text variant="lg-display" ref={register(1)}>

--- a/src/v2/Apps/Onboarding/Views/OnboardingQuestionThree.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingQuestionThree.tsx
@@ -69,7 +69,7 @@ export const OnboardingQuestionThree: FC = () => {
           justifyContent="space-between"
           width="100%"
         >
-          <OnboardingProgress />
+          <OnboardingProgress preview={loading} />
 
           <Box width="100%">
             <Text variant="lg-display" ref={register(1)}>

--- a/src/v2/Apps/Onboarding/Views/OnboardingQuestionTwo.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingQuestionTwo.tsx
@@ -30,7 +30,7 @@ export const OnboardingQuestionTwo: FC = () => {
           justifyContent="space-between"
           width="100%"
         >
-          <OnboardingProgress />
+          <OnboardingProgress preview={loading} />
 
           <Box width="100%">
             <Text variant="lg-display" ref={register(1)}>

--- a/src/v2/Utils/Hooks/useDebounce.ts
+++ b/src/v2/Utils/Hooks/useDebounce.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from "react"
+import { debounce } from "lodash"
+
+interface UseDebounce {
+  delay?: number
+  callback: (...args: any[]) => void
+}
+
+export const useDebounce = ({ callback, delay = 200 }: UseDebounce) => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useCallback(debounce(callback, delay), [callback, delay])
+}
+
+interface UseDebouncedValue<T> {
+  value: T
+  delay?: number
+}
+
+export const useDebouncedValue = <T>({
+  value,
+  delay = 200,
+}: UseDebouncedValue<T>) => {
+  const [debouncedValue, setValue] = useState(value)
+  const debouncedSetValue = useDebounce({ callback: setValue, delay })
+
+  useEffect(() => {
+    debouncedSetValue(value)
+  }, [debouncedSetValue, value])
+
+  return { debouncedValue }
+}


### PR DESCRIPTION
Closes [GRO-1093](https://artsyproduct.atlassian.net/browse/GRO-1093)

A little tricky: we need to either relocate the progress bar to the parent `OnboardingSteps` so that it transitions smoothly — this is non-ideal, structurally. Or: we can transition to the next state _before_ the step renders, as the old one is transitioning out. This works but is slightly weird since there's a spare render that happens inside the step that picks up the previous progress; since this is a computed value coming from the workflow engine. A bit of a hacky solution then: just debounce the progress value so that we loose that spare render.