### PR TITLE
[WIP]feat(onboarding): flesh out UI for thank you loading screen

### DIFF
--- a/src/Components/Onboarding/Components/OnboardingGene.tsx
+++ b/src/Components/Onboarding/Components/OnboardingGene.tsx
@@ -137,7 +137,7 @@ export const OnboardingGeneQueryRenderer: FC<OnboardingGeneQueryRendererProps> =
         }
 
         if (!props?.gene) {
-          return <OnboardingLoadingCollection />
+          return <OnboardingLoadingCollection type="" />
         }
 
         return (
@@ -147,7 +147,7 @@ export const OnboardingGeneQueryRenderer: FC<OnboardingGeneQueryRendererProps> =
           />
         )
       }}
-      placeholder={<OnboardingLoadingCollection />}
+      placeholder={<OnboardingLoadingCollection type="" />}
     />
   )
 }

--- a/src/Components/Onboarding/Components/OnboardingLoadingCollection.tsx
+++ b/src/Components/Onboarding/Components/OnboardingLoadingCollection.tsx
@@ -2,7 +2,13 @@ import { Flex, Spacer, Spinner, Text } from "@artsy/palette"
 import { FC } from "react"
 import { useOnboardingFadeTransition } from "../Hooks/useOnboardingFadeTransition"
 
-export const OnboardingLoadingCollection: FC = () => {
+interface OnboardingLoadingCollectionProps {
+  type: string
+}
+
+export const OnboardingLoadingCollection: FC<OnboardingLoadingCollectionProps> = ({
+  type,
+}) => {
   const { register } = useOnboardingFadeTransition({ next: () => {} })
 
   return (
@@ -16,15 +22,28 @@ export const OnboardingLoadingCollection: FC = () => {
       height="100%"
       p={4}
     >
-      <Spinner position="static" color="blue100" />
+      {type === "thank-you-loading" ? (
+        <Spinner position="static" color="white100" />
+      ) : (
+        <Spinner position="static" color="blue100" />
+      )}
 
       <Spacer mt={4} />
 
-      <Text variant="lg-display">
-        Great choice
-        <br />
-        We’re finding a collection for you
-      </Text>
+      {type === "thank-you-loading" ? (
+        <Text variant="lg-display" color="white100">
+          Great start
+          <br />
+          Follow more as you browse and <br />
+          continue tailoring Artsy to your tastes
+        </Text>
+      ) : (
+        <Text variant="lg-display">
+          Great choice
+          <br />
+          We’re finding a collection for you
+        </Text>
+      )}
     </Flex>
   )
 }

--- a/src/Components/Onboarding/Views/OnboardingThankYou.tsx
+++ b/src/Components/Onboarding/Views/OnboardingThankYou.tsx
@@ -1,7 +1,6 @@
-import { Box, Flex, Text } from "@artsy/palette"
+import { Box, Image, ResponsiveBox } from "@artsy/palette"
 import { FC, useEffect } from "react"
-import { OnboardingFigure } from "../Components/OnboardingFigure"
-import { OnboardingSplitLayout } from "../Components/OnboardingSplitLayout"
+import { OnboardingLoadingCollection } from "../Components/OnboardingLoadingCollection"
 import { useOnboardingContext } from "../Hooks/useOnboardingContext"
 
 export const OnboardingThankYou: FC = () => {
@@ -12,22 +11,37 @@ export const OnboardingThankYou: FC = () => {
   }, [onComplete])
 
   return (
-    <OnboardingSplitLayout
-      left={
-        <OnboardingFigure
-          src="https://files.artsy.net/images/question-one-img.jpg"
-          aspectWidth={1600}
-          aspectHeight={2764}
-          caption="Adegboyega Adesina, Painting of Rechel, 2021"
+    <Box
+      position="fixed"
+      top={0}
+      left={0}
+      width="100%"
+      height="100%"
+      z-index={1}
+    >
+      <ResponsiveBox aspectWidth={300} aspectHeight={400} maxWidth="100%">
+        <Image
+          src="https://files.artsy.net/images/hirst-damien-the-wonder-of-you.jpg"
+          lazyLoad
+          width="100%"
+          height="100%"
+          style={{
+            objectFit: "cover",
+          }}
+          alt=""
+          z-index={1}
         />
-      }
-      right={
-        <Flex flexDirection="column" justifyContent="space-between" p={4}>
-          <Box width="100%">
-            <Text variant="lg-display">Thank you! Now, get outta here!</Text>
-          </Box>
-        </Flex>
-      }
-    />
+      </ResponsiveBox>
+      <Box
+        position="fixed"
+        top={0}
+        left={0}
+        width="100%"
+        height="100%"
+        z-index={2}
+      >
+        <OnboardingLoadingCollection type="thank-you-loading" />
+      </Box>
+    </Box>
   )
 }


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1162]

### Description

<!-- Implementation description -->

The goal of this WIP PR is to build out the new thank you loading screen that displays after the user is done following artists/galleries in the Onboarding flow. The figma mock is here: 
https://www.figma.com/file/3hH4ezSdEafc6lSgdVP7Hb/Onboarding-App?node-id=2159%3A55399

I am not exactly happy with the way I am trying to make the <OnboardingLoadingCollection /> component code to work for a loader of a different type. Also, working with images is super hard and I'll have to do more reading on how to make a high res image fit perfectly in the background. Open to feedback!


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1162]: https://artsyproduct.atlassian.net/browse/GRO-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ