### PR TITLE
ci(smoke-tests): parallelize smoke tests on live env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,7 @@ jobs:
         environment:
           TERM: xterm
     working_directory: ~/app
+    parallelism: 4
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Missed the `smoke-test-on-live-env` job 