### PR TITLE
feat(onboarding): define analytics tracking for onboarding user events

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "superagent": "3.8.3"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.59.0",
+    "@artsy/cohesion": "4.61.0",
     "@artsy/commerce_helpers": "artsy/commerce_helpers",
     "@artsy/detect-responsive-traits": "^0.1.0",
     "@artsy/eigen-web-association": "^1.5.3",

--- a/src/Components/Onboarding/Hooks/useOnboardingTracking.tsx
+++ b/src/Components/Onboarding/Hooks/useOnboardingTracking.tsx
@@ -1,0 +1,128 @@
+import { useTracking } from "react-tracking"
+import { useAnalyticsContext } from "System"
+import {
+  ActionType,
+  ContextModule,
+  StartedOnboarding,
+  CompletedOnboarding,
+  OnboardingUserInputData,
+  // FollowedArtist,
+  // FollowedPartner,
+  // FollowedGene,
+  // followedPartner,
+  // unfollowedPartner,
+  // followedArtist,
+  // unfollowedArtist,
+  // followedGene,
+  // unfollowedGene,
+} from "@artsy/cohesion"
+
+export const useOnboardingTracking = () => {
+  const { trackEvent } = useTracking()
+
+  const {
+    contextPageOwnerId,
+    contextPageOwnerType,
+    contextPageOwnerSlug,
+  } = useAnalyticsContext()
+
+  if (!contextPageOwnerId || !contextPageOwnerType || !contextPageOwnerSlug) {
+    console.warn("Missing analytics context")
+  }
+
+  const context = {
+    context_page_owner_id: contextPageOwnerId,
+    context_page_owner_type: contextPageOwnerType,
+    context_page_owner_slug: contextPageOwnerSlug,
+  }
+
+  return {
+    // user clicks get started
+    userStartedOnboarding: () => {
+      const payload: StartedOnboarding = {
+        action: ActionType.startedOnboarding,
+        ...context,
+      }
+
+      trackEvent(payload)
+    },
+
+    // user clicks next after answering "have you bought art before"
+    userAnsweredCollectorQuestion: () => {
+      const payload: OnboardingUserInputData = {
+        action: ActionType.onboardingUserInputData,
+        context_module: ContextModule.onboardingCollectorLevel,
+        data_input: "[userCollectorLevel]",
+        ...context,
+      }
+
+      trackEvent(payload)
+    },
+
+    // user clicks next after answering "what do you love most about art"
+    userAnsweredInterestQuestion: () => {
+      const payload: OnboardingUserInputData = {
+        action: ActionType.onboardingUserInputData,
+        context_module: ContextModule.onboardingInterests,
+        data_input: "[userInterests]",
+        ...context,
+      }
+
+      trackEvent(payload)
+    },
+
+    // user clicks next after answering "what would you like to see first"
+    userAnsweredActivityQuestion: () => {
+      const payload: OnboardingUserInputData = {
+        action: ActionType.onboardingUserInputData,
+        context_module: ContextModule.onboardingActivity,
+        data_input: "[userActivity]",
+        ...context,
+      }
+
+      trackEvent(payload)
+    },
+
+    // user follows or unfollows a artist
+    trackArtistFollows: isFollowed => {
+      // const payload: FollowedArtist = {
+      //   action: ActionType.followedArtist,
+      //   context_module: ContextModule.onboardingFlow,
+      //   ...context,
+      // }
+      // change payload based on follow or unfollow
+      // trackEvent(isFollowed ? unfollowedArtist() : followedArtist())
+    },
+
+    // user follows or unfollows a gallery
+    trackGalleryFollows: isFollowed => {
+      // const payload: FollowedPartner = {
+      //   action: ActionType.followedPartner,
+      //   context_module: ContextModule.onboardingFlow,
+      //   ...context,
+      // }
+      // change payload based on follow or unfollow
+      // trackEvent(isFollowed ? unfollowedPartner() : followedPartner())
+    },
+
+    // user follows or unfollows a gene
+    trackGeneFollows: isFollowed => {
+      // const payload: FollowedGene = {
+      //   action: ActionType.followedGene,
+      //   context_module: ContextModule.onboardingFlow,
+      //   ...context,
+      // }
+      // change payload based on follow or unfollow
+      // trackEvent(isFollowed ? unfollowedGene() : followedGene())
+    },
+
+    // whenever we decide onboarding is complete
+    userCompletedOnboarding: () => {
+      const payload: CompletedOnboarding = {
+        action: ActionType.completedOnboarding,
+      }
+
+      trackEvent(payload)
+    },
+  }
+}

--- a/src/Components/Onboarding/Hooks/useOnboardingTracking.tsx
+++ b/src/Components/Onboarding/Hooks/useOnboardingTracking.tsx
@@ -1,119 +1,139 @@
 import { useTracking } from "react-tracking"
-import { useAnalyticsContext } from "System"
 import {
   ActionType,
   ContextModule,
   StartedOnboarding,
   CompletedOnboarding,
   OnboardingUserInputData,
-  // FollowedArtist,
-  // FollowedPartner,
-  // FollowedGene,
-  // followedPartner,
-  // unfollowedPartner,
-  // followedArtist,
-  // unfollowedArtist,
-  // followedGene,
-  // unfollowedGene,
+  OwnerType,
+  FollowedArtist,
+  FollowedPartner,
+  FollowedGene,
+  UnfollowedArtist,
+  UnfollowedPartner,
+  UnfollowedGene,
 } from "@artsy/cohesion"
+import { getContextPageFromClient } from "lib/getContextPage"
 
 export const useOnboardingTracking = () => {
   const { trackEvent } = useTracking()
-
-  const {
-    contextPageOwnerId,
-    contextPageOwnerType,
-    contextPageOwnerSlug,
-  } = useAnalyticsContext()
-
-  if (!contextPageOwnerId || !contextPageOwnerType || !contextPageOwnerSlug) {
-    console.warn("Missing analytics context")
-  }
-
-  const context = {
-    context_page_owner_id: contextPageOwnerId,
-    context_page_owner_type: contextPageOwnerType,
-    context_page_owner_slug: contextPageOwnerSlug,
-  }
 
   return {
     // user clicks get started
     userStartedOnboarding: () => {
       const payload: StartedOnboarding = {
         action: ActionType.startedOnboarding,
-        ...context,
       }
 
       trackEvent(payload)
     },
 
     // user clicks next after answering "have you bought art before"
-    userAnsweredCollectorQuestion: () => {
+    userAnsweredCollectorQuestion: response => {
       const payload: OnboardingUserInputData = {
         action: ActionType.onboardingUserInputData,
         context_module: ContextModule.onboardingCollectorLevel,
-        data_input: "[userCollectorLevel]",
-        ...context,
+        data_input: response,
       }
 
       trackEvent(payload)
     },
 
     // user clicks next after answering "what do you love most about art"
-    userAnsweredInterestQuestion: () => {
+    userAnsweredInterestQuestion: response => {
       const payload: OnboardingUserInputData = {
         action: ActionType.onboardingUserInputData,
         context_module: ContextModule.onboardingInterests,
-        data_input: "[userInterests]",
-        ...context,
+        data_input: response,
       }
 
       trackEvent(payload)
     },
 
     // user clicks next after answering "what would you like to see first"
-    userAnsweredActivityQuestion: () => {
+    userAnsweredActivityQuestion: response => {
       const payload: OnboardingUserInputData = {
         action: ActionType.onboardingUserInputData,
         context_module: ContextModule.onboardingActivity,
-        data_input: "[userActivity]",
-        ...context,
+        data_input: response,
       }
 
       trackEvent(payload)
     },
 
     // user follows or unfollows a artist
-    trackArtistFollows: isFollowed => {
-      // const payload: FollowedArtist = {
-      //   action: ActionType.followedArtist,
-      //   context_module: ContextModule.onboardingFlow,
-      //   ...context,
-      // }
-      // change payload based on follow or unfollow
-      // trackEvent(isFollowed ? unfollowedArtist() : followedArtist())
+    trackArtistFollows: (isFollowed, internalID) => {
+      const contextPage = getContextPageFromClient()
+
+      const followPayload: FollowedArtist = {
+        action: ActionType.followedArtist,
+        context_module: ContextModule.onboardingFlow,
+        context_owner_type: OwnerType.savesAndFollows,
+        owner_id: internalID,
+        owner_slug: contextPage?.pageSlug!,
+        owner_type: OwnerType.artist,
+      }
+
+      const unfollowPayload: UnfollowedArtist = {
+        action: ActionType.unfollowedArtist,
+        context_module: ContextModule.onboardingFlow,
+        context_owner_type: OwnerType.savesAndFollows,
+        owner_id: internalID,
+        owner_slug: contextPage?.pageSlug!,
+        owner_type: OwnerType.artist,
+      }
+
+      trackEvent(isFollowed ? followPayload : unfollowPayload)
     },
 
     // user follows or unfollows a gallery
-    trackGalleryFollows: isFollowed => {
-      // const payload: FollowedPartner = {
-      //   action: ActionType.followedPartner,
-      //   context_module: ContextModule.onboardingFlow,
-      //   ...context,
-      // }
-      // change payload based on follow or unfollow
-      // trackEvent(isFollowed ? unfollowedPartner() : followedPartner())
+    trackGalleryFollows: (isFollowed, internalID) => {
+      const contextPage = getContextPageFromClient()
+
+      const followedPayload: FollowedPartner = {
+        action: ActionType.followedPartner,
+        context_module: ContextModule.onboardingFlow,
+        context_owner_type: OwnerType.savesAndFollows,
+        owner_id: internalID,
+        owner_slug: contextPage?.pageSlug!,
+        owner_type: OwnerType.partner,
+      }
+
+      const unfollowedPayload: UnfollowedPartner = {
+        action: ActionType.unfollowedPartner,
+        context_module: ContextModule.onboardingFlow,
+        context_owner_type: OwnerType.savesAndFollows,
+        owner_id: internalID,
+        owner_slug: contextPage?.pageSlug!,
+        owner_type: OwnerType.partner,
+      }
+
+      trackEvent(isFollowed ? followedPayload : unfollowedPayload)
     },
 
     // user follows or unfollows a gene
-    trackGeneFollows: isFollowed => {
-      // const payload: FollowedGene = {
-      //   action: ActionType.followedGene,
-      //   context_module: ContextModule.onboardingFlow,
-      //   ...context,
-      // }
-      // change payload based on follow or unfollow
-      // trackEvent(isFollowed ? unfollowedGene() : followedGene())
+    trackGeneFollows: (isFollowed, internalID) => {
+      const contextPage = getContextPageFromClient()
+
+      const followedPayload: FollowedGene = {
+        action: ActionType.followedGene,
+        context_module: ContextModule.onboardingFlow,
+        context_owner_type: OwnerType.savesAndFollows,
+        owner_id: internalID,
+        owner_slug: contextPage?.pageSlug!,
+        owner_type: OwnerType.gene,
+      }
+
+      const unfollowedPayload: UnfollowedGene = {
+        action: ActionType.unfollowedGene,
+        context_module: ContextModule.onboardingFlow,
+        context_owner_type: OwnerType.savesAndFollows,
+        owner_id: internalID,
+        owner_slug: contextPage?.pageSlug!,
+        owner_type: OwnerType.gene,
+      }
+
+      trackEvent(isFollowed ? followedPayload : unfollowedPayload)
     },
 
     // whenever we decide onboarding is complete

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,10 +26,10 @@
     lodash "^4.17.21"
     prettier "^1.19.1"
 
-"@artsy/cohesion@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.59.0.tgz#114a1c2fb79f7c780c773567e5fe77306a6ce9ab"
-  integrity sha512-RGzeUT6loLxvzTv20W6FGfpVRD/Sd9z/239zA7OHqV0ykI1nk4hc4h3mddvzOGPL8DlgachHkdQe4JyUCjloXA==
+"@artsy/cohesion@4.61.0":
+  version "4.61.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.61.0.tgz#f9939c70722c0fc9824185233d367c98784a0885"
+  integrity sha512-6gSmAkiv7SIKu9qj7wIsOhnmMHsFNehH2o83UrW4gg0RDMPLK75Hg2QFSPUqFh6sNv/tGlGHfK2T1W6JsraKMQ==
   dependencies:
     core-js "3"
 


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1153]

### Description

<!-- Implementation description -->
The goal of this PR is to bundle up all the analytics tracking events defined in this spreadsheet here: https://docs.google.com/spreadsheets/d/12wj1rt-j5SguboPJMuaM1GqJD-5B5u5piipw8MQ5Zuk/edit?pli=1#gid=275928850 
All analytics events are defined in a hook file and ready to be fired whenever the user completes specific tasks in the onboarding flow (as noted by the comments).

Will add a separate PR for wiring up the analytics calls in the Onboarding app and tests. 

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1153]: https://artsyproduct.atlassian.net/browse/GRO-1153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ