### PR TITLE
Revert "chore(deps): update cypress/base docker tag to v16.14.2"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ jobs:
 
   smoke-test-on-live-env:
     docker:
-      - image: cypress/base:16.14.2
+      - image: cypress/base:16.14.0
         environment:
           TERM: xterm
     working_directory: ~/app


### PR DESCRIPTION
Reverts artsy/force#10729

Possible that this is breaking our builds? https://artsy.slack.com/archives/C2TQ4PT8R/p1660222140815259