### PR TITLE
fix(onboarding): thank you page fix & small changes

### DIFF
--- a/src/Components/Onboarding/Components/OnboardingGene.tsx
+++ b/src/Components/Onboarding/Components/OnboardingGene.tsx
@@ -18,7 +18,6 @@ interface OnboardingGeneProps {
 
 const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
   const artworks = extractNodes(gene.artworks)
-  const { onClose } = useOnboardingContext()
 
   return (
     <Box px={[2, 4]} py={6}>

--- a/src/Components/Onboarding/Components/OnboardingGene.tsx
+++ b/src/Components/Onboarding/Components/OnboardingGene.tsx
@@ -53,14 +53,7 @@ const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
           {artworks.map(artwork => {
             return (
               <Fragment key={artwork.internalID}>
-                <ArtworkGridItemFragmentContainer
-                  artwork={artwork}
-                  onMouseUp={() => {
-                    setTimeout(() => {
-                      onClose()
-                    }, 10)
-                  }}
-                />
+                <ArtworkGridItemFragmentContainer artwork={artwork} />
 
                 <Spacer mb={2} />
               </Fragment>

--- a/src/Components/Onboarding/Views/OnboardingThankYou.tsx
+++ b/src/Components/Onboarding/Views/OnboardingThankYou.tsx
@@ -8,7 +8,7 @@ interface OnboardingThankYouProps {
   message: JSX.Element
 }
 
-const AUTOCLOSE_DELAY = 3000
+const AUTOCLOSE_DELAY = 5000
 
 export const OnboardingThankYou: FC<OnboardingThankYouProps> = ({
   autoClose,


### PR DESCRIPTION
The type of this PR is:  fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves issues surfaced from the most recent Onboarding QA here: https://www.notion.so/artsy/Onboarding-Web-QA-c5f83b5a7b004cce9694ae4c4fb97771

### Description

<!-- Implementation description -->
This PR adds more time delay for users to read the thank you page copy text as well as removing an unnecessary onMouseUp handler on the artworkgrid items that cause the onboarding modal to close when liking an artwork. 

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ