### PR TITLE
ci(smoke-tests): parallelize smoke tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,7 @@ jobs:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     working_directory: /app
+    parallelism: 4
     steps:
       - run: /app/scripts/xvfb-run.sh /usr/local/bin/yarn test:smoke
       - store_artifacts:

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -26,8 +26,17 @@ done
 
 export ELECTRON_EXTRA_LAUNCH_ARGS=disable-dev-shm-usage
 
+
+
 # run ./cypress/integration/* tests in headless mode
-./node_modules/.bin/cypress run
+if [ "$CI" == "true" ]; then
+    # Parallelize smoke tests on CI
+    TESTS=$(circleci tests glob "cypress/integration/**/*" | circleci tests split | paste -sd ',')
+    ./node_modules/.bin/cypress run --spec $TESTS
+else
+    ./node_modules/.bin/cypress run
+fi
+
 
 # Kill the server
 kill -9 $! || true


### PR DESCRIPTION
The type of this PR is: **CI**

This PR solves [WP-111]

### Description

Following the work done in https://github.com/artsy/integrity/pull/368, this parallelizes our smoke tests in Force in an effort to bring the smoke test runner down by 3min. 

cc @artsy/grow-devs 


[WP-111]: https://artsyproduct.atlassian.net/browse/WP-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ