### PR TITLE
feat(GRO-1097)(onboarding): Build top auction lots screen

### DIFF
--- a/src/v2/Apps/Onboarding/Components/OnboardingGene.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingGene.tsx
@@ -59,7 +59,7 @@ export const OnboardingGeneFragmentContainer = createFragmentContainer(
     gene: graphql`
       fragment OnboardingGene_gene on Gene {
         name
-        artworks: filterArtworksConnection(first: 40) {
+        artworks: filterArtworksConnection(first: 100) {
           edges {
             node {
               internalID

--- a/src/v2/Apps/Onboarding/Components/OnboardingGene.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingGene.tsx
@@ -1,0 +1,85 @@
+import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { OnboardingGene_gene } from "v2/__generated__/OnboardingGene_gene.graphql"
+import { OnboardingGeneQuery } from "v2/__generated__/OnboardingGeneQuery.graphql"
+import { OnboardingLoadingCollection } from "v2/Apps/Onboarding/Components/OnboardingLoadingCollection"
+import { ArtworkGridItemFragmentContainer } from "v2/Components/Artwork/GridItem"
+
+import { Masonry } from "v2/Components/Masonry"
+import { extractNodes } from "v2/Utils/extractNodes"
+
+interface OnboardingGeneProps {
+  gene: OnboardingGene_gene
+}
+
+const OnboardingGene: FC<OnboardingGeneProps> = ({ gene }) => {
+  const artworks = extractNodes(gene.artworks)
+
+  return (
+    <>
+      <Masonry>
+        {artworks.map((artwork, index) => {
+          return (
+            <ArtworkGridItemFragmentContainer artwork={artwork} key={index} />
+          )
+        })}
+      </Masonry>
+    </>
+  )
+}
+
+export const OnboardingGeneFragmentContainer = createFragmentContainer(
+  OnboardingGene,
+  {
+    gene: graphql`
+      fragment OnboardingGene_gene on Gene {
+        name
+        artworks: filterArtworksConnection(first: 10) {
+          counts {
+            total
+          }
+          edges {
+            node {
+              ...GridItem_artwork
+            }
+          }
+        }
+      }
+    `,
+  }
+)
+
+interface OnboardingGeneQueryRendererProps {
+  id: string
+}
+
+export const OnboardingGeneQueryRenderer: FC<OnboardingGeneQueryRendererProps> = ({
+  id,
+}) => {
+  return (
+    <SystemQueryRenderer<OnboardingGeneQuery>
+      query={graphql`
+        query OnboardingGeneQuery($id: String!) {
+          gene(id: $id) {
+            ...OnboardingGene_gene
+          }
+        }
+      `}
+      variables={{ id }}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props?.gene) {
+          return <OnboardingLoadingCollection />
+        }
+
+        return <OnboardingGeneFragmentContainer gene={props.gene} />
+      }}
+      placeholder={<OnboardingLoadingCollection />}
+    />
+  )
+}

--- a/src/v2/Apps/Onboarding/Components/OnboardingGene.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingGene.tsx
@@ -1,31 +1,55 @@
-import { FC } from "react"
+import { FC, Fragment } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { OnboardingGene_gene } from "v2/__generated__/OnboardingGene_gene.graphql"
 import { OnboardingGeneQuery } from "v2/__generated__/OnboardingGeneQuery.graphql"
 import { OnboardingLoadingCollection } from "v2/Apps/Onboarding/Components/OnboardingLoadingCollection"
 import { ArtworkGridItemFragmentContainer } from "v2/Components/Artwork/GridItem"
-
 import { Masonry } from "v2/Components/Masonry"
 import { extractNodes } from "v2/Utils/extractNodes"
+import { Box, Column, GridColumns, Spacer, Text } from "@artsy/palette"
+import { FollowGeneButtonFragmentContainer } from "v2/Components/FollowButton/FollowGeneButton"
 
 interface OnboardingGeneProps {
   gene: OnboardingGene_gene
+  description: JSX.Element
 }
 
-const OnboardingGene: FC<OnboardingGeneProps> = ({ gene }) => {
+const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
   const artworks = extractNodes(gene.artworks)
 
   return (
-    <>
-      <Masonry>
-        {artworks.map((artwork, index) => {
+    <Box padding={6}>
+      <GridColumns>
+        <Column span={10}>
+          <Text variant="xl" color="black100">
+            {gene.name}
+          </Text>
+        </Column>
+
+        <Column span={2}>
+          <FollowGeneButtonFragmentContainer gene={gene} />
+        </Column>
+      </GridColumns>
+
+      <Text variant="sm-display" color="black60" mt={2}>
+        {description}
+      </Text>
+
+      <Spacer mb={4} />
+
+      <Masonry columnCount={[2, 3, 4]}>
+        {artworks.map(artwork => {
           return (
-            <ArtworkGridItemFragmentContainer artwork={artwork} key={index} />
+            <Fragment key={artwork.internalID}>
+              <ArtworkGridItemFragmentContainer artwork={artwork} />
+
+              <Spacer mb={2} />
+            </Fragment>
           )
         })}
       </Masonry>
-    </>
+    </Box>
   )
 }
 
@@ -35,16 +59,15 @@ export const OnboardingGeneFragmentContainer = createFragmentContainer(
     gene: graphql`
       fragment OnboardingGene_gene on Gene {
         name
-        artworks: filterArtworksConnection(first: 10) {
-          counts {
-            total
-          }
+        artworks: filterArtworksConnection(first: 40) {
           edges {
             node {
+              internalID
               ...GridItem_artwork
             }
           }
         }
+        ...FollowGeneButton_gene
       }
     `,
   }
@@ -52,10 +75,12 @@ export const OnboardingGeneFragmentContainer = createFragmentContainer(
 
 interface OnboardingGeneQueryRendererProps {
   id: string
+  description: JSX.Element
 }
 
 export const OnboardingGeneQueryRenderer: FC<OnboardingGeneQueryRendererProps> = ({
   id,
+  description,
 }) => {
   return (
     <SystemQueryRenderer<OnboardingGeneQuery>
@@ -77,7 +102,12 @@ export const OnboardingGeneQueryRenderer: FC<OnboardingGeneQueryRendererProps> =
           return <OnboardingLoadingCollection />
         }
 
-        return <OnboardingGeneFragmentContainer gene={props.gene} />
+        return (
+          <OnboardingGeneFragmentContainer
+            gene={props.gene}
+            description={description}
+          />
+        )
       }}
       placeholder={<OnboardingLoadingCollection />}
     />

--- a/src/v2/Apps/Onboarding/Components/__tests__/OnboardingGene.jest.tsx
+++ b/src/v2/Apps/Onboarding/Components/__tests__/OnboardingGene.jest.tsx
@@ -1,0 +1,38 @@
+import { graphql } from "react-relay"
+import { screen } from "@testing-library/react"
+import { setupTestWrapperTL } from "v2/DevTools/setupTestWrapper"
+import { OnboardingGeneFragmentContainer } from "../OnboardingGene"
+
+jest.unmock("react-relay")
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: props => {
+    return (
+      // @ts-ignore
+      <OnboardingGeneFragmentContainer
+        {...props}
+        description={<>Example description</>}
+      />
+    )
+  },
+  query: graphql`
+    query OnboardingGene_Test_Query @relay_test_operation {
+      gene(id: "example") {
+        ...OnboardingGene_gene
+      }
+    }
+  `,
+})
+
+describe("OnboardingGene", () => {
+  it("renders correctly", () => {
+    renderWithRelay({
+      Gene: () => ({
+        name: "Example Gene",
+      }),
+    })
+
+    expect(screen.getByText("Example Gene")).toBeInTheDocument()
+    expect(screen.getByText("Example description")).toBeInTheDocument()
+  })
+})

--- a/src/v2/Apps/Onboarding/Views/OnboardingArtistsOnTheRise.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingArtistsOnTheRise.tsx
@@ -1,10 +1,17 @@
-import { Text, Flex } from "@artsy/palette"
 import { FC } from "react"
+import { OnboardingGeneQueryRenderer } from "../Components/OnboardingGene"
 
 export const OnboardingArtistsOnTheRise: FC = () => {
   return (
-    <Flex flexDirection="column">
-      <Text variant="lg-display">TODO: OnboardingArtistsOnTheRise</Text>
-    </Flex>
+    <OnboardingGeneQueryRenderer
+      id="artists-on-the-rise"
+      description={
+        <>
+          Click the heart to save artworks you love.
+          <br />
+          Follow the collection to stay up-to-date with artists on the rise.
+        </>
+      }
+    />
   )
 }

--- a/src/v2/Apps/Onboarding/Views/OnboardingCuratedArtworks.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingCuratedArtworks.tsx
@@ -1,10 +1,18 @@
-import { Text, Flex } from "@artsy/palette"
 import { FC } from "react"
+import { OnboardingGeneQueryRenderer } from "../Components/OnboardingGene"
 
 export const OnboardingCuratedArtworks: FC = () => {
   return (
-    <Flex flexDirection="column">
-      <Text variant="lg-display">TODO: OnboardingCuratedArtworks</Text>
-    </Flex>
+    <OnboardingGeneQueryRenderer
+      id="trove"
+      description={
+        <>
+          Save artworks to your profile by clicking the heart.
+          <br />
+          Follow the collection to stay up-to-date with emerging and
+          sought-after artists.
+        </>
+      }
+    />
   )
 }

--- a/src/v2/Apps/Onboarding/Views/OnboardingTopAuctionLots.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingTopAuctionLots.tsx
@@ -1,10 +1,6 @@
-import { Text, Flex } from "@artsy/palette"
 import { FC } from "react"
+import { OnboardingGeneQueryRenderer } from "v2/Apps/Onboarding/Components/OnboardingGene"
 
 export const OnboardingTopAuctionLots: FC = () => {
-  return (
-    <Flex flexDirection="column">
-      <Text variant="lg-display">TODO: OnboardingTopAuctionLots</Text>
-    </Flex>
-  )
+  return <OnboardingGeneQueryRenderer id="our-top-auction-lots" />
 }

--- a/src/v2/Apps/Onboarding/Views/OnboardingTopAuctionLots.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingTopAuctionLots.tsx
@@ -2,5 +2,16 @@ import { FC } from "react"
 import { OnboardingGeneQueryRenderer } from "v2/Apps/Onboarding/Components/OnboardingGene"
 
 export const OnboardingTopAuctionLots: FC = () => {
-  return <OnboardingGeneQueryRenderer id="our-top-auction-lots" />
+  return (
+    <OnboardingGeneQueryRenderer
+      id="our-top-auction-lots"
+      description={
+        <>
+          Click the heart to save artworks you love.
+          <br />
+          Follow the collection to stay up-to-date with the latest auction lots.
+        </>
+      }
+    />
+  )
 }

--- a/src/v2/Apps/Onboarding/config.ts
+++ b/src/v2/Apps/Onboarding/config.ts
@@ -11,8 +11,6 @@ export const useConfig = ({ basis, onDone }: UseConfig) => {
   const workflowEngine = useRef(
     new WorkflowEngine({
       workflow: [
-        // TODO: remove top auction lots from workflow
-        VIEW_TOP_AUCTION_LOTS,
         VIEW_WELCOME,
         VIEW_QUESTION_ONE,
         VIEW_QUESTION_TWO,

--- a/src/v2/Apps/Onboarding/config.ts
+++ b/src/v2/Apps/Onboarding/config.ts
@@ -11,6 +11,8 @@ export const useConfig = ({ basis, onDone }: UseConfig) => {
   const workflowEngine = useRef(
     new WorkflowEngine({
       workflow: [
+        // TODO: remove top auction lots from workflow
+        VIEW_TOP_AUCTION_LOTS,
         VIEW_WELCOME,
         VIEW_QUESTION_ONE,
         VIEW_QUESTION_TWO,

--- a/src/v2/__generated__/OnboardingGeneQuery.graphql.ts
+++ b/src/v2/__generated__/OnboardingGeneQuery.graphql.ts
@@ -139,7 +139,7 @@ fragment NewSaveButton_artwork on Artwork {
 
 fragment OnboardingGene_gene on Gene {
   name
-  artworks: filterArtworksConnection(first: 40) {
+  artworks: filterArtworksConnection(first: 100) {
     edges {
       node {
         internalID
@@ -286,7 +286,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "first",
-                "value": 40
+                "value": 100
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -623,7 +623,7 @@ return {
               },
               (v6/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:40)"
+            "storageKey": "filterArtworksConnection(first:100)"
           },
           (v6/*: any*/),
           (v9/*: any*/),
@@ -641,12 +641,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8157a1422839486d91ef385ab3d7daed",
+    "cacheID": "d3400e43651c77b9c4e1e817ffca31bd",
     "id": null,
     "metadata": {},
     "name": "OnboardingGeneQuery",
     "operationKind": "query",
-    "text": "query OnboardingGeneQuery(\n  $id: String!\n) {\n  gene(id: $id) {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  name\n  artworks: filterArtworksConnection(first: 40) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n  ...FollowGeneButton_gene\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query OnboardingGeneQuery(\n  $id: String!\n) {\n  gene(id: $id) {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  name\n  artworks: filterArtworksConnection(first: 100) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n  ...FollowGeneButton_gene\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/OnboardingGeneQuery.graphql.ts
+++ b/src/v2/__generated__/OnboardingGeneQuery.graphql.ts
@@ -1,0 +1,654 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type OnboardingGeneQueryVariables = {
+    id: string;
+};
+export type OnboardingGeneQueryResponse = {
+    readonly gene: {
+        readonly " $fragmentRefs": FragmentRefs<"OnboardingGene_gene">;
+    } | null;
+};
+export type OnboardingGeneQuery = {
+    readonly response: OnboardingGeneQueryResponse;
+    readonly variables: OnboardingGeneQueryVariables;
+};
+
+
+
+/*
+query OnboardingGeneQuery(
+  $id: String!
+) {
+  gene(id: $id) {
+    ...OnboardingGene_gene
+    id
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    endAt
+    cascadingEndTimeIntervalMinutes
+    extendedBiddingIntervalMinutes
+    startAt
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    lotID
+    lotLabel
+    endAt
+    extendedBiddingEndAt
+    formattedEndDateTime
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+  ...NewSaveButton_artwork
+  ...HoverDetails_artwork
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  artistNames
+  href
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+
+fragment HoverDetails_artwork on Artwork {
+  internalID
+  attributionClass {
+    name
+    id
+  }
+  mediumType {
+    filterGene {
+      name
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  href
+}
+
+fragment NewSaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment OnboardingGene_gene on Gene {
+  name
+  artworks: filterArtworksConnection(first: 10) {
+    counts {
+      total
+    }
+    edges {
+      node {
+        ...GridItem_artwork
+        id
+      }
+    }
+    id
+  }
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v8 = [
+  (v2/*: any*/),
+  (v5/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "OnboardingGeneQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Gene",
+        "kind": "LinkedField",
+        "name": "gene",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "OnboardingGene_gene"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "OnboardingGeneQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Gene",
+        "kind": "LinkedField",
+        "name": "gene",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": "artworks",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "total",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "image_title",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "imageTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "placeholder",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large"
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:\"large\")"
+                          },
+                          {
+                            "alias": "aspect_ratio",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "artistNames",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v4/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v5/*: any*/),
+                          (v3/*: any*/),
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v4/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v3/*: any*/),
+                          (v5/*: any*/)
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          (v6/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "cascadingEndTimeIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "startAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v5/*: any*/),
+                          {
+                            "alias": "is_preview",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isPreview",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "display_timely_at",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "displayTimelyAt",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotID",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotLabel",
+                            "storageKey": null
+                          },
+                          (v6/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingEndAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "formattedEndDateTime",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v7/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v7/*: any*/),
+                            "storageKey": null
+                          },
+                          (v5/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "AttributionClass",
+                        "kind": "LinkedField",
+                        "name": "attributionClass",
+                        "plural": false,
+                        "selections": (v8/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkMedium",
+                        "kind": "LinkedField",
+                        "name": "mediumType",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Gene",
+                            "kind": "LinkedField",
+                            "name": "filterGene",
+                            "plural": false,
+                            "selections": (v8/*: any*/),
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_biddable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isBiddable",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:10)"
+          },
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "237356535bb72ee3cdd253f1837c5411",
+    "id": null,
+    "metadata": {},
+    "name": "OnboardingGeneQuery",
+    "operationKind": "query",
+    "text": "query OnboardingGeneQuery(\n  $id: String!\n) {\n  gene(id: $id) {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  name\n  artworks: filterArtworksConnection(first: 10) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+  }
+};
+})();
+(node as any).hash = '12d0a4f322ee457beee90abcfe58cceb';
+export default node;

--- a/src/v2/__generated__/OnboardingGene_Test_Query.graphql.ts
+++ b/src/v2/__generated__/OnboardingGene_Test_Query.graphql.ts
@@ -4,26 +4,22 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type OnboardingGeneQueryVariables = {
-    id: string;
-};
-export type OnboardingGeneQueryResponse = {
+export type OnboardingGene_Test_QueryVariables = {};
+export type OnboardingGene_Test_QueryResponse = {
     readonly gene: {
         readonly " $fragmentRefs": FragmentRefs<"OnboardingGene_gene">;
     } | null;
 };
-export type OnboardingGeneQuery = {
-    readonly response: OnboardingGeneQueryResponse;
-    readonly variables: OnboardingGeneQueryVariables;
+export type OnboardingGene_Test_Query = {
+    readonly response: OnboardingGene_Test_QueryResponse;
+    readonly variables: OnboardingGene_Test_QueryVariables;
 };
 
 
 
 /*
-query OnboardingGeneQuery(
-  $id: String!
-) {
-  gene(id: $id) {
+query OnboardingGene_Test_Query {
+  gene(id: "example") {
     ...OnboardingGene_gene
     id
   }
@@ -164,61 +160,54 @@ fragment SaveButton_artwork on Artwork {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "id"
-  }
-],
-v1 = [
-  {
-    "kind": "Variable",
+    "kind": "Literal",
     "name": "id",
-    "variableName": "id"
+    "value": "example"
   }
 ],
-v2 = {
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v5 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v8 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -227,27 +216,57 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v10 = [
-  (v2/*: any*/),
-  (v6/*: any*/)
-];
+v9 = [
+  (v1/*: any*/),
+  (v5/*: any*/)
+],
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Gene"
+},
+v11 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v12 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v13 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v14 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+};
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "OnboardingGeneQuery",
+    "name": "OnboardingGene_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Gene",
         "kind": "LinkedField",
         "name": "gene",
@@ -259,7 +278,7 @@ return {
             "name": "OnboardingGene_gene"
           }
         ],
-        "storageKey": null
+        "storageKey": "gene(id:\"example\")"
       }
     ],
     "type": "Query",
@@ -267,19 +286,19 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "OnboardingGeneQuery",
+    "name": "OnboardingGene_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Gene",
         "kind": "LinkedField",
         "name": "gene",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
+          (v1/*: any*/),
           {
             "alias": "artworks",
             "args": [
@@ -310,7 +329,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -370,7 +389,7 @@ return {
                         "name": "artistNames",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -394,15 +413,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v4/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v6/*: any*/),
-                          (v4/*: any*/),
-                          (v2/*: any*/)
+                          (v5/*: any*/),
+                          (v3/*: any*/),
+                          (v1/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -415,15 +434,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v4/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v2/*: any*/),
-                          (v4/*: any*/),
-                          (v6/*: any*/)
+                          (v1/*: any*/),
+                          (v3/*: any*/),
+                          (v5/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -435,7 +454,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -471,7 +490,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": "is_preview",
                             "args": null,
@@ -511,7 +530,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -551,7 +570,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v7/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -561,15 +580,15 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v7/*: any*/),
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v6/*: any*/),
-                      (v9/*: any*/),
+                      (v5/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -584,7 +603,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v10/*: any*/),
+                        "selections": (v9/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -602,7 +621,7 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -621,13 +640,13 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(first:40)"
           },
-          (v6/*: any*/),
-          (v9/*: any*/),
-          (v3/*: any*/),
+          (v5/*: any*/),
+          (v8/*: any*/),
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -636,19 +655,162 @@ return {
             "storageKey": null
           }
         ],
-        "storageKey": null
+        "storageKey": "gene(id:\"example\")"
       }
     ]
   },
   "params": {
-    "cacheID": "8157a1422839486d91ef385ab3d7daed",
+    "cacheID": "998c1aa5a0d6df7da2142df458ec51a3",
     "id": null,
-    "metadata": {},
-    "name": "OnboardingGeneQuery",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "gene": (v10/*: any*/),
+        "gene.artworks": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FilterArtworksConnection"
+        },
+        "gene.artworks.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "FilterArtworksEdge"
+        },
+        "gene.artworks.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "gene.artworks.edges.node.artistNames": (v11/*: any*/),
+        "gene.artworks.edges.node.artists": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Artist"
+        },
+        "gene.artworks.edges.node.artists.href": (v11/*: any*/),
+        "gene.artworks.edges.node.artists.id": (v12/*: any*/),
+        "gene.artworks.edges.node.artists.name": (v11/*: any*/),
+        "gene.artworks.edges.node.attributionClass": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AttributionClass"
+        },
+        "gene.artworks.edges.node.attributionClass.id": (v12/*: any*/),
+        "gene.artworks.edges.node.attributionClass.name": (v11/*: any*/),
+        "gene.artworks.edges.node.collecting_institution": (v11/*: any*/),
+        "gene.artworks.edges.node.cultural_maker": (v11/*: any*/),
+        "gene.artworks.edges.node.date": (v11/*: any*/),
+        "gene.artworks.edges.node.href": (v11/*: any*/),
+        "gene.artworks.edges.node.id": (v12/*: any*/),
+        "gene.artworks.edges.node.image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "gene.artworks.edges.node.image.aspect_ratio": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Float"
+        },
+        "gene.artworks.edges.node.image.placeholder": (v11/*: any*/),
+        "gene.artworks.edges.node.image.url": (v11/*: any*/),
+        "gene.artworks.edges.node.image_title": (v11/*: any*/),
+        "gene.artworks.edges.node.internalID": (v12/*: any*/),
+        "gene.artworks.edges.node.is_biddable": (v13/*: any*/),
+        "gene.artworks.edges.node.is_saved": (v13/*: any*/),
+        "gene.artworks.edges.node.mediumType": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkMedium"
+        },
+        "gene.artworks.edges.node.mediumType.filterGene": (v10/*: any*/),
+        "gene.artworks.edges.node.mediumType.filterGene.id": (v12/*: any*/),
+        "gene.artworks.edges.node.mediumType.filterGene.name": (v11/*: any*/),
+        "gene.artworks.edges.node.partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "gene.artworks.edges.node.partner.href": (v11/*: any*/),
+        "gene.artworks.edges.node.partner.id": (v12/*: any*/),
+        "gene.artworks.edges.node.partner.name": (v11/*: any*/),
+        "gene.artworks.edges.node.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "gene.artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v14/*: any*/),
+        "gene.artworks.edges.node.sale.display_timely_at": (v11/*: any*/),
+        "gene.artworks.edges.node.sale.endAt": (v11/*: any*/),
+        "gene.artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v14/*: any*/),
+        "gene.artworks.edges.node.sale.id": (v12/*: any*/),
+        "gene.artworks.edges.node.sale.is_auction": (v13/*: any*/),
+        "gene.artworks.edges.node.sale.is_closed": (v13/*: any*/),
+        "gene.artworks.edges.node.sale.is_preview": (v13/*: any*/),
+        "gene.artworks.edges.node.sale.startAt": (v11/*: any*/),
+        "gene.artworks.edges.node.sale_artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtwork"
+        },
+        "gene.artworks.edges.node.sale_artwork.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkCounts"
+        },
+        "gene.artworks.edges.node.sale_artwork.counts.bidder_positions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FormattedNumber"
+        },
+        "gene.artworks.edges.node.sale_artwork.endAt": (v11/*: any*/),
+        "gene.artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v11/*: any*/),
+        "gene.artworks.edges.node.sale_artwork.formattedEndDateTime": (v11/*: any*/),
+        "gene.artworks.edges.node.sale_artwork.highest_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkHighestBid"
+        },
+        "gene.artworks.edges.node.sale_artwork.highest_bid.display": (v11/*: any*/),
+        "gene.artworks.edges.node.sale_artwork.id": (v12/*: any*/),
+        "gene.artworks.edges.node.sale_artwork.lotID": (v11/*: any*/),
+        "gene.artworks.edges.node.sale_artwork.lotLabel": (v11/*: any*/),
+        "gene.artworks.edges.node.sale_artwork.opening_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkOpeningBid"
+        },
+        "gene.artworks.edges.node.sale_artwork.opening_bid.display": (v11/*: any*/),
+        "gene.artworks.edges.node.sale_message": (v11/*: any*/),
+        "gene.artworks.edges.node.slug": (v12/*: any*/),
+        "gene.artworks.edges.node.title": (v11/*: any*/),
+        "gene.artworks.id": (v12/*: any*/),
+        "gene.id": (v12/*: any*/),
+        "gene.internalID": (v12/*: any*/),
+        "gene.isFollowed": (v13/*: any*/),
+        "gene.name": (v11/*: any*/),
+        "gene.slug": (v12/*: any*/)
+      }
+    },
+    "name": "OnboardingGene_Test_Query",
     "operationKind": "query",
-    "text": "query OnboardingGeneQuery(\n  $id: String!\n) {\n  gene(id: $id) {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  name\n  artworks: filterArtworksConnection(first: 40) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n  ...FollowGeneButton_gene\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query OnboardingGene_Test_Query {\n  gene(id: \"example\") {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  name\n  artworks: filterArtworksConnection(first: 40) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n  ...FollowGeneButton_gene\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();
-(node as any).hash = '12d0a4f322ee457beee90abcfe58cceb';
+(node as any).hash = '712839d653d2a3e80adb4cef64ec6aec';
 export default node;

--- a/src/v2/__generated__/OnboardingGene_Test_Query.graphql.ts
+++ b/src/v2/__generated__/OnboardingGene_Test_Query.graphql.ts
@@ -135,7 +135,7 @@ fragment NewSaveButton_artwork on Artwork {
 
 fragment OnboardingGene_gene on Gene {
   name
-  artworks: filterArtworksConnection(first: 40) {
+  artworks: filterArtworksConnection(first: 100) {
     edges {
       node {
         internalID
@@ -305,7 +305,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "first",
-                "value": 40
+                "value": 100
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -642,7 +642,7 @@ return {
               },
               (v5/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:40)"
+            "storageKey": "filterArtworksConnection(first:100)"
           },
           (v5/*: any*/),
           (v8/*: any*/),
@@ -660,7 +660,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "998c1aa5a0d6df7da2142df458ec51a3",
+    "cacheID": "16575049d003c0e7d2ef49e93f457396",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -808,7 +808,7 @@ return {
     },
     "name": "OnboardingGene_Test_Query",
     "operationKind": "query",
-    "text": "query OnboardingGene_Test_Query {\n  gene(id: \"example\") {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  name\n  artworks: filterArtworksConnection(first: 40) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n  ...FollowGeneButton_gene\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query OnboardingGene_Test_Query {\n  gene(id: \"example\") {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  name\n  artworks: filterArtworksConnection(first: 100) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n  ...FollowGeneButton_gene\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/OnboardingGene_gene.graphql.ts
+++ b/src/v2/__generated__/OnboardingGene_gene.graphql.ts
@@ -7,15 +7,14 @@ import { FragmentRefs } from "relay-runtime";
 export type OnboardingGene_gene = {
     readonly name: string | null;
     readonly artworks: {
-        readonly counts: {
-            readonly total: number | null;
-        } | null;
         readonly edges: ReadonlyArray<{
             readonly node: {
+                readonly internalID: string;
                 readonly " $fragmentRefs": FragmentRefs<"GridItem_artwork">;
             } | null;
         } | null> | null;
     } | null;
+    readonly " $fragmentRefs": FragmentRefs<"FollowGeneButton_gene">;
     readonly " $refType": "OnboardingGene_gene";
 };
 export type OnboardingGene_gene$data = OnboardingGene_gene;
@@ -45,7 +44,7 @@ const node: ReaderFragment = {
         {
           "kind": "Literal",
           "name": "first",
-          "value": 10
+          "value": 40
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -53,24 +52,6 @@ const node: ReaderFragment = {
       "name": "filterArtworksConnection",
       "plural": false,
       "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "FilterArtworksCounts",
-          "kind": "LinkedField",
-          "name": "counts",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "total",
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        },
         {
           "alias": null,
           "args": null,
@@ -88,6 +69,13 @@ const node: ReaderFragment = {
               "plural": false,
               "selections": [
                 {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
                   "args": null,
                   "kind": "FragmentSpread",
                   "name": "GridItem_artwork"
@@ -99,11 +87,16 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "filterArtworksConnection(first:10)"
+      "storageKey": "filterArtworksConnection(first:40)"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "FollowGeneButton_gene"
     }
   ],
   "type": "Gene",
   "abstractKey": null
 };
-(node as any).hash = 'd71d47d1332404b48921af5d8835ae91';
+(node as any).hash = '364d09440a0aba97c794209a5b135468';
 export default node;

--- a/src/v2/__generated__/OnboardingGene_gene.graphql.ts
+++ b/src/v2/__generated__/OnboardingGene_gene.graphql.ts
@@ -1,0 +1,109 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type OnboardingGene_gene = {
+    readonly name: string | null;
+    readonly artworks: {
+        readonly counts: {
+            readonly total: number | null;
+        } | null;
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly " $fragmentRefs": FragmentRefs<"GridItem_artwork">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "OnboardingGene_gene";
+};
+export type OnboardingGene_gene$data = OnboardingGene_gene;
+export type OnboardingGene_gene$key = {
+    readonly " $data"?: OnboardingGene_gene$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"OnboardingGene_gene">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "OnboardingGene_gene",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": "artworks",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 10
+        }
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "kind": "LinkedField",
+      "name": "filterArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "FilterArtworksCounts",
+          "kind": "LinkedField",
+          "name": "counts",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "total",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "FilterArtworksEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "GridItem_artwork"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "filterArtworksConnection(first:10)"
+    }
+  ],
+  "type": "Gene",
+  "abstractKey": null
+};
+(node as any).hash = 'd71d47d1332404b48921af5d8835ae91';
+export default node;

--- a/src/v2/__generated__/OnboardingGene_gene.graphql.ts
+++ b/src/v2/__generated__/OnboardingGene_gene.graphql.ts
@@ -44,7 +44,7 @@ const node: ReaderFragment = {
         {
           "kind": "Literal",
           "name": "first",
-          "value": 40
+          "value": 100
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -87,7 +87,7 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "filterArtworksConnection(first:40)"
+      "storageKey": "filterArtworksConnection(first:100)"
     },
     {
       "args": null,
@@ -98,5 +98,5 @@ const node: ReaderFragment = {
   "type": "Gene",
   "abstractKey": null
 };
-(node as any).hash = '364d09440a0aba97c794209a5b135468';
+(node as any).hash = 'c347d9a61ca6c0d74296d14e3b296dda';
 export default node;


### PR DESCRIPTION
The type of this PR is: *feat*

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1097]

### Description
The intention of this code is to build out the Top Auction Lots rewards screen that occurs at the end of the Onboarding workflow. By writing the component to be re-usable based on gene name and sub-header description as a prop, the config for Trove and Artists on the Rise reward screens are also included in this pr. 

Acceptance criteria: 

- [x] user sees header copy and sub-header copy
- [x] user sees top auction lots collection 
- [x] artworks are populated by the above gene linked
- [x] user can follow the collection
- [x] user can favorite artworks
- [x] user can scroll through artworks grid 
- [x] user sees up to 100 artworks (no pagination) 
- [x] user can click x and leave the onboarding flow 

Top Auction Lots
<img width="865" alt="Screen Shot 2022-06-29 at 3 48 08 PM" src="https://user-images.githubusercontent.com/23108927/176542436-078d5b0a-552b-4e1b-ad49-eb890fa3c559.png">

Artists on the Rise
<img width="863" alt="Screen Shot 2022-06-29 at 3 59 13 PM" src="https://user-images.githubusercontent.com/23108927/176543747-86deff3b-62ab-4028-9cd9-5deaed4d647a.png">


Trove
<img width="860" alt="Screen Shot 2022-06-29 at 3 58 45 PM" src="https://user-images.githubusercontent.com/23108927/176543684-942e0d63-cab4-436a-9f90-0e8a7f20c35c.png">


<!-- Implementation description -->

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1097]: https://artsyproduct.atlassian.net/browse/GRO-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ