### PR TITLE
feat(FX-4067): add countdown timer to lot card in "Works By Artists You Follow" rail on Sail/Auction page

### DIFF
--- a/src/Apps/Auction/Components/AuctionWorksByFollowedArtistsRail.tsx
+++ b/src/Apps/Auction/Components/AuctionWorksByFollowedArtistsRail.tsx
@@ -19,7 +19,7 @@ const AuctionWorksByFollowedArtistsRail: React.FC<AuctionWorksByFollowedArtistsR
   }
 
   return (
-    <ArtworkGridContextProvider isAuctionArtwork>
+    <ArtworkGridContextProvider isAuctionArtwork hideLotLabel>
       <Rail
         title="Works By Artists You Follow"
         viewAllOnClick={() => {

--- a/src/Apps/Auction/Components/AuctionWorksByFollowedArtistsRail.tsx
+++ b/src/Apps/Auction/Components/AuctionWorksByFollowedArtistsRail.tsx
@@ -3,6 +3,7 @@ import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
 import { Rail } from "Components/Rail"
 import { extractNodes } from "Utils/extractNodes"
 import { AuctionWorksByFollowedArtistsRail_viewer } from "__generated__/AuctionWorksByFollowedArtistsRail_viewer.graphql"
+import { ArtworkGridContextProvider } from "Components/ArtworkGrid/ArtworkGridContext"
 
 interface AuctionWorksByFollowedArtistsRailProps {
   viewer: AuctionWorksByFollowedArtistsRail_viewer
@@ -18,7 +19,7 @@ const AuctionWorksByFollowedArtistsRail: React.FC<AuctionWorksByFollowedArtistsR
   }
 
   return (
-    <>
+    <ArtworkGridContextProvider isAuctionArtwork>
       <Rail
         title="Works By Artists You Follow"
         viewAllOnClick={() => {
@@ -37,7 +38,7 @@ const AuctionWorksByFollowedArtistsRail: React.FC<AuctionWorksByFollowedArtistsR
           })
         }}
       />
-    </>
+    </ArtworkGridContextProvider>
   )
 }
 

--- a/src/Apps/Auction/Components/__tests__/AuctionWorksByFollowedArtistsRail.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionWorksByFollowedArtistsRail.jest.tsx
@@ -1,4 +1,5 @@
 import { graphql } from "react-relay"
+import { DateTime } from "luxon"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { AuctionWorksByFollowedArtistsRailFragmentContainer } from "../AuctionWorksByFollowedArtistsRail"
 import { AuctionWorksByFollowedArtistsRailTestQuery } from "__generated__/AuctionWorksByFollowedArtistsRailTestQuery.graphql"
@@ -29,5 +30,40 @@ describe("AuctionWorksByFollowedArtistsRail", () => {
   it("renders correct title", () => {
     const wrapper = getWrapper()
     expect(wrapper.text()).toContain("Works By Artists You Follow")
+  })
+
+  it("renders the lot number and countdown timer labels", () => {
+    const baseDate = DateTime.local()
+    const startDate = baseDate.minus({ hours: 1 })
+    const endDate = baseDate.plus({ hours: 1 })
+
+    const wrapper = getWrapper({
+      Viewer: () => ({
+        saleArtworksConnection: {
+          edges: [
+            {
+              node: {
+                sale: {
+                  cascadingEndTimeIntervalMinutes: 1,
+                  extendedBiddingIntervalMinutes: 2,
+                  startAt: startDate.toString(),
+                  endAt: endDate.toString(),
+                  is_auction: true,
+                  is_closed: false,
+                },
+                sale_artwork: {
+                  lotLabel: "123",
+                  endAt: endDate.toString(),
+                  extendedBiddingEndAt: null,
+                },
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(wrapper.text()).toContain("Lot 123")
+    expect(wrapper.text()).toContain("Closes in 59m 59s")
   })
 })

--- a/src/Apps/Auction/Components/__tests__/AuctionWorksByFollowedArtistsRail.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionWorksByFollowedArtistsRail.jest.tsx
@@ -32,7 +32,7 @@ describe("AuctionWorksByFollowedArtistsRail", () => {
     expect(wrapper.text()).toContain("Works By Artists You Follow")
   })
 
-  it("renders the lot number and countdown timer labels", () => {
+  it("renders the countdown timer label", () => {
     const baseDate = DateTime.local()
     const startDate = baseDate.minus({ hours: 1 })
     const endDate = baseDate.plus({ hours: 1 })
@@ -63,7 +63,6 @@ describe("AuctionWorksByFollowedArtistsRail", () => {
       }),
     })
 
-    expect(wrapper.text()).toContain("Lot 123")
     expect(wrapper.text()).toContain("Closes in 59m 59s")
   })
 })

--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -175,17 +175,19 @@ export const Details: React.FC<DetailsProps> = ({
   contextModule,
   ...rest
 }) => {
-  const { isAuctionArtwork } = useArtworkGridContext()
+  const { isAuctionArtwork, hideLotLabel } = useArtworkGridContext()
 
   return (
     <Box>
       {isAuctionArtwork && (
         <Flex flexDirection="row">
-          <Text variant="xs">Lot {rest.artwork?.sale_artwork?.lotLabel}</Text>
+          {!hideLotLabel && (
+            <Text variant="xs">Lot {rest.artwork?.sale_artwork?.lotLabel}</Text>
+          )}
           {rest?.artwork?.sale?.cascadingEndTimeIntervalMinutes &&
             rest?.artwork?.sale_artwork && (
               <>
-                <Spacer mx={0.5} />
+                {!hideLotLabel && <Spacer mx={0.5} />}
                 <LotCloseInfo
                   saleArtwork={rest.artwork.sale_artwork}
                   sale={rest.artwork.sale}

--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -1,4 +1,4 @@
-import { Link, Text, LinkProps, Flex, Spacer, Box } from "@artsy/palette"
+import { Link, Text, LinkProps, Flex, Spacer, Box, Join } from "@artsy/palette"
 import { Details_artwork } from "__generated__/Details_artwork.graphql"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -181,19 +181,23 @@ export const Details: React.FC<DetailsProps> = ({
     <Box>
       {isAuctionArtwork && (
         <Flex flexDirection="row">
-          {!hideLotLabel && (
-            <Text variant="xs">Lot {rest.artwork?.sale_artwork?.lotLabel}</Text>
-          )}
-          {rest?.artwork?.sale?.cascadingEndTimeIntervalMinutes &&
-            rest?.artwork?.sale_artwork && (
-              <>
-                {!hideLotLabel && <Spacer mx={0.5} />}
-                <LotCloseInfo
-                  saleArtwork={rest.artwork.sale_artwork}
-                  sale={rest.artwork.sale}
-                />
-              </>
+          <Join separator={<Spacer mx={0.5} />}>
+            {!hideLotLabel && (
+              <Text variant="xs">
+                Lot {rest.artwork?.sale_artwork?.lotLabel}
+              </Text>
             )}
+
+            {rest?.artwork?.sale?.cascadingEndTimeIntervalMinutes &&
+              rest?.artwork?.sale_artwork && (
+                <>
+                  <LotCloseInfo
+                    saleArtwork={rest.artwork.sale_artwork}
+                    sale={rest.artwork.sale}
+                  />
+                </>
+              )}
+          </Join>
         </Flex>
       )}
       <Flex flexDirection="row" justifyContent="space-between">

--- a/src/Components/ArtworkGrid/ArtworkGridContext.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGridContext.tsx
@@ -9,10 +9,13 @@ interface ArtworkGridContextProps {
    * If its an auction artwork, no need to show bid badge, and show lot number
    */
   isAuctionArtwork?: boolean
+
+  hideLotLabel?: boolean
 }
 
 const ArtworkGridContext = createContext<ArtworkGridContextProps>({
   isAuctionArtwork: false,
+  hideLotLabel: false,
 })
 
 export const ArtworkGridContextProvider: React.FC<ArtworkGridContextProps> = ({


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR solves [FX-4067]

Review app: https://countdown-timer.artsy.net/

### Demo
| Before | After |
| ------------- | ------------- |
| <img width="470" alt="before" src="https://user-images.githubusercontent.com/3513494/181456297-67b77800-6c0f-4f7d-9b0f-f7d7fa3865f1.png"> | <img width="470" alt="after" src="https://user-images.githubusercontent.com/3513494/181456334-915794ad-8549-46a7-a696-04da021cf7d7.png"> |

#### Different states
| Closes on | Closes in | Closed |
| ------------- | ------------- | ------------- |
| <img width="470" alt="after" src="https://user-images.githubusercontent.com/3513494/181457796-eb9eaf15-b4c6-40aa-9670-965ce4d5d0cc.png"> | <img width="458" alt="after-2" src="https://user-images.githubusercontent.com/3513494/181457738-98a70c73-4b63-46bd-a468-800c7224b4d7.png"> | <img width="458" alt="after-3" src="https://user-images.githubusercontent.com/3513494/181458277-848cd244-a15b-4b0b-9590-d24d49917b46.png"> |

### Acceptance Criteria
* Display the countdown timer for artworks in "Works By Artists You Follow" rail on Sail/Auction page
* Display only the countdown timer (without the lot number)
* The countdown timer timer should be displayed above the artist name similar to the artwork grid

<!-- Implementation description -->


[FX-4067]: https://artsyproduct.atlassian.net/browse/FX-4067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ