### PR TITLE
feat(CX-2713): navigate to my collection artworks on artwork press

### DIFF
--- a/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
@@ -20,6 +20,7 @@ import { MetaTags } from "Components/MetaTags"
 import { MyCollectionRoute_me } from "__generated__/MyCollectionRoute_me.graphql"
 import { EmptyMyCollectionPage } from "./Components/EmptyMyCollectionPage"
 import { SETTINGS_ROUTE_TABS_MARGIN } from "Apps/Settings/SettingsApp"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface MyCollectionRouteProps {
   me: MyCollectionRoute_me
@@ -29,6 +30,9 @@ interface MyCollectionRouteProps {
 const MyCollectionRoute: FC<MyCollectionRouteProps> = ({ me, relay }) => {
   const [loading, setLoading] = useState(false)
   const [hasDismissedMessage, setHasDismissedMessage] = useState(true)
+
+  const enableMyCollectionPhase2 = useFeatureFlag("my-collection-web-phase-2")
+
   const { scrollTo } = useScrollTo({ behavior: "smooth" })
 
   useEffect(() => {
@@ -131,7 +135,8 @@ const MyCollectionRoute: FC<MyCollectionRouteProps> = ({ me, relay }) => {
                     hideSaleInfo
                     showSaveButton={false}
                     showHoverDetails={false}
-                    disableRouterLinking
+                    disableRouterLinking={!enableMyCollectionPhase2}
+                    isMyCollectionArtwork
                   />
 
                   <Spacer mt={4} />

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -17,10 +17,11 @@ interface ArtworkGridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   contextModule?: AuthContextModule
   disableRouterLinking?: boolean
   hideSaleInfo?: boolean
+  isMyCollectionArtwork?: boolean
   lazyLoad?: boolean
   onClick?: () => void
-  showSaveButton?: boolean
   showHoverDetails?: boolean
+  showSaveButton?: boolean
 }
 
 export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
@@ -28,6 +29,7 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
   contextModule,
   disableRouterLinking,
   hideSaleInfo,
+  isMyCollectionArtwork = false,
   lazyLoad = true,
   onClick,
   showHoverDetails,
@@ -83,6 +85,7 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
           artwork={artwork}
           disableRouterLinking={disableRouterLinking}
           onClick={handleClick}
+          isMyCollectionArtwork={isMyCollectionArtwork}
         >
           {imageURL ? (
             <MagnifyImage
@@ -141,10 +144,19 @@ const DisabledLink = styled(Box)`
 `
 
 const LinkContainer: React.FC<
-  Pick<ArtworkGridItemProps, "artwork" | "disableRouterLinking"> & {
+  Pick<
+    ArtworkGridItemProps,
+    "artwork" | "disableRouterLinking" | "isMyCollectionArtwork"
+  > & {
     onClick: () => void
   }
-> = ({ artwork, children, disableRouterLinking, onClick }) => {
+> = ({
+  artwork,
+  children,
+  disableRouterLinking,
+  onClick,
+  isMyCollectionArtwork,
+}) => {
   const imageURL = artwork.image?.url
   if (!!disableRouterLinking) {
     return (
@@ -157,12 +169,20 @@ const LinkContainer: React.FC<
       </DisabledLink>
     )
   }
+
+  // My collection artwork is a special case. We don't want to link to the standard artwork page,
+  // but to a custom my collection artwork page.
+  const to = !isMyCollectionArtwork
+    ? artwork.href
+    : `/my-collection/artwork/${artwork.internalID}`
+
   return (
     <Link
-      to={artwork.href}
+      to={to}
       onClick={onClick}
       aria-label={`${artwork.title} by ${artwork.artistNames}`}
       position={imageURL ? "absolute" : "relative"}
+      data-testid="artwork-link"
     >
       {children}
     </Link>

--- a/src/Components/Artwork/__tests__/GridItem.jest.js
+++ b/src/Components/Artwork/__tests__/GridItem.jest.js
@@ -1,0 +1,36 @@
+"use strict"
+let __makeTemplateObject =
+  (this && this.__makeTemplateObject) ||
+  function (cooked, raw) {
+    if (Object.defineProperty) {
+      Object.defineProperty(cooked, "raw", { value: raw })
+    } else {
+      cooked.raw = raw
+    }
+    return cooked
+  }
+exports.__esModule = true
+let setupTestWrapper_1 = require("DevTools/setupTestWrapper")
+let react_relay_1 = require("react-relay")
+let GridItem_1 = require("../GridItem")
+jest.unmock("react-relay")
+describe("GridItem", function () {
+  let getWrapper = (0, setupTestWrapper_1.setupTestWrapper)({
+    Component: GridItem_1["default"],
+    query: (0, react_relay_1.graphql)(
+      templateObject_1 ||
+        (templateObject_1 = __makeTemplateObject(
+          [
+            '\n      query GridItem_Test_Query {\n        artwork(id: "foo") {\n          ...GridItem_artwork\n        }\n      }\n    ',
+          ],
+          [
+            '\n      query GridItem_Test_Query {\n        artwork(id: "foo") {\n          ...GridItem_artwork\n        }\n      }\n    ',
+          ]
+        ))
+    ),
+  }).getWrapper
+  it("navigates to the standard artwork page when clicked", function () {
+    let wrapper = getWrapper(_, { isMyCwollectionArtwork: false })
+  })
+})
+let templateObject_1

--- a/src/Components/Artwork/__tests__/GridItem.jest.tsx
+++ b/src/Components/Artwork/__tests__/GridItem.jest.tsx
@@ -1,0 +1,56 @@
+import { screen } from "@testing-library/react"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { graphql } from "react-relay"
+
+import { GridItem_Test_Query } from "../../../__generated__/GridItem_Test_Query.graphql"
+import ArtworkGridItemFragmentContainer from "../GridItem"
+
+jest.unmock("react-relay")
+describe("GridItem", () => {
+  const { renderWithRelay } = setupTestWrapperTL<GridItem_Test_Query>({
+    Component: props => {
+      if (props.artwork) {
+        return <ArtworkGridItemFragmentContainer {...(props as any)} />
+      }
+      return null
+    },
+    query: graphql`
+      query GridItem_Test_Query @relay_test_operation {
+        artwork(id: "foo") {
+          ...GridItem_artwork
+        }
+      }
+    `,
+  })
+
+  it("navigates to the standard artwork page for standard artworks", async () => {
+    renderWithRelay(mockResolvers, false, { isMyCollectionArtwork: false })
+
+    expect(screen.getByText("artwork-title")).toBeInTheDocument()
+
+    expect(screen.getByTestId("artwork-link")).toHaveAttribute(
+      "href",
+      "artwork/id"
+    )
+  })
+
+  it("navigates to my collection artwork page for my collection artworks", async () => {
+    renderWithRelay(mockResolvers, false, { isMyCollectionArtwork: true })
+
+    expect(screen.getByText("artwork-title")).toBeInTheDocument()
+
+    expect(screen.getByTestId("artwork-link")).toHaveAttribute(
+      "href",
+      "/my-collection/artwork/artwork-id"
+    )
+  })
+})
+
+const mockResolvers = {
+  Artwork: () => ({
+    title: "artwork-title",
+    href: "artwork/id",
+    image: { url: "image.url" },
+    internalID: "artwork-id",
+  }),
+}

--- a/src/DevTools/setupTestWrapper.tsx
+++ b/src/DevTools/setupTestWrapper.tsx
@@ -85,7 +85,8 @@ export const setupTestWrapperTL = <T extends OperationType>({
 }: SetupTestWrapper<T>) => {
   const renderWithRelay = (
     mockResolvers: MockResolvers = {},
-    manualEnvControl?: boolean
+    manualEnvControl?: boolean,
+    componentProps?: {}
   ): RenderWithRelay => {
     const env = createMockEnvironment()
     const TestRenderer = () => (
@@ -96,7 +97,7 @@ export const setupTestWrapperTL = <T extends OperationType>({
         render={({ props, error }) => {
           if (props) {
             // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-            return <Component {...props} />
+            return <Component {...componentProps} {...props} />
           } else if (error) {
             console.error(error)
           }
@@ -126,9 +127,13 @@ export const setupTestWrapper = <T extends OperationType>({
   query,
   variables = {},
 }: SetupTestWrapper<T>) => {
-  const getWrapper = (mockResolvers: MockResolvers = {}) => {
+  const getWrapper = (
+    mockResolvers: MockResolvers = {},
+    componentProps: {} = {}
+  ) => {
     const env = createMockEnvironment()
 
+    // componentProps["children"][""]
     const TestRenderer = () => (
       <QueryRenderer<T>
         environment={env}
@@ -137,7 +142,7 @@ export const setupTestWrapper = <T extends OperationType>({
         render={({ props, error }) => {
           if (props) {
             // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-            return <Component {...props} />
+            return <Component {...(componentProps || {})} {...props} />
           } else if (error) {
             console.error(error)
           }

--- a/src/__generated__/GridItem_Test_Query.graphql.ts
+++ b/src/__generated__/GridItem_Test_Query.graphql.ts
@@ -1,0 +1,720 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type GridItem_Test_QueryVariables = {};
+export type GridItem_Test_QueryResponse = {
+    readonly artwork: {
+        readonly " $fragmentRefs": FragmentRefs<"GridItem_artwork">;
+    } | null;
+};
+export type GridItem_Test_Query = {
+    readonly response: GridItem_Test_QueryResponse;
+    readonly variables: GridItem_Test_QueryVariables;
+};
+
+
+
+/*
+query GridItem_Test_Query {
+  artwork(id: "foo") {
+    ...GridItem_artwork
+    id
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    endAt
+    cascadingEndTimeIntervalMinutes
+    extendedBiddingIntervalMinutes
+    startAt
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    lotID
+    lotLabel
+    endAt
+    extendedBiddingEndAt
+    formattedEndDateTime
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+  ...NewSaveButton_artwork
+  ...HoverDetails_artwork
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  artistNames
+  href
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+
+fragment HoverDetails_artwork on Artwork {
+  internalID
+  attributionClass {
+    name
+    id
+  }
+  mediumType {
+    filterGene {
+      name
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  href
+}
+
+fragment NewSaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "foo"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v7 = [
+  (v4/*: any*/),
+  (v3/*: any*/)
+],
+v8 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v9 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v11 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "GridItem_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "GridItem_artwork"
+          }
+        ],
+        "storageKey": "artwork(id:\"foo\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "GridItem_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          {
+            "alias": "image_title",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "imageTitle",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "placeholder",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:\"large\")"
+              },
+              {
+                "alias": "aspect_ratio",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "aspectRatio",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "artistNames",
+            "storageKey": null
+          },
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "date",
+            "storageKey": null
+          },
+          {
+            "alias": "sale_message",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "saleMessage",
+            "storageKey": null
+          },
+          {
+            "alias": "cultural_maker",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "culturalMaker",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "Artist",
+            "kind": "LinkedField",
+            "name": "artists",
+            "plural": true,
+            "selections": [
+              (v3/*: any*/),
+              (v1/*: any*/),
+              (v4/*: any*/)
+            ],
+            "storageKey": "artists(shallow:true)"
+          },
+          {
+            "alias": "collecting_institution",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "collectingInstitution",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "Partner",
+            "kind": "LinkedField",
+            "name": "partner",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/),
+              (v1/*: any*/),
+              (v3/*: any*/)
+            ],
+            "storageKey": "partner(shallow:true)"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Sale",
+            "kind": "LinkedField",
+            "name": "sale",
+            "plural": false,
+            "selections": [
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cascadingEndTimeIntervalMinutes",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "extendedBiddingIntervalMinutes",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "startAt",
+                "storageKey": null
+              },
+              {
+                "alias": "is_auction",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isAuction",
+                "storageKey": null
+              },
+              {
+                "alias": "is_closed",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isClosed",
+                "storageKey": null
+              },
+              (v3/*: any*/),
+              {
+                "alias": "is_preview",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isPreview",
+                "storageKey": null
+              },
+              {
+                "alias": "display_timely_at",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "displayTimelyAt",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": "sale_artwork",
+            "args": null,
+            "concreteType": "SaleArtwork",
+            "kind": "LinkedField",
+            "name": "saleArtwork",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "lotID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "lotLabel",
+                "storageKey": null
+              },
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "extendedBiddingEndAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "formattedEndDateTime",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "SaleArtworkCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": "bidder_positions",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "bidderPositions",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": "highest_bid",
+                "args": null,
+                "concreteType": "SaleArtworkHighestBid",
+                "kind": "LinkedField",
+                "name": "highestBid",
+                "plural": false,
+                "selections": (v6/*: any*/),
+                "storageKey": null
+              },
+              {
+                "alias": "opening_bid",
+                "args": null,
+                "concreteType": "SaleArtworkOpeningBid",
+                "kind": "LinkedField",
+                "name": "openingBid",
+                "plural": false,
+                "selections": (v6/*: any*/),
+                "storageKey": null
+              },
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": "is_saved",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isSaved",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "kind": "LinkedField",
+            "name": "attributionClass",
+            "plural": false,
+            "selections": (v7/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkMedium",
+            "kind": "LinkedField",
+            "name": "mediumType",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Gene",
+                "kind": "LinkedField",
+                "name": "filterGene",
+                "plural": false,
+                "selections": (v7/*: any*/),
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": "is_biddable",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isBiddable",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "artwork(id:\"foo\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "9d555e7d188f0371bd6411ec360dfc56",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "artwork.artistNames": (v8/*: any*/),
+        "artwork.artists": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Artist"
+        },
+        "artwork.artists.href": (v8/*: any*/),
+        "artwork.artists.id": (v9/*: any*/),
+        "artwork.artists.name": (v8/*: any*/),
+        "artwork.attributionClass": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AttributionClass"
+        },
+        "artwork.attributionClass.id": (v9/*: any*/),
+        "artwork.attributionClass.name": (v8/*: any*/),
+        "artwork.collecting_institution": (v8/*: any*/),
+        "artwork.cultural_maker": (v8/*: any*/),
+        "artwork.date": (v8/*: any*/),
+        "artwork.href": (v8/*: any*/),
+        "artwork.id": (v9/*: any*/),
+        "artwork.image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "artwork.image.aspect_ratio": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Float"
+        },
+        "artwork.image.placeholder": (v8/*: any*/),
+        "artwork.image.url": (v8/*: any*/),
+        "artwork.image_title": (v8/*: any*/),
+        "artwork.internalID": (v9/*: any*/),
+        "artwork.is_biddable": (v10/*: any*/),
+        "artwork.is_saved": (v10/*: any*/),
+        "artwork.mediumType": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkMedium"
+        },
+        "artwork.mediumType.filterGene": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Gene"
+        },
+        "artwork.mediumType.filterGene.id": (v9/*: any*/),
+        "artwork.mediumType.filterGene.name": (v8/*: any*/),
+        "artwork.partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "artwork.partner.href": (v8/*: any*/),
+        "artwork.partner.id": (v9/*: any*/),
+        "artwork.partner.name": (v8/*: any*/),
+        "artwork.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "artwork.sale.cascadingEndTimeIntervalMinutes": (v11/*: any*/),
+        "artwork.sale.display_timely_at": (v8/*: any*/),
+        "artwork.sale.endAt": (v8/*: any*/),
+        "artwork.sale.extendedBiddingIntervalMinutes": (v11/*: any*/),
+        "artwork.sale.id": (v9/*: any*/),
+        "artwork.sale.is_auction": (v10/*: any*/),
+        "artwork.sale.is_closed": (v10/*: any*/),
+        "artwork.sale.is_preview": (v10/*: any*/),
+        "artwork.sale.startAt": (v8/*: any*/),
+        "artwork.sale_artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtwork"
+        },
+        "artwork.sale_artwork.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkCounts"
+        },
+        "artwork.sale_artwork.counts.bidder_positions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FormattedNumber"
+        },
+        "artwork.sale_artwork.endAt": (v8/*: any*/),
+        "artwork.sale_artwork.extendedBiddingEndAt": (v8/*: any*/),
+        "artwork.sale_artwork.formattedEndDateTime": (v8/*: any*/),
+        "artwork.sale_artwork.highest_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkHighestBid"
+        },
+        "artwork.sale_artwork.highest_bid.display": (v8/*: any*/),
+        "artwork.sale_artwork.id": (v9/*: any*/),
+        "artwork.sale_artwork.lotID": (v8/*: any*/),
+        "artwork.sale_artwork.lotLabel": (v8/*: any*/),
+        "artwork.sale_artwork.opening_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkOpeningBid"
+        },
+        "artwork.sale_artwork.opening_bid.display": (v8/*: any*/),
+        "artwork.sale_message": (v8/*: any*/),
+        "artwork.slug": (v9/*: any*/),
+        "artwork.title": (v8/*: any*/)
+      }
+    },
+    "name": "GridItem_Test_Query",
+    "operationKind": "query",
+    "text": "query GridItem_Test_Query {\n  artwork(id: \"foo\") {\n    ...GridItem_artwork\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+  }
+};
+})();
+(node as any).hash = '90e7b6e4050a84cea1783b067221fafd';
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2713]

### Description

- Navigate the user to my collection artwork screen when clicking on a my collection artwork with phase 2 of MyC ff enabled.
- Add support for props injection inside `renderWithRelay`. I only have the prop set as an object now since I didn't manage to get typescript React.ComponentProps to work, it would be great to visit that in the future. 

| For MyC artworks | For standard artworks |
| --- | --- |
| https://user-images.githubusercontent.com/11945712/184091970-353703b7-a115-432d-8a84-ec8a4e7e45e9.mov  | https://user-images.githubusercontent.com/11945712/184091920-a62805a5-2ec1-4376-9b55-9db28b0fe61e.mov |


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2713]: https://artsyproduct.atlassian.net/browse/CX-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ