### PR TITLE
fix [CX-2689]: Fix My Collection empty state stretched image

### DIFF
--- a/src/Apps/Settings/Routes/MyCollection/Components/MyCollectionAppDownload.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/Components/MyCollectionAppDownload.tsx
@@ -15,7 +15,7 @@ import { Media } from "Utils/Responsive"
 const image = resized(
   "https://files.artsy.net/images/my-coll-get-app-img.jpg",
   {
-    width: 910,
+    width: 770,
     height: 652,
   }
 )
@@ -78,7 +78,7 @@ const DesktopLayout: React.FC = () => {
       </Column>
 
       <Column span={6}>
-        <ResponsiveBox aspectHeight={652} aspectWidth={910} maxWidth="100%">
+        <ResponsiveBox aspectHeight={652} aspectWidth={770} maxWidth="100%">
           <Image
             src={image.src}
             width="100%"
@@ -97,7 +97,7 @@ const MobileLayout: React.FC = () => {
   return (
     <GridColumns gridRowGap={4} alignItems="center">
       <Column span={6}>
-        <ResponsiveBox aspectHeight={652} aspectWidth={910} maxWidth="100%">
+        <ResponsiveBox aspectHeight={652} aspectWidth={770} maxWidth="100%">
           <Image
             src={image.src}
             width="100%"


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2689]

### Description

This PR updates the aspect ratio of the image in My Collection empty state to fix it being stretched

| - | Before | After |
| -- | -- | -- |
| Mobile view | ![image](https://user-images.githubusercontent.com/20655703/182670419-f2e5fb78-04e9-4293-b45d-16601e13b96e.png) | ![image](https://user-images.githubusercontent.com/20655703/182670453-33ed002d-2b8b-4eab-81a2-4b8b3485eafa.png) |
| Desktop view | ![image](https://user-images.githubusercontent.com/20655703/182671031-326f958c-6961-4227-b500-f037607cfbe9.png) | ![image](https://user-images.githubusercontent.com/20655703/182670966-2be19ed3-b672-411d-85c4-245777c307b4.png) | 






<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2689]: https://artsyproduct.atlassian.net/browse/CX-2689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ