### PR TITLE
feat(onboarding)[WIP]: build screen for follow artists reward path

### DIFF
--- a/src/v2/Apps/Onboarding/Components/OnboardingOrderedSet.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingOrderedSet.tsx
@@ -1,0 +1,111 @@
+import { Column, GridColumns, Box } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { OnboardingLoadingCollection } from "./OnboardingLoadingCollection"
+import { OnboardingOrderedSet_orderedSet } from "v2/__generated__/OnboardingOrderedSet_orderedSet.graphql"
+import { OnboardingOrderedSetQuery } from "v2/__generated__/OnboardingOrderedSetQuery.graphql"
+import { FC } from "react"
+// import { EntityHeaderArtistFragmentContainer } from "v2/Components/EntityHeaders/EntityHeaderArtist"
+// import { extractNodes } from "v2/Utils/extractNodes"
+
+interface OnboardingOrderedSetProps {
+  orderedSet: OnboardingOrderedSet_orderedSet
+}
+
+export const OnboardingOrderedSet: FC<OnboardingOrderedSetProps> = ({
+  orderedSet,
+}) => {
+  // const artists = extractNodes(orderedSet)
+  // TODO: artists is currently an empty array will fix
+
+  return (
+    <>
+      <GridColumns>
+        <Column span={6}>
+          <Box
+            color="black100"
+            border="1px solid"
+            width="100%"
+            height="100%"
+          ></Box>
+        </Column>
+        <Column span={6}>
+          {/* {artists.map(artist => {
+            if (!artist || artist.name) return null
+
+            return (
+              <EntityHeaderArtistFragmentContainer
+                artist={artist}
+                key={artist.internalID}
+              />
+            )
+          })} */}
+        </Column>
+      </GridColumns>
+    </>
+  )
+}
+
+const OnboardingOrderedSetFragmentContainer = createFragmentContainer(
+  OnboardingOrderedSet,
+  {
+    orderedSet: graphql`
+      fragment OnboardingOrderedSet_orderedSet on OrderedSet {
+        orderedItemsConnection(first: 50) {
+          edges {
+            node {
+              ... on Artist {
+                name
+                slug
+                internalID
+                image {
+                  imageURL
+                  internalID
+                }
+                formattedNationalityAndBirthday
+              }
+            }
+          }
+        }
+      }
+    `,
+  }
+)
+
+interface OnboardingOrderedSetQueryRendererProps {
+  id: string
+}
+
+export const OnboardingOrderedSetQueryRenderer: FC<OnboardingOrderedSetQueryRendererProps> = ({
+  id,
+}) => {
+  return (
+    <SystemQueryRenderer<OnboardingOrderedSetQuery>
+      placeholder={<OnboardingLoadingCollection />}
+      query={graphql`
+        query OnboardingOrderedSetQuery($key: String!) {
+          orderedSets(key: $key) {
+            ...OnboardingOrderedSet_orderedSet
+          }
+        }
+      `}
+      variables={{ key: id }}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props?.orderedSets) {
+          return <OnboardingLoadingCollection />
+        }
+
+        const [orderedSet] = props.orderedSets
+
+        if (!orderedSet) return null
+
+        return <OnboardingOrderedSetFragmentContainer orderedSet={orderedSet} />
+      }}
+    />
+  )
+}

--- a/src/v2/Apps/Onboarding/Components/OnboardingSearchResults.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingSearchResults.tsx
@@ -1,0 +1,102 @@
+import { Join, Separator } from "@artsy/palette"
+import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { EntityHeaderArtistFragmentContainer } from "v2/Components/EntityHeaders/EntityHeaderArtist"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+// import { extractNodes } from "v2/Utils/extractNodes"
+import { useOnboardingContext } from "../useOnboardingContext"
+import { OnboardingSearchResults_viewer } from "v2/__generated__/OnboardingSearchResults_viewer.graphql"
+import { OnboardingSearchResultsQuery } from ""
+
+interface OnboardingSearchResultsProps {
+  viewer: OnboardingSearchResults_viewer
+}
+
+const OnboardingSearchResults: FC<OnboardingSearchResultsProps> = ({
+  viewer,
+}) => {
+  const { dispatch } = useOnboardingContext()
+  // const nodes = extractNodes(searchResults)
+
+  return (
+    <>
+      <Join separator={<Separator my={2} />}>
+        {nodes.map(node => {
+          if (!node || !node.name) return null
+
+          return (
+            <EntityHeaderArtistFragmentContainer
+              artist={node}
+              key={node.internalID}
+              // TODO: Switch this to `onFollow`
+              onClick={() => {
+                dispatch({ type: "FOLLOW", payload: node.internalID! })
+              }}
+            />
+          )
+        })}
+      </Join>
+    </>
+  )
+}
+
+export const OnboardingSearchResultsFragmentContainer = createFragmentContainer(
+  OnboardingSearchResults,
+  {
+    viewer: graphql`
+      fragment OnboardingSearchResults_viewer on Viewer
+        @argumentDefinitions(query: { type: "String!", defaultValue: "" }) {
+        searchConnection(query: $query, entities: [ARTIST], first: 10) {
+          edges {
+            node {
+              ... on Artist {
+                name
+                internalID
+                ...EntityHeaderArtist_artist
+              }
+            }
+          }
+        }
+      }
+    `,
+  }
+)
+
+interface OnboardingOrderedSetQueryRendererProps {
+  query: string
+}
+
+export const OnboardingSearchResultsQueryRenderer: FC<OnboardingOrderedSetQueryRendererProps> = ({
+  query,
+}) => {
+  // TODO: figure out why OnboardingSearchResults_viewer cant be spread into the query
+
+  return (
+    <SystemQueryRenderer<OnboardingSearchResultsQuery>
+      query={graphql`
+        query OnboardingSearchResultsQuery($query: String!) {
+          viewer {
+            searchConnection(query: $query) {
+              ...OnboardingSearchResults_viewer
+            }
+          }
+        }
+      `}
+      variables={{ query: query }}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props?.viewer) {
+          return null
+        }
+
+        return (
+          <OnboardingSearchResultsFragmentContainer viewer={props.viewer} />
+        )
+      }}
+    />
+  )
+}

--- a/src/v2/Apps/Onboarding/Components/OnboardingSearchResults.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingSearchResults.tsx
@@ -3,10 +3,10 @@ import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { EntityHeaderArtistFragmentContainer } from "v2/Components/EntityHeaders/EntityHeaderArtist"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
-// import { extractNodes } from "v2/Utils/extractNodes"
+import { extractNodes } from "v2/Utils/extractNodes"
 import { useOnboardingContext } from "../useOnboardingContext"
 import { OnboardingSearchResults_viewer } from "v2/__generated__/OnboardingSearchResults_viewer.graphql"
-import { OnboardingSearchResultsQuery } from ""
+import { OnboardingSearchResultsQuery } from "v2/__generated__/OnboardingSearchResultsQuery.graphql"
 
 interface OnboardingSearchResultsProps {
   viewer: OnboardingSearchResults_viewer
@@ -16,7 +16,7 @@ const OnboardingSearchResults: FC<OnboardingSearchResultsProps> = ({
   viewer,
 }) => {
   const { dispatch } = useOnboardingContext()
-  // const nodes = extractNodes(searchResults)
+  const nodes = extractNodes(viewer.searchConnection)
 
   return (
     <>
@@ -69,16 +69,12 @@ interface OnboardingOrderedSetQueryRendererProps {
 export const OnboardingSearchResultsQueryRenderer: FC<OnboardingOrderedSetQueryRendererProps> = ({
   query,
 }) => {
-  // TODO: figure out why OnboardingSearchResults_viewer cant be spread into the query
-
   return (
     <SystemQueryRenderer<OnboardingSearchResultsQuery>
       query={graphql`
         query OnboardingSearchResultsQuery($query: String!) {
           viewer {
-            searchConnection(query: $query) {
-              ...OnboardingSearchResults_viewer
-            }
+            ...OnboardingSearchResults_viewer @arguments(query: $query)
           }
         }
       `}
@@ -88,11 +84,9 @@ export const OnboardingSearchResultsQueryRenderer: FC<OnboardingOrderedSetQueryR
           console.error(error)
           return null
         }
-
         if (!props?.viewer) {
           return null
         }
-
         return (
           <OnboardingSearchResultsFragmentContainer viewer={props.viewer} />
         )

--- a/src/v2/Apps/Onboarding/Components/OnboardingSearchResults.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingSearchResults.tsx
@@ -2,7 +2,6 @@ import { Join, Separator } from "@artsy/palette"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { EntityHeaderArtistFragmentContainer } from "v2/Components/EntityHeaders/EntityHeaderArtist"
-// import { EntityHeaderPartnerFragmentContainer } from "v2/Components/EntityHeaders/EntityHeaderPartner"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { extractNodes } from "v2/Utils/extractNodes"
 import { useOnboardingContext } from "../useOnboardingContext"
@@ -17,7 +16,6 @@ const OnboardingSearchResults: FC<OnboardingSearchResultsProps> = ({
   viewer,
 }) => {
   const { dispatch } = useOnboardingContext()
-  // case statement goes here
   const nodes = extractNodes(viewer.matchConnection)
 
   return (
@@ -60,7 +58,6 @@ export const OnboardingSearchResultsFragmentContainer = createFragmentContainer(
                 name
                 internalID
                 ...EntityHeaderArtist_artist
-                ...EntityHeaderPartner_partner
               }
             }
           }

--- a/src/v2/Apps/Onboarding/Views/OnboardingFollowArtists.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingFollowArtists.tsx
@@ -1,10 +1,6 @@
-import { Text, Flex } from "@artsy/palette"
 import { FC } from "react"
+import { OnboardingOrderedSetQueryRenderer } from "../Components/OnboardingOrderedSet"
 
 export const OnboardingFollowArtists: FC = () => {
-  return (
-    <Flex flexDirection="column">
-      <Text variant="lg-display">TODO: OnboardingFollowArtists</Text>
-    </Flex>
-  )
+  return <OnboardingOrderedSetQueryRenderer id="onboarding:suggested-artists" />
 }

--- a/src/v2/Apps/Onboarding/Views/OnboardingFollowArtists.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingFollowArtists.tsx
@@ -1,6 +1,64 @@
-import { FC } from "react"
+import {
+  Box,
+  Text,
+  LabeledInput,
+  MagnifyingGlassIcon,
+  Button,
+  Flex,
+} from "@artsy/palette"
+import { FC, useState } from "react"
 import { OnboardingOrderedSetQueryRenderer } from "../Components/OnboardingOrderedSet"
+import { OnboardingSplitLayout } from "../Components/OnboardingSplitLayout"
+import { useOnboardingContext } from "../useOnboardingContext"
+import { OnboardingSearchResultsQueryRenderer } from "../Components/OnboardingSearchResults"
 
 export const OnboardingFollowArtists: FC = () => {
-  return <OnboardingOrderedSetQueryRenderer id="onboarding:suggested-artists" />
+  const { next, state } = useOnboardingContext()
+  const [query, setQuery] = useState("")
+
+  return (
+    <OnboardingSplitLayout
+      left={<Box width="100%" height="100%" bg="black10" />}
+      right={
+        <Flex flexDirection="column">
+          <Box pt={4} px={4}>
+            <Text variant="lg-display" mb={2}>
+              Follow artists to see more of their work
+            </Text>
+
+            <LabeledInput
+              label={<MagnifyingGlassIcon />}
+              placeholder="Search Artists"
+              mb={4}
+              onChange={event => setQuery(event.currentTarget.value)}
+            />
+          </Box>
+
+          <Box
+            px={4}
+            flex={1}
+            overflowY="auto"
+            style={{ WebkitOverflowScrolling: "touch" }}
+          >
+            {query ? (
+              <OnboardingSearchResultsQueryRenderer query={query} />
+            ) : (
+              // TODO: pass in onboardingSearchResultsQueryRenderer here
+              <OnboardingOrderedSetQueryRenderer id="onboarding:suggested-artists" />
+            )}
+          </Box>
+
+          <Box p={2}>
+            <Button
+              width="100%"
+              onClick={next}
+              disabled={state.followedIds.length === 0}
+            >
+              Done
+            </Button>
+          </Box>
+        </Flex>
+      }
+    />
+  )
 }

--- a/src/v2/Apps/Onboarding/Views/OnboardingFollowArtists.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingFollowArtists.tsx
@@ -41,9 +41,8 @@ export const OnboardingFollowArtists: FC = () => {
             style={{ WebkitOverflowScrolling: "touch" }}
           >
             {query ? (
-              <OnboardingSearchResultsQueryRenderer query={query} />
+              <OnboardingSearchResultsQueryRenderer term={query} />
             ) : (
-              // TODO: pass in onboardingSearchResultsQueryRenderer here
               <OnboardingOrderedSetQueryRenderer id="onboarding:suggested-artists" />
             )}
           </Box>

--- a/src/v2/Apps/Onboarding/__tests__/config.jest.ts
+++ b/src/v2/Apps/Onboarding/__tests__/config.jest.ts
@@ -22,6 +22,7 @@ describe("config", () => {
             questionOne: OPTION_YES_I_LOVE_COLLECTING_ART,
             questionTwo: [OPTION_DEVELOPING_MY_ART_TASTES],
             questionThree: OPTION_TOP_AUCTION_LOTS,
+            followedIds: [],
           },
         },
       })
@@ -40,6 +41,7 @@ describe("config", () => {
         questionOne: OPTION_YES_I_LOVE_COLLECTING_ART,
         questionTwo: [OPTION_DEVELOPING_MY_ART_TASTES],
         questionThree: null,
+        followedIds: [],
       } as State,
     }
     const {

--- a/src/v2/Apps/Onboarding/config.ts
+++ b/src/v2/Apps/Onboarding/config.ts
@@ -11,8 +11,6 @@ export const useConfig = ({ basis, onDone }: UseConfig) => {
   const workflowEngine = useRef(
     new WorkflowEngine({
       workflow: [
-        //TODO: remove follow_artists from workflow
-        VIEW_FOLLOW_ARTISTS,
         VIEW_WELCOME,
         VIEW_QUESTION_ONE,
         VIEW_QUESTION_TWO,

--- a/src/v2/Apps/Onboarding/config.ts
+++ b/src/v2/Apps/Onboarding/config.ts
@@ -11,6 +11,8 @@ export const useConfig = ({ basis, onDone }: UseConfig) => {
   const workflowEngine = useRef(
     new WorkflowEngine({
       workflow: [
+        //TODO: remove follow_artists from workflow
+        VIEW_FOLLOW_ARTISTS,
         VIEW_WELCOME,
         VIEW_QUESTION_ONE,
         VIEW_QUESTION_TWO,

--- a/src/v2/Apps/Onboarding/useOnboardingContext.tsx
+++ b/src/v2/Apps/Onboarding/useOnboardingContext.tsx
@@ -13,12 +13,14 @@ export type State = {
   questionOne: string | null
   questionTwo: string[]
   questionThree: string | null
+  followedIds: string[]
 }
 
 export const DEFAULT_STATE: State = {
   questionOne: null,
   questionTwo: [],
   questionThree: null,
+  followedIds: [],
 }
 
 type Action =
@@ -26,6 +28,7 @@ type Action =
   | { type: "SET_ANSWER_ONE"; payload: string }
   | { type: "SET_ANSWER_TWO"; payload: string }
   | { type: "SET_ANSWER_THREE"; payload: string }
+  | { type: "FOLLOW"; payload: string }
 
 const reducer = (onReset: () => void) => (state: State, action: Action) => {
   switch (action.type) {
@@ -51,6 +54,14 @@ const reducer = (onReset: () => void) => (state: State, action: Action) => {
       return {
         ...state,
         questionThree: action.payload,
+      }
+
+    case "FOLLOW":
+      return {
+        ...state,
+        followedIds: state.followedIds.includes(action.payload)
+          ? state.followedIds.filter(id => id !== action.payload)
+          : [...state.followedIds, action.payload],
       }
 
     default:

--- a/src/v2/__generated__/OnboardingOrderedSetQuery.graphql.ts
+++ b/src/v2/__generated__/OnboardingOrderedSetQuery.graphql.ts
@@ -1,0 +1,265 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type OnboardingOrderedSetQueryVariables = {
+    key: string;
+};
+export type OnboardingOrderedSetQueryResponse = {
+    readonly orderedSets: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"OnboardingOrderedSet_orderedSet">;
+    } | null> | null;
+};
+export type OnboardingOrderedSetQuery = {
+    readonly response: OnboardingOrderedSetQueryResponse;
+    readonly variables: OnboardingOrderedSetQueryVariables;
+};
+
+
+
+/*
+query OnboardingOrderedSetQuery(
+  $key: String!
+) {
+  orderedSets(key: $key) {
+    ...OnboardingOrderedSet_orderedSet
+    id
+  }
+}
+
+fragment OnboardingOrderedSet_orderedSet on OrderedSet {
+  orderedItemsConnection(first: 50) {
+    edges {
+      node {
+        __typename
+        ... on Artist {
+          name
+          slug
+          internalID
+          image {
+            imageURL
+            internalID
+          }
+          formattedNationalityAndBirthday
+        }
+        ... on Node {
+          __isNode: __typename
+          id
+        }
+        ... on FeaturedLink {
+          id
+        }
+        ... on Profile {
+          id
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "key"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "key",
+    "variableName": "key"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  (v3/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "OnboardingOrderedSetQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSets",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "OnboardingOrderedSet_orderedSet"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "OnboardingOrderedSetQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSets",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 50
+              }
+            ],
+            "concreteType": "OrderedSetItemConnection",
+            "kind": "LinkedField",
+            "name": "orderedItemsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "OrderedSetItemEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "slug",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "imageURL",
+                                "storageKey": null
+                              },
+                              (v2/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "formattedNationalityAndBirthday",
+                            "storageKey": null
+                          }
+                        ],
+                        "type": "Artist",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": (v4/*: any*/),
+                        "type": "Node",
+                        "abstractKey": "__isNode"
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": (v4/*: any*/),
+                        "type": "FeaturedLink",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": (v4/*: any*/),
+                        "type": "Profile",
+                        "abstractKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "orderedItemsConnection(first:50)"
+          },
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1914701cbeff220c2aebeaf33ca65327",
+    "id": null,
+    "metadata": {},
+    "name": "OnboardingOrderedSetQuery",
+    "operationKind": "query",
+    "text": "query OnboardingOrderedSetQuery(\n  $key: String!\n) {\n  orderedSets(key: $key) {\n    ...OnboardingOrderedSet_orderedSet\n    id\n  }\n}\n\nfragment OnboardingOrderedSet_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 50) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          slug\n          internalID\n          image {\n            imageURL\n            internalID\n          }\n          formattedNationalityAndBirthday\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n        ... on Profile {\n          id\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '1f698c68f9f2741b52867749c6466971';
+export default node;

--- a/src/v2/__generated__/OnboardingOrderedSetQuery.graphql.ts
+++ b/src/v2/__generated__/OnboardingOrderedSetQuery.graphql.ts
@@ -29,20 +29,34 @@ query OnboardingOrderedSetQuery(
   }
 }
 
+fragment EntityHeaderArtist_artist on Artist {
+  internalID
+  href
+  slug
+  name
+  initials
+  formattedNationalityAndBirthday
+  counts {
+    artworks
+    forSaleArtworks
+  }
+  avatar: image {
+    cropped(width: 45, height: 45) {
+      src
+      srcSet
+    }
+  }
+}
+
 fragment OnboardingOrderedSet_orderedSet on OrderedSet {
   orderedItemsConnection(first: 50) {
     edges {
       node {
         __typename
         ... on Artist {
+          ...EntityHeaderArtist_artist
           name
-          slug
           internalID
-          image {
-            imageURL
-            internalID
-          }
-          formattedNationalityAndBirthday
         }
         ... on Node {
           __isNode: __typename
@@ -79,18 +93,11 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = [
-  (v3/*: any*/)
+v3 = [
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -177,7 +184,14 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "name",
+                            "name": "internalID",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "href",
                             "storageKey": null
                           },
                           {
@@ -187,24 +201,18 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v2/*: any*/),
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "Image",
-                            "kind": "LinkedField",
-                            "name": "image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "imageURL",
-                                "storageKey": null
-                              },
-                              (v2/*: any*/)
-                            ],
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "initials",
                             "storageKey": null
                           },
                           {
@@ -213,6 +221,78 @@ return {
                             "kind": "ScalarField",
                             "name": "formattedNationalityAndBirthday",
                             "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtistCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "artworks",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "forSaleArtworks",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "avatar",
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "height",
+                                    "value": 45
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 45
+                                  }
+                                ],
+                                "concreteType": "CroppedImageUrl",
+                                "kind": "LinkedField",
+                                "name": "cropped",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "src",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "srcSet",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": "cropped(height:45,width:45)"
+                              }
+                            ],
+                            "storageKey": null
                           }
                         ],
                         "type": "Artist",
@@ -220,19 +300,19 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v4/*: any*/),
+                        "selections": (v3/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v4/*: any*/),
+                        "selections": (v3/*: any*/),
                         "type": "FeaturedLink",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v4/*: any*/),
+                        "selections": (v3/*: any*/),
                         "type": "Profile",
                         "abstractKey": null
                       }
@@ -245,19 +325,19 @@ return {
             ],
             "storageKey": "orderedItemsConnection(first:50)"
           },
-          (v3/*: any*/)
+          (v2/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "1914701cbeff220c2aebeaf33ca65327",
+    "cacheID": "d61b18b1581d16b8e4f8f7a85833d917",
     "id": null,
     "metadata": {},
     "name": "OnboardingOrderedSetQuery",
     "operationKind": "query",
-    "text": "query OnboardingOrderedSetQuery(\n  $key: String!\n) {\n  orderedSets(key: $key) {\n    ...OnboardingOrderedSet_orderedSet\n    id\n  }\n}\n\nfragment OnboardingOrderedSet_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 50) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          slug\n          internalID\n          image {\n            imageURL\n            internalID\n          }\n          formattedNationalityAndBirthday\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n        ... on Profile {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query OnboardingOrderedSetQuery(\n  $key: String!\n) {\n  orderedSets(key: $key) {\n    ...OnboardingOrderedSet_orderedSet\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment OnboardingOrderedSet_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 50) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          ...EntityHeaderArtist_artist\n          name\n          internalID\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n        ... on Profile {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/OnboardingOrderedSet_orderedSet.graphql.ts
+++ b/src/v2/__generated__/OnboardingOrderedSet_orderedSet.graphql.ts
@@ -1,0 +1,139 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type OnboardingOrderedSet_orderedSet = {
+    readonly orderedItemsConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly name?: string | null | undefined;
+                readonly slug?: string | undefined;
+                readonly internalID?: string | undefined;
+                readonly image?: {
+                    readonly imageURL: string | null;
+                    readonly internalID: string | null;
+                } | null | undefined;
+                readonly formattedNationalityAndBirthday?: string | null | undefined;
+            } | null;
+        } | null> | null;
+    };
+    readonly " $refType": "OnboardingOrderedSet_orderedSet";
+};
+export type OnboardingOrderedSet_orderedSet$data = OnboardingOrderedSet_orderedSet;
+export type OnboardingOrderedSet_orderedSet$key = {
+    readonly " $data"?: OnboardingOrderedSet_orderedSet$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"OnboardingOrderedSet_orderedSet">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "OnboardingOrderedSet_orderedSet",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 50
+        }
+      ],
+      "concreteType": "OrderedSetItemConnection",
+      "kind": "LinkedField",
+      "name": "orderedItemsConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "OrderedSetItemEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "name",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "slug",
+                      "storageKey": null
+                    },
+                    (v0/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Image",
+                      "kind": "LinkedField",
+                      "name": "image",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "imageURL",
+                          "storageKey": null
+                        },
+                        (v0/*: any*/)
+                      ],
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "formattedNationalityAndBirthday",
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "Artist",
+                  "abstractKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "orderedItemsConnection(first:50)"
+    }
+  ],
+  "type": "OrderedSet",
+  "abstractKey": null
+};
+})();
+(node as any).hash = 'f53aa4e1a9b9cbee9df5254831f4840d';
+export default node;

--- a/src/v2/__generated__/OnboardingSearchResultsQuery.graphql.ts
+++ b/src/v2/__generated__/OnboardingSearchResultsQuery.graphql.ts
@@ -5,7 +5,7 @@
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type OnboardingSearchResultsQueryVariables = {
-    query: string;
+    term: string;
 };
 export type OnboardingSearchResultsQueryResponse = {
     readonly viewer: {
@@ -21,10 +21,10 @@ export type OnboardingSearchResultsQuery = {
 
 /*
 query OnboardingSearchResultsQuery(
-  $query: String!
+  $term: String!
 ) {
   viewer {
-    ...OnboardingSearchResults_viewer_1Qr5xf
+    ...OnboardingSearchResults_viewer_4hh6ED
   }
 }
 
@@ -47,8 +47,8 @@ fragment EntityHeaderArtist_artist on Artist {
   }
 }
 
-fragment OnboardingSearchResults_viewer_1Qr5xf on Viewer {
-  searchConnection(query: $query, entities: [ARTIST], first: 10) {
+fragment OnboardingSearchResults_viewer_4hh6ED on Viewer {
+  matchConnection(term: $term, entities: [ARTIST], first: 10, mode: AUTOSUGGEST) {
     edges {
       node {
         __typename
@@ -59,6 +59,15 @@ fragment OnboardingSearchResults_viewer_1Qr5xf on Viewer {
         }
         ... on Node {
           __isNode: __typename
+          id
+        }
+        ... on Feature {
+          id
+        }
+        ... on Page {
+          id
+        }
+        ... on Profile {
           id
         }
       }
@@ -72,14 +81,23 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "query"
+    "name": "term"
   }
 ],
 v1 = {
   "kind": "Variable",
-  "name": "query",
-  "variableName": "query"
-};
+  "name": "term",
+  "variableName": "term"
+},
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "id",
+    "storageKey": null
+  }
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -138,17 +156,22 @@ return {
                 "name": "first",
                 "value": 10
               },
+              {
+                "kind": "Literal",
+                "name": "mode",
+                "value": "AUTOSUGGEST"
+              },
               (v1/*: any*/)
             ],
-            "concreteType": "SearchableConnection",
+            "concreteType": "MatchConnection",
             "kind": "LinkedField",
-            "name": "searchConnection",
+            "name": "matchConnection",
             "plural": false,
             "selections": [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "SearchableEdge",
+                "concreteType": "MatchEdge",
                 "kind": "LinkedField",
                 "name": "edges",
                 "plural": true,
@@ -291,17 +314,27 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "id",
-                            "storageKey": null
-                          }
-                        ],
+                        "selections": (v2/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": (v2/*: any*/),
+                        "type": "Feature",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": (v2/*: any*/),
+                        "type": "Page",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": (v2/*: any*/),
+                        "type": "Profile",
+                        "abstractKey": null
                       }
                     ],
                     "storageKey": null
@@ -318,14 +351,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "70fb2e6f2e15417f50621b8586a0d7fb",
+    "cacheID": "218ed76080c46860b1447c4c2b234528",
     "id": null,
     "metadata": {},
     "name": "OnboardingSearchResultsQuery",
     "operationKind": "query",
-    "text": "query OnboardingSearchResultsQuery(\n  $query: String!\n) {\n  viewer {\n    ...OnboardingSearchResults_viewer_1Qr5xf\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment OnboardingSearchResults_viewer_1Qr5xf on Viewer {\n  searchConnection(query: $query, entities: [ARTIST], first: 10) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          ...EntityHeaderArtist_artist\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query OnboardingSearchResultsQuery(\n  $term: String!\n) {\n  viewer {\n    ...OnboardingSearchResults_viewer_4hh6ED\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment OnboardingSearchResults_viewer_4hh6ED on Viewer {\n  matchConnection(term: $term, entities: [ARTIST], first: 10, mode: AUTOSUGGEST) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          ...EntityHeaderArtist_artist\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on Feature {\n          id\n        }\n        ... on Page {\n          id\n        }\n        ... on Profile {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '5b3583189d22ae921a74d758c4320cdb';
+(node as any).hash = '36f77eb82d49c4aa1aaba20b02298c16';
 export default node;

--- a/src/v2/__generated__/OnboardingSearchResultsQuery.graphql.ts
+++ b/src/v2/__generated__/OnboardingSearchResultsQuery.graphql.ts
@@ -1,0 +1,331 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type OnboardingSearchResultsQueryVariables = {
+    query: string;
+};
+export type OnboardingSearchResultsQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"OnboardingSearchResults_viewer">;
+    } | null;
+};
+export type OnboardingSearchResultsQuery = {
+    readonly response: OnboardingSearchResultsQueryResponse;
+    readonly variables: OnboardingSearchResultsQueryVariables;
+};
+
+
+
+/*
+query OnboardingSearchResultsQuery(
+  $query: String!
+) {
+  viewer {
+    ...OnboardingSearchResults_viewer_1Qr5xf
+  }
+}
+
+fragment EntityHeaderArtist_artist on Artist {
+  internalID
+  href
+  slug
+  name
+  initials
+  formattedNationalityAndBirthday
+  counts {
+    artworks
+    forSaleArtworks
+  }
+  avatar: image {
+    cropped(width: 45, height: 45) {
+      src
+      srcSet
+    }
+  }
+}
+
+fragment OnboardingSearchResults_viewer_1Qr5xf on Viewer {
+  searchConnection(query: $query, entities: [ARTIST], first: 10) {
+    edges {
+      node {
+        __typename
+        ... on Artist {
+          name
+          internalID
+          ...EntityHeaderArtist_artist
+        }
+        ... on Node {
+          __isNode: __typename
+          id
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "query"
+  }
+],
+v1 = {
+  "kind": "Variable",
+  "name": "query",
+  "variableName": "query"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "OnboardingSearchResultsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": [
+              (v1/*: any*/)
+            ],
+            "kind": "FragmentSpread",
+            "name": "OnboardingSearchResults_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "OnboardingSearchResultsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "entities",
+                "value": [
+                  "ARTIST"
+                ]
+              },
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10
+              },
+              (v1/*: any*/)
+            ],
+            "concreteType": "SearchableConnection",
+            "kind": "LinkedField",
+            "name": "searchConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "SearchableEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "internalID",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "href",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "slug",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "initials",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "formattedNationalityAndBirthday",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtistCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "artworks",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "forSaleArtworks",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "avatar",
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "height",
+                                    "value": 45
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 45
+                                  }
+                                ],
+                                "concreteType": "CroppedImageUrl",
+                                "kind": "LinkedField",
+                                "name": "cropped",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "src",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "srcSet",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": "cropped(height:45,width:45)"
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "type": "Artist",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "id",
+                            "storageKey": null
+                          }
+                        ],
+                        "type": "Node",
+                        "abstractKey": "__isNode"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "70fb2e6f2e15417f50621b8586a0d7fb",
+    "id": null,
+    "metadata": {},
+    "name": "OnboardingSearchResultsQuery",
+    "operationKind": "query",
+    "text": "query OnboardingSearchResultsQuery(\n  $query: String!\n) {\n  viewer {\n    ...OnboardingSearchResults_viewer_1Qr5xf\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment OnboardingSearchResults_viewer_1Qr5xf on Viewer {\n  searchConnection(query: $query, entities: [ARTIST], first: 10) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          ...EntityHeaderArtist_artist\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '5b3583189d22ae921a74d758c4320cdb';
+export default node;

--- a/src/v2/__generated__/OnboardingSearchResults_viewer.graphql.ts
+++ b/src/v2/__generated__/OnboardingSearchResults_viewer.graphql.ts
@@ -4,8 +4,8 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type OnboardingOrderedSet_orderedSet = {
-    readonly orderedItemsConnection: {
+export type OnboardingSearchResults_viewer = {
+    readonly searchConnection: {
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly name?: string | null | undefined;
@@ -13,41 +13,59 @@ export type OnboardingOrderedSet_orderedSet = {
                 readonly " $fragmentRefs": FragmentRefs<"EntityHeaderArtist_artist">;
             } | null;
         } | null> | null;
-    };
-    readonly " $refType": "OnboardingOrderedSet_orderedSet";
+    } | null;
+    readonly " $refType": "OnboardingSearchResults_viewer";
 };
-export type OnboardingOrderedSet_orderedSet$data = OnboardingOrderedSet_orderedSet;
-export type OnboardingOrderedSet_orderedSet$key = {
-    readonly " $data"?: OnboardingOrderedSet_orderedSet$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"OnboardingOrderedSet_orderedSet">;
+export type OnboardingSearchResults_viewer$data = OnboardingSearchResults_viewer;
+export type OnboardingSearchResults_viewer$key = {
+    readonly " $data"?: OnboardingSearchResults_viewer$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"OnboardingSearchResults_viewer">;
 };
 
 
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "defaultValue": "",
+      "kind": "LocalArgument",
+      "name": "query"
+    }
+  ],
   "kind": "Fragment",
   "metadata": null,
-  "name": "OnboardingOrderedSet_orderedSet",
+  "name": "OnboardingSearchResults_viewer",
   "selections": [
     {
       "alias": null,
       "args": [
         {
           "kind": "Literal",
+          "name": "entities",
+          "value": [
+            "ARTIST"
+          ]
+        },
+        {
+          "kind": "Literal",
           "name": "first",
-          "value": 50
+          "value": 10
+        },
+        {
+          "kind": "Variable",
+          "name": "query",
+          "variableName": "query"
         }
       ],
-      "concreteType": "OrderedSetItemConnection",
+      "concreteType": "SearchableConnection",
       "kind": "LinkedField",
-      "name": "orderedItemsConnection",
+      "name": "searchConnection",
       "plural": false,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "OrderedSetItemEdge",
+          "concreteType": "SearchableEdge",
           "kind": "LinkedField",
           "name": "edges",
           "plural": true,
@@ -93,11 +111,11 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "orderedItemsConnection(first:50)"
+      "storageKey": null
     }
   ],
-  "type": "OrderedSet",
+  "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = '744ce891870f559e1680069f33b7bd76';
+(node as any).hash = '57e6e3d2b0b863c1dc8cb78f5b5193be';
 export default node;

--- a/src/v2/__generated__/OnboardingSearchResults_viewer.graphql.ts
+++ b/src/v2/__generated__/OnboardingSearchResults_viewer.graphql.ts
@@ -5,7 +5,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type OnboardingSearchResults_viewer = {
-    readonly searchConnection: {
+    readonly matchConnection: {
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly name?: string | null | undefined;
@@ -29,7 +29,7 @@ const node: ReaderFragment = {
     {
       "defaultValue": "",
       "kind": "LocalArgument",
-      "name": "query"
+      "name": "term"
     }
   ],
   "kind": "Fragment",
@@ -52,20 +52,25 @@ const node: ReaderFragment = {
           "value": 10
         },
         {
+          "kind": "Literal",
+          "name": "mode",
+          "value": "AUTOSUGGEST"
+        },
+        {
           "kind": "Variable",
-          "name": "query",
-          "variableName": "query"
+          "name": "term",
+          "variableName": "term"
         }
       ],
-      "concreteType": "SearchableConnection",
+      "concreteType": "MatchConnection",
       "kind": "LinkedField",
-      "name": "searchConnection",
+      "name": "matchConnection",
       "plural": false,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "SearchableEdge",
+          "concreteType": "MatchEdge",
           "kind": "LinkedField",
           "name": "edges",
           "plural": true,
@@ -117,5 +122,5 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = '57e6e3d2b0b863c1dc8cb78f5b5193be';
+(node as any).hash = '0bac4a9d48935ebac0ce2af757db64e3';
 export default node;


### PR DESCRIPTION
The type of this PR is: _feat_

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1096]

### Description

The intention of this code is to build out the Follow Artists rewards screen that occurs at the end of the Onboarding workflow. Currently, an `orderedSet` is being used to backfill featured artists and a search filter will be implemented. 

Acceptance criteria:

- [x] User sees follow artists screen
- [x] User sees artwork image
- [x] User sees default list of artists from an orderedSet in admin
- [x] User can search artists
- [x] User sees artists name populating after search
- [x] User can continue after selecting at least one artist 
- [x] User can follow as many artists as they would like 
- [x] User can click x and leave the onboarding flow 
- [ ] Responsiveness







<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1096]: https://artsyproduct.atlassian.net/browse/GRO-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ