### PR TITLE
chore: run detect-secrets in CI without recovery logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,27 +213,7 @@ jobs:
     working_directory: /usr/src/app
     steps:
       - checkout
-      - run: |
-          cp .secrets.baseline /tmp/.secrets.baseline
-          set +e && set +o pipefail
-          detect-secrets-hook --baseline .secrets.baseline $(git ls-files)
-          code=$?
-          if [[ $code -ne 3 ]]; then
-            exit $code
-          else
-            lines=$(diff -y --suppress-common-lines .secrets.baseline /tmp/.secrets.baseline | wc -l)
-            [ $lines -eq 1 ] && git restore .secrets.baseline && exit 0
-            cat \<<EOF
-            Changes to baseline results need to be committed.
-
-            If seeing this message in CI you may have ran your commit using --no-verify, thereby skipping the detect-secrets git-hook.
-
-            To fix, run:
-              git reset --soft HEAD^
-              yarn detect-secrets:hook
-          EOF
-            exit $code
-          fi
+      - run: git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline --verbose
 
   smoke-test-on-live-env:
     docker:


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

Back in the fall of 2021, we [expanded the run command](https://github.com/artsy/force/pull/8648) to recover from '_random_' baseline mutations. This was necessary (at the time) as it was causing developer friction and failed builds in CI.

Seeing as the tool has had a couple of releases since then and some projects ([eigen](https://github.com/artsy/eigen/blob/main/scripts/secrets-check-all)) do not experience the same issue, I wanted to remove the conditional recovery logic and verify if the extra logic is still necessary.

I picked Force to try this out on because:

1. Force was one of the projects that had this issue in the past.
2. Force has a lot of daily builds so if the recovery logic is still necessary, the problem should surface (hopefully) relatively quickly.

Following this change, if we notice that detect-secrets step stars failing randomly we will revert this PR.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ