### PR TITLE
fix: mobile layout on the order status page

### DIFF
--- a/src/v2/Apps/Order/Components/TwoColumnLayout.tsx
+++ b/src/v2/Apps/Order/Components/TwoColumnLayout.tsx
@@ -1,5 +1,5 @@
 import { Box, Column, Flex, GridColumns, Spacer } from "@artsy/palette"
-import { Children } from "react";
+import { Children } from "react"
 import { Media } from "v2/Utils/Responsive"
 
 const CONTENT_SPAN = 7
@@ -52,8 +52,8 @@ const DefaultLayout = ({ Content, Sidebar }) => (
   </GridColumns>
 )
 
-const XsLayout = ({ Content, Sidebar }) => (
-  <GridColumns>
+const XsLayout = ({ Content, Sidebar, noRowGap }) => (
+  <GridColumns gridRowGap={noRowGap ? 0 : undefined}>
     <Column span={12}>{Content}</Column>
     <Column span={12}>{Sidebar}</Column>
   </GridColumns>

--- a/src/v2/Apps/Order/Routes/Status/index.tsx
+++ b/src/v2/Apps/Order/Routes/Status/index.tsx
@@ -91,6 +91,7 @@ export class StatusRoute extends Component<StatusProps> {
                 {flowName} <span data-test="OrderCode">#{order.code}</span>
               </Text>
               <TwoColumnLayout
+                noRowGap
                 Content={
                   <>
                     <Title>{flowName} status | Artsy</Title>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

This PR removes a small gap between sections on the mobile

Before
![Screenshot from 2022-07-11 13-11-24](https://user-images.githubusercontent.com/79979820/178241916-e8e82858-4306-47ee-bf9c-15707ce8e4bf.png)
After
![Screenshot from 2022-07-11 13-11-01](https://user-images.githubusercontent.com/79979820/178241921-6be5d66f-f4ca-45e8-adc3-07bd156effb7.png)



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ