### PR TITLE
chore: Extract string for cv link text

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -20,7 +20,7 @@ Locales are defined on [src/System/i18n/locales](https://github.com/artsy/force/
 1. Import the library:
 
 ```jsx
-import { useTranslation } from "react-i18next”
+import { useTranslation } from "react-i18next"
 ```
 
 2. Use the `useTranslation` hook on functional components:

--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -18,14 +18,15 @@ import { FollowArtistButtonFragmentContainer } from "Components/FollowButton/Fol
 import { ArtistHeader_artist } from "__generated__/ArtistHeader_artist.graphql"
 import { ArtistInsightPillsFragmentContainer } from "Apps/Artist/Components/ArtistInsights"
 import { RouterLink } from "System/Router/RouterLink"
-
-export const CV_LINK_TEXT = "See all past shows and fair booths"
+import { useTranslation } from "react-i18next"
 
 interface ArtistHeaderProps {
   artist: ArtistHeader_artist
 }
 
 const ArtistHeader: React.FC<ArtistHeaderProps> = ({ artist }) => {
+  const { t } = useTranslation()
+
   const hideBioInHeaderIfPartnerSupplied = Boolean(
     artist.biographyBlurb!.credit
   )
@@ -136,7 +137,7 @@ const ArtistHeader: React.FC<ArtistHeaderProps> = ({ artist }) => {
             {!hideBioInHeaderIfPartnerSupplied && (
               <>
                 <RouterLink to={`/artist/${artist.slug}/cv`}>
-                  {CV_LINK_TEXT}
+                  {t("artistPage.overview.cvLink")}
                 </RouterLink>
               </>
             )}

--- a/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
@@ -3,7 +3,7 @@ import { ArtistHeaderFragmentContainer } from "../ArtistHeader"
 import { useTracking } from "react-tracking"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { screen } from "@testing-library/react"
-import { CV_LINK_TEXT } from "../ArtistHeader"
+import "System/i18n/i18n"
 
 jest.unmock("react-relay")
 jest.mock("react-tracking")
@@ -56,7 +56,7 @@ describe("ArtistHeader", () => {
     expect(screen.getByText("USA, Jan 1 1980")).toBeInTheDocument()
     expect(screen.getByText("111 Followers")).toBeInTheDocument()
     expect(screen.getByText("biographyBlurbText")).toBeInTheDocument()
-    const cvLink = screen.getByText(CV_LINK_TEXT)
+    const cvLink = screen.getByText("See all past shows and fair booths")
     expect(cvLink).toHaveAttribute(
       "href",
       expect.stringContaining("/artist/artistSlug/cv")
@@ -71,7 +71,9 @@ describe("ArtistHeader", () => {
     })
 
     expect(screen.queryByText("biographyBlurbText")).not.toBeInTheDocument()
-    expect(screen.queryByText(CV_LINK_TEXT)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("See all past shows and fair booths")
+    ).not.toBeInTheDocument()
   })
 
   it("hides follows if count is zero", () => {

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistCareerHighlights.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistCareerHighlights.tsx
@@ -12,7 +12,7 @@ import { ArtistInsightBadgesPlaceholder } from "Apps/Artist/Components/ArtistIns
 import { extractNodes } from "Utils/extractNodes"
 import { RouterLink } from "System/Router/RouterLink"
 import { getENV } from "Utils/getENV"
-import { CV_LINK_TEXT } from "Apps/Artist/Components/ArtistHeader/ArtistHeader"
+import { useTranslation } from "react-i18next"
 
 interface ArtistCareerHighlightsProps {
   artist: ArtistCareerHighlights_artist
@@ -21,6 +21,7 @@ interface ArtistCareerHighlightsProps {
 const ArtistCareerHighlights: React.FC<ArtistCareerHighlightsProps> = ({
   artist,
 }) => {
+  const { t } = useTranslation()
   const { credit, partner, text } = artist.biographyBlurb!
   const showPartnerBio =
     Boolean(credit) && Boolean(text) && partner?.profile?.href
@@ -52,7 +53,7 @@ const ArtistCareerHighlights: React.FC<ArtistCareerHighlightsProps> = ({
           </Box>
           <Spacer my={2} />
           <RouterLink to={`/artist/${artist.slug}/cv`}>
-            {CV_LINK_TEXT}
+            {t("artistPage.overview.cvLink")}
           </RouterLink>
           <Spacer my={4} />
         </>

--- a/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistCareerHighlights.jest.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistCareerHighlights.jest.tsx
@@ -2,7 +2,7 @@ import { graphql } from "react-relay"
 import { ArtistCareerHighlightsFragmentContainer } from "../ArtistCareerHighlights"
 import { screen } from "@testing-library/react"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { CV_LINK_TEXT } from "Apps/Artist/Components/ArtistHeader/ArtistHeader"
+import "System/i18n/i18n"
 
 jest.unmock("react-relay")
 
@@ -80,6 +80,8 @@ describe("ArtistCareerHighlights", () => {
       expect.stringContaining("partner/number-one-best-gallery")
     )
     expect(screen.getByText("this artist rocks")).toBeInTheDocument()
-    expect(screen.queryByText(CV_LINK_TEXT)).toBeInTheDocument()
+    expect(
+      screen.queryByText("See all past shows and fair booths")
+    ).toBeInTheDocument()
   })
 })

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -5,6 +5,9 @@
       "fairTitle": "Fair booths",
       "groupTitle": "Group shows",
       "soloTitle": "Solo shows"
+    },
+    "overview": {
+      "cvLink": "See all past shows and fair booths"
     }
   },
   "navbar": {


### PR DESCRIPTION
Returning to the topic of artist CV links and https://github.com/artsy/force/pull/10631. After that PR was merged I realized that this would have been a good time to extract a string into the locale file so I'm opening a PR to do this.

I extracted the string and used the hook/helper to update the two call sites in the implementation code. Then I went back to the testing code and replaced the const with the actual string itself.

What do folks think about this - is this the right way to do this?

/cc @artsy/grow-devs 