### PR TITLE
fix [CX-2714]: Update My Collection download app badges logic

### DIFF
--- a/src/Apps/Settings/Routes/MyCollection/Components/DownloadAppBadgesDark.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/Components/DownloadAppBadgesDark.tsx
@@ -1,0 +1,61 @@
+import { Box, Flex, Image, Spacer } from "@artsy/palette"
+import { RouterLink } from "System/Router/RouterLink"
+import {
+  useDeviceDetection,
+  Device,
+  DOWNLOAD_APP_URLS,
+} from "Utils/Hooks/useDeviceDetection"
+
+export const DownloadAppBadgesDark: React.FC = () => {
+  const { device } = useDeviceDetection()
+
+  if (device === Device.Android) {
+    return <PlayStoreBadge />
+  }
+
+  if (device === Device.iPhone) {
+    return <AppStoreBadge />
+  }
+
+  return (
+    <Flex>
+      <AppStoreBadge />
+
+      <Spacer ml={2} />
+
+      <PlayStoreBadge />
+    </Flex>
+  )
+}
+
+const PlayStoreBadge: React.FC = () => {
+  return (
+    <RouterLink to={DOWNLOAD_APP_URLS[Device.Android]} target="_blank">
+      <Box width={136} height={40}>
+        <Image
+          src="https://files.artsy.net/images/download-android-app.svg"
+          width="100%"
+          height="100%"
+          alt="android play store button"
+          loading="lazy"
+        />
+      </Box>
+    </RouterLink>
+  )
+}
+
+const AppStoreBadge: React.FC = () => {
+  return (
+    <RouterLink to={DOWNLOAD_APP_URLS[Device.iPhone]} target="_blank">
+      <Box width={120} height={40}>
+        <Image
+          src="https://files.artsy.net/images/download-ios-app.svg"
+          width="100%"
+          height="100%"
+          alt="ios app store button"
+          loading="lazy"
+        />
+      </Box>
+    </RouterLink>
+  )
+}

--- a/src/Apps/Settings/Routes/MyCollection/Components/DownloadAppBadgesDark.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/Components/DownloadAppBadgesDark.tsx
@@ -7,13 +7,13 @@ import {
 } from "Utils/Hooks/useDeviceDetection"
 
 export const DownloadAppBadgesDark: React.FC = () => {
-  const { device } = useDeviceDetection()
+  const { device: deviceOS } = useDeviceDetection()
 
-  if (device === Device.Android) {
+  if (deviceOS === Device.Android) {
     return <PlayStoreBadge />
   }
 
-  if (device === Device.iPhone) {
+  if (deviceOS === Device.iPhone) {
     return <AppStoreBadge />
   }
 

--- a/src/Apps/Settings/Routes/MyCollection/Components/MyCollectionAppDownload.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/Components/MyCollectionAppDownload.tsx
@@ -1,16 +1,7 @@
-import {
-  Box,
-  Column,
-  Flex,
-  GridColumns,
-  Image,
-  ResponsiveBox,
-  Spacer,
-  Text,
-} from "@artsy/palette"
-import { RouterLink } from "System/Router/RouterLink"
+import { Column, GridColumns, Image, ResponsiveBox, Text } from "@artsy/palette"
 import { resized } from "Utils/resized"
 import { Media } from "Utils/Responsive"
+import { DownloadAppBadgesDark } from "./DownloadAppBadgesDark"
 
 const image = resized(
   "https://files.artsy.net/images/my-coll-get-app-img.jpg",
@@ -18,42 +9,6 @@ const image = resized(
     width: 770,
     height: 652,
   }
-)
-
-const AppStoreBadges = () => (
-  <Flex>
-    <RouterLink
-      to="https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080"
-      target="_blank"
-    >
-      <Box width={120} height={40}>
-        <Image
-          src="https://files.artsy.net/images/download-ios-app.svg"
-          width="100%"
-          height="100%"
-          alt="ios app store button"
-          loading="lazy"
-        />
-      </Box>
-    </RouterLink>
-
-    <Spacer ml={2} />
-
-    <RouterLink
-      to={"https://play.google.com/store/apps/details?id=net.artsy.app"}
-      target="_blank"
-    >
-      <Box width={120} height={40}>
-        <Image
-          src="https://files.artsy.net/images/download-android-app.svg"
-          width="100%"
-          height="100%"
-          alt="android play store button"
-          loading="lazy"
-        />
-      </Box>
-    </RouterLink>
-  </Flex>
 )
 
 const DescriptionColumn = () => (
@@ -66,7 +21,7 @@ const DescriptionColumn = () => (
       Discover all the features of My Collection on the Artsy app. Coming soon
       also on web.
     </Text>
-    <AppStoreBadges />
+    <DownloadAppBadgesDark />
   </>
 )
 


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2714]

### Description
This PR updates the download badges logic inside My Collection empty state to show the badge according to the device (Play Store for Androids and App Store for iPhones)

| iPhone | Android |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/20655703/182819860-361921f4-5402-4951-b15d-5d4f576c3f69.png) | ![image](https://user-images.githubusercontent.com/20655703/182819893-af4f85d5-be23-41b7-b7ae-1b41f3a0f981.png) |


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2714]: https://artsyproduct.atlassian.net/browse/CX-2714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ