### PR TITLE
fix: PX-5140 - artist url redirect

### DIFF
--- a/src/Apps/Redirects/__tests__/redirectsServerRoutes.jest.ts
+++ b/src/Apps/Redirects/__tests__/redirectsServerRoutes.jest.ts
@@ -1,11 +1,165 @@
 import { Request, NextFunction } from "express"
 import {
-  handlePartner,
+  handlePartnerOverview,
+  handlePartnerWorks,
+  handlePartnerArtist,
+  handlePartnerGenericRedirect,
+  handleFairArtworks,
   handleFair,
   ResWithProfile,
 } from "../redirectsServerRoutes"
 
-describe("handlePartner", () => {
+describe("handlePartnerOverview", () => {
+  let req: Request
+  let res: ResWithProfile
+  let next: jest.Mock<NextFunction>
+
+  beforeEach(() => {
+    jest.resetModules()
+
+    res = ({
+      locals: {
+        profile: {
+          owner: {
+            __typename: "Partner",
+            slug: "white-cube",
+          },
+        },
+      },
+      redirect: jest.fn(),
+    } as unknown) as ResWithProfile
+
+    next = jest.fn()
+  })
+
+  it.each([
+    [
+      "/:id/overview,/:id/about",
+      "/partner/white-cube",
+      "/white-cube/overview",
+      { id: "white-cube" },
+    ],
+    [
+      "/:id/overview,/:id/about",
+      "/partner/white-cube",
+      "/white-cube",
+      { id: "white-cube" },
+    ],
+  ])(
+    "redirects %s to %s",
+    (route: string, result: string, path: string, params: any) => {
+      req = ({
+        route: { path: route },
+        path,
+        params,
+      } as unknown) as Request
+
+      handlePartnerOverview(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith(301, result)
+    }
+  )
+})
+
+describe("handlePartnerWorks", () => {
+  let req: Request
+  let res: ResWithProfile
+  let next: jest.Mock<NextFunction>
+
+  beforeEach(() => {
+    jest.resetModules()
+
+    res = ({
+      locals: {
+        profile: {
+          owner: {
+            __typename: "Partner",
+            slug: "white-cube",
+          },
+        },
+      },
+      redirect: jest.fn(),
+    } as unknown) as ResWithProfile
+
+    next = jest.fn()
+  })
+
+  it.each([
+    [
+      "/:id/shop,/:id/collection",
+      "/partner/white-cube/works",
+      "/white-cube/collection",
+      { id: "white-cube" },
+    ],
+    [
+      "/:id/shop,/:id/collection",
+      "/partner/white-cube/works",
+      "/white-cube/shop",
+      { id: "white-cube" },
+    ],
+  ])(
+    "redirects %s to %s",
+    (route: string, result: string, path: string, params: any) => {
+      req = ({
+        route: { path: route },
+        path,
+        params,
+      } as unknown) as Request
+
+      handlePartnerWorks(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith(301, result)
+    }
+  )
+})
+
+describe("handlePartnerArtist", () => {
+  let req: Request
+  let res: ResWithProfile
+  let next: jest.Mock<NextFunction>
+
+  beforeEach(() => {
+    jest.resetModules()
+
+    res = ({
+      locals: {
+        profile: {
+          owner: {
+            __typename: "Partner",
+            slug: "white-cube",
+          },
+        },
+      },
+      redirect: jest.fn(),
+    } as unknown) as ResWithProfile
+
+    next = jest.fn()
+  })
+
+  it.each([
+    [
+      "/:id/artist/:artistId",
+      "/partner/white-cube/artists/artist_slug",
+      "/white-cube/artist/artist_slug",
+      { artistId: "artist_slug", id: "white-cube" },
+    ],
+  ])(
+    "redirects %s to %s",
+    (route: string, result: string, path: string, params: any) => {
+      req = ({
+        route: { path: route },
+        path,
+        params,
+      } as unknown) as Request
+
+      handlePartnerArtist(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith(301, result)
+    }
+  )
+})
+
+describe("handlePartnerFallbackRedirect", () => {
   let req: Request
   let res: ResWithProfile
   let next: jest.Mock<NextFunction>
@@ -31,12 +185,6 @@ describe("handlePartner", () => {
   it.each([
     ["/:id", "/partner/white-cube", "/white-cube", { id: "white-cube" }],
     [
-      "/:id/overview",
-      "/partner/white-cube",
-      "/white-cube/overview",
-      { id: "white-cube" },
-    ],
-    [
       "/:id/shows",
       "/partner/white-cube/shows",
       "/white-cube/shows",
@@ -55,12 +203,6 @@ describe("handlePartner", () => {
       { id: "white-cube" },
     ],
     [
-      "/:id/artist/:artistId",
-      "/partner/white-cube/artists/artist_slug",
-      "/white-cube/artist/artist_slug",
-      { artistId: "artist_slug", id: "white-cube" },
-    ],
-    [
       "/:id/articles",
       "/partner/white-cube/articles",
       "/white-cube/articles",
@@ -72,30 +214,11 @@ describe("handlePartner", () => {
       "/white-cube/contact",
       { id: "white-cube" },
     ],
-    ["/:id/about", "/partner/white-cube", "/white-cube", { id: "white-cube" }],
-    [
-      "/:id/collection",
-      "/partner/white-cube/works",
-      "/white-cube/collection",
-      { id: "white-cube" },
-    ],
-    [
-      "/:id/shop",
-      "/partner/white-cube/works",
-      "/white-cube/shop",
-      { id: "white-cube" },
-    ],
     [
       "/:id/contact",
       "/partner/white-cube/contact",
       "/white-cube-gallery/contact",
       { id: "white-cube-gallery" },
-    ],
-    [
-      "/:id/artist/:artistId",
-      "/partner/white-cube/artists/artist_slug",
-      "/white-cube-gallery/artist/artist_slug",
-      { artistId: "artist_slug", id: "white-cube-gallery" },
     ],
   ])(
     "redirects %s to %s",
@@ -106,7 +229,7 @@ describe("handlePartner", () => {
         params,
       } as unknown) as Request
 
-      handlePartner(req, res, next)
+      handlePartnerGenericRedirect(req, res, next)
 
       expect(res.redirect).toHaveBeenCalledWith(301, result)
     }
@@ -125,10 +248,52 @@ describe("handlePartner", () => {
       redirect: jest.fn(),
     } as unknown) as ResWithProfile
 
-    handlePartner(req, res, next)
+    handlePartnerGenericRedirect(req, res, next)
 
     expect(res.redirect).not.toHaveBeenCalled()
     expect(next).toHaveBeenCalled()
+  })
+})
+
+describe("handleFairArtworks", () => {
+  let req: Request
+  let res: ResWithProfile
+  let next: jest.Mock<NextFunction>
+
+  beforeEach(() => {
+    jest.resetModules()
+
+    req = ({
+      params: { id: "big-expo" },
+      route: "/:id",
+    } as unknown) as Request
+
+    res = ({
+      locals: {
+        profile: {
+          owner: {
+            __typename: "Fair",
+            slug: "big-expo-2020",
+          },
+        },
+      },
+      redirect: jest.fn(),
+    } as unknown) as ResWithProfile
+
+    next = jest.fn()
+  })
+
+  it("redirects /:profileSlug/browse/artworks to /fair/:fairSlug/artworks", () => {
+    req.params = { id: "big-expo", "0": "artworks" }
+    req.route = { path: "/:id/browse/*" }
+    res.locals.tab = "browse"
+
+    handleFairArtworks(req, res, next)
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      301,
+      "/fair/big-expo-2020/artworks"
+    )
   })
 })
 
@@ -167,29 +332,6 @@ describe("handleFair", () => {
     handleFair(req, res, next)
 
     expect(res.redirect).toHaveBeenCalledWith(301, "/fair/big-expo-2020")
-  })
-
-  it("redirects /:profileSlug/info to /fair/:fairSlug/info", () => {
-    req.params = { id: "big-expo" }
-    req.route = { path: "/:id/:tab*" }
-    res.locals.tab = "info"
-
-    handleFair(req, res, next)
-
-    expect(res.redirect).toHaveBeenCalledWith(301, "/fair/big-expo-2020/info")
-  })
-
-  it("redirects /:profileSlug/browse/artworks to /fair/:fairSlug/artworks", () => {
-    req.params = { id: "big-expo", "0": "artworks" }
-    req.route = { path: "/:id/browse/*" }
-    res.locals.tab = "browse"
-
-    handleFair(req, res, next)
-
-    expect(res.redirect).toHaveBeenCalledWith(
-      301,
-      "/fair/big-expo-2020/artworks"
-    )
   })
 
   it("temporarily redirects to /art-fairs if there is no ID for some reason", () => {

--- a/src/Apps/Redirects/redirectsServerRoutes.tsx
+++ b/src/Apps/Redirects/redirectsServerRoutes.tsx
@@ -112,7 +112,7 @@ export const handlePartnerArtist = (
   )
 }
 
-export const handlePartnerFallbackRedirect = (
+export const handlePartnerGenericRedirect = (
   req: Request,
   res: ResWithProfile,
   next: NextFunction
@@ -140,7 +140,7 @@ export const handleFairArtworks = (
     return res.redirect(302, "/art-fairs")
   }
 
-  return res.redirect(301, `/fair/${fairSlug}/info`)
+  return res.redirect(301, `/fair/${fairSlug}/artworks`)
 }
 
 export const handleFair = (
@@ -211,12 +211,12 @@ redirectsServerRoutes
       "/:id/articles",
       "/:id/contact",
     ],
-    handlePartnerFallbackRedirect
+    handlePartnerGenericRedirect
   )
 
   // Fairs
 
-  // /:id/browse/artworks => /fair/:id/info
+  // /:id/browse/artworks => /fair/:id/artworks
   .get("/:id/browse/artworks", handleFairArtworks)
 
   .get(


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PX-5140]

### Description

<!-- Implementation description -->
It seems that the redirection was broken with the latest changes. The reason for this (and why the tests did not pick this up) is that the tests were passing in the valid `req.route.path` which doesn't actually happen in the real world. When passed an array like is done [here](https://github.com/artsy/force/blob/c9b7c872408e743614419fd0703874b4cee56357/src/Apps/Redirects/redirectsServerRoutes.tsx#L162-L176), the specific path which triggers the function from being run is lost and instead the entire array of routes are passed through to the function, e.g.

```
/:id,/:id/overview,/:id/about,/:id/shows,/:id/works,/:id/collection,/:id/shop,/:id/artists,/:id/artist/:artistId,/:id/articles,/:id/contact
```

This breaks all logic that relies on this specific path, including the artist URL redirect which is found [here](https://github.com/artsy/force/blob/c9b7c872408e743614419fd0703874b4cee56357/src/Apps/Redirects/redirectsServerRoutes.tsx#L93-L99).

I have broken out the logic so that each function only needs to deal with the routes it cares about to avoid this issue. Additionally, as part of these changes, I have removed a route redirection for fair info which was not working and also potentially has not been working for a while. Some discussion about this can be found [here](https://artsy.slack.com/archives/CP9P4KR35/p1658915137403989)

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PX-5140]: https://artsyproduct.atlassian.net/browse/PX-5140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ