### PR TITLE
chore(navbar): Remove focus state on logo in navbar

### DIFF
--- a/src/Components/NavBar/NavBarPrimaryLogo.tsx
+++ b/src/Components/NavBar/NavBarPrimaryLogo.tsx
@@ -2,7 +2,6 @@ import * as React from "react"
 import { ArtsyMarkIcon } from "@artsy/palette"
 import styled from "styled-components"
 import { RouterLink, RouterLinkProps } from "System/Router/RouterLink"
-import { themeGet } from "@styled-system/theme-get"
 
 export const NavBarPrimaryLogo: React.FC<Omit<
   RouterLinkProps,
@@ -23,13 +22,5 @@ const HitArea = styled(RouterLink)`
 
   > svg {
     box-sizing: content-box;
-  }
-
-  &:focus {
-    outline: none;
-
-    > svg {
-      fill: ${themeGet("colors.brand")};
-    }
   }
 `


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [GRO-1194]

### Description

As a number of people have flagged this as (seemingly) a bug, this removes the blue focus state on the logo in the navbar. If we can figure out a way to make the behavior feel a little more solid then lets give it a shot (as I assume this was done for a specific reason). 


[GRO-1194]: https://artsyproduct.atlassian.net/browse/GRO-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ