### PR TITLE
docs: Fix presentation link

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -9,7 +9,7 @@ We are using the [react-i18next](https://react.i18next.com/) internationalizatio
 The goal of these change is separating the text content from the codebase, so copy updates can handled in a smoother process.
 
 See [this
-presentation](https://docs.google.com/presentation/d/1VT44uoGAaHX0EcDaYwGHiY8VU-fAkOXK6rSHto/edit#slide=id.gd1b1ff661f_0_12) about the benefits we expect to achieve.
+presentation](https://docs.google.com/presentation/d/1VT44uoGAaHX0EcDaYwGHiYVjkYR8VU-fAkOXK6rSHto/edit#slide=id.gd1b1ff661f_0_12) about the benefits we expect to achieve.
 
 ## How to
 


### PR DESCRIPTION
The type of this PR is: **Documentation**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->
Google drive presentation link was incorrect

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ