### PR TITLE
feat(onboarding): build screen for follow galleries path

### DIFF
--- a/src/v2/Apps/Onboarding/Components/OnboardingSearchResults.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingSearchResults.tsx
@@ -1,4 +1,4 @@
-import { Join, Message, Separator, Text } from "@artsy/palette"
+import { Join, Message, Separator } from "@artsy/palette"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { EntityHeaderArtistFragmentContainer } from "v2/Components/EntityHeaders/EntityHeaderArtist"

--- a/src/v2/Apps/Onboarding/Components/OnboardingSplitLayout.tsx
+++ b/src/v2/Apps/Onboarding/Components/OnboardingSplitLayout.tsx
@@ -21,6 +21,7 @@ export const OnboardingSplitLayout: FC<OnboardingSplitLayoutProps> = ({
         bg="black100"
         flexBasis="50%"
         position="relative"
+        flexShrink={0}
         {...leftProps}
       >
         {left}
@@ -28,7 +29,12 @@ export const OnboardingSplitLayout: FC<OnboardingSplitLayoutProps> = ({
         <ArtsyLogoIcon fill="white100" position="absolute" top={2} left={2} />
       </Box>
 
-      <Flex flexBasis={["100%", "50%"]} {...rightProps}>
+      <Flex
+        flexBasis={["100%", "50%"]}
+        flexGrow={0}
+        minWidth={0}
+        {...rightProps}
+      >
         {right}
       </Flex>
     </Flex>

--- a/src/v2/Apps/Onboarding/Views/OnboardingFollowArtists.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingFollowArtists.tsx
@@ -41,7 +41,10 @@ export const OnboardingFollowArtists: FC = () => {
             style={{ WebkitOverflowScrolling: "touch" }}
           >
             {query ? (
-              <OnboardingSearchResultsQueryRenderer term={query} />
+              <OnboardingSearchResultsQueryRenderer
+                term={query}
+                entities="ARTIST"
+              />
             ) : (
               <OnboardingOrderedSetQueryRenderer id="onboarding:suggested-artists" />
             )}

--- a/src/v2/Apps/Onboarding/Views/OnboardingFollowArtists.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingFollowArtists.tsx
@@ -11,10 +11,13 @@ import { OnboardingOrderedSetQueryRenderer } from "../Components/OnboardingOrder
 import { OnboardingSplitLayout } from "../Components/OnboardingSplitLayout"
 import { useOnboardingContext } from "../useOnboardingContext"
 import { OnboardingSearchResultsQueryRenderer } from "../Components/OnboardingSearchResults"
+import { useDebouncedValue } from "v2/Utils/Hooks/useDebounce"
 
 export const OnboardingFollowArtists: FC = () => {
   const { next, state } = useOnboardingContext()
   const [query, setQuery] = useState("")
+
+  const { debouncedValue } = useDebouncedValue({ value: query, delay: 200 })
 
   return (
     <OnboardingSplitLayout
@@ -40,9 +43,9 @@ export const OnboardingFollowArtists: FC = () => {
             overflowY="auto"
             style={{ WebkitOverflowScrolling: "touch" }}
           >
-            {query ? (
+            {debouncedValue ? (
               <OnboardingSearchResultsQueryRenderer
-                term={query}
+                term={debouncedValue}
                 entities="ARTIST"
               />
             ) : (

--- a/src/v2/Apps/Onboarding/Views/OnboardingFollowGalleries.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingFollowGalleries.tsx
@@ -1,10 +1,66 @@
-import { Text, Flex } from "@artsy/palette"
-import { FC } from "react"
+import {
+  Box,
+  Text,
+  LabeledInput,
+  MagnifyingGlassIcon,
+  Button,
+  Flex,
+} from "@artsy/palette"
+import { FC, useState } from "react"
+import { OnboardingOrderedSetQueryRenderer } from "../Components/OnboardingOrderedSet"
+import { OnboardingSplitLayout } from "../Components/OnboardingSplitLayout"
+import { useOnboardingContext } from "../useOnboardingContext"
+import { OnboardingSearchResultsQueryRenderer } from "../Components/OnboardingSearchResults"
 
 export const OnboardingFollowGalleries: FC = () => {
+  const { next, state } = useOnboardingContext()
+  const [query, setQuery] = useState("")
+
   return (
-    <Flex flexDirection="column">
-      <Text variant="lg-display">TODO: OnboardingFollowGalleries</Text>
-    </Flex>
+    <OnboardingSplitLayout
+      left={<Box width="100%" height="100%" bg="black10" />}
+      right={
+        <Flex flexDirection="column">
+          <Box pt={4} px={4}>
+            <Text variant="lg-display" mb={2}>
+              Follow galleries you love to see events and news
+            </Text>
+
+            <LabeledInput
+              label={<MagnifyingGlassIcon />}
+              placeholder="Search Galleries"
+              mb={4}
+              onChange={event => setQuery(event.currentTarget.value)}
+            />
+          </Box>
+
+          <Box
+            px={4}
+            flex={1}
+            overflowY="auto"
+            style={{ WebkitOverflowScrolling: "touch" }}
+          >
+            {query ? (
+              <OnboardingSearchResultsQueryRenderer
+                term={query}
+                entities="GALLERY"
+              />
+            ) : (
+              <OnboardingOrderedSetQueryRenderer id="onboarding:suggested-galleries" />
+            )}
+          </Box>
+
+          <Box p={2}>
+            <Button
+              width="100%"
+              onClick={next}
+              disabled={state.followedIds.length === 0}
+            >
+              Done
+            </Button>
+          </Box>
+        </Flex>
+      }
+    />
   )
 }

--- a/src/v2/Apps/Onboarding/Views/OnboardingFollowGalleries.tsx
+++ b/src/v2/Apps/Onboarding/Views/OnboardingFollowGalleries.tsx
@@ -11,16 +11,19 @@ import { OnboardingOrderedSetQueryRenderer } from "../Components/OnboardingOrder
 import { OnboardingSplitLayout } from "../Components/OnboardingSplitLayout"
 import { useOnboardingContext } from "../useOnboardingContext"
 import { OnboardingSearchResultsQueryRenderer } from "../Components/OnboardingSearchResults"
+import { useDebouncedValue } from "v2/Utils/Hooks/useDebounce"
 
 export const OnboardingFollowGalleries: FC = () => {
   const { next, state } = useOnboardingContext()
   const [query, setQuery] = useState("")
 
+  const { debouncedValue } = useDebouncedValue({ value: query, delay: 200 })
+
   return (
     <OnboardingSplitLayout
       left={<Box width="100%" height="100%" bg="black10" />}
       right={
-        <Flex flexDirection="column">
+        <Flex flexDirection="column" minWidth={0}>
           <Box pt={4} px={4}>
             <Text variant="lg-display" mb={2}>
               Follow galleries you love to see events and news
@@ -40,10 +43,10 @@ export const OnboardingFollowGalleries: FC = () => {
             overflowY="auto"
             style={{ WebkitOverflowScrolling: "touch" }}
           >
-            {query ? (
+            {debouncedValue ? (
               <OnboardingSearchResultsQueryRenderer
-                term={query}
-                entities="GALLERY"
+                term={debouncedValue}
+                entities="PROFILE"
               />
             ) : (
               <OnboardingOrderedSetQueryRenderer id="onboarding:suggested-galleries" />

--- a/src/v2/__generated__/OnboardingOrderedSetQuery.graphql.ts
+++ b/src/v2/__generated__/OnboardingOrderedSetQuery.graphql.ts
@@ -48,24 +48,83 @@ fragment EntityHeaderArtist_artist on Artist {
   }
 }
 
+fragment EntityHeaderPartner_partner on Partner {
+  internalID
+  type
+  slug
+  href
+  name
+  initials
+  locationsConnection(first: 15) {
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
+  categories {
+    name
+    slug
+    id
+  }
+  profile {
+    ...FollowProfileButton_profile
+    avatar: image {
+      cropped(width: 45, height: 45) {
+        src
+        srcSet
+      }
+    }
+    icon {
+      cropped(width: 45, height: 45, version: ["untouched-png", "large", "square"]) {
+        src
+        srcSet
+      }
+    }
+    id
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  isFollowed
+}
+
 fragment OnboardingOrderedSet_orderedSet on OrderedSet {
   orderedItemsConnection(first: 50) {
     edges {
       node {
         __typename
         ... on Artist {
-          ...EntityHeaderArtist_artist
-          name
           internalID
+          ...EntityHeaderArtist_artist
+        }
+        ... on Profile {
+          internalID
+          owner {
+            __typename
+            ... on Partner {
+              ...EntityHeaderPartner_partner
+            }
+            ... on Node {
+              __isNode: __typename
+              id
+            }
+            ... on FairOrganizer {
+              id
+            }
+          }
+          id
         }
         ... on Node {
           __isNode: __typename
           id
         }
         ... on FeaturedLink {
-          id
-        }
-        ... on Profile {
           id
         }
       }
@@ -93,12 +152,110 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "initials",
+  "storageKey": null
+},
+v8 = {
+  "kind": "Literal",
+  "name": "height",
+  "value": 45
+},
+v9 = {
+  "kind": "Literal",
+  "name": "width",
+  "value": 45
+},
+v10 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "src",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+],
+v11 = {
+  "alias": "avatar",
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        (v8/*: any*/),
+        (v9/*: any*/)
+      ],
+      "concreteType": "CroppedImageUrl",
+      "kind": "LinkedField",
+      "name": "cropped",
+      "plural": false,
+      "selections": (v10/*: any*/),
+      "storageKey": "cropped(height:45,width:45)"
+    }
+  ],
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v3 = [
-  (v2/*: any*/)
-];
+v13 = [
+  (v12/*: any*/)
+],
+v14 = {
+  "kind": "InlineFragment",
+  "selections": (v13/*: any*/),
+  "type": "Node",
+  "abstractKey": "__isNode"
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -170,51 +327,15 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "__typename",
-                        "storageKey": null
-                      },
+                      (v2/*: any*/),
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "internalID",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "href",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "slug",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "name",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "initials",
-                            "storageKey": null
-                          },
+                          (v3/*: any*/),
+                          (v4/*: any*/),
+                          (v5/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -247,73 +368,180 @@ return {
                             ],
                             "storageKey": null
                           },
-                          {
-                            "alias": "avatar",
-                            "args": null,
-                            "concreteType": "Image",
-                            "kind": "LinkedField",
-                            "name": "image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "height",
-                                    "value": 45
-                                  },
-                                  {
-                                    "kind": "Literal",
-                                    "name": "width",
-                                    "value": 45
-                                  }
-                                ],
-                                "concreteType": "CroppedImageUrl",
-                                "kind": "LinkedField",
-                                "name": "cropped",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "src",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "srcSet",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": "cropped(height:45,width:45)"
-                              }
-                            ],
-                            "storageKey": null
-                          }
+                          (v11/*: any*/)
                         ],
                         "type": "Artist",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v3/*: any*/),
-                        "type": "Node",
-                        "abstractKey": "__isNode"
-                      },
-                      {
-                        "kind": "InlineFragment",
-                        "selections": (v3/*: any*/),
-                        "type": "FeaturedLink",
+                        "selections": [
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "owner",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v3/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "type",
+                                    "storageKey": null
+                                  },
+                                  (v5/*: any*/),
+                                  (v4/*: any*/),
+                                  (v6/*: any*/),
+                                  (v7/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "first",
+                                        "value": 15
+                                      }
+                                    ],
+                                    "concreteType": "LocationConnection",
+                                    "kind": "LinkedField",
+                                    "name": "locationsConnection",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "LocationEdge",
+                                        "kind": "LinkedField",
+                                        "name": "edges",
+                                        "plural": true,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Location",
+                                            "kind": "LinkedField",
+                                            "name": "node",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "city",
+                                                "storageKey": null
+                                              },
+                                              (v12/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "locationsConnection(first:15)"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "PartnerCategory",
+                                    "kind": "LinkedField",
+                                    "name": "categories",
+                                    "plural": true,
+                                    "selections": [
+                                      (v6/*: any*/),
+                                      (v5/*: any*/),
+                                      (v12/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Profile",
+                                    "kind": "LinkedField",
+                                    "name": "profile",
+                                    "plural": false,
+                                    "selections": [
+                                      (v12/*: any*/),
+                                      (v5/*: any*/),
+                                      (v6/*: any*/),
+                                      (v3/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isFollowed",
+                                        "storageKey": null
+                                      },
+                                      (v11/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Image",
+                                        "kind": "LinkedField",
+                                        "name": "icon",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": [
+                                              (v8/*: any*/),
+                                              {
+                                                "kind": "Literal",
+                                                "name": "version",
+                                                "value": [
+                                                  "untouched-png",
+                                                  "large",
+                                                  "square"
+                                                ]
+                                              },
+                                              (v9/*: any*/)
+                                            ],
+                                            "concreteType": "CroppedImageUrl",
+                                            "kind": "LinkedField",
+                                            "name": "cropped",
+                                            "plural": false,
+                                            "selections": (v10/*: any*/),
+                                            "storageKey": "cropped(height:45,version:[\"untouched-png\",\"large\",\"square\"],width:45)"
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "Partner",
+                                "abstractKey": null
+                              },
+                              (v14/*: any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": (v13/*: any*/),
+                                "type": "FairOrganizer",
+                                "abstractKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          (v12/*: any*/)
+                        ],
+                        "type": "Profile",
                         "abstractKey": null
                       },
+                      (v14/*: any*/),
                       {
                         "kind": "InlineFragment",
-                        "selections": (v3/*: any*/),
-                        "type": "Profile",
+                        "selections": (v13/*: any*/),
+                        "type": "FeaturedLink",
                         "abstractKey": null
                       }
                     ],
@@ -325,19 +553,19 @@ return {
             ],
             "storageKey": "orderedItemsConnection(first:50)"
           },
-          (v2/*: any*/)
+          (v12/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "d61b18b1581d16b8e4f8f7a85833d917",
+    "cacheID": "57d42ffc43b84c44f2b105d0f25a3ac7",
     "id": null,
     "metadata": {},
     "name": "OnboardingOrderedSetQuery",
     "operationKind": "query",
-    "text": "query OnboardingOrderedSetQuery(\n  $key: String!\n) {\n  orderedSets(key: $key) {\n    ...OnboardingOrderedSet_orderedSet\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment OnboardingOrderedSet_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 50) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          ...EntityHeaderArtist_artist\n          name\n          internalID\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n        ... on Profile {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query OnboardingOrderedSetQuery(\n  $key: String!\n) {\n  orderedSets(key: $key) {\n    ...OnboardingOrderedSet_orderedSet\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment OnboardingOrderedSet_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 50) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          internalID\n          ...EntityHeaderArtist_artist\n        }\n        ... on Profile {\n          internalID\n          owner {\n            __typename\n            ... on Partner {\n              ...EntityHeaderPartner_partner\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n            ... on FairOrganizer {\n              id\n            }\n          }\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/OnboardingOrderedSet_orderedSet.graphql.ts
+++ b/src/v2/__generated__/OnboardingOrderedSet_orderedSet.graphql.ts
@@ -7,11 +7,26 @@ import { FragmentRefs } from "relay-runtime";
 export type OnboardingOrderedSet_orderedSet = {
     readonly orderedItemsConnection: {
         readonly edges: ReadonlyArray<{
-            readonly node: {
-                readonly name?: string | null | undefined;
-                readonly internalID?: string | undefined;
+            readonly node: ({
+                readonly __typename: "Artist";
+                readonly internalID: string;
                 readonly " $fragmentRefs": FragmentRefs<"EntityHeaderArtist_artist">;
-            } | null;
+            } | {
+                readonly __typename: "Profile";
+                readonly internalID: string;
+                readonly owner: {
+                    readonly __typename: "Partner";
+                    readonly " $fragmentRefs": FragmentRefs<"EntityHeaderPartner_partner">;
+                } | {
+                    /*This will never be '%other', but we need some
+                    value in case none of the concrete values match.*/
+                    readonly __typename: "%other";
+                };
+            } | {
+                /*This will never be '%other', but we need some
+                value in case none of the concrete values match.*/
+                readonly __typename: "%other";
+            }) | null;
         } | null> | null;
     };
     readonly " $refType": "OnboardingOrderedSet_orderedSet";
@@ -24,7 +39,22 @@ export type OnboardingOrderedSet_orderedSet$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -60,23 +90,11 @@ const node: ReaderFragment = {
               "name": "node",
               "plural": false,
               "selections": [
+                (v0/*: any*/),
                 {
                   "kind": "InlineFragment",
                   "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "name",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "internalID",
-                      "storageKey": null
-                    },
+                    (v1/*: any*/),
                     {
                       "args": null,
                       "kind": "FragmentSpread",
@@ -84,6 +102,38 @@ const node: ReaderFragment = {
                     }
                   ],
                   "type": "Artist",
+                  "abstractKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": null,
+                      "kind": "LinkedField",
+                      "name": "owner",
+                      "plural": false,
+                      "selections": [
+                        (v0/*: any*/),
+                        {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "args": null,
+                              "kind": "FragmentSpread",
+                              "name": "EntityHeaderPartner_partner"
+                            }
+                          ],
+                          "type": "Partner",
+                          "abstractKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "Profile",
                   "abstractKey": null
                 }
               ],
@@ -99,5 +149,6 @@ const node: ReaderFragment = {
   "type": "OrderedSet",
   "abstractKey": null
 };
-(node as any).hash = '744ce891870f559e1680069f33b7bd76';
+})();
+(node as any).hash = '833d51a13cbdbf0213aaaacea673e85a';
 export default node;

--- a/src/v2/__generated__/OnboardingSearchResultsQuery.graphql.ts
+++ b/src/v2/__generated__/OnboardingSearchResultsQuery.graphql.ts
@@ -4,8 +4,10 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type SearchEntity = "ARTICLE" | "ARTIST" | "ARTIST_SERIES" | "ARTWORK" | "CITY" | "COLLECTION" | "FAIR" | "FEATURE" | "GALLERY" | "GENE" | "INSTITUTION" | "PAGE" | "PROFILE" | "SALE" | "SHOW" | "TAG" | "VIEWING_ROOM" | "%future added value";
 export type OnboardingSearchResultsQueryVariables = {
     term: string;
+    entities: Array<SearchEntity>;
 };
 export type OnboardingSearchResultsQueryResponse = {
     readonly viewer: {
@@ -22,9 +24,10 @@ export type OnboardingSearchResultsQuery = {
 /*
 query OnboardingSearchResultsQuery(
   $term: String!
+  $entities: [SearchEntity!]!
 ) {
   viewer {
-    ...OnboardingSearchResults_viewer_4hh6ED
+    ...OnboardingSearchResults_viewer_plJt2
   }
 }
 
@@ -47,15 +50,77 @@ fragment EntityHeaderArtist_artist on Artist {
   }
 }
 
-fragment OnboardingSearchResults_viewer_4hh6ED on Viewer {
-  matchConnection(term: $term, entities: [ARTIST], first: 10, mode: AUTOSUGGEST) {
+fragment EntityHeaderPartner_partner on Partner {
+  internalID
+  type
+  slug
+  href
+  name
+  initials
+  locationsConnection(first: 15) {
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
+  categories {
+    name
+    slug
+    id
+  }
+  profile {
+    ...FollowProfileButton_profile
+    avatar: image {
+      cropped(width: 45, height: 45) {
+        src
+        srcSet
+      }
+    }
+    icon {
+      cropped(width: 45, height: 45, version: ["untouched-png", "large", "square"]) {
+        src
+        srcSet
+      }
+    }
+    id
+  }
+}
+
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  isFollowed
+}
+
+fragment OnboardingSearchResults_viewer_plJt2 on Viewer {
+  matchConnection(term: $term, entities: $entities, first: 10, mode: AUTOSUGGEST) {
     edges {
       node {
         __typename
         ... on Artist {
-          name
           internalID
           ...EntityHeaderArtist_artist
+        }
+        ... on Profile {
+          internalID
+          owner {
+            __typename
+            ... on Partner {
+              ...EntityHeaderPartner_partner
+            }
+            ... on Node {
+              __isNode: __typename
+              id
+            }
+            ... on FairOrganizer {
+              id
+            }
+          }
+          id
         }
         ... on Node {
           __isNode: __typename
@@ -67,9 +132,6 @@ fragment OnboardingSearchResults_viewer_4hh6ED on Viewer {
         ... on Page {
           id
         }
-        ... on Profile {
-          id
-        }
       }
     }
   }
@@ -77,30 +139,140 @@ fragment OnboardingSearchResults_viewer_4hh6ED on Viewer {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "term"
-  }
-],
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "entities"
+},
 v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "term"
+},
+v2 = {
+  "kind": "Variable",
+  "name": "entities",
+  "variableName": "entities"
+},
+v3 = {
   "kind": "Variable",
   "name": "term",
   "variableName": "term"
 },
-v2 = [
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "initials",
+  "storageKey": null
+},
+v10 = {
+  "kind": "Literal",
+  "name": "height",
+  "value": 45
+},
+v11 = {
+  "kind": "Literal",
+  "name": "width",
+  "value": 45
+},
+v12 = [
   {
     "alias": null,
     "args": null,
     "kind": "ScalarField",
-    "name": "id",
+    "name": "src",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
     "storageKey": null
   }
-];
+],
+v13 = {
+  "alias": "avatar",
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        (v10/*: any*/),
+        (v11/*: any*/)
+      ],
+      "concreteType": "CroppedImageUrl",
+      "kind": "LinkedField",
+      "name": "cropped",
+      "plural": false,
+      "selections": (v12/*: any*/),
+      "storageKey": "cropped(height:45,width:45)"
+    }
+  ],
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v15 = [
+  (v14/*: any*/)
+],
+v16 = {
+  "kind": "InlineFragment",
+  "selections": (v15/*: any*/),
+  "type": "Node",
+  "abstractKey": "__isNode"
+};
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
     "kind": "Fragment",
     "metadata": null,
     "name": "OnboardingSearchResultsQuery",
@@ -115,7 +287,8 @@ return {
         "selections": [
           {
             "args": [
-              (v1/*: any*/)
+              (v2/*: any*/),
+              (v3/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "OnboardingSearchResults_viewer"
@@ -129,7 +302,10 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
     "kind": "Operation",
     "name": "OnboardingSearchResultsQuery",
     "selections": [
@@ -144,13 +320,7 @@ return {
           {
             "alias": null,
             "args": [
-              {
-                "kind": "Literal",
-                "name": "entities",
-                "value": [
-                  "ARTIST"
-                ]
-              },
+              (v2/*: any*/),
               {
                 "kind": "Literal",
                 "name": "first",
@@ -161,7 +331,7 @@ return {
                 "name": "mode",
                 "value": "AUTOSUGGEST"
               },
-              (v1/*: any*/)
+              (v3/*: any*/)
             ],
             "concreteType": "MatchConnection",
             "kind": "LinkedField",
@@ -184,51 +354,15 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "__typename",
-                        "storageKey": null
-                      },
+                      (v4/*: any*/),
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "name",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "internalID",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "href",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "slug",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "initials",
-                            "storageKey": null
-                          },
+                          (v5/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/),
+                          (v8/*: any*/),
+                          (v9/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -261,79 +395,186 @@ return {
                             ],
                             "storageKey": null
                           },
-                          {
-                            "alias": "avatar",
-                            "args": null,
-                            "concreteType": "Image",
-                            "kind": "LinkedField",
-                            "name": "image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "height",
-                                    "value": 45
-                                  },
-                                  {
-                                    "kind": "Literal",
-                                    "name": "width",
-                                    "value": 45
-                                  }
-                                ],
-                                "concreteType": "CroppedImageUrl",
-                                "kind": "LinkedField",
-                                "name": "cropped",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "src",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "srcSet",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": "cropped(height:45,width:45)"
-                              }
-                            ],
-                            "storageKey": null
-                          }
+                          (v13/*: any*/)
                         ],
                         "type": "Artist",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v2/*: any*/),
-                        "type": "Node",
-                        "abstractKey": "__isNode"
+                        "selections": [
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "owner",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v5/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "type",
+                                    "storageKey": null
+                                  },
+                                  (v7/*: any*/),
+                                  (v6/*: any*/),
+                                  (v8/*: any*/),
+                                  (v9/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "first",
+                                        "value": 15
+                                      }
+                                    ],
+                                    "concreteType": "LocationConnection",
+                                    "kind": "LinkedField",
+                                    "name": "locationsConnection",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "LocationEdge",
+                                        "kind": "LinkedField",
+                                        "name": "edges",
+                                        "plural": true,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Location",
+                                            "kind": "LinkedField",
+                                            "name": "node",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "city",
+                                                "storageKey": null
+                                              },
+                                              (v14/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "locationsConnection(first:15)"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "PartnerCategory",
+                                    "kind": "LinkedField",
+                                    "name": "categories",
+                                    "plural": true,
+                                    "selections": [
+                                      (v8/*: any*/),
+                                      (v7/*: any*/),
+                                      (v14/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Profile",
+                                    "kind": "LinkedField",
+                                    "name": "profile",
+                                    "plural": false,
+                                    "selections": [
+                                      (v14/*: any*/),
+                                      (v7/*: any*/),
+                                      (v8/*: any*/),
+                                      (v5/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isFollowed",
+                                        "storageKey": null
+                                      },
+                                      (v13/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Image",
+                                        "kind": "LinkedField",
+                                        "name": "icon",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": [
+                                              (v10/*: any*/),
+                                              {
+                                                "kind": "Literal",
+                                                "name": "version",
+                                                "value": [
+                                                  "untouched-png",
+                                                  "large",
+                                                  "square"
+                                                ]
+                                              },
+                                              (v11/*: any*/)
+                                            ],
+                                            "concreteType": "CroppedImageUrl",
+                                            "kind": "LinkedField",
+                                            "name": "cropped",
+                                            "plural": false,
+                                            "selections": (v12/*: any*/),
+                                            "storageKey": "cropped(height:45,version:[\"untouched-png\",\"large\",\"square\"],width:45)"
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "Partner",
+                                "abstractKey": null
+                              },
+                              (v16/*: any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": (v15/*: any*/),
+                                "type": "FairOrganizer",
+                                "abstractKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          (v14/*: any*/)
+                        ],
+                        "type": "Profile",
+                        "abstractKey": null
                       },
+                      (v16/*: any*/),
                       {
                         "kind": "InlineFragment",
-                        "selections": (v2/*: any*/),
+                        "selections": (v15/*: any*/),
                         "type": "Feature",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v2/*: any*/),
+                        "selections": (v15/*: any*/),
                         "type": "Page",
-                        "abstractKey": null
-                      },
-                      {
-                        "kind": "InlineFragment",
-                        "selections": (v2/*: any*/),
-                        "type": "Profile",
                         "abstractKey": null
                       }
                     ],
@@ -351,14 +592,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "218ed76080c46860b1447c4c2b234528",
+    "cacheID": "49af927fcbb933d497fed019063c5eb1",
     "id": null,
     "metadata": {},
     "name": "OnboardingSearchResultsQuery",
     "operationKind": "query",
-    "text": "query OnboardingSearchResultsQuery(\n  $term: String!\n) {\n  viewer {\n    ...OnboardingSearchResults_viewer_4hh6ED\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment OnboardingSearchResults_viewer_4hh6ED on Viewer {\n  matchConnection(term: $term, entities: [ARTIST], first: 10, mode: AUTOSUGGEST) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          ...EntityHeaderArtist_artist\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on Feature {\n          id\n        }\n        ... on Page {\n          id\n        }\n        ... on Profile {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query OnboardingSearchResultsQuery(\n  $term: String!\n  $entities: [SearchEntity!]!\n) {\n  viewer {\n    ...OnboardingSearchResults_viewer_plJt2\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment OnboardingSearchResults_viewer_plJt2 on Viewer {\n  matchConnection(term: $term, entities: $entities, first: 10, mode: AUTOSUGGEST) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          internalID\n          ...EntityHeaderArtist_artist\n        }\n        ... on Profile {\n          internalID\n          owner {\n            __typename\n            ... on Partner {\n              ...EntityHeaderPartner_partner\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n            ... on FairOrganizer {\n              id\n            }\n          }\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on Feature {\n          id\n        }\n        ... on Page {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '36f77eb82d49c4aa1aaba20b02298c16';
+(node as any).hash = '2739e833d6fd9864920fe6f1e7796bed';
 export default node;

--- a/src/v2/__generated__/OnboardingSearchResults_viewer.graphql.ts
+++ b/src/v2/__generated__/OnboardingSearchResults_viewer.graphql.ts
@@ -7,11 +7,26 @@ import { FragmentRefs } from "relay-runtime";
 export type OnboardingSearchResults_viewer = {
     readonly matchConnection: {
         readonly edges: ReadonlyArray<{
-            readonly node: {
-                readonly name?: string | null | undefined;
-                readonly internalID?: string | undefined;
+            readonly node: ({
+                readonly __typename: "Artist";
+                readonly internalID: string;
                 readonly " $fragmentRefs": FragmentRefs<"EntityHeaderArtist_artist">;
-            } | null;
+            } | {
+                readonly __typename: "Profile";
+                readonly internalID: string;
+                readonly owner: {
+                    readonly __typename: "Partner";
+                    readonly " $fragmentRefs": FragmentRefs<"EntityHeaderPartner_partner">;
+                } | {
+                    /*This will never be '%other', but we need some
+                    value in case none of the concrete values match.*/
+                    readonly __typename: "%other";
+                };
+            } | {
+                /*This will never be '%other', but we need some
+                value in case none of the concrete values match.*/
+                readonly __typename: "%other";
+            }) | null;
         } | null> | null;
     } | null;
     readonly " $refType": "OnboardingSearchResults_viewer";
@@ -24,8 +39,28 @@ export type OnboardingSearchResults_viewer$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
+return {
   "argumentDefinitions": [
+    {
+      "defaultValue": [],
+      "kind": "LocalArgument",
+      "name": "entities"
+    },
     {
       "defaultValue": "",
       "kind": "LocalArgument",
@@ -40,11 +75,9 @@ const node: ReaderFragment = {
       "alias": null,
       "args": [
         {
-          "kind": "Literal",
+          "kind": "Variable",
           "name": "entities",
-          "value": [
-            "ARTIST"
-          ]
+          "variableName": "entities"
         },
         {
           "kind": "Literal",
@@ -83,23 +116,11 @@ const node: ReaderFragment = {
               "name": "node",
               "plural": false,
               "selections": [
+                (v0/*: any*/),
                 {
                   "kind": "InlineFragment",
                   "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "name",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "internalID",
-                      "storageKey": null
-                    },
+                    (v1/*: any*/),
                     {
                       "args": null,
                       "kind": "FragmentSpread",
@@ -107,6 +128,38 @@ const node: ReaderFragment = {
                     }
                   ],
                   "type": "Artist",
+                  "abstractKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": null,
+                      "kind": "LinkedField",
+                      "name": "owner",
+                      "plural": false,
+                      "selections": [
+                        (v0/*: any*/),
+                        {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "args": null,
+                              "kind": "FragmentSpread",
+                              "name": "EntityHeaderPartner_partner"
+                            }
+                          ],
+                          "type": "Partner",
+                          "abstractKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "Profile",
                   "abstractKey": null
                 }
               ],
@@ -122,5 +175,6 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = '0bac4a9d48935ebac0ce2af757db64e3';
+})();
+(node as any).hash = '6308eedc3c65cbc97ef33cc1e3d1970e';
 export default node;


### PR DESCRIPTION
The type of this PR is: _feat_

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1100]

### Description

The intention of this code is to build out the Follow Galleries rewards screen that occurs at the end of the Onboarding workflow. Currently, an `orderedSet` is being used to backfill featured partner profiles and a search filter will be implemented. 

Acceptance criteria:

- [x] User sees follow galleries screen
- [x] User sees partner profile image
- [x] User sees default list of galleries from an orderedSet in admin
- [x] User can search galleries
- [x] User sees galleries populating after search
- [x] User can continue after selecting at least one gallery
- [ ] User can follow as many galleries as they would like 
- [x] User can click x and leave the onboarding flow 
- [ ] Responsiveness


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1100]: https://artsyproduct.atlassian.net/browse/GRO-1100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ