### PR TITLE
Fix malformed RSS tag

### DIFF
--- a/src/Apps/RSS/templates/article.ejs
+++ b/src/Apps/RSS/templates/article.ejs
@@ -5,7 +5,7 @@
   <author><%= article.byline %></author>
   <pubDate><%= new Date(article.publishedAt).toUTCString() %></pubDate>
   <% if (article.thumbnailImage && article.thumbnailImage.resized) { %>
-    <enclosure url="<%= article.thumbnailImage.resized.src %>" length=0 type="image/jpeg" />
+    <enclosure url="<%= article.thumbnailImage.resized.src %>" length="0" type="image/jpeg" />
   <% } %>
   <description>
     <![CDATA[


### PR DESCRIPTION
I swear I tested this folks but clearly something went wrong - without proper quotes this is not valid XML and that's been breaking the Editorial version of the iOS widget. 

/cc @artsy/grow-devs 