### PR TITLE
feat: update copy in Artist dropdown

### DIFF
--- a/src/v2/Components/NavBar/menuData.ts
+++ b/src/v2/Components/NavBar/menuData.ts
@@ -40,8 +40,8 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
         href: "/gene/black-painters-on-our-radar",
       },
       {
-        text: "Our Top Auction Lots",
-        href: "/gene/our-top-auction-lots",
+        text: "Top Auction Lots",
+        href: "/gene/top-auction-lots",
         dividerBelow: true,
       },
       {


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR solves [FX-4083]

### Description

Just a [small copy change](https://artsy.slack.com/archives/C9SATFLUU/p1657209665949729) for the **Artist** dropdown menu: `Our Top Auction Lots` → `Top Auction Lots`

|Desktop|Mobile|
|---|---|
|<img width="1195" alt="Screen Shot 2022-07-11 at 3 49 00 AM" src="https://user-images.githubusercontent.com/140521/178215111-08232b24-67ec-485b-b8d7-73fce4ad376b.png">|<img width="443" alt="Screen Shot 2022-07-11 at 3 49 28 AM" src="https://user-images.githubusercontent.com/140521/178215120-35c764a2-3dca-4549-92c8-dc6b88e61d06.png">|


[FX-4083]: https://artsyproduct.atlassian.net/browse/FX-4083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ