### PR TITLE
fix: adjust no-image image container

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -47,31 +47,53 @@ export const ArtworkImageBrowser: React.FC<ArtworkImageBrowserProps> = ({
     const defaultIndex = figures?.findIndex(image => !!image?.isDefault) ?? 0
     setCursor(defaultIndex)
   }
+  const noImageImage = (
+    <Flex
+      position="absolute"
+      top={0}
+      left={0}
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <NoImageIcon width="28px" height="28px" fill="black60" />
+    </Flex>
+  )
 
   if ((figures ?? []).length === 0) {
     return (
-      <Flex>
-        <ResponsiveBox
-          data-testid="artwork-browser-no-image-box"
-          bg="black10"
-          mx={[0, 2, 4]}
-          maxWidth="100%"
-          aspectWidth={1}
-          aspectHeight={1}
-        >
-          <Flex
-            position="absolute"
-            top={0}
-            left={0}
-            width="100%"
-            height="100%"
-            justifyContent="center"
-            alignItems="center"
-          >
-            <NoImageIcon width="28px" height="28px" fill="black60" />
+      <>
+        <Media greaterThanOrEqual="md">
+          <Flex justifyContent="center">
+            <ResponsiveBox
+              data-testid="artwork-browser-no-image-box"
+              bg="black10"
+              mx={[0, 2, 4]}
+              maxWidth={600}
+              aspectWidth={1}
+              aspectHeight={1}
+            >
+              {noImageImage}
+            </ResponsiveBox>
           </Flex>
-        </ResponsiveBox>
-      </Flex>
+        </Media>
+
+        <Media lessThan="md">
+          <Flex justifyContent="center">
+            <ResponsiveBox
+              data-testid="artwork-browser-no-image-box"
+              bg="black10"
+              mx={[0, 2, 4]}
+              maxWidth="100%"
+              aspectWidth={1}
+              aspectHeight={1}
+            >
+              {noImageImage}
+            </ResponsiveBox>
+          </Flex>
+        </Media>
+      </>
     )
   }
 


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2770]

### Description

<!-- Implementation description -->
If screen size is >= "md" - maxImageWidth is 600 (took this number from `ResponsiveImageWithMaxWidth`)
if screen size is < "md" - maxImageWidth is "100%"


https://user-images.githubusercontent.com/36167539/185410497-00a0ada5-2e70-4455-8b0f-539054f5fc92.mov



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2770]: https://artsyproduct.atlassian.net/browse/CX-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ