### PR TITLE
fix: Restore the news rss feed GRO-1145

### DIFF
--- a/src/v2/Apps/RSS/queries/RssArticlesQuery.ts
+++ b/src/v2/Apps/RSS/queries/RssArticlesQuery.ts
@@ -1,7 +1,7 @@
 import { graphql } from "relay-runtime"
 
-export const RSS_PARTNER_UPDATES_QUERY = graphql`
-  query RssPartnerUpdatesQuery($channelId: String!) {
+export const RSS_ARTICLES_QUERY = graphql`
+  query RssArticlesQuery($channelId: String!) {
     articlesConnection(
       channelId: $channelId
       sort: PUBLISHED_AT_DESC
@@ -39,10 +39,10 @@ export const RSS_PARTNER_UPDATES_QUERY = graphql`
               figures {
                 __typename
                 ... on Artwork {
-                  ...RssPartnerUpdatesQuery_artwork @relay(mask: false)
+                  ...RssArticlesQuery_artwork @relay(mask: false)
                 }
                 ... on ArticleImageSection {
-                  ...RssPartnerUpdatesQuery_image @relay(mask: false)
+                  ...RssArticlesQuery_image @relay(mask: false)
                 }
               }
             }
@@ -50,10 +50,10 @@ export const RSS_PARTNER_UPDATES_QUERY = graphql`
               figures {
                 __typename
                 ... on Artwork {
-                  ...RssPartnerUpdatesQuery_artwork @relay(mask: false)
+                  ...RssArticlesQuery_artwork @relay(mask: false)
                 }
                 ... on ArticleImageSection {
-                  ...RssPartnerUpdatesQuery_image @relay(mask: false)
+                  ...RssArticlesQuery_image @relay(mask: false)
                 }
               }
             }
@@ -65,7 +65,7 @@ export const RSS_PARTNER_UPDATES_QUERY = graphql`
 `
 
 graphql`
-  fragment RssPartnerUpdatesQuery_artwork on Artwork {
+  fragment RssArticlesQuery_artwork on Artwork {
     title
     date
     artists {
@@ -86,7 +86,7 @@ graphql`
 `
 
 graphql`
-  fragment RssPartnerUpdatesQuery_image on ArticleImageSection {
+  fragment RssArticlesQuery_image on ArticleImageSection {
     image {
       caption
       resized(width: 500) {

--- a/src/v2/Apps/RSS/rssServerApp.tsx
+++ b/src/v2/Apps/RSS/rssServerApp.tsx
@@ -1,25 +1,48 @@
 import express from "express"
 import { fetchQuery } from "relay-runtime"
 import { createRelaySSREnvironment } from "v2/System/Relay/createRelaySSREnvironment"
-import { RSS_PARTNER_UPDATES_QUERY } from "./queries/RssPartnerUpdatesQuery"
-import { RssPartnerUpdatesQuery } from "v2/__generated__/RssPartnerUpdatesQuery.graphql"
+import { RSS_ARTICLES_QUERY } from "./queries/RssArticlesQuery"
+import { RssArticlesQuery } from "v2/__generated__/RssArticlesQuery.graphql"
 import { extractNodes } from "v2/Utils/extractNodes"
 import { getENV } from "v2/Utils/getENV"
-import { GALLERY_PARTNER_UPDATES_CHANNEL } from "config"
+import {
+  ARTSY_EDITORIAL_CHANNEL,
+  GALLERY_PARTNER_UPDATES_CHANNEL,
+} from "config"
 
 const rssServerApp = express()
 
 rssServerApp.set("views", `${__dirname}/templates`)
 rssServerApp.set("view engine", "ejs")
 
+rssServerApp.get("/rss/news", async (req, res) => {
+  const relayEnvironment = createRelaySSREnvironment({
+    userAgent: req.header("User-Agent"),
+  })
+
+  const { articlesConnection } = await fetchQuery<RssArticlesQuery>(
+    relayEnvironment,
+    RSS_ARTICLES_QUERY,
+    { channelId: ARTSY_EDITORIAL_CHANNEL }
+  )
+
+  const articles = extractNodes(articlesConnection)
+
+  res.set("Content-Type", "application/rss+xml")
+  res.render("news", {
+    appUrl: getENV("APP_URL"),
+    articles,
+  })
+})
+
 rssServerApp.get("/rss/partner-updates", async (req, res) => {
   const relayEnvironment = createRelaySSREnvironment({
     userAgent: req.header("User-Agent"),
   })
 
-  const { articlesConnection } = await fetchQuery<RssPartnerUpdatesQuery>(
+  const { articlesConnection } = await fetchQuery<RssArticlesQuery>(
     relayEnvironment,
-    RSS_PARTNER_UPDATES_QUERY,
+    RSS_ARTICLES_QUERY,
     { channelId: GALLERY_PARTNER_UPDATES_CHANNEL }
   )
 

--- a/src/v2/Apps/RSS/templates/news.ejs
+++ b/src/v2/Apps/RSS/templates/news.ejs
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Artsy News</title>
+    <link><%= appUrl %></link>
+    <atom:link href="<%= appUrl %>/rss/news" rel="self" type="application/rss+xml"></atom:link>
+    <description>Featured Artsy articles.</description>
+    <language>en-US</language>
+
+    <% if (articles.length) { %>
+      <lastBuildDate>
+        <%= new Date(articles[0].publishedAt).toUTCString() %>
+      </lastBuildDate>
+    <% } %>
+
+    <% articles.forEach((article) => { %>
+      <%- include('article.ejs', { article: article }) %>
+    <% }); %>
+  </channel>
+</rss>

--- a/src/v2/__generated__/RssArticlesQuery.graphql.ts
+++ b/src/v2/__generated__/RssArticlesQuery.graphql.ts
@@ -3,10 +3,10 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from "relay-runtime";
-export type RssPartnerUpdatesQueryVariables = {
+export type RssArticlesQueryVariables = {
     channelId: string;
 };
-export type RssPartnerUpdatesQueryResponse = {
+export type RssArticlesQueryResponse = {
     readonly articlesConnection: {
         readonly edges: ReadonlyArray<{
             readonly node: {
@@ -113,15 +113,15 @@ export type RssPartnerUpdatesQueryResponse = {
         } | null> | null;
     } | null;
 };
-export type RssPartnerUpdatesQuery = {
-    readonly response: RssPartnerUpdatesQueryResponse;
-    readonly variables: RssPartnerUpdatesQueryVariables;
+export type RssArticlesQuery = {
+    readonly response: RssArticlesQueryResponse;
+    readonly variables: RssArticlesQueryVariables;
 };
 
 
 
 /*
-query RssPartnerUpdatesQuery(
+query RssArticlesQuery(
   $channelId: String!
 ) {
   articlesConnection(channelId: $channelId, sort: PUBLISHED_AT_DESC, first: 50) {
@@ -634,7 +634,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "RssPartnerUpdatesQuery",
+    "name": "RssArticlesQuery",
     "selections": [
       {
         "alias": null,
@@ -721,7 +721,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "RssPartnerUpdatesQuery",
+    "name": "RssArticlesQuery",
     "selections": [
       {
         "alias": null,
@@ -804,14 +804,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "166129c9c392d010aeb96cf95a83d621",
+    "cacheID": "40ba14944f81248bf9be792556c7a43f",
     "id": null,
     "metadata": {},
-    "name": "RssPartnerUpdatesQuery",
+    "name": "RssArticlesQuery",
     "operationKind": "query",
-    "text": "query RssPartnerUpdatesQuery(\n  $channelId: String!\n) {\n  articlesConnection(channelId: $channelId, sort: PUBLISHED_AT_DESC, first: 50) {\n    edges {\n      node {\n        id\n        publishedAt\n        thumbnailTitle\n        href\n        byline\n        hero {\n          __typename\n          ... on ArticleFeatureSection {\n            embed\n            image {\n              resized(width: 1100) {\n                src\n              }\n            }\n          }\n        }\n        sections {\n          __typename\n          ... on ArticleSectionText {\n            body\n          }\n          ... on ArticleSectionEmbed {\n            url\n          }\n          ... on ArticleSectionVideo {\n            embed\n          }\n          ... on ArticleSectionImageCollection {\n            figures {\n              __typename\n              ... on Artwork {\n                title\n                date\n                artists {\n                  name\n                  id\n                }\n                partner {\n                  name\n                  id\n                }\n                image {\n                  resized(width: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n                    width\n                    height\n                    src\n                    srcSet\n                  }\n                }\n              }\n              ... on ArticleImageSection {\n                image {\n                  caption\n                  resized(width: 500) {\n                    width\n                    height\n                    src\n                    srcSet\n                  }\n                }\n                id\n              }\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n          }\n          ... on ArticleSectionImageSet {\n            figures {\n              __typename\n              ... on Artwork {\n                title\n                date\n                artists {\n                  name\n                  id\n                }\n                partner {\n                  name\n                  id\n                }\n                image {\n                  resized(width: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n                    width\n                    height\n                    src\n                    srcSet\n                  }\n                }\n              }\n              ... on ArticleImageSection {\n                image {\n                  caption\n                  resized(width: 500) {\n                    width\n                    height\n                    src\n                    srcSet\n                  }\n                }\n                id\n              }\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query RssArticlesQuery(\n  $channelId: String!\n) {\n  articlesConnection(channelId: $channelId, sort: PUBLISHED_AT_DESC, first: 50) {\n    edges {\n      node {\n        id\n        publishedAt\n        thumbnailTitle\n        href\n        byline\n        hero {\n          __typename\n          ... on ArticleFeatureSection {\n            embed\n            image {\n              resized(width: 1100) {\n                src\n              }\n            }\n          }\n        }\n        sections {\n          __typename\n          ... on ArticleSectionText {\n            body\n          }\n          ... on ArticleSectionEmbed {\n            url\n          }\n          ... on ArticleSectionVideo {\n            embed\n          }\n          ... on ArticleSectionImageCollection {\n            figures {\n              __typename\n              ... on Artwork {\n                title\n                date\n                artists {\n                  name\n                  id\n                }\n                partner {\n                  name\n                  id\n                }\n                image {\n                  resized(width: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n                    width\n                    height\n                    src\n                    srcSet\n                  }\n                }\n              }\n              ... on ArticleImageSection {\n                image {\n                  caption\n                  resized(width: 500) {\n                    width\n                    height\n                    src\n                    srcSet\n                  }\n                }\n                id\n              }\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n          }\n          ... on ArticleSectionImageSet {\n            figures {\n              __typename\n              ... on Artwork {\n                title\n                date\n                artists {\n                  name\n                  id\n                }\n                partner {\n                  name\n                  id\n                }\n                image {\n                  resized(width: 500, version: [\"normalized\", \"larger\", \"large\"]) {\n                    width\n                    height\n                    src\n                    srcSet\n                  }\n                }\n              }\n              ... on ArticleImageSection {\n                image {\n                  caption\n                  resized(width: 500) {\n                    width\n                    height\n                    src\n                    srcSet\n                  }\n                }\n                id\n              }\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '458b75993ed1b38deb167f860d23ed72';
+(node as any).hash = '04b7e8540180b3445c0d47149e5d6fef';
 export default node;

--- a/src/v2/__generated__/RssArticlesQuery_artwork.graphql.ts
+++ b/src/v2/__generated__/RssArticlesQuery_artwork.graphql.ts
@@ -4,7 +4,7 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type RssPartnerUpdatesQuery_artwork = {
+export type RssArticlesQuery_artwork = {
     readonly title: string | null;
     readonly date: string | null;
     readonly artists: ReadonlyArray<{
@@ -21,12 +21,12 @@ export type RssPartnerUpdatesQuery_artwork = {
             readonly srcSet: string;
         } | null;
     } | null;
-    readonly " $refType": "RssPartnerUpdatesQuery_artwork";
+    readonly " $refType": "RssArticlesQuery_artwork";
 };
-export type RssPartnerUpdatesQuery_artwork$data = RssPartnerUpdatesQuery_artwork;
-export type RssPartnerUpdatesQuery_artwork$key = {
-    readonly " $data"?: RssPartnerUpdatesQuery_artwork$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"RssPartnerUpdatesQuery_artwork">;
+export type RssArticlesQuery_artwork$data = RssArticlesQuery_artwork;
+export type RssArticlesQuery_artwork$key = {
+    readonly " $data"?: RssArticlesQuery_artwork$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"RssArticlesQuery_artwork">;
 };
 
 
@@ -45,7 +45,7 @@ return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
-  "name": "RssPartnerUpdatesQuery_artwork",
+  "name": "RssArticlesQuery_artwork",
   "selections": [
     {
       "alias": null,
@@ -151,5 +151,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'eb88e455b01f5a05b663ae669a6efe5f';
+(node as any).hash = '6b22b706b0b17abac5a31e1733c588cd';
 export default node;

--- a/src/v2/__generated__/RssArticlesQuery_image.graphql.ts
+++ b/src/v2/__generated__/RssArticlesQuery_image.graphql.ts
@@ -4,7 +4,7 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type RssPartnerUpdatesQuery_image = {
+export type RssArticlesQuery_image = {
     readonly image: {
         readonly caption: string | null;
         readonly resized: {
@@ -14,12 +14,12 @@ export type RssPartnerUpdatesQuery_image = {
             readonly srcSet: string;
         } | null;
     } | null;
-    readonly " $refType": "RssPartnerUpdatesQuery_image";
+    readonly " $refType": "RssArticlesQuery_image";
 };
-export type RssPartnerUpdatesQuery_image$data = RssPartnerUpdatesQuery_image;
-export type RssPartnerUpdatesQuery_image$key = {
-    readonly " $data"?: RssPartnerUpdatesQuery_image$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"RssPartnerUpdatesQuery_image">;
+export type RssArticlesQuery_image$data = RssArticlesQuery_image;
+export type RssArticlesQuery_image$key = {
+    readonly " $data"?: RssArticlesQuery_image$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"RssArticlesQuery_image">;
 };
 
 
@@ -28,7 +28,7 @@ const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
-  "name": "RssPartnerUpdatesQuery_image",
+  "name": "RssArticlesQuery_image",
   "selections": [
     {
       "alias": null,
@@ -97,5 +97,5 @@ const node: ReaderFragment = {
   "type": "ArticleImageSection",
   "abstractKey": null
 };
-(node as any).hash = 'd4e6b588cf375aef269108de80a4e0ad';
+(node as any).hash = '7cb5893d8865f5400a25e45f85de1556';
 export default node;


### PR DESCRIPTION
Over on https://github.com/artsy/force/pull/10491/ we migrated the RSS code but dropped the feed at `/rss/news` - this was a mistake. It's true that we no longer publish news but this is the official editorial RSS feed that powers all sorts of things including the iOS widget's editorial version. Apple News is another customer. It's poorly named but I'm not touching that here - just trying to restore what was broken.

Anyway, all I did here was copy what I saw for the partner updates feed but then change the channel id over to the editorial one. Then I created a new feed template and copy/pasted from that other PR so that the title/description/etc looked as it did before the deletion.

https://artsyproduct.atlassian.net/browse/GRO-1145

/cc @artsy/grow-devs