### PR TITLE
chore: add redis to installed services

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,6 +12,11 @@ if [[ ! -z $NVM_DIR ]]; then # skip if nvm is not available
   nvm install
 fi
 
+echo "Installing dependencies from Homebrew..."
+brew bundle --file=- <<EOF
+brew 'redis', restart_service: true
+EOF
+
 echo "Installing dependencies..."
 yarn install || (npm install --global yarn@latest && yarn install)
 


### PR DESCRIPTION
The type of this PR is: **enhancement**

### Description

I noticed when setting up Artsy services on a loaner recently that Force didn't include Redis in its setup script despite requiring it. Adding it here to make that explicit!
