### PR TITLE
refactor(followbutton): cleans up gene/profile follow buttons

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
@@ -121,9 +121,8 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends Component<
                   showPartnerFollow && partner?.profile ? (
                     <FollowProfileButton
                       profile={partner.profile}
-                      user={user}
                       contextModule={ContextModule.aboutTheWork}
-                      buttonProps={{ size: "small" }}
+                      size="small"
                     />
                   ) : undefined
                 }

--- a/src/v2/Apps/Partner/Components/PartnerHeader/index.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerHeader/index.tsx
@@ -12,7 +12,6 @@ import {
 import { PartnerHeaderAddress } from "./PartnerHeaderAddress"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FollowProfileButtonFragmentContainer as FollowProfileButton } from "v2/Components/FollowButton/FollowProfileButton"
-import { useSystemContext } from "v2/System"
 import { ContextModule } from "@artsy/cohesion"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { PartnerHeader_partner } from "v2/__generated__/PartnerHeader_partner.graphql"
@@ -27,7 +26,6 @@ export const HeaderImage = styled(Image)`
 `
 
 export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
-  const { user } = useSystemContext()
   // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   const hasLocations = partner.locations?.totalCount > 0
   // TODO: Remove after page migration.
@@ -82,9 +80,8 @@ export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
         {canFollow && (
           <FollowProfileButton
             profile={partner.profile}
-            user={user}
             contextModule={ContextModule.partnerHeader}
-            buttonProps={{ width: "100%" }}
+            width="100%"
           />
         )}
       </Column>

--- a/src/v2/Apps/Partners/Components/PartnersFeaturedCarouselCell.tsx
+++ b/src/v2/Apps/Partners/Components/PartnersFeaturedCarouselCell.tsx
@@ -3,7 +3,6 @@ import { Box, Flex, Image, Text } from "@artsy/palette"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FollowProfileButtonFragmentContainer } from "v2/Components/FollowButton/FollowProfileButton"
-import { useSystemContext } from "v2/System"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { PartnersFeaturedCarouselCell_profile } from "v2/__generated__/PartnersFeaturedCarouselCell_profile.graphql"
 
@@ -14,8 +13,6 @@ interface PartnersFeaturedCarouselCellProps {
 const PartnersFeaturedCarouselCell: FC<PartnersFeaturedCarouselCellProps> = ({
   profile,
 }) => {
-  const { user } = useSystemContext()
-
   const partner = profile.owner
 
   if (!partner) return null
@@ -75,7 +72,6 @@ const PartnersFeaturedCarouselCell: FC<PartnersFeaturedCarouselCellProps> = ({
 
             <FollowProfileButtonFragmentContainer
               profile={profile}
-              user={user}
               contextModule={ContextModule.featuredGalleriesRail}
             />
           </RouterLink>

--- a/src/v2/Components/EntityHeaders/EntityHeaderFair.tsx
+++ b/src/v2/Components/EntityHeaders/EntityHeaderFair.tsx
@@ -2,7 +2,6 @@ import { ContextModule } from "@artsy/cohesion"
 import { BoxProps, Flex, Text, Avatar } from "@artsy/palette"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { useSystemContext } from "v2/System"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { EntityHeaderFair_fair } from "v2/__generated__/EntityHeaderFair_fair.graphql"
 import { FollowProfileButtonFragmentContainer } from "../FollowButton/FollowProfileButton"
@@ -21,8 +20,6 @@ const EntityHeaderFair: FC<EntityHeaderFairProps> = ({
   FollowButton,
   ...rest
 }) => {
-  const { user } = useSystemContext()
-
   const image = fair?.avatar?.cropped
   const meta = [fair.startAt, fair.endAt].filter(Boolean).join(" – ")
   const initials = fair.profile?.initials ?? fair.name?.[0]
@@ -62,10 +59,9 @@ const EntityHeaderFair: FC<EntityHeaderFairProps> = ({
 
       {FollowButton || (
         <FollowProfileButtonFragmentContainer
-          user={user}
           profile={fair.profile!}
           contextModule={ContextModule.fairsHeader}
-          buttonProps={{ size: "small" }}
+          size="small"
         />
       )}
     </Flex>

--- a/src/v2/Components/EntityHeaders/EntityHeaderFairOrganizer.tsx
+++ b/src/v2/Components/EntityHeaders/EntityHeaderFairOrganizer.tsx
@@ -2,7 +2,6 @@ import { ContextModule } from "@artsy/cohesion"
 import { Text, BoxProps, Flex, Avatar } from "@artsy/palette"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { useSystemContext } from "v2/System"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { EntityHeaderFairOrganizer_fairOrganizer } from "v2/__generated__/EntityHeaderFairOrganizer_fairOrganizer.graphql"
 import { FollowProfileButtonFragmentContainer } from "../FollowButton/FollowProfileButton"
@@ -21,8 +20,6 @@ const EntityHeaderFairOrganizer: FC<EntityHeaderFairOrganizerProps> = ({
   FollowButton,
   ...rest
 }) => {
-  const { user } = useSystemContext()
-
   const initials = fairOrganizer.profile?.initials ?? fairOrganizer.name?.[0]
   const image = fairOrganizer.profile?.avatar?.cropped
   const totalCount = fairOrganizer.fairsConnection?.totalCount ?? 0
@@ -68,10 +65,9 @@ const EntityHeaderFairOrganizer: FC<EntityHeaderFairOrganizerProps> = ({
 
       {FollowButton || (
         <FollowProfileButtonFragmentContainer
-          user={user}
           profile={fairOrganizer.profile!}
           contextModule={ContextModule.fairsHeader}
-          buttonProps={{ size: "small" }}
+          size="small"
         />
       )}
     </Flex>

--- a/src/v2/Components/EntityHeaders/EntityHeaderPartner.tsx
+++ b/src/v2/Components/EntityHeaders/EntityHeaderPartner.tsx
@@ -3,7 +3,6 @@ import { Avatar, BoxProps, Text, Flex, Label } from "@artsy/palette"
 import { compact, uniq } from "lodash"
 import { FC, Fragment } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { useSystemContext } from "v2/System"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { extractNodes } from "v2/Utils/extractNodes"
 import { EntityHeaderPartner_partner } from "v2/__generated__/EntityHeaderPartner_partner.graphql"
@@ -29,8 +28,6 @@ const EntityHeaderPartner: FC<EntityHeaderPartnerProps> = ({
   onClick,
   ...rest
 }) => {
-  const { user } = useSystemContext()
-
   const locations = extractNodes(partner.locationsConnection)
   const meta = uniq(locations.map(location => location.city?.trim())).join(", ")
   const image =
@@ -89,10 +86,9 @@ const EntityHeaderPartner: FC<EntityHeaderPartnerProps> = ({
       {isFollowable &&
         (FollowButton || (
           <FollowProfileButtonFragmentContainer
-            user={user}
             profile={partner.profile!}
             contextModule={ContextModule.partnerHeader}
-            buttonProps={{ size: "small" }}
+            size="small"
           />
         ))}
     </Flex>

--- a/src/v2/Components/FollowButton/Button.tsx
+++ b/src/v2/Components/FollowButton/Button.tsx
@@ -1,24 +1,32 @@
 import { Box, Button, ButtonProps } from "@artsy/palette"
-import { useState } from "react"
-import * as React from "react"
+import {
+  forwardRef,
+  ForwardRefExoticComponent,
+  MouseEventHandler,
+  Ref,
+  useMemo,
+  useState,
+} from "react"
 
 interface FollowButtonProps {
   isFollowed?: boolean
   buttonProps?: Omit<Partial<ButtonProps>, "variant">
-  handleFollow?: React.MouseEventHandler<HTMLButtonElement>
+  handleFollow?: MouseEventHandler<HTMLButtonElement>
 }
 
-export const FollowButton: React.ForwardRefExoticComponent<
-  FollowButtonProps & { ref?: React.Ref<HTMLElement> }
-> = React.forwardRef(
+export const FollowButton: ForwardRefExoticComponent<
+  FollowButtonProps & { ref?: Ref<HTMLElement> }
+> = forwardRef(
   ({ isFollowed = false, buttonProps = {}, handleFollow }, forwardedRef) => {
     const [showUnfollow, setShowUnfollow] = useState(false)
 
-    const text = isFollowed
-      ? showUnfollow
-        ? "Unfollow"
-        : "Following"
-      : "Follow"
+    const label = useMemo(() => {
+      if (isFollowed && showUnfollow) return "Unfollow"
+
+      if (isFollowed) return "Following"
+
+      return "Follow"
+    }, [isFollowed, showUnfollow])
 
     return (
       <Button
@@ -53,7 +61,7 @@ export const FollowButton: React.ForwardRefExoticComponent<
             left="50%"
             style={{ transform: "translate(-50%, -50%)" }}
           >
-            {text}
+            {label}
           </Box>
         </Box>
       </Button>

--- a/src/v2/Components/FollowButton/FollowProfileButton.tsx
+++ b/src/v2/Components/FollowButton/FollowProfileButton.tsx
@@ -1,177 +1,102 @@
-import { FollowProfileButtonMutation } from "v2/__generated__/FollowProfileButtonMutation.graphql"
-import * as Artsy from "v2/System"
 import * as React from "react"
-import track, { TrackingProp } from "react-tracking"
-import { FollowProfileButton_profile } from "../../__generated__/FollowProfileButton_profile.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useSystemContext } from "v2/System/useSystemContext"
 import { FollowButton } from "./Button"
+import { FollowProfileButton_profile } from "v2/__generated__/FollowProfileButton_profile.graphql"
+import { ButtonProps } from "@artsy/palette"
 import { openAuthToSatisfyIntent } from "v2/Utils/openAuthModal"
-import {
-  AuthContextModule,
-  FollowedArgs,
-  Intent,
-  followedPartner,
-  unfollowedPartner,
-} from "@artsy/cohesion"
-import {
-  AnalyticsContextProps,
-  withAnalyticsContext,
-} from "v2/System/Analytics/AnalyticsContext"
-import { ButtonProps, Clickable } from "@artsy/palette"
-import {
-  RelayProp,
-  commitMutation,
-  createFragmentContainer,
-  graphql,
-} from "react-relay"
+import { Intent, AuthContextModule, ContextModule } from "@artsy/cohesion"
+import { useMutation } from "v2/Utils/Hooks/useMutation"
+import { useFollowButtonTracking } from "./useFollowButtonTracking"
 
-interface Props
-  extends React.HTMLProps<FollowProfileButton>,
-    Artsy.SystemContextProps,
-    AnalyticsContextProps {
-  relay?: RelayProp
-  profile?: FollowProfileButton_profile
-  tracking?: TrackingProp
-  contextModule: AuthContextModule
-  /**
-   * Pass palette props to button
-   */
-  buttonProps?: Partial<ButtonProps>
-  /**
-   * Custom renderer if palette button is not desired
-   */
-  render?: (profile: FollowProfileButton_profile) => JSX.Element
+interface FollowProfileButtonProps extends Omit<ButtonProps, "variant"> {
+  profile: FollowProfileButton_profile
+  contextModule?: AuthContextModule
 }
 
-export class FollowProfileButton extends React.Component<Props> {
-  static defaultProps = {
-    buttonProps: {},
-  }
+const FollowProfileButton: React.FC<FollowProfileButtonProps> = ({
+  profile,
+  contextModule = ContextModule.partnerHeader,
+  ...rest
+}) => {
+  const { isLoggedIn, mediator } = useSystemContext()
 
-  trackFollow = () => {
-    const {
-      tracking,
-      profile,
-      contextModule,
-      contextPageOwnerId,
-      contextPageOwnerSlug,
-      contextPageOwnerType,
-    } = this.props
+  const { trackFollow } = useFollowButtonTracking({
+    ownerId: profile.internalID,
+    ownerSlug: profile.slug,
+    contextModule,
+  })
 
-    const args: FollowedArgs = {
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      ownerId: profile.internalID,
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      ownerSlug: profile.slug,
-      contextModule,
-      contextOwnerId: contextPageOwnerId,
-      contextOwnerSlug: contextPageOwnerSlug,
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      contextOwnerType: contextPageOwnerType,
-    }
-
-    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-    const analyticsData = profile.is_followed
-      ? unfollowedPartner(args)
-      : followedPartner(args)
-
-    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-    tracking.trackEvent(analyticsData)
-  }
-
-  handleFollow = e => {
-    e.preventDefault() // If this button is part of a link, we _probably_ dont want to actually follow the link.
-    const { contextModule, profile, user, relay, mediator } = this.props
-
-    if (user && user.id) {
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      commitMutation<FollowProfileButtonMutation>(relay.environment, {
-        // TODO: Inputs to the mutation might have changed case of the keys!
-        mutation: graphql`
-          mutation FollowProfileButtonMutation($input: FollowProfileInput!) {
-            followProfile(input: $input) {
-              profile {
-                id
-                is_followed: isFollowed
-              }
-            }
+  const { submitMutation } = useMutation({
+    mutation: graphql`
+      mutation FollowProfileButtonMutation($input: FollowProfileInput!) {
+        followProfile(input: $input) {
+          profile {
+            id
+            isFollowed
           }
-        `,
-        variables: {
-          input: {
-            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-            profileID: profile.internalID,
-            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-            unfollow: profile.is_followed,
-          },
+        }
+      }
+    `,
+    optimisticResponse: {
+      followProfile: {
+        profile: {
+          id: profile.id,
+          isFollowed: !profile.isFollowed,
         },
-        optimisticResponse: {
-          followProfile: {
-            profile: {
-              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-              id: profile.id,
-              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-              is_followed: !profile.is_followed,
-            },
-          },
-        },
-      })
-      this.trackFollow()
-    } else {
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      openAuthToSatisfyIntent(mediator, {
-        entity: {
-          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-          name: profile.name,
-          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-          slug: profile.slug,
-        },
+      },
+    },
+  })
+
+  const handleClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    event.preventDefault()
+
+    if (!isLoggedIn) {
+      openAuthToSatisfyIntent(mediator!, {
+        entity: { name: profile.name!, slug: profile.slug },
         contextModule,
         intent: Intent.followPartner,
       })
+
+      return
     }
+
+    submitMutation({
+      variables: {
+        input: {
+          profileID: profile.internalID,
+          unfollow: profile.isFollowed,
+        },
+      },
+    })
+
+    trackFollow(!!profile.isFollowed)
   }
 
-  render() {
-    const { profile, buttonProps, render } = this.props
-
-    // Custom button renderer
-    if (render) {
-      return (
-        <Clickable onClick={this.handleFollow} data-test="followButton">
-          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
-          {render(profile)}
-        </Clickable>
-      )
-    } else {
-      return (
-        <FollowButton
-          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-          isFollowed={profile && profile.is_followed}
-          handleFollow={this.handleFollow}
-          buttonProps={buttonProps}
-        />
-      )
-    }
-  }
+  return (
+    <FollowButton
+      isFollowed={!!profile.isFollowed}
+      handleFollow={handleClick}
+      buttonProps={rest}
+    />
+  )
 }
 
-export const FollowProfileButtonFragmentContainer = track({})(
-  createFragmentContainer(
-    Artsy.withSystemContext(
-      withAnalyticsContext(FollowProfileButton)
-    ) as React.ComponentType<Props>,
-    {
-      profile: graphql`
-        fragment FollowProfileButton_profile on Profile {
-          id
-          slug
-          name
-          internalID
-          is_followed: isFollowed
-        }
-      `,
-    }
-  )
+export const FollowProfileButtonFragmentContainer = createFragmentContainer(
+  FollowProfileButton,
+  {
+    profile: graphql`
+      fragment FollowProfileButton_profile on Profile {
+        id
+        slug
+        name
+        internalID
+        isFollowed
+      }
+    `,
+  }
 )
 
-// TODO: Implement QueryRenderer — requires top-level profile query first
+// TODO: QueryRenderer (requires top-level profile field in Metaphysics)

--- a/src/v2/Components/FollowButton/__tests__/Button.jest.tsx
+++ b/src/v2/Components/FollowButton/__tests__/Button.jest.tsx
@@ -1,3 +1,4 @@
+//
 import { mount } from "enzyme"
 import "jest-styled-components"
 import { FollowButton } from "../Button"

--- a/src/v2/Components/FollowButton/useFollowButtonTracking.ts
+++ b/src/v2/Components/FollowButton/useFollowButtonTracking.ts
@@ -1,0 +1,63 @@
+import {
+  AuthContextModule,
+  FollowedArgs,
+  followedPartner,
+  unfollowedPartner,
+} from "@artsy/cohesion"
+import { useCallback } from "react"
+import { useTracking } from "react-tracking"
+import { useAnalyticsContext } from "v2/System"
+
+interface UseFollowButtonTracking {
+  ownerId: string
+  ownerSlug: string
+  contextModule: AuthContextModule
+}
+
+export const useFollowButtonTracking = ({
+  ownerId,
+  ownerSlug,
+  contextModule,
+}: UseFollowButtonTracking) => {
+  const {
+    contextPageOwnerId,
+    contextPageOwnerSlug,
+    contextPageOwnerType,
+  } = useAnalyticsContext()
+
+  const { trackEvent } = useTracking()
+
+  const trackFollow = useCallback(
+    (isFollowed: boolean) => {
+      if (
+        !contextPageOwnerId ||
+        !contextPageOwnerSlug ||
+        !contextPageOwnerType
+      ) {
+        return
+      }
+
+      const args: FollowedArgs = {
+        ownerId,
+        ownerSlug,
+        contextModule,
+        contextOwnerId: contextPageOwnerId,
+        contextOwnerSlug: contextPageOwnerSlug,
+        contextOwnerType: contextPageOwnerType,
+      }
+
+      trackEvent(isFollowed ? unfollowedPartner(args) : followedPartner(args))
+    },
+    [
+      contextModule,
+      contextPageOwnerId,
+      contextPageOwnerSlug,
+      contextPageOwnerType,
+      ownerId,
+      ownerSlug,
+      trackEvent,
+    ]
+  )
+
+  return { trackFollow }
+}

--- a/src/v2/Utils/Hooks/useMutation.ts
+++ b/src/v2/Utils/Hooks/useMutation.ts
@@ -7,8 +7,10 @@ import { useSystemContext } from "v2/System/useSystemContext"
 
 export const useMutation = <T extends MutationParameters>({
   mutation,
+  optimisticResponse,
 }: {
   mutation: GraphQLTaggedNode
+  optimisticResponse?: T["response"]
 }) => {
   const { relayEnvironment } = useSystemContext()
 
@@ -22,6 +24,7 @@ export const useMutation = <T extends MutationParameters>({
       commitMutation<T>(relayEnvironment!, {
         mutation,
         variables,
+        optimisticResponse,
         onError: reject,
         onCompleted: (res, errors) => {
           if (errors !== null) {

--- a/src/v2/__generated__/ArtworkDetailsQuery.graphql.ts
+++ b/src/v2/__generated__/ArtworkDetailsQuery.graphql.ts
@@ -142,7 +142,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -381,7 +381,7 @@ return {
                   (v7/*: any*/),
                   (v4/*: any*/),
                   {
-                    "alias": "is_followed",
+                    "alias": null,
                     "args": null,
                     "kind": "ScalarField",
                     "name": "isFollowed",
@@ -648,12 +648,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b5246e449fa1da4f316d66a37ef6f509",
+    "cacheID": "03c89dd10edfefcf47dffede729f5e10",
     "id": null,
     "metadata": {},
     "name": "ArtworkDetailsQuery",
     "operationKind": "query",
-    "text": "query ArtworkDetailsQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...ArtworkDetails_artwork\n    id\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        cropped(width: 45, height: 45) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    publishedAt(format: \"MMM Do, YYYY\")\n    thumbnailImage {\n      cropped(width: 200, height: 150) {\n        src\n        srcSet\n      }\n    }\n    thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetailsMediumModal_artwork on Artwork {\n  mediumType {\n    name\n    longDescription\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query ArtworkDetailsQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...ArtworkDetails_artwork\n    id\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        cropped(width: 45, height: 45) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    publishedAt(format: \"MMM Do, YYYY\")\n    thumbnailImage {\n      cropped(width: 200, height: 150) {\n        src\n        srcSet\n      }\n    }\n    thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetailsMediumModal_artwork on Artwork {\n  mediumType {\n    name\n    longDescription\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ArtworkDetails_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ArtworkDetails_Test_Query.graphql.ts
@@ -138,7 +138,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -412,7 +412,7 @@ return {
                   (v6/*: any*/),
                   (v3/*: any*/),
                   {
-                    "alias": "is_followed",
+                    "alias": null,
                     "args": null,
                     "kind": "ScalarField",
                     "name": "isFollowed",
@@ -679,7 +679,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e9be102424c9de70570d5e130b39a2de",
+    "cacheID": "91c737bd015e5b3c0082eaee21dd0121",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -772,7 +772,7 @@ return {
         "artwork.partner.profile.icon.cropped.srcSet": (v13/*: any*/),
         "artwork.partner.profile.id": (v10/*: any*/),
         "artwork.partner.profile.internalID": (v10/*: any*/),
-        "artwork.partner.profile.is_followed": (v14/*: any*/),
+        "artwork.partner.profile.isFollowed": (v14/*: any*/),
         "artwork.partner.profile.name": (v9/*: any*/),
         "artwork.partner.profile.slug": (v10/*: any*/),
         "artwork.partner.slug": (v10/*: any*/),
@@ -796,7 +796,7 @@ return {
     },
     "name": "ArtworkDetails_Test_Query",
     "operationKind": "query",
-    "text": "query ArtworkDetails_Test_Query {\n  artwork(id: \"example\") {\n    ...ArtworkDetails_artwork\n    id\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        cropped(width: 45, height: 45) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    publishedAt(format: \"MMM Do, YYYY\")\n    thumbnailImage {\n      cropped(width: 200, height: 150) {\n        src\n        srcSet\n      }\n    }\n    thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetailsMediumModal_artwork on Artwork {\n  mediumType {\n    name\n    longDescription\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query ArtworkDetails_Test_Query {\n  artwork(id: \"example\") {\n    ...ArtworkDetails_artwork\n    id\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        cropped(width: 45, height: 45) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    publishedAt(format: \"MMM Do, YYYY\")\n    thumbnailImage {\n      cropped(width: 200, height: 150) {\n        src\n        srcSet\n      }\n    }\n    thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetailsMediumModal_artwork on Artwork {\n  mediumType {\n    name\n    longDescription\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/CellPartnerFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/CellPartnerFragmentContainer_Test_Query.graphql.ts
@@ -100,7 +100,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -335,7 +335,7 @@ return {
               (v3/*: any*/),
               (v1/*: any*/),
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -450,7 +450,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0492c71ba3b045a8d33df980fb426b53",
+    "cacheID": "965276e986a50ba0a4c9daaeec2850e4",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -514,7 +514,7 @@ return {
         "partner.profile.image.cropped.src": (v12/*: any*/),
         "partner.profile.image.cropped.srcSet": (v12/*: any*/),
         "partner.profile.internalID": (v8/*: any*/),
-        "partner.profile.is_followed": {
+        "partner.profile.isFollowed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
@@ -528,7 +528,7 @@ return {
     },
     "name": "CellPartnerFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query CellPartnerFragmentContainer_Test_Query {\n  partner(id: \"example\") {\n    ...CellPartner_partner\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query CellPartnerFragmentContainer_Test_Query {\n  partner(id: \"example\") {\n    ...CellPartner_partner\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/CellPartnerStoryQuery.graphql.ts
+++ b/src/v2/__generated__/CellPartnerStoryQuery.graphql.ts
@@ -104,7 +104,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -316,7 +316,7 @@ return {
               (v4/*: any*/),
               (v2/*: any*/),
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -431,12 +431,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9f6cb79f8cea05d74de497fea557f64e",
+    "cacheID": "dbbabd4fb01d859d8c67a257a00cc664",
     "id": null,
     "metadata": {},
     "name": "CellPartnerStoryQuery",
     "operationKind": "query",
-    "text": "query CellPartnerStoryQuery(\n  $id: String!\n) {\n  partner(id: $id) {\n    ...CellPartner_partner\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query CellPartnerStoryQuery(\n  $id: String!\n) {\n  partner(id: $id) {\n    ...CellPartner_partner\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/EntityHeaderFairFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/EntityHeaderFairFragmentContainer_Test_Query.graphql.ts
@@ -49,7 +49,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -242,7 +242,7 @@ return {
               (v2/*: any*/),
               (v1/*: any*/),
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -265,7 +265,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "76a04d66141d48e6678b04364e7d21d4",
+    "cacheID": "b708dfc33f3dec97f614e394f6d76d9b",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -303,7 +303,7 @@ return {
         "fair.profile.id": (v6/*: any*/),
         "fair.profile.initials": (v5/*: any*/),
         "fair.profile.internalID": (v6/*: any*/),
-        "fair.profile.is_followed": {
+        "fair.profile.isFollowed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
@@ -316,7 +316,7 @@ return {
     },
     "name": "EntityHeaderFairFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query EntityHeaderFairFragmentContainer_Test_Query {\n  fair(id: \"example\") {\n    ...EntityHeaderFair_fair\n    id\n  }\n}\n\nfragment EntityHeaderFair_fair on Fair {\n  internalID\n  href\n  name\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    initials\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query EntityHeaderFairFragmentContainer_Test_Query {\n  fair(id: \"example\") {\n    ...EntityHeaderFair_fair\n    id\n  }\n}\n\nfragment EntityHeaderFair_fair on Fair {\n  internalID\n  href\n  name\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    initials\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/EntityHeaderFairOrganizerFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/EntityHeaderFairOrganizerFragmentContainer_Test_Query.graphql.ts
@@ -51,7 +51,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -184,7 +184,7 @@ return {
               (v3/*: any*/),
               (v1/*: any*/),
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -261,7 +261,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9dfc607a7f23f51710c9d89d497a9a61",
+    "cacheID": "45e3ed08c81663a6362f98fdb7b9a51d",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -310,7 +310,7 @@ return {
         "fairOrganizer.profile.id": (v5/*: any*/),
         "fairOrganizer.profile.initials": (v6/*: any*/),
         "fairOrganizer.profile.internalID": (v5/*: any*/),
-        "fairOrganizer.profile.is_followed": {
+        "fairOrganizer.profile.isFollowed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
@@ -323,7 +323,7 @@ return {
     },
     "name": "EntityHeaderFairOrganizerFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query EntityHeaderFairOrganizerFragmentContainer_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...EntityHeaderFairOrganizer_fairOrganizer\n    id\n  }\n}\n\nfragment EntityHeaderFairOrganizer_fairOrganizer on FairOrganizer {\n  internalID\n  slug\n  name\n  fairsConnection {\n    totalCount\n  }\n  profile {\n    ...FollowProfileButton_profile\n    href\n    initials\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query EntityHeaderFairOrganizerFragmentContainer_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...EntityHeaderFairOrganizer_fairOrganizer\n    id\n  }\n}\n\nfragment EntityHeaderFairOrganizer_fairOrganizer on FairOrganizer {\n  internalID\n  slug\n  name\n  fairsConnection {\n    totalCount\n  }\n  profile {\n    ...FollowProfileButton_profile\n    href\n    initials\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/EntityHeaderFairOrganizerStoryQuery.graphql.ts
+++ b/src/v2/__generated__/EntityHeaderFairOrganizerStoryQuery.graphql.ts
@@ -55,7 +55,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -177,7 +177,7 @@ return {
               (v4/*: any*/),
               (v2/*: any*/),
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -254,12 +254,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "88efc28c7ad5215ff65af4e0c3d54e6a",
+    "cacheID": "8b2acf8531cb3cbd611468b39515264c",
     "id": null,
     "metadata": {},
     "name": "EntityHeaderFairOrganizerStoryQuery",
     "operationKind": "query",
-    "text": "query EntityHeaderFairOrganizerStoryQuery(\n  $id: String!\n) {\n  fairOrganizer(id: $id) {\n    ...EntityHeaderFairOrganizer_fairOrganizer\n    id\n  }\n}\n\nfragment EntityHeaderFairOrganizer_fairOrganizer on FairOrganizer {\n  internalID\n  slug\n  name\n  fairsConnection {\n    totalCount\n  }\n  profile {\n    ...FollowProfileButton_profile\n    href\n    initials\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query EntityHeaderFairOrganizerStoryQuery(\n  $id: String!\n) {\n  fairOrganizer(id: $id) {\n    ...EntityHeaderFairOrganizer_fairOrganizer\n    id\n  }\n}\n\nfragment EntityHeaderFairOrganizer_fairOrganizer on FairOrganizer {\n  internalID\n  slug\n  name\n  fairsConnection {\n    totalCount\n  }\n  profile {\n    ...FollowProfileButton_profile\n    href\n    initials\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/EntityHeaderFairStoryQuery.graphql.ts
+++ b/src/v2/__generated__/EntityHeaderFairStoryQuery.graphql.ts
@@ -53,7 +53,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -235,7 +235,7 @@ return {
               (v3/*: any*/),
               (v2/*: any*/),
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -258,12 +258,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b5b28b0983133a0893bdaa686dc609d3",
+    "cacheID": "4898a8a1ade8074ed2a737b0fdc8a9af",
     "id": null,
     "metadata": {},
     "name": "EntityHeaderFairStoryQuery",
     "operationKind": "query",
-    "text": "query EntityHeaderFairStoryQuery(\n  $id: String!\n) {\n  fair(id: $id) {\n    ...EntityHeaderFair_fair\n    id\n  }\n}\n\nfragment EntityHeaderFair_fair on Fair {\n  internalID\n  href\n  name\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    initials\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query EntityHeaderFairStoryQuery(\n  $id: String!\n) {\n  fair(id: $id) {\n    ...EntityHeaderFair_fair\n    id\n  }\n}\n\nfragment EntityHeaderFair_fair on Fair {\n  internalID\n  href\n  name\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    initials\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/EntityHeaderPartnerFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/EntityHeaderPartnerFragmentContainer_Test_Query.graphql.ts
@@ -68,7 +68,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -303,7 +303,7 @@ return {
               (v3/*: any*/),
               (v1/*: any*/),
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -376,7 +376,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "050eef7b5876f5e27ef1f9aeac890da0",
+    "cacheID": "70ac7d1fcbece25a5872bea3f52fec2f",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -436,7 +436,7 @@ return {
         "partner.profile.icon.cropped.srcSet": (v12/*: any*/),
         "partner.profile.id": (v8/*: any*/),
         "partner.profile.internalID": (v8/*: any*/),
-        "partner.profile.is_followed": {
+        "partner.profile.isFollowed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
@@ -450,7 +450,7 @@ return {
     },
     "name": "EntityHeaderPartnerFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query EntityHeaderPartnerFragmentContainer_Test_Query {\n  partner(id: \"example\") {\n    ...EntityHeaderPartner_partner\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query EntityHeaderPartnerFragmentContainer_Test_Query {\n  partner(id: \"example\") {\n    ...EntityHeaderPartner_partner\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/EntityHeaderPartnerStoryQuery.graphql.ts
+++ b/src/v2/__generated__/EntityHeaderPartnerStoryQuery.graphql.ts
@@ -72,7 +72,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -284,7 +284,7 @@ return {
               (v4/*: any*/),
               (v2/*: any*/),
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -357,12 +357,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5e9a9950e7d4a0b3a44f19cc7211e1d1",
+    "cacheID": "1cb52e7d6632ff31955c7cfdb6890da9",
     "id": null,
     "metadata": {},
     "name": "EntityHeaderPartnerStoryQuery",
     "operationKind": "query",
-    "text": "query EntityHeaderPartnerStoryQuery(\n  $id: String!\n) {\n  partner(id: $id) {\n    ...EntityHeaderPartner_partner\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query EntityHeaderPartnerStoryQuery(\n  $id: String!\n) {\n  partner(id: $id) {\n    ...EntityHeaderPartner_partner\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/EntityTooltipPartnerQuery.graphql.ts
+++ b/src/v2/__generated__/EntityTooltipPartnerQuery.graphql.ts
@@ -90,7 +90,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -304,7 +304,7 @@ return {
               (v4/*: any*/),
               (v2/*: any*/),
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -448,12 +448,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "08405b1062f676c82861fb2f4af7b9e5",
+    "cacheID": "4a7a5439204da16099e580e59f7ba882",
     "id": null,
     "metadata": {},
     "name": "EntityTooltipPartnerQuery",
     "operationKind": "query",
-    "text": "query EntityTooltipPartnerQuery(\n  $id: String!\n) {\n  partner(id: $id) {\n    ...EntityTooltipPartner_partner\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityTooltipPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  href\n  profile {\n    bio\n    fullBio\n    image {\n      cropped(width: 260, height: 146, version: [\"wide\", \"medium250x165\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query EntityTooltipPartnerQuery(\n  $id: String!\n) {\n  partner(id: $id) {\n    ...EntityTooltipPartner_partner\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityTooltipPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  href\n  profile {\n    bio\n    fullBio\n    image {\n      cropped(width: 260, height: 146, version: [\"wide\", \"medium250x165\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairExhibitors_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairExhibitors_Test_Query.graphql.ts
@@ -111,7 +111,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -400,7 +400,7 @@ return {
                           (v5/*: any*/),
                           (v3/*: any*/),
                           {
-                            "alias": "is_followed",
+                            "alias": null,
                             "args": null,
                             "kind": "ScalarField",
                             "name": "isFollowed",
@@ -483,7 +483,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "97db139b334bdb4f70ad932e9e173508",
+    "cacheID": "781d78c6067386580f3ea9d974163cf2",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -561,7 +561,7 @@ return {
         "fair.exhibitorsGroupedByName.exhibitors.partner.profile.icon.cropped.srcSet": (v14/*: any*/),
         "fair.exhibitorsGroupedByName.exhibitors.partner.profile.id": (v10/*: any*/),
         "fair.exhibitorsGroupedByName.exhibitors.partner.profile.internalID": (v10/*: any*/),
-        "fair.exhibitorsGroupedByName.exhibitors.partner.profile.is_followed": {
+        "fair.exhibitorsGroupedByName.exhibitors.partner.profile.isFollowed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
@@ -580,7 +580,7 @@ return {
     },
     "name": "FairExhibitors_Test_Query",
     "operationKind": "query",
-    "text": "query FairExhibitors_Test_Query(\n  $id: String!\n) {\n  fair(id: $id) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairExhibitorCard_exhibitor on FairExhibitor {\n  profileID\n  partner {\n    ...EntityHeaderPartner_partner\n    internalID\n    slug\n    id\n  }\n}\n\nfragment FairExhibitorCard_fair on Fair {\n  href\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    ...FairExhibitorCard_exhibitor\n    partner {\n      internalID\n      id\n    }\n  }\n}\n\nfragment FairExhibitorsGroup_fair on Fair {\n  ...FairExhibitorCard_fair\n}\n\nfragment FairExhibitors_fair on Fair {\n  ...FairExhibitorsGroup_fair\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query FairExhibitors_Test_Query(\n  $id: String!\n) {\n  fair(id: $id) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairExhibitorCard_exhibitor on FairExhibitor {\n  profileID\n  partner {\n    ...EntityHeaderPartner_partner\n    internalID\n    slug\n    id\n  }\n}\n\nfragment FairExhibitorCard_fair on Fair {\n  href\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    ...FairExhibitorCard_exhibitor\n    partner {\n      internalID\n      id\n    }\n  }\n}\n\nfragment FairExhibitorsGroup_fair on Fair {\n  ...FairExhibitorCard_fair\n}\n\nfragment FairExhibitors_fair on Fair {\n  ...FairExhibitorsGroup_fair\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FollowProfileButtonMutation.graphql.ts
+++ b/src/v2/__generated__/FollowProfileButtonMutation.graphql.ts
@@ -15,7 +15,7 @@ export type FollowProfileButtonMutationResponse = {
     readonly followProfile: {
         readonly profile: {
             readonly id: string;
-            readonly is_followed: boolean | null;
+            readonly isFollowed: boolean | null;
         } | null;
     } | null;
 };
@@ -33,7 +33,7 @@ mutation FollowProfileButtonMutation(
   followProfile(input: $input) {
     profile {
       id
-      is_followed: isFollowed
+      isFollowed
     }
   }
 }
@@ -78,7 +78,7 @@ v1 = [
             "storageKey": null
           },
           {
-            "alias": "is_followed",
+            "alias": null,
             "args": null,
             "kind": "ScalarField",
             "name": "isFollowed",
@@ -109,14 +109,14 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "1c1b6c4931b2dbe3029e2bce65d6a025",
+    "cacheID": "9114abb5a82e2df610c2ccdae0a8bf44",
     "id": null,
     "metadata": {},
     "name": "FollowProfileButtonMutation",
     "operationKind": "mutation",
-    "text": "mutation FollowProfileButtonMutation(\n  $input: FollowProfileInput!\n) {\n  followProfile(input: $input) {\n    profile {\n      id\n      is_followed: isFollowed\n    }\n  }\n}\n"
+    "text": "mutation FollowProfileButtonMutation(\n  $input: FollowProfileInput!\n) {\n  followProfile(input: $input) {\n    profile {\n      id\n      isFollowed\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'fa116a6824af830210198ab020a8d472';
+(node as any).hash = 'f3ac77cf6f3bdc0d0ce912fa06939749';
 export default node;

--- a/src/v2/__generated__/FollowProfileButton_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FollowProfileButton_Test_Query.graphql.ts
@@ -1,0 +1,203 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FollowProfileButton_Test_QueryVariables = {};
+export type FollowProfileButton_Test_QueryResponse = {
+    readonly partner: {
+        readonly profile: {
+            readonly " $fragmentRefs": FragmentRefs<"FollowProfileButton_profile">;
+        } | null;
+    } | null;
+};
+export type FollowProfileButton_Test_Query = {
+    readonly response: FollowProfileButton_Test_QueryResponse;
+    readonly variables: FollowProfileButton_Test_QueryVariables;
+};
+
+
+
+/*
+query FollowProfileButton_Test_Query {
+  partner(id: "example") {
+    profile {
+      ...FollowProfileButton_profile
+      id
+    }
+    id
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  isFollowed
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "FollowProfileButton_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Profile",
+            "kind": "LinkedField",
+            "name": "profile",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "FollowProfileButton_profile"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "partner(id:\"example\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "FollowProfileButton_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Profile",
+            "kind": "LinkedField",
+            "name": "profile",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "slug",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isFollowed",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": "partner(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "14f72f94b9b2cd587bcb1cd5c4eeb73d",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "partner.id": (v2/*: any*/),
+        "partner.profile": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Profile"
+        },
+        "partner.profile.id": (v2/*: any*/),
+        "partner.profile.internalID": (v2/*: any*/),
+        "partner.profile.isFollowed": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "partner.profile.name": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "String"
+        },
+        "partner.profile.slug": (v2/*: any*/)
+      }
+    },
+    "name": "FollowProfileButton_Test_Query",
+    "operationKind": "query",
+    "text": "query FollowProfileButton_Test_Query {\n  partner(id: \"example\") {\n    profile {\n      ...FollowProfileButton_profile\n      id\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
+  }
+};
+})();
+(node as any).hash = 'b07d88251880bd24bdfa7de9fb3d0ebb';
+export default node;

--- a/src/v2/__generated__/FollowProfileButton_profile.graphql.ts
+++ b/src/v2/__generated__/FollowProfileButton_profile.graphql.ts
@@ -9,7 +9,7 @@ export type FollowProfileButton_profile = {
     readonly slug: string;
     readonly name: string | null;
     readonly internalID: string;
-    readonly is_followed: boolean | null;
+    readonly isFollowed: boolean | null;
     readonly " $refType": "FollowProfileButton_profile";
 };
 export type FollowProfileButton_profile$data = FollowProfileButton_profile;
@@ -55,7 +55,7 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
-      "alias": "is_followed",
+      "alias": null,
       "args": null,
       "kind": "ScalarField",
       "name": "isFollowed",
@@ -65,5 +65,5 @@ const node: ReaderFragment = {
   "type": "Profile",
   "abstractKey": null
 };
-(node as any).hash = '85041d28bca019f2610df442f360079f';
+(node as any).hash = '5e106dc0f6d28037e1b1cb894aa58dca';
 export default node;

--- a/src/v2/__generated__/GalleriesRouteFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/GalleriesRouteFragmentContainer_Test_Query.graphql.ts
@@ -29,7 +29,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment GalleriesRoute_viewer on Viewer {
@@ -271,7 +271,7 @@ return {
                               },
                               (v3/*: any*/),
                               {
-                                "alias": "is_followed",
+                                "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
                                 "name": "isFollowed",
@@ -455,7 +455,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "592bb7a9d5d85d41519566307aa3da6e",
+    "cacheID": "b6247a945bfebacf7e0f70d4a5507c7e",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -494,7 +494,7 @@ return {
         "viewer.orderedSet.orderedItemsConnection.edges.node.__typename": (v9/*: any*/),
         "viewer.orderedSet.orderedItemsConnection.edges.node.id": (v8/*: any*/),
         "viewer.orderedSet.orderedItemsConnection.edges.node.internalID": (v8/*: any*/),
-        "viewer.orderedSet.orderedItemsConnection.edges.node.is_followed": {
+        "viewer.orderedSet.orderedItemsConnection.edges.node.isFollowed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
@@ -559,7 +559,7 @@ return {
     },
     "name": "GalleriesRouteFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query GalleriesRouteFragmentContainer_Test_Query {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      href\n      name\n      featuredShow {\n        href\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query GalleriesRouteFragmentContainer_Test_Query {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      href\n      name\n      featuredShow {\n        href\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/HomeFeaturedGalleriesRailQuery.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRailQuery.graphql.ts
@@ -100,7 +100,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
@@ -402,7 +402,7 @@ return {
                                       (v4/*: any*/),
                                       (v2/*: any*/),
                                       {
-                                        "alias": "is_followed",
+                                        "alias": null,
                                         "args": null,
                                         "kind": "ScalarField",
                                         "name": "isFollowed",
@@ -552,12 +552,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "75ab12e31e0c4d2d0f840c1388098628",
+    "cacheID": "64212f8fe95d5873d3122a5e5ae9ff90",
     "id": null,
     "metadata": {},
     "name": "HomeFeaturedGalleriesRailQuery",
     "operationKind": "query",
-    "text": "query HomeFeaturedGalleriesRailQuery {\n  orderedSet(id: \"6193c9ede70512000fbf3e8d\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          owner {\n            __typename\n            ...CellPartner_partner\n            ... on Partner {\n              internalID\n              slug\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n            ... on FairOrganizer {\n              id\n            }\n          }\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query HomeFeaturedGalleriesRailQuery {\n  orderedSet(id: \"6193c9ede70512000fbf3e8d\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          owner {\n            __typename\n            ...CellPartner_partner\n            ... on Partner {\n              internalID\n              slug\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n            ... on FairOrganizer {\n              id\n            }\n          }\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/HomeFeaturedGalleriesRail_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedGalleriesRail_Test_Query.graphql.ts
@@ -100,7 +100,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {
@@ -432,7 +432,7 @@ return {
                                       (v4/*: any*/),
                                       (v2/*: any*/),
                                       {
-                                        "alias": "is_followed",
+                                        "alias": null,
                                         "args": null,
                                         "kind": "ScalarField",
                                         "name": "isFollowed",
@@ -582,7 +582,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "80e8c16f15bd7c900068e9bc885d8477",
+    "cacheID": "6e4114321cff22ab7c49a94394533fb3",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -676,7 +676,7 @@ return {
         "orderedSet.orderedItemsConnection.edges.node.owner.profile.image.cropped.src": (v12/*: any*/),
         "orderedSet.orderedItemsConnection.edges.node.owner.profile.image.cropped.srcSet": (v12/*: any*/),
         "orderedSet.orderedItemsConnection.edges.node.owner.profile.internalID": (v11/*: any*/),
-        "orderedSet.orderedItemsConnection.edges.node.owner.profile.is_followed": {
+        "orderedSet.orderedItemsConnection.edges.node.owner.profile.isFollowed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
@@ -690,7 +690,7 @@ return {
     },
     "name": "HomeFeaturedGalleriesRail_Test_Query",
     "operationKind": "query",
-    "text": "query HomeFeaturedGalleriesRail_Test_Query {\n  orderedSet(id: \"example\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          owner {\n            __typename\n            ...CellPartner_partner\n            ... on Partner {\n              internalID\n              slug\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n            ... on FairOrganizer {\n              id\n            }\n          }\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query HomeFeaturedGalleriesRail_Test_Query {\n  orderedSet(id: \"example\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          owner {\n            __typename\n            ...CellPartner_partner\n            ... on Partner {\n              internalID\n              slug\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n            ... on FairOrganizer {\n              id\n            }\n          }\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/InstitutionPartnershipsProfilesQuery.graphql.ts
+++ b/src/v2/__generated__/InstitutionPartnershipsProfilesQuery.graphql.ts
@@ -100,7 +100,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment InstitutionPartnershipsProfiles_orderedSet on OrderedSet {
@@ -376,7 +376,7 @@ return {
                               (v4/*: any*/),
                               (v2/*: any*/),
                               {
-                                "alias": "is_followed",
+                                "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
                                 "name": "isFollowed",
@@ -520,12 +520,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4d5adb78291b9822feedb6071cfc4ca1",
+    "cacheID": "c3ab4627a3e7a229083917b5e63258fc",
     "id": null,
     "metadata": {},
     "name": "InstitutionPartnershipsProfilesQuery",
     "operationKind": "query",
-    "text": "query InstitutionPartnershipsProfilesQuery {\n  orderedSet(id: \"62ace82dd1b5bd000b4e674e\") {\n    ...InstitutionPartnershipsProfiles_orderedSet\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionPartnershipsProfiles_orderedSet on OrderedSet {\n  items {\n    __typename\n    ... on Profile {\n      internalID\n      owner {\n        __typename\n        ... on Partner {\n          ...CellPartner_partner\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FairOrganizer {\n          id\n        }\n      }\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FeaturedLink {\n      id\n    }\n  }\n}\n"
+    "text": "query InstitutionPartnershipsProfilesQuery {\n  orderedSet(id: \"62ace82dd1b5bd000b4e674e\") {\n    ...InstitutionPartnershipsProfiles_orderedSet\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment InstitutionPartnershipsProfiles_orderedSet on OrderedSet {\n  items {\n    __typename\n    ... on Profile {\n      internalID\n      owner {\n        __typename\n        ... on Partner {\n          ...CellPartner_partner\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FairOrganizer {\n          id\n        }\n      }\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FeaturedLink {\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/InstitutionsRouteFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/InstitutionsRouteFragmentContainer_Test_Query.graphql.ts
@@ -29,7 +29,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment InstitutionsRoute_viewer on Viewer {
@@ -271,7 +271,7 @@ return {
                               },
                               (v3/*: any*/),
                               {
-                                "alias": "is_followed",
+                                "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
                                 "name": "isFollowed",
@@ -455,7 +455,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0e17b314b1549a5eef7b420cfbeaf93d",
+    "cacheID": "20306ce032da99c8690bbfe4d9b232bb",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -494,7 +494,7 @@ return {
         "viewer.orderedSet.orderedItemsConnection.edges.node.__typename": (v9/*: any*/),
         "viewer.orderedSet.orderedItemsConnection.edges.node.id": (v8/*: any*/),
         "viewer.orderedSet.orderedItemsConnection.edges.node.internalID": (v8/*: any*/),
-        "viewer.orderedSet.orderedItemsConnection.edges.node.is_followed": {
+        "viewer.orderedSet.orderedItemsConnection.edges.node.isFollowed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
@@ -559,7 +559,7 @@ return {
     },
     "name": "InstitutionsRouteFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query InstitutionsRouteFragmentContainer_Test_Query {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      href\n      name\n      featuredShow {\n        href\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query InstitutionsRouteFragmentContainer_Test_Query {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      href\n      name\n      featuredShow {\n        href\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/NearbyGalleriesRailRendererQuery.graphql.ts
+++ b/src/v2/__generated__/NearbyGalleriesRailRendererQuery.graphql.ts
@@ -107,7 +107,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment NearbyGalleriesRail_partners on PartnerEdge {
@@ -374,7 +374,7 @@ return {
                       (v4/*: any*/),
                       (v2/*: any*/),
                       {
-                        "alias": "is_followed",
+                        "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "isFollowed",
@@ -495,12 +495,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6d1c99e0bc277d01ca787c2aa4a019b6",
+    "cacheID": "2134752a5f668cbc3d8f8791aebef67d",
     "id": null,
     "metadata": {},
     "name": "NearbyGalleriesRailRendererQuery",
     "operationKind": "query",
-    "text": "query NearbyGalleriesRailRendererQuery(\n  $near: String!\n) {\n  partnersConnection(first: 12, near: $near, eligibleForListing: true, defaultProfilePublic: true, sort: RANDOM_SCORE_DESC) {\n    edges {\n      ...NearbyGalleriesRail_partners\n    }\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NearbyGalleriesRail_partners on PartnerEdge {\n  node {\n    ...CellPartner_partner\n    internalID\n    id\n  }\n}\n"
+    "text": "query NearbyGalleriesRailRendererQuery(\n  $near: String!\n) {\n  partnersConnection(first: 12, near: $near, eligibleForListing: true, defaultProfilePublic: true, sort: RANDOM_SCORE_DESC) {\n    edges {\n      ...NearbyGalleriesRail_partners\n    }\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment NearbyGalleriesRail_partners on PartnerEdge {\n  node {\n    ...CellPartner_partner\n    internalID\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
@@ -30,7 +30,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment NavigationTabs_partner on Partner {
@@ -437,7 +437,7 @@ return {
                 "storageKey": null
               },
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -752,7 +752,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a910efd4e5a88bea389a02c853637790",
+    "cacheID": "a54143ed38828fa79c8f1136e33d2247",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -848,7 +848,7 @@ return {
         "partner.profile.image": (v18/*: any*/),
         "partner.profile.image.url": (v10/*: any*/),
         "partner.profile.internalID": (v9/*: any*/),
-        "partner.profile.is_followed": (v12/*: any*/),
+        "partner.profile.isFollowed": (v12/*: any*/),
         "partner.profile.name": (v10/*: any*/),
         "partner.profile.slug": (v9/*: any*/),
         "partner.representedArtists": (v17/*: any*/),
@@ -866,7 +866,7 @@ return {
     },
     "name": "PartnerApp_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
+    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerHeader_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerHeader_Test_Query.graphql.ts
@@ -26,7 +26,7 @@ export type PartnerHeader_Test_QueryRawResponse = {
             readonly slug: string;
             readonly name: string | null;
             readonly internalID: string;
-            readonly is_followed: boolean | null;
+            readonly isFollowed: boolean | null;
         }) | null;
         readonly locations: ({
             readonly totalCount: number | null;
@@ -61,7 +61,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment PartnerHeader_partner on Partner {
@@ -258,7 +258,7 @@ return {
                 "storageKey": null
               },
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -328,7 +328,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "787df13f06f3422cee9fe1286bd9e366",
+    "cacheID": "3a44ba6e8ebb3ad8bbd00dadda34cc8a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -388,7 +388,7 @@ return {
         "partner.profile.icon.resized.srcSet": (v6/*: any*/),
         "partner.profile.id": (v4/*: any*/),
         "partner.profile.internalID": (v4/*: any*/),
-        "partner.profile.is_followed": {
+        "partner.profile.isFollowed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
@@ -402,7 +402,7 @@ return {
     },
     "name": "PartnerHeader_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerHeader_Test_Query {\n  partner(id: \"white-cube\") {\n    ...PartnerHeader_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query PartnerHeader_Test_Query {\n  partner(id: \"white-cube\") {\n    ...PartnerHeader_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnersFeaturedCarousel_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnersFeaturedCarousel_Test_Query.graphql.ts
@@ -29,7 +29,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment PartnersFeaturedCarouselCell_profile on Profile {
@@ -268,7 +268,7 @@ return {
                               },
                               (v4/*: any*/),
                               {
-                                "alias": "is_followed",
+                                "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
                                 "name": "isFollowed",
@@ -452,7 +452,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d2c4e661d5d5c5fee30e2eeecac34085",
+    "cacheID": "a3f74ff49fd8d881f59b81b37331840e",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -491,7 +491,7 @@ return {
         "viewer.orderedSet.orderedItemsConnection.edges.node.__typename": (v10/*: any*/),
         "viewer.orderedSet.orderedItemsConnection.edges.node.id": (v9/*: any*/),
         "viewer.orderedSet.orderedItemsConnection.edges.node.internalID": (v9/*: any*/),
-        "viewer.orderedSet.orderedItemsConnection.edges.node.is_followed": {
+        "viewer.orderedSet.orderedItemsConnection.edges.node.isFollowed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
@@ -556,7 +556,7 @@ return {
     },
     "name": "PartnersFeaturedCarousel_Test_Query",
     "operationKind": "query",
-    "text": "query PartnersFeaturedCarousel_Test_Query {\n  viewer {\n    ...PartnersFeaturedCarousel_viewer_3GNcE2\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      href\n      name\n      featuredShow {\n        href\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3GNcE2 on Viewer {\n  orderedSet(id: \"example\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query PartnersFeaturedCarousel_Test_Query {\n  viewer {\n    ...PartnersFeaturedCarousel_viewer_3GNcE2\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      href\n      name\n      featuredShow {\n        href\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3GNcE2 on Viewer {\n  orderedSet(id: \"example\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnersFilteredCellsQuery.graphql.ts
+++ b/src/v2/__generated__/PartnersFilteredCellsQuery.graphql.ts
@@ -110,7 +110,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment PartnersFilteredCells_viewer_iDCAR on Viewer {
@@ -442,7 +442,7 @@ return {
                           (v10/*: any*/),
                           (v8/*: any*/),
                           {
-                            "alias": "is_followed",
+                            "alias": null,
                             "args": null,
                             "kind": "ScalarField",
                             "name": "isFollowed",
@@ -621,12 +621,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7ad656439937ba1a607dfba482a78a3f",
+    "cacheID": "ba3ca473b66fb072d3be548aff0368a3",
     "id": null,
     "metadata": {},
     "name": "PartnersFilteredCellsQuery",
     "operationKind": "query",
-    "text": "query PartnersFilteredCellsQuery(\n  $after: String\n  $near: String\n  $category: [String]\n  $type: [PartnerClassification]\n) {\n  viewer {\n    ...PartnersFilteredCells_viewer_iDCAR\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnersFilteredCells_viewer_iDCAR on Viewer {\n  partnersConnection(after: $after, defaultProfilePublic: true, eligibleForListing: true, first: 12, near: $near, partnerCategories: $category, sort: RANDOM_SCORE_DESC, type: $type) {\n    totalCount\n    edges {\n      node {\n        internalID\n        ...CellPartner_partner\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query PartnersFilteredCellsQuery(\n  $after: String\n  $near: String\n  $category: [String]\n  $type: [PartnerClassification]\n) {\n  viewer {\n    ...PartnersFilteredCells_viewer_iDCAR\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment PartnersFilteredCells_viewer_iDCAR on Viewer {\n  partnersConnection(after: $after, defaultProfilePublic: true, eligibleForListing: true, first: 12, near: $near, partnerCategories: $category, sort: RANDOM_SCORE_DESC, type: $type) {\n    totalCount\n    edges {\n      node {\n        internalID\n        ...CellPartner_partner\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnersRailQuery.graphql.ts
+++ b/src/v2/__generated__/PartnersRailQuery.graphql.ts
@@ -109,7 +109,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment PartnersRail_partnerCategory_43V8rY on PartnerCategory {
@@ -328,7 +328,7 @@ v16 = [
       (v5/*: any*/),
       (v10/*: any*/),
       {
-        "alias": "is_followed",
+        "alias": null,
         "args": null,
         "kind": "ScalarField",
         "name": "isFollowed",
@@ -544,12 +544,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3d911624679676f412e711733c6a5d8f",
+    "cacheID": "4697189bc303ddeccf2ed51fc0cf6cb4",
     "id": null,
     "metadata": {},
     "name": "PartnersRailQuery",
     "operationKind": "query",
-    "text": "query PartnersRailQuery(\n  $id: String!\n  $category: [String]\n  $type: [PartnerClassification!]!\n) {\n  partnerCategory(id: $id) {\n    ...PartnersRail_partnerCategory_43V8rY\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnersRail_partnerCategory_43V8rY on PartnerCategory {\n  name\n  primary: partners(defaultProfilePublic: true, eligibleForListing: true, eligibleForPrimaryBucket: true, partnerCategories: $category, sort: RANDOM_SCORE_DESC, type: $type) {\n    internalID\n    ...CellPartner_partner\n    id\n  }\n  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: $type, partnerCategories: $category, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...CellPartner_partner\n    id\n  }\n}\n"
+    "text": "query PartnersRailQuery(\n  $id: String!\n  $category: [String]\n  $type: [PartnerClassification!]!\n) {\n  partnerCategory(id: $id) {\n    ...PartnersRail_partnerCategory_43V8rY\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment PartnersRail_partnerCategory_43V8rY on PartnerCategory {\n  name\n  primary: partners(defaultProfilePublic: true, eligibleForListing: true, eligibleForPrimaryBucket: true, partnerCategories: $category, sort: RANDOM_SCORE_DESC, type: $type) {\n    internalID\n    ...CellPartner_partner\n    id\n  }\n  secondary: partners(eligibleForListing: true, eligibleForSecondaryBucket: true, type: $type, partnerCategories: $category, sort: RANDOM_SCORE_DESC, defaultProfilePublic: true) {\n    internalID\n    ...CellPartner_partner\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/SettingsSavesProfilesQuery.graphql.ts
+++ b/src/v2/__generated__/SettingsSavesProfilesQuery.graphql.ts
@@ -112,7 +112,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment SettingsSavesProfiles_me_WGPvJ on Me {
@@ -292,7 +292,7 @@ v14 = {
   "storageKey": null
 },
 v15 = {
-  "alias": "is_followed",
+  "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isFollowed",
@@ -698,12 +698,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f1dd233bafd7933c3cda429430a0baa8",
+    "cacheID": "035d604bf1e2380afaa1429dede21ec6",
     "id": null,
     "metadata": {},
     "name": "SettingsSavesProfilesQuery",
     "operationKind": "query",
-    "text": "query SettingsSavesProfilesQuery(\n  $after: String\n) {\n  me {\n    ...SettingsSavesProfiles_me_WGPvJ\n    id\n  }\n}\n\nfragment EntityHeaderFairOrganizer_fairOrganizer on FairOrganizer {\n  internalID\n  slug\n  name\n  fairsConnection {\n    totalCount\n  }\n  profile {\n    ...FollowProfileButton_profile\n    href\n    initials\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderFair_fair on Fair {\n  internalID\n  href\n  name\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    initials\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment SettingsSavesProfiles_me_WGPvJ on Me {\n  followsAndSaves {\n    profilesConnection(first: 12, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          profile {\n            name\n            href\n            avatar: image {\n              cropped(width: 45, height: 45) {\n                src\n                srcSet\n              }\n            }\n            owner {\n              __typename\n              ... on Partner {\n                ...EntityHeaderPartner_partner\n              }\n              ... on Fair {\n                ...EntityHeaderFair_fair\n              }\n              ... on FairOrganizer {\n                ...EntityHeaderFairOrganizer_fairOrganizer\n                id\n              }\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsSavesProfilesQuery(\n  $after: String\n) {\n  me {\n    ...SettingsSavesProfiles_me_WGPvJ\n    id\n  }\n}\n\nfragment EntityHeaderFairOrganizer_fairOrganizer on FairOrganizer {\n  internalID\n  slug\n  name\n  fairsConnection {\n    totalCount\n  }\n  profile {\n    ...FollowProfileButton_profile\n    href\n    initials\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderFair_fair on Fair {\n  internalID\n  href\n  name\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    initials\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment SettingsSavesProfiles_me_WGPvJ on Me {\n  followsAndSaves {\n    profilesConnection(first: 12, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          profile {\n            name\n            href\n            avatar: image {\n              cropped(width: 45, height: 45) {\n                src\n                srcSet\n              }\n            }\n            owner {\n              __typename\n              ... on Partner {\n                ...EntityHeaderPartner_partner\n              }\n              ... on Fair {\n                ...EntityHeaderFair_fair\n              }\n              ... on FairOrganizer {\n                ...EntityHeaderFairOrganizer_fairOrganizer\n                id\n              }\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/SettingsSavesProfiles_test_Query.graphql.ts
+++ b/src/v2/__generated__/SettingsSavesProfiles_test_Query.graphql.ts
@@ -112,7 +112,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment SettingsSavesProfiles_me_WGPvJ on Me {
@@ -292,7 +292,7 @@ v14 = {
   "storageKey": null
 },
 v15 = {
-  "alias": "is_followed",
+  "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isFollowed",
@@ -734,7 +734,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3266c1c107fd2bdf1aea5e6d698bf383",
+    "cacheID": "ce197daeef6e36bf023cc9edd994dc09",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -857,7 +857,7 @@ return {
         "me.followsAndSaves.profilesConnection.edges.node.profile.owner.profile.id": (v17/*: any*/),
         "me.followsAndSaves.profilesConnection.edges.node.profile.owner.profile.initials": (v20/*: any*/),
         "me.followsAndSaves.profilesConnection.edges.node.profile.owner.profile.internalID": (v17/*: any*/),
-        "me.followsAndSaves.profilesConnection.edges.node.profile.owner.profile.is_followed": {
+        "me.followsAndSaves.profilesConnection.edges.node.profile.owner.profile.isFollowed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
@@ -887,7 +887,7 @@ return {
     },
     "name": "SettingsSavesProfiles_test_Query",
     "operationKind": "query",
-    "text": "query SettingsSavesProfiles_test_Query(\n  $after: String\n) {\n  me {\n    ...SettingsSavesProfiles_me_WGPvJ\n    id\n  }\n}\n\nfragment EntityHeaderFairOrganizer_fairOrganizer on FairOrganizer {\n  internalID\n  slug\n  name\n  fairsConnection {\n    totalCount\n  }\n  profile {\n    ...FollowProfileButton_profile\n    href\n    initials\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderFair_fair on Fair {\n  internalID\n  href\n  name\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    initials\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment SettingsSavesProfiles_me_WGPvJ on Me {\n  followsAndSaves {\n    profilesConnection(first: 12, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          profile {\n            name\n            href\n            avatar: image {\n              cropped(width: 45, height: 45) {\n                src\n                srcSet\n              }\n            }\n            owner {\n              __typename\n              ... on Partner {\n                ...EntityHeaderPartner_partner\n              }\n              ... on Fair {\n                ...EntityHeaderFair_fair\n              }\n              ... on FairOrganizer {\n                ...EntityHeaderFairOrganizer_fairOrganizer\n                id\n              }\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsSavesProfiles_test_Query(\n  $after: String\n) {\n  me {\n    ...SettingsSavesProfiles_me_WGPvJ\n    id\n  }\n}\n\nfragment EntityHeaderFairOrganizer_fairOrganizer on FairOrganizer {\n  internalID\n  slug\n  name\n  fairsConnection {\n    totalCount\n  }\n  profile {\n    ...FollowProfileButton_profile\n    href\n    initials\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderFair_fair on Fair {\n  internalID\n  href\n  name\n  startAt(format: \"MMM Do\")\n  endAt(format: \"MMM Do YYYY\")\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  profile {\n    ...FollowProfileButton_profile\n    initials\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment SettingsSavesProfiles_me_WGPvJ on Me {\n  followsAndSaves {\n    profilesConnection(first: 12, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          profile {\n            name\n            href\n            avatar: image {\n              cropped(width: 45, height: 45) {\n                src\n                srcSet\n              }\n            }\n            owner {\n              __typename\n              ... on Partner {\n                ...EntityHeaderPartner_partner\n              }\n              ... on Fair {\n                ...EntityHeaderFair_fair\n              }\n              ... on FairOrganizer {\n                ...EntityHeaderFairOrganizer_fairOrganizer\n                id\n              }\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ShowInfo_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowInfo_Test_Query.graphql.ts
@@ -68,7 +68,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment ShowHours_show on Show {
@@ -529,7 +529,7 @@ return {
                       (v5/*: any*/),
                       (v6/*: any*/),
                       {
-                        "alias": "is_followed",
+                        "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "isFollowed",
@@ -621,12 +621,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4847b62cb5b561e08fad8c3d9ee48150",
+    "cacheID": "2e595a9aeb431bde804131d69cf20160",
     "id": null,
     "metadata": {},
     "name": "ShowInfo_Test_Query",
     "operationKind": "query",
-    "text": "query ShowInfo_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment ShowHours_show on Show {\n  location {\n    ...ShowLocationHours_location\n    id\n  }\n  fair {\n    location {\n      ...ShowLocationHours_location\n      id\n    }\n    id\n  }\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      display\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  ...ShowHours_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  partner {\n    __typename\n    ... on Partner {\n      ...EntityHeaderPartner_partner\n      type\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowLocationHours_location on Location {\n  openingHours {\n    __typename\n    ... on OpeningHoursArray {\n      schedules {\n        days\n        hours\n      }\n    }\n    ... on OpeningHoursText {\n      text\n    }\n  }\n}\n"
+    "text": "query ShowInfo_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment ShowHours_show on Show {\n  location {\n    ...ShowLocationHours_location\n    id\n  }\n  fair {\n    location {\n      ...ShowLocationHours_location\n      id\n    }\n    id\n  }\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      display\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  ...ShowHours_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  partner {\n    __typename\n    ... on Partner {\n      ...EntityHeaderPartner_partner\n      type\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowLocationHours_location on Location {\n  openingHours {\n    __typename\n    ... on OpeningHoursArray {\n      schedules {\n        days\n        hours\n      }\n    }\n    ... on OpeningHoursText {\n      text\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/fairRoutes_FairExhibitorsQuery.graphql.ts
+++ b/src/v2/__generated__/fairRoutes_FairExhibitorsQuery.graphql.ts
@@ -111,7 +111,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 */
 
@@ -370,7 +370,7 @@ return {
                           (v5/*: any*/),
                           (v3/*: any*/),
                           {
-                            "alias": "is_followed",
+                            "alias": null,
                             "args": null,
                             "kind": "ScalarField",
                             "name": "isFollowed",
@@ -453,12 +453,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bd1df3df61270d56f9d92ff342e4c00b",
+    "cacheID": "5fb3204fb69b76952189b8136f9223ec",
     "id": null,
     "metadata": {},
     "name": "fairRoutes_FairExhibitorsQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairExhibitorCard_exhibitor on FairExhibitor {\n  profileID\n  partner {\n    ...EntityHeaderPartner_partner\n    internalID\n    slug\n    id\n  }\n}\n\nfragment FairExhibitorCard_fair on Fair {\n  href\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    ...FairExhibitorCard_exhibitor\n    partner {\n      internalID\n      id\n    }\n  }\n}\n\nfragment FairExhibitorsGroup_fair on Fair {\n  ...FairExhibitorCard_fair\n}\n\nfragment FairExhibitors_fair on Fair {\n  ...FairExhibitorsGroup_fair\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query fairRoutes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairExhibitorCard_exhibitor on FairExhibitor {\n  profileID\n  partner {\n    ...EntityHeaderPartner_partner\n    internalID\n    slug\n    id\n  }\n}\n\nfragment FairExhibitorCard_fair on Fair {\n  href\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    ...FairExhibitorCard_exhibitor\n    partner {\n      internalID\n      id\n    }\n  }\n}\n\nfragment FairExhibitorsGroup_fair on Fair {\n  ...FairExhibitorCard_fair\n}\n\nfragment FairExhibitors_fair on Fair {\n  ...FairExhibitorsGroup_fair\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -38,7 +38,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment NavigationTabs_partner on Partner {
@@ -384,7 +384,7 @@ return {
                 "storageKey": null
               },
               {
-                "alias": "is_followed",
+                "alias": null,
                 "args": null,
                 "kind": "ScalarField",
                 "name": "isFollowed",
@@ -699,12 +699,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ec8f5fdbc388ebec242d278cd0fa7eaf",
+    "cacheID": "f4a9482a872da48345c91b11b2b47475",
     "id": null,
     "metadata": {},
     "name": "partnerRoutes_PartnerQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/partnersRoutes_GalleriesRouteQuery.graphql.ts
+++ b/src/v2/__generated__/partnersRoutes_GalleriesRouteQuery.graphql.ts
@@ -29,7 +29,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment GalleriesRoute_viewer on Viewer {
@@ -253,7 +253,7 @@ return {
                               },
                               (v3/*: any*/),
                               {
-                                "alias": "is_followed",
+                                "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
                                 "name": "isFollowed",
@@ -437,12 +437,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ffcb4e0cf075e2fe0119715121908cb2",
+    "cacheID": "04b48eb16b56d63bdae0a30c6341fab6",
     "id": null,
     "metadata": {},
     "name": "partnersRoutes_GalleriesRouteQuery",
     "operationKind": "query",
-    "text": "query partnersRoutes_GalleriesRouteQuery {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      href\n      name\n      featuredShow {\n        href\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query partnersRoutes_GalleriesRouteQuery {\n  viewer {\n    ...GalleriesRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GalleriesRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_4uWBz4\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      href\n      name\n      featuredShow {\n        href\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_4uWBz4 on Viewer {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/partnersRoutes_InstitutionsRouteQuery.graphql.ts
+++ b/src/v2/__generated__/partnersRoutes_InstitutionsRouteQuery.graphql.ts
@@ -29,7 +29,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment InstitutionsRoute_viewer on Viewer {
@@ -253,7 +253,7 @@ return {
                               },
                               (v3/*: any*/),
                               {
-                                "alias": "is_followed",
+                                "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
                                 "name": "isFollowed",
@@ -437,12 +437,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "acc42081abd48bef9ba629faeb7f3762",
+    "cacheID": "3014a6ec1ef499745fa362e979840e9b",
     "id": null,
     "metadata": {},
     "name": "partnersRoutes_InstitutionsRouteQuery",
     "operationKind": "query",
-    "text": "query partnersRoutes_InstitutionsRouteQuery {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      href\n      name\n      featuredShow {\n        href\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query partnersRoutes_InstitutionsRouteQuery {\n  viewer {\n    ...InstitutionsRoute_viewer\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment InstitutionsRoute_viewer on Viewer {\n  ...PartnersFeaturedCarousel_viewer_3Ao4DD\n}\n\nfragment PartnersFeaturedCarouselCell_profile on Profile {\n  ...FollowProfileButton_profile\n  owner {\n    __typename\n    ... on Partner {\n      internalID\n      href\n      name\n      featuredShow {\n        href\n        name\n        status\n        statusUpdate\n        startAt(format: \"MMM D\")\n        endAt(format: \"MMM D\")\n        isOnlineExclusive\n        location {\n          city\n          id\n        }\n        coverImage {\n          resized(height: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on FairOrganizer {\n      id\n    }\n  }\n}\n\nfragment PartnersFeaturedCarousel_viewer_3Ao4DD on Viewer {\n  orderedSet(id: \"564e181a258faf3d5c000080\") {\n    orderedItemsConnection(first: 50) {\n      edges {\n        node {\n          __typename\n          ... on Profile {\n            internalID\n            ...PartnersFeaturedCarouselCell_profile\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on FeaturedLink {\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/showRoutes_ShowInfoQuery.graphql.ts
+++ b/src/v2/__generated__/showRoutes_ShowInfoQuery.graphql.ts
@@ -72,7 +72,7 @@ fragment FollowProfileButton_profile on Profile {
   slug
   name
   internalID
-  is_followed: isFollowed
+  isFollowed
 }
 
 fragment ShowHours_show on Show {
@@ -540,7 +540,7 @@ return {
                       (v6/*: any*/),
                       (v7/*: any*/),
                       {
-                        "alias": "is_followed",
+                        "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "isFollowed",
@@ -632,12 +632,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "dd99ca43f7f5b195973b566496d5456b",
+    "cacheID": "05d02da32e161e66bf5bbd2d56813aaf",
     "id": null,
     "metadata": {},
     "name": "showRoutes_ShowInfoQuery",
     "operationKind": "query",
-    "text": "query showRoutes_ShowInfoQuery(\n  $slug: String!\n) {\n  show(id: $slug) @principalField {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment ShowHours_show on Show {\n  location {\n    ...ShowLocationHours_location\n    id\n  }\n  fair {\n    location {\n      ...ShowLocationHours_location\n      id\n    }\n    id\n  }\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      display\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  ...ShowHours_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  partner {\n    __typename\n    ... on Partner {\n      ...EntityHeaderPartner_partner\n      type\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowLocationHours_location on Location {\n  openingHours {\n    __typename\n    ... on OpeningHoursArray {\n      schedules {\n        days\n        hours\n      }\n    }\n    ... on OpeningHoursText {\n      text\n    }\n  }\n}\n"
+    "text": "query showRoutes_ShowInfoQuery(\n  $slug: String!\n) {\n  show(id: $slug) @principalField {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment ShowHours_show on Show {\n  location {\n    ...ShowLocationHours_location\n    id\n  }\n  fair {\n    location {\n      ...ShowLocationHours_location\n      id\n    }\n    id\n  }\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      display\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  ...ShowHours_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  partner {\n    __typename\n    ... on Partner {\n      ...EntityHeaderPartner_partner\n      type\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowLocationHours_location on Location {\n  openingHours {\n    __typename\n    ... on OpeningHoursArray {\n      schedules {\n        days\n        hours\n      }\n    }\n    ... on OpeningHoursText {\n      text\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/jest.envSetup.ts
+++ b/src/v2/jest.envSetup.ts
@@ -6,9 +6,11 @@ import { format } from "util"
 import "@testing-library/jest-dom"
 
 jest.mock("react-tracking")
-import _track from "react-tracking"
+import _track, { useTracking as _useTracking } from "react-tracking"
 const track = _track as jest.Mock<typeof _track>
+const useTracking = _useTracking as jest.Mock
 track.mockImplementation(() => x => x as any)
+useTracking.mockImplementation(() => ({ trackEvent: jest.fn() }))
 
 jest.mock("react-sizeme", () => jest.fn(() => d => d))
 jest.mock("v2/Utils/logger")


### PR DESCRIPTION
In an effort to remove Unstated from the artist follow button, I want to set a good example here with some consistently implemented gene and profile buttons.

If we were smart we'd simply implement a generic follow mutation that accepts a `type` along with a top-level union follow field and have a single follow button implementation. But I'll save that for another day.