### PR TITLE
feat[TX-562]: include PROCESSING_APPROVAL orders in order history

### DIFF
--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchases.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchases.tsx
@@ -38,7 +38,14 @@ const SettingsPurchases: FC<SettingsPurchasesProps> = ({
       {
         after: cursor,
         first: 10,
-        states: ["APPROVED", "SUBMITTED", "CANCELED", "FULFILLED", "REFUNDED"],
+        states: [
+          "APPROVED",
+          "SUBMITTED",
+          "CANCELED",
+          "FULFILLED",
+          "REFUNDED",
+          "PROCESSING_APPROVAL",
+        ],
       },
       null,
       error => {
@@ -94,7 +101,14 @@ export const SettingsPurchasesFragmentContainer = createRefetchContainer(
           first: { type: "Int", defaultValue: 10 }
           states: {
             type: "[CommerceOrderStateEnum!]"
-            defaultValue: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED]
+            defaultValue: [
+              APPROVED
+              CANCELED
+              FULFILLED
+              REFUNDED
+              SUBMITTED
+              PROCESSING_APPROVAL
+            ]
           }
         ) {
         name


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-562](https://artsyproduct.atlassian.net/browse/TX-562)

### Description
`PROCESSING_APPROVAL` orders (`wire_transfer` or `us_bank_account` orders) are not being fetched by the `/purchases` route, this fixes it.

<!-- Implementation description -->
