### PR TITLE
fix(TX-500): remove underline from US bank account only label 

### DIFF
--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -227,7 +227,7 @@ const getAvailablePaymentMethods = (
   let paymentMethod: CommercePaymentMethodEnum = "CREDIT_CARD"
   const paymentMethods = [
     <BorderedRadio
-      className="payment-method"
+      data-test-id="credit-card"
       key="CREDIT_CARD"
       value={paymentMethod}
       label={
@@ -243,7 +243,7 @@ const getAvailablePaymentMethods = (
   if (availablePaymentMethods.includes("WIRE_TRANSFER")) {
     paymentMethods.push(
       <BorderedRadio
-        className="payment-method"
+        data-test-id="wire-transfer"
         key="WIRE_TRANSFER"
         value={(paymentMethod = "WIRE_TRANSFER")}
         label={
@@ -260,7 +260,7 @@ const getAvailablePaymentMethods = (
   if (availablePaymentMethods.includes("US_BANK_ACCOUNT")) {
     paymentMethods.unshift(
       <RadioWithLabel
-        className="payment-method"
+        data-test-id="us-bank-account"
         key="US_BANK_ACCOUNT"
         value={(paymentMethod = "US_BANK_ACCOUNT")}
         label={

--- a/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -319,7 +319,7 @@ describe("Payment", () => {
     })
 
     it("tracks when the user selects the credit card payment method", async () => {
-      page.selectPaymentMethod(1)
+      page.selectPaymentMethod("CreditCard")
 
       expect(trackEvent).toHaveBeenLastCalledWith({
         action: "clickedPaymentMethod",
@@ -334,8 +334,8 @@ describe("Payment", () => {
     })
 
     it("tracks when the user selects the bank payment method", async () => {
-      page.selectPaymentMethod(1)
-      page.selectPaymentMethod(0)
+      page.selectPaymentMethod("CreditCard")
+      page.selectPaymentMethod("USBankAccount")
 
       // We toggle back and forth to test the selecttion starting from bank account
       expect(
@@ -344,7 +344,7 @@ describe("Payment", () => {
     })
 
     it("renders credit card element when credit card is chosen as payment method", async () => {
-      page.selectPaymentMethod(1)
+      page.selectPaymentMethod("CreditCard")
 
       const creditCardCollapse = page
         .find(CreditCardPickerFragmentContainer)
@@ -355,7 +355,7 @@ describe("Payment", () => {
     })
 
     it("renders bank element when bank transfer is chosen as payment method", async () => {
-      page.selectPaymentMethod(0)
+      page.selectPaymentMethod("USBankAccount")
       const creditCardCollapse = page
         .find(CreditCardPickerFragmentContainer)
         .closest(Collapse)
@@ -367,7 +367,7 @@ describe("Payment", () => {
     })
 
     it("renders description body for bank transfer when selected", async () => {
-      page.selectPaymentMethod(0)
+      page.selectPaymentMethod("USBankAccount")
 
       expect(page.text()).toContain("• Bank transfer is powered by Stripe.")
       expect(page.text()).toContain(
@@ -407,7 +407,7 @@ describe("Payment", () => {
     })
 
     it("renders description body for wire transfer when selected", async () => {
-      await page.selectPaymentMethod(1)
+      await page.selectPaymentMethod("WireTransfer")
 
       expect(page.text()).toContain(
         "• To pay by wire transfer, complete checkout"
@@ -418,7 +418,7 @@ describe("Payment", () => {
     })
 
     it("transitions to review step when wire transfer is chosen", async () => {
-      await page.selectPaymentMethod(0)
+      await page.selectPaymentMethod("CreditCard")
       const submitMutationMock = jest.fn().mockResolvedValue({
         commerceSetPayment: {
           orderOrError: {
@@ -430,7 +430,7 @@ describe("Payment", () => {
         submitMutation: submitMutationMock,
       }))
 
-      await page.selectPaymentMethod(1)
+      await page.selectPaymentMethod("WireTransfer")
       await page.clickSubmit()
 
       expect(submitMutationMock).toHaveBeenCalledWith({
@@ -466,7 +466,7 @@ describe("Payment", () => {
     })
 
     it("works correctly with ACH", () => {
-      page.selectPaymentMethod(0)
+      page.selectPaymentMethod("USBankAccount")
 
       expect(trackEvent).toHaveBeenCalledWith({
         action: "clickedPaymentMethod",
@@ -481,7 +481,7 @@ describe("Payment", () => {
     })
 
     it("works correctly with Credit Card", () => {
-      page.selectPaymentMethod(1)
+      page.selectPaymentMethod("CreditCard")
 
       expect(trackEvent).toHaveBeenCalledWith({
         action: "clickedPaymentMethod",
@@ -496,7 +496,7 @@ describe("Payment", () => {
     })
 
     it("works correctly with Wire Transfer", () => {
-      page.selectPaymentMethod(2)
+      page.selectPaymentMethod("WireTransfer")
 
       expect(trackEvent).toHaveBeenCalledWith({
         action: "clickedPaymentMethod",

--- a/src/Apps/Order/Routes/__tests__/Utils/OrderAppTestPage.tsx
+++ b/src/Apps/Order/Routes/__tests__/Utils/OrderAppTestPage.tsx
@@ -108,8 +108,18 @@ export class OrderAppTestPage extends RootTestPage {
     await this.update()
   }
 
-  async selectPaymentMethod(option: number) {
-    this.find("label.payment-method").at(option).simulate("click")
+  async selectPaymentMethod(paymentMethod: string) {
+    switch (paymentMethod) {
+      case "CreditCard":
+        this.find("label[data-test-id='credit-card']").simulate("click")
+        break
+      case "WireTransfer":
+        this.find("label[data-test-id='wire-transfer']").simulate("click")
+        break
+      case "USBankAccount":
+        this.find("label[data-test-id='us-bank-account']").simulate("click")
+        break
+    }
     await this.update()
   }
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-500]

### Description

This PR is to remove the hover and focus underline style on the radio button "US banks only" label for ACH. This is a one-off fix until a solution for this is developed in Palette.  

My solution was to use the radio description which doesn't have an underline and change its position.

<!-- Implementation description -->
### Screenshots 
<img width="1715" alt="Screenshot 2022-08-03 at 9 52 49 AM" src="https://user-images.githubusercontent.com/50849237/182557103-61a9263b-8262-4fb4-b09f-145569e8736f.png">
<img width="395" alt="Screenshot 2022-08-03 at 9 54 49 AM" src="https://user-images.githubusercontent.com/50849237/182557117-add87625-5660-4283-b462-a2e070ed1ad3.png">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-500]: https://artsyproduct.atlassian.net/browse/TX-500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ