### PR TITLE
feat(onboarding): include thank you screen after follow view

### DIFF
--- a/src/Components/Onboarding/Components/OnboardingSteps.tsx
+++ b/src/Components/Onboarding/Components/OnboardingSteps.tsx
@@ -9,6 +9,7 @@ import {
   VIEW_FOLLOW_GALLERIES,
   VIEW_FOLLOW_ARTISTS,
   VIEW_ARTISTS_ON_THE_RISE,
+  VIEW_THANK_YOU,
 } from "../config"
 import { useOnboardingContext } from "../Hooks/useOnboardingContext"
 import { OnboardingWelcome } from "../Views/OnboardingWelcome"
@@ -20,6 +21,7 @@ import { OnboardingTopAuctionLots } from "../Views/OnboardingTopAuctionLots"
 import { OnboardingCuratedArtworks } from "../Views/OnboardingCuratedArtworks"
 import { OnboardingArtistsOnTheRise } from "../Views/OnboardingArtistsOnTheRise"
 import { OnboardingFollowGalleries } from "../Views/OnboardingFollowGalleries"
+import { OnboardingThankYou } from "../Views/OnboardingThankYou"
 
 interface OnboardingStepsProps {}
 
@@ -53,6 +55,9 @@ export const OnboardingSteps: FC<OnboardingStepsProps> = () => {
 
     case VIEW_FOLLOW_GALLERIES:
       return <OnboardingFollowGalleries />
+
+    case VIEW_THANK_YOU:
+      return <OnboardingThankYou />
 
     default:
       return null

--- a/src/Components/Onboarding/Views/OnboardingThankYou.tsx
+++ b/src/Components/Onboarding/Views/OnboardingThankYou.tsx
@@ -1,0 +1,26 @@
+import { Box, Flex, Text } from "@artsy/palette"
+import { FC } from "react"
+import { OnboardingFigure } from "../Components/OnboardingFigure"
+import { OnboardingSplitLayout } from "../Components/OnboardingSplitLayout"
+
+export const OnboardingThankYou: FC = () => {
+  return (
+    <OnboardingSplitLayout
+      left={
+        <OnboardingFigure
+          src="https://files.artsy.net/images/question-one-img.jpg"
+          aspectWidth={1600}
+          aspectHeight={2764}
+          caption="Adegboyega Adesina, Painting of Rechel, 2021"
+        />
+      }
+      right={
+        <Flex flexDirection="column" justifyContent="space-between" p={4}>
+          <Box width="100%">
+            <Text variant="lg-display">Thank you! Now, get outta here!</Text>
+          </Box>
+        </Flex>
+      }
+    />
+  )
+}

--- a/src/Components/Onboarding/config.ts
+++ b/src/Components/Onboarding/config.ts
@@ -20,8 +20,14 @@ export const useConfig = ({ basis, onDone }: UseConfig) => {
             [OPTION_TOP_AUCTION_LOTS]: [VIEW_TOP_AUCTION_LOTS],
             [OPTION_A_CURATED_SELECTION_OF_ARTWORKS]: [VIEW_CURATED_ARTWORKS],
             [OPTION_ARTISTS_ON_THE_RISE]: [VIEW_ARTISTS_ON_THE_RISE],
-            [OPTION_FOLLOW_ARTISTS_IM_INTERESTED_IN]: [VIEW_FOLLOW_ARTISTS],
-            [OPTION_FOLLOW_GALLERIES_I_LOVE]: [VIEW_FOLLOW_GALLERIES],
+            [OPTION_FOLLOW_ARTISTS_IM_INTERESTED_IN]: [
+              VIEW_FOLLOW_ARTISTS,
+              VIEW_THANK_YOU,
+            ],
+            [OPTION_FOLLOW_GALLERIES_I_LOVE]: [
+              VIEW_FOLLOW_GALLERIES,
+              VIEW_THANK_YOU,
+            ],
           },
         },
       ],
@@ -80,5 +86,7 @@ export const useConfig = ({ basis, onDone }: UseConfig) => {
 /* prettier-ignore */ export const VIEW_CURATED_ARTWORKS = "VIEW_CURATED_ARTWORKS"
 /* prettier-ignore */ export const VIEW_ARTISTS_ON_THE_RISE = "VIEW_ARTISTS_ON_THE_RISE"
 /* prettier-ignore */ export const VIEW_FOLLOW_GALLERIES = "VIEW_FOLLOW_GALLERIES"
+
+/* prettier-ignore */ export const VIEW_THANK_YOU = "VIEW_THANK_YOU"
 
 /* prettier-ignore */ export const DECISION_WHERE_WOULD_YOU_LIKE_TO_DIVE_IN = "DECISION_WHERE_WOULD_YOU_LIKE_TO_DIVE_IN"


### PR DESCRIPTION
The type of this PR is: _feat_

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1162]

### Description

<!-- Implementation description -->

This PR is a result of the tickets that address Onboarding Phase 1 QA. There was discussion about adding closure to the onboarding flow, right now I'm unsure of where exactly the `OnboardingThankYou` screen is supposed to go tbh. There was chatter about it going after the `Follow` screens so I included a boilerplate component there for now. Moving it around in the flow is simple because all views and decision views exist in an array.

Also, this PR is a WIP until design provides mocks.

To do:
- [ ] place thank you screen in the correct order in the flow
- [ ] update styling based on design mock
- [ ] testing that it renders in moves through workflow jest test

![onboarding-thankyou](https://user-images.githubusercontent.com/23108927/181302262-7dad1db4-a27a-4009-9045-b57fbdc612dd.gif)



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1162]: https://artsyproduct.atlassian.net/browse/GRO-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ