### PR TITLE
feat(CX-2708): Add My Collection Artwork details overview  

### DIFF
--- a/cypress/integration/myCollection.spec.ts
+++ b/cypress/integration/myCollection.spec.ts
@@ -1,11 +1,13 @@
 /* eslint-disable jest/expect-expect */
 
-describe("/my-collection/artwork/:artworkSlug", () => {
+describe("/my-collection/artwork/:artworkID", () => {
   before(() => {
-    cy.visit("/my-collection/artwork/pablo-picasso-guernica")
+    cy.visit("/my-collection/artwork/trudy-benson-boost")
   })
 
-  it("renders the empty page content", () => {
-    cy.contains("YOU'RE HERE!")
+  it("renders page content", () => {
+    cy.get("h1").should("contain", "Trudy Benson")
+    cy.get("h1").should("contain", "Boost, 2022")
+    cy.contains("This is a unique work")
   })
 })

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkMeta.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkMeta.tsx
@@ -1,0 +1,31 @@
+import { MetaTags } from "Components/MetaTags"
+import { createFragmentContainer, graphql } from "react-relay"
+import { MyCollectionArtworkMeta_artwork } from "__generated__/MyCollectionArtworkMeta_artwork.graphql"
+
+interface MyCollectionArtworkMetaProps {
+  artwork: MyCollectionArtworkMeta_artwork
+}
+
+const MyCollectionArtworkMeta: React.FC<MyCollectionArtworkMetaProps> = ({
+  artwork,
+}) => {
+  const { artistNames, title } = artwork
+
+  return (
+    <>
+      <MetaTags title={`${title} - ${artistNames} | Artsy`} />
+    </>
+  )
+}
+
+export const MyCollectionArtworkMetaFragmentContainer = createFragmentContainer(
+  MyCollectionArtworkMeta,
+  {
+    artwork: graphql`
+      fragment MyCollectionArtworkMeta_artwork on Artwork {
+        artistNames
+        title
+      }
+    `,
+  }
+)

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
@@ -82,7 +82,6 @@ export const MyCollectionArtworkSidebarMetadataFragmentContainer = createFragmen
           in
           cm
         }
-        date
         provenance
         attributionClass {
           shortDescription

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
@@ -1,16 +1,100 @@
-// import { Text } from "@artsy/palette"
-// import { Component } from "react"
-// import { createFragmentContainer, graphql } from "react-relay"
-// import { ArtworkSidebarClassificationFragmentContainer } from "./ArtworkSidebarClassification"
-// import { ArtworkSidebarSizeInfoFragmentContainer } from "./ArtworkSidebarSizeInfo"
-// import { ArtworkSidebarTitleInfoFragmentContainer } from "./ArtworkSidebarTitleInfo"
-// import { ArtworkSidebarMetadata_artwork } from "__generated__/ArtworkSidebarMetadata_artwork.graphql"
-
 import { Box, Spacer, Text } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { MyCollectionArtworkSidebarMetadata_artwork } from "__generated__/MyCollectionArtworkSidebarMetadata_artwork.graphql"
 
-// export interface ArtworkSidebarMetadataProps {
-//   artwork: ArtworkSidebarMetadata_artwork
-// }
+export interface MyCollectionArtworkSidebarMetadataProps {
+  artwork: MyCollectionArtworkSidebarMetadata_artwork
+}
+
+export const MyCollectionArtworkSidebarMetadata: React.FC<MyCollectionArtworkSidebarMetadataProps> = ({
+  artwork,
+}) => {
+  const {
+    artistNames,
+    artworkLocation,
+    attributionClass,
+    category,
+    dimensions,
+    medium,
+    pricePaid,
+    provenance,
+    title,
+  } = artwork
+
+  return (
+    <>
+      <Text variant="lg">{artistNames}</Text>
+      <Text variant="lg" fontStyle="italic" color="black60" mb={[0.5, 0]}>
+        {title}
+      </Text>
+
+      <Spacer m={[1, 2]} />
+
+      <MetadataField label="Medium" value={category} />
+      <MetadataField label="Materials" value={medium} />
+      <MetadataField
+        label="Rarity"
+        value={attributionClass?.shortDescription}
+      />
+
+      <Box mb={[1, 0.5]} display="flex" flexDirection={["column", "row"]}>
+        <Text variant="sm" minWidth={190} mr={2}>
+          Size
+        </Text>
+
+        {dimensions ? (
+          <Box>
+            {!!dimensions.in && (
+              <Text variant="sm" color="black60">
+                {dimensions.in}
+              </Text>
+            )}
+            {!!dimensions.cm && (
+              <Text variant="sm" color="black60">
+                {dimensions.cm}
+              </Text>
+            )}
+          </Box>
+        ) : (
+          <Text variant="sm" color="black60">
+            ----
+          </Text>
+        )}
+      </Box>
+
+      <MetadataField label="Location" value={artworkLocation} />
+      <MetadataField label="Provenance" value={provenance} />
+      <MetadataField label="Price Paid" value={pricePaid?.display} />
+    </>
+  )
+}
+
+export const MyCollectionArtworkSidebarMetadataFragmentContainer = createFragmentContainer(
+  MyCollectionArtworkSidebarMetadata,
+  {
+    artwork: graphql`
+      fragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {
+        artistNames
+        title
+        category
+        medium
+        dimensions {
+          in
+          cm
+        }
+        date
+        provenance
+        attributionClass {
+          shortDescription
+        }
+        pricePaid {
+          display
+        }
+        artworkLocation
+      }
+    `,
+  }
+)
 
 const MetadataField = ({ label, value }) => {
   return (
@@ -18,84 +102,12 @@ const MetadataField = ({ label, value }) => {
       <Text variant="sm" minWidth={190} mr={2}>
         {label}
       </Text>
-      <Text variant="sm" color="black60">
-        {value || "----"}
-      </Text>
+
+      <Box display="flex" flexDirection="column">
+        <Text variant="sm" color="black60">
+          {value || "----"}
+        </Text>
+      </Box>
     </Box>
   )
 }
-
-export const MyCollectionArtworkSidebarMetadata: React.FC<any> = ({
-  artwork,
-}) => {
-  return (
-    <>
-      <Text variant="lg">Artist Name</Text>
-      <Text variant="lg" fontStyle="italic" color="black60" mb={[0.5, 0]}>
-        Artwork title
-      </Text>
-
-      <Spacer m={[1, 2]} />
-
-      <MetadataField label="Medium" value="Painting" />
-      <MetadataField
-        label="Materials"
-        value="Paint &Paint &Paint &Paint &Paint &"
-      />
-      <MetadataField label="Rarity" value="Very rare" />
-      <MetadataField label="Size" value={null} />
-      <MetadataField label="Location" value="Berlin" />
-      <MetadataField label="Provenance" value="" />
-      <MetadataField label="Price Paid" value="$20,000" />
-    </>
-  )
-}
-
-// export class ArtworkSidebarMetadata extends Component<any
-// > {
-//   render() {
-//     const { artwork } = this.props
-
-//     const lotLabel = artwork.is_biddable
-//       ? artwork.sale_artwork?.lot_label
-//       : null
-
-//     return (
-//       <>
-//         {lotLabel && (
-//           <Text variant="xs" color="black100" mb={0.5}>
-//             Lot {lotLabel}
-//           </Text>
-//         )}
-
-//         <ArtworkSidebarTitleInfoFragmentContainer artwork={artwork} />
-
-//         {(artwork.edition_sets?.length ?? 0) < 2 && (
-//           <ArtworkSidebarSizeInfoFragmentContainer piece={artwork} />
-//         )}
-
-//         <ArtworkSidebarClassificationFragmentContainer artwork={artwork} />
-//       </>
-//     )
-//   }
-// }
-
-// export const ArtworkSidebarMetadataFragmentContainer = createFragmentContainer(
-//   ArtworkSidebarMetadata,
-//   {
-//     artwork: graphql`
-//       fragment ArtworkSidebarMetadata_artwork on Artwork {
-//         is_biddable: isBiddable
-//         edition_sets: editionSets {
-//           __typename
-//         }
-//         sale_artwork: saleArtwork {
-//           lot_label: lotLabel
-//         }
-//         ...ArtworkSidebarTitleInfo_artwork
-//         ...ArtworkSidebarSizeInfo_piece
-//         ...ArtworkSidebarClassification_artwork
-//       }
-//     `,
-//   }
-// )

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
@@ -1,5 +1,6 @@
 import { Box, Spacer, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
+import styled from "styled-components"
 import { MyCollectionArtworkSidebarMetadata_artwork } from "__generated__/MyCollectionArtworkSidebarMetadata_artwork.graphql"
 
 export interface MyCollectionArtworkSidebarMetadataProps {
@@ -40,31 +41,10 @@ export const MyCollectionArtworkSidebarMetadata: React.FC<MyCollectionArtworkSid
         label="Rarity"
         value={attributionClass?.shortDescription}
       />
-
-      <Box mb={[1, 0.5]} display="flex" flexDirection={["column", "row"]}>
-        <Text variant="sm" minWidth={190} mr={2}>
-          Size
-        </Text>
-
-        {dimensions ? (
-          <Box>
-            {!!dimensions.in && (
-              <Text variant="sm" color="black60">
-                {dimensions.in}
-              </Text>
-            )}
-            {!!dimensions.cm && (
-              <Text variant="sm" color="black60">
-                {dimensions.cm}
-              </Text>
-            )}
-          </Box>
-        ) : (
-          <Text variant="sm" color="black60">
-            ----
-          </Text>
-        )}
-      </Box>
+      <MetadataField
+        label="Size"
+        value={[dimensions?.in, dimensions?.cm].filter(d => d).join("\n")}
+      />
 
       <MetadataField label="Location" value={artworkLocation} />
       <MetadataField label="Provenance" value={provenance} />
@@ -108,10 +88,14 @@ const MetadataField = ({ label, value }) => {
       </Text>
 
       <Box display="flex" flexDirection="column">
-        <Text variant="sm" color="black60">
+        <WrappedTest variant="sm" color="black60">
           {value || "----"}
-        </Text>
+        </WrappedTest>
       </Box>
     </Box>
   )
 }
+
+const WrappedTest = styled(Text)`
+  white-space: pre-line;
+`

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
@@ -81,6 +81,8 @@ export const MyCollectionArtworkSidebarMetadataFragmentContainer = createFragmen
 )
 
 const MetadataField = ({ label, value }) => {
+  const emptyValue = "----"
+
   return (
     <Box mb={[1, 0.5]} display="flex" flexDirection={["column", "row"]}>
       <Text variant="sm" minWidth={190} mr={2}>
@@ -89,7 +91,7 @@ const MetadataField = ({ label, value }) => {
 
       <Box display="flex" flexDirection="column">
         <WrappedTest variant="sm" color="black60">
-          {value || "----"}
+          {value || emptyValue}
         </WrappedTest>
       </Box>
     </Box>

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
@@ -14,6 +14,7 @@ export const MyCollectionArtworkSidebarMetadata: React.FC<MyCollectionArtworkSid
     artworkLocation,
     attributionClass,
     category,
+    date,
     dimensions,
     medium,
     pricePaid,
@@ -23,9 +24,12 @@ export const MyCollectionArtworkSidebarMetadata: React.FC<MyCollectionArtworkSid
 
   return (
     <>
-      <Text variant="lg">{artistNames}</Text>
-      <Text variant="lg" fontStyle="italic" color="black60" mb={[0.5, 0]}>
-        {title}
+      <Text as="h1" variant="lg-display">
+        {artistNames}
+      </Text>
+      <Text as="h1" variant="lg-display" color="black60" mb={[0.5, 0]}>
+        <i>{title?.trim()}</i>
+        {date && date.replace(/\s+/g, "").length > 0 && ", " + date}
       </Text>
 
       <Spacer m={[1, 2]} />
@@ -76,6 +80,7 @@ export const MyCollectionArtworkSidebarMetadataFragmentContainer = createFragmen
       fragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {
         artistNames
         title
+        date
         category
         medium
         dimensions {

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
@@ -1,0 +1,101 @@
+// import { Text } from "@artsy/palette"
+// import { Component } from "react"
+// import { createFragmentContainer, graphql } from "react-relay"
+// import { ArtworkSidebarClassificationFragmentContainer } from "./ArtworkSidebarClassification"
+// import { ArtworkSidebarSizeInfoFragmentContainer } from "./ArtworkSidebarSizeInfo"
+// import { ArtworkSidebarTitleInfoFragmentContainer } from "./ArtworkSidebarTitleInfo"
+// import { ArtworkSidebarMetadata_artwork } from "__generated__/ArtworkSidebarMetadata_artwork.graphql"
+
+import { Box, Spacer, Text } from "@artsy/palette"
+
+// export interface ArtworkSidebarMetadataProps {
+//   artwork: ArtworkSidebarMetadata_artwork
+// }
+
+const MetadataField = ({ label, value }) => {
+  return (
+    <Box mb={[1, 0.5]} display="flex" flexDirection={["column", "row"]}>
+      <Text variant="sm" minWidth={190} mr={2}>
+        {label}
+      </Text>
+      <Text variant="sm" color="black60">
+        {value || "----"}
+      </Text>
+    </Box>
+  )
+}
+
+export const MyCollectionArtworkSidebarMetadata: React.FC<any> = ({
+  artwork,
+}) => {
+  return (
+    <>
+      <Text variant="lg">Artist Name</Text>
+      <Text variant="lg" fontStyle="italic" color="black60" mb={[0.5, 0]}>
+        Artwork title
+      </Text>
+
+      <Spacer m={[1, 2]} />
+
+      <MetadataField label="Medium" value="Painting" />
+      <MetadataField
+        label="Materials"
+        value="Paint &Paint &Paint &Paint &Paint &"
+      />
+      <MetadataField label="Rarity" value="Very rare" />
+      <MetadataField label="Size" value={null} />
+      <MetadataField label="Location" value="Berlin" />
+      <MetadataField label="Provenance" value="" />
+      <MetadataField label="Price Paid" value="$20,000" />
+    </>
+  )
+}
+
+// export class ArtworkSidebarMetadata extends Component<any
+// > {
+//   render() {
+//     const { artwork } = this.props
+
+//     const lotLabel = artwork.is_biddable
+//       ? artwork.sale_artwork?.lot_label
+//       : null
+
+//     return (
+//       <>
+//         {lotLabel && (
+//           <Text variant="xs" color="black100" mb={0.5}>
+//             Lot {lotLabel}
+//           </Text>
+//         )}
+
+//         <ArtworkSidebarTitleInfoFragmentContainer artwork={artwork} />
+
+//         {(artwork.edition_sets?.length ?? 0) < 2 && (
+//           <ArtworkSidebarSizeInfoFragmentContainer piece={artwork} />
+//         )}
+
+//         <ArtworkSidebarClassificationFragmentContainer artwork={artwork} />
+//       </>
+//     )
+//   }
+// }
+
+// export const ArtworkSidebarMetadataFragmentContainer = createFragmentContainer(
+//   ArtworkSidebarMetadata,
+//   {
+//     artwork: graphql`
+//       fragment ArtworkSidebarMetadata_artwork on Artwork {
+//         is_biddable: isBiddable
+//         edition_sets: editionSets {
+//           __typename
+//         }
+//         sale_artwork: saleArtwork {
+//           lot_label: lotLabel
+//         }
+//         ...ArtworkSidebarTitleInfo_artwork
+//         ...ArtworkSidebarSizeInfo_piece
+//         ...ArtworkSidebarClassification_artwork
+//       }
+//     `,
+//   }
+// )

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/__tests__/MyCollectionArtworkSidebarMetadata.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/__tests__/MyCollectionArtworkSidebarMetadata.jest.tsx
@@ -1,0 +1,132 @@
+import { screen } from "@testing-library/react"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { graphql } from "relay-runtime"
+import { MyCollectionArtworkSidebarMetadataTestQuery } from "__generated__/MyCollectionArtworkSidebarMetadataTestQuery.graphql"
+import { MyCollectionArtworkSidebarMetadataFragmentContainer } from "../MyCollectionArtworkSidebarMetadata"
+
+jest.unmock("react-relay")
+
+describe("MyCollectionArtworkSidebarMetadata", () => {
+  const { renderWithRelay } = setupTestWrapperTL<
+    MyCollectionArtworkSidebarMetadataTestQuery
+  >({
+    Component: props => {
+      if (props?.artwork) {
+        return (
+          <MyCollectionArtworkSidebarMetadataFragmentContainer
+            {...(props as any)}
+          />
+        )
+      }
+      return null
+    },
+    query: graphql`
+      query MyCollectionArtworkSidebarMetadataTestQuery @relay_test_operation {
+        artwork(id: "foo") {
+          ...MyCollectionArtworkSidebarMetadata_artwork
+        }
+      }
+    `,
+  })
+
+  describe("for artwork with metadata", () => {
+    beforeEach(() => {
+      renderWithRelay(mockResolversWithData, false)
+    })
+
+    it("displays artists names and title", () => {
+      expect(screen.getByText("Jean-Michel Basquiat")).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          "Basquiat hand-painted sweatshirt 1979/1980 (early Jean-Michel Basquiat)"
+        )
+      ).toBeInTheDocument()
+    })
+
+    it("displays metadata", () => {
+      expect(
+        screen.getByText("Acrylic on cotton sweatshirt.")
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText("Drawing, Collage or other Work on Paper")
+      ).toBeInTheDocument()
+      expect(screen.getByText("22 × 16 1/2 in")).toBeInTheDocument()
+      expect(screen.getByText("55.9 × 41.9 cm")).toBeInTheDocument()
+      expect(screen.getByText("Bought in a gallery")).toBeInTheDocument()
+      expect(screen.getByText("This is a unique work")).toBeInTheDocument()
+      expect(screen.getByText("€25,300")).toBeInTheDocument()
+      expect(screen.getByText("Berlin")).toBeInTheDocument()
+    })
+  })
+
+  describe("for artwork with minimal metadata", () => {
+    beforeEach(() => {
+      renderWithRelay(emptyMockResolvers, false)
+    })
+
+    it("displays artists names and title", () => {
+      expect(screen.getByText("Jean-Michel Basquiat")).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          "Basquiat hand-painted sweatshirt 1979/1980 (early Jean-Michel Basquiat)"
+        )
+      ).toBeInTheDocument()
+    })
+
+    it("displays minimal metadata", () => {
+      expect(
+        screen.getByText("Acrylic on cotton sweatshirt.")
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText("Drawing, Collage or other Work on Paper")
+      ).toBeInTheDocument()
+
+      // shows labels when no data are available
+      expect(screen.getByText("Size")).toBeInTheDocument()
+      expect(screen.getByText("Provenance")).toBeInTheDocument()
+      expect(screen.getByText("Rarity")).toBeInTheDocument()
+      expect(screen.getByText("Price Paid")).toBeInTheDocument()
+      expect(screen.getByText("Location")).toBeInTheDocument()
+
+      // replaces empty values with ----
+      expect(screen.getAllByText("----")).toHaveLength(5)
+    })
+  })
+})
+
+const mockResolversWithData = {
+  Artwork: () => ({
+    artistNames: "Jean-Michel Basquiat",
+    title:
+      "Basquiat hand-painted sweatshirt 1979/1980 (early Jean-Michel Basquiat)",
+    category: "Drawing, Collage or other Work on Paper",
+    medium: "Acrylic on cotton sweatshirt.",
+    dimensions: {
+      in: "22 × 16 1/2 in",
+      cm: "55.9 × 41.9 cm",
+    },
+    provenance: "Bought in a gallery",
+    attributionClass: {
+      shortDescription: "This is a unique work",
+    },
+    pricePaid: {
+      display: "€25,300",
+    },
+    artworkLocation: "Berlin",
+  }),
+}
+
+const emptyMockResolvers = {
+  Artwork: () => ({
+    artistNames: "Jean-Michel Basquiat",
+    title:
+      "Basquiat hand-painted sweatshirt 1979/1980 (early Jean-Michel Basquiat)",
+    category: "Drawing, Collage or other Work on Paper",
+    medium: "Acrylic on cotton sweatshirt.",
+    dimensions: null,
+    provenance: null,
+    attributionClass: null,
+    pricePaid: null,
+    artworkLocation: null,
+  }),
+}

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/__tests__/MyCollectionArtworkSidebarMetadata.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/__tests__/MyCollectionArtworkSidebarMetadata.jest.tsx
@@ -41,6 +41,7 @@ describe("MyCollectionArtworkSidebarMetadata", () => {
           "Basquiat hand-painted sweatshirt 1979/1980 (early Jean-Michel Basquiat)"
         )
       ).toBeInTheDocument()
+      expect(screen.getByText(", 1979")).toBeInTheDocument()
     })
 
     it("displays metadata", () => {
@@ -50,8 +51,11 @@ describe("MyCollectionArtworkSidebarMetadata", () => {
       expect(
         screen.getByText("Drawing, Collage or other Work on Paper")
       ).toBeInTheDocument()
-      expect(screen.getByText("22 × 16 1/2 in")).toBeInTheDocument()
-      expect(screen.getByText("55.9 × 41.9 cm")).toBeInTheDocument()
+      expect(
+        screen.getByText("22 × 16 1/2 in 55.9 × 41.9 cm", {
+          collapseWhitespace: true,
+        })
+      ).toBeInTheDocument()
       expect(screen.getByText("Bought in a gallery")).toBeInTheDocument()
       expect(screen.getByText("This is a unique work")).toBeInTheDocument()
       expect(screen.getByText("€25,300")).toBeInTheDocument()
@@ -71,6 +75,7 @@ describe("MyCollectionArtworkSidebarMetadata", () => {
           "Basquiat hand-painted sweatshirt 1979/1980 (early Jean-Michel Basquiat)"
         )
       ).toBeInTheDocument()
+      expect(screen.getByText(", 1979")).toBeInTheDocument()
     })
 
     it("displays minimal metadata", () => {
@@ -100,6 +105,7 @@ const mockResolversWithData = {
     title:
       "Basquiat hand-painted sweatshirt 1979/1980 (early Jean-Michel Basquiat)",
     category: "Drawing, Collage or other Work on Paper",
+    date: "1979",
     medium: "Acrylic on cotton sweatshirt.",
     dimensions: {
       in: "22 × 16 1/2 in",
@@ -121,6 +127,7 @@ const emptyMockResolvers = {
     artistNames: "Jean-Michel Basquiat",
     title:
       "Basquiat hand-painted sweatshirt 1979/1980 (early Jean-Michel Basquiat)",
+    date: "1979",
     category: "Drawing, Collage or other Work on Paper",
     medium: "Acrylic on cotton sweatshirt.",
     dimensions: null,

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/index.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/index.tsx
@@ -1,0 +1,103 @@
+// export interface ArtworkSidebarProps {
+//   artwork: ArtworkSidebar_artwork
+//   me: ArtworkSidebar_me
+// }
+
+import { Box } from "@artsy/palette"
+import { MyCollectionArtworkSidebarMetadata } from "./MyCollectionArtworkSidebarMetadata"
+
+const MyCollectionArtworkSidebarContainer = Box
+
+export const MyCollectionArtworkSidebar: React.FC<any> = ({ artwork, me }) => {
+  // If we have info about the lot end time (cascading), use that.
+  // const { sale, saleArtwork, is_sold, is_in_auction } = artwork
+  // const endAt = saleArtwork?.endAt
+  // const extendedBiddingEndAt = saleArtwork?.extendedBiddingEndAt
+  // const biddingEndAt = extendedBiddingEndAt ?? endAt
+
+  // const startAt = sale?.startAt
+
+  // const shouldRenderArtworkBadges =
+  //   shouldRenderVerifiedSeller(artwork) ||
+  //   shouldRenderBuyerGuaranteeAndSecurePayment(artwork)
+
+  // const [updatedBiddingEndAt, setUpdatedBiddingEndAt] = React.useState(
+  //   biddingEndAt
+  // )
+
+  // useAuctionWebsocket({
+  //   lotID: saleArtwork?.lotID!,
+  //   onChange: ({ extended_bidding_end_at }) => {
+  //     setUpdatedBiddingEndAt(extended_bidding_end_at)
+  //   },
+  // })
+
+  // const { hasEnded } = useTimer(updatedBiddingEndAt!, startAt!)
+  // const shouldHideDetailsCreateAlertCTA =
+  //   artwork.artists?.length === 0 ||
+  //   (is_in_auction && hasEnded) ||
+  //   (is_in_auction && lotIsClosed(sale, saleArtwork)) ||
+  //   is_sold
+
+  return (
+    <MyCollectionArtworkSidebarContainer
+    // data-test={ContextModule.artworkSidebar}
+    >
+      {/* <ArtworkSidebarMetadataFragmentContainer artwork={artwork} /> */}
+      <MyCollectionArtworkSidebarMetadata />
+    </MyCollectionArtworkSidebarContainer>
+  )
+}
+
+// export const ArtworkSidebarFragmentContainer = createFragmentContainer(
+//   ArtworkSidebar,
+//   {
+//     artwork: graphql`
+//       fragment ArtworkSidebar_artwork on Artwork {
+//         is_in_auction: isInAuction
+//         is_sold: isSold
+//         is_biddable: isBiddable
+//         is_acquireable: isAcquireable
+//         is_offerable: isOfferable
+//         hasCertificateOfAuthenticity
+//         partner {
+//           isVerifiedSeller
+//         }
+//         ...ArtworkSidebarArtists_artwork
+//         ...ArtworkSidebarMetadata_artwork
+//         ...ArtworkSidebarAuctionPartnerInfo_artwork
+//         ...ArtworkSidebarAuctionInfoPolling_artwork
+//         ...ArtworkSidebarAuctionTimer_artwork
+//         ...ArtworkSidebarCommercial_artwork
+//         ...ArtworkSidebarPartnerInfo_artwork
+//         ...ArtworkSidebarExtraLinks_artwork
+//         ...SecurePayment_artwork
+//         ...VerifiedSeller_artwork
+//         ...AuthenticityCertificate_artwork
+//         ...BuyerGuarantee_artwork
+//         ...CreateArtworkAlertSection_artwork
+//         ...ArtworkSidebarBiddingClosedMessage_artwork
+//         sale {
+//           is_closed: isClosed
+//           startAt
+//           internalID
+//           extendedBiddingIntervalMinutes
+//         }
+//         saleArtwork {
+//           endAt
+//           endedAt
+//           extendedBiddingEndAt
+//           lotID
+//         }
+//         artists {
+//           internalID
+//         }
+//       }
+//     `,
+//     me: graphql`
+//       fragment ArtworkSidebar_me on Me {
+//         ...ArtworkSidebarAuctionInfoPolling_me
+//       }
+//     `,
+//   }
+// )

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/index.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/index.tsx
@@ -1,103 +1,31 @@
-// export interface ArtworkSidebarProps {
-//   artwork: ArtworkSidebar_artwork
-//   me: ArtworkSidebar_me
-// }
-
 import { Box } from "@artsy/palette"
-import { MyCollectionArtworkSidebarMetadata } from "./MyCollectionArtworkSidebarMetadata"
+import { createFragmentContainer, graphql } from "react-relay"
+import { MyCollectionArtworkSidebarMetadataFragmentContainer } from "./MyCollectionArtworkSidebarMetadata"
+import { MyCollectionArtworkSidebar_artwork } from "__generated__/MyCollectionArtworkSidebar_artwork.graphql"
 
 const MyCollectionArtworkSidebarContainer = Box
 
-export const MyCollectionArtworkSidebar: React.FC<any> = ({ artwork, me }) => {
-  // If we have info about the lot end time (cascading), use that.
-  // const { sale, saleArtwork, is_sold, is_in_auction } = artwork
-  // const endAt = saleArtwork?.endAt
-  // const extendedBiddingEndAt = saleArtwork?.extendedBiddingEndAt
-  // const biddingEndAt = extendedBiddingEndAt ?? endAt
+interface MyCollectionArtworkSidebarProps {
+  artwork: MyCollectionArtworkSidebar_artwork
+}
 
-  // const startAt = sale?.startAt
-
-  // const shouldRenderArtworkBadges =
-  //   shouldRenderVerifiedSeller(artwork) ||
-  //   shouldRenderBuyerGuaranteeAndSecurePayment(artwork)
-
-  // const [updatedBiddingEndAt, setUpdatedBiddingEndAt] = React.useState(
-  //   biddingEndAt
-  // )
-
-  // useAuctionWebsocket({
-  //   lotID: saleArtwork?.lotID!,
-  //   onChange: ({ extended_bidding_end_at }) => {
-  //     setUpdatedBiddingEndAt(extended_bidding_end_at)
-  //   },
-  // })
-
-  // const { hasEnded } = useTimer(updatedBiddingEndAt!, startAt!)
-  // const shouldHideDetailsCreateAlertCTA =
-  //   artwork.artists?.length === 0 ||
-  //   (is_in_auction && hasEnded) ||
-  //   (is_in_auction && lotIsClosed(sale, saleArtwork)) ||
-  //   is_sold
-
+export const MyCollectionArtworkSidebar: React.FC<MyCollectionArtworkSidebarProps> = ({
+  artwork,
+}) => {
   return (
-    <MyCollectionArtworkSidebarContainer
-    // data-test={ContextModule.artworkSidebar}
-    >
-      {/* <ArtworkSidebarMetadataFragmentContainer artwork={artwork} /> */}
-      <MyCollectionArtworkSidebarMetadata />
+    <MyCollectionArtworkSidebarContainer>
+      <MyCollectionArtworkSidebarMetadataFragmentContainer artwork={artwork} />
     </MyCollectionArtworkSidebarContainer>
   )
 }
 
-// export const ArtworkSidebarFragmentContainer = createFragmentContainer(
-//   ArtworkSidebar,
-//   {
-//     artwork: graphql`
-//       fragment ArtworkSidebar_artwork on Artwork {
-//         is_in_auction: isInAuction
-//         is_sold: isSold
-//         is_biddable: isBiddable
-//         is_acquireable: isAcquireable
-//         is_offerable: isOfferable
-//         hasCertificateOfAuthenticity
-//         partner {
-//           isVerifiedSeller
-//         }
-//         ...ArtworkSidebarArtists_artwork
-//         ...ArtworkSidebarMetadata_artwork
-//         ...ArtworkSidebarAuctionPartnerInfo_artwork
-//         ...ArtworkSidebarAuctionInfoPolling_artwork
-//         ...ArtworkSidebarAuctionTimer_artwork
-//         ...ArtworkSidebarCommercial_artwork
-//         ...ArtworkSidebarPartnerInfo_artwork
-//         ...ArtworkSidebarExtraLinks_artwork
-//         ...SecurePayment_artwork
-//         ...VerifiedSeller_artwork
-//         ...AuthenticityCertificate_artwork
-//         ...BuyerGuarantee_artwork
-//         ...CreateArtworkAlertSection_artwork
-//         ...ArtworkSidebarBiddingClosedMessage_artwork
-//         sale {
-//           is_closed: isClosed
-//           startAt
-//           internalID
-//           extendedBiddingIntervalMinutes
-//         }
-//         saleArtwork {
-//           endAt
-//           endedAt
-//           extendedBiddingEndAt
-//           lotID
-//         }
-//         artists {
-//           internalID
-//         }
-//       }
-//     `,
-//     me: graphql`
-//       fragment ArtworkSidebar_me on Me {
-//         ...ArtworkSidebarAuctionInfoPolling_me
-//       }
-//     `,
-//   }
-// )
+export const MyCollectionArtworkSidebarFragmentContainer = createFragmentContainer(
+  MyCollectionArtworkSidebar,
+  {
+    artwork: graphql`
+      fragment MyCollectionArtworkSidebar_artwork on Artwork {
+        ...MyCollectionArtworkSidebarMetadata_artwork
+      }
+    `,
+  }
+)

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
@@ -2,6 +2,7 @@ import { Box, Column, GridColumns } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { MyCollectionArtworkSidebarFragmentContainer } from "./Components/MyCollectionArtworkSidebar"
 import { MyCollectionArtwork_artwork } from "__generated__/MyCollectionArtwork_artwork.graphql"
+import { MyCollectionArtworkMetaFragmentContainer } from "./Components/MyCollectionArtworkMeta"
 
 interface MyCollectionArtworkProps {
   artwork: MyCollectionArtwork_artwork
@@ -11,6 +12,8 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
 }) => {
   return (
     <>
+      <MyCollectionArtworkMetaFragmentContainer artwork={artwork} />
+
       <GridColumns>
         <Column span={8}>
           <Box width={[335, 780]} height={[320, 870]} bg="black5" />
@@ -30,6 +33,7 @@ export const MyCollectionArtworkFragmentContainer = createFragmentContainer(
     artwork: graphql`
       fragment MyCollectionArtwork_artwork on Artwork {
         ...MyCollectionArtworkSidebar_artwork
+        ...MyCollectionArtworkMeta_artwork
       }
     `,
   }

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
@@ -1,28 +1,36 @@
-import { Column, GridColumns, Spacer, Text } from "@artsy/palette"
-import { MyCollectionArtworkSidebar } from "./Components/MyCollectionArtworkSidebar"
+import { Box, Column, GridColumns } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { MyCollectionArtworkSidebarFragmentContainer } from "./Components/MyCollectionArtworkSidebar"
+import { MyCollectionArtwork_artwork } from "__generated__/MyCollectionArtwork_artwork.graphql"
 
-export const MyCollectionArtworkFragmentContainer = () => {
+interface MyCollectionArtworkProps {
+  artwork: MyCollectionArtwork_artwork
+}
+const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
+  artwork,
+}) => {
   return (
     <>
       <GridColumns>
         <Column span={8}>
-          {/* <ArtworkImageBrowserFragmentContainer artwork={artwork} /> */}
-          <div
-            style={{
-              width: "400px",
-              height: "400px",
-              background: "rebeccapurple",
-            }}
-          />
-          {/* <Media greaterThanOrEqual="sm">{BelowTheFoldArtworkDetails}</Media> */}
+          <Box width={[335, 780]} height={[320, 870]} bg="black5" />
         </Column>
 
         <Column span={4} pt={[0, 2]}>
-          <MyCollectionArtworkSidebar />
-
-          {/* <ArtworkSidebarFragmentContainer artwork={artwork} me={me} /> */}
+          <MyCollectionArtworkSidebarFragmentContainer artwork={artwork} />
         </Column>
       </GridColumns>
     </>
   )
 }
+
+export const MyCollectionArtworkFragmentContainer = createFragmentContainer(
+  MyCollectionArtwork,
+  {
+    artwork: graphql`
+      fragment MyCollectionArtwork_artwork on Artwork {
+        ...MyCollectionArtworkSidebar_artwork
+      }
+    `,
+  }
+)

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
@@ -1,5 +1,28 @@
-import { Text } from "@artsy/palette"
+import { Column, GridColumns, Spacer, Text } from "@artsy/palette"
+import { MyCollectionArtworkSidebar } from "./Components/MyCollectionArtworkSidebar"
 
 export const MyCollectionArtworkFragmentContainer = () => {
-  return <Text>YOU'RE HERE!</Text>
+  return (
+    <>
+      <GridColumns>
+        <Column span={8}>
+          {/* <ArtworkImageBrowserFragmentContainer artwork={artwork} /> */}
+          <div
+            style={{
+              width: "400px",
+              height: "400px",
+              background: "rebeccapurple",
+            }}
+          />
+          {/* <Media greaterThanOrEqual="sm">{BelowTheFoldArtworkDetails}</Media> */}
+        </Column>
+
+        <Column span={4} pt={[0, 2]}>
+          <MyCollectionArtworkSidebar />
+
+          {/* <ArtworkSidebarFragmentContainer artwork={artwork} me={me} /> */}
+        </Column>
+      </GridColumns>
+    </>
+  )
 }

--- a/src/Apps/MyCollection/myCollectionRoutes.tsx
+++ b/src/Apps/MyCollection/myCollectionRoutes.tsx
@@ -1,4 +1,5 @@
 import loadable from "@loadable/component"
+import { graphql } from "relay-runtime"
 import { AppRouteConfig } from "System/Router/Route"
 
 const MyCollectionArtwork = loadable(
@@ -14,10 +15,25 @@ const MyCollectionArtwork = loadable(
 
 export const myCollectionRoutes: AppRouteConfig[] = [
   {
-    path: "/my-collection/artwork/:Slug",
+    path: "/my-collection/artwork/:artworkID",
     getComponent: () => MyCollectionArtwork,
     onClientSideRender: () => {
       MyCollectionArtwork.preload()
+    },
+    prepareVariables: ({ artworkID }, props) => {
+      return {
+        artworkID,
+      }
+    },
+    query: graphql`
+      query myCollectionRoutes_ArtworkQuery($artworkID: String!) {
+        artwork(id: $artworkID) @principalField {
+          ...MyCollectionArtwork_artwork
+        }
+      }
+    `,
+    cacheConfig: {
+      force: true,
     },
   },
 ]

--- a/src/__generated__/MyCollectionArtworkMeta_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkMeta_artwork.graphql.ts
@@ -1,0 +1,45 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type MyCollectionArtworkMeta_artwork = {
+    readonly artistNames: string | null;
+    readonly title: string | null;
+    readonly " $refType": "MyCollectionArtworkMeta_artwork";
+};
+export type MyCollectionArtworkMeta_artwork$data = MyCollectionArtworkMeta_artwork;
+export type MyCollectionArtworkMeta_artwork$key = {
+    readonly " $data"?: MyCollectionArtworkMeta_artwork$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkMeta_artwork">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "MyCollectionArtworkMeta_artwork",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artistNames",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    }
+  ],
+  "type": "Artwork",
+  "abstractKey": null
+};
+(node as any).hash = '300c9a3093b0d34db5c35b91dc4a569c';
+export default node;

--- a/src/__generated__/MyCollectionArtworkSidebarMetadataTestQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkSidebarMetadataTestQuery.graphql.ts
@@ -28,6 +28,7 @@ query MyCollectionArtworkSidebarMetadataTestQuery {
 fragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {
   artistNames
   title
+  date
   category
   medium
   dimensions {
@@ -132,6 +133,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "date",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "category",
             "storageKey": null
           },
@@ -225,7 +233,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9b945b136281bbc6cd4209c7bcf8685a",
+    "cacheID": "84bf8fa670b3afab14bf534a53e4d82b",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -246,6 +254,7 @@ return {
         "artwork.attributionClass.id": (v3/*: any*/),
         "artwork.attributionClass.shortDescription": (v2/*: any*/),
         "artwork.category": (v2/*: any*/),
+        "artwork.date": (v2/*: any*/),
         "artwork.dimensions": {
           "enumValues": null,
           "nullable": true,
@@ -269,7 +278,7 @@ return {
     },
     "name": "MyCollectionArtworkSidebarMetadataTestQuery",
     "operationKind": "query",
-    "text": "query MyCollectionArtworkSidebarMetadataTestQuery {\n  artwork(id: \"foo\") {\n    ...MyCollectionArtworkSidebarMetadata_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n"
+    "text": "query MyCollectionArtworkSidebarMetadataTestQuery {\n  artwork(id: \"foo\") {\n    ...MyCollectionArtworkSidebarMetadata_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  date\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n"
   }
 };
 })();

--- a/src/__generated__/MyCollectionArtworkSidebarMetadataTestQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkSidebarMetadataTestQuery.graphql.ts
@@ -1,0 +1,277 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type MyCollectionArtworkSidebarMetadataTestQueryVariables = {};
+export type MyCollectionArtworkSidebarMetadataTestQueryResponse = {
+    readonly artwork: {
+        readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkSidebarMetadata_artwork">;
+    } | null;
+};
+export type MyCollectionArtworkSidebarMetadataTestQuery = {
+    readonly response: MyCollectionArtworkSidebarMetadataTestQueryResponse;
+    readonly variables: MyCollectionArtworkSidebarMetadataTestQueryVariables;
+};
+
+
+
+/*
+query MyCollectionArtworkSidebarMetadataTestQuery {
+  artwork(id: "foo") {
+    ...MyCollectionArtworkSidebarMetadata_artwork
+    id
+  }
+}
+
+fragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {
+  artistNames
+  title
+  category
+  medium
+  dimensions {
+    in
+    cm
+  }
+  provenance
+  attributionClass {
+    shortDescription
+    id
+  }
+  pricePaid {
+    display
+  }
+  artworkLocation
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "foo"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v3 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "MyCollectionArtworkSidebarMetadataTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "MyCollectionArtworkSidebarMetadata_artwork"
+          }
+        ],
+        "storageKey": "artwork(id:\"foo\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "MyCollectionArtworkSidebarMetadataTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "artistNames",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "medium",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "dimensions",
+            "kind": "LinkedField",
+            "name": "dimensions",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "in",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cm",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "provenance",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "kind": "LinkedField",
+            "name": "attributionClass",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "shortDescription",
+                "storageKey": null
+              },
+              (v1/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Money",
+            "kind": "LinkedField",
+            "name": "pricePaid",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "display",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "artworkLocation",
+            "storageKey": null
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": "artwork(id:\"foo\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "9b945b136281bbc6cd4209c7bcf8685a",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "artwork.artistNames": (v2/*: any*/),
+        "artwork.artworkLocation": (v2/*: any*/),
+        "artwork.attributionClass": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AttributionClass"
+        },
+        "artwork.attributionClass.id": (v3/*: any*/),
+        "artwork.attributionClass.shortDescription": (v2/*: any*/),
+        "artwork.category": (v2/*: any*/),
+        "artwork.dimensions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "dimensions"
+        },
+        "artwork.dimensions.cm": (v2/*: any*/),
+        "artwork.dimensions.in": (v2/*: any*/),
+        "artwork.id": (v3/*: any*/),
+        "artwork.medium": (v2/*: any*/),
+        "artwork.pricePaid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Money"
+        },
+        "artwork.pricePaid.display": (v2/*: any*/),
+        "artwork.provenance": (v2/*: any*/),
+        "artwork.title": (v2/*: any*/)
+      }
+    },
+    "name": "MyCollectionArtworkSidebarMetadataTestQuery",
+    "operationKind": "query",
+    "text": "query MyCollectionArtworkSidebarMetadataTestQuery {\n  artwork(id: \"foo\") {\n    ...MyCollectionArtworkSidebarMetadata_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n"
+  }
+};
+})();
+(node as any).hash = 'ca880f2c1b88f4a29ab5905c4d9cfb26';
+export default node;

--- a/src/__generated__/MyCollectionArtworkSidebarMetadata_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkSidebarMetadata_artwork.graphql.ts
@@ -13,7 +13,6 @@ export type MyCollectionArtworkSidebarMetadata_artwork = {
         readonly in: string | null;
         readonly cm: string | null;
     } | null;
-    readonly date: string | null;
     readonly provenance: string | null;
     readonly attributionClass: {
         readonly shortDescription: string | null;
@@ -95,13 +94,6 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "date",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
       "name": "provenance",
       "storageKey": null
     },
@@ -152,5 +144,5 @@ const node: ReaderFragment = {
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = 'd3fa3b35e98ea5f1120b6ae697f6da54';
+(node as any).hash = 'e9f65618d5d777cda6ea0020c1a5d211';
 export default node;

--- a/src/__generated__/MyCollectionArtworkSidebarMetadata_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkSidebarMetadata_artwork.graphql.ts
@@ -7,6 +7,7 @@ import { FragmentRefs } from "relay-runtime";
 export type MyCollectionArtworkSidebarMetadata_artwork = {
     readonly artistNames: string | null;
     readonly title: string | null;
+    readonly date: string | null;
     readonly category: string | null;
     readonly medium: string | null;
     readonly dimensions: {
@@ -49,6 +50,13 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "ScalarField",
       "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "date",
       "storageKey": null
     },
     {
@@ -144,5 +152,5 @@ const node: ReaderFragment = {
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = 'e9f65618d5d777cda6ea0020c1a5d211';
+(node as any).hash = 'f16d0f242ce8fbe21185dd52ea4bd80e';
 export default node;

--- a/src/__generated__/MyCollectionArtworkSidebarMetadata_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkSidebarMetadata_artwork.graphql.ts
@@ -1,0 +1,156 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type MyCollectionArtworkSidebarMetadata_artwork = {
+    readonly artistNames: string | null;
+    readonly title: string | null;
+    readonly category: string | null;
+    readonly medium: string | null;
+    readonly dimensions: {
+        readonly in: string | null;
+        readonly cm: string | null;
+    } | null;
+    readonly date: string | null;
+    readonly provenance: string | null;
+    readonly attributionClass: {
+        readonly shortDescription: string | null;
+    } | null;
+    readonly pricePaid: {
+        readonly display: string | null;
+    } | null;
+    readonly artworkLocation: string | null;
+    readonly " $refType": "MyCollectionArtworkSidebarMetadata_artwork";
+};
+export type MyCollectionArtworkSidebarMetadata_artwork$data = MyCollectionArtworkSidebarMetadata_artwork;
+export type MyCollectionArtworkSidebarMetadata_artwork$key = {
+    readonly " $data"?: MyCollectionArtworkSidebarMetadata_artwork$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkSidebarMetadata_artwork">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "MyCollectionArtworkSidebarMetadata_artwork",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artistNames",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "category",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "medium",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "dimensions",
+      "kind": "LinkedField",
+      "name": "dimensions",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "in",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "cm",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "date",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "provenance",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AttributionClass",
+      "kind": "LinkedField",
+      "name": "attributionClass",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "shortDescription",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Money",
+      "kind": "LinkedField",
+      "name": "pricePaid",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "display",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artworkLocation",
+      "storageKey": null
+    }
+  ],
+  "type": "Artwork",
+  "abstractKey": null
+};
+(node as any).hash = 'd3fa3b35e98ea5f1120b6ae697f6da54';
+export default node;

--- a/src/__generated__/MyCollectionArtworkSidebar_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkSidebar_artwork.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type MyCollectionArtworkSidebar_artwork = {
+    readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkSidebarMetadata_artwork">;
+    readonly " $refType": "MyCollectionArtworkSidebar_artwork";
+};
+export type MyCollectionArtworkSidebar_artwork$data = MyCollectionArtworkSidebar_artwork;
+export type MyCollectionArtworkSidebar_artwork$key = {
+    readonly " $data"?: MyCollectionArtworkSidebar_artwork$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkSidebar_artwork">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "MyCollectionArtworkSidebar_artwork",
+  "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "MyCollectionArtworkSidebarMetadata_artwork"
+    }
+  ],
+  "type": "Artwork",
+  "abstractKey": null
+};
+(node as any).hash = '79af56d0e4f5662d0753ac3bc53d9380';
+export default node;

--- a/src/__generated__/MyCollectionArtwork_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtwork_artwork.graphql.ts
@@ -5,7 +5,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type MyCollectionArtwork_artwork = {
-    readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkSidebar_artwork">;
+    readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkSidebar_artwork" | "MyCollectionArtworkMeta_artwork">;
     readonly " $refType": "MyCollectionArtwork_artwork";
 };
 export type MyCollectionArtwork_artwork$data = MyCollectionArtwork_artwork;
@@ -26,10 +26,15 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "FragmentSpread",
       "name": "MyCollectionArtworkSidebar_artwork"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "MyCollectionArtworkMeta_artwork"
     }
   ],
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = 'ef3a9486aeedb5fc0244ce7d154b6102';
+(node as any).hash = '290602b3523eac88e780646189d11f9d';
 export default node;

--- a/src/__generated__/MyCollectionArtwork_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtwork_artwork.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type MyCollectionArtwork_artwork = {
+    readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkSidebar_artwork">;
+    readonly " $refType": "MyCollectionArtwork_artwork";
+};
+export type MyCollectionArtwork_artwork$data = MyCollectionArtwork_artwork;
+export type MyCollectionArtwork_artwork$key = {
+    readonly " $data"?: MyCollectionArtwork_artwork$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtwork_artwork">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "MyCollectionArtwork_artwork",
+  "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "MyCollectionArtworkSidebar_artwork"
+    }
+  ],
+  "type": "Artwork",
+  "abstractKey": null
+};
+(node as any).hash = 'ef3a9486aeedb5fc0244ce7d154b6102';
+export default node;

--- a/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
@@ -1,0 +1,253 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type myCollectionRoutes_ArtworkQueryVariables = {
+    artworkID: string;
+};
+export type myCollectionRoutes_ArtworkQueryResponse = {
+    readonly artwork: {
+        readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtwork_artwork">;
+    } | null;
+};
+export type myCollectionRoutes_ArtworkQuery = {
+    readonly response: myCollectionRoutes_ArtworkQueryResponse;
+    readonly variables: myCollectionRoutes_ArtworkQueryVariables;
+};
+
+
+
+/*
+query myCollectionRoutes_ArtworkQuery(
+  $artworkID: String!
+) {
+  artwork(id: $artworkID) @principalField {
+    ...MyCollectionArtwork_artwork
+    id
+  }
+}
+
+fragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {
+  artistNames
+  title
+  category
+  medium
+  dimensions {
+    in
+    cm
+  }
+  date
+  provenance
+  attributionClass {
+    shortDescription
+    id
+  }
+  pricePaid {
+    display
+  }
+  artworkLocation
+}
+
+fragment MyCollectionArtworkSidebar_artwork on Artwork {
+  ...MyCollectionArtworkSidebarMetadata_artwork
+}
+
+fragment MyCollectionArtwork_artwork on Artwork {
+  ...MyCollectionArtworkSidebar_artwork
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "artworkID"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artworkID"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "myCollectionRoutes_ArtworkQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "MyCollectionArtwork_artwork"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "myCollectionRoutes_ArtworkQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "artistNames",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "medium",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "dimensions",
+            "kind": "LinkedField",
+            "name": "dimensions",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "in",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cm",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "date",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "provenance",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "kind": "LinkedField",
+            "name": "attributionClass",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "shortDescription",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Money",
+            "kind": "LinkedField",
+            "name": "pricePaid",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "display",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "artworkLocation",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1a2562f713074a3d298e9477dfdcb136",
+    "id": null,
+    "metadata": {},
+    "name": "myCollectionRoutes_ArtworkQuery",
+    "operationKind": "query",
+    "text": "query myCollectionRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  date\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n\nfragment MyCollectionArtworkSidebar_artwork on Artwork {\n  ...MyCollectionArtworkSidebarMetadata_artwork\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkSidebar_artwork\n}\n"
+  }
+};
+})();
+(node as any).hash = 'eb0d685c52377b6950abe6d49acab502';
+export default node;

--- a/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
@@ -29,6 +29,11 @@ query myCollectionRoutes_ArtworkQuery(
   }
 }
 
+fragment MyCollectionArtworkMeta_artwork on Artwork {
+  artistNames
+  title
+}
+
 fragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {
   artistNames
   title
@@ -56,6 +61,7 @@ fragment MyCollectionArtworkSidebar_artwork on Artwork {
 
 fragment MyCollectionArtwork_artwork on Artwork {
   ...MyCollectionArtworkSidebar_artwork
+  ...MyCollectionArtworkMeta_artwork
 }
 */
 
@@ -240,12 +246,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "31d5650022445d4873eb51cc5d9b17f7",
+    "cacheID": "3b198b0f7d5fa990e90b05985fd4e7f5",
     "id": null,
     "metadata": {},
     "name": "myCollectionRoutes_ArtworkQuery",
     "operationKind": "query",
-    "text": "query myCollectionRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  date\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n\nfragment MyCollectionArtworkSidebar_artwork on Artwork {\n  ...MyCollectionArtworkSidebarMetadata_artwork\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkSidebar_artwork\n}\n"
+    "text": "query myCollectionRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkMeta_artwork on Artwork {\n  artistNames\n  title\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  date\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n\nfragment MyCollectionArtworkSidebar_artwork on Artwork {\n  ...MyCollectionArtworkSidebarMetadata_artwork\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkSidebar_artwork\n  ...MyCollectionArtworkMeta_artwork\n}\n"
   }
 };
 })();

--- a/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
@@ -32,6 +32,7 @@ query myCollectionRoutes_ArtworkQuery(
 fragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {
   artistNames
   title
+  date
   category
   medium
   dimensions {
@@ -139,6 +140,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "date",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "category",
             "storageKey": null
           },
@@ -232,12 +240,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ecb17b4dd5e9d9aa93bd908ceb855614",
+    "cacheID": "31d5650022445d4873eb51cc5d9b17f7",
     "id": null,
     "metadata": {},
     "name": "myCollectionRoutes_ArtworkQuery",
     "operationKind": "query",
-    "text": "query myCollectionRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n\nfragment MyCollectionArtworkSidebar_artwork on Artwork {\n  ...MyCollectionArtworkSidebarMetadata_artwork\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkSidebar_artwork\n}\n"
+    "text": "query myCollectionRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  date\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n\nfragment MyCollectionArtworkSidebar_artwork on Artwork {\n  ...MyCollectionArtworkSidebarMetadata_artwork\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkSidebar_artwork\n}\n"
   }
 };
 })();

--- a/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
@@ -38,7 +38,6 @@ fragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {
     in
     cm
   }
-  date
   provenance
   attributionClass {
     shortDescription
@@ -179,13 +178,6 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "date",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
             "name": "provenance",
             "storageKey": null
           },
@@ -240,12 +232,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1a2562f713074a3d298e9477dfdcb136",
+    "cacheID": "ecb17b4dd5e9d9aa93bd908ceb855614",
     "id": null,
     "metadata": {},
     "name": "myCollectionRoutes_ArtworkQuery",
     "operationKind": "query",
-    "text": "query myCollectionRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  date\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n\nfragment MyCollectionArtworkSidebar_artwork on Artwork {\n  ...MyCollectionArtworkSidebarMetadata_artwork\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkSidebar_artwork\n}\n"
+    "text": "query myCollectionRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n\nfragment MyCollectionArtworkSidebar_artwork on Artwork {\n  ...MyCollectionArtworkSidebarMetadata_artwork\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkSidebar_artwork\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2708]

### Description
This PR adds the overview section (sidebar) in My Collection artwork details page

### Screenshots
|Mobile| Desktop|
|--|--|
| ![image](https://user-images.githubusercontent.com/20655703/184369414-9a3d42d7-8704-4fb2-8678-f2e92255e454.png) |  ![image](https://user-images.githubusercontent.com/20655703/184369451-fd49d43c-6eed-41f2-a2f8-da9a290db457.png) |



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2708]: https://artsyproduct.atlassian.net/browse/CX-2708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ