### PR TITLE
feat(onboarding): Add new onComplete handler to context, invoking the updateUserProfile mutation

### DIFF
--- a/src/Apps/Home/Hooks/useOnboarding.tsx
+++ b/src/Apps/Home/Hooks/useOnboarding.tsx
@@ -13,7 +13,7 @@ export const useOnboarding = () => {
     showOnboarding,
     hideOnboarding,
   } = _useOnboarding({
-    onDone: () => {
+    onClose: () => {
       hideOnboarding()
     },
   })

--- a/src/Apps/Onboarding/OnboardingApp.tsx
+++ b/src/Apps/Onboarding/OnboardingApp.tsx
@@ -13,7 +13,7 @@ export const OnboardingApp: FC = () => {
   }
 
   return (
-    <OnboardingProvider onDone={handleDone}>
+    <OnboardingProvider onClose={handleDone}>
       <OnboardingDebug />
 
       <Spacer mt={2} />

--- a/src/Components/Onboarding/Components/OnboardingGene.tsx
+++ b/src/Components/Onboarding/Components/OnboardingGene.tsx
@@ -18,7 +18,7 @@ interface OnboardingGeneProps {
 
 const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
   const artworks = extractNodes(gene.artworks)
-  const { onDone } = useOnboardingContext()
+  const { onClose } = useOnboardingContext()
 
   return (
     <Box px={[2, 4]} py={6}>
@@ -57,7 +57,7 @@ const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
                   artwork={artwork}
                   onMouseUp={() => {
                     setTimeout(() => {
-                      onDone()
+                      onClose()
                     }, 10)
                   }}
                 />

--- a/src/Components/Onboarding/Hooks/useOnboarding.tsx
+++ b/src/Components/Onboarding/Hooks/useOnboarding.tsx
@@ -4,14 +4,14 @@ import { OnboardingSteps } from "../Components/OnboardingSteps"
 import { OnboardingProvider } from "./useOnboardingContext"
 
 interface UseOnboarding {
-  onDone(): void
+  onClose(): void
 }
 
-export const useOnboarding = ({ onDone }: UseOnboarding) => {
+export const useOnboarding = ({ onClose }: UseOnboarding) => {
   const { isVisible, showDialog, hideDialog, dialogComponent } = useDialog({
     Dialog: () => {
       return (
-        <OnboardingProvider onDone={onDone}>
+        <OnboardingProvider onClose={onClose}>
           <OnboardingModal onClose={hideDialog}>
             <OnboardingSteps />
           </OnboardingModal>

--- a/src/Components/Onboarding/Hooks/useOnboardingContext.tsx
+++ b/src/Components/Onboarding/Hooks/useOnboardingContext.tsx
@@ -75,11 +75,8 @@ const OnboardingContext = createContext<{
   current: string
   dispatch: React.Dispatch<Action>
   next(): void
-  // Called when the user has finished the onboarding process
   onComplete(): void
-  // Called on close and other cancel actions
-  // TODO: Should we rename this to onClose?
-  onDone(): void
+  onClose(): void
   progress: number
   state: State
   workflowEngine: WorkflowEngine
@@ -88,19 +85,19 @@ const OnboardingContext = createContext<{
   dispatch: () => {},
   next: () => {},
   onComplete: () => {},
-  onDone: () => {},
+  onClose: () => {},
   progress: 0,
   state: DEFAULT_STATE,
   workflowEngine: new WorkflowEngine({ workflow: [] }),
 })
 
 interface OnboardingProviderProps {
-  onDone(): void
+  onClose(): void
 }
 
 export const OnboardingProvider: FC<OnboardingProviderProps> = ({
   children,
-  onDone,
+  onClose,
 }) => {
   const basis = useRef<State>(DEFAULT_STATE)
   const { relayEnvironment } = useSystemContext()
@@ -120,7 +117,7 @@ export const OnboardingProvider: FC<OnboardingProviderProps> = ({
 
   const { workflowEngine, current, next, reset: __reset__ } = useConfig({
     basis,
-    onDone,
+    onClose,
   })
 
   const [state, dispatch] = useReducer(reducer(__reset__), DEFAULT_STATE)
@@ -139,7 +136,7 @@ export const OnboardingProvider: FC<OnboardingProviderProps> = ({
         dispatch,
         next,
         onComplete: handleComplete,
-        onDone,
+        onClose,
         progress,
         state,
         workflowEngine,

--- a/src/Components/Onboarding/Views/OnboardingWelcome.tsx
+++ b/src/Components/Onboarding/Views/OnboardingWelcome.tsx
@@ -8,7 +8,7 @@ import { useOnboardingContext } from "../Hooks/useOnboardingContext"
 
 export const OnboardingWelcome = () => {
   const { user } = useSystemContext()
-  const { next, onDone } = useOnboardingContext()
+  const { next, onClose } = useOnboardingContext()
   const { register, handleNext, loading } = useOnboardingFadeTransition({
     next,
   })
@@ -52,7 +52,7 @@ export const OnboardingWelcome = () => {
               // @ts-ignore
               as={RouterLink}
               to="/"
-              onClick={onDone}
+              onClick={onClose}
             >
               Skip
             </Button>

--- a/src/Components/Onboarding/__tests__/config.jest.ts
+++ b/src/Components/Onboarding/__tests__/config.jest.ts
@@ -16,7 +16,7 @@ describe("config", () => {
       },
     } = renderHook(() =>
       useConfig({
-        onDone: jest.fn(),
+        onClose: jest.fn(),
         basis: {
           current: {
             questionOne: OPTION_YES_I_LOVE_COLLECTING_ART,
@@ -48,7 +48,7 @@ describe("config", () => {
       result: {
         current: { workflowEngine },
       },
-    } = renderHook(() => useConfig({ onDone: jest.fn(), basis }))
+    } = renderHook(() => useConfig({ onClose: jest.fn(), basis }))
 
     expect(workflowEngine.current()).toEqual("VIEW_WELCOME")
     expect(workflowEngine.next()).toEqual("VIEW_QUESTION_ONE")

--- a/src/Components/Onboarding/config.ts
+++ b/src/Components/Onboarding/config.ts
@@ -4,10 +4,10 @@ import { State } from "./Hooks/useOnboardingContext"
 
 interface UseConfig {
   basis: React.RefObject<State>
-  onDone(): void
+  onClose(): void
 }
 
-export const useConfig = ({ basis, onDone }: UseConfig) => {
+export const useConfig = ({ basis, onClose }: UseConfig) => {
   const workflowEngine = useRef(
     new WorkflowEngine({
       workflow: [
@@ -43,7 +43,7 @@ export const useConfig = ({ basis, onDone }: UseConfig) => {
 
   const next = () => {
     if (workflowEngine.current.isEnd()) {
-      onDone()
+      onClose()
       return
     }
 


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR solves [GRO-1168]

### Description

Part 1 of a two PR body of work. This PR updates the onboarding flow's context with a new `onComplete` function that can be called when we're certain onboarding has completed. When invoked, it calls the `updateUserProfile` with a `completedOnboarding: true` value. 

Also renames `onDone` to `onClose`.  

Follow-up PR will wire up to the final thank you screen, to be invoked. 

cc @artsy/grow-devs 


[GRO-1168]: https://artsyproduct.atlassian.net/browse/GRO-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ