### PR TITLE
chore: track first payment selected as we track others

### DIFF
--- a/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -16,6 +16,7 @@ import { useSetPayment } from "../../Components/Mutations/useSetPayment"
 import { CommercePaymentMethodEnum } from "v2/__generated__/Payment_order.graphql"
 import { flushPromiseQueue, MockBoot } from "v2/DevTools"
 import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { ReactWrapper } from "enzyme"
 
 jest.unmock("react-tracking")
 jest.unmock("react-relay")
@@ -277,6 +278,7 @@ describe("Payment", () => {
 
   describe("stripe ACH enabled", () => {
     let page: PaymentTestPage
+    let wrapper: ReactWrapper
 
     const achOrder = {
       ...testOrder,
@@ -287,23 +289,19 @@ describe("Payment", () => {
       ] as CommercePaymentMethodEnum[],
     }
 
-    it("renders selection of payment methods", async () => {
-      const wrapper = getWrapper({
+    beforeEach(() => {
+      wrapper = getWrapper({
         CommerceOrder: () => achOrder,
       })
       page = new PaymentTestPage(wrapper)
+    })
 
+    it("renders selection of payment methods", async () => {
       expect(page.text()).toContain("Credit card")
       expect(page.text()).toContain("Bank transfer")
     })
 
     it("tracks the initially-selected payment method on load like any other selection", async () => {
-      getWrapper({
-        CommerceOrder: () => ({
-          ...achOrder,
-        }),
-      })
-
       await flushPromiseQueue()
 
       expect(trackEvent).toHaveBeenLastCalledWith({
@@ -319,10 +317,6 @@ describe("Payment", () => {
     })
 
     it("tracks when the user selects the credit card payment method", async () => {
-      const wrapper = getWrapper({
-        CommerceOrder: () => achOrder,
-      })
-      page = new PaymentTestPage(wrapper)
       page.selectPaymentMethod(1)
 
       expect(trackEvent).toHaveBeenLastCalledWith({
@@ -338,34 +332,16 @@ describe("Payment", () => {
     })
 
     it("tracks when the user selects the bank payment method", async () => {
-      const wrapper = getWrapper({
-        CommerceOrder: () => ({
-          ...achOrder,
-          paymentMethod: "CREDIT_CARD",
-        }),
-      })
-      page = new PaymentTestPage(wrapper)
-
+      page.selectPaymentMethod(1)
       page.selectPaymentMethod(0)
 
-      expect(trackEvent).toHaveBeenCalledTimes(2)
-      expect(trackEvent).toHaveBeenLastCalledWith({
-        action: "clickedPaymentMethod",
-        amount: "$12,000",
-        context_page_owner_type: "orders-payment",
-        currency: "USD",
-        flow: "BUY",
-        order_id: "1234",
-        payment_method: "US_BANK_ACCOUNT",
-        subject: "click_payment_method",
-      })
+      // We toggle back and forth to test the selecttion starting from bank account
+      expect(
+        trackEvent.mock.calls.map(args => args[0]?.["payment_method"])
+      ).toEqual(["US_BANK_ACCOUNT", "CREDIT_CARD", "US_BANK_ACCOUNT"])
     })
 
     it("renders credit card element when credit card is chosen as payment method", async () => {
-      const wrapper = getWrapper({
-        CommerceOrder: () => achOrder,
-      })
-      page = new PaymentTestPage(wrapper)
       page.selectPaymentMethod(1)
 
       const creditCardCollapse = page
@@ -377,12 +353,6 @@ describe("Payment", () => {
     })
 
     it("renders bank element when bank transfer is chosen as payment method", async () => {
-      const wrapper = getWrapper({
-        CommerceOrder: () => achOrder,
-      })
-
-      page = new PaymentTestPage(wrapper)
-      page.selectPaymentMethod(0)
       page.selectPaymentMethod(3)
       const creditCardCollapse = page
         .find(CreditCardPickerFragmentContainer)
@@ -393,11 +363,8 @@ describe("Payment", () => {
     })
 
     it("renders description body for bank transfer when selected", async () => {
-      const wrapper = getWrapper({
-        CommerceOrder: () => achOrder,
-      })
+      page.selectPaymentMethod(0)
 
-      page = new PaymentTestPage(wrapper)
       expect(page.text()).toContain("• Bank transfer is powered by Stripe.")
       expect(page.text()).toContain(
         "• If you can not find your bank, please check your spelling or choose"

--- a/src/v2/Components/BankDebitForm/BankDebitForm.tsx
+++ b/src/v2/Components/BankDebitForm/BankDebitForm.tsx
@@ -44,23 +44,7 @@ export const BankDebitForm: FC<Props> = ({
       })
     }
 
-    if (!event.empty) {
-      trackedEvents.push({
-        flow: order.mode,
-        order_id: order.internalID,
-        subject: "TODO:_not_empty_thing",
-      })
-    }
-
     trackedEvents.forEach(event => tracking.trackEvent(event))
-  }
-
-  const trackClickedContinue = () => {
-    tracking.trackEvent({
-      flow: order.mode!,
-      order_id: order.internalID,
-      subject: "TODO:_clicked_save_and_continue",
-    })
   }
 
   const handleSubmit = async event => {
@@ -91,17 +75,10 @@ export const BankDebitForm: FC<Props> = ({
       <LoadingArea isLoading={isPaymentElementLoading}>
         {isPaymentElementLoading && <Box height={300}></Box>}
         <PaymentElement
-          onReady={(...args) => {
-            console.log({ onReady: args })
-            tracking.trackEvent({ payment_method_selected: "fillmein" })
+          onReady={() => {
             setIsPaymentElementLoading(false)
           }}
-          onBlur={(...args) => console.log({ onBlur: args })}
-          onFocus={(...args) => console.log({ onFocus: args })}
-          onEscape={(...args) => console.log({ onEscape: args })}
-          onClick={(...args) => console.log({ onClick: args })}
           onChange={event => {
-            console.log({ onchange: [event] })
             trackPaymentElementEvent(event)
           }}
           options={{
@@ -154,7 +131,6 @@ export const BankDebitForm: FC<Props> = ({
         {bankAccountHasInsufficientFunds && <InsufficientFundsError />}
 
         <Button
-          onClick={trackClickedContinue}
           disabled={!stripe || bankAccountHasInsufficientFunds}
           variant="primaryBlack"
           width={["100%", "50%"]}

--- a/src/v2/Components/BankDebitForm/BankDebitForm.tsx
+++ b/src/v2/Components/BankDebitForm/BankDebitForm.tsx
@@ -91,8 +91,17 @@ export const BankDebitForm: FC<Props> = ({
       <LoadingArea isLoading={isPaymentElementLoading}>
         {isPaymentElementLoading && <Box height={300}></Box>}
         <PaymentElement
-          onReady={() => setIsPaymentElementLoading(false)}
+          onReady={(...args) => {
+            console.log({ onReady: args })
+            tracking.trackEvent({ payment_method_selected: "fillmein" })
+            setIsPaymentElementLoading(false)
+          }}
+          onBlur={(...args) => console.log({ onBlur: args })}
+          onFocus={(...args) => console.log({ onFocus: args })}
+          onEscape={(...args) => console.log({ onEscape: args })}
+          onClick={(...args) => console.log({ onClick: args })}
           onChange={event => {
+            console.log({ onchange: [event] })
             trackPaymentElementEvent(event)
           }}
           options={{

--- a/src/v2/Components/BankDebitForm/__tests__/BankDebitForm.jest.tsx
+++ b/src/v2/Components/BankDebitForm/__tests__/BankDebitForm.jest.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react"
+import { render } from "@testing-library/react"
 import { BuyOrderWithShippingDetails } from "v2/Apps/__tests__/Fixtures/Order"
 import { useSystemContext, useTracking } from "v2/System"
 import { PaymentTestQueryRawResponse } from "v2/__generated__/PaymentTestQuery.graphql"
@@ -64,64 +64,6 @@ describe("BankDebitForm", () => {
       flow: "BUY",
       order_id: "1234",
       subject: "bank_account_selected",
-    })
-  })
-
-  it("tracks a non-`empty` event from the onChange handler", () => {
-    mockEvent = { empty: false }
-
-    render(
-      <BankDebitForm
-        order={testOrder}
-        returnURL={""}
-        bankAccountHasInsufficientFunds={false}
-      />
-    )
-
-    expect(trackEvent).toHaveBeenCalledWith({
-      flow: "BUY",
-      order_id: "1234",
-      subject: "TODO:_not_empty_thing",
-    })
-  })
-  it("tracks a both complete and non-empty events if both apply", () => {
-    mockEvent = { complete: true, empty: false }
-
-    render(
-      <BankDebitForm
-        order={testOrder}
-        returnURL={""}
-        bankAccountHasInsufficientFunds={false}
-      />
-    )
-
-    expect(trackEvent).toHaveBeenCalledWith({
-      flow: "BUY",
-      order_id: "1234",
-      subject: "bank_account_selected",
-    })
-
-    expect(trackEvent).toHaveBeenCalledWith({
-      flow: "BUY",
-      order_id: "1234",
-      subject: "TODO:_not_empty_thing",
-    })
-  })
-
-  it("tracks a click on the continue button", () => {
-    const screen = render(
-      <BankDebitForm
-        order={testOrder}
-        returnURL={""}
-        bankAccountHasInsufficientFunds={false}
-      />
-    )
-
-    fireEvent.click(screen.getByText("Save and Continue"))
-    expect(trackEvent).toHaveBeenCalledWith({
-      flow: "BUY",
-      order_id: "1234",
-      subject: "TODO:_clicked_save_and_continue",
     })
   })
 


### PR DESCRIPTION
The type of this PR is: **feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR solves [TX-443](https://artsyproduct.atlassian.net/browse/TX-443)

### Description

This PR logs the selected payment method when the payment component mounts. It logs it the same as any time a user selects a payment method.

It also removes some events that were never fully defined. These were intended to be a part of [TX-227] but we need to invest more time to fully understand our options there. My intent is that we can revert or re-implement parts of what we remove in 750255d79a815f0d7e664bd1ebca7bdb46dfaed8 to complete this.

[TX-227]: https://artsyproduct.atlassian.net/browse/TX-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ