### PR TITLE
fix(onboarding): Fix image and next button size

### DIFF
--- a/src/Components/Onboarding/Components/OnboardingFigure.tsx
+++ b/src/Components/Onboarding/Components/OnboardingFigure.tsx
@@ -36,7 +36,7 @@ export const OnboardingFigure: ForwardRefExoticComponent<
           src={img.src}
           srcSet={img.srcSet}
           width="100%"
-          height="100%"
+          height="auto"
           alt=""
           lazyLoad
         />

--- a/src/Components/Onboarding/Components/OnboardingQuestionPanel.tsx
+++ b/src/Components/Onboarding/Components/OnboardingQuestionPanel.tsx
@@ -40,6 +40,7 @@ export const OnboardingQuestionPanel: FC<OnboardingQuestionPanelProps> = ({
         loading={loading}
         onClick={onNext}
         width="100%"
+        minHeight={50}
       >
         Next
       </Button>


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This fixes the issue where the next button and the image would be squished depending on the responsive size: 

<img width="860" alt="Screen Shot 2022-08-15 at 2 01 18 PM" src="https://user-images.githubusercontent.com/236943/184717886-463b9803-1eb3-402c-93c7-75e27beb71f1.png">

cc @artsy/grow-devs 