### PR TITLE
bug(Footer): add z-index to footer

### DIFF
--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -100,7 +100,7 @@ export const AppShell: React.FC<AppShellProps> = props => {
         </Flex>
 
         {showFooter && (
-          <Flex bg="white100">
+          <Flex bg="white100" zIndex={Z.footer}>
             <AppContainer>
               <HorizontalPadding>
                 <Footer />

--- a/src/v2/Apps/Components/constants.ts
+++ b/src/v2/Apps/Components/constants.ts
@@ -2,4 +2,5 @@ export const Z = {
   toasts: 50,
   globalNav: 100,
   dropdown: 200,
+  footer: 1,
 }


### PR DESCRIPTION
The type of this PR is: **BUG**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1037]

### Description
This bug likely effected only very small screens.

Upon scrolling to the very bottom of the page sticky messages currently overlap the app footer, which is not the desired behavior. This change forces message banners to instead slide beneath the footer. 

- Add footer value to `Z` constant
- Apply constant value to `Footer` wrapper in `AppShell`
- Magic
<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1037]: https://artsyproduct.atlassian.net/browse/GRO-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ