### PR TITLE
feat: render a timestamped update for an offer processing approval

### DIFF
--- a/src/v2/Apps/Conversation/Components/OrderUpdate.tsx
+++ b/src/v2/Apps/Conversation/Components/OrderUpdate.tsx
@@ -24,6 +24,7 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({
   setShowDetails,
 }) => {
   let color: Color
+  let textColor: Color | null = null
   let message: string
   let Icon: React.FC<IconProps> = MoneyFillIcon
   let action: { label?: string; onClick?: () => void } = {}
@@ -58,7 +59,11 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({
     const { orderUpdateState, state, stateReason } = event
     const reasonLapsed = stateReason?.includes("_lapsed")
     const reasonRejected = stateReason?.includes("_rejected")
-    if (state === "APPROVED") {
+    if (state === "PROCESSING_APPROVAL") {
+      color = "yellow100"
+      textColor = "black100"
+      message = "Offer accepted. Payment pending"
+    } else if (state === "APPROVED") {
       color = "green100"
       message = `${
         orderUpdateState === "offer_approved" ? "Offer" : "Purchase"
@@ -93,7 +98,7 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({
         <Flex flexDirection="row">
           <Icon fill={color} />
           <Flex flexDirection="column" pl={1}>
-            <Text color={color} variant="xs">
+            <Text color={textColor || color} variant="xs">
               {message}
               {action.label && action.onClick && (
                 <>

--- a/src/v2/Apps/Conversation/Components/__tests__/OrderUpdate.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/OrderUpdate.jest.tsx
@@ -208,6 +208,29 @@ describe("testing different statuses", () => {
     expect(screen.getByText("Offer Accepted")).toBeInTheDocument()
     expect(screen.queryByText("See details.")).not.toBeInTheDocument()
   })
+  it("render Offer Processing approval", () => {
+    renderWithRelay({
+      Conversation: () => ({
+        orderConnection: {
+          edges: [
+            {
+              node: {
+                orderHistory: [
+                  {
+                    __typename: "CommerceOrderStateChangedEvent",
+                    state: "PROCESSING_APPROVAL",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    })
+    expect(
+      screen.getByText("Offer accepted. Payment pending")
+    ).toBeInTheDocument()
+  })
   it("render Offer Declined", () => {
     renderWithRelay({
       Conversation: () => ({


### PR DESCRIPTION
The type of this PR is: **feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR relates to [TX-479]. It is the order event portion, with an equivalent change necessary in eigen.

Screenshot of the yellow message with black text- It appears identically before the bank transfer fails, just without the banner.
For the approved offer with successful payment, disregard yellow text as that was fixed, but now i have to sign off for the day and the dev server is no longer running.

![image](https://user-images.githubusercontent.com/9088720/179861407-ed553e4b-0649-4142-bb66-36611aa6cb72.png)


![image](https://user-images.githubusercontent.com/9088720/179861576-305adaaa-041c-4e3a-95b3-c386e90cc76e.png)
