### PR TITLE
feat(TX-411): add US bank account only label 

### DIFF
--- a/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -25,6 +25,8 @@ import { useTracking } from "v2/System"
 import { ActionType, OwnerType } from "@artsy/cohesion"
 import { CommercePaymentMethodEnum } from "v2/__generated__/useSetPaymentMutation.graphql"
 import { BankAccountPickerFragmentContainer } from "../../Components/BankAccountPicker"
+import styled from "styled-components"
+import { themeGet } from "@styled-system/theme-get"
 
 export interface Props {
   order: Payment_order
@@ -163,7 +165,7 @@ export const PaymentContent: FC<Props> = props => {
             onClick={setPayment}
             variant="primaryBlack"
             loading={isLoading}
-            width="100%"
+            width="50%"
           >
             Save and Continue
           </Button>
@@ -222,13 +224,20 @@ const getAvailablePaymentMethods = (
 
   // when available, unshift ACH since it's the first option we want to offer
   if (availablePaymentMethods.includes("US_BANK_ACCOUNT")) {
+    const USBankOnlyLabel = styled(Text)`
+      background-color: ${themeGet("colors.orange10")};
+      color: ${themeGet("colors.orange150")};
+      padding: 1px 5px;
+      border-radius: 2px;
+    `
     paymentMethods.unshift(
       <BorderedRadio
         value={(paymentMethod = "US_BANK_ACCOUNT")}
         label={
           <>
             <InstitutionIcon fill="green100" />
-            <Text ml={1}>Bank transfer (US bank account)</Text>
+            <Text ml={1}>Bank transfer</Text>
+            <USBankOnlyLabel ml={1}>US bank account only</USBankOnlyLabel>
           </>
         }
       />

--- a/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -187,6 +187,13 @@ const PaymentContentWrapper: FC<{ isLoading: boolean }> = ({
   </Flex>
 )
 
+const USBankOnlyLabel = styled(Text)`
+  background-color: ${themeGet("colors.orange10")};
+  color: ${themeGet("colors.orange150")};
+  padding: 1px 5px;
+  border-radius: 2px;
+`
+
 /*
 returns all available payment methods, by checking relevant feature flags
 TODO: when ACH and wire_transfer FFs is removed, this function can be removed and radios can be moved to PaymentContent
@@ -224,12 +231,6 @@ const getAvailablePaymentMethods = (
 
   // when available, unshift ACH since it's the first option we want to offer
   if (availablePaymentMethods.includes("US_BANK_ACCOUNT")) {
-    const USBankOnlyLabel = styled(Text)`
-      background-color: ${themeGet("colors.orange10")};
-      color: ${themeGet("colors.orange150")};
-      padding: 1px 5px;
-      border-radius: 2px;
-    `
     paymentMethods.unshift(
       <BorderedRadio
         value={(paymentMethod = "US_BANK_ACCOUNT")}


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-411]

### Description

This PR adds the "US bank account only" label to the ACH payment method selection.

[Figma](https://www.figma.com/file/rhcgsn0cMrogxN0TXu5l6T/TX-ACH-Bank-Transfer%2F-Wire-transfer?node-id=4261%3A56669)
 
<!-- Implementation description -->
### Screenshot
<img width="1187" alt="Screenshot 2022-07-01 at 3 39 04 PM" src="https://user-images.githubusercontent.com/50849237/176907720-62ed1618-9a69-47b9-8f3b-980e55d2088c.png">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-411]: https://artsyproduct.atlassian.net/browse/TX-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ