### PR TITLE
fix: password required in CreateBackupSecondFactorsInput

### DIFF
--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/useCreateSettingsBackupSecondFactorsMutation.ts
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/useCreateSettingsBackupSecondFactorsMutation.ts
@@ -10,7 +10,7 @@ export const useCreateSettingsBackupSecondFactors = () => {
   const { relayEnvironment } = useSystemContext()
 
   const submitCreateSettingsBackupSecondFactors = (
-    input: CreateBackupSecondFactorsInput = {}
+    input: CreateBackupSecondFactorsInput
   ): Promise<useCreateSettingsBackupSecondFactorsMutationResponse> => {
     return new Promise((resolve, reject) => {
       commitMutation<useCreateSettingsBackupSecondFactorsMutation>(


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves: [PLATFORM-4340](https://artsyproduct.atlassian.net/browse/PLATFORM-4340)

### Description

<!-- Implementation description -->

This updates `useCreateSettingsBackupSecondFactorsMutation.ts` to no longer default to an empty object as a password is now required by the schema. [MP pr here](https://github.com/artsy/metaphysics/pull/4247).

This would resolve the _type-error_ observed in https://github.com/artsy/force/pull/10590. Failed job run [here](https://app.circleci.com/pipelines/github/artsy/force/34427/workflows/fa9e10a7-1851-493c-aec0-733c6e7040ae/jobs/265378).

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ