### PR TITLE
fix(RouterLink): Prevent Disabled RouterLink from routing to top of page

### DIFF
--- a/src/Components/Artwork/Metadata.tsx
+++ b/src/Components/Artwork/Metadata.tsx
@@ -6,7 +6,6 @@ import { BoxProps } from "@artsy/palette"
 import { RouterLink } from "System/Router/RouterLink"
 import { AuthContextModule } from "@artsy/cohesion"
 import styled from "styled-components"
-import { useRouter } from "System/Router/useRouter"
 
 export interface MetadataProps
   extends BoxProps,
@@ -37,12 +36,11 @@ export const Metadata: React.FC<MetadataProps> = ({
   showSaveButton,
   ...rest
 }) => {
-  const { match } = useRouter()
   const LinkContainer = disableRouterLinking ? DisabledLink : RouterLink
 
   return (
     <LinkContainer
-      to={disableRouterLinking ? match.location.pathname : artwork.href}
+      to={disableRouterLinking ? null : artwork.href}
       display="block"
       textDecoration="none"
       textAlign="left"
@@ -65,7 +63,7 @@ export const Metadata: React.FC<MetadataProps> = ({
 }
 
 const DisabledLink = styled(RouterLink)`
-  cursor: not-allowed;
+  cursor: default;
 `
 
 export default createFragmentContainer(Metadata, {

--- a/src/System/Router/RouterLink.tsx
+++ b/src/System/Router/RouterLink.tsx
@@ -42,7 +42,9 @@ export const RouterLink: React.FC<RouterLinkProps> = React.forwardRef(
       return <RouterAwareLink to={to ?? ""} {...deprecated} {...rest} />
     }
 
-    return <RouterUnawareLink href={to ?? ""} {...deprecated} {...rest} />
+    return (
+      <RouterUnawareLink href={to ?? undefined} {...deprecated} {...rest} />
+    )
   }
 )
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves []

### Description
- When a RouterLink's `to` prop is passed a `null`, onClick automatically jumps to top of page. This PR fixes that.
<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ