### PR TITLE
feat: Add empty state CV page GRO-1177

### DIFF
--- a/src/Apps/Artist/Routes/CV/Components/ArtistCVGroup.tsx
+++ b/src/Apps/Artist/Routes/CV/Components/ArtistCVGroup.tsx
@@ -37,7 +37,18 @@ const ArtistCVGroup: FC<ArtistCVGroupProps> = ({ artist, relay, title }) => {
   const nodes = extractNodes(artist.showsConnection)
 
   if (nodes.length === 0) {
-    return null
+    return (
+      <GridColumns>
+        <Column span={12}>
+          <Text variant="lg-display">{title}</Text>
+        </Column>
+        <Column span={8} start={4}>
+          <Text variant="sm-display">
+            This dumb artist has no {title.toLowerCase()} yet.
+          </Text>
+        </Column>
+      </GridColumns>
+    )
   }
 
   const groupedByYear = groupBy(nodes, show => show.startAt)

--- a/src/Apps/Artist/Routes/CV/__tests__/ArtistCVRoute.jest.tsx
+++ b/src/Apps/Artist/Routes/CV/__tests__/ArtistCVRoute.jest.tsx
@@ -23,13 +23,13 @@ describe("ArtistCVRoute", () => {
     },
   })
 
-  it("does not render rail if no shows", () => {
+  it("renders a message with no show info", () => {
     const wrapper = getWrapper({
       Artist: () => ({
         showsConnection: { edges: null },
       }),
     })
-    expect(wrapper.find('[data-test="artistCVGroup"]').length).toBe(0)
+    expect(wrapper.text()).toMatch(/This artist has no/)
   })
 
   it("renders correctly", () => {


### PR DESCRIPTION
Another nice and easy one - I just updated the CV page so that rather than returning `null` when no shows are returned it runs a message. Note that the test I found was not actually testing anything. 😬 I made it better and will go red if the message is not there. 👍 

https://artsyproduct.atlassian.net/browse/GRO-1177

/cc @artsy/grow-devs