### PR TITLE
chore: CI uses Artsy managed docker image to execute detect-secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,10 +208,9 @@ jobs:
 
   detect-secrets:
     docker:
-      - image: lirantal/detect-secrets
+      - image: artsy/detect-secrets:1.3.0
     working_directory: /usr/src/app
     steps:
-      - run: apt-get update && apt-get install -y openssh-client
       - checkout
       - run: |
           cp .secrets.baseline /tmp/.secrets.baseline


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

Switch over to Artsy managed docker image for executing detect-secrets in CI.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Two reasons for this change:

1. we have control over detect-secrets releases
2. I want to remove [this workaround](https://github.com/artsy/force/blob/main/.circleci/config.yml#L217-L236) in another PR  to see if it is still necessary.
  i. In case I have to revert the change ☝️. This PR change will stay in place.