### PR TITLE
fix(tracking): add correct action type for clicked payment method

### DIFF
--- a/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -58,7 +58,7 @@ export const PaymentContent: FC<Props> = props => {
     const event = {
       subject: "click_payment_method",
       payment_method: val,
-      action: ActionType.clickedChangePaymentMethod,
+      action: ActionType.clickedPaymentMethod,
       flow: order.mode!,
       context_page_owner_type: OwnerType.ordersPayment,
       order_id: order.internalID,

--- a/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -323,7 +323,7 @@ describe("Payment", () => {
       page.selectPaymentMethod(1)
 
       expect(trackEvent).toHaveBeenCalledWith({
-        action: "clickedChangePaymentMethod",
+        action: "clickedPaymentMethod",
         amount: "$12,000",
         context_page_owner_type: "orders-payment",
         currency: "USD",
@@ -342,7 +342,7 @@ describe("Payment", () => {
       page.selectPaymentMethod(0)
 
       expect(trackEvent).toHaveBeenCalledWith({
-        action: "clickedChangePaymentMethod",
+        action: "clickedPaymentMethod",
         amount: "$12,000",
         context_page_owner_type: "orders-payment",
         currency: "USD",
@@ -468,7 +468,7 @@ describe("Payment", () => {
       page.selectPaymentMethod(1)
 
       expect(trackEvent).toHaveBeenCalledWith({
-        action: "clickedChangePaymentMethod",
+        action: "clickedPaymentMethod",
         amount: "$12,000",
         context_page_owner_type: "orders-payment",
         currency: "USD",


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

This adds the correct action type for clicked payment method. 
[Slack thread](https://artsy.slack.com/archives/C02JHHHKP5K/p1656518383285269)
<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ