### PR TITLE
fix(): Alican/Provide data-test id to button element directly instead of wrapper

### DIFF
--- a/src/Apps/Order/Components/BankAccountPicker.tsx
+++ b/src/Apps/Order/Components/BankAccountPicker.tsx
@@ -149,7 +149,7 @@ export const BankAccountPicker: FC<Props> = props => {
           {bankAccountHasInsufficientFunds && <InsufficientFundsError />}
           <Spacer mt={4} />
           <SaveAndContinueButton
-            data-test="bankTransferSaveExisting"
+            testId="bankTransferSaveExisting"
             onClick={handleContinue}
             disabled={!bankAccountSelection.type}
           />

--- a/src/Apps/Order/Components/SaveAndContinueButton.tsx
+++ b/src/Apps/Order/Components/SaveAndContinueButton.tsx
@@ -3,16 +3,18 @@ import { Button } from "@artsy/palette"
 import { Media } from "Utils/Responsive"
 
 export const SaveAndContinueButton: FC<{
+  testId?: string
   onClick?: () => void
   media?: { [key: string]: string }
   loading?: boolean
   disabled?: boolean
-}> = ({ onClick, media, loading = false, disabled = false }) => {
+}> = ({ testId, onClick, media, loading = false, disabled = false }) => {
   return (
     <>
       {media ? (
         <Media {...media}>
           <Button
+            data-test={testId}
             onClick={onClick}
             variant="primaryBlack"
             width={["100%", "50%"]}
@@ -24,6 +26,7 @@ export const SaveAndContinueButton: FC<{
         </Media>
       ) : (
         <Button
+          data-test={testId}
           onClick={onClick}
           variant="primaryBlack"
           width={["100%", "50%"]}

--- a/src/Components/BankDebitForm/BankDebitForm.tsx
+++ b/src/Components/BankDebitForm/BankDebitForm.tsx
@@ -133,7 +133,7 @@ export const BankDebitForm: FC<Props> = ({
         {bankAccountHasInsufficientFunds && <InsufficientFundsError />}
         <Spacer mt={4} />
         <SaveAndContinueButton
-          data-test="bankTransferSaveNew"
+          testId="bankTransferSaveNew"
           disabled={!stripe || bankAccountHasInsufficientFunds}
         />
         <Spacer mb={2} />


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description
Currently our Integrity tests are [failing](https://app.circleci.com/pipelines/github/artsy/integrity/13620/workflows/884ea3e4-d687-4d16-845d-68bfd3a0890b/jobs/67584) because it looks for specific test Ids on button elements. This PR attempts to fix this issue by moving test IDs from the wrapper component `SaveAndCotinuebutton` to `Button` element directly. 
