### PR TITLE
fix(followbutton): fixes props spread

### DIFF
--- a/src/v2/Components/FollowArtistPopover/FollowArtistPopoverRow.tsx
+++ b/src/v2/Components/FollowArtistPopover/FollowArtistPopoverRow.tsx
@@ -128,7 +128,7 @@ class FollowArtistPopoverRow extends Component<Props, State> {
           <FollowButton
             isFollowed={this.state.followed}
             handleFollow={() => this.handleClick(artistID)}
-            buttonProps={{ size: "small" }}
+            size="small"
           />
         }
       />

--- a/src/v2/Components/FollowButton/Button.tsx
+++ b/src/v2/Components/FollowButton/Button.tsx
@@ -8,16 +8,15 @@ import {
   useState,
 } from "react"
 
-interface FollowButtonProps {
+interface FollowButtonProps extends Omit<Partial<ButtonProps>, "variant"> {
   isFollowed?: boolean
-  buttonProps?: Omit<Partial<ButtonProps>, "variant">
   handleFollow?: MouseEventHandler<HTMLButtonElement>
 }
 
 export const FollowButton: ForwardRefExoticComponent<
   FollowButtonProps & { ref?: Ref<HTMLElement> }
 > = forwardRef(
-  ({ isFollowed = false, buttonProps = {}, handleFollow }, forwardedRef) => {
+  ({ isFollowed = false, handleFollow, ...rest }, forwardedRef) => {
     const [showUnfollow, setShowUnfollow] = useState(false)
 
     const label = useMemo(() => {
@@ -38,7 +37,7 @@ export const FollowButton: ForwardRefExoticComponent<
         onMouseLeave={() => setShowUnfollow(false)}
         data-follow={isFollowed}
         data-test="followButton"
-        {...buttonProps}
+        {...rest}
       >
         {/*
           To prevent layout shift: the longest string this

--- a/src/v2/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/v2/Components/FollowButton/FollowArtistButton.tsx
@@ -1,5 +1,5 @@
 import { AuthContextModule, Intent, ContextModule } from "@artsy/cohesion"
-import { Box, ButtonProps, Popover } from "@artsy/palette"
+import { ButtonProps, Popover } from "@artsy/palette"
 import { FollowArtistButtonMutation } from "v2/__generated__/FollowArtistButtonMutation.graphql"
 import { FollowArtistPopoverQueryRenderer } from "v2/Components/FollowArtistPopover"
 import * as React from "react"
@@ -114,37 +114,36 @@ const FollowArtistButton: React.FC<FollowArtistButtonProps> = ({
   }
 
   return (
-    <Box data-test="followArtistButton">
-      <Popover
-        title="Other artists you might like"
-        placement="bottom"
-        popover={
-          artist ? (
-            <FollowArtistPopoverQueryRenderer artistID={artist.internalID} />
-          ) : null
-        }
-      >
-        {({ anchorRef, onVisible }) => {
-          const openSuggestions = () => {
-            if (isLoggedIn && triggerSuggestions && !artist.isFollowed) {
-              onVisible()
-            }
+    <Popover
+      title="Other artists you might like"
+      placement="bottom"
+      popover={
+        artist ? (
+          <FollowArtistPopoverQueryRenderer artistID={artist.internalID} />
+        ) : null
+      }
+    >
+      {({ anchorRef, onVisible }) => {
+        const openSuggestions = () => {
+          if (isLoggedIn && triggerSuggestions && !artist.isFollowed) {
+            onVisible()
           }
+        }
 
-          return (
-            <FollowButton
-              ref={anchorRef}
-              isFollowed={!!artist.isFollowed}
-              handleFollow={event => {
-                handleClick(event)
-                openSuggestions()
-              }}
-              buttonProps={rest}
-            />
-          )
-        }}
-      </Popover>
-    </Box>
+        return (
+          <FollowButton
+            data-test="followArtistButton"
+            ref={anchorRef}
+            isFollowed={!!artist.isFollowed}
+            handleFollow={event => {
+              handleClick(event)
+              openSuggestions()
+            }}
+            {...rest}
+          />
+        )
+      }}
+    </Popover>
   )
 }
 
@@ -189,11 +188,11 @@ export const FollowArtistButtonQueryRenderer: React.FC<FollowArtistButtonQueryRe
           }
         }
       `}
-      placeholder={<FollowButton buttonProps={rest} />}
+      placeholder={<FollowButton {...rest} />}
       variables={{ id }}
       render={({ error, props }) => {
         if (error || !props?.artist) {
-          return <FollowButton buttonProps={rest} />
+          return <FollowButton {...rest} />
         }
 
         return (

--- a/src/v2/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/v2/Components/FollowButton/FollowGeneButton.tsx
@@ -82,7 +82,7 @@ const FollowGeneButton: React.FC<FollowGeneButtonProps> = ({
     <FollowButton
       isFollowed={!!gene.isFollowed}
       handleFollow={handleClick}
-      buttonProps={rest}
+      {...rest}
     />
   )
 }

--- a/src/v2/Components/FollowButton/FollowProfileButton.tsx
+++ b/src/v2/Components/FollowButton/FollowProfileButton.tsx
@@ -82,7 +82,7 @@ const FollowProfileButton: React.FC<FollowProfileButtonProps> = ({
     <FollowButton
       isFollowed={!!profile.isFollowed}
       handleFollow={handleClick}
-      buttonProps={rest}
+      {...rest}
     />
   )
 }


### PR DESCRIPTION
I guess the old button had a click that propagated to the button? I'm actually not sure how this was previously even working. But: relocated the data-test attr onto the actual button; but then also had to get rid of this weird isolated `buttonProps` thing so they merged correctly. Better now + should fix Integrity specs.