### PR TITLE
fix: correct order processing approval event color and icon type

### DIFF
--- a/src/Apps/Conversation/Components/OrderUpdate.tsx
+++ b/src/Apps/Conversation/Components/OrderUpdate.tsx
@@ -9,6 +9,7 @@ import {
   MoneyFillIcon,
   Spacer,
   Text,
+  THEME_V3,
 } from "@artsy/palette"
 
 import { TimeSince } from "./TimeSince"
@@ -60,7 +61,8 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({
     const reasonLapsed = stateReason?.includes("_lapsed")
     const reasonRejected = stateReason?.includes("_rejected")
     if (state === "PROCESSING_APPROVAL") {
-      color = "yellow100"
+      Icon = AlertCircleFillIcon
+      color = THEME_V3.colors.yellow100 as Color
       textColor = "black100"
       message = "Offer accepted. Payment pending"
     } else if (state === "APPROVED") {


### PR DESCRIPTION
The type of this PR is: **bugfix**

#10565  contained an incorrect v2 color (causing yellow100 to render as copper100) and the wrong icon for an order processing approval event in a conversation. This is a #minor pr to fix that.

[slack conversation where we discovered this 🔒](https://artsy.slack.com/archives/C02JHHHKP5K/p1658329405084939?thread_ts=1658270238.787909&cid=C02JHHHKP5K)
![image](https://user-images.githubusercontent.com/9088720/180087337-41eda333-992f-4a8e-bea6-6130fc2534c5.png)
