### PR TITLE
feat: further normalize to improve gallery location filter matches 

### DIFF
--- a/src/Apps/Partners/Components/PartnersLocationAutocomplete.tsx
+++ b/src/Apps/Partners/Components/PartnersLocationAutocomplete.tsx
@@ -7,6 +7,7 @@ import { PartnersLocationAutocomplete_viewer } from "__generated__/PartnersLocat
 import { PartnersLocationAutocompleteQuery } from "__generated__/PartnersLocationAutocompleteQuery.graphql"
 import { useRouter } from "System/Router/useRouter"
 import { omit } from "lodash"
+import { filterCities } from "../Utils/filterUtils"
 
 interface PartnersLocationAutocompleteProps {
   viewer: PartnersLocationAutocomplete_viewer
@@ -28,10 +29,7 @@ const PartnersLocationAutocomplete: FC<PartnersLocationAutocompleteProps> = ({
     }
 
     const cities = value.length > 2 ? allCities : featuredCities
-
-    const filtered = cities.filter(({ text }) => {
-      return text.toLowerCase().includes(value.toLowerCase())
-    })
+    const filtered = filterCities(cities, value)
 
     setOptions(filtered)
   }

--- a/src/Apps/Partners/Utils/__tests__/filterUtils.jest.ts
+++ b/src/Apps/Partners/Utils/__tests__/filterUtils.jest.ts
@@ -1,0 +1,14 @@
+import { filterCities } from "../filterUtils"
+
+describe("filterCities", () => {
+  const cities = [{ text: "Bogotá" }, { text: "Périgueux" }]
+
+  it("normalizes cities and search term by lowercasing characeters", () => {
+    expect(filterCities(cities, "bogota")).toEqual([cities[0]])
+    expect(filterCities(cities, "PERIGUEUX")).toEqual([cities[1]])
+  })
+  it("returns correct results without accented search terms", () => {
+    expect(filterCities(cities, "Bogota")).toEqual([cities[0]])
+    expect(filterCities(cities, "Perigueux")).toEqual([cities[1]])
+  })
+})

--- a/src/Apps/Partners/Utils/filterUtils.ts
+++ b/src/Apps/Partners/Utils/filterUtils.ts
@@ -1,0 +1,13 @@
+export const filterCities = (cities, value: string) => {
+  return cities.filter(({ text }) => {
+    const lowercased = text.toLowerCase()
+    const unaccented = lowercased
+      .normalize("NFD")
+      .replace(/([\u0300-\u036f]|[^0-9a-zA-Z\s])/g, "")
+
+    return (
+      lowercased.includes(value.toLowerCase()) ||
+      unaccented.includes(value.toLowerCase())
+    )
+  })
+}


### PR DESCRIPTION
Jira: [FX-4161](https://artsyproduct.atlassian.net/browse/FX-4161)

The /galleries page currently has a location filter to narrow down displayed galleries.

The filter is backed by lists of cities generated by Gravity and exposed via Metaphysics. The filtering currently takes place client-side using a simple string lowercase / include mechanism.

This is not inclusive of cities whose names contain accented characters. When searching for Bogotá or Périgueux, if you replace accented characters when unaccented variation, the expected results do not show up. Short of switching to a completely different back-end implementation, I've opted for simpler client-side patch here by further normalizing the characters.

The use of `String.normalize` seems widely supported in browsers today: https://caniuse.com/mdn-javascript_builtins_string_normalize

## Screen Recordings

**Before**

![2022-08-15 17 02 46](https://user-images.githubusercontent.com/123595/184662843-dc41ca8a-9621-418f-b2a9-1102bda57109.gif)


**After**

![2022-08-15 17 02 23](https://user-images.githubusercontent.com/123595/184662868-d586b586-0c34-489a-a6ba-6b1088fd31e5.gif)
