### PR TITLE
feat: Update staff info on advisory page 1164

### DIFF
--- a/src/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
+++ b/src/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
@@ -130,8 +130,15 @@ const ADVISORY_SPECIALISTS: Specialist[] = [
       "https://files.artsy.net/images/alexander-forbes-artsy-headshot-2019.jpg",
   },
   {
+    name: "Christine Aschwald",
+    title: "Head of Advisory and Senior Private Sales Director",
+    location: "New York",
+    email: "christine.aschwald@artsy.net",
+    image: "https://files.artsy.net/images/Christine_Aschwald.JPG",
+  },
+  {
     name: "Akanksha Ballaney",
-    title: "Associate Director",
+    title: "Associate Director, Private Sales",
     location: "New York",
     email: "akanksha@artsy.net",
     image: "https://files.artsy.net/images/akanksha.jpeg",
@@ -146,11 +153,26 @@ const ADVISORY_SPECIALISTS: Specialist[] = [
   },
   {
     name: "Robin Roche",
-    title: "Senior Advisor",
+    title: "Senior Private Sales Director",
     location: "New York",
     email: "robin.roche@artsy.net",
     phone: "+1 646 707 9450",
     image: "https://files.artsy.net/images/robin.jpeg",
+  },
+  {
+    name: "Meave Hamill",
+    title: "Senior Advisor, Private Sales",
+    location: "London",
+    email: "meave@artsy.net",
+    image: "https://files.artsy.net/images/meave.jpeg",
+  },
+  {
+    name: "George King",
+    title: "Senior Advisor, Private Sales",
+    location: "London",
+    email: "george.king@artsy.net",
+    phone: "+44 7850 739913",
+    image: "https://files.artsy.net/images/george.jpeg",
   },
   {
     name: "Daniela Bianco-Duppen",
@@ -169,21 +191,6 @@ const ADVISORY_SPECIALISTS: Specialist[] = [
     image: "https://files.artsy.net/images/alexandra.jpeg",
   },
   {
-    name: "Meave Hamill",
-    title: "Advisor",
-    location: "London",
-    email: "meave@artsy.net",
-    image: "https://files.artsy.net/images/meave.jpeg",
-  },
-  {
-    name: "George King",
-    title: "Advisor",
-    location: "London",
-    email: "george.king@artsy.net",
-    phone: "+44 7850 739913",
-    image: "https://files.artsy.net/images/george.jpeg",
-  },
-  {
     name: "Caroline Perkins",
     title: "Advisor",
     location: "New York",
@@ -198,6 +205,20 @@ const ADVISORY_SPECIALISTS: Specialist[] = [
     email: "itziar.ramos@artsy.net",
     phone: "+44 7429 093319",
     image: "https://files.artsy.net/images/itziar.jpeg",
+  },
+  {
+    name: "Adriana Almeida",
+    title: "Senior Private Sales Director",
+    location: "London",
+    email: "adriana.almeida@artsy.net",
+    image: "https://files.artsy.net/images/Adriana_Almeida.jpg",
+  },
+  {
+    name: "Sarah Punzel",
+    title: "Private Sales Coordinator",
+    location: "New York",
+    email: "sarah.punzel@artsy.net",
+    image: "https://files.artsy.net/images/Sarah_Punzel.png",
   },
 ]
 
@@ -300,7 +321,7 @@ const COLLECTOR_SERVICES_SPECIALISTS: Specialist[] = [
 ]
 
 const SPECIALISTS = [
-  { title: "Advisory and Private Sales", specialists: ADVISORY_SPECIALISTS },
+  { title: "Private Sales & Advisory", specialists: ADVISORY_SPECIALISTS },
   { title: "Auctions", specialists: AUCTION_SPECIALISTS },
   { title: "Collector Services", specialists: COLLECTOR_SERVICES_SPECIALISTS },
 ]

--- a/src/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
+++ b/src/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
@@ -12,8 +12,11 @@ import {
 import { MetaTags } from "Components/MetaTags"
 import { FC } from "react"
 import { cropped } from "Utils/resized"
+import { useTranslation } from "react-i18next"
 
 export const MeetTheSpecialistsIndex: FC = () => {
+  const { t } = useTranslation()
+
   return (
     <>
       <MetaTags
@@ -25,7 +28,7 @@ export const MeetTheSpecialistsIndex: FC = () => {
       <Spacer mt={4} />
 
       <Text as="h1" variant={["xl", "xxl"]}>
-        Meet the Specialists
+        {t`specialists.meetTheSpecialists`}
       </Text>
 
       <Spacer mt={2} />
@@ -33,9 +36,7 @@ export const MeetTheSpecialistsIndex: FC = () => {
       <GridColumns>
         <Column span={8}>
           <Text color="black60" variant={["lg-display", "xl"]}>
-            Whether you’re seeking a specific work for your growing collection
-            or wish to sell, our globe-spanning team is ready to source, sell,
-            advise, and research on your behalf.
+            {t`specialists.ourTeamIsReady`}
           </Text>
 
           <Spacer mt={2} />
@@ -57,11 +58,11 @@ export const MeetTheSpecialistsIndex: FC = () => {
       <Spacer mt={12} />
 
       <Join separator={<Separator my={12} />}>
-        {SPECIALISTS.map(({ title, specialists }) => {
+        {SPECIALISTS.map(({ i18nKey, specialists }) => {
           return (
             <GridColumns gridRowGap={4}>
               <Column span={4}>
-                <Text variant="xl">{title}</Text>
+                <Text variant="xl">{t(i18nKey)}</Text>
               </Column>
 
               <Column span={8}>
@@ -321,7 +322,10 @@ const COLLECTOR_SERVICES_SPECIALISTS: Specialist[] = [
 ]
 
 const SPECIALISTS = [
-  { title: "Private Sales & Advisory", specialists: ADVISORY_SPECIALISTS },
-  { title: "Auctions", specialists: AUCTION_SPECIALISTS },
-  { title: "Collector Services", specialists: COLLECTOR_SERVICES_SPECIALISTS },
+  { i18nKey: "specialists.privateSales", specialists: ADVISORY_SPECIALISTS },
+  { i18nKey: "specialists.auctions", specialists: AUCTION_SPECIALISTS },
+  {
+    i18nKey: "specialists.collectorServices",
+    specialists: COLLECTOR_SERVICES_SPECIALISTS,
+  },
 ]

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -1,24 +1,30 @@
 {
-  "navbar":{
-    "show":"Show",
-    "shows":"Shows",
-    "buy":"Buy",
-    "artists":"Artists",
-    "artworks":"Artworks",
-    "galleries":"Galleries",
-    "auctions":"Auctions",
-    "fairs":"Fairs",
-    "museums":"Museums",
-    "viewingRooms":"Viewing Rooms",
-    "nfts":"NFTs",
-    "signup":"Sign Up",
-    "login":"Log In",
-    "sell":"Sell",
-    "priceDatabase":"Price Database",
-    "editorial":"Editorial",
-    "downloadApp":"Download Apps",
+  "navbar": {
+    "show": "Show",
+    "shows": "Shows",
+    "buy": "Buy",
+    "artists": "Artists",
+    "artworks": "Artworks",
+    "galleries": "Galleries",
+    "auctions": "Auctions",
+    "fairs": "Fairs",
+    "museums": "Museums",
+    "viewingRooms": "Viewing Rooms",
+    "nfts": "NFTs",
+    "signup": "Sign Up",
+    "login": "Log In",
+    "sell": "Sell",
+    "priceDatabase": "Price Database",
+    "editorial": "Editorial",
+    "downloadApp": "Download Apps",
     "searchBy": "Search by artist, gallery, style, theme, tag, etc.",
     "searchArtsy": "Search Artsy"
+  },
+  "specialists": {
+    "auctions": "Auctions",
+    "collectorServices": "Collector Services",
+    "meetTheSpecialists": "Meet the Specialists",
+    "ourTeamIsReady": "Whether you’re seeking a specific work for your growing collection or wish to sell, our globe-spanning team is ready to source, sell, advise, and research on your behalf.",
+    "privateSales": "Private Sales & Advisory"
   }
 }
-


### PR DESCRIPTION
~You know me, I just really like a good `quick win` PR on a Friday before vacay.~ 😎 🌴 🍹 

I realized that this PR would be a good chance to try out the i18n work that @lidimayra and friends have put so much time into and I think it worked pretty well! I first made the changes to the page that the ticket called for and then I took a step back and extracted certain strings to the en-EU file. Here's how I thought about the page:

<details>

<summary>meet the specialists: i18n pass</summary>

![meet-the-specialists](https://user-images.githubusercontent.com/79799/181831929-37b4561b-99d1-4a59-801c-dd53ab98f2a7.png)

</details>

In that screenshot I have labels various bits of text with the i18n keys I used to populate the page. I skipped the sections in black with the following reasoning:

* those questions at the top seem pretty static and ripe for extraction but they contain HTML - how should i handle that?
* the information about the people on the page has been extracted already into objects - that doesn't seem worth translating, right?

I'm curious to hear feedback about what I extracted and the names used for the keys - fire away!

https://artsyproduct.atlassian.net/browse/1164

/cc @artsy/grow-devs