### PR TITLE
fix: timer copy changes auctions

### DIFF
--- a/src/v2/Components/Artwork/Details.tsx
+++ b/src/v2/Components/Artwork/Details.tsx
@@ -272,7 +272,7 @@ export const LotCloseInfo: React.FC<LotCloseInfoProps> = ({
       lotCloseCopy = isExtended
         ? // show Extended: timer if bidding has been extended
           timerCopy.copy
-        : `Closes, ${timerCopy.copy}`
+        : `Closes ${timerCopy.copy}`
       if (timerCopy.color === "red100") {
         labelColor = "red100"
       } else {

--- a/src/v2/Components/Artwork/__tests__/Details.jest.tsx
+++ b/src/v2/Components/Artwork/__tests__/Details.jest.tsx
@@ -258,7 +258,7 @@ describe("Details", () => {
 
         const wrapper = await getWrapper(data)
 
-        expect(wrapper.html()).toContain("Closes on 1454d 7h")
+        expect(wrapper.html()).toContain("Closes in 1454d 7h")
       })
 
       it("shows the lot is closing with the hours countdown if lots are hours from closing and the sale has cascading end times enabled", async () => {

--- a/src/v2/Components/Artwork/__tests__/Details.jest.tsx
+++ b/src/v2/Components/Artwork/__tests__/Details.jest.tsx
@@ -258,7 +258,7 @@ describe("Details", () => {
 
         const wrapper = await getWrapper(data)
 
-        expect(wrapper.html()).toContain("Closes, 1454d 7h")
+        expect(wrapper.html()).toContain("Closes on 1454d 7h")
       })
 
       it("shows the lot is closing with the hours countdown if lots are hours from closing and the sale has cascading end times enabled", async () => {
@@ -277,7 +277,7 @@ describe("Details", () => {
 
         const wrapper = await getWrapper(data)
 
-        expect(wrapper.html()).toContain("Closes, 11h 11m")
+        expect(wrapper.html()).toContain("Closes in 11h 11m")
       })
 
       it("shows the lot is closing with the formatted end time of the sale if the lots have not started closing and the sale has cascading end times enabled", async () => {
@@ -369,7 +369,7 @@ describe("Details", () => {
 
             const wrapper = await getWrapper(data)
 
-            expect(wrapper.html()).toContain("Closes, 1m 5s")
+            expect(wrapper.html()).toContain("Closes in 1m 5s")
           })
         })
       })

--- a/src/v2/Utils/__tests__/getSaleOrLotTimerInfo.jest.ts
+++ b/src/v2/Utils/__tests__/getSaleOrLotTimerInfo.jest.ts
@@ -118,7 +118,7 @@ describe("getSaleOrLotTimerInfo", () => {
         const time = { days: "01", hours: "23", minutes: "33", seconds: "00" }
         it("formats the timer to show 'xd xh' in blue", () => {
           const lotTimerInfo = getSaleOrLotTimerInfo(time, { hasStarted })
-          expect(lotTimerInfo.copy).toEqual("1d 23h")
+          expect(lotTimerInfo.copy).toEqual("in 1d 23h")
           expect(lotTimerInfo.color).toEqual("blue100")
         })
       })
@@ -128,7 +128,7 @@ describe("getSaleOrLotTimerInfo", () => {
 
         it("formats the timer to show 'xh xm' in blue", () => {
           const lotTimerInfo = getSaleOrLotTimerInfo(time, { hasStarted })
-          expect(lotTimerInfo.copy).toEqual("23h 33m")
+          expect(lotTimerInfo.copy).toEqual("in 23h 33m")
           expect(lotTimerInfo.color).toEqual("blue100")
         })
       })
@@ -144,7 +144,7 @@ describe("getSaleOrLotTimerInfo", () => {
 
           it("formats the timer to show 'xm xs' in red", () => {
             const lotTimerInfo = getSaleOrLotTimerInfo(time, { hasStarted })
-            expect(lotTimerInfo.copy).toEqual("10m 59s")
+            expect(lotTimerInfo.copy).toEqual("in 10m 59s")
             expect(lotTimerInfo.color).toEqual("red100")
           })
         })
@@ -159,7 +159,7 @@ describe("getSaleOrLotTimerInfo", () => {
 
           it("formats the timer to show 'xm xs' in red", () => {
             const lotTimerInfo = getSaleOrLotTimerInfo(time, { hasStarted })
-            expect(lotTimerInfo.copy).toEqual("0m 59s")
+            expect(lotTimerInfo.copy).toEqual("in 0m 59s")
             expect(lotTimerInfo.color).toEqual("red100")
           })
         })
@@ -180,7 +180,7 @@ describe("getSaleOrLotTimerInfo", () => {
               hasStarted,
               urgencyIntervalMinutes,
             })
-            expect(lotTimerInfo.copy).toEqual("10m 59s")
+            expect(lotTimerInfo.copy).toEqual("in 10m 59s")
             expect(lotTimerInfo.color).toEqual("black100")
           })
         })
@@ -198,7 +198,7 @@ describe("getSaleOrLotTimerInfo", () => {
               hasStarted,
               urgencyIntervalMinutes,
             })
-            expect(lotTimerInfo.copy).toEqual("0m 59s")
+            expect(lotTimerInfo.copy).toEqual("in 0m 59s")
             expect(lotTimerInfo.color).toEqual("red100")
           })
         })

--- a/src/v2/Utils/getSaleOrLotTimerInfo.ts
+++ b/src/v2/Utils/getSaleOrLotTimerInfo.ts
@@ -81,17 +81,17 @@ export const getSaleOrLotTimerInfo = (
     } else {
       // More than 24 hours until close
       if (parsedDays >= 1) {
-        copy = `${parsedDays}d ${parsedHours}h`
+        copy = `in ${parsedDays}d ${parsedHours}h`
       }
 
       // 1-24 hours until close
       else if (parsedDays < 1 && parsedHours >= 1) {
-        copy = `${parsedHours}h ${parsedMinutes}m`
+        copy = `in ${parsedHours}h ${parsedMinutes}m`
       }
 
       // <60 mins until close
       else if (parsedDays < 1 && parsedHours < 1) {
-        copy = `${parsedMinutes}m ${parsedSeconds}s`
+        copy = `in ${parsedMinutes}m ${parsedSeconds}s`
         // less than cascade interval until close
         if (urgencyIntervalMinutes && parsedMinutes >= urgencyIntervalMinutes) {
           color = "black100"


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4068]

### Description

This pr updates the copy of the popcorn bidding timers that we show on lots for the close time.

Note that when the lots close in > 24hrs we get the whole string value from metaphysics from [here](https://github.com/artsy/metaphysics/blob/main/src/lib/date.ts#L305)

When the lots close in < 24hrs we format the date on the clients.

Metaphysics PR for > 24hrs https://github.com/artsy/metaphysics/pull/4220

#### Screenshots

|>24hrs|<24hrs|
|---|---|
|![Screenshot 2022-07-08 at 11 02 53](https://user-images.githubusercontent.com/21178754/177959507-f8c761ff-51c6-4339-b94a-1d746d7ce844.png)|![Screenshot 2022-07-08 at 11 02 21](https://user-images.githubusercontent.com/21178754/177959527-9b7cc1f8-c173-4ce5-96d6-a2bdee7bf930.png)|

<!-- Implementation description -->


[FX-4068]: https://artsyproduct.atlassian.net/browse/FX-4068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ