### PR TITLE
feat(about2): Add first pass /about2

### DIFF
--- a/src/Apps/About2/AboutApp2.tsx
+++ b/src/Apps/About2/AboutApp2.tsx
@@ -1,0 +1,193 @@
+import {
+  Box,
+  BoxProps,
+  Button,
+  Flex,
+  Image,
+  ResponsiveBox,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { MetaTags } from "Components/MetaTags"
+import { RouterLink } from "System/Router/RouterLink"
+import { resized } from "Utils/resized"
+import { AboutArtworksRail2QueryRenderer } from "./AboutArtworksRail2"
+import {
+  FullBleedHeader,
+  FullBleedHeaderOverlay,
+} from "Components/FullBleedHeader"
+import { Masonry } from "Components/Masonry"
+
+export const AboutApp2: React.FC = () => {
+  return (
+    <>
+      <MetaTags
+        title="About | Artsy"
+        description="Artsy’s mission is to make all of the world’s art accessible to anyone with an Internet connection."
+        pathname="/about"
+      />
+
+      <FullBleedHeader src="https://files.artsy.net/images/0-aboutHero.png">
+        <FullBleedHeaderOverlay alignItems="center" color="white100" p={4}>
+          <Flex width="100%" flexDirection="column">
+            <Box>
+              <Text variant="xxl" as="h1">
+                The Future of Art Collecting
+              </Text>
+            </Box>
+
+            <RouterLink to="/" textDecoration="none">
+              <Button variant="primaryWhite">CTA</Button>
+            </RouterLink>
+          </Flex>
+        </FullBleedHeaderOverlay>
+      </FullBleedHeader>
+
+      <Spacer mt={4} />
+
+      <Box textAlign="center">
+        <Text as="h1" variant="lg-display">
+          Artsy is for art collectors.
+        </Text>
+        <Text variant={["sm-display", "lg-display"]} mt={2}>
+          As the leading marketplace for the world’s in-demand and emerging
+          artists, we’ve made it easy for new and seasoned collectors alike to
+          discover, buy, and sell art. And so much more. Everything you’ll ever
+          need to collect art, you’ll find on Artsy.
+        </Text>
+      </Box>
+
+      <Spacer mt={6} />
+
+      <Masonry columnCount={[1, 2]}>
+        {SECTION_DATA.map((section, index) => {
+          return (
+            <>
+              <Section
+                title={section.title}
+                description={section.description}
+                caption={section.caption}
+                href={section.href}
+                imageUrl={section.imageUrl}
+                key={index}
+                mb={2}
+              />
+            </>
+          )
+        })}
+      </Masonry>
+
+      <Spacer mt={6} />
+
+      <AboutArtworksRail2QueryRenderer />
+
+      <Spacer my={12} />
+    </>
+  )
+}
+
+interface SectionProps {
+  imageUrl: string
+  title: string
+  description: string
+  caption: string
+  href: string
+}
+
+const Section: React.FC<SectionProps & BoxProps> = ({
+  imageUrl,
+  title,
+  description,
+  caption,
+  href,
+  ...rest
+}) => {
+  const image = resized(imageUrl, {
+    width: 640,
+  })
+  return (
+    <Box {...rest}>
+      <ResponsiveBox aspectWidth={640} aspectHeight={480} maxWidth="100%">
+        <Image
+          src={image.src}
+          width="100%"
+          height="100%"
+          srcSet={image.srcSet}
+          lazyLoad
+          alt=""
+        />
+      </ResponsiveBox>
+
+      <Spacer my={1} />
+
+      <Box>
+        <Text variant={["lg", "xl"]}>{title}</Text>
+        <Text variant="sm">{description}</Text>
+      </Box>
+    </Box>
+  )
+}
+
+const SECTION_DATA: SectionProps[] = [
+  {
+    title: "Find the Art you Want",
+    description:
+      "Be the first to know when the art you’re looking for is available with custom alerts.",
+    caption: "Angela Heisch, Diving for Pearls, 2021",
+    href: "",
+    imageUrl: "https://files.artsy.net/images/1-aboutFind.png",
+  },
+  {
+    title: "Buy Art with Ease",
+    description: "Buy art simply and safely, from purchase to delivery. ",
+    caption: "Andy Warhol, Flowers F&S ll.64, 1970.",
+    href: "",
+    imageUrl: "https://files.artsy.net/images/2-aboutBuy.png",
+  },
+  {
+    title: "Bid in Global Auctions",
+    description: "Bid in leading global auctions, from wherever you are.",
+    caption: "Anna Park, Brenda, 2019.",
+    href: "",
+    imageUrl: "https://files.artsy.net/images/3-aboutBid.png",
+  },
+  {
+    title: "Track the Art Market",
+    description: "Invest smarter with our free auction results database.",
+    caption: "Harold Ancart, Untitled, 2016.",
+    href: "",
+    imageUrl: "https://files.artsy.net/images/4-aboutTrack.png",
+  },
+  {
+    title: "Manage your Collection",
+    description:
+      "Get insight into the market value of artworks in your collection.",
+    caption: "John Baldessari, Marina Abramovic, 2018.",
+    href: "",
+    imageUrl: "https://files.artsy.net/images/5-aboutManage.png",
+  },
+  {
+    title: "Sell Artwork from Your Collection",
+    description:
+      "Sell art from your collection to the right buyer with the help of our experts. ",
+    caption: "John Baldessari, Marina Abramovic, 2018.",
+    href: "",
+    imageUrl: "https://files.artsy.net/images/6-aboutSell.png",
+  },
+  {
+    title: "Discover New Talents",
+    description:
+      "Get to know today’s up-and-coming artists and trends in the art world.",
+    caption: "Evie O'Connor, Delivery Down The Grand Canal, 2021.",
+    href: "",
+    imageUrl: "https://files.artsy.net/images/7-aboutDiscover.png",
+  },
+  {
+    title: "Follow your Favorite Artists",
+    description:
+      "Follow artists for updates on their latest works and career milestones. ",
+    caption: "Kerry James Marshall, Vignette 13, 2008.",
+    href: "https://files.artsy.net/images/8-aboutFollow.png",
+    imageUrl: "https://files.artsy.net/images/8-aboutFollow.png",
+  },
+]

--- a/src/Apps/About2/AboutArtworksRail2.tsx
+++ b/src/Apps/About2/AboutArtworksRail2.tsx
@@ -1,0 +1,108 @@
+import { createFragmentContainer, graphql } from "react-relay"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import { AboutArtworksRail2Query } from "__generated__/AboutArtworksRail2Query.graphql"
+import { AboutArtworksRail2_viewer } from "__generated__/AboutArtworksRail2_viewer.graphql"
+import { Rail } from "Components/Rail"
+import { extractNodes } from "Utils/extractNodes"
+import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  Box,
+  Skeleton,
+  SkeletonBox,
+  SkeletonText,
+  Spacer,
+} from "@artsy/palette"
+
+interface AboutArtworksRail2Props {
+  viewer: AboutArtworksRail2_viewer
+}
+
+export const AboutArtworksRail2: React.FC<AboutArtworksRail2Props> = props => {
+  const artworks = extractNodes(props.viewer.artworksConnection)
+  return (
+    <Rail
+      title="Trending Now"
+      viewAllLabel="View All"
+      viewAllHref="/gene/trending-this-week"
+      getItems={() => {
+        return artworks.map(artwork => (
+          <ShelfArtworkFragmentContainer
+            artwork={artwork}
+            key={artwork.internalID}
+          />
+        ))
+      }}
+    />
+  )
+}
+
+export const AboutArtworksRail2FragmentContainer = createFragmentContainer(
+  AboutArtworksRail2,
+  {
+    viewer: graphql`
+      fragment AboutArtworksRail2_viewer on Viewer {
+        artworksConnection(first: 50, geneIDs: "trending-this-week") {
+          edges {
+            node {
+              ...ShelfArtwork_artwork @arguments(width: 210)
+              internalID
+              slug
+              href
+            }
+          }
+        }
+      }
+    `,
+  }
+)
+
+export const AboutArtworksRail2QueryRenderer: React.FC = () => {
+  return (
+    <SystemQueryRenderer<AboutArtworksRail2Query>
+      placeholder={PLACEHOLDER}
+      query={graphql`
+        query AboutArtworksRail2Query {
+          viewer {
+            ...AboutArtworksRail2_viewer
+          }
+        }
+      `}
+      render={({ props, error }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props?.viewer) {
+          return PLACEHOLDER
+        }
+
+        return <AboutArtworksRail2FragmentContainer viewer={props.viewer} />
+      }}
+    />
+  )
+}
+
+const PLACEHOLDER = (
+  <Skeleton>
+    <Rail
+      title="Trending Now"
+      viewAllLabel="View All"
+      viewAllHref="/gene/trending-this-week"
+      getItems={() => {
+        return [...new Array(8)].map((_, i) => {
+          return (
+            <Box width={200} key={i}>
+              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
+              <Spacer mt={1} />
+              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
+              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
+              <SkeletonText variant="xs">Partner</SkeletonText>
+              <SkeletonText variant="xs">Price</SkeletonText>
+            </Box>
+          )
+        })
+      }}
+    />
+  </Skeleton>
+)

--- a/src/Apps/About2/aboutRoutes2.tsx
+++ b/src/Apps/About2/aboutRoutes2.tsx
@@ -1,0 +1,16 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "System/Router/Route"
+
+const AboutApp = loadable(
+  () => import(/* webpackChunkName: "aboutBundle" */ "./AboutApp2"),
+  {
+    resolveComponent: component => component.AboutApp2,
+  }
+)
+
+export const aboutRoutes2: AppRouteConfig[] = [
+  {
+    path: "/about2",
+    getComponent: () => AboutApp,
+  },
+]

--- a/src/__generated__/AboutArtworksRail2Query.graphql.ts
+++ b/src/__generated__/AboutArtworksRail2Query.graphql.ts
@@ -1,0 +1,642 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type AboutArtworksRail2QueryVariables = {};
+export type AboutArtworksRail2QueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"AboutArtworksRail2_viewer">;
+    } | null;
+};
+export type AboutArtworksRail2Query = {
+    readonly response: AboutArtworksRail2QueryResponse;
+    readonly variables: AboutArtworksRail2QueryVariables;
+};
+
+
+
+/*
+query AboutArtworksRail2Query {
+  viewer {
+    ...AboutArtworksRail2_viewer
+  }
+}
+
+fragment AboutArtworksRail2_viewer on Viewer {
+  artworksConnection(first: 50, geneIDs: "trending-this-week") {
+    edges {
+      node {
+        ...ShelfArtwork_artwork_1s6r3G
+        internalID
+        slug
+        href
+        id
+      }
+    }
+    id
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    endAt
+    cascadingEndTimeIntervalMinutes
+    extendedBiddingIntervalMinutes
+    startAt
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    lotID
+    lotLabel
+    endAt
+    extendedBiddingEndAt
+    formattedEndDateTime
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+  ...NewSaveButton_artwork
+  ...HoverDetails_artwork
+}
+
+fragment HoverDetails_artwork on Artwork {
+  internalID
+  attributionClass {
+    name
+    id
+  }
+  mediumType {
+    filterGene {
+      name
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  href
+}
+
+fragment NewSaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment ShelfArtwork_artwork_1s6r3G on Artwork {
+  image {
+    resized(width: 210) {
+      src
+      srcSet
+      width
+      height
+    }
+    aspectRatio
+    height
+  }
+  imageTitle
+  title
+  href
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v7 = [
+  (v4/*: any*/),
+  (v3/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AboutArtworksRail2Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "AboutArtworksRail2_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "AboutArtworksRail2Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 50
+              },
+              {
+                "kind": "Literal",
+                "name": "geneIDs",
+                "value": "trending-this-week"
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "artworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 210
+                              }
+                            ],
+                            "concreteType": "ResizedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "resized",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "width",
+                                "storageKey": null
+                              },
+                              (v0/*: any*/)
+                            ],
+                            "storageKey": "resized(width:210)"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          },
+                          (v0/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "imageTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v3/*: any*/),
+                          (v1/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v1/*: any*/),
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "cascadingEndTimeIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "startAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/),
+                          {
+                            "alias": "is_preview",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isPreview",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "display_timely_at",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "displayTimelyAt",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotID",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotLabel",
+                            "storageKey": null
+                          },
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingEndAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "formattedEndDateTime",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v6/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v6/*: any*/),
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "AttributionClass",
+                        "kind": "LinkedField",
+                        "name": "attributionClass",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkMedium",
+                        "kind": "LinkedField",
+                        "name": "mediumType",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Gene",
+                            "kind": "LinkedField",
+                            "name": "filterGene",
+                            "plural": false,
+                            "selections": (v7/*: any*/),
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_biddable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isBiddable",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v3/*: any*/)
+            ],
+            "storageKey": "artworksConnection(first:50,geneIDs:\"trending-this-week\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2f5b20a350370ffe87f6a630cbe89540",
+    "id": null,
+    "metadata": {},
+    "name": "AboutArtworksRail2Query",
+    "operationKind": "query",
+    "text": "query AboutArtworksRail2Query {\n  viewer {\n    ...AboutArtworksRail2_viewer\n  }\n}\n\nfragment AboutArtworksRail2_viewer on Viewer {\n  artworksConnection(first: 50, geneIDs: \"trending-this-week\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork_1s6r3G\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+  }
+};
+})();
+(node as any).hash = '9167b791918af04b2024e64fb29e35a8';
+export default node;

--- a/src/__generated__/AboutArtworksRail2_viewer.graphql.ts
+++ b/src/__generated__/AboutArtworksRail2_viewer.graphql.ts
@@ -1,0 +1,115 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type AboutArtworksRail2_viewer = {
+    readonly artworksConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly slug: string;
+                readonly href: string | null;
+                readonly " $fragmentRefs": FragmentRefs<"ShelfArtwork_artwork">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "AboutArtworksRail2_viewer";
+};
+export type AboutArtworksRail2_viewer$data = AboutArtworksRail2_viewer;
+export type AboutArtworksRail2_viewer$key = {
+    readonly " $data"?: AboutArtworksRail2_viewer$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"AboutArtworksRail2_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "AboutArtworksRail2_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 50
+        },
+        {
+          "kind": "Literal",
+          "name": "geneIDs",
+          "value": "trending-this-week"
+        }
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "kind": "LinkedField",
+      "name": "artworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "FilterArtworksEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "slug",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "href",
+                  "storageKey": null
+                },
+                {
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "width",
+                      "value": 210
+                    }
+                  ],
+                  "kind": "FragmentSpread",
+                  "name": "ShelfArtwork_artwork"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artworksConnection(first:50,geneIDs:\"trending-this-week\")"
+    }
+  ],
+  "type": "Viewer",
+  "abstractKey": null
+};
+(node as any).hash = '68de5b6d2fa2f7af6dcb83c2c048f626';
+export default node;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,5 @@
 import { aboutRoutes } from "Apps/About/aboutRoutes"
+import { aboutRoutes2 } from "Apps/About2/aboutRoutes2"
 import { adminRoutes } from "Apps/Admin/adminRoutes"
 import { AppRouteConfig } from "System/Router/Route"
 import { artAppraisalsRoutes } from "Apps/ArtAppraisals/artAppraisalsRoutes"
@@ -50,6 +51,7 @@ import { newForYouRoutes } from "Apps/NewForYou/newForYouRoutes"
 export const getAppRoutes = (): AppRouteConfig[] => {
   return buildAppRoutes([
     { routes: aboutRoutes },
+    { routes: aboutRoutes2 },
     { routes: adminRoutes },
     { routes: artAppraisalsRoutes },
     { routes: articleRoutes },


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR solves [GRO-1154]

### Description

This creates a new /about2 route, with the first pass of the new layout. Note there are no links on the subsections yet; we're still working out the designs. 

Figma: https://www.figma.com/file/nVRxXK7ChPHqMJ0NAQsDQA/CVP?node-id=138%3A1968

[GRO-1154]: https://artsyproduct.atlassian.net/browse/GRO-1154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

cc @artsy/grow-devs 