### PR TITLE
chore(compiler): Add .swc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 .env
 .env.*
+.swc
 .yalc
 *.csv
 *.dat

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 The type of this PR is: **TYPE**
 
-<!-- Bugfix/Feature/Enhancement/Documentation -->
+<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->
 
 <!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
      The Jira integration will turn it into a clickable link for you. -->


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

This adds the `.swc` output folder to `.gitignore` and also updates our PR template to include all of the categories from Semantic Commit 
