### PR TITLE
chore: regenerate secrets baseline for version 1.3.0

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.3.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -112,26 +112,13 @@
       "pattern": [
         "(foo|secret|reset|true|toggle|trackForgotClick|passwordNextButton|hook)",
         "^https://.*$",
-        "^onPassword.*$"
+        "^onPassword.*$",
+        "[a-fA-F0-9]{24}"
       ]
     }
   ],
   "results": {
     ".env.oss": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".env.oss",
-        "hashed_secret": "c686af63b78768713592e8af81622b9001443d8f",
-        "is_verified": false,
-        "line_number": 14
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".env.oss",
-        "hashed_secret": "c686af63b78768713592e8af81622b9001443d8f",
-        "is_verified": false,
-        "line_number": 14
-      },
       {
         "type": "Secret Keyword",
         "filename": ".env.oss",
@@ -140,62 +127,36 @@
         "line_number": 22
       }
     ],
-    "src/config.ts": [
+    "src/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx": [
       {
-        "type": "Hex High Entropy String",
-        "filename": "src/config.ts",
-        "hashed_secret": "cb7910b388d3066900fe2af1942a46817c46d329",
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx",
+        "hashed_secret": "582731c15a3c47c3becb427891f54e1e5e90387a",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 198
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "src/config.ts",
-        "hashed_secret": "3f845c458dbcf7c4bee4be6c02440c754882c270",
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx",
+        "hashed_secret": "fbadd9158203745bb5094bf61c69c110c0dbced4",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 218
+      }
+    ],
+    "src/Apps/ViewingRoom/Routes/Works/__tests__/ViewingRoomWorksRoute.jest.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/ViewingRoom/Routes/Works/__tests__/ViewingRoomWorksRoute.jest.tsx",
+        "hashed_secret": "582731c15a3c47c3becb427891f54e1e5e90387a",
+        "is_verified": false,
+        "line_number": 163
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "src/config.ts",
-        "hashed_secret": "f83913bbf45e92c31a11a52dcd55de047f515bd1",
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/ViewingRoom/Routes/Works/__tests__/ViewingRoomWorksRoute.jest.tsx",
+        "hashed_secret": "fbadd9158203745bb5094bf61c69c110c0dbced4",
         "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/config.ts",
-        "hashed_secret": "f347153cbbbac117be7de356317cfa065864392e",
-        "is_verified": false,
-        "line_number": 60
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/config.ts",
-        "hashed_secret": "d40d2a9d95cce5051476edb87e21f03c5202b4fd",
-        "is_verified": false,
-        "line_number": 61
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/config.ts",
-        "hashed_secret": "e5f00840dfe1479a2f4ee1f0833d0d2a828c0784",
-        "is_verified": false,
-        "line_number": 68
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/config.ts",
-        "hashed_secret": "61063161509eac1a7ba9bf7eb5a9b72b4b086c5c",
-        "is_verified": false,
-        "line_number": 69
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/config.ts",
-        "hashed_secret": "e88b861dd023258e4bbecae2721a214c49564a7c",
-        "is_verified": false,
-        "line_number": 95
+        "line_number": 253
       }
     ],
     "src/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx": [
@@ -205,6 +166,13 @@
         "hashed_secret": "d62b42cc21382044595c7c5131b0f28e8588ae62",
         "is_verified": false,
         "line_number": 40
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx",
+        "hashed_secret": "d7fc89e39d93a3ec26b311594abff287d01b2ace",
+        "is_verified": false,
+        "line_number": 358
       }
     ],
     "src/Apps/__tests__/Fixtures/Artwork/ArtistInfo.ts": [
@@ -218,12 +186,79 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtistInfo.ts",
+        "hashed_secret": "d5116787f7320c9597b7bfbfc8456eabf6cc64aa",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtistInfo.ts",
         "hashed_secret": "98926394d5d11bf0813d5c14e72575c58d0af241",
         "is_verified": false,
         "line_number": 55
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtistInfo.ts",
+        "hashed_secret": "2dcb01cd2dc70c3d7d8c8ab712db7ca91e457074",
+        "is_verified": false,
+        "line_number": 73
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtistInfo.ts",
+        "hashed_secret": "ba624fe9c0702af24cdd9de626230abc4281ab5b",
+        "is_verified": false,
+        "line_number": 105
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtistInfo.ts",
+        "hashed_secret": "2613922213e5e6b793b2ae151ba6004988200caa",
+        "is_verified": false,
+        "line_number": 118
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtistInfo.ts",
+        "hashed_secret": "a11e18f6d613adcc32df05c18dd68e0e8754c22f",
+        "is_verified": false,
+        "line_number": 132
+      }
+    ],
+    "src/Apps/__tests__/Fixtures/Artwork/ArtworkRelatedArtists.fixture.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtworkRelatedArtists.fixture.ts",
+        "hashed_secret": "5d8ec40feec3571389f895806c8ba6e06eabdf3c",
+        "is_verified": false,
+        "line_number": 45
+      }
+    ],
+    "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarCommercial.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarCommercial.ts",
+        "hashed_secret": "588490dbc7660c22cd4ae02a12a3e4c02066fc48",
+        "is_verified": false,
+        "line_number": 247
       }
     ],
     "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarExtraLinks.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarExtraLinks.ts",
+        "hashed_secret": "14474c47e184aca37458213a1110b20defa05c89",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarExtraLinks.ts",
+        "hashed_secret": "583e9a1ce54cb0c3813dce977766112d9dfbd240",
+        "is_verified": false,
+        "line_number": 67
+      },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarExtraLinks.ts",
@@ -248,9 +283,39 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarExtraLinks.ts",
+        "hashed_secret": "ef4daad5282f14e15c85bef300e8526f80453ac4",
+        "is_verified": false,
+        "line_number": 117
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarExtraLinks.ts",
         "hashed_secret": "eb8b35f59a4e03bb4a813a514c9c2d06f99d1024",
         "is_verified": false,
         "line_number": 134
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarExtraLinks.ts",
+        "hashed_secret": "269c93c0f6ca63ba01d978a96e96ce9a38e15088",
+        "is_verified": false,
+        "line_number": 154
+      }
+    ],
+    "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarMetadata.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarMetadata.ts",
+        "hashed_secret": "3506f1486ed84316dae22d23f8c93680d8bc20df",
+        "is_verified": false,
+        "line_number": 86
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/ArtworkSidebar/ArtworkSidebarMetadata.ts",
+        "hashed_secret": "a5ce98a294efb3dfd3f63beeacbfd1cf2e0f67ad",
+        "is_verified": false,
+        "line_number": 94
       }
     ],
     "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts": [
@@ -264,9 +329,23 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "9dc0e7cefb628f3a98cdf9cdc5a0c4c8dee8feb4",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
         "hashed_secret": "03416b534d47aa67d609f26bdcf38fba4ae48f16",
         "is_verified": false,
         "line_number": 61
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "78e0df0da7ab7670613f7763f2600fbde7781f13",
+        "is_verified": false,
+        "line_number": 67
       },
       {
         "type": "Base64 High Entropy String",
@@ -278,9 +357,191 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "8d321eacf75637ad1819b40695baca63aeb406e4",
+        "is_verified": false,
+        "line_number": 108
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "adfaaa8c185f2049dd664efd53af4f99465de295",
+        "is_verified": false,
+        "line_number": 113
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "1a97a386e5fafa0ec5ef42f4d807dacfca1158bf",
+        "is_verified": false,
+        "line_number": 118
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "011638a99fd079790dcd739c739001883921614a",
+        "is_verified": false,
+        "line_number": 128
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "6ff4fcdbe6e98a003eaa7362a4b4c4cf911ab46c",
+        "is_verified": false,
+        "line_number": 133
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "60c569a944530c1b10781032b04bdcf93d9dd37a",
+        "is_verified": false,
+        "line_number": 148
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "a7f3db07a4e0aff0006e078ce53f67d84bdb1883",
+        "is_verified": false,
+        "line_number": 419
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "b87320c33d3fb985799ea3aad6985ccf20314dc5",
+        "is_verified": false,
+        "line_number": 450
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "76cc1716f9d3781172a45b3e9c3d90b2328ca0e2",
+        "is_verified": false,
+        "line_number": 462
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "e6423fcf69167d8e393362f1b93ce5c367c925bc",
+        "is_verified": false,
+        "line_number": 466
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "9dac05840a6e8e0dc6b8ae5981a0c5e6f723c912",
+        "is_verified": false,
+        "line_number": 476
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "7220576713b157b7feb9b11af93b44de92c49e84",
+        "is_verified": false,
+        "line_number": 477
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "0b59d36ed63eb10ac678b727583cc7cb61884469",
+        "is_verified": false,
+        "line_number": 478
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "f9f2e5fbe0de5bb7a321425dec1b86c5a5847217",
+        "is_verified": false,
+        "line_number": 479
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "14abf7fe9bfd639273c1907253cba80d2156cf58",
+        "is_verified": false,
+        "line_number": 482
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "38b4cba0fc6e088225dcbc7ecf84ae488f01eb4c",
+        "is_verified": false,
+        "line_number": 485
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "7f37e6cfefc65ba56450401a220c32a53d56f219",
+        "is_verified": false,
+        "line_number": 486
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "448cdd905f125a75035e9713aeb5d03cc5a40d66",
+        "is_verified": false,
+        "line_number": 487
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "fe05b94e2caca18ad223ad8cd5a6c5ae770a41c3",
+        "is_verified": false,
+        "line_number": 490
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "874d690435c7e302548470d4ab55d62fcecf75f5",
+        "is_verified": false,
+        "line_number": 606
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "f17931047a0e197fa1e4377939da6ea8ac6e639b",
+        "is_verified": false,
+        "line_number": 633
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "dda58bbc9c4793182f320c610326a1793d5217ae",
+        "is_verified": false,
+        "line_number": 647
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "902dff5e1b47e4954cb4223dc5c74ecc576e5b03",
+        "is_verified": false,
+        "line_number": 688
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
         "hashed_secret": "c1f4016bbb0ecc23aea10dd69e7ffd6c8f9974a2",
         "is_verified": false,
         "line_number": 730
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "cb88a97128b01371f75362819617c391dd53216f",
+        "is_verified": false,
+        "line_number": 772
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "a735f2cef9df7e1b163de93b82e555f348c68b7f",
+        "is_verified": false,
+        "line_number": 813
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "10ebf82a6eae9289bee2554bf77f6099484f3bf6",
+        "is_verified": false,
+        "line_number": 840
       },
       {
         "type": "Base64 High Entropy String",
@@ -362,9 +623,44 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "69376c706643f518597246892e5f81ff1b426a35",
+        "is_verified": false,
+        "line_number": 1251
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "a682b64642894a52c53c21dd47e7563474bf68a5",
+        "is_verified": false,
+        "line_number": 1292
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "fe84bb583068e6bbec50a6b5446692f13a8f41e5",
+        "is_verified": false,
+        "line_number": 1343
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
         "hashed_secret": "af67a808cc06f43c26274d5dc4f4db57555e96ad",
         "is_verified": false,
         "line_number": 1385
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "5d8ec40feec3571389f895806c8ba6e06eabdf3c",
+        "is_verified": false,
+        "line_number": 1404
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "777e558f47abc427582b6d20685411b389c55285",
+        "is_verified": false,
+        "line_number": 1454
       },
       {
         "type": "Base64 High Entropy String",
@@ -383,12 +679,89 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "80df3ca24340401adcc08a2dea8db78f8d38dfaa",
+        "is_verified": false,
+        "line_number": 1530
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
         "hashed_secret": "6155ce21221595cb7a98063aff8caa37557680a5",
         "is_verified": false,
         "line_number": 1554
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "ed535be61c5aee70edfab89fa7bd3906f7d68400",
+        "is_verified": false,
+        "line_number": 1596
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "a447837e40a7fce5e7e239b0dbe6bea3a1cec5f2",
+        "is_verified": false,
+        "line_number": 1623
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "50e4b8ab671509806fdc48b5094886d512af2472",
+        "is_verified": false,
+        "line_number": 1648
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "764ca658f6ef923769650fb48ebc9826665a57fa",
+        "is_verified": false,
+        "line_number": 1653
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "9a1d75fd7a8e50263bdce0bbbf4a365a7781f843",
+        "is_verified": false,
+        "line_number": 1663
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "40b244ca4ea011ad0bc61aba1a652c2e73e7a6ba",
+        "is_verified": false,
+        "line_number": 1668
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artwork/FullArtwork.fixture.ts",
+        "hashed_secret": "f33a5fe2a9f3e251c7a672006f25466f43dad2a8",
+        "is_verified": false,
+        "line_number": 1673
       }
     ],
     "src/Apps/__tests__/Fixtures/Artworks.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "856fa56ee4b725bcea41421738debc81ed122ba1",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "d84930a74869f928c98f7b9b170a84689460d06e",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "eec6f77b22007fc8265806606a70f26f4e303b8c",
+        "is_verified": false,
+        "line_number": 59
+      },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
@@ -399,9 +772,65 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "660c83d9480b5a0e99fe8927b9840cc675241540",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "d492b3d28e264fe3b447c845c7bc5a4759d3ab3d",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "84de9414f2b51b7ab44280bc40daa8deaa32235c",
+        "is_verified": false,
+        "line_number": 199
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "80e3581dd7cc6100ba96343e71d759d5b8fb3426",
+        "is_verified": false,
+        "line_number": 229
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "16fa4d22eebb214c5f9a2e3e258f863c8bcb153e",
+        "is_verified": false,
+        "line_number": 255
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
         "hashed_secret": "967e59feb986be2da0e80c403a3cb06b346d3d45",
         "is_verified": false,
         "line_number": 292
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "8cfd4a2950ec4a7015d3d114e7af79aae66fe5c1",
+        "is_verified": false,
+        "line_number": 390
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "10aed2d719d008821214c9881f204c4bf5623fd8",
+        "is_verified": false,
+        "line_number": 408
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "042fb650b4b9d1591f1e68d187e29f644867a05a",
+        "is_verified": false,
+        "line_number": 483
       },
       {
         "type": "Base64 High Entropy String",
@@ -420,9 +849,44 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "b05fef50a3844d110521aa3e558361965a96b943",
+        "is_verified": false,
+        "line_number": 608
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "ea350ffc4c35cf9aa6447459aa5e9961f280e11f",
+        "is_verified": false,
+        "line_number": 649
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
         "hashed_secret": "553c84643023767f8b592b6f52ddbf1de9d52d57",
         "is_verified": false,
         "line_number": 666
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "6bb5891340c8965484662d298445004323b58f0d",
+        "is_verified": false,
+        "line_number": 744
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "5a50fa40c6e1a994b0d82cdd125ff13e2b07c43a",
+        "is_verified": false,
+        "line_number": 774
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Artworks.ts",
+        "hashed_secret": "57b924b0488d61cfac2557e0c2d2354eb181529e",
+        "is_verified": false,
+        "line_number": 783
       }
     ],
     "src/Apps/__tests__/Fixtures/Carousel.ts": [
@@ -436,9 +900,148 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/__tests__/Fixtures/Carousel.ts",
+        "hashed_secret": "6bf727d7102bad9a246ebc2d679b1094567ec209",
+        "is_verified": false,
+        "line_number": 113
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Carousel.ts",
         "hashed_secret": "cef4e0294ece14fb5663a56041b8320167fcf123",
         "is_verified": false,
         "line_number": 188
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Carousel.ts",
+        "hashed_secret": "580d23060d198d92c33ad6d9be7888377d11b30c",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Carousel.ts",
+        "hashed_secret": "e290e95b1e6a129889fa2216f4ce155d44161ac3",
+        "is_verified": false,
+        "line_number": 248
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Carousel.ts",
+        "hashed_secret": "ea9beca121ad49d913e8de4ac4f0067ea6a07fb8",
+        "is_verified": false,
+        "line_number": 262
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Carousel.ts",
+        "hashed_secret": "810d7a1e78edb028fdc2ac2f128ec59455d8e547",
+        "is_verified": false,
+        "line_number": 299
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Carousel.ts",
+        "hashed_secret": "0938c9f62dc4b1b377722753e175ac8201623dc7",
+        "is_verified": false,
+        "line_number": 322
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Carousel.ts",
+        "hashed_secret": "03842f450c95182b5bbfff07bbf9aebfb0f6e61a",
+        "is_verified": false,
+        "line_number": 336
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Carousel.ts",
+        "hashed_secret": "492b2a4495d4df42a8e24eb37e82824f8afb8bfe",
+        "is_verified": false,
+        "line_number": 373
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Carousel.ts",
+        "hashed_secret": "8e0a93a8a76284855c3ab5791098ce1b12cd5ab2",
+        "is_verified": false,
+        "line_number": 410
+      }
+    ],
+    "src/Apps/__tests__/Fixtures/Conversation.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Conversation.ts",
+        "hashed_secret": "d5d5029d13f568d1109e7c7a513604aa395ab1d1",
+        "is_verified": false,
+        "line_number": 116
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Conversation.ts",
+        "hashed_secret": "eb73509ac7c976f846ba313b9776986d038dac48",
+        "is_verified": false,
+        "line_number": 121
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/Conversation.ts",
+        "hashed_secret": "efdea412ca1685fff18e3761c89cee0f9bb9368c",
+        "is_verified": false,
+        "line_number": 203
+      }
+    ],
+    "src/Apps/__tests__/Fixtures/MarketInsights.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/MarketInsights.ts",
+        "hashed_secret": "8d321eacf75637ad1819b40695baca63aeb406e4",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/MarketInsights.ts",
+        "hashed_secret": "adfaaa8c185f2049dd664efd53af4f99465de295",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/MarketInsights.ts",
+        "hashed_secret": "1a97a386e5fafa0ec5ef42f4d807dacfca1158bf",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/MarketInsights.ts",
+        "hashed_secret": "011638a99fd079790dcd739c739001883921614a",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/MarketInsights.ts",
+        "hashed_secret": "6ff4fcdbe6e98a003eaa7362a4b4c4cf911ab46c",
+        "is_verified": false,
+        "line_number": 66
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Apps/__tests__/Fixtures/MarketInsights.ts",
+        "hashed_secret": "60c569a944530c1b10781032b04bdcf93d9dd37a",
+        "is_verified": false,
+        "line_number": 68
+      }
+    ],
+    "src/Apps/__tests__/Fixtures/Order.ts": [
+      {
+        "type": "Artifactory Credentials",
+        "filename": "src/Apps/__tests__/Fixtures/Order.ts",
+        "hashed_secret": "561db44f1e3e6d68736144c5d6969e1356c04a54",
+        "is_verified": false,
+        "line_number": 233
       }
     ],
     "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx": [
@@ -452,9 +1055,100 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "e5a1e64e5aa583dbaf67dbb4abfd2e092681efc2",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "145bdc9483588e8243c544e00dab4fd93040ff68",
+        "is_verified": false,
+        "line_number": 74
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "de8d20175b765cac693a529d51145d55d3912082",
+        "is_verified": false,
+        "line_number": 118
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "ebdf5259929f473604297bbbccd696fcd037c6f9",
+        "is_verified": false,
+        "line_number": 153
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "2dcb5df59b78708ed33c9be2f53cf2e713cc136c",
         "is_verified": false,
         "line_number": 163
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "36b5f9cd656a82144f10643146f5278fa4e1f9be",
+        "is_verified": false,
+        "line_number": 201
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "b55958b35c43c441f87ff29bfee3fe29d778b9b5",
+        "is_verified": false,
+        "line_number": 210
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "d56b9e588e1770b8ddf404a22b46d570e2bce004",
+        "is_verified": false,
+        "line_number": 254
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "b0f93ef51b0daf64e471655e9f77cc90f230903d",
+        "is_verified": false,
+        "line_number": 298
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "0483a680292f6e280adc41f57031fd77673088b8",
+        "is_verified": false,
+        "line_number": 342
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "f4a65a11c81626ba80381ac4c60fb13531289963",
+        "is_verified": false,
+        "line_number": 377
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "03b840a21f4dae9999524027fa91483b420138b0",
+        "is_verified": false,
+        "line_number": 386
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "98612cabb08050b711614f3e0a250f7c5836678a",
+        "is_verified": false,
+        "line_number": 430
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "c1c070cf96af376813ed8c4db59a2ff2d15f28ee",
+        "is_verified": false,
+        "line_number": 465
       },
       {
         "type": "Base64 High Entropy String",
@@ -487,9 +1181,58 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "adacb996fb2315f6c435cf0bd98e7c117152a80e",
+        "is_verified": false,
+        "line_number": 654
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "0f1163ee647469ef875eb67211d730376f28d6cf",
         "is_verified": false,
         "line_number": 664
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "ec6c8d32d50c6f05c046e52629a2e1a464ac33d2",
+        "is_verified": false,
+        "line_number": 711
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "aec29cbcda0c20fb980b12c463ed12fb16eb4d07",
+        "is_verified": false,
+        "line_number": 746
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "e4dec77ed41da21f2db9ec8d14e6b64d5f5807cf",
+        "is_verified": false,
+        "line_number": 755
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "1de1e75512b60c7a905448217786ec745b387142",
+        "is_verified": false,
+        "line_number": 799
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "7aed2cddeb110852a1012df39f2bba85aa103776",
+        "is_verified": false,
+        "line_number": 843
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "84de9414f2b51b7ab44280bc40daa8deaa32235c",
+        "is_verified": false,
+        "line_number": 878
       },
       {
         "type": "Base64 High Entropy String",
@@ -508,9 +1251,23 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "58cae497261e0b72dfce1338c9288d3421e699e4",
+        "is_verified": false,
+        "line_number": 979
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "9a2ed348bb3b66bde3e1dbe6b1e6b6ee83c79975",
         "is_verified": false,
         "line_number": 1024
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "2203e03a62a0efc06caeefbdf793a766dd831366",
+        "is_verified": false,
+        "line_number": 1113
       },
       {
         "type": "Base64 High Entropy String",
@@ -522,9 +1279,74 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "3d59c4db2a714d8af140b7a2d5624753e2bf5060",
+        "is_verified": false,
+        "line_number": 1203
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "10ebf82a6eae9289bee2554bf77f6099484f3bf6",
+        "is_verified": false,
+        "line_number": 1238
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "7e19d2e69f6f62b49510c83d28e1a5694feaff7b",
+        "is_verified": false,
+        "line_number": 1247
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
+        "hashed_secret": "e1e8b627d3d71d392eb8b237c1514ccc6bfff594",
+        "is_verified": false,
+        "line_number": 1291
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "fd7df1a90d15d76b63d73bbf5873f23aadcceda8",
         "is_verified": false,
         "line_number": 1336
+      }
+    ],
+    "src/Components/ArtworkGrid/__tests__/ArtworkGridFixture.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkGrid/__tests__/ArtworkGridFixture.ts",
+        "hashed_secret": "24cf26afecb4eba14ea7b3acb48f0d74128b65ca",
+        "is_verified": false,
+        "line_number": 57
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkGrid/__tests__/ArtworkGridFixture.ts",
+        "hashed_secret": "84de9414f2b51b7ab44280bc40daa8deaa32235c",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkGrid/__tests__/ArtworkGridFixture.ts",
+        "hashed_secret": "1b2772fb032d093a00871bb1a2ba6cd1de353548",
+        "is_verified": false,
+        "line_number": 107
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkGrid/__tests__/ArtworkGridFixture.ts",
+        "hashed_secret": "64f893fb0ebd467e50ce3327d5a4217cba35ff13",
+        "is_verified": false,
+        "line_number": 157
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/Components/ArtworkGrid/__tests__/ArtworkGridFixture.ts",
+        "hashed_secret": "c89c1e081e7e14316cdd8aef59b891f9c9b9b35f",
+        "is_verified": false,
+        "line_number": 182
       }
     ],
     "src/Components/NavBar/Menus/__tests__/NavBarNotifications.jest.tsx": [
@@ -556,7 +1378,16 @@
         "is_verified": false,
         "line_number": 117
       }
+    ],
+    "src/lib/passport-local-with-otp/test/strategy.fields.jest.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/passport-local-with-otp/test/strategy.fields.jest.js",
+        "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
+        "is_verified": false,
+        "line_number": 9
+      }
     ]
   },
-  "generated_at": "2022-07-19T23:30:25Z"
+  "generated_at": "2022-07-25T16:37:10Z"
 }


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

detect-secrets [v1.3.0](https://github.com/Yelp/detect-secrets/releases/tag/v1.3.0) has been released last Friday. CI has automatically picked up the new version and [is currently failing](https://app.circleci.com/pipelines/github/artsy/force/34427/workflows/fa9e10a7-1851-493c-aec0-733c6e7040ae/jobs/265361). The failure seems to be a result of some changes in the new version, specifically around "_Base64 High Entropy String_" plugin. The new version seems to be picking up a lot of new secret like strings that match that _Type_.
 
To resolve this, I've regenerated the _baseline_ from scratch using the latest version of the tool. The [one notable change](https://github.com/artsy/force/pull/10597/files#diff-d8447df0cd384602c76086081f13f27ad0b45902297c42da35a6fc51fdf1cec3R116) is adding an exclusion for mongo ID like strings. 

To regenerate the baseline I ran the following command (_detect-secrets v1.3.0_):

```
detect-secrets scan --baseline .secrets.baseline --exclude-files 'src/__generated__/.*\.ts$' --exclude-secrets '(foo|secret|reset|true|toggle|trackForgotClick|passwordNextButton|hook)' --exclude-secrets '^https://.*$' --exclude-secrets '^onPassword.*$' --exclude-secrets '[a-fA-F0-9]{24}'
```


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ