### PR TITLE
feat(TX-406): change size of CTA length on order routes 

### DIFF
--- a/src/v2/Apps/Order/Components/BankAccountPicker.tsx
+++ b/src/v2/Apps/Order/Components/BankAccountPicker.tsx
@@ -135,7 +135,7 @@ export const BankAccountPicker: FC<Props> = props => {
             onClick={handleContinue}
             disabled={!bankAccountSelection.type}
             variant="primaryBlack"
-            width="50%"
+            width={["100%", "50%"]}
           >
             Save and Continue
           </Button>

--- a/src/v2/Apps/Order/Routes/Accept/index.tsx
+++ b/src/v2/Apps/Order/Routes/Accept/index.tsx
@@ -283,7 +283,7 @@ export class Accept extends Component<AcceptProps & StripeProps> {
                   onClick={this.onSubmit}
                   loading={isCommittingMutation}
                   variant="primaryBlack"
-                  width="100%"
+                  width="50%"
                 >
                   Submit
                 </Button>

--- a/src/v2/Apps/Order/Routes/Counter/index.tsx
+++ b/src/v2/Apps/Order/Routes/Counter/index.tsx
@@ -160,7 +160,7 @@ export class CounterRoute extends Component<CounterProps> {
                   onClick={this.onSubmitButtonPressed}
                   loading={isCommittingMutation}
                   variant="primaryBlack"
-                  width="100%"
+                  width="50%"
                 >
                   Submit
                 </Button>

--- a/src/v2/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/v2/Apps/Order/Routes/NewPayment/index.tsx
@@ -30,7 +30,7 @@ import { createStripeWrapper } from "v2/Utils/createStripeWrapper"
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 
 export const ContinueButton = props => (
-  <Button variant="primaryBlack" width="100%" {...props}>
+  <Button variant="primaryBlack" width={["100%", "50%"]} {...props}>
     Continue
   </Button>
 )

--- a/src/v2/Apps/Order/Routes/Offer/index.tsx
+++ b/src/v2/Apps/Order/Routes/Offer/index.tsx
@@ -314,7 +314,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
                   onClick={this.onContinueButtonPressed}
                   loading={isCommittingMutation}
                   variant="primaryBlack"
-                  width="100%"
+                  width="50%"
                 >
                   Continue
                 </Button>

--- a/src/v2/Apps/Order/Routes/Payment/index.tsx
+++ b/src/v2/Apps/Order/Routes/Payment/index.tsx
@@ -35,7 +35,7 @@ import { useSetPayment } from "../../Components/Mutations/useSetPayment"
 import { getInitialPaymentMethodValue } from "../../Utils/orderUtils"
 
 export const ContinueButton = props => (
-  <Button variant="primaryBlack" width="100%" {...props}>
+  <Button variant="primaryBlack" width={["100%", "50%"]} {...props}>
     Continue
   </Button>
 )

--- a/src/v2/Apps/Order/Routes/Reject/index.tsx
+++ b/src/v2/Apps/Order/Routes/Reject/index.tsx
@@ -5,7 +5,7 @@ import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "v2/Ap
 import { ConditionsOfSaleDisclaimer } from "v2/Apps/Order/Components/ConditionsOfSaleDisclaimer"
 import { TwoColumnLayout } from "v2/Apps/Order/Components/TwoColumnLayout"
 import { Router } from "found"
-import { Component } from "react";
+import { Component } from "react"
 
 import { CountdownTimer } from "v2/Components/CountdownTimer"
 import { StepSummaryItem } from "v2/Components/StepSummaryItem"
@@ -132,7 +132,7 @@ export class Reject extends Component<RejectProps> {
                   onClick={this.onSubmit}
                   loading={isCommittingMutation}
                   variant="primaryBlack"
-                  width="100%"
+                  width="50%"
                 >
                   Submit
                 </Button>

--- a/src/v2/Apps/Order/Routes/Respond/index.tsx
+++ b/src/v2/Apps/Order/Routes/Respond/index.tsx
@@ -314,7 +314,7 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
                   onClick={this.onContinueButtonPressed}
                   loading={isCommittingMutation}
                   variant="primaryBlack"
-                  width="100%"
+                  width="50%"
                 >
                   Continue
                 </Button>

--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -411,7 +411,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
               <Spacer mb={2} />
               <Button
                 variant="primaryBlack"
-                width="100%"
+                width="50%"
                 loading={isCommittingMutation}
                 onClick={() => onSubmit()}
               >

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -772,7 +772,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                   onClick={this.onContinueButtonPressed}
                   loading={isCommittingMutation}
                   variant="primaryBlack"
-                  width="100%"
+                  width="50%"
                 >
                   Continue
                 </Button>

--- a/src/v2/Components/BankDebitForm/BankDebitForm.tsx
+++ b/src/v2/Components/BankDebitForm/BankDebitForm.tsx
@@ -92,7 +92,7 @@ export const BankDebitForm: FC<Props> = ({ order, returnURL }) => {
           onClick={trackClickedContinue}
           disabled={!stripe}
           variant="primaryBlack"
-          width="50%"
+          width={["100%", "50%"]}
         >
           Save and Continue
         </Button>


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-406]

### Description
This PR changes the size of the CTA length on all order routes to 50% width, but the CTA length will stay at 100% width on mobile. 

<!-- Implementation description -->
### Screenshots
<img width="1427" alt="Screenshot 2022-07-01 at 11 44 34 AM" src="https://user-images.githubusercontent.com/50849237/176870664-36262298-4012-43b2-9412-6462fa1354f7.png">
<img width="390" alt="Screenshot 2022-07-01 at 11 44 20 AM" src="https://user-images.githubusercontent.com/50849237/176870688-eb09d9e0-7a95-4934-bc0a-8f8c321ea510.png">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-406]: https://artsyproduct.atlassian.net/browse/TX-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ