### PR TITLE
fix: Restore artist CV link 1150

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -114,8 +114,6 @@ const ArtistHeader: React.FC<ArtistHeaderProps> = ({ artist }) => {
           <Column span={6}>
             <ArtistInsightPillsFragmentContainer artist={artist} />
 
-            <Spacer mb={4} />
-
             {!hideBioInHeaderIfPartnerSupplied && artist.biographyBlurb?.text && (
               <>
                 <Text variant="xs" mt={[2, 0]} mb={1}>

--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -17,6 +17,9 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { FollowArtistButtonFragmentContainer } from "Components/FollowButton/FollowArtistButton"
 import { ArtistHeader_artist } from "__generated__/ArtistHeader_artist.graphql"
 import { ArtistInsightPillsFragmentContainer } from "Apps/Artist/Components/ArtistInsights"
+import { RouterLink } from "System/Router/RouterLink"
+
+export const CV_LINK_TEXT = "See all past shows and fair booths"
 
 interface ArtistHeaderProps {
   artist: ArtistHeader_artist
@@ -127,6 +130,14 @@ const ArtistHeader: React.FC<ArtistHeaderProps> = ({ artist }) => {
                     />
                   </HTML>
                 </Text>
+                <Spacer mb={2} />
+              </>
+            )}
+            {!hideBioInHeaderIfPartnerSupplied && (
+              <>
+                <RouterLink to={`/artist/${artist.slug}/cv`}>
+                  {CV_LINK_TEXT}
+                </RouterLink>
               </>
             )}
           </Column>

--- a/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
@@ -3,6 +3,7 @@ import { ArtistHeaderFragmentContainer } from "../ArtistHeader"
 import { useTracking } from "react-tracking"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { screen } from "@testing-library/react"
+import { CV_LINK_TEXT } from "../ArtistHeader"
 
 jest.unmock("react-relay")
 jest.mock("react-tracking")
@@ -55,9 +56,14 @@ describe("ArtistHeader", () => {
     expect(screen.getByText("USA, Jan 1 1980")).toBeInTheDocument()
     expect(screen.getByText("111 Followers")).toBeInTheDocument()
     expect(screen.getByText("biographyBlurbText")).toBeInTheDocument()
+    const cvLink = screen.getByText(CV_LINK_TEXT)
+    expect(cvLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("/artist/artistSlug/cv")
+    )
   })
 
-  it("hides bio section if partner supplied bio", () => {
+  it("hides bio section and cv link if partner supplied bio", () => {
     renderWithRelay({
       Artist: () => ({
         biographyBlurb: { text: "biographyBlurbText", credit: true },
@@ -65,6 +71,7 @@ describe("ArtistHeader", () => {
     })
 
     expect(screen.queryByText("biographyBlurbText")).not.toBeInTheDocument()
+    expect(screen.queryByText(CV_LINK_TEXT)).not.toBeInTheDocument()
   })
 
   it("hides follows if count is zero", () => {

--- a/src/Apps/Artist/Components/ArtistInsights/ArtistInsightPills.tsx
+++ b/src/Apps/Artist/Components/ArtistInsights/ArtistInsightPills.tsx
@@ -1,4 +1,4 @@
-import { Flex, Pill } from "@artsy/palette"
+import { Flex, Pill, Spacer } from "@artsy/palette"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { extractNodes } from "Utils/extractNodes"
@@ -23,27 +23,30 @@ export const ArtistInsightPills: FC<ArtistInsightPillsProps> = ({ artist }) => {
   }
 
   return (
-    <Flex flexDirection="row" flexWrap="wrap" mb={-1}>
-      {artist.insightsList.map(insight => {
-        return (
-          <Pill
-            variant="badge"
-            mr={1}
-            mb={1}
-            key={insight.kind!}
-            onClick={handleClick}
-          >
-            {insight.label}
-          </Pill>
-        )
-      })}
+    <>
+      <Flex flexDirection="row" flexWrap="wrap" mb={-1}>
+        {artist.insightsList.map(insight => {
+          return (
+            <Pill
+              variant="badge"
+              mr={1}
+              mb={1}
+              key={insight.kind!}
+              onClick={handleClick}
+            >
+              {insight.label}
+            </Pill>
+          )
+        })}
 
-      {highAuctionResult?.priceRealized?.display && (
-        <Pill variant="badge" mr={1} mb={1} onClick={handleClick}>
-          High Auction Record
-        </Pill>
-      )}
-    </Flex>
+        {highAuctionResult?.priceRealized?.display && (
+          <Pill variant="badge" mr={1} mb={1} onClick={handleClick}>
+            High Auction Record
+          </Pill>
+        )}
+      </Flex>
+      <Spacer mb={4} />
+    </>
   )
 }
 

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistCareerHighlights.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistCareerHighlights.tsx
@@ -12,6 +12,7 @@ import { ArtistInsightBadgesPlaceholder } from "Apps/Artist/Components/ArtistIns
 import { extractNodes } from "Utils/extractNodes"
 import { RouterLink } from "System/Router/RouterLink"
 import { getENV } from "Utils/getENV"
+import { CV_LINK_TEXT } from "Apps/Artist/Components/ArtistHeader/ArtistHeader"
 
 interface ArtistCareerHighlightsProps {
   artist: ArtistCareerHighlights_artist
@@ -49,6 +50,10 @@ const ArtistCareerHighlights: React.FC<ArtistCareerHighlightsProps> = ({
             </Text>
             <HTML html={text!} variant="sm" />
           </Box>
+          <Spacer my={2} />
+          <RouterLink to={`/artist/${artist.slug}/cv`}>
+            {CV_LINK_TEXT}
+          </RouterLink>
           <Spacer my={4} />
         </>
       )}
@@ -110,6 +115,7 @@ export const ArtistCareerHighlightsFragmentContainer = createFragmentContainer(
           credit
           text
         }
+        slug
       }
     `,
   }

--- a/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistCareerHighlights.jest.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistCareerHighlights.jest.tsx
@@ -2,6 +2,7 @@ import { graphql } from "react-relay"
 import { ArtistCareerHighlightsFragmentContainer } from "../ArtistCareerHighlights"
 import { screen } from "@testing-library/react"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { CV_LINK_TEXT } from "Apps/Artist/Components/ArtistHeader/ArtistHeader"
 
 jest.unmock("react-relay")
 
@@ -79,5 +80,6 @@ describe("ArtistCareerHighlights", () => {
       expect.stringContaining("partner/number-one-best-gallery")
     )
     expect(screen.getByText("this artist rocks")).toBeInTheDocument()
+    expect(screen.queryByText(CV_LINK_TEXT)).toBeInTheDocument()
   })
 })

--- a/src/__generated__/ArtistCareerHighlightsQuery.graphql.ts
+++ b/src/__generated__/ArtistCareerHighlightsQuery.graphql.ts
@@ -63,6 +63,7 @@ fragment ArtistCareerHighlights_artist on Artist {
     credit
     text
   }
+  slug
 }
 
 fragment ArtistInsightAchievements_artist on Artist {
@@ -489,12 +490,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b3660734c7e54691695b7c3cd591658f",
+    "cacheID": "4ecfc965027db8ad13dbd4ea215b0a9e",
     "id": null,
     "metadata": {},
     "name": "ArtistCareerHighlightsQuery",
     "operationKind": "query",
-    "text": "query ArtistCareerHighlightsQuery(\n  $slug: String!\n) {\n  artist(id: $slug) {\n    ...ArtistCareerHighlights_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlights_artist on Artist {\n  ...ArtistInsightBadges_artist\n  ...ArtistInsightAchievements_artist\n  insightAchievements: insights(kind: [SOLO_SHOW, GROUP_SHOW, COLLECTED, REVIEWED, BIENNIAL]) {\n    __typename\n  }\n  insightBadges: insights(kind: [ACTIVE_SECONDARY_MARKET]) {\n    __typename\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    totalCount\n  }\n  artistHighlights: highlights {\n    partnersConnection(first: 1, partnerCategory: [\"blue-chip\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    partner {\n      profile {\n        href\n        id\n      }\n      id\n    }\n    credit\n    text\n  }\n}\n\nfragment ArtistInsightAchievements_artist on Artist {\n  slug\n  insightAchievements: insights(kind: [SOLO_SHOW, GROUP_SHOW, COLLECTED, REVIEWED, BIENNIAL]) {\n    label\n    entities\n  }\n}\n\nfragment ArtistInsightBadges_artist on Artist {\n  insights(kind: [ACTIVE_SECONDARY_MARKET]) {\n    kind\n    label\n    description\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query ArtistCareerHighlightsQuery(\n  $slug: String!\n) {\n  artist(id: $slug) {\n    ...ArtistCareerHighlights_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlights_artist on Artist {\n  ...ArtistInsightBadges_artist\n  ...ArtistInsightAchievements_artist\n  insightAchievements: insights(kind: [SOLO_SHOW, GROUP_SHOW, COLLECTED, REVIEWED, BIENNIAL]) {\n    __typename\n  }\n  insightBadges: insights(kind: [ACTIVE_SECONDARY_MARKET]) {\n    __typename\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    totalCount\n  }\n  artistHighlights: highlights {\n    partnersConnection(first: 1, partnerCategory: [\"blue-chip\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    partner {\n      profile {\n        href\n        id\n      }\n      id\n    }\n    credit\n    text\n  }\n  slug\n}\n\nfragment ArtistInsightAchievements_artist on Artist {\n  slug\n  insightAchievements: insights(kind: [SOLO_SHOW, GROUP_SHOW, COLLECTED, REVIEWED, BIENNIAL]) {\n    label\n    entities\n  }\n}\n\nfragment ArtistInsightBadges_artist on Artist {\n  insights(kind: [ACTIVE_SECONDARY_MARKET]) {\n    kind\n    label\n    description\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistCareerHighlights_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistCareerHighlights_Test_Query.graphql.ts
@@ -59,6 +59,7 @@ fragment ArtistCareerHighlights_artist on Artist {
     credit
     text
   }
+  slug
 }
 
 fragment ArtistInsightAchievements_artist on Artist {
@@ -508,7 +509,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a08109ce5389383f1749fbdd67770bab",
+    "cacheID": "d292dbcbcc624ff3161d53225bb6ba1f",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -625,7 +626,7 @@ return {
     },
     "name": "ArtistCareerHighlights_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistCareerHighlights_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistCareerHighlights_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlights_artist on Artist {\n  ...ArtistInsightBadges_artist\n  ...ArtistInsightAchievements_artist\n  insightAchievements: insights(kind: [SOLO_SHOW, GROUP_SHOW, COLLECTED, REVIEWED, BIENNIAL]) {\n    __typename\n  }\n  insightBadges: insights(kind: [ACTIVE_SECONDARY_MARKET]) {\n    __typename\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    totalCount\n  }\n  artistHighlights: highlights {\n    partnersConnection(first: 1, partnerCategory: [\"blue-chip\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    partner {\n      profile {\n        href\n        id\n      }\n      id\n    }\n    credit\n    text\n  }\n}\n\nfragment ArtistInsightAchievements_artist on Artist {\n  slug\n  insightAchievements: insights(kind: [SOLO_SHOW, GROUP_SHOW, COLLECTED, REVIEWED, BIENNIAL]) {\n    label\n    entities\n  }\n}\n\nfragment ArtistInsightBadges_artist on Artist {\n  insights(kind: [ACTIVE_SECONDARY_MARKET]) {\n    kind\n    label\n    description\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query ArtistCareerHighlights_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistCareerHighlights_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlights_artist on Artist {\n  ...ArtistInsightBadges_artist\n  ...ArtistInsightAchievements_artist\n  insightAchievements: insights(kind: [SOLO_SHOW, GROUP_SHOW, COLLECTED, REVIEWED, BIENNIAL]) {\n    __typename\n  }\n  insightBadges: insights(kind: [ACTIVE_SECONDARY_MARKET]) {\n    __typename\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    totalCount\n  }\n  artistHighlights: highlights {\n    partnersConnection(first: 1, partnerCategory: [\"blue-chip\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    partner {\n      profile {\n        href\n        id\n      }\n      id\n    }\n    credit\n    text\n  }\n  slug\n}\n\nfragment ArtistInsightAchievements_artist on Artist {\n  slug\n  insightAchievements: insights(kind: [SOLO_SHOW, GROUP_SHOW, COLLECTED, REVIEWED, BIENNIAL]) {\n    label\n    entities\n  }\n}\n\nfragment ArtistInsightBadges_artist on Artist {\n  insights(kind: [ACTIVE_SECONDARY_MARKET]) {\n    kind\n    label\n    description\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistCareerHighlights_artist.graphql.ts
+++ b/src/__generated__/ArtistCareerHighlights_artist.graphql.ts
@@ -32,6 +32,7 @@ export type ArtistCareerHighlights_artist = {
         readonly credit: string | null;
         readonly text: string | null;
     } | null;
+    readonly slug: string;
     readonly " $fragmentRefs": FragmentRefs<"ArtistInsightBadges_artist" | "ArtistInsightAchievements_artist">;
     readonly " $refType": "ArtistCareerHighlights_artist";
 };
@@ -252,6 +253,13 @@ return {
       "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
     },
     {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "ArtistInsightBadges_artist"
@@ -266,5 +274,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '568e31aa9ef1a86a7cb4f38bde03418d';
+(node as any).hash = 'a5be3acd46d6516fd2ac44432994b4b9';
 export default node;


### PR DESCRIPTION
This PR restores the CV link using the follow logic:

* if the artist has an editorial bio, then run the link under that text
* if the artist has a partner supplied bio, then run the link under that text
* if the artist has no bio at all then run the link where the editorial bio would normally go

Here's some pictures of those various states:

<img width="1207" alt="Screen Shot 2022-07-28 at 11 12 07 AM" src="https://user-images.githubusercontent.com/79799/181603697-ac6a1b97-cb1e-4e90-ae54-a8bab6bbe07e.png">
<img width="1207" alt="Screen Shot 2022-07-28 at 11 12 17 AM" src="https://user-images.githubusercontent.com/79799/181603709-6c2cab2d-00cc-4d46-b05e-11c4ea133894.png">
<img width="1207" alt="Screen Shot 2022-07-28 at 11 12 21 AM" src="https://user-images.githubusercontent.com/79799/181603713-221b9820-1f49-4c37-97d7-dd554afb7e9a.png">
<img width="1207" alt="Screen Shot 2022-07-28 at 12 47 14 PM" src="https://user-images.githubusercontent.com/79799/181603715-ed9a254f-724b-43de-b7c5-d8c5270caf9e.png">

I'm going to get some missing tests around this - hang tight @TMcMeans!! 🙏 

https://artsyproduct.atlassian.net/browse/1150

/cc @artsy/grow-devs