### PR TITLE
feat(TX-480): add processing approval state to status page

### DIFF
--- a/src/Apps/Order/Routes/__tests__/Status.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Status.jest.tsx
@@ -158,6 +158,21 @@ describe("Status", () => {
       })
     })
 
+    describe("processing approval", () => {
+      it("should say 'Offer accepted. Payment processing.' and have message box", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...OfferOrderWithShippingDetails,
+            displayState: "PROCESSING_APPROVAL",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
+
+        expect(page.text()).toContain("Offer accepted. Payment processing.")
+        expect(page.getMessage()).toBe(1)
+      })
+    })
+
     describe("in transit", () => {
       it("should say confirmed, have message box and the tracking URL", async () => {
         const wrapper = getWrapper({
@@ -382,6 +397,23 @@ describe("Status", () => {
         const page = new StatusTestPage(wrapper)
 
         expect(page.text()).toContain("Your order is confirmed")
+      })
+    })
+
+    describe("processing approval", () => {
+      it("should say 'Your order is confirmed. Payment processing.' and have message box", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...BuyOrderWithShippingDetails,
+            displayState: "PROCESSING_APPROVAL",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
+
+        expect(page.text()).toContain(
+          "Your order is confirmed. Payment processing."
+        )
+        expect(page.getMessage()).toBe(1)
       })
     })
 

--- a/src/Apps/Order/Utils/getStatusCopy.tsx
+++ b/src/Apps/Order/Utils/getStatusCopy.tsx
@@ -75,6 +75,17 @@ export const getStatusCopy = (order, logger?): StatusPageConfig => {
           </>
         ),
       }
+    case "PROCESSING_APPROVAL":
+      return {
+        title: `${approvedTitle(isOfferFlow)}. Payment processing.`,
+        description: (
+          <>
+            Thank you for your purchase. {deliverText(order)}More delivery
+            information will be available once your order ships.
+            {covidNote()}
+          </>
+        ),
+      }
     case "IN_TRANSIT":
       return {
         title: "Your order has shipped",


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-480]

### Description

This PR adds the `processing_approval` state to the status page. 

<!-- Implementation description -->
<img width="1443" alt="Screenshot 2022-07-29 at 11 11 06 AM" src="https://user-images.githubusercontent.com/50849237/181730702-059d8e44-779e-4c44-8b9e-e990f3d93e64.png">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-480]: https://artsyproduct.atlassian.net/browse/TX-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ