### PR TITLE
Support URL params on New For You page

### DIFF
--- a/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
+++ b/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
@@ -29,8 +29,11 @@ export const NewForYouArtworksGridFragmentContainer = createFragmentContainer(
   {
     viewer: graphql`
       fragment NewForYouArtworksGrid_viewer on Viewer
-        @argumentDefinitions(first: { type: "Int" }) {
-        artworksForUser(first: $first, includeBackfill: true) {
+        @argumentDefinitions(
+          first: { type: "Int" }
+          includeBackfill: { type: "Boolean!" }
+        ) {
+        artworksForUser(first: $first, includeBackfill: $includeBackfill) {
           totalCount
           ...ArtworkGrid_artworks
           pageInfo {

--- a/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
+++ b/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
@@ -29,7 +29,7 @@ export const NewForYouArtworksGridFragmentContainer = createFragmentContainer(
   {
     viewer: graphql`
       fragment NewForYouArtworksGrid_viewer on Viewer
-        @argumentDefinitions(first: { type: "Int", defaultValue: 20 }) {
+        @argumentDefinitions(first: { type: "Int" }) {
         artworksForUser(first: $first, includeBackfill: true) {
           totalCount
           ...ArtworkGrid_artworks

--- a/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
+++ b/src/v2/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
@@ -32,8 +32,13 @@ export const NewForYouArtworksGridFragmentContainer = createFragmentContainer(
         @argumentDefinitions(
           first: { type: "Int" }
           includeBackfill: { type: "Boolean!" }
+          version: { type: "String" }
         ) {
-        artworksForUser(first: $first, includeBackfill: $includeBackfill) {
+        artworksForUser(
+          first: $first
+          includeBackfill: $includeBackfill
+          version: $version
+        ) {
           totalCount
           ...ArtworkGrid_artworks
           pageInfo {

--- a/src/v2/Apps/NewForYou/NewForYouApp.tsx
+++ b/src/v2/Apps/NewForYou/NewForYouApp.tsx
@@ -46,8 +46,12 @@ export const NewForYouAppFragmentContainer = createFragmentContainer(
   {
     viewer: graphql`
       fragment NewForYouApp_viewer on Viewer
-        @argumentDefinitions(first: { type: "Int" }) {
-        ...NewForYouArtworksGrid_viewer @arguments(first: $first)
+        @argumentDefinitions(
+          first: { type: "Int" }
+          includeBackfill: { type: "Boolean!" }
+        ) {
+        ...NewForYouArtworksGrid_viewer
+          @arguments(first: $first, includeBackfill: $includeBackfill)
       }
     `,
   }

--- a/src/v2/Apps/NewForYou/NewForYouApp.tsx
+++ b/src/v2/Apps/NewForYou/NewForYouApp.tsx
@@ -49,9 +49,14 @@ export const NewForYouAppFragmentContainer = createFragmentContainer(
         @argumentDefinitions(
           first: { type: "Int" }
           includeBackfill: { type: "Boolean!" }
+          version: { type: "String" }
         ) {
         ...NewForYouArtworksGrid_viewer
-          @arguments(first: $first, includeBackfill: $includeBackfill)
+          @arguments(
+            first: $first
+            includeBackfill: $includeBackfill
+            version: $version
+          )
       }
     `,
   }

--- a/src/v2/Apps/NewForYou/NewForYouApp.tsx
+++ b/src/v2/Apps/NewForYou/NewForYouApp.tsx
@@ -45,8 +45,9 @@ export const NewForYouAppFragmentContainer = createFragmentContainer(
   NewForYouApp,
   {
     viewer: graphql`
-      fragment NewForYouApp_viewer on Viewer {
-        ...NewForYouArtworksGrid_viewer
+      fragment NewForYouApp_viewer on Viewer
+        @argumentDefinitions(first: { type: "Int" }) {
+        ...NewForYouArtworksGrid_viewer @arguments(first: $first)
       }
     `,
   }

--- a/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
+++ b/src/v2/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
@@ -23,9 +23,11 @@ beforeEach(() => {
 const { renderWithRelay } = setupTestWrapperTL({
   Component: NewForYouAppFragmentContainer,
   query: graphql`
-    query NewForYouApp_test_Query @relay_test_operation {
+    query NewForYouApp_test_Query($first: Int, $includeBackfill: Boolean!)
+      @relay_test_operation {
       viewer: viewer {
         ...NewForYouArtworksGrid_viewer
+          @arguments(first: $first, includeBackfill: $includeBackfill)
       }
     }
   `,

--- a/src/v2/Apps/NewForYou/newForYouRoutes.tsx
+++ b/src/v2/Apps/NewForYou/newForYouRoutes.tsx
@@ -13,10 +13,19 @@ export const newForYouRoutes: AppRouteConfig[] = [
     onClientSideRender: () => {
       NewForYouApp.preload()
     },
+    prepareVariables: (params, props) => {
+      const first = parseInt(props.location.query.first, 10) || 20
+
+      return {
+        ...params,
+        ...props,
+        first,
+      }
+    },
     query: graphql`
-      query newForYouRoutes_TopLevelQuery {
+      query newForYouRoutes_TopLevelQuery($first: Int) {
         viewer {
-          ...NewForYouApp_viewer
+          ...NewForYouApp_viewer @arguments(first: $first)
         }
       }
     `,

--- a/src/v2/Apps/NewForYou/newForYouRoutes.tsx
+++ b/src/v2/Apps/NewForYou/newForYouRoutes.tsx
@@ -16,22 +16,29 @@ export const newForYouRoutes: AppRouteConfig[] = [
     prepareVariables: (params, props) => {
       const first = parseInt(props.location.query.first, 10) || 20
       const includeBackfill = props.location.query.includeBackfill ?? true
+      const version = props.location.query.version
 
       return {
         ...params,
         ...props,
         first,
         includeBackfill,
+        version,
       }
     },
     query: graphql`
       query newForYouRoutes_TopLevelQuery(
         $first: Int
         $includeBackfill: Boolean!
+        $version: String
       ) {
         viewer {
           ...NewForYouApp_viewer
-            @arguments(first: $first, includeBackfill: $includeBackfill)
+            @arguments(
+              first: $first
+              includeBackfill: $includeBackfill
+              version: $version
+            )
         }
       }
     `,

--- a/src/v2/Apps/NewForYou/newForYouRoutes.tsx
+++ b/src/v2/Apps/NewForYou/newForYouRoutes.tsx
@@ -15,17 +15,23 @@ export const newForYouRoutes: AppRouteConfig[] = [
     },
     prepareVariables: (params, props) => {
       const first = parseInt(props.location.query.first, 10) || 20
+      const includeBackfill = props.location.query.includeBackfill ?? true
 
       return {
         ...params,
         ...props,
         first,
+        includeBackfill,
       }
     },
     query: graphql`
-      query newForYouRoutes_TopLevelQuery($first: Int) {
+      query newForYouRoutes_TopLevelQuery(
+        $first: Int
+        $includeBackfill: Boolean!
+      ) {
         viewer {
-          ...NewForYouApp_viewer @arguments(first: $first)
+          ...NewForYouApp_viewer
+            @arguments(first: $first, includeBackfill: $includeBackfill)
         }
       }
     `,

--- a/src/v2/__generated__/NewForYouApp_test_Query.graphql.ts
+++ b/src/v2/__generated__/NewForYouApp_test_Query.graphql.ts
@@ -4,7 +4,10 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type NewForYouApp_test_QueryVariables = {};
+export type NewForYouApp_test_QueryVariables = {
+    first?: number | null | undefined;
+    includeBackfill: boolean;
+};
 export type NewForYouApp_test_QueryResponse = {
     readonly viewer: {
         readonly " $fragmentRefs": FragmentRefs<"NewForYouArtworksGrid_viewer">;
@@ -18,9 +21,12 @@ export type NewForYouApp_test_Query = {
 
 
 /*
-query NewForYouApp_test_Query {
+query NewForYouApp_test_Query(
+  $first: Int
+  $includeBackfill: Boolean!
+) {
   viewer {
-    ...NewForYouArtworksGrid_viewer
+    ...NewForYouArtworksGrid_viewer_2GVV1c
   }
 }
 
@@ -169,8 +175,8 @@ fragment Metadata_artwork on Artwork {
   href
 }
 
-fragment NewForYouArtworksGrid_viewer on Viewer {
-  artworksForUser(includeBackfill: true) {
+fragment NewForYouArtworksGrid_viewer_2GVV1c on Viewer {
+  artworksForUser(first: $first, includeBackfill: $includeBackfill) {
     totalCount
     ...ArtworkGrid_artworks
     pageInfo {
@@ -198,56 +204,80 @@ fragment SaveButton_artwork on Artwork {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = {
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "first"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "includeBackfill"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  },
+  {
+    "kind": "Variable",
+    "name": "includeBackfill",
+    "variableName": "includeBackfill"
+  }
+],
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v1 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v5 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v6 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v7 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -256,41 +286,41 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = [
-  (v3/*: any*/),
-  (v0/*: any*/)
+v10 = [
+  (v5/*: any*/),
+  (v2/*: any*/)
 ],
-v9 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v10 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "ID"
-},
 v11 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
   "type": "String"
 },
 v12 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "Int"
+  "type": "ID"
 },
 v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Boolean"
+  "type": "String"
 },
 v14 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v15 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -298,7 +328,7 @@ v14 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "NewForYouApp_test_Query",
@@ -312,7 +342,7 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": null,
+            "args": (v1/*: any*/),
             "kind": "FragmentSpread",
             "name": "NewForYouArtworksGrid_viewer"
           }
@@ -325,7 +355,7 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "NewForYouApp_test_Query",
     "selections": [
@@ -339,13 +369,7 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "includeBackfill",
-                "value": true
-              }
-            ],
+            "args": (v1/*: any*/),
             "concreteType": "ArtworkConnection",
             "kind": "LinkedField",
             "name": "artworksForUser",
@@ -409,7 +433,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v0/*: any*/),
+                          (v2/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -417,7 +441,7 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v1/*: any*/),
+                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -561,15 +585,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v2/*: any*/),
+                            "args": (v4/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
-                              (v0/*: any*/),
-                              (v1/*: any*/),
-                              (v3/*: any*/)
+                              (v2/*: any*/),
+                              (v3/*: any*/),
+                              (v5/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -582,15 +606,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v2/*: any*/),
+                            "args": (v4/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
+                              (v5/*: any*/),
                               (v3/*: any*/),
-                              (v1/*: any*/),
-                              (v0/*: any*/)
+                              (v2/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
                           },
@@ -602,7 +626,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v4/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -638,7 +662,7 @@ return {
                                 "name": "isClosed",
                                 "storageKey": null
                               },
-                              (v0/*: any*/),
+                              (v2/*: any*/),
                               {
                                 "alias": "is_preview",
                                 "args": null,
@@ -671,7 +695,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v5/*: any*/),
+                              (v7/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -679,8 +703,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v4/*: any*/),
                               (v6/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -713,7 +737,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v7/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -723,10 +747,10 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v7/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
-                              (v0/*: any*/)
+                              (v2/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -744,7 +768,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v10/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -762,7 +786,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v8/*: any*/),
+                                "selections": (v10/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -783,10 +807,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v4/*: any*/),
                               (v6/*: any*/),
-                              (v5/*: any*/),
-                              (v0/*: any*/)
+                              (v8/*: any*/),
+                              (v7/*: any*/),
+                              (v2/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -796,7 +820,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v0/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -809,7 +833,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksForUser(includeBackfill:true)"
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -817,7 +841,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b707bda98211c8ec6a9b1a00b24fa16e",
+    "cacheID": "89b15b7256fa10a91bffdd4458bb87b2",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -833,45 +857,45 @@ return {
           "plural": false,
           "type": "ArtworkConnection"
         },
-        "viewer.artworksForUser.__isArtworkConnectionInterface": (v9/*: any*/),
+        "viewer.artworksForUser.__isArtworkConnectionInterface": (v11/*: any*/),
         "viewer.artworksForUser.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "viewer.artworksForUser.edges.__isNode": (v9/*: any*/),
-        "viewer.artworksForUser.edges.__typename": (v9/*: any*/),
-        "viewer.artworksForUser.edges.id": (v10/*: any*/),
+        "viewer.artworksForUser.edges.__isNode": (v11/*: any*/),
+        "viewer.artworksForUser.edges.__typename": (v11/*: any*/),
+        "viewer.artworksForUser.edges.id": (v12/*: any*/),
         "viewer.artworksForUser.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Artwork"
         },
-        "viewer.artworksForUser.edges.node.artistNames": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.artistNames": (v13/*: any*/),
         "viewer.artworksForUser.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "viewer.artworksForUser.edges.node.artists.href": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.artists.id": (v10/*: any*/),
-        "viewer.artworksForUser.edges.node.artists.name": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.artists.href": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.artists.id": (v12/*: any*/),
+        "viewer.artworksForUser.edges.node.artists.name": (v13/*: any*/),
         "viewer.artworksForUser.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "viewer.artworksForUser.edges.node.attributionClass.id": (v10/*: any*/),
-        "viewer.artworksForUser.edges.node.attributionClass.name": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.collecting_institution": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.cultural_maker": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.date": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.href": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.id": (v10/*: any*/),
+        "viewer.artworksForUser.edges.node.attributionClass.id": (v12/*: any*/),
+        "viewer.artworksForUser.edges.node.attributionClass.name": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.collecting_institution": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.cultural_maker": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.date": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.href": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.id": (v12/*: any*/),
         "viewer.artworksForUser.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -884,22 +908,22 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "viewer.artworksForUser.edges.node.image.placeholder": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.image.placeholder": (v13/*: any*/),
         "viewer.artworksForUser.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "viewer.artworksForUser.edges.node.image.resized.height": (v12/*: any*/),
-        "viewer.artworksForUser.edges.node.image.resized.src": (v9/*: any*/),
-        "viewer.artworksForUser.edges.node.image.resized.srcSet": (v9/*: any*/),
-        "viewer.artworksForUser.edges.node.image.resized.width": (v12/*: any*/),
-        "viewer.artworksForUser.edges.node.image.url": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.image_title": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.internalID": (v10/*: any*/),
-        "viewer.artworksForUser.edges.node.is_biddable": (v13/*: any*/),
-        "viewer.artworksForUser.edges.node.is_saved": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.image.resized.height": (v14/*: any*/),
+        "viewer.artworksForUser.edges.node.image.resized.src": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.image.resized.srcSet": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.image.resized.width": (v14/*: any*/),
+        "viewer.artworksForUser.edges.node.image.url": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.image_title": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.internalID": (v12/*: any*/),
+        "viewer.artworksForUser.edges.node.is_biddable": (v15/*: any*/),
+        "viewer.artworksForUser.edges.node.is_saved": (v15/*: any*/),
         "viewer.artworksForUser.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -912,39 +936,39 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "viewer.artworksForUser.edges.node.mediumType.filterGene.id": (v10/*: any*/),
-        "viewer.artworksForUser.edges.node.mediumType.filterGene.name": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.mediumType.filterGene.id": (v12/*: any*/),
+        "viewer.artworksForUser.edges.node.mediumType.filterGene.name": (v13/*: any*/),
         "viewer.artworksForUser.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewer.artworksForUser.edges.node.partner.href": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.partner.id": (v10/*: any*/),
-        "viewer.artworksForUser.edges.node.partner.name": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.partner.href": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.partner.id": (v12/*: any*/),
+        "viewer.artworksForUser.edges.node.partner.name": (v13/*: any*/),
         "viewer.artworksForUser.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "viewer.artworksForUser.edges.node.sale.cascadingEndTimeIntervalMinutes": (v12/*: any*/),
-        "viewer.artworksForUser.edges.node.sale.display_timely_at": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.sale.endAt": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.sale.extendedBiddingIntervalMinutes": (v12/*: any*/),
-        "viewer.artworksForUser.edges.node.sale.extendedBiddingPeriodMinutes": (v12/*: any*/),
-        "viewer.artworksForUser.edges.node.sale.id": (v10/*: any*/),
-        "viewer.artworksForUser.edges.node.sale.is_auction": (v13/*: any*/),
-        "viewer.artworksForUser.edges.node.sale.is_closed": (v13/*: any*/),
-        "viewer.artworksForUser.edges.node.sale.is_preview": (v13/*: any*/),
-        "viewer.artworksForUser.edges.node.sale.startAt": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.saleArtwork": (v14/*: any*/),
-        "viewer.artworksForUser.edges.node.saleArtwork.endAt": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.saleArtwork.extendedBiddingEndAt": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.saleArtwork.id": (v10/*: any*/),
-        "viewer.artworksForUser.edges.node.saleArtwork.lotID": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.sale_artwork": (v14/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.cascadingEndTimeIntervalMinutes": (v14/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.display_timely_at": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.endAt": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.extendedBiddingIntervalMinutes": (v14/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.extendedBiddingPeriodMinutes": (v14/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.id": (v12/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.is_auction": (v15/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.is_closed": (v15/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.is_preview": (v15/*: any*/),
+        "viewer.artworksForUser.edges.node.sale.startAt": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.saleArtwork": (v16/*: any*/),
+        "viewer.artworksForUser.edges.node.saleArtwork.endAt": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.saleArtwork.extendedBiddingEndAt": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.saleArtwork.id": (v12/*: any*/),
+        "viewer.artworksForUser.edges.node.saleArtwork.lotID": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork": (v16/*: any*/),
         "viewer.artworksForUser.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
@@ -957,50 +981,50 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "viewer.artworksForUser.edges.node.sale_artwork.endAt": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.sale_artwork.extendedBiddingEndAt": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.sale_artwork.formattedEndDateTime": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.endAt": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.extendedBiddingEndAt": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.formattedEndDateTime": (v13/*: any*/),
         "viewer.artworksForUser.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "viewer.artworksForUser.edges.node.sale_artwork.highest_bid.display": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.sale_artwork.id": (v10/*: any*/),
-        "viewer.artworksForUser.edges.node.sale_artwork.lotID": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.sale_artwork.lotLabel": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.highest_bid.display": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.id": (v12/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.lotID": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.lotLabel": (v13/*: any*/),
         "viewer.artworksForUser.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "viewer.artworksForUser.edges.node.sale_artwork.opening_bid.display": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.sale_message": (v11/*: any*/),
-        "viewer.artworksForUser.edges.node.slug": (v10/*: any*/),
-        "viewer.artworksForUser.edges.node.title": (v11/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_artwork.opening_bid.display": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.sale_message": (v13/*: any*/),
+        "viewer.artworksForUser.edges.node.slug": (v12/*: any*/),
+        "viewer.artworksForUser.edges.node.title": (v13/*: any*/),
         "viewer.artworksForUser.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "viewer.artworksForUser.pageInfo.endCursor": (v11/*: any*/),
+        "viewer.artworksForUser.pageInfo.endCursor": (v13/*: any*/),
         "viewer.artworksForUser.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "viewer.artworksForUser.totalCount": (v12/*: any*/)
+        "viewer.artworksForUser.totalCount": (v14/*: any*/)
       }
     },
     "name": "NewForYouApp_test_Query",
     "operationKind": "query",
-    "text": "query NewForYouApp_test_Query {\n  viewer {\n    ...NewForYouArtworksGrid_viewer\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewForYouArtworksGrid_viewer on Viewer {\n  artworksForUser(includeBackfill: true) {\n    totalCount\n    ...ArtworkGrid_artworks\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query NewForYouApp_test_Query(\n  $first: Int\n  $includeBackfill: Boolean!\n) {\n  viewer {\n    ...NewForYouArtworksGrid_viewer_2GVV1c\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewForYouArtworksGrid_viewer_2GVV1c on Viewer {\n  artworksForUser(first: $first, includeBackfill: $includeBackfill) {\n    totalCount\n    ...ArtworkGrid_artworks\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();
-(node as any).hash = 'eb7c817ecb03a4142ac6901239ce42de';
+(node as any).hash = '862f781bcd9c74ba696247183591a393';
 export default node;

--- a/src/v2/__generated__/NewForYouApp_test_Query.graphql.ts
+++ b/src/v2/__generated__/NewForYouApp_test_Query.graphql.ts
@@ -170,7 +170,7 @@ fragment Metadata_artwork on Artwork {
 }
 
 fragment NewForYouArtworksGrid_viewer on Viewer {
-  artworksForUser(first: 20, includeBackfill: true) {
+  artworksForUser(includeBackfill: true) {
     totalCount
     ...ArtworkGrid_artworks
     pageInfo {
@@ -340,11 +340,6 @@ return {
           {
             "alias": null,
             "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 20
-              },
               {
                 "kind": "Literal",
                 "name": "includeBackfill",
@@ -814,7 +809,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksForUser(first:20,includeBackfill:true)"
+            "storageKey": "artworksForUser(includeBackfill:true)"
           }
         ],
         "storageKey": null
@@ -822,7 +817,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "df806b9e28dfb14f10f908f4c88a3875",
+    "cacheID": "b707bda98211c8ec6a9b1a00b24fa16e",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1003,7 +998,7 @@ return {
     },
     "name": "NewForYouApp_test_Query",
     "operationKind": "query",
-    "text": "query NewForYouApp_test_Query {\n  viewer {\n    ...NewForYouArtworksGrid_viewer\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewForYouArtworksGrid_viewer on Viewer {\n  artworksForUser(first: 20, includeBackfill: true) {\n    totalCount\n    ...ArtworkGrid_artworks\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query NewForYouApp_test_Query {\n  viewer {\n    ...NewForYouArtworksGrid_viewer\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewForYouArtworksGrid_viewer on Viewer {\n  artworksForUser(includeBackfill: true) {\n    totalCount\n    ...ArtworkGrid_artworks\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/NewForYouApp_viewer.graphql.ts
+++ b/src/v2/__generated__/NewForYouApp_viewer.graphql.ts
@@ -17,13 +17,25 @@ export type NewForYouApp_viewer$key = {
 
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "first"
+    }
+  ],
   "kind": "Fragment",
   "metadata": null,
   "name": "NewForYouApp_viewer",
   "selections": [
     {
-      "args": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "first",
+          "variableName": "first"
+        }
+      ],
       "kind": "FragmentSpread",
       "name": "NewForYouArtworksGrid_viewer"
     }
@@ -31,5 +43,5 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = 'c0853067c5df9e2c4f11fa5787d41abb';
+(node as any).hash = '931ff1fd40cb3ac476d2a6b6da34e326';
 export default node;

--- a/src/v2/__generated__/NewForYouApp_viewer.graphql.ts
+++ b/src/v2/__generated__/NewForYouApp_viewer.graphql.ts
@@ -27,6 +27,11 @@ const node: ReaderFragment = {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "includeBackfill"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "version"
     }
   ],
   "kind": "Fragment",
@@ -44,6 +49,11 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "includeBackfill",
           "variableName": "includeBackfill"
+        },
+        {
+          "kind": "Variable",
+          "name": "version",
+          "variableName": "version"
         }
       ],
       "kind": "FragmentSpread",
@@ -53,5 +63,5 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = '5406907df36bec5eeebc08c1a686d205';
+(node as any).hash = 'c8f71ef5675999e803e6ea924c24685e';
 export default node;

--- a/src/v2/__generated__/NewForYouApp_viewer.graphql.ts
+++ b/src/v2/__generated__/NewForYouApp_viewer.graphql.ts
@@ -22,6 +22,11 @@ const node: ReaderFragment = {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "first"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "includeBackfill"
     }
   ],
   "kind": "Fragment",
@@ -34,6 +39,11 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "first",
           "variableName": "first"
+        },
+        {
+          "kind": "Variable",
+          "name": "includeBackfill",
+          "variableName": "includeBackfill"
         }
       ],
       "kind": "FragmentSpread",
@@ -43,5 +53,5 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = '931ff1fd40cb3ac476d2a6b6da34e326';
+(node as any).hash = '5406907df36bec5eeebc08c1a686d205';
 export default node;

--- a/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
+++ b/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
@@ -29,6 +29,11 @@ const node: ReaderFragment = {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "first"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "includeBackfill"
     }
   ],
   "kind": "Fragment",
@@ -44,9 +49,9 @@ const node: ReaderFragment = {
           "variableName": "first"
         },
         {
-          "kind": "Literal",
+          "kind": "Variable",
           "name": "includeBackfill",
-          "value": true
+          "variableName": "includeBackfill"
         }
       ],
       "concreteType": "ArtworkConnection",
@@ -98,5 +103,5 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = 'ba522927b47e2ad3a5de17351af64541';
+(node as any).hash = 'ff2199368da1a055fcce05cacc32d79b';
 export default node;

--- a/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
+++ b/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
@@ -26,7 +26,7 @@ export type NewForYouArtworksGrid_viewer$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
-      "defaultValue": 20,
+      "defaultValue": null,
       "kind": "LocalArgument",
       "name": "first"
     }
@@ -98,5 +98,5 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = '717ce1fe6dd0cd381c1992f726c3c190';
+(node as any).hash = 'ba522927b47e2ad3a5de17351af64541';
 export default node;

--- a/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
+++ b/src/v2/__generated__/NewForYouArtworksGrid_viewer.graphql.ts
@@ -34,6 +34,11 @@ const node: ReaderFragment = {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "includeBackfill"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "version"
     }
   ],
   "kind": "Fragment",
@@ -52,6 +57,11 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "includeBackfill",
           "variableName": "includeBackfill"
+        },
+        {
+          "kind": "Variable",
+          "name": "version",
+          "variableName": "version"
         }
       ],
       "concreteType": "ArtworkConnection",
@@ -103,5 +113,5 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = 'ff2199368da1a055fcce05cacc32d79b';
+(node as any).hash = 'f5bf554270769e034860baf604d273e6';
 export default node;

--- a/src/v2/__generated__/newForYouRoutes_TopLevelQuery.graphql.ts
+++ b/src/v2/__generated__/newForYouRoutes_TopLevelQuery.graphql.ts
@@ -7,6 +7,7 @@ import { FragmentRefs } from "relay-runtime";
 export type newForYouRoutes_TopLevelQueryVariables = {
     first?: number | null | undefined;
     includeBackfill: boolean;
+    version?: string | null | undefined;
 };
 export type newForYouRoutes_TopLevelQueryResponse = {
     readonly viewer: {
@@ -24,9 +25,10 @@ export type newForYouRoutes_TopLevelQuery = {
 query newForYouRoutes_TopLevelQuery(
   $first: Int
   $includeBackfill: Boolean!
+  $version: String
 ) {
   viewer {
-    ...NewForYouApp_viewer_2GVV1c
+    ...NewForYouApp_viewer_1hZglA
   }
 }
 
@@ -175,12 +177,12 @@ fragment Metadata_artwork on Artwork {
   href
 }
 
-fragment NewForYouApp_viewer_2GVV1c on Viewer {
-  ...NewForYouArtworksGrid_viewer_2GVV1c
+fragment NewForYouApp_viewer_1hZglA on Viewer {
+  ...NewForYouArtworksGrid_viewer_1hZglA
 }
 
-fragment NewForYouArtworksGrid_viewer_2GVV1c on Viewer {
-  artworksForUser(first: $first, includeBackfill: $includeBackfill) {
+fragment NewForYouArtworksGrid_viewer_1hZglA on Viewer {
+  artworksForUser(first: $first, includeBackfill: $includeBackfill, version: $version) {
     totalCount
     ...ArtworkGrid_artworks
     pageInfo {
@@ -218,6 +220,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "includeBackfill"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "version"
   }
 ],
 v1 = [
@@ -230,6 +237,11 @@ v1 = [
     "kind": "Variable",
     "name": "includeBackfill",
     "variableName": "includeBackfill"
+  },
+  {
+    "kind": "Variable",
+    "name": "version",
+    "variableName": "version"
   }
 ],
 v2 = {
@@ -809,14 +821,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "733d1afc3d6d8aa642bf371c04975c91",
+    "cacheID": "ef6912eabf27e88ae2af83a041cc9db0",
     "id": null,
     "metadata": {},
     "name": "newForYouRoutes_TopLevelQuery",
     "operationKind": "query",
-    "text": "query newForYouRoutes_TopLevelQuery(\n  $first: Int\n  $includeBackfill: Boolean!\n) {\n  viewer {\n    ...NewForYouApp_viewer_2GVV1c\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewForYouApp_viewer_2GVV1c on Viewer {\n  ...NewForYouArtworksGrid_viewer_2GVV1c\n}\n\nfragment NewForYouArtworksGrid_viewer_2GVV1c on Viewer {\n  artworksForUser(first: $first, includeBackfill: $includeBackfill) {\n    totalCount\n    ...ArtworkGrid_artworks\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query newForYouRoutes_TopLevelQuery(\n  $first: Int\n  $includeBackfill: Boolean!\n  $version: String\n) {\n  viewer {\n    ...NewForYouApp_viewer_1hZglA\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewForYouApp_viewer_1hZglA on Viewer {\n  ...NewForYouArtworksGrid_viewer_1hZglA\n}\n\nfragment NewForYouArtworksGrid_viewer_1hZglA on Viewer {\n  artworksForUser(first: $first, includeBackfill: $includeBackfill, version: $version) {\n    totalCount\n    ...ArtworkGrid_artworks\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();
-(node as any).hash = 'ab37fbc2fb44ac27671af785bca6f801';
+(node as any).hash = 'fcc4b1ded97a7a3d992b0aa9688017ac';
 export default node;

--- a/src/v2/__generated__/newForYouRoutes_TopLevelQuery.graphql.ts
+++ b/src/v2/__generated__/newForYouRoutes_TopLevelQuery.graphql.ts
@@ -6,6 +6,7 @@ import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type newForYouRoutes_TopLevelQueryVariables = {
     first?: number | null | undefined;
+    includeBackfill: boolean;
 };
 export type newForYouRoutes_TopLevelQueryResponse = {
     readonly viewer: {
@@ -22,9 +23,10 @@ export type newForYouRoutes_TopLevelQuery = {
 /*
 query newForYouRoutes_TopLevelQuery(
   $first: Int
+  $includeBackfill: Boolean!
 ) {
   viewer {
-    ...NewForYouApp_viewer_3ASum4
+    ...NewForYouApp_viewer_2GVV1c
   }
 }
 
@@ -173,12 +175,12 @@ fragment Metadata_artwork on Artwork {
   href
 }
 
-fragment NewForYouApp_viewer_3ASum4 on Viewer {
-  ...NewForYouArtworksGrid_viewer_3ASum4
+fragment NewForYouApp_viewer_2GVV1c on Viewer {
+  ...NewForYouArtworksGrid_viewer_2GVV1c
 }
 
-fragment NewForYouArtworksGrid_viewer_3ASum4 on Viewer {
-  artworksForUser(first: $first, includeBackfill: true) {
+fragment NewForYouArtworksGrid_viewer_2GVV1c on Viewer {
+  artworksForUser(first: $first, includeBackfill: $includeBackfill) {
     totalCount
     ...ArtworkGrid_artworks
     pageInfo {
@@ -211,13 +213,25 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "first"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "includeBackfill"
   }
 ],
-v1 = {
-  "kind": "Variable",
-  "name": "first",
-  "variableName": "first"
-},
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  },
+  {
+    "kind": "Variable",
+    "name": "includeBackfill",
+    "variableName": "includeBackfill"
+  }
+],
 v2 = {
   "alias": null,
   "args": null,
@@ -296,9 +310,7 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": [
-              (v1/*: any*/)
-            ],
+            "args": (v1/*: any*/),
             "kind": "FragmentSpread",
             "name": "NewForYouApp_viewer"
           }
@@ -325,14 +337,7 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": [
-              (v1/*: any*/),
-              {
-                "kind": "Literal",
-                "name": "includeBackfill",
-                "value": true
-              }
-            ],
+            "args": (v1/*: any*/),
             "concreteType": "ArtworkConnection",
             "kind": "LinkedField",
             "name": "artworksForUser",
@@ -804,14 +809,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "97dc12fb1091eb7b8078797cc75d9162",
+    "cacheID": "733d1afc3d6d8aa642bf371c04975c91",
     "id": null,
     "metadata": {},
     "name": "newForYouRoutes_TopLevelQuery",
     "operationKind": "query",
-    "text": "query newForYouRoutes_TopLevelQuery(\n  $first: Int\n) {\n  viewer {\n    ...NewForYouApp_viewer_3ASum4\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewForYouApp_viewer_3ASum4 on Viewer {\n  ...NewForYouArtworksGrid_viewer_3ASum4\n}\n\nfragment NewForYouArtworksGrid_viewer_3ASum4 on Viewer {\n  artworksForUser(first: $first, includeBackfill: true) {\n    totalCount\n    ...ArtworkGrid_artworks\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query newForYouRoutes_TopLevelQuery(\n  $first: Int\n  $includeBackfill: Boolean!\n) {\n  viewer {\n    ...NewForYouApp_viewer_2GVV1c\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewForYouApp_viewer_2GVV1c on Viewer {\n  ...NewForYouArtworksGrid_viewer_2GVV1c\n}\n\nfragment NewForYouArtworksGrid_viewer_2GVV1c on Viewer {\n  artworksForUser(first: $first, includeBackfill: $includeBackfill) {\n    totalCount\n    ...ArtworkGrid_artworks\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();
-(node as any).hash = '809d895d4b8955f5d4324757d5cae873';
+(node as any).hash = 'ab37fbc2fb44ac27671af785bca6f801';
 export default node;

--- a/src/v2/__generated__/newForYouRoutes_TopLevelQuery.graphql.ts
+++ b/src/v2/__generated__/newForYouRoutes_TopLevelQuery.graphql.ts
@@ -4,7 +4,9 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type newForYouRoutes_TopLevelQueryVariables = {};
+export type newForYouRoutes_TopLevelQueryVariables = {
+    first?: number | null | undefined;
+};
 export type newForYouRoutes_TopLevelQueryResponse = {
     readonly viewer: {
         readonly " $fragmentRefs": FragmentRefs<"NewForYouApp_viewer">;
@@ -18,9 +20,11 @@ export type newForYouRoutes_TopLevelQuery = {
 
 
 /*
-query newForYouRoutes_TopLevelQuery {
+query newForYouRoutes_TopLevelQuery(
+  $first: Int
+) {
   viewer {
-    ...NewForYouApp_viewer
+    ...NewForYouApp_viewer_3ASum4
   }
 }
 
@@ -169,12 +173,12 @@ fragment Metadata_artwork on Artwork {
   href
 }
 
-fragment NewForYouApp_viewer on Viewer {
-  ...NewForYouArtworksGrid_viewer
+fragment NewForYouApp_viewer_3ASum4 on Viewer {
+  ...NewForYouArtworksGrid_viewer_3ASum4
 }
 
-fragment NewForYouArtworksGrid_viewer on Viewer {
-  artworksForUser(first: 20, includeBackfill: true) {
+fragment NewForYouArtworksGrid_viewer_3ASum4 on Viewer {
+  artworksForUser(first: $first, includeBackfill: true) {
     totalCount
     ...ArtworkGrid_artworks
     pageInfo {
@@ -202,56 +206,68 @@ fragment SaveButton_artwork on Artwork {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = {
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "first"
+  }
+],
+v1 = {
+  "kind": "Variable",
+  "name": "first",
+  "variableName": "first"
+},
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v1 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v5 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v6 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v7 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -260,13 +276,13 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = [
-  (v3/*: any*/),
-  (v0/*: any*/)
+v10 = [
+  (v5/*: any*/),
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "newForYouRoutes_TopLevelQuery",
@@ -280,7 +296,9 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": null,
+            "args": [
+              (v1/*: any*/)
+            ],
             "kind": "FragmentSpread",
             "name": "NewForYouApp_viewer"
           }
@@ -293,7 +311,7 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "newForYouRoutes_TopLevelQuery",
     "selections": [
@@ -308,11 +326,7 @@ return {
           {
             "alias": null,
             "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 20
-              },
+              (v1/*: any*/),
               {
                 "kind": "Literal",
                 "name": "includeBackfill",
@@ -382,7 +396,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v0/*: any*/),
+                          (v2/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -390,7 +404,7 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v1/*: any*/),
+                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -534,15 +548,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v2/*: any*/),
+                            "args": (v4/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
-                              (v0/*: any*/),
-                              (v1/*: any*/),
-                              (v3/*: any*/)
+                              (v2/*: any*/),
+                              (v3/*: any*/),
+                              (v5/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -555,15 +569,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v2/*: any*/),
+                            "args": (v4/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
+                              (v5/*: any*/),
                               (v3/*: any*/),
-                              (v1/*: any*/),
-                              (v0/*: any*/)
+                              (v2/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
                           },
@@ -575,7 +589,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v4/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -611,7 +625,7 @@ return {
                                 "name": "isClosed",
                                 "storageKey": null
                               },
-                              (v0/*: any*/),
+                              (v2/*: any*/),
                               {
                                 "alias": "is_preview",
                                 "args": null,
@@ -644,7 +658,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v5/*: any*/),
+                              (v7/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -652,8 +666,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v4/*: any*/),
                               (v6/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -686,7 +700,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v7/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -696,10 +710,10 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v7/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
-                              (v0/*: any*/)
+                              (v2/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -717,7 +731,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v10/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -735,7 +749,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v8/*: any*/),
+                                "selections": (v10/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -756,10 +770,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v4/*: any*/),
                               (v6/*: any*/),
-                              (v5/*: any*/),
-                              (v0/*: any*/)
+                              (v8/*: any*/),
+                              (v7/*: any*/),
+                              (v2/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -769,7 +783,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v0/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -782,7 +796,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksForUser(first:20,includeBackfill:true)"
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -790,14 +804,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d97537ebb476d7511cc2a668042a8194",
+    "cacheID": "97dc12fb1091eb7b8078797cc75d9162",
     "id": null,
     "metadata": {},
     "name": "newForYouRoutes_TopLevelQuery",
     "operationKind": "query",
-    "text": "query newForYouRoutes_TopLevelQuery {\n  viewer {\n    ...NewForYouApp_viewer\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewForYouApp_viewer on Viewer {\n  ...NewForYouArtworksGrid_viewer\n}\n\nfragment NewForYouArtworksGrid_viewer on Viewer {\n  artworksForUser(first: 20, includeBackfill: true) {\n    totalCount\n    ...ArtworkGrid_artworks\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query newForYouRoutes_TopLevelQuery(\n  $first: Int\n) {\n  viewer {\n    ...NewForYouApp_viewer_3ASum4\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewForYouApp_viewer_3ASum4 on Viewer {\n  ...NewForYouArtworksGrid_viewer_3ASum4\n}\n\nfragment NewForYouArtworksGrid_viewer_3ASum4 on Viewer {\n  artworksForUser(first: $first, includeBackfill: true) {\n    totalCount\n    ...ArtworkGrid_artworks\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();
-(node as any).hash = '2bf8c321e0fdb3e3a81f9441c60048dd';
+(node as any).hash = '809d895d4b8955f5d4324757d5cae873';
 export default node;


### PR DESCRIPTION
This PR is well described over on https://github.com/artsy/force/pull/10482 but the tl;dr is that I've updated the `/new-for-you` page so that you can pass `first`, `includeBackfill` and `version` to override defaults.

/cc @artsy/grow-devs @joeyAghion @kathytafel 