### PR TITLE
feat(FX-4059): display warning message on edit alert screen

### DIFF
--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -5,6 +5,7 @@ import {
   Flex,
   Input,
   Join,
+  Message,
   Spacer,
   Text,
 } from "@artsy/palette"
@@ -43,6 +44,7 @@ import {
 } from "v2/Components/SavedSearchAlert/Utils/convertLabelsToPills"
 import { useFeatureFlag } from "v2/System/useFeatureFlag"
 import { extractNodes } from "v2/Utils/extractNodes"
+import { RouterLink } from "v2/System/Router/RouterLink"
 
 const logger = createLogger(
   "v2/Apps/SavedSearchAlerts/Components/SavedSearchAlertEditForm"
@@ -185,7 +187,22 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
                 >
                   Email Alerts
                 </Checkbox>
+                {shouldShowEmailWarning && (
+                  <Message
+                    variant="alert"
+                    title="Change your email preferences"
+                    mt={2}
+                  >
+                    To receive Email Alerts, please update{" "}
+                    <RouterLink to="/unsubscribe">
+                      your email preferences
+                    </RouterLink>
+                    .
+                  </Message>
+                )}
+
                 <Spacer mt={4} />
+
                 <Checkbox
                   onSelect={selected => setFieldValue("push", selected)}
                   selected={values.push}

--- a/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/__tests__/SavedSearchAlertEditForm.jest.tsx
+++ b/src/v2/Apps/Settings/Routes/SavedSearchAlerts/Components/__tests__/SavedSearchAlertEditForm.jest.tsx
@@ -48,6 +48,7 @@ describe("SavedSearchAlertEditForm", () => {
         <MockBoot breakpoint="lg">
           <SavedSearchAlertEditFormFragmentContainer
             me={props.me!}
+            viewer={props.viewer!}
             artistsConnection={props.artistsConnection!}
             artworksConnection={props.artworksConnection!}
             editAlertEntity={defaultEditAlertEntity}
@@ -60,6 +61,9 @@ describe("SavedSearchAlertEditForm", () => {
     query: graphql`
       query SavedSearchAlertEditForm_Test_Query($artistIDs: [String!])
         @raw_response_type {
+        viewer {
+          ...SavedSearchAlertEditForm_viewer
+        }
         me {
           ...SavedSearchAlertEditForm_me
             @arguments(savedSearchId: "id", withAggregations: true)
@@ -105,6 +109,29 @@ describe("SavedSearchAlertEditForm", () => {
     expect(screen.getByText("Banksy")).toBeInTheDocument()
     expect(screen.getByText("KAWS")).toBeInTheDocument()
     expect(screen.getByText("David Shrigley")).toBeInTheDocument()
+  })
+
+  it("should show warning message when `Email Alerts` is enabled and `Custom Alerts` email setting is disabled", () => {
+    const viewerMocked = {
+      notificationPreferences: [
+        {
+          status: "UNSUBSCRIBED",
+          name: "custom_alerts",
+          channel: "email",
+        },
+      ],
+    }
+
+    renderWithRelay({
+      ArtistConnection: () => artistsConnectionMocked,
+      FilterArtworksConnection: () => filterArtworksConnectionMocked,
+      Me: () => meMocked,
+      Viewer: () => viewerMocked,
+    })
+
+    const title = "Change your email preferences"
+
+    expect(screen.getByText(title)).toBeInTheDocument()
   })
 
   it('should call delete alert handler when "Delete Alert" button is pressed', () => {

--- a/src/v2/__generated__/SavedSearchAlertEditFormQuery.graphql.ts
+++ b/src/v2/__generated__/SavedSearchAlertEditFormQuery.graphql.ts
@@ -10,6 +10,9 @@ export type SavedSearchAlertEditFormQueryVariables = {
     withAggregations: boolean;
 };
 export type SavedSearchAlertEditFormQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"SavedSearchAlertEditForm_viewer">;
+    } | null;
     readonly me: {
         readonly " $fragmentRefs": FragmentRefs<"SavedSearchAlertEditForm_me">;
     } | null;
@@ -33,6 +36,9 @@ query SavedSearchAlertEditFormQuery(
   $artistIds: [String!]
   $withAggregations: Boolean!
 ) {
+  viewer {
+    ...SavedSearchAlertEditForm_viewer
+  }
   me {
     ...SavedSearchAlertEditForm_me_2FI717
     id
@@ -100,6 +106,14 @@ fragment SavedSearchAlertEditForm_me_2FI717 on Me {
     }
   }
 }
+
+fragment SavedSearchAlertEditForm_viewer on Viewer {
+  notificationPreferences {
+    status
+    name
+    channel
+  }
+}
 */
 
 const node: ConcreteRequest = (function(){
@@ -152,14 +166,14 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "name",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "internalID",
   "storageKey": null
 },
 v7 = {
@@ -187,6 +201,22 @@ return {
     "metadata": null,
     "name": "SavedSearchAlertEditFormQuery",
     "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SavedSearchAlertEditForm_viewer"
+          }
+        ],
+        "storageKey": null
+      },
       {
         "alias": null,
         "args": null,
@@ -270,6 +300,43 @@ return {
       {
         "alias": null,
         "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "NotificationPreference",
+            "kind": "LinkedField",
+            "name": "notificationPreferences",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "status",
+                "storageKey": null
+              },
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "channel",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
         "concreteType": "Me",
         "kind": "LinkedField",
         "name": "me",
@@ -289,7 +356,7 @@ return {
             "name": "savedSearch",
             "plural": false,
             "selections": [
-              (v5/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -417,7 +484,7 @@ return {
                 "name": "userAlertSettings",
                 "plural": false,
                 "selections": [
-                  (v6/*: any*/),
+                  (v5/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -499,8 +566,8 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v5/*: any*/),
                   (v6/*: any*/),
+                  (v5/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -561,7 +628,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v5/*: any*/),
                       (v7/*: any*/)
                     ],
                     "storageKey": null
@@ -578,14 +645,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "62f8f533172e6774fbd07194173642d8",
+    "cacheID": "6c58f85d4f6756066f5ae03f44bebb0f",
     "id": null,
     "metadata": {},
     "name": "SavedSearchAlertEditFormQuery",
     "operationKind": "query",
-    "text": "query SavedSearchAlertEditFormQuery(\n  $id: ID!\n  $artistIds: [String!]\n  $withAggregations: Boolean!\n) {\n  me {\n    ...SavedSearchAlertEditForm_me_2FI717\n    id\n  }\n  artistsConnection(slugs: $artistIds) {\n    ...SavedSearchAlertEditForm_artistsConnection\n  }\n  artworksConnection(first: 0, artistIDs: $artistIds, aggregations: [LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]) @include(if: $withAggregations) {\n    ...SavedSearchAlertEditForm_artworksConnection\n    id\n  }\n}\n\nfragment SavedSearchAlertEditForm_artistsConnection on ArtistConnection {\n  edges {\n    node {\n      internalID\n      name\n      slug\n      id\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      value\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_me_2FI717 on Me {\n  savedSearch(id: $id) {\n    internalID\n    acquireable\n    additionalGeneIDs\n    artistIDs\n    atAuction\n    attributionClass\n    colors\n    dimensionRange\n    sizes\n    width\n    height\n    inquireableOnly\n    locationCities\n    majorPeriods\n    materialsTerms\n    offerable\n    partnerIDs\n    priceRange\n    userAlertSettings {\n      name\n      email\n      push\n    }\n    labels @skip(if: $withAggregations) {\n      field\n      value\n      displayValue\n    }\n  }\n}\n"
+    "text": "query SavedSearchAlertEditFormQuery(\n  $id: ID!\n  $artistIds: [String!]\n  $withAggregations: Boolean!\n) {\n  viewer {\n    ...SavedSearchAlertEditForm_viewer\n  }\n  me {\n    ...SavedSearchAlertEditForm_me_2FI717\n    id\n  }\n  artistsConnection(slugs: $artistIds) {\n    ...SavedSearchAlertEditForm_artistsConnection\n  }\n  artworksConnection(first: 0, artistIDs: $artistIds, aggregations: [LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]) @include(if: $withAggregations) {\n    ...SavedSearchAlertEditForm_artworksConnection\n    id\n  }\n}\n\nfragment SavedSearchAlertEditForm_artistsConnection on ArtistConnection {\n  edges {\n    node {\n      internalID\n      name\n      slug\n      id\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      value\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_me_2FI717 on Me {\n  savedSearch(id: $id) {\n    internalID\n    acquireable\n    additionalGeneIDs\n    artistIDs\n    atAuction\n    attributionClass\n    colors\n    dimensionRange\n    sizes\n    width\n    height\n    inquireableOnly\n    locationCities\n    majorPeriods\n    materialsTerms\n    offerable\n    partnerIDs\n    priceRange\n    userAlertSettings {\n      name\n      email\n      push\n    }\n    labels @skip(if: $withAggregations) {\n      field\n      value\n      displayValue\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_viewer on Viewer {\n  notificationPreferences {\n    status\n    name\n    channel\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '33fa0442ca99a7c1ec2cb82d2a49c399';
+(node as any).hash = '832ca3f53f31802f63eb2c78468de9c3';
 export default node;

--- a/src/v2/__generated__/SavedSearchAlertEditForm_Test_Query.graphql.ts
+++ b/src/v2/__generated__/SavedSearchAlertEditForm_Test_Query.graphql.ts
@@ -5,10 +5,14 @@
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "SIMPLE_PRICE_HISTOGRAM" | "TOTAL" | "%future added value";
+export type SubGroupStatus = "SUBSCRIBED" | "UNSUBSCRIBED" | "%future added value";
 export type SavedSearchAlertEditForm_Test_QueryVariables = {
     artistIDs?: Array<string> | null | undefined;
 };
 export type SavedSearchAlertEditForm_Test_QueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"SavedSearchAlertEditForm_viewer">;
+    } | null;
     readonly me: {
         readonly " $fragmentRefs": FragmentRefs<"SavedSearchAlertEditForm_me">;
     } | null;
@@ -20,6 +24,13 @@ export type SavedSearchAlertEditForm_Test_QueryResponse = {
     } | null;
 };
 export type SavedSearchAlertEditForm_Test_QueryRawResponse = {
+    readonly viewer: ({
+        readonly notificationPreferences: ReadonlyArray<{
+            readonly status: SubGroupStatus;
+            readonly name: string;
+            readonly channel: string;
+        }>;
+    }) | null;
     readonly me: ({
         readonly savedSearch: ({
             readonly internalID: string;
@@ -82,6 +93,9 @@ export type SavedSearchAlertEditForm_Test_Query = {
 query SavedSearchAlertEditForm_Test_Query(
   $artistIDs: [String!]
 ) {
+  viewer {
+    ...SavedSearchAlertEditForm_viewer
+  }
   me {
     ...SavedSearchAlertEditForm_me_1EL2c3
     id
@@ -144,6 +158,14 @@ fragment SavedSearchAlertEditForm_me_1EL2c3 on Me {
     }
   }
 }
+
+fragment SavedSearchAlertEditForm_viewer on Viewer {
+  notificationPreferences {
+    status
+    name
+    channel
+  }
+}
 */
 
 const node: ConcreteRequest = (function(){
@@ -188,14 +210,14 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "name",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "internalID",
   "storageKey": null
 },
 v5 = {
@@ -212,6 +234,22 @@ return {
     "metadata": null,
     "name": "SavedSearchAlertEditForm_Test_Query",
     "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SavedSearchAlertEditForm_viewer"
+          }
+        ],
+        "storageKey": null
+      },
       {
         "alias": null,
         "args": null,
@@ -284,6 +322,43 @@ return {
       {
         "alias": null,
         "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "NotificationPreference",
+            "kind": "LinkedField",
+            "name": "notificationPreferences",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "status",
+                "storageKey": null
+              },
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "channel",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
         "concreteType": "Me",
         "kind": "LinkedField",
         "name": "me",
@@ -303,7 +378,7 @@ return {
             "name": "savedSearch",
             "plural": false,
             "selections": [
-              (v3/*: any*/),
+              (v4/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -431,7 +506,7 @@ return {
                 "name": "userAlertSettings",
                 "plural": false,
                 "selections": [
-                  (v4/*: any*/),
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -480,8 +555,8 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v3/*: any*/),
                   (v4/*: any*/),
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -537,7 +612,7 @@ return {
                     "name": "count",
                     "storageKey": null
                   },
-                  (v4/*: any*/),
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -558,14 +633,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5578f7f925ecb1446a2442f5e5f47aba",
+    "cacheID": "a44a1d76f5f1752b083a741072a0fbb8",
     "id": null,
     "metadata": {},
     "name": "SavedSearchAlertEditForm_Test_Query",
     "operationKind": "query",
-    "text": "query SavedSearchAlertEditForm_Test_Query(\n  $artistIDs: [String!]\n) {\n  me {\n    ...SavedSearchAlertEditForm_me_1EL2c3\n    id\n  }\n  artistsConnection(slugs: $artistIDs) {\n    ...SavedSearchAlertEditForm_artistsConnection\n  }\n  artworksConnection(first: 0, artistIDs: $artistIDs, aggregations: [LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]) {\n    ...SavedSearchAlertEditForm_artworksConnection\n    id\n  }\n}\n\nfragment SavedSearchAlertEditForm_artistsConnection on ArtistConnection {\n  edges {\n    node {\n      internalID\n      name\n      slug\n      id\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      value\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_me_1EL2c3 on Me {\n  savedSearch(id: \"id\") {\n    internalID\n    acquireable\n    additionalGeneIDs\n    artistIDs\n    atAuction\n    attributionClass\n    colors\n    dimensionRange\n    sizes\n    width\n    height\n    inquireableOnly\n    locationCities\n    majorPeriods\n    materialsTerms\n    offerable\n    partnerIDs\n    priceRange\n    userAlertSettings {\n      name\n      email\n      push\n    }\n  }\n}\n"
+    "text": "query SavedSearchAlertEditForm_Test_Query(\n  $artistIDs: [String!]\n) {\n  viewer {\n    ...SavedSearchAlertEditForm_viewer\n  }\n  me {\n    ...SavedSearchAlertEditForm_me_1EL2c3\n    id\n  }\n  artistsConnection(slugs: $artistIDs) {\n    ...SavedSearchAlertEditForm_artistsConnection\n  }\n  artworksConnection(first: 0, artistIDs: $artistIDs, aggregations: [LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]) {\n    ...SavedSearchAlertEditForm_artworksConnection\n    id\n  }\n}\n\nfragment SavedSearchAlertEditForm_artistsConnection on ArtistConnection {\n  edges {\n    node {\n      internalID\n      name\n      slug\n      id\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      value\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_me_1EL2c3 on Me {\n  savedSearch(id: \"id\") {\n    internalID\n    acquireable\n    additionalGeneIDs\n    artistIDs\n    atAuction\n    attributionClass\n    colors\n    dimensionRange\n    sizes\n    width\n    height\n    inquireableOnly\n    locationCities\n    majorPeriods\n    materialsTerms\n    offerable\n    partnerIDs\n    priceRange\n    userAlertSettings {\n      name\n      email\n      push\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_viewer on Viewer {\n  notificationPreferences {\n    status\n    name\n    channel\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '6f1e02de8740e8d00d1ce5c1d94783ac';
+(node as any).hash = 'c00b8209f78cc7989a5c7e22b2e8895a';
 export default node;

--- a/src/v2/__generated__/SavedSearchAlertEditForm_viewer.graphql.ts
+++ b/src/v2/__generated__/SavedSearchAlertEditForm_viewer.graphql.ts
@@ -1,0 +1,67 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SubGroupStatus = "SUBSCRIBED" | "UNSUBSCRIBED" | "%future added value";
+export type SavedSearchAlertEditForm_viewer = {
+    readonly notificationPreferences: ReadonlyArray<{
+        readonly status: SubGroupStatus;
+        readonly name: string;
+        readonly channel: string;
+    }>;
+    readonly " $refType": "SavedSearchAlertEditForm_viewer";
+};
+export type SavedSearchAlertEditForm_viewer$data = SavedSearchAlertEditForm_viewer;
+export type SavedSearchAlertEditForm_viewer$key = {
+    readonly " $data"?: SavedSearchAlertEditForm_viewer$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"SavedSearchAlertEditForm_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SavedSearchAlertEditForm_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "NotificationPreference",
+      "kind": "LinkedField",
+      "name": "notificationPreferences",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "status",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "channel",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Viewer",
+  "abstractKey": null
+};
+(node as any).hash = '7793cf50a0f573d8b329a1de785b2cfe';
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR solves [FX-4059]

Review app: https://warning-message.artsy.net/

### Description
Display a warning message on edit alert screen if the "Email Alerts" toggle is enabled, but the "Custom Alerts" setting is disabled in the [Email Preference Center](https://artsy.net/unsubscribe) on Force (this is already [implemented for Eigen](https://github.com/artsy/eigen/pull/6070))

There may be a situation when the user previously created a saved search alert and enabled "Email Alerts" toggle, but later set "Email Preferences" to "None". And it would be useful to warn the user about this on edit alert screen

### Demo
#### Screenshot
<img width="1882" alt="demo" src="https://user-images.githubusercontent.com/3513494/177382493-46c550e4-31a9-4c34-a882-14b4aa8e6996.png">

#### Video
https://user-images.githubusercontent.com/3513494/177386719-e13a89eb-97bb-47d2-acd2-8edd32094aec.mp4

<!-- Implementation description -->

[FX-4059]: https://artsyproduct.atlassian.net/browse/FX-4059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ