### PR TITLE
fix(onboarding): add zero state to artwork gene masonry grid 

### DIFF
--- a/src/v2/Components/Onboarding/Components/OnboardingGene.tsx
+++ b/src/v2/Components/Onboarding/Components/OnboardingGene.tsx
@@ -7,7 +7,7 @@ import { OnboardingLoadingCollection } from "v2/Components/Onboarding/Components
 import { ArtworkGridItemFragmentContainer } from "v2/Components/Artwork/GridItem"
 import { Masonry } from "v2/Components/Masonry"
 import { extractNodes } from "v2/Utils/extractNodes"
-import { Box, Flex, Spacer, Text } from "@artsy/palette"
+import { Box, Flex, Message, Spacer, Text } from "@artsy/palette"
 import { FollowGeneButtonFragmentContainer } from "v2/Components/FollowButton/FollowGeneButton"
 
 interface OnboardingGeneProps {
@@ -17,6 +17,26 @@ interface OnboardingGeneProps {
 
 const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
   const artworks = extractNodes(gene.artworks)
+
+  if (artworks.length === 0) {
+    return (
+      <Box px={[2, 4]} py={6}>
+        <Flex justifyContent="space-between">
+          <Box>
+            <Text variant="xl">{gene.name}</Text>
+
+            <Text variant={["sm", "md"]} color="black60" mt={2}>
+              {description}
+            </Text>
+          </Box>
+        </Flex>
+
+        <Spacer mb={4} />
+
+        <Message title="No results found" />
+      </Box>
+    )
+  }
 
   return (
     <Box px={[2, 4]} py={6}>

--- a/src/v2/Components/Onboarding/Components/OnboardingGene.tsx
+++ b/src/v2/Components/Onboarding/Components/OnboardingGene.tsx
@@ -18,26 +18,6 @@ interface OnboardingGeneProps {
 const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
   const artworks = extractNodes(gene.artworks)
 
-  if (artworks.length === 0) {
-    return (
-      <Box px={[2, 4]} py={6}>
-        <Flex justifyContent="space-between">
-          <Box>
-            <Text variant="xl">{gene.name}</Text>
-
-            <Text variant={["sm", "md"]} color="black60" mt={2}>
-              {description}
-            </Text>
-          </Box>
-        </Flex>
-
-        <Spacer mb={4} />
-
-        <Message title="No results found" />
-      </Box>
-    )
-  }
-
   return (
     <Box px={[2, 4]} py={6}>
       <Flex justifyContent="space-between">
@@ -64,17 +44,21 @@ const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
 
       <Spacer mb={4} />
 
-      <Masonry columnCount={[2, 3]}>
-        {artworks.map(artwork => {
-          return (
-            <Fragment key={artwork.internalID}>
-              <ArtworkGridItemFragmentContainer artwork={artwork} />
+      {artworks.length === 0 ? (
+        <Message title="No results found" />
+      ) : (
+        <Masonry columnCount={[2, 3]}>
+          {artworks.map(artwork => {
+            return (
+              <Fragment key={artwork.internalID}>
+                <ArtworkGridItemFragmentContainer artwork={artwork} />
 
-              <Spacer mb={2} />
-            </Fragment>
-          )
-        })}
-      </Masonry>
+                <Spacer mb={2} />
+              </Fragment>
+            )
+          })}
+        </Masonry>
+      )}
     </Box>
   )
 }

--- a/src/v2/Components/Onboarding/Components/__tests__/OnboardingGene.jest.tsx
+++ b/src/v2/Components/Onboarding/Components/__tests__/OnboardingGene.jest.tsx
@@ -35,4 +35,14 @@ describe("OnboardingGene", () => {
     expect(screen.getByText("Example Gene")).toBeInTheDocument()
     expect(screen.getByText("Example description")).toBeInTheDocument()
   })
+
+  it("shows no results if none found", () => {
+    renderWithRelay({
+      Gene: () => ({
+        artworks: { edges: [] },
+      }),
+    })
+
+    expect(screen.getByText("No results found")).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
The type of this PR is: _fix_

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->
The intention of this PR is to add a zero state to the artwork grid views at the end of the Onboarding flow.

<img width="884" alt="Screen Shot 2022-07-14 at 1 54 17 PM" src="https://user-images.githubusercontent.com/23108927/179062021-9b234205-db9b-4a75-8093-6279a5c73d5e.png">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ