### PR TITLE
Add new for you rail to homepage

### DIFF
--- a/src/v2/Apps/Home/Components/HomeNewWorksForYouRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeNewWorksForYouRail.tsx
@@ -1,0 +1,146 @@
+import {
+  Box,
+  Shelf,
+  Skeleton,
+  SkeletonText,
+  SkeletonBox,
+  Spacer,
+} from "@artsy/palette"
+import * as React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useSystemContext, useTracking } from "v2/System"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { HomeNewWorksForYouRail_artworksForUser } from "v2/__generated__/HomeNewWorksForYouRail_artworksForUser.graphql"
+import { HomeNewWorksForYouRailQuery } from "v2/__generated__/HomeNewWorksForYouRailQuery.graphql"
+import { ShelfArtworkFragmentContainer } from "v2/Components/Artwork/ShelfArtwork"
+import { extractNodes } from "v2/Utils/extractNodes"
+import {
+  ActionType,
+  ClickedArtworkGroup,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
+
+interface HomeNewWorksForYouRailProps {
+  artworksForUser: HomeNewWorksForYouRail_artworksForUser
+}
+
+const HomeNewWorksForYouRail: React.FC<HomeNewWorksForYouRailProps> = ({
+  artworksForUser,
+}) => {
+  const { trackEvent } = useTracking()
+
+  const artworks = extractNodes(artworksForUser)
+  if (!artworks || artworks?.length === 0) {
+    return null
+  }
+
+  return (
+    <Shelf>
+      {artworks.map((artwork, index) => {
+        if (!artwork) {
+          return <></>
+        }
+
+        return (
+          <ShelfArtworkFragmentContainer
+            artwork={artwork}
+            key={index}
+            // TODO: Add home type to cohesion once we have tracking
+            contextModule={null as any}
+            lazyLoad
+            onClick={() => {
+              const trackingEvent: ClickedArtworkGroup = {
+                action: ActionType.clickedArtworkGroup,
+                context_module: ContextModule.newWorksForYouRail,
+                context_page_owner_type: OwnerType.home,
+                destination_page_owner_id: artwork.internalID,
+                destination_page_owner_slug: artwork.slug,
+                destination_page_owner_type: OwnerType.artwork,
+                type: "thumbnail",
+              }
+              trackEvent(trackingEvent)
+            }}
+          />
+        )
+      })}
+    </Shelf>
+  )
+}
+
+const PLACEHOLDER = (
+  <Skeleton>
+    <Shelf>
+      {[...new Array(8)].map((_, i) => {
+        return (
+          <Box width={200} key={i}>
+            <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
+
+            <Spacer mt={1} />
+
+            <SkeletonText variant="sm-display">Artist Name</SkeletonText>
+            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
+            <SkeletonText variant="xs">Partner</SkeletonText>
+            <SkeletonText variant="xs">Price</SkeletonText>
+          </Box>
+        )
+      })}
+    </Shelf>
+  </Skeleton>
+)
+
+export const HomeNewWorksForYouRailFragmentContainer = createFragmentContainer(
+  HomeNewWorksForYouRail,
+  {
+    artworksForUser: graphql`
+      fragment HomeNewWorksForYouRail_artworksForUser on ArtworkConnection {
+        edges {
+          node {
+            internalID
+            slug
+            ...ShelfArtwork_artwork @arguments(width: 210)
+          }
+        }
+      }
+    `,
+  }
+)
+
+export const HomeNewWorksForYouRailQueryRenderer: React.FC = () => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <SystemQueryRenderer<HomeNewWorksForYouRailQuery>
+      lazyLoad
+      environment={relayEnvironment}
+      query={graphql`
+        query HomeNewWorksForYouRailQuery {
+          artworksForUser(includeBackfill: true, first: 20) {
+            ...HomeNewWorksForYouRail_artworksForUser
+          }
+        }
+      `}
+      placeholder={PLACEHOLDER}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props) {
+          return PLACEHOLDER
+        }
+
+        if (props.artworksForUser) {
+          return (
+            <HomeNewWorksForYouRailFragmentContainer
+              artworksForUser={props.artworksForUser}
+            />
+          )
+        }
+
+        return null
+      }}
+    />
+  )
+}

--- a/src/v2/Apps/Home/Components/HomeWorksForYouTabBar.tsx
+++ b/src/v2/Apps/Home/Components/HomeWorksForYouTabBar.tsx
@@ -1,6 +1,7 @@
 import { Tab, Tabs } from "@artsy/palette"
-import * as React from "react";
+import * as React from "react"
 import { useSystemContext } from "v2/System"
+import { HomeNewWorksForYouRailQueryRenderer } from "./HomeNewWorksForYouRail"
 import { HomeRecentlyViewedRailQueryRenderer } from "./HomeRecentlyViewedRail"
 import { HomeWorksByArtistsYouFollowRailQueryRenderer } from "./HomeWorksByArtistsYouFollowRail"
 
@@ -13,6 +14,9 @@ export const HomeWorksForYouTabBar: React.FC = () => {
 
   return (
     <Tabs>
+      <Tab name="New Works For You">
+        <HomeNewWorksForYouRailQueryRenderer />
+      </Tab>
       <Tab name="New Works by Artists You Follow">
         <HomeWorksByArtistsYouFollowRailQueryRenderer />
       </Tab>

--- a/src/v2/Apps/Home/__tests__/HomeNewWorksForYouRail.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeNewWorksForYouRail.jest.tsx
@@ -1,0 +1,71 @@
+import { graphql } from "relay-runtime"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { HomeNewWorksForYouRailFragmentContainer } from "../Components/HomeNewWorksForYouRail"
+import { HomeNewWorksForYouRail_Test_Query } from "v2/__generated__/HomeNewWorksForYouRail_Test_Query.graphql"
+import { useTracking } from "v2/System/Analytics/useTracking"
+
+jest.unmock("react-relay")
+jest.mock("v2/System/Analytics/useTracking")
+
+const { getWrapper } = setupTestWrapper<HomeNewWorksForYouRail_Test_Query>({
+  Component: props => {
+    return (
+      <HomeNewWorksForYouRailFragmentContainer
+        artworksForUser={props.artworksForUser!}
+      />
+    )
+  },
+  query: graphql`
+    query HomeNewWorksForYouRail_Test_Query @relay_test_operation {
+      artworksForUser(includeBackfill: true, first: 20) {
+        ...HomeNewWorksForYouRail_artworksForUser
+      }
+    }
+  `,
+})
+
+const trackEvent = jest.fn()
+
+beforeAll(() => {
+  ;(useTracking as jest.Mock).mockImplementation(() => ({ trackEvent }))
+})
+
+afterEach(() => {
+  trackEvent.mockClear()
+})
+
+describe("HomeNewWorksForYouRail", () => {
+  it("renders correctly", () => {
+    const wrapper = getWrapper({
+      ArtworkConnection: () => ({
+        edges: [
+          {
+            node: {
+              title: "Test Artist",
+              href: "test-href",
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(wrapper.text()).toContain("Test Artist")
+    expect(wrapper.html()).toContain("test-href")
+  })
+
+  describe("tracking", () => {
+    it("tracks item clicks", () => {
+      const wrapper = getWrapper()
+      wrapper.find("RouterLink").first().simulate("click")
+      expect(trackEvent).toBeCalledWith({
+        action: "clickedArtworkGroup",
+        context_module: "newWorksForYouRail",
+        context_page_owner_type: "home",
+        destination_page_owner_id: "<Artwork-mock-id-1>",
+        destination_page_owner_slug: "<Artwork-mock-id-2>",
+        destination_page_owner_type: "artwork",
+        type: "thumbnail",
+      })
+    })
+  })
+})

--- a/src/v2/Apps/Home/__tests__/HomeWorksForYouTabBar.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeWorksForYouTabBar.jest.tsx
@@ -1,11 +1,14 @@
 import { mount } from "enzyme"
 import { HomeWorksForYouTabBar } from "../Components/HomeWorksForYouTabBar"
 
-jest.mock("v2/Apps/Home/Components/HomeWorksByArtistsYouFollowRail", () => ({
-  HomeWorksByArtistsYouFollowRailQueryRenderer: () => null,
+jest.mock("v2/Apps/Home/Components/HomeNewWorksForYouRail", () => ({
+  HomeNewWorksForYouRailQueryRenderer: () => null,
 }))
 jest.mock("v2/Apps/Home/Components/HomeRecentlyViewedRail", () => ({
   HomeRecentlyViewedRailQueryRenderer: () => null,
+}))
+jest.mock("v2/Apps/Home/Components/HomeWorksByArtistsYouFollowRail", () => ({
+  HomeWorksByArtistsYouFollowRailQueryRenderer: () => null,
 }))
 jest.mock("v2/System/useSystemContext", () => ({
   useSystemContext: jest.fn().mockReturnValue({ user: true }),
@@ -16,24 +19,28 @@ describe("HomeWorksForYouTabBar", () => {
     return mount(<HomeWorksForYouTabBar />)
   }
 
-  it("renders correctly on first load", () => {
+  it("renders the new for you tab by default", () => {
     const wrapper = getWrapper()
+    expect(wrapper.text()).toContain("New Works For You")
     expect(wrapper.text()).toContain("New Works by Artists You Follow")
     expect(wrapper.text()).toContain("Recently Viewed")
+
+    expect(wrapper.find("HomeNewWorksForYouRailQueryRenderer")).toHaveLength(1)
     expect(
-      wrapper.find("HomeWorksByArtistsYouFollowRailQueryRenderer").length
-    ).toEqual(1)
+      wrapper.find("HomeWorksByArtistsYouFollowRailQueryRenderer")
+    ).toHaveLength(0)
+    expect(wrapper.find("HomeRecentlyViewedRailQueryRenderer")).toHaveLength(0)
   })
 
-  it("renders correct tab content", () => {
+  it("renders other tabs when clicking", () => {
     const wrapper = getWrapper()
-    wrapper.find("button").first().simulate("click")
+    wrapper.find("button").at(2).simulate("click")
+    expect(wrapper.find("HomeRecentlyViewedRailQueryRenderer")).toHaveLength(1)
+    wrapper.find("button").at(1).simulate("click")
     expect(
-      wrapper.find("HomeWorksByArtistsYouFollowRailQueryRenderer").length
-    ).toEqual(1)
-    wrapper.find("button").last().simulate("click")
-    expect(wrapper.find("HomeRecentlyViewedRailQueryRenderer").length).toEqual(
-      1
-    )
+      wrapper.find("HomeWorksByArtistsYouFollowRailQueryRenderer")
+    ).toHaveLength(1)
+    wrapper.find("button").at(0).simulate("click")
+    expect(wrapper.find("HomeNewWorksForYouRailQueryRenderer")).toHaveLength(1)
   })
 })

--- a/src/v2/__generated__/HomeNewWorksForYouRailQuery.graphql.ts
+++ b/src/v2/__generated__/HomeNewWorksForYouRailQuery.graphql.ts
@@ -1,0 +1,627 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeNewWorksForYouRailQueryVariables = {};
+export type HomeNewWorksForYouRailQueryResponse = {
+    readonly artworksForUser: {
+        readonly " $fragmentRefs": FragmentRefs<"HomeNewWorksForYouRail_artworksForUser">;
+    } | null;
+};
+export type HomeNewWorksForYouRailQuery = {
+    readonly response: HomeNewWorksForYouRailQueryResponse;
+    readonly variables: HomeNewWorksForYouRailQueryVariables;
+};
+
+
+
+/*
+query HomeNewWorksForYouRailQuery {
+  artworksForUser(includeBackfill: true, first: 20) {
+    ...HomeNewWorksForYouRail_artworksForUser
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    endAt
+    cascadingEndTimeIntervalMinutes
+    extendedBiddingIntervalMinutes
+    startAt
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    lotID
+    lotLabel
+    endAt
+    extendedBiddingEndAt
+    formattedEndDateTime
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+  ...NewSaveButton_artwork
+  ...HoverDetails_artwork
+}
+
+fragment HomeNewWorksForYouRail_artworksForUser on ArtworkConnection {
+  edges {
+    node {
+      internalID
+      slug
+      ...ShelfArtwork_artwork_1s6r3G
+      id
+    }
+  }
+}
+
+fragment HoverDetails_artwork on Artwork {
+  internalID
+  attributionClass {
+    name
+    id
+  }
+  mediumType {
+    filterGene {
+      name
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  href
+}
+
+fragment NewSaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment ShelfArtwork_artwork_1s6r3G on Artwork {
+  image {
+    resized(width: 210) {
+      src
+      srcSet
+      width
+      height
+    }
+    aspectRatio
+    height
+  }
+  imageTitle
+  title
+  href
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 20
+  },
+  {
+    "kind": "Literal",
+    "name": "includeBackfill",
+    "value": true
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v8 = [
+  (v5/*: any*/),
+  (v4/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeNewWorksForYouRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "ArtworkConnection",
+        "kind": "LinkedField",
+        "name": "artworksForUser",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "HomeNewWorksForYouRail_artworksForUser"
+          }
+        ],
+        "storageKey": "artworksForUser(first:20,includeBackfill:true)"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeNewWorksForYouRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "ArtworkConnection",
+        "kind": "LinkedField",
+        "name": "artworksForUser",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "internalID",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slug",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "width",
+                            "value": 210
+                          }
+                        ],
+                        "concreteType": "ResizedImageUrl",
+                        "kind": "LinkedField",
+                        "name": "resized",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "src",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "srcSet",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          (v1/*: any*/)
+                        ],
+                        "storageKey": "resized(width:210)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "aspectRatio",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "imageTitle",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "title",
+                    "storageKey": null
+                  },
+                  (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "date",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_message",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "saleMessage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "cultural_maker",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "culturalMaker",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v3/*: any*/),
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "artists",
+                    "plural": true,
+                    "selections": [
+                      (v4/*: any*/),
+                      (v2/*: any*/),
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": "artists(shallow:true)"
+                  },
+                  {
+                    "alias": "collecting_institution",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "collectingInstitution",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v3/*: any*/),
+                    "concreteType": "Partner",
+                    "kind": "LinkedField",
+                    "name": "partner",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": "partner(shallow:true)"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Sale",
+                    "kind": "LinkedField",
+                    "name": "sale",
+                    "plural": false,
+                    "selections": [
+                      (v6/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cascadingEndTimeIntervalMinutes",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "extendedBiddingIntervalMinutes",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "startAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_auction",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isAuction",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_closed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isClosed",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      {
+                        "alias": "is_preview",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isPreview",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "display_timely_at",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "displayTimelyAt",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_artwork",
+                    "args": null,
+                    "concreteType": "SaleArtwork",
+                    "kind": "LinkedField",
+                    "name": "saleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotLabel",
+                        "storageKey": null
+                      },
+                      (v6/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "extendedBiddingEndAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "formattedEndDateTime",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "bidder_positions",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "bidderPositions",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "highest_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkHighestBid",
+                        "kind": "LinkedField",
+                        "name": "highestBid",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "opening_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkOpeningBid",
+                        "kind": "LinkedField",
+                        "name": "openingBid",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": null
+                      },
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v4/*: any*/),
+                  {
+                    "alias": "is_saved",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isSaved",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AttributionClass",
+                    "kind": "LinkedField",
+                    "name": "attributionClass",
+                    "plural": false,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ArtworkMedium",
+                    "kind": "LinkedField",
+                    "name": "mediumType",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Gene",
+                        "kind": "LinkedField",
+                        "name": "filterGene",
+                        "plural": false,
+                        "selections": (v8/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "is_biddable",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isBiddable",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "artworksForUser(first:20,includeBackfill:true)"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "17b0b83246bc519c5886900bbf63c855",
+    "id": null,
+    "metadata": {},
+    "name": "HomeNewWorksForYouRailQuery",
+    "operationKind": "query",
+    "text": "query HomeNewWorksForYouRailQuery {\n  artworksForUser(includeBackfill: true, first: 20) {\n    ...HomeNewWorksForYouRail_artworksForUser\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeNewWorksForYouRail_artworksForUser on ArtworkConnection {\n  edges {\n    node {\n      internalID\n      slug\n      ...ShelfArtwork_artwork_1s6r3G\n      id\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+  }
+};
+})();
+(node as any).hash = '15c03429b17e3d50d2a9a64b1d8b1ce6';
+export default node;

--- a/src/v2/__generated__/HomeNewWorksForYouRail_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeNewWorksForYouRail_Test_Query.graphql.ts
@@ -1,0 +1,806 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeNewWorksForYouRail_Test_QueryVariables = {};
+export type HomeNewWorksForYouRail_Test_QueryResponse = {
+    readonly artworksForUser: {
+        readonly " $fragmentRefs": FragmentRefs<"HomeNewWorksForYouRail_artworksForUser">;
+    } | null;
+};
+export type HomeNewWorksForYouRail_Test_Query = {
+    readonly response: HomeNewWorksForYouRail_Test_QueryResponse;
+    readonly variables: HomeNewWorksForYouRail_Test_QueryVariables;
+};
+
+
+
+/*
+query HomeNewWorksForYouRail_Test_Query {
+  artworksForUser(includeBackfill: true, first: 20) {
+    ...HomeNewWorksForYouRail_artworksForUser
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    endAt
+    cascadingEndTimeIntervalMinutes
+    extendedBiddingIntervalMinutes
+    startAt
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    lotID
+    lotLabel
+    endAt
+    extendedBiddingEndAt
+    formattedEndDateTime
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+  ...NewSaveButton_artwork
+  ...HoverDetails_artwork
+}
+
+fragment HomeNewWorksForYouRail_artworksForUser on ArtworkConnection {
+  edges {
+    node {
+      internalID
+      slug
+      ...ShelfArtwork_artwork_1s6r3G
+      id
+    }
+  }
+}
+
+fragment HoverDetails_artwork on Artwork {
+  internalID
+  attributionClass {
+    name
+    id
+  }
+  mediumType {
+    filterGene {
+      name
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  href
+}
+
+fragment NewSaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment ShelfArtwork_artwork_1s6r3G on Artwork {
+  image {
+    resized(width: 210) {
+      src
+      srcSet
+      width
+      height
+    }
+    aspectRatio
+    height
+  }
+  imageTitle
+  title
+  href
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 20
+  },
+  {
+    "kind": "Literal",
+    "name": "includeBackfill",
+    "value": true
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v8 = [
+  (v5/*: any*/),
+  (v4/*: any*/)
+],
+v9 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v10 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v11 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v12 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v13 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeNewWorksForYouRail_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "ArtworkConnection",
+        "kind": "LinkedField",
+        "name": "artworksForUser",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "HomeNewWorksForYouRail_artworksForUser"
+          }
+        ],
+        "storageKey": "artworksForUser(first:20,includeBackfill:true)"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeNewWorksForYouRail_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "ArtworkConnection",
+        "kind": "LinkedField",
+        "name": "artworksForUser",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "internalID",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slug",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "width",
+                            "value": 210
+                          }
+                        ],
+                        "concreteType": "ResizedImageUrl",
+                        "kind": "LinkedField",
+                        "name": "resized",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "src",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "srcSet",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          (v1/*: any*/)
+                        ],
+                        "storageKey": "resized(width:210)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "aspectRatio",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "imageTitle",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "title",
+                    "storageKey": null
+                  },
+                  (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "date",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_message",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "saleMessage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "cultural_maker",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "culturalMaker",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v3/*: any*/),
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "artists",
+                    "plural": true,
+                    "selections": [
+                      (v4/*: any*/),
+                      (v2/*: any*/),
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": "artists(shallow:true)"
+                  },
+                  {
+                    "alias": "collecting_institution",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "collectingInstitution",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v3/*: any*/),
+                    "concreteType": "Partner",
+                    "kind": "LinkedField",
+                    "name": "partner",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": "partner(shallow:true)"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Sale",
+                    "kind": "LinkedField",
+                    "name": "sale",
+                    "plural": false,
+                    "selections": [
+                      (v6/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cascadingEndTimeIntervalMinutes",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "extendedBiddingIntervalMinutes",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "startAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_auction",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isAuction",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_closed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isClosed",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      {
+                        "alias": "is_preview",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isPreview",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "display_timely_at",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "displayTimelyAt",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_artwork",
+                    "args": null,
+                    "concreteType": "SaleArtwork",
+                    "kind": "LinkedField",
+                    "name": "saleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotLabel",
+                        "storageKey": null
+                      },
+                      (v6/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "extendedBiddingEndAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "formattedEndDateTime",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "bidder_positions",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "bidderPositions",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "highest_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkHighestBid",
+                        "kind": "LinkedField",
+                        "name": "highestBid",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "opening_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkOpeningBid",
+                        "kind": "LinkedField",
+                        "name": "openingBid",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": null
+                      },
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v4/*: any*/),
+                  {
+                    "alias": "is_saved",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isSaved",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AttributionClass",
+                    "kind": "LinkedField",
+                    "name": "attributionClass",
+                    "plural": false,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ArtworkMedium",
+                    "kind": "LinkedField",
+                    "name": "mediumType",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Gene",
+                        "kind": "LinkedField",
+                        "name": "filterGene",
+                        "plural": false,
+                        "selections": (v8/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "is_biddable",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isBiddable",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "artworksForUser(first:20,includeBackfill:true)"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "f28a1a0148b5f321505c1def7d6a49c0",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artworksForUser": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkConnection"
+        },
+        "artworksForUser.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArtworkEdge"
+        },
+        "artworksForUser.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "artworksForUser.edges.node.artists": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Artist"
+        },
+        "artworksForUser.edges.node.artists.href": (v9/*: any*/),
+        "artworksForUser.edges.node.artists.id": (v10/*: any*/),
+        "artworksForUser.edges.node.artists.name": (v9/*: any*/),
+        "artworksForUser.edges.node.attributionClass": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AttributionClass"
+        },
+        "artworksForUser.edges.node.attributionClass.id": (v10/*: any*/),
+        "artworksForUser.edges.node.attributionClass.name": (v9/*: any*/),
+        "artworksForUser.edges.node.collecting_institution": (v9/*: any*/),
+        "artworksForUser.edges.node.cultural_maker": (v9/*: any*/),
+        "artworksForUser.edges.node.date": (v9/*: any*/),
+        "artworksForUser.edges.node.href": (v9/*: any*/),
+        "artworksForUser.edges.node.id": (v10/*: any*/),
+        "artworksForUser.edges.node.image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "artworksForUser.edges.node.image.aspectRatio": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Float"
+        },
+        "artworksForUser.edges.node.image.height": (v11/*: any*/),
+        "artworksForUser.edges.node.image.resized": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ResizedImageUrl"
+        },
+        "artworksForUser.edges.node.image.resized.height": (v11/*: any*/),
+        "artworksForUser.edges.node.image.resized.src": (v12/*: any*/),
+        "artworksForUser.edges.node.image.resized.srcSet": (v12/*: any*/),
+        "artworksForUser.edges.node.image.resized.width": (v11/*: any*/),
+        "artworksForUser.edges.node.imageTitle": (v9/*: any*/),
+        "artworksForUser.edges.node.internalID": (v10/*: any*/),
+        "artworksForUser.edges.node.is_biddable": (v13/*: any*/),
+        "artworksForUser.edges.node.is_saved": (v13/*: any*/),
+        "artworksForUser.edges.node.mediumType": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkMedium"
+        },
+        "artworksForUser.edges.node.mediumType.filterGene": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Gene"
+        },
+        "artworksForUser.edges.node.mediumType.filterGene.id": (v10/*: any*/),
+        "artworksForUser.edges.node.mediumType.filterGene.name": (v9/*: any*/),
+        "artworksForUser.edges.node.partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "artworksForUser.edges.node.partner.href": (v9/*: any*/),
+        "artworksForUser.edges.node.partner.id": (v10/*: any*/),
+        "artworksForUser.edges.node.partner.name": (v9/*: any*/),
+        "artworksForUser.edges.node.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "artworksForUser.edges.node.sale.cascadingEndTimeIntervalMinutes": (v11/*: any*/),
+        "artworksForUser.edges.node.sale.display_timely_at": (v9/*: any*/),
+        "artworksForUser.edges.node.sale.endAt": (v9/*: any*/),
+        "artworksForUser.edges.node.sale.extendedBiddingIntervalMinutes": (v11/*: any*/),
+        "artworksForUser.edges.node.sale.id": (v10/*: any*/),
+        "artworksForUser.edges.node.sale.is_auction": (v13/*: any*/),
+        "artworksForUser.edges.node.sale.is_closed": (v13/*: any*/),
+        "artworksForUser.edges.node.sale.is_preview": (v13/*: any*/),
+        "artworksForUser.edges.node.sale.startAt": (v9/*: any*/),
+        "artworksForUser.edges.node.sale_artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtwork"
+        },
+        "artworksForUser.edges.node.sale_artwork.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkCounts"
+        },
+        "artworksForUser.edges.node.sale_artwork.counts.bidder_positions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FormattedNumber"
+        },
+        "artworksForUser.edges.node.sale_artwork.endAt": (v9/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.extendedBiddingEndAt": (v9/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.formattedEndDateTime": (v9/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.highest_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkHighestBid"
+        },
+        "artworksForUser.edges.node.sale_artwork.highest_bid.display": (v9/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.id": (v10/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.lotID": (v9/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.lotLabel": (v9/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.opening_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkOpeningBid"
+        },
+        "artworksForUser.edges.node.sale_artwork.opening_bid.display": (v9/*: any*/),
+        "artworksForUser.edges.node.sale_message": (v9/*: any*/),
+        "artworksForUser.edges.node.slug": (v10/*: any*/),
+        "artworksForUser.edges.node.title": (v9/*: any*/)
+      }
+    },
+    "name": "HomeNewWorksForYouRail_Test_Query",
+    "operationKind": "query",
+    "text": "query HomeNewWorksForYouRail_Test_Query {\n  artworksForUser(includeBackfill: true, first: 20) {\n    ...HomeNewWorksForYouRail_artworksForUser\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeNewWorksForYouRail_artworksForUser on ArtworkConnection {\n  edges {\n    node {\n      internalID\n      slug\n      ...ShelfArtwork_artwork_1s6r3G\n      id\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+  }
+};
+})();
+(node as any).hash = '1c3fcdeabae66d34870c414f6077c820';
+export default node;

--- a/src/v2/__generated__/HomeNewWorksForYouRail_artworksForUser.graphql.ts
+++ b/src/v2/__generated__/HomeNewWorksForYouRail_artworksForUser.graphql.ts
@@ -1,0 +1,83 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeNewWorksForYouRail_artworksForUser = {
+    readonly edges: ReadonlyArray<{
+        readonly node: {
+            readonly internalID: string;
+            readonly slug: string;
+            readonly " $fragmentRefs": FragmentRefs<"ShelfArtwork_artwork">;
+        } | null;
+    } | null> | null;
+    readonly " $refType": "HomeNewWorksForYouRail_artworksForUser";
+};
+export type HomeNewWorksForYouRail_artworksForUser$data = HomeNewWorksForYouRail_artworksForUser;
+export type HomeNewWorksForYouRail_artworksForUser$key = {
+    readonly " $data"?: HomeNewWorksForYouRail_artworksForUser$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"HomeNewWorksForYouRail_artworksForUser">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "HomeNewWorksForYouRail_artworksForUser",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArtworkEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Artwork",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "internalID",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "slug",
+              "storageKey": null
+            },
+            {
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "width",
+                  "value": 210
+                }
+              ],
+              "kind": "FragmentSpread",
+              "name": "ShelfArtwork_artwork"
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "ArtworkConnection",
+  "abstractKey": null
+};
+(node as any).hash = 'c80497b8abf280f4f25d4ab38900546f';
+export default node;


### PR DESCRIPTION
This PR updates the homepage app to default to a rail powered by the `artworksForUser` query that ends up populating the rail with the newest affinity based artwork recs. Looks like this:

<img width="1661" alt="Screen Shot 2022-06-28 at 10 04 56 AM" src="https://user-images.githubusercontent.com/79799/176213825-32b0f552-66dd-4d46-956d-ea070f6253ce.png">

https://artsyproduct.atlassian.net/browse/GRO-1103

/cc @artsy/grow-devs 