### PR TITLE
chore(webpack): Opt-in to SWC compiler, vs on by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
     parallelism: 4
     environment:
       # TODO: Remove this flag once things have stabilized
-      - EXPERIMENTAL_SWC_COMPILER_DISABLED: false
+      - EXPERIMENTAL_SWC_COMPILER_ENABLED: false
     steps:
       - run: yarn test --shard=$(expr $CIRCLE_NODE_INDEX + 1)/$CIRCLE_NODE_TOTAL
 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -3,6 +3,7 @@
 set -ex
 
 rm -rf .cache
+rm -rf .swc
 rm -f manifest.json
 rm -rf public
 mkdir public

--- a/webpack/webpackEnv.js
+++ b/webpack/webpackEnv.js
@@ -9,7 +9,7 @@ const webpackEnv = {
   isDevelopment: process.env.NODE_ENV === "development",
   isProduction: process.env.NODE_ENV === "production",
   experimentalSWCCompiler:
-    process.env.EXPERIMENTAL_SWC_COMPILER_DISABLED !== "true",
+    process.env.EXPERIMENTAL_SWC_COMPILER_ENABLED === "true",
 }
 
 const basePath = process.cwd()
@@ -24,7 +24,7 @@ if (process.env.CI || process.env.WEBPACK_LOG_CONFIG) {
   console.log("\n[Webpack Environment]")
   console.log("  basePath".padEnd(40), chalk.yellow(basePath))
   console.log("  CI".padEnd(40), chalk.yellow(process.env.CI))
-  console.log("  EXPERIMENTAL_SWC_COMPILER_DISABLED".padEnd(40), chalk.yellow(!!process.env.EXPERIMENTAL_SWC_COMPILER_DISABLED))
+  console.log("  EXPERIMENTAL_SWC_COMPILER_ENABLED".padEnd(40), chalk.yellow(webpackEnv.experimentalSWCCompiler))
   console.log("  NODE_ENV".padEnd(40), chalk.yellow(process.env.NODE_ENV))
   console.log("  WEBPACK_BUNDLE_REPORT".padEnd(40), chalk.yellow(process.env.WEBPACK_BUNDLE_REPORT))
   console.log("  WEBPACK_DEVTOOL".padEnd(40), chalk.yellow(process.env.WEBPACK_DEVTOOL))


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

Due to a strange issue that was spotted by @pam-, this updates our SWC compiler settings to be opt-in via the `EXPERIMENTAL_SWC_COMPILER_ENABLED` env var, versus on by default. We need to test this out a bit more before launching it more widely to the team.  

To repo issue: 
- set `EXPERIMENTAL_SWC_COMPILER_ENABLED=true` in `.env` 
- `yarn clean && yarn start`
- Navigate to `/artist/andy-warhol` and see something along the lines of:  
```sh
Invariant Violation: loadable: cannot find Components-ArtistNotableWorksRail in stats
```

Perhaps it's not properly compiling our  [dynamic import statements](https://github.com/artsy/force/blob/main/src/Apps/Artist/Routes/Overview/ArtistOverviewRoute.tsx#L16-L22)? Note that this only happens when visiting a page with SSR, so perhaps it also has something to do with our bundle splitting + webpack implementation. 


