### PR TITLE
feat: filter some params from logs

### DIFF
--- a/src/lib/middleware/__tests__/morgan.jest.ts
+++ b/src/lib/middleware/__tests__/morgan.jest.ts
@@ -1,0 +1,53 @@
+import { StringDecoder } from "string_decoder"
+import { logFormat } from "../morgan"
+
+const mockUrl = jest.fn()
+let tokens = {
+  status: jest.fn(),
+  method: jest.fn(),
+  "remote-addr": jest.fn(),
+  "response-time": jest.fn(),
+  "user-agent": jest.fn(),
+  url: mockUrl,
+}
+
+let req = {} as any
+let res = {} as any
+
+let url: string
+
+describe("logFormat", () => {
+  describe("forbidden query param", () => {
+    beforeEach(() => {
+      url =
+        "https://artsy.biz/artworks?foo=abc&setup_intent_client_secret=SECRET&bar=def"
+    })
+
+    it("strips sensitive query params whilst preserving the url", () => {
+      mockUrl.mockReturnValue(url)
+
+      const result = logFormat(tokens, req, res)
+
+      expect(result).toMatch(
+        "https://artsy.biz/artworks?foo=abc&setup_intent_client_secret=[FILTERED]&bar=def"
+      )
+    })
+    it("preserves other params", () => {
+      mockUrl.mockReturnValue(url)
+
+      const result = logFormat(tokens, req, res)
+
+      expect(result).toMatch("foo=abc")
+      expect(result).toMatch("setup_intent_client_secret=[FILTERED]")
+      expect(result).toMatch("bar=def")
+    })
+  })
+  it("leaves an innocent url untouched", () => {
+    url = "https://artsy.biz/artworks?foo=abc&bar=def"
+    mockUrl.mockReturnValue(url)
+
+    const result = logFormat(tokens, req, res)
+
+    expect(result).toMatch(url)
+  })
+})

--- a/src/lib/middleware/morgan.ts
+++ b/src/lib/middleware/morgan.ts
@@ -26,12 +26,22 @@ function skipAssets(req: ArtsyRequest, res: ArtsyResponse): boolean {
   )
 }
 
+const BANNED_PARAMS = ["setup_intent_client_secret"]
+export function filterParams(url: string): string {
+  const cleaned = BANNED_PARAMS.reduce((prevUrl, key) => {
+    const re = new RegExp(`${key}=([^&]+)`)
+    return prevUrl.replace(re, (match, p1) => match.replace(p1, "[FILTERED]"))
+  }, url)
+
+  return cleaned
+}
+
 export function logFormat(
   tokens: any,
   req: ArtsyRequest,
   res: ArtsyResponse
 ): string {
-  const url = tokens.url(req, res)
+  const url = filterParams(tokens.url(req, res))
   const status = tokens.status(req, res)
 
   return (


### PR DESCRIPTION
The type of this PR is: **feat**

This PR adds a small filtering function to our middleware to remove sensitive query parameters from artsy logs. I paired with @artsyjian on the equivalent change [here](https://github.com/artsy/substance/pull/281) in our ingress controller and there was some question whether we could accomplish a similar goal using our logspout configuration here. However, this approach seems to work, and stops logs going to STDOUT locally from displaying sensitive params either. Because the match used to filter is a regular expression (roughly `${term}=(.+)&`) can match on a term up to the equals sign we could simply exclude all keys ending with `secret` which seems like it would be safe. As it is we are targetting a specific key.
