### PR TITLE
[chore][TX-418]: AlicanAkyuz/Inform users about wire transfer fees

### DIFF
--- a/src/v2/Apps/Order/Components/WireTransferDetails.tsx
+++ b/src/v2/Apps/Order/Components/WireTransferDetails.tsx
@@ -27,7 +27,8 @@ export const WireTransferDetails = ({
           team will contact you with next steps by email.
         </Text>
         <Text color="black60" fontSize={13}>
-          • Your bank may charge a fee for the transaction.
+          • Please inform your bank that you will be responsible for all wire
+          transfer fees.
         </Text>
       </Flex>
     )}

--- a/src/v2/Apps/Order/Components/__tests__/WireTransferDetails.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/WireTransferDetails.jest.tsx
@@ -10,7 +10,9 @@ describe("WireTransferDetails", () => {
   it("renders 2 description texts when no props passed", () => {
     render(<WireTransferDetails />)
     expect(
-      screen.queryByText("• Your bank may charge a fee for the transaction.")
+      screen.queryByText(
+        "• Please inform your bank that you will be responsible for all wire transfer fees."
+      )
     ).toBeInTheDocument()
     expect(
       screen.queryByText(
@@ -22,7 +24,9 @@ describe("WireTransferDetails", () => {
   it("does not render description texts when withDescription dictates so", () => {
     render(<WireTransferDetails withDescription={false} />)
     expect(
-      screen.queryByText("• Your bank may charge a fee for the transaction.")
+      screen.queryByText(
+        "• Please inform your bank that you will be responsible for all wire transfer fees."
+      )
     ).not.toBeInTheDocument()
     expect(
       screen.queryByText(

--- a/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/v2/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -151,7 +151,8 @@ export const PaymentContent: FC<Props> = props => {
           team will contact you with next steps by email.
         </Text>
         <Text color="black60" variant="sm">
-          • Your bank may charge a fee for the transaction.
+          • Please inform your bank that you will be responsible for all wire
+          transfer fees.
         </Text>
         <Text color="black60" variant="sm">
           • Questions? Email{" "}


### PR DESCRIPTION
The type of this PR is: **Enhancement**

This PR solves [TX-418]

### Description
In the wire order checkout flow, we tell users that their bank may charge a fee for the wire transfer. This is incorrect because their bank is expected to charge the buyer a fee for the wire transfer.

This PR changes the message from “Your bank may charge a fee for the transaction.” to “Please inform your bank that you will be responsible for all wire transfer fees.”


[TX-418]: https://artsyproduct.atlassian.net/browse/TX-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ