### PR TITLE
feat: Add My Collection to Settings tabs

### DIFF
--- a/src/Apps/Settings/SettingsApp.tsx
+++ b/src/Apps/Settings/SettingsApp.tsx
@@ -1,26 +1,34 @@
 import { Text } from "@artsy/palette"
-import React from "react"
-import { SettingsApp_me } from "__generated__/SettingsApp_me.graphql"
-import { createFragmentContainer, graphql } from "react-relay"
-import { RouteTab, RouteTabs } from "Components/RouteTabs"
 import { MetaTags } from "Components/MetaTags"
+import { RouteTab, RouteTabs } from "Components/RouteTabs"
+import { compact } from "lodash"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useFeatureFlag } from "System/useFeatureFlag"
+import { SettingsApp_me } from "__generated__/SettingsApp_me.graphql"
 
 interface SettingsAppProps {
   me: SettingsApp_me
 }
 
-const TABS = [
-  { name: "Edit Settings", url: "/settings/edit-settings" },
-  { name: "Collector Profile", url: "/settings/edit-profile" },
-  { name: "Saves & Follows", url: "/settings/saves" },
-  { name: "Your Alerts", url: "/settings/alerts" },
-  { name: "Order History", url: "/settings/purchases" },
-  { name: "Bids", url: "/settings/auctions" },
-  { name: "Payments", url: "/settings/payments" },
-  { name: "Shipping", url: "/settings/shipping" },
-]
-
 const SettingsApp: React.FC<SettingsAppProps> = ({ me, children }) => {
+  const isMyCollectionEnabled = useFeatureFlag("my-collection-web")
+
+  const tabs = compact([
+    { name: "Edit Settings", url: "/settings/edit-settings" },
+    { name: "Collector Profile", url: "/settings/edit-profile" },
+    isMyCollectionEnabled && {
+      name: "My Collection",
+      url: "/settings/my-collection",
+    },
+    { name: "Saves & Follows", url: "/settings/saves" },
+    { name: "Your Alerts", url: "/settings/alerts" },
+    { name: "Order History", url: "/settings/purchases" },
+    { name: "Bids", url: "/settings/auctions" },
+    { name: "Payments", url: "/settings/payments" },
+    { name: "Shipping", url: "/settings/shipping" },
+  ])
+
   return (
     <>
       <MetaTags title="Settings | Artsy" />
@@ -30,7 +38,7 @@ const SettingsApp: React.FC<SettingsAppProps> = ({ me, children }) => {
       </Text>
 
       <RouteTabs my={4}>
-        {TABS.map(tab => {
+        {tabs.map(tab => {
           return (
             <RouteTab key={tab.url} to={tab.url}>
               {tab.name}


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2658]

### Description

This PR adds My Collection tab inside SettingsApp when `my-collection-web` feature flag is enabled.

Original PR: [my-collection-web](https://github.com/artsy/force/pull/10580)

<img width="1730" alt="image" src="https://user-images.githubusercontent.com/20655703/180214631-a5384e04-0d38-4af9-becd-ecf992bf6eeb.png">

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2658]: https://artsyproduct.atlassian.net/browse/CX-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ