### PR TITLE
enhancement(2fa): includes password in enable second factor mutation

### DIFF
--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -42,10 +42,11 @@ interface AppSecondFactorModalProps {
   onComplete: () => void
   // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   secondFactor: CreateAppSecondFactorMutationResponse["createAppSecondFactor"]["secondFactorOrErrors"]
+  confirmedPassword: string
 }
 
 export const AppSecondFactorModal: React.FC<AppSecondFactorModalProps> = props => {
-  const { secondFactor, onComplete } = props
+  const { secondFactor, confirmedPassword, onComplete } = props
   const { relayEnvironment } = useSystemContext()
 
   const [showForm, setShowForm] = useState(true)
@@ -96,6 +97,7 @@ export const AppSecondFactorModal: React.FC<AppSecondFactorModalProps> = props =
       const response = await EnableSecondFactor(relayEnvironment, {
         secondFactorID: secondFactor.internalID,
         code: values.code,
+        password: confirmedPassword,
       })
 
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -41,6 +41,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = ({
     false
   )
   const [stagedSecondFactor, setStagedSecondFactor] = useState(null)
+  const [confirmedPassword, setConfirmedPassword] = useState("")
   const [isDisabling] = useState(false) // ???
   const [isCreating, setCreating] = useState(false)
 
@@ -139,6 +140,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = ({
       })
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       setStagedSecondFactor(response.createAppSecondFactor.secondFactorOrErrors)
+      setConfirmedPassword(password)
       setShowConfirmPassword(false)
       setShowSetupModal(true)
     } catch (error) {
@@ -246,6 +248,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = ({
       <AppSecondFactorModal
         show={showSetupModal}
         secondFactor={stagedSecondFactor}
+        confirmedPassword={confirmedPassword}
         onComplete={onComplete}
         onClose={() => setShowSetupModal(false)}
       />

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -29,10 +29,11 @@ interface SmsSecondFactorModalProps {
   onComplete: () => void
   // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   secondFactor: CreateSmsSecondFactorMutationResponse["createSmsSecondFactor"]["secondFactorOrErrors"]
+  confirmedPassword: string
 }
 
 export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props => {
-  const { secondFactor, onComplete } = props
+  const { secondFactor, confirmedPassword, onComplete } = props
   const { relayEnvironment } = useSystemContext()
   const [isSubmitting, setSubmitting] = useState(false)
   const [isDelivering, setDelivering] = useState(false)
@@ -56,6 +57,7 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
         secondFactorID: secondFactor.internalID,
         // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         code: values.code,
+        password: confirmedPassword,
       })
 
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION

--- a/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -59,6 +59,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = ({
   const { sendToast } = useToasts()
 
   const [stagedSecondFactor, setStagedSecondFactor] = useState(null)
+  const [confirmedPassword, setConfirmedPassword] = useState("")
 
   const redirectTo = afterUpdateRedirect()
 
@@ -142,6 +143,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = ({
       const factor = response.createSmsSecondFactor.secondFactorOrErrors
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       setStagedSecondFactor(factor)
+      setConfirmedPassword(password)
       setShowConfirmPassword(false)
       setShowSetupModal(true)
     } catch (error) {
@@ -246,6 +248,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = ({
       <SmsSecondFactorModal
         show={showSetupModal}
         secondFactor={stagedSecondFactor}
+        confirmedPassword={confirmedPassword}
         onComplete={onComplete}
         onClose={() => setShowSetupModal(false)}
       />


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PLATFORM-4319](https://artsyproduct.atlassian.net/browse/PLATFORM-4319)

### Description

<!-- Implementation description -->

`EnableSecondFactor` mutation includes a user _password_ in the input vars.

---

This change is related to an accepted [security bounty submission](https://artsyproduct.atlassian.net/browse/PLATFORM-4316) that surfaced: _Password is validated but not required on OTP changes_.

When setting up 2fa (App or Sms) we require a user to confirm their password. The password is then sent with the initial _Create[[App](https://github.com/artsy/force/blob/main/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx#L136)|[Sms](https://github.com/artsy/force/blob/main/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx#L137)]SecondFactor_ mutation but it is not sent with the following mutation that enables second factor, _[EnableSecondFactor](https://github.com/artsy/force/blob/main/src/v2/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx#L96)_.

The password is _currently optional_ in both, [MP](https://github.com/artsy/metaphysics/blob/f4bbd051032bf47caa233b7e6fb56f6cb3e73214/_schemaV2.graphql#L7471) and [Gravity](https://github.com/artsy/gravity/blob/000b3af443c8b770a0066875497efaf19dfdc2d5/app/graphql/mutations/enable_second_factor.rb#L7). We want to make this a requirement and thus the first step is to pass the password from the client.


