### PR TITLE
feat(CX-2662): Add my collection menu item to NavBarUserMenu

### DIFF
--- a/src/v2/Components/NavBar/Menus/NavBarUserMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/NavBarUserMenu.tsx
@@ -1,6 +1,7 @@
 import { useContext } from "react"
 import * as React from "react"
 import {
+  ArtworkIcon,
   BellIcon,
   HeartIcon,
   PowerIcon,
@@ -88,6 +89,14 @@ export const NavBarUserMenu: React.FC = () => {
         onClick={trackClick}
       >
         <SoloIcon mr={1} aria-hidden="true" /> Collector Profile
+      </NavBarMenuItemLink>
+
+      <NavBarMenuItemLink
+        aria-label="View your Collection"
+        to="/settings/my-collection"
+        onClick={trackClick}
+      >
+        <ArtworkIcon mr={1} aria-hidden="true" /> My Collection
       </NavBarMenuItemLink>
 
       <NavBarMenuItemLink

--- a/src/v2/Components/NavBar/Menus/NavBarUserMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/NavBarUserMenu.tsx
@@ -16,6 +16,7 @@ import { useTracking } from "v2/System/Analytics/useTracking"
 import { userIsAdmin } from "v2/Utils/user"
 import { NavBarMenuItemButton, NavBarMenuItemLink } from "./NavBarMenuItem"
 import { getENV } from "v2/Utils/getENV"
+import { useFeatureFlag } from "v2/System/useFeatureFlag"
 
 export const NavBarUserMenu: React.FC = () => {
   const { trackEvent } = useTracking()
@@ -40,6 +41,8 @@ export const NavBarUserMenu: React.FC = () => {
 
   const isAdmin = userIsAdmin(user)
   const hasPartnerAccess = Boolean(user?.has_partner_access)
+
+  const isMyCollectionEnabled = useFeatureFlag("my-collection-web")
 
   return (
     <Text variant="sm" py={1} width={230}>
@@ -91,13 +94,15 @@ export const NavBarUserMenu: React.FC = () => {
         <SoloIcon mr={1} aria-hidden="true" /> Collector Profile
       </NavBarMenuItemLink>
 
-      <NavBarMenuItemLink
-        aria-label="View your Collection"
-        to="/settings/my-collection"
-        onClick={trackClick}
-      >
-        <ArtworkIcon mr={1} aria-hidden="true" /> My Collection
-      </NavBarMenuItemLink>
+      {isMyCollectionEnabled && (
+        <NavBarMenuItemLink
+          aria-label="View your Collection"
+          to="/settings/my-collection"
+          onClick={trackClick}
+        >
+          <ArtworkIcon mr={1} aria-hidden="true" /> My Collection
+        </NavBarMenuItemLink>
+      )}
 
       <NavBarMenuItemLink
         aria-label="Edit your settings"


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2662]

### Description
- This PR adds `My Collection` item to NavBarUserMenu
- Hidden behind `my-collection-web` user flag

https://user-images.githubusercontent.com/18648835/179798863-8bdb36ed-3802-4e10-ac04-cab4edd8348e.mov



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2662]: https://artsyproduct.atlassian.net/browse/CX-2662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ