### PR TITLE
(onboarding): increase padding between progress bar and close button

### DIFF
--- a/src/Components/Onboarding/Components/OnboardingProgress.tsx
+++ b/src/Components/Onboarding/Components/OnboardingProgress.tsx
@@ -22,7 +22,7 @@ export const OnboardingProgress: FC<OnboardingProgressProps> = ({
   return (
     <ProgressBar
       width="100%"
-      my={0}
+      my={2}
       transition="transform 250ms"
       percentComplete={debouncedProgress}
     />


### PR DESCRIPTION
The type of this PR is: fix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1160]

### Description

<!-- Implementation description -->
This is a small fix to the margins between the close button and the progress bar. 

<img width="892" alt="Screen Shot 2022-07-26 at 12 14 36 PM" src="https://user-images.githubusercontent.com/23108927/181069459-447ffcdc-93c2-4e28-b4f5-a33e448bf177.png">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1160]: https://artsyproduct.atlassian.net/browse/GRO-1160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ