### PR TITLE
[Do Not Merge] => feat(onboarding): Update auth flow to trigger onboarding

### DIFF
--- a/src/Apps/Article/ArticleApp.tsx
+++ b/src/Apps/Article/ArticleApp.tsx
@@ -31,6 +31,9 @@ const ArticleApp: FC<ArticleAppProps> = ({ article }) => {
       contextModule: ContextModule.popUpModal,
       copy: "Sign up for the latest in art market news",
       destination: location.pathname,
+      // TODO: Onboarding is triggered based on contents of redirectTo
+      // prop. Move this to `afterSignupAction.action`
+      redirectTo: location.pathname,
       afterSignUpAction: { action: "editorialSignup" },
     },
   })

--- a/src/Apps/Authentication/Utils/__tests__/helpers.jest.ts
+++ b/src/Apps/Authentication/Utils/__tests__/helpers.jest.ts
@@ -2,9 +2,13 @@ import {
   apiAuthWithRedirectUrl,
   getRedirect,
   handleSubmit,
+  maybeUpdateRedirectTo,
   setCookies,
 } from "../helpers"
-import { ModalType } from "Components/Authentication/Types"
+import {
+  COMMERCIAL_AUTH_INTENTS,
+  ModalType,
+} from "Components/Authentication/Types"
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { mockLocation } from "DevTools/mockLocation"
 import { mediator } from "lib/mediator"
@@ -519,6 +523,43 @@ describe("Authentication Helpers", () => {
     it("Returns window.location by default", () => {
       const redirectTo = getRedirect("login")
       expect(redirectTo.toString()).toBe("https://artsy.net/articles")
+    })
+  })
+
+  describe("#maybeUpdateRedirectTo", () => {
+    const originalRedirect = "http://test.com"
+
+    it.each([ModalType.forgot, ModalType.login])(
+      "returns original redirectTo if not signup",
+      type => {
+        const redirectTo = maybeUpdateRedirectTo(
+          type,
+          "http://test.com",
+          Intent.followArtist
+        )
+        expect(redirectTo).toEqual(originalRedirect)
+      }
+    )
+
+    it.each(COMMERCIAL_AUTH_INTENTS)(
+      "returns original redirectTo if signup and commercial intent",
+      intent => {
+        const redirectTo = maybeUpdateRedirectTo(
+          ModalType.signup,
+          "http://test.com",
+          intent
+        )
+        expect(redirectTo).toEqual(originalRedirect)
+      }
+    )
+
+    it("returns redirectTo with onboarding flag if signup and non-commercial intent", () => {
+      const redirectTo = maybeUpdateRedirectTo(
+        ModalType.signup,
+        "http://test.com",
+        Intent.followArtist
+      )
+      expect(redirectTo).toEqual(originalRedirect + "?onboarding=true")
     })
   })
 })

--- a/src/Apps/Authentication/Utils/__tests__/helpers.jest.ts
+++ b/src/Apps/Authentication/Utils/__tests__/helpers.jest.ts
@@ -561,5 +561,30 @@ describe("Authentication Helpers", () => {
       )
       expect(redirectTo).toEqual(originalRedirect + "?onboarding=true")
     })
+
+    it("preserves existing query params", () => {
+      let redirectTo = maybeUpdateRedirectTo(
+        ModalType.signup,
+        "http://test.com",
+        Intent.followArtist
+      )
+      expect(redirectTo).toEqual(originalRedirect + "?onboarding=true")
+
+      redirectTo = maybeUpdateRedirectTo(
+        ModalType.signup,
+        "http://test.com?foo=true",
+        Intent.followArtist
+      )
+      expect(redirectTo).toEqual(originalRedirect + "?foo=true&onboarding=true")
+
+      redirectTo = maybeUpdateRedirectTo(
+        ModalType.signup,
+        "http://test.com?foo=true&bar=true",
+        Intent.followArtist
+      )
+      expect(redirectTo).toEqual(
+        originalRedirect + "?foo=true&bar=true&onboarding=true"
+      )
+    })
   })
 })

--- a/src/Apps/Authentication/Utils/helpers.ts
+++ b/src/Apps/Authentication/Utils/helpers.ts
@@ -1,5 +1,9 @@
 import Cookies from "cookies-js"
-import { ModalOptions, ModalType } from "Components/Authentication/Types"
+import {
+  COMMERCIAL_AUTH_INTENTS,
+  ModalOptions,
+  ModalType,
+} from "Components/Authentication/Types"
 // eslint-disable-next-line no-restricted-imports
 import { data as sd } from "sharify"
 import qs from "qs"
@@ -13,6 +17,7 @@ import {
   AuthModalType,
   AuthTrigger,
   AuthContextModule,
+  AuthIntent,
 } from "@artsy/cohesion"
 import { pick } from "lodash"
 import { mediator } from "lib/mediator"
@@ -98,7 +103,10 @@ export const handleSubmit = async (
 
       let afterAuthURL: URL
       if (modalOptions.redirectTo) {
-        afterAuthURL = new URL(modalOptions.redirectTo, sd.APP_URL)
+        afterAuthURL = new URL(
+          maybeUpdateRedirectTo(type, modalOptions.redirectTo, intent!),
+          sd.APP_URL
+        )
       } else {
         afterAuthURL = getRedirect(type)
       }
@@ -130,6 +138,24 @@ export const handleSubmit = async (
     case ModalType.forgot:
       await forgotUserPassword(userAttributes, options)
       break
+  }
+}
+
+export const maybeUpdateRedirectTo = (
+  type: ModalType,
+  redirectTo: string = "/",
+  intent: AuthIntent
+): string | URL => {
+  if (type !== ModalType.signup) {
+    return redirectTo
+  }
+
+  if (COMMERCIAL_AUTH_INTENTS.includes(intent)) {
+    return redirectTo
+  } else {
+    // For all non-commercial intents, update the redirectTo url with an
+    // onboarding query param flag.
+    return redirectTo + "?onboarding=true"
   }
 }
 

--- a/src/Apps/Authentication/Utils/helpers.ts
+++ b/src/Apps/Authentication/Utils/helpers.ts
@@ -103,6 +103,9 @@ export const handleSubmit = async (
 
       let afterAuthURL: URL
       if (modalOptions.redirectTo) {
+        // This will potentially update the URL with an onboarding=true query
+        // param which will trigger the onboarding flow
+        // TODO: Move this prop to something more formal, like afterSignupAction
         afterAuthURL = new URL(
           maybeUpdateRedirectTo(type, modalOptions.redirectTo, intent!),
           sd.APP_URL
@@ -153,9 +156,17 @@ export const maybeUpdateRedirectTo = (
   if (COMMERCIAL_AUTH_INTENTS.includes(intent)) {
     return redirectTo
   } else {
+    const [redirectToWithoutParams, params] = redirectTo.split("?")
+
     // For all non-commercial intents, update the redirectTo url with an
     // onboarding query param flag.
-    return redirectTo + "?onboarding=true"
+    const updatedParams = qs.stringify({
+      ...qs.parse(params),
+      onboarding: true,
+    })
+
+    const updatedRedirectTo = redirectToWithoutParams + "?" + updatedParams
+    return updatedRedirectTo
   }
 }
 

--- a/src/Apps/Authentication/Utils/useAuthForm.ts
+++ b/src/Apps/Authentication/Utils/useAuthForm.ts
@@ -32,7 +32,7 @@ export function useAuthForm({ canonical, pageTitle, type }: UseAuthFormProps) {
     pageTitle,
   })
 
-  const redirectTo = getENV("AUTHENTICATION_REDIRECT_TO")
+  const redirectTo = getENV("AUTHENTICATION_REDIRECT_TO") ?? "/"
   const signupReferer = getENV("AUTHENTICATION_REFERER")
 
   if (action) {

--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -20,6 +20,7 @@ import { Z } from "./constants"
 import { MNTNConversionPixel, MNTNTrackingPixel } from "Components/MNTNPixels"
 import { createGlobalStyle } from "styled-components"
 import { useDidMount } from "Utils/Hooks/useDidMount"
+import { useOnboardingModal } from "Utils/Hooks/useOnboardingModal"
 
 const logger = createLogger("Apps/Components/AppShell")
 interface AppShellProps {
@@ -29,6 +30,7 @@ interface AppShellProps {
 
 export const AppShell: React.FC<AppShellProps> = props => {
   const isMounted = useDidMount()
+  const { onboardingComponent } = useOnboardingModal()
 
   useAuthIntent()
   useAuthValidation()
@@ -106,6 +108,8 @@ export const AppShell: React.FC<AppShellProps> = props => {
           </Flex>
         )}
       </Theme>
+
+      {onboardingComponent}
 
       <MNTNConversionPixel />
       <MNTNTrackingPixel />

--- a/src/Apps/Home/HomeApp.tsx
+++ b/src/Apps/Home/HomeApp.tsx
@@ -16,7 +16,6 @@ import { HomeAuctionLotsRailQueryRenderer } from "./Components/HomeAuctionLotsRa
 import { HomeWorksForYouTabBar } from "./Components/HomeWorksForYouTabBar"
 import { MyBidsQueryRenderer } from "../Auctions/Components/MyBids/MyBids"
 import { HomeTroveArtworksRailQueryRenderer } from "./Components/HomeTroveArtworksRail"
-import { useOnboarding } from "./Hooks/useOnboarding"
 
 interface HomeAppProps {
   homePage: HomeApp_homePage | null
@@ -27,12 +26,8 @@ export const HomeApp: React.FC<HomeAppProps> = ({
   homePage,
   featuredEventsOrderedSet,
 }) => {
-  const { onboardingComponent } = useOnboarding()
-
   return (
     <>
-      {onboardingComponent}
-
       <HomeMeta />
 
       <FlashBannerQueryRenderer />

--- a/src/Components/Authentication/Types.ts
+++ b/src/Components/Authentication/Types.ts
@@ -1,4 +1,4 @@
-import { AuthContextModule, AuthIntent } from "@artsy/cohesion"
+import { AuthContextModule, AuthIntent, Intent } from "@artsy/cohesion"
 import { FormikProps } from "formik"
 
 export enum ModalType {
@@ -46,6 +46,15 @@ export interface AfterSignUpAction {
   objectId?: string
   kind?: "artist" | "artworks" | "gene" | "profile" | "show"
 }
+
+export const COMMERCIAL_AUTH_INTENTS = [
+  Intent.bid,
+  Intent.buyNow,
+  Intent.createAlert,
+  Intent.inquire,
+  Intent.makeOffer,
+  Intent.registerToBid,
+]
 
 export interface ModalOptions {
   /**

--- a/src/Components/Onboarding/Components/OnboardingGene.tsx
+++ b/src/Components/Onboarding/Components/OnboardingGene.tsx
@@ -19,6 +19,15 @@ interface OnboardingGeneProps {
 
 const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
   const artworks = extractNodes(gene.artworks)
+  const { onClose } = useOnboardingContext()
+
+  useEffect(() => {
+    return () => {
+      if (onClose) {
+        onClose()
+      }
+    }
+  }, [onClose])
 
   return (
     <Box px={[2, 4]} py={6}>

--- a/src/System/Router/__tests__/buildClientApp.jest.tsx
+++ b/src/System/Router/__tests__/buildClientApp.jest.tsx
@@ -15,6 +15,10 @@ jest.mock("react-relay", () => ({
   },
 }))
 
+jest.mock("Utils/Hooks/useOnboardingModal", () => ({
+  useOnboardingModal: jest.fn(),
+}))
+
 describe("buildClientApp", () => {
   it("resolves with a <ClientApp /> component", async () => {
     const { ClientApp } = await buildClientApp({

--- a/src/Utils/Hooks/useOnboardingModal.ts
+++ b/src/Utils/Hooks/useOnboardingModal.ts
@@ -1,22 +1,20 @@
 import { omit } from "lodash"
 import { useEffect } from "react"
-import { useOnboarding as _useOnboarding } from "Components/Onboarding"
+import { useOnboarding } from "Components/Onboarding"
 import { useSystemContext } from "System"
 import { useRouter } from "System/Router/useRouter"
 
-export const useOnboarding = () => {
+export const useOnboardingModal = () => {
   const { isLoggedIn } = useSystemContext()
   const { match, router } = useRouter()
 
-  const {
-    onboardingComponent,
-    showOnboarding,
-    hideOnboarding,
-  } = _useOnboarding({
-    onClose: () => {
-      hideOnboarding()
-    },
-  })
+  const { onboardingComponent, showOnboarding, hideOnboarding } = useOnboarding(
+    {
+      onClose: () => {
+        hideOnboarding()
+      },
+    }
+  )
 
   // Check to see if we should open onboarding (logged in + ?onboarding=true),
   // show it, and then immediately remove the query param

--- a/src/Utils/Hooks/useScrollToOpenArtistAuthModal.ts
+++ b/src/Utils/Hooks/useScrollToOpenArtistAuthModal.ts
@@ -80,6 +80,9 @@ export const useScrollToOpenArtistAuthModal = () => {
             contextModule: ContextModule.popUpModal,
             copy: `Sign up to discover new works by ${artist.name} and more artists you love`,
             destination: location.href,
+            // TODO: Onboarding is triggered based on contents of redirectTo
+            // prop. Move this to `afterSignupAction` prop
+            redirectTo: location.href,
             image,
             intent: Intent.viewArtist,
             mode: ModalType.signup,


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [GRO-1191]

(Merging this PR will launch the new onboarding flow!) 

### Description

This PR fully integrates onboarding globally into the app by checking against the users intent before showing. Note that we exclude all commercial intents in this onboarding behavior, including: 

```tsx
const COMMERCIAL_AUTH_INTENTS = [
  Intent.bid,
  Intent.buyNow,
  Intent.createAlert,
  Intent.inquire,
  Intent.makeOffer,
  Intent.registerToBid,
]
```

Leveraged the `useOnboarding` code that @dzucconi added to the HomeApp by moving the hook to `Utils/Hooks`, adding it to the `AppShell` and then listening for a `?onboarding=true` queryParam. 

cc @artsy/grow-devs 

[GRO-1191]: https://artsyproduct.atlassian.net/browse/GRO-1191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ