### PR TITLE
chore: removing feature shows limit

### DIFF
--- a/src/v2/Apps/Home/Components/HomeFeaturedShowsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedShowsRail.tsx
@@ -29,6 +29,10 @@ const HomeFeaturedShowsRail: React.FC<HomeFeaturedShowsRailProps> = ({
     item.__typename === "Show" ? [item] : []
   )
 
+  if (shows.length === 0) {
+    return null
+  }
+
   return (
     <Rail
       alignItems="flex-start"

--- a/src/v2/Apps/Home/Components/HomeFeaturedShowsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedShowsRail.tsx
@@ -16,8 +16,6 @@ import { HomeFeaturedShowsRailQuery } from "v2/__generated__/HomeFeaturedShowsRa
 import { HomeFeaturedShowsRail_orderedSet } from "v2/__generated__/HomeFeaturedShowsRail_orderedSet.graphql"
 import { HomeFeaturedShowFragmentContainer } from "./HomeFeaturedShow"
 
-const SHOWS_LIMIT = 6
-
 interface HomeFeaturedShowsRailProps {
   orderedSet: HomeFeaturedShowsRail_orderedSet
 }
@@ -30,8 +28,7 @@ const HomeFeaturedShowsRail: React.FC<HomeFeaturedShowsRailProps> = ({
   const shows = take(
     compact(orderedSet.items).flatMap(item =>
       item.__typename === "Show" ? [item] : []
-    ),
-    SHOWS_LIMIT
+    )
   )
 
   if (shows.length === 0) {

--- a/src/v2/Apps/Home/Components/HomeFeaturedShowsRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedShowsRail.tsx
@@ -5,7 +5,7 @@ import {
   OwnerType,
 } from "@artsy/cohesion"
 import { Skeleton } from "@artsy/palette"
-import { compact, take } from "lodash"
+import { compact } from "lodash"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { CellShowPlaceholder } from "v2/Components/Cells/CellShow"
@@ -25,15 +25,9 @@ const HomeFeaturedShowsRail: React.FC<HomeFeaturedShowsRailProps> = ({
 }) => {
   const { trackEvent } = useTracking()
 
-  const shows = take(
-    compact(orderedSet.items).flatMap(item =>
-      item.__typename === "Show" ? [item] : []
-    )
+  const shows = compact(orderedSet.items).flatMap(item =>
+    item.__typename === "Show" ? [item] : []
   )
-
-  if (shows.length === 0) {
-    return null
-  }
 
   return (
     <Rail


### PR DESCRIPTION
The type of this PR is: **CHORE**
This PR solves [GRO-1034]

### Description

Previously the FeaturedShows component used to be a grid and so was limited to 6. It’s now a rail so the limit can be removed.

[GRO-1034]: https://artsyproduct.atlassian.net/browse/GRO-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ