### PR TITLE
feat(FX-4039): expand auto-selection of user's preferred measurement system for size filter on auction results grid

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -318,7 +318,7 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
       <AuctionResultsFilterContextProvider
         earliestCreatedYear={startAt}
         latestCreatedYear={endAt}
-        userPreferedMetric={userPreferences?.metric}
+        userPreferredMetric={userPreferences?.metric}
         filters={filters}
         onChange={filterState =>
           updateUrl(allowedAuctionResultFilters(filterState))

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -23,7 +23,7 @@ import {
 import { ModalType } from "Components/Authentication/Types"
 import { LoadingArea } from "Components/LoadingArea"
 import { PaginationFragmentContainer as Pagination } from "Components/Pagination"
-import { SystemContext } from "System"
+import { SystemContext, useSystemContext } from "System"
 import { useRouter } from "System/Router/useRouter"
 import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 import { usePrevious } from "Utils/Hooks/usePrevious"
@@ -311,12 +311,14 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
       props.artist.auctionResultsConnection?.createdYearRange ?? {}
 
     const { match } = useRouter()
+    const { userPreferences } = useSystemContext()
     const filters = paramsToCamelCase(match?.location.query)
 
     return (
       <AuctionResultsFilterContextProvider
         earliestCreatedYear={startAt}
         latestCreatedYear={endAt}
+        userPreferedMetric={userPreferences?.metric}
         filters={filters}
         onChange={filterState =>
           updateUrl(allowedAuctionResultFilters(filterState))

--- a/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
@@ -87,7 +87,7 @@ export interface AuctionResultsFilterContextProps {
   earliestCreatedYear?: number | null
   /** Used to get the overall latest created year for all lots of given artist */
   latestCreatedYear?: number | null
-  userPreferedMetric?: Metric
+  userPreferredMetric?: Metric
 }
 
 /**
@@ -113,7 +113,7 @@ export type SharedAuctionResultsFilterContextProps = Pick<
   | "ZeroState"
   | "earliestCreatedYear"
   | "latestCreatedYear"
-  | "userPreferedMetric"
+  | "userPreferredMetric"
 > & {
   onChange?: (filterState) => void
 }
@@ -130,13 +130,13 @@ export const AuctionResultsFilterContextProvider: React.FC<
   ZeroState,
   earliestCreatedYear = null,
   latestCreatedYear = null,
-  userPreferedMetric,
+  userPreferredMetric,
 }) => {
   const initialFilterState = {
     ...initialAuctionResultsFilterState({
       startDate: earliestCreatedYear,
       endDate: latestCreatedYear,
-      metric: userPreferedMetric,
+      metric: userPreferredMetric,
     }),
     ...filters,
   }
@@ -221,7 +221,7 @@ export const AuctionResultsFilterContextProvider: React.FC<
         payload: {
           earliestCreatedYear,
           latestCreatedYear,
-          metric: userPreferedMetric,
+          metric: userPreferredMetric,
         } as any,
       }
       dispatchOrStage(action)

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SizeFilter.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SizeFilter.tsx
@@ -1,16 +1,23 @@
 import * as React from "react"
-import { Checkbox, Flex, Text } from "@artsy/palette"
+import { Checkbox, Flex, Radio, RadioGroup, Text } from "@artsy/palette"
 import { FilterExpandable } from "Components/ArtworkFilter/ArtworkFilters/FilterExpandable"
 import { ShowMore } from "Components/ArtworkFilter/ArtworkFilters/ShowMore"
 import {
   useAuctionResultsFilterContext,
   useCurrentlySelectedFiltersForAuctionResults,
 } from "../../AuctionResultsFilterContext"
+import { Metric } from "Utils/metrics"
 
 export const sizeMap = [
   { displayName: "Small (under 40cm)", name: "SMALL" },
   { displayName: "Medium (40 – 100cm)", name: "MEDIUM" },
   { displayName: "Large (over 100cm)", name: "LARGE" },
+]
+
+export const sizeMapInInches = [
+  { displayName: "Small (under 16in)", name: "SMALL" },
+  { displayName: "Medium (16 – 40in)", name: "MEDIUM" },
+  { displayName: "Large (over 40in)", name: "LARGE" },
 ]
 
 /**
@@ -19,7 +26,8 @@ export const sizeMap = [
  */
 export const SizeFilter: React.FC = () => {
   const { setFilter } = useAuctionResultsFilterContext()
-  const { sizes = [] } = useCurrentlySelectedFiltersForAuctionResults()
+  const { sizes = [], metric } = useCurrentlySelectedFiltersForAuctionResults()
+  const options = metric === "in" ? sizeMapInInches : sizeMap
 
   const toggleSelection = (selected: boolean, name: string) => {
     let updatedValues = sizes
@@ -33,14 +41,33 @@ export const SizeFilter: React.FC = () => {
     setFilter?.("sizes", updatedValues)
   }
 
+  const handleSelectMetric = (nextMetric: Metric) => {
+    if (metric === nextMetric) {
+      return
+    }
+
+    setFilter?.("metric", nextMetric)
+  }
+
   return (
     <FilterExpandable label="Size" expanded>
       <Flex flexDirection="column" alignItems="left">
         <Text variant="sm">
           This is based on the artwork’s average dimension.
         </Text>
+
+        <RadioGroup
+          defaultValue={metric}
+          onSelect={handleSelectMetric}
+          flexDirection="row"
+          my={2}
+        >
+          <Radio value="cm" label="cm" flex={1} />
+          <Radio value="in" label="in" flex={1} />
+        </RadioGroup>
+
         <ShowMore>
-          {sizeMap.map((checkbox, index) => {
+          {options.map((checkbox, index) => {
             const { name, displayName } = checkbox
             const props = {
               key: index,

--- a/src/Apps/Artist/Utils/allowedAuctionResultFilters.ts
+++ b/src/Apps/Artist/Utils/allowedAuctionResultFilters.ts
@@ -27,4 +27,4 @@ export const allowedAuctionResultFilters = (
 
 const INTEGER_INPUT_ARGS = ["createdAfterYear", "createdBeforeYear"]
 const BOOLEAN_INPUT_ARGS = ["allowEmptyCreatedDates"]
-const SUPPORTED_INPUT_ARGS = ["organizations", "categories", "sizes"]
+const SUPPORTED_INPUT_ARGS = ["organizations", "categories", "sizes", "metric"]


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR solves [FX-4039]

Related PRs: artsy/force#10593, artsy/force#10572

Review app: https://auction-results-metric.artsy.net

Demo link: https://auction-results-metric.artsy.net/artist/salman-toor/auction-results

### Demo
https://user-images.githubusercontent.com/3513494/180767621-b04e69f6-ad99-407b-862e-ddc9822963bc.mp4

<!-- Implementation description -->


[FX-4039]: https://artsyproduct.atlassian.net/browse/FX-4039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ