### PR TITLE
(fix)(onboarding): edit query filter to match gene artwork on gene page

### DIFF
--- a/src/Components/Onboarding/Components/OnboardingGene.tsx
+++ b/src/Components/Onboarding/Components/OnboardingGene.tsx
@@ -69,7 +69,18 @@ export const OnboardingGeneFragmentContainer = createFragmentContainer(
     gene: graphql`
       fragment OnboardingGene_gene on Gene {
         name
-        artworks: filterArtworksConnection(first: 100) {
+        artworks: filterArtworksConnection(
+          first: 50
+          page: 1
+          sort: "-decayed_merch"
+          height: "*-*"
+          width: "*-*"
+          priceRange: "*-*"
+          marketable: true
+          offerable: true
+          inquireableOnly: true
+          forSale: true
+        ) {
           edges {
             node {
               internalID

--- a/src/__generated__/OnboardingGeneQuery.graphql.ts
+++ b/src/__generated__/OnboardingGeneQuery.graphql.ts
@@ -139,7 +139,7 @@ fragment NewSaveButton_artwork on Artwork {
 
 fragment OnboardingGene_gene on Gene {
   name
-  artworks: filterArtworksConnection(first: 100) {
+  artworks: filterArtworksConnection(first: 50, page: 1, sort: "-decayed_merch", height: "*-*", width: "*-*", priceRange: "*-*", marketable: true, offerable: true, inquireableOnly: true, forSale: true) {
     edges {
       node {
         internalID
@@ -286,7 +286,52 @@ return {
               {
                 "kind": "Literal",
                 "name": "first",
-                "value": 100
+                "value": 50
+              },
+              {
+                "kind": "Literal",
+                "name": "forSale",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "height",
+                "value": "*-*"
+              },
+              {
+                "kind": "Literal",
+                "name": "inquireableOnly",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "marketable",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "offerable",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "page",
+                "value": 1
+              },
+              {
+                "kind": "Literal",
+                "name": "priceRange",
+                "value": "*-*"
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "-decayed_merch"
+              },
+              {
+                "kind": "Literal",
+                "name": "width",
+                "value": "*-*"
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -623,7 +668,7 @@ return {
               },
               (v6/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:100)"
+            "storageKey": "filterArtworksConnection(first:50,forSale:true,height:\"*-*\",inquireableOnly:true,marketable:true,offerable:true,page:1,priceRange:\"*-*\",sort:\"-decayed_merch\",width:\"*-*\")"
           },
           (v6/*: any*/),
           (v9/*: any*/),
@@ -641,12 +686,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d3400e43651c77b9c4e1e817ffca31bd",
+    "cacheID": "a6fd4abe9ca4505fc9084336081a08c5",
     "id": null,
     "metadata": {},
     "name": "OnboardingGeneQuery",
     "operationKind": "query",
-    "text": "query OnboardingGeneQuery(\n  $id: String!\n) {\n  gene(id: $id) {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  name\n  artworks: filterArtworksConnection(first: 100) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n  ...FollowGeneButton_gene\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query OnboardingGeneQuery(\n  $id: String!\n) {\n  gene(id: $id) {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  name\n  artworks: filterArtworksConnection(first: 50, page: 1, sort: \"-decayed_merch\", height: \"*-*\", width: \"*-*\", priceRange: \"*-*\", marketable: true, offerable: true, inquireableOnly: true, forSale: true) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n  ...FollowGeneButton_gene\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/OnboardingGene_Test_Query.graphql.ts
+++ b/src/__generated__/OnboardingGene_Test_Query.graphql.ts
@@ -135,7 +135,7 @@ fragment NewSaveButton_artwork on Artwork {
 
 fragment OnboardingGene_gene on Gene {
   name
-  artworks: filterArtworksConnection(first: 100) {
+  artworks: filterArtworksConnection(first: 50, page: 1, sort: "-decayed_merch", height: "*-*", width: "*-*", priceRange: "*-*", marketable: true, offerable: true, inquireableOnly: true, forSale: true) {
     edges {
       node {
         internalID
@@ -305,7 +305,52 @@ return {
               {
                 "kind": "Literal",
                 "name": "first",
-                "value": 100
+                "value": 50
+              },
+              {
+                "kind": "Literal",
+                "name": "forSale",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "height",
+                "value": "*-*"
+              },
+              {
+                "kind": "Literal",
+                "name": "inquireableOnly",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "marketable",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "offerable",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "page",
+                "value": 1
+              },
+              {
+                "kind": "Literal",
+                "name": "priceRange",
+                "value": "*-*"
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "-decayed_merch"
+              },
+              {
+                "kind": "Literal",
+                "name": "width",
+                "value": "*-*"
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -642,7 +687,7 @@ return {
               },
               (v5/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:100)"
+            "storageKey": "filterArtworksConnection(first:50,forSale:true,height:\"*-*\",inquireableOnly:true,marketable:true,offerable:true,page:1,priceRange:\"*-*\",sort:\"-decayed_merch\",width:\"*-*\")"
           },
           (v5/*: any*/),
           (v8/*: any*/),
@@ -660,7 +705,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "16575049d003c0e7d2ef49e93f457396",
+    "cacheID": "52f94da42645b52023689863dcbc550c",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -808,7 +853,7 @@ return {
     },
     "name": "OnboardingGene_Test_Query",
     "operationKind": "query",
-    "text": "query OnboardingGene_Test_Query {\n  gene(id: \"example\") {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  name\n  artworks: filterArtworksConnection(first: 100) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n  ...FollowGeneButton_gene\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query OnboardingGene_Test_Query {\n  gene(id: \"example\") {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  name\n  artworks: filterArtworksConnection(first: 50, page: 1, sort: \"-decayed_merch\", height: \"*-*\", width: \"*-*\", priceRange: \"*-*\", marketable: true, offerable: true, inquireableOnly: true, forSale: true) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n  ...FollowGeneButton_gene\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/OnboardingGene_gene.graphql.ts
+++ b/src/__generated__/OnboardingGene_gene.graphql.ts
@@ -44,7 +44,52 @@ const node: ReaderFragment = {
         {
           "kind": "Literal",
           "name": "first",
-          "value": 100
+          "value": 50
+        },
+        {
+          "kind": "Literal",
+          "name": "forSale",
+          "value": true
+        },
+        {
+          "kind": "Literal",
+          "name": "height",
+          "value": "*-*"
+        },
+        {
+          "kind": "Literal",
+          "name": "inquireableOnly",
+          "value": true
+        },
+        {
+          "kind": "Literal",
+          "name": "marketable",
+          "value": true
+        },
+        {
+          "kind": "Literal",
+          "name": "offerable",
+          "value": true
+        },
+        {
+          "kind": "Literal",
+          "name": "page",
+          "value": 1
+        },
+        {
+          "kind": "Literal",
+          "name": "priceRange",
+          "value": "*-*"
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "-decayed_merch"
+        },
+        {
+          "kind": "Literal",
+          "name": "width",
+          "value": "*-*"
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -87,7 +132,7 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "filterArtworksConnection(first:100)"
+      "storageKey": "filterArtworksConnection(first:50,forSale:true,height:\"*-*\",inquireableOnly:true,marketable:true,offerable:true,page:1,priceRange:\"*-*\",sort:\"-decayed_merch\",width:\"*-*\")"
     },
     {
       "args": null,
@@ -98,5 +143,5 @@ const node: ReaderFragment = {
   "type": "Gene",
   "abstractKey": null
 };
-(node as any).hash = 'c347d9a61ca6c0d74296d14e3b296dda';
+(node as any).hash = 'b3e1ab6675c1dadf0befc91eb69b357b';
 export default node;


### PR DESCRIPTION
The type of this PR is: _fix_

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1163]

### Description

<!-- Implementation description -->

The goal of this PR is to address the concerns surfaced during Onboarding QA here: https://www.notion.so/artsy/for-curated-collections-the-modal-doesn-t-match-the-collection-632acc9da57f4eb5983dbaa5e4611462

The intention rather than to just pull the first 100 artworks from gene collections for the artwork collection reward screen at the end of the onboarding flow, to instead filter the query to match the artworks presented on the gene's page. This code solves for the `trove`, `artists on the rise` and `top auction lots` gene collections. 

An example (artists on the rise): 
<img width="892" alt="Screen Shot 2022-07-22 at 3 57 51 PM" src="https://user-images.githubusercontent.com/23108927/180567540-8ddd8225-f65c-425f-a0cd-3e65b3e34c37.png">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1163]: https://artsyproduct.atlassian.net/browse/GRO-1163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ