### PR TITLE
chore: skip counting custom default sort value

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -291,14 +291,18 @@ export const ArtworkFilterContextProvider: React.FC<
   sortOptions,
   ZeroState,
 }) => {
+  const camelCasedFilters: ArtworkFiltersState = paramsToCamelCase(filters)
   const defaultSort = sortOptions?.[0].value ?? initialArtworkFilterState.sort!
+  const defaultMetric =
+    camelCasedFilters?.metric ?? initialArtworkFilterState.metric!
   const defaultFilters = {
     ...initialArtworkFilterState,
     sort: defaultSort,
+    metric: defaultMetric,
   }
   const initialFilterState = {
     ...defaultFilters,
-    ...paramsToCamelCase(filters),
+    ...camelCasedFilters,
   }
 
   const [artworkFilterState, dispatch] = useReducer(

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -288,9 +288,10 @@ export const ArtworkFilterContextProvider: React.FC<
   sortOptions,
   ZeroState,
 }) => {
+  const defaultSort = sortOptions?.[0].value ?? initialArtworkFilterState.sort!
   const initialFilterState = {
     ...initialArtworkFilterState,
-    sort: sortOptions?.[0].value ?? initialArtworkFilterState.sort,
+    sort: defaultSort,
     ...paramsToCamelCase(filters),
   }
 
@@ -329,9 +330,10 @@ export const ArtworkFilterContextProvider: React.FC<
     shouldStageFilterChanges ? stage(action) : dispatch(action)
   }
 
-  const currentlySelectedFiltersCounts = getSelectedFiltersCounts(
-    currentlySelectedFilters()
-  )
+  const currentlySelectedFiltersCounts = getSelectedFiltersCounts({
+    filters: currentlySelectedFilters(),
+    defaultSort,
+  })
 
   const artworkFilterContext = {
     mountedContext: true,
@@ -395,6 +397,7 @@ export const ArtworkFilterContextProvider: React.FC<
         type: "RESET",
         payload: {
           metric: initialFilterState.metric,
+          sort: defaultSort,
         },
       }
       dispatchOrStage(action)
@@ -603,13 +606,19 @@ const artworkFilterReducer = (
   }
 }
 
+interface SelectedFiltersCountsOptions {
+  filters: ArtworkFilters
+  defaultSort: string
+}
+
 export const getSelectedFiltersCounts = (
-  selectedFilters: ArtworkFilters = {}
+  options: SelectedFiltersCountsOptions
 ) => {
+  const { filters, defaultSort } = options
   const counts: Partial<SelectedFiltersCounts> = {}
   const filtersParams = Object.values(FilterParamName)
 
-  Object.entries(selectedFilters).forEach(([paramName, paramValue]) => {
+  Object.entries(filters).forEach(([paramName, paramValue]) => {
     if (!filtersParams.includes(paramName as FilterParamName)) {
       return
     }
@@ -641,7 +650,7 @@ export const getSelectedFiltersCounts = (
         break
       }
       case paramName === FilterParamName.sort: {
-        if (paramValue !== initialArtworkFilterState.sort) {
+        if (paramValue !== defaultSort) {
           counts[paramName] = 1
         }
         break

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterMobileActionSheet.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterMobileActionSheet.tsx
@@ -2,10 +2,7 @@ import { Box, Button, Clickable, Flex, ModalBase, Text } from "@artsy/palette"
 import { useEffect, useRef } from "react"
 import * as React from "react"
 import styled from "styled-components"
-import {
-  initialArtworkFilterState,
-  useArtworkFilterContext,
-} from "./ArtworkFilterContext"
+import { useArtworkFilterContext } from "./ArtworkFilterContext"
 import { isEqual, omit } from "lodash"
 import { countChangedFilters } from "./Utils/countChangedFilters"
 import { themeGet } from "@styled-system/theme-get"
@@ -21,7 +18,7 @@ export const ArtworkFilterMobileActionSheet: React.FC<{
   // This reflects our zero state for this UI which doesn't include the keyword
   const isReset = isEqual(
     omit(filterContext.stagedFilters, "reset", "keyword"),
-    initialArtworkFilterState
+    filterContext.defaultFilters
   )
 
   const handleScrollToTop = () => {

--- a/src/v2/Components/ArtworkFilter/Utils/__tests__/getSelectedFiltersCounts.jest.ts
+++ b/src/v2/Components/ArtworkFilter/Utils/__tests__/getSelectedFiltersCounts.jest.ts
@@ -51,36 +51,55 @@ describe("getSelectedFiltersCounts helper", () => {
   }
 
   it("returns empty object if it is initial filters", () => {
-    const result = getSelectedFiltersCounts(initialArtworkFilterState)
+    const result = getSelectedFiltersCounts({
+      filters: initialArtworkFilterState,
+      defaultSort,
+    })
     expect(result).toEqual({})
   })
 
   it("counts multiselect filters correctly", () => {
-    const result = getSelectedFiltersCounts(multiSelectFilters)
+    const result = getSelectedFiltersCounts({
+      filters: multiSelectFilters,
+      defaultSort,
+    })
     expect(result).toEqual(multiSelectFiltersExpectedResult)
   })
 
   it("counts single option filters correctly", () => {
-    const result = getSelectedFiltersCounts(singleOptionFilters)
+    const result = getSelectedFiltersCounts({
+      filters: singleOptionFilters,
+      defaultSort,
+    })
     expect(result).toEqual(singleOptionFiltersExpectedResult)
   })
 
   it("counts ways to buy options correctly", () => {
-    const result = getSelectedFiltersCounts(waysToBuyFilters)
+    const result = getSelectedFiltersCounts({
+      filters: waysToBuyFilters,
+      defaultSort,
+    })
     expect(result).toEqual(waysToBuyFiltersExpectedResult)
   })
 
   it("counts artists options correctly", () => {
-    const result = getSelectedFiltersCounts(artistsFilters)
+    const result = getSelectedFiltersCounts({
+      filters: artistsFilters,
+      defaultSort,
+    })
     expect(result).toEqual(artistsFiltersExpectedResult)
   })
 
   it("counts all filters correctly", () => {
-    const result = getSelectedFiltersCounts({
+    const filters = {
       ...multiSelectFilters,
       ...singleOptionFilters,
       ...waysToBuyFilters,
       ...artistsFilters,
+    }
+    const result = getSelectedFiltersCounts({
+      filters,
+      defaultSort,
     })
     expect(result).toEqual({
       ...multiSelectFiltersExpectedResult,
@@ -89,4 +108,59 @@ describe("getSelectedFiltersCounts helper", () => {
       ...artistsFiltersExpectedResult,
     })
   })
+
+  describe("sort option", () => {
+    it("should be correctly counted when default sort value is passed", () => {
+      const filters = {
+        sort: "-decayed_merch",
+      }
+      const result = getSelectedFiltersCounts({
+        filters,
+        defaultSort,
+      })
+
+      expect(result).toEqual({})
+    })
+
+    it("should be correctly counted when custom sort value is passed", () => {
+      const filters = {
+        sort: "year",
+      }
+      const result = getSelectedFiltersCounts({
+        filters,
+        defaultSort,
+      })
+
+      expect(result).toEqual({
+        sort: 1,
+      })
+    })
+
+    it("should be correctly counted when custom default sort value is passed", () => {
+      const filters = {
+        sort: "year",
+      }
+      const result = getSelectedFiltersCounts({
+        filters,
+        defaultSort,
+      })
+
+      expect(result).toEqual({
+        sort: 1,
+      })
+    })
+
+    it("should be correctly counted when filters and custom default sort value are passed", () => {
+      const result = getSelectedFiltersCounts({
+        defaultSort: "year",
+        filters: singleOptionFilters,
+      })
+
+      expect(result).toEqual({
+        priceRange: 1,
+      })
+    })
+  })
 })
+
+const defaultSort = "-decayed_merch"

--- a/src/v2/Components/ArtworkFilter/Utils/__tests__/getSelectedFiltersCounts.jest.ts
+++ b/src/v2/Components/ArtworkFilter/Utils/__tests__/getSelectedFiltersCounts.jest.ts
@@ -51,42 +51,42 @@ describe("getSelectedFiltersCounts helper", () => {
   }
 
   it("returns empty object if it is initial filters", () => {
-    const result = getSelectedFiltersCounts({
-      filters: initialArtworkFilterState,
-      defaultSort,
-    })
+    const result = getSelectedFiltersCounts(
+      initialArtworkFilterState,
+      initialArtworkFilterState
+    )
     expect(result).toEqual({})
   })
 
   it("counts multiselect filters correctly", () => {
-    const result = getSelectedFiltersCounts({
-      filters: multiSelectFilters,
-      defaultSort,
-    })
+    const result = getSelectedFiltersCounts(
+      multiSelectFilters,
+      initialArtworkFilterState
+    )
     expect(result).toEqual(multiSelectFiltersExpectedResult)
   })
 
   it("counts single option filters correctly", () => {
-    const result = getSelectedFiltersCounts({
-      filters: singleOptionFilters,
-      defaultSort,
-    })
+    const result = getSelectedFiltersCounts(
+      singleOptionFilters,
+      initialArtworkFilterState
+    )
     expect(result).toEqual(singleOptionFiltersExpectedResult)
   })
 
   it("counts ways to buy options correctly", () => {
-    const result = getSelectedFiltersCounts({
-      filters: waysToBuyFilters,
-      defaultSort,
-    })
+    const result = getSelectedFiltersCounts(
+      waysToBuyFilters,
+      initialArtworkFilterState
+    )
     expect(result).toEqual(waysToBuyFiltersExpectedResult)
   })
 
   it("counts artists options correctly", () => {
-    const result = getSelectedFiltersCounts({
-      filters: artistsFilters,
-      defaultSort,
-    })
+    const result = getSelectedFiltersCounts(
+      artistsFilters,
+      initialArtworkFilterState
+    )
     expect(result).toEqual(artistsFiltersExpectedResult)
   })
 
@@ -97,10 +97,7 @@ describe("getSelectedFiltersCounts helper", () => {
       ...waysToBuyFilters,
       ...artistsFilters,
     }
-    const result = getSelectedFiltersCounts({
-      filters,
-      defaultSort,
-    })
+    const result = getSelectedFiltersCounts(filters, initialArtworkFilterState)
     expect(result).toEqual({
       ...multiSelectFiltersExpectedResult,
       ...singleOptionFiltersExpectedResult,
@@ -114,10 +111,10 @@ describe("getSelectedFiltersCounts helper", () => {
       const filters = {
         sort: "-decayed_merch",
       }
-      const result = getSelectedFiltersCounts({
+      const result = getSelectedFiltersCounts(
         filters,
-        defaultSort,
-      })
+        initialArtworkFilterState
+      )
 
       expect(result).toEqual({})
     })
@@ -126,10 +123,10 @@ describe("getSelectedFiltersCounts helper", () => {
       const filters = {
         sort: "year",
       }
-      const result = getSelectedFiltersCounts({
+      const result = getSelectedFiltersCounts(
         filters,
-        defaultSort,
-      })
+        initialArtworkFilterState
+      )
 
       expect(result).toEqual({
         sort: 1,
@@ -140,10 +137,10 @@ describe("getSelectedFiltersCounts helper", () => {
       const filters = {
         sort: "year",
       }
-      const result = getSelectedFiltersCounts({
+      const result = getSelectedFiltersCounts(
         filters,
-        defaultSort,
-      })
+        initialArtworkFilterState
+      )
 
       expect(result).toEqual({
         sort: 1,
@@ -151,10 +148,13 @@ describe("getSelectedFiltersCounts helper", () => {
     })
 
     it("should be correctly counted when filters and custom default sort value are passed", () => {
-      const result = getSelectedFiltersCounts({
-        defaultSort: "year",
-        filters: singleOptionFilters,
-      })
+      const defaultFilters = {
+        sort: "year",
+      }
+      const result = getSelectedFiltersCounts(
+        singleOptionFilters,
+        defaultFilters
+      )
 
       expect(result).toEqual({
         priceRange: 1,
@@ -162,5 +162,3 @@ describe("getSelectedFiltersCounts helper", () => {
     })
   })
 })
-
-const defaultSort = "-decayed_merch"


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

### Quick demo links with custom sort value by default
* [Show Artworks](https://custom-default-sort.artsy.net/show/ko-austere-imaginary)
* [Auction artworks](https://custom-default-sort.artsy.net/auction/artsy-x-thurgood-marshall-college-fund-spring-selections)

### Changes
#### Skip counting custom default sort value
For example, when A/B test is launched and the default sort value should be different from `-decayed_merch` ([FX-3972](https://artsyproduct.atlassian.net/browse/FX-3972))

| Before  | After |
| ------------- | ------------- |
| <img width="344" alt="before-1" src="https://user-images.githubusercontent.com/3513494/176003002-71622180-163e-4e8a-94f3-ecc42bce9abf.png"> | <img width="344" alt="after-1" src="https://user-images.githubusercontent.com/3513494/176003120-c572818a-230b-43ad-837e-bd3f9442edd5.png"> |

#### Reset sort value
Correctly reset sort value, when custom default sort value is used and "Clear All" button is pressed

**Before**

https://user-images.githubusercontent.com/3513494/176153053-0681421c-12eb-4003-a879-30cc4edf2726.mp4

**After**

https://user-images.githubusercontent.com/3513494/176153175-21148619-768b-47ee-a3b9-341ed1e54bf9.mp4

#### Clear All button
"Clear All" button is available to click by default if the custom default sort value was specified

**Before**

https://user-images.githubusercontent.com/3513494/176153518-d8a2bd2d-5b4a-40b3-9e4e-de85103bc3ea.mp4

**After**

https://user-images.githubusercontent.com/3513494/176153618-38b26da2-3bc1-457f-9d0f-11b5a5b991fa.mp4

<!-- Implementation description -->
