### PR TITLE
fix(FX-4027): fixes Artist Works For Sale filters markup

### DIFF
--- a/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/v2/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -14,6 +14,7 @@ import { KeywordFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/Keywor
 import { useFeatureFlag } from "v2/System/useFeatureFlag"
 import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { useSystemContext } from "v2/System"
+import { Join, Spacer } from "@artsy/palette"
 
 interface ArtistArtworkFiltersProps {
   relayEnvironment?: RelayModernEnvironment
@@ -26,7 +27,7 @@ export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props =
   const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
 
   return (
-    <>
+    <Join separator={<Spacer mt={4} />}>
       {showKeywordFilter && <KeywordFilter />}
       <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
       <AttributionClassFilter expanded />
@@ -40,6 +41,6 @@ export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props =
       <TimePeriodFilter />
       <ColorFilter />
       <PartnersFilter />
-    </>
+    </Join>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

Small markup fix. Fixes paddings between filter components on Artist Works for sale grid

This PR solves [FX-4027]

## Currently on staging

![Screenshot 2022-07-04 at 16 38 55](https://user-images.githubusercontent.com/3934579/177176483-6fc0a572-9463-4a2a-bf9b-93a1e946984f.png)

## Currently on production:

![Screenshot 2022-07-04 at 16 39 42](https://user-images.githubusercontent.com/3934579/177176560-8b05b58c-c3ff-4f4d-9655-993ddadc8d80.png)

## Fix

![Screenshot 2022-07-04 at 16 40 25](https://user-images.githubusercontent.com/3934579/177176679-4f665211-521d-4330-8623-0778fd07d66c.png)

[FX-4027]: https://artsyproduct.atlassian.net/browse/FX-4027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ