### PR TITLE
ci(test): Speed up tests on CI via parallelism 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,10 +137,9 @@ jobs:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     working_directory: /app
-    environment:
-      - JEST_JUNIT_OUTPUT: reports/junit/js-test-results.xml
+    parallelism: 4
     steps:
-      - run: yarn test
+      - run: yarn test --shard=$(expr $CIRCLE_NODE_INDEX + 1)/$CIRCLE_NODE_TOTAL
 
   type-check:
     docker:

--- a/scripts/jest.sh
+++ b/scripts/jest.sh
@@ -2,16 +2,14 @@
 
 set -ex
 
+
 NODE_ENV=test
 
-function runJest() {
-  node \
-    --expose-gc \
-    --max_old_space_size=4096 \
-    ./node_modules/.bin/jest \
-      --logHeapUsage \
-      --maxWorkers 3 \
-      --config "${1}"
-}
-
-runJest jest.config.js
+node \
+  --expose-gc \
+  --max_old_space_size=4096 \
+  ./node_modules/.bin/jest \
+    --logHeapUsage \
+    --maxWorkers 3 \
+    --config jest.config.js \
+    "$@"


### PR DESCRIPTION
Related https://github.com/artsy/force/pull/10668 

The type of this PR is: **CI**

### Description

#### Jest 

Jest 28 comes with [a new `--shard` argument](https://jestjs.io/docs/next/cli#--shard) which allows one to split the tests across processes all run in parallel. 

Test speeds went from 6+ minutes per run [down to ~2m](https://app.circleci.com/pipelines/github/artsy/force/34836/workflows/ba6af729-8d73-4696-ae37-b00a0445ff4b/jobs/267865/parallel-runs/0?filterBy=ALL), so a 2/3rds reduction in time. If we wanted to decrease it further we could increase the `parallelism` value in our circle config.

The only question here is: Will this in any way constrain other jobs being executed on CircleCI outside of Force? 