### PR TITLE
bug(NewForYou): add redirect after login

### DIFF
--- a/src/v2/Apps/NewForYou/NewForYouApp.tsx
+++ b/src/v2/Apps/NewForYou/NewForYouApp.tsx
@@ -6,6 +6,7 @@ import { NewForYouApp_viewer } from "v2/__generated__/NewForYouApp_viewer.graphq
 import { NewForYouArtworksGridFragmentContainer } from "v2/Apps/NewForYou/Components/NewForYouArtworksGrid"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { useSystemContext } from "v2/System"
+import { useRouter } from "v2/System/Router/useRouter"
 
 interface NewForYouAppProps {
   viewer: NewForYouApp_viewer
@@ -13,6 +14,8 @@ interface NewForYouAppProps {
 
 export const NewForYouApp: FC<NewForYouAppProps> = ({ viewer }) => {
   const { isLoggedIn } = useSystemContext()
+  const { route } = useRouter()
+
   return (
     <>
       <Spacer mt={2} />
@@ -24,7 +27,10 @@ export const NewForYouApp: FC<NewForYouAppProps> = ({ viewer }) => {
       {!isLoggedIn && (
         <>
           <Message variant="warning">
-            Already have an account? <RouterLink to="/login">Log in</RouterLink>{" "}
+            Already have an account?{" "}
+            <RouterLink to={`/login?redirectTo=${route.path}`}>
+              Log in
+            </RouterLink>{" "}
             to see your personalized recommendations.
           </Message>
           <Spacer mt={4} />

--- a/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
+++ b/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
@@ -10,7 +10,7 @@ jest.mock("v2/Components/MetaTags", () => ({
   MetaTags: () => "MetaTags",
 }))
 jest.mock("v2/System/Router/useRouter", () => ({
-  useRouter: jest.fn(),
+  useRouter: jest.fn().mockReturnValue({ route: { path: "/new-for-you" } }),
 }))
 jest.mock("v2/System", () => ({
   useSystemContext: jest.fn(),


### PR DESCRIPTION
The type of this PR is: **BUG**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1129]

### Description

Add query param to url so user is redirected back to `/new-for-you` after logging in.

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1129]: https://artsyproduct.atlassian.net/browse/GRO-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ