### PR TITLE
chore(GRO-1190): change copy of new works for you

### DIFF
--- a/src/Apps/Home/Components/HomeWorksForYouTabBar.tsx
+++ b/src/Apps/Home/Components/HomeWorksForYouTabBar.tsx
@@ -14,7 +14,7 @@ export const HomeWorksForYouTabBar: React.FC = () => {
 
   return (
     <Tabs>
-      <Tab name="New Works For You">
+      <Tab name="New Works for You">
         <HomeNewWorksForYouRailQueryRenderer />
       </Tab>
       <Tab name="New Works by Artists You Follow">

--- a/src/Apps/Home/__tests__/HomeWorksForYouTabBar.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeWorksForYouTabBar.jest.tsx
@@ -21,7 +21,7 @@ describe("HomeWorksForYouTabBar", () => {
 
   it("renders the new for you tab by default", () => {
     const wrapper = getWrapper()
-    expect(wrapper.text()).toContain("New Works For You")
+    expect(wrapper.text()).toContain("New Works for You")
     expect(wrapper.text()).toContain("New Works by Artists You Follow")
     expect(wrapper.text()).toContain("Recently Viewed")
 

--- a/src/Apps/NewForYou/NewForYouApp.tsx
+++ b/src/Apps/NewForYou/NewForYouApp.tsx
@@ -21,7 +21,7 @@ export const NewForYouApp: FC<NewForYouAppProps> = ({ viewer }) => {
       <Spacer mt={2} />
       <MetaTags title="New For You" />
       <Text variant="xl" mt={4}>
-        New Works For You
+        New Works for You
       </Text>
       <Spacer mt={4} />
       {!isLoggedIn && (

--- a/src/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
+++ b/src/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
@@ -38,7 +38,7 @@ describe("NewForYouApp", () => {
     renderWithRelay()
 
     expect(screen.getByText("MetaTags")).toBeInTheDocument()
-    expect(screen.getByText("New Works For You")).toBeInTheDocument()
+    expect(screen.getByText("New Works for You")).toBeInTheDocument()
   })
 
   it("displays expected messaging for logged out users", () => {


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1190]

### Description

Just a tiny copy change

`New Works For You` -> `New Works for You`

#### Screenshots

![Screenshot 2022-08-05 at 17 31 35](https://user-images.githubusercontent.com/21178754/183111098-a3949d04-7eed-4a07-a231-1be653ce0789.png)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1190]: https://artsyproduct.atlassian.net/browse/GRO-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ