### PR TITLE
fix(onboarding): handle /signup case slightly better

### DIFF
--- a/src/Apps/Authentication/Utils/__tests__/helpers.jest.ts
+++ b/src/Apps/Authentication/Utils/__tests__/helpers.jest.ts
@@ -4,6 +4,7 @@ import {
   handleSubmit,
   maybeUpdateRedirectTo,
   setCookies,
+  updateURLWithOnboardingParam,
 } from "../helpers"
 import {
   COMMERCIAL_AUTH_INTENTS,
@@ -232,7 +233,9 @@ describe("Authentication Helpers", () => {
               Object {},
             ]
           `)
-        expect(window.location.assign).toBeCalledWith("https://artsy.net/")
+        expect(window.location.assign).toBeCalledWith(
+          "https://artsy.net/?onboarding=true"
+        )
       })
     })
 
@@ -515,9 +518,9 @@ describe("Authentication Helpers", () => {
       expect(redirectTo.toString()).toBe("https://artsy.net/")
     })
 
-    it("Returns / if type is signup", () => {
+    it("Returns with `onboarding=true` if type is signup", () => {
       const redirectTo = getRedirect("signup")
-      expect(redirectTo.toString()).toBe("https://artsy.net/")
+      expect(redirectTo.toString()).toBe("https://artsy.net/?onboarding=true")
     })
 
     it("Returns window.location by default", () => {
@@ -585,6 +588,24 @@ describe("Authentication Helpers", () => {
       expect(redirectTo).toEqual(
         originalRedirect + "?foo=true&bar=true&onboarding=true"
       )
+    })
+  })
+
+  describe("#updateURLWithOnboardingParam", () => {
+    it("adds the onboarding param to the url", () => {
+      expect(updateURLWithOnboardingParam("https://artsy.net")).toEqual(
+        "https://artsy.net?onboarding=true"
+      )
+    })
+
+    it("preserves existing query params", () => {
+      expect(
+        updateURLWithOnboardingParam("https://artsy.net?foo=true")
+      ).toEqual("https://artsy.net?foo=true&onboarding=true")
+
+      expect(
+        updateURLWithOnboardingParam("https://artsy.net?foo=true&bar=true")
+      ).toEqual("https://artsy.net?foo=true&bar=true&onboarding=true")
     })
   })
 })

--- a/src/Apps/Authentication/Utils/helpers.ts
+++ b/src/Apps/Authentication/Utils/helpers.ts
@@ -144,6 +144,20 @@ export const handleSubmit = async (
   }
 }
 
+export const updateURLWithOnboardingParam = (url: string) => {
+  const [redirectToWithoutParams, params] = url.split("?")
+
+  // For all non-commercial intents, update the redirectTo url with an
+  // onboarding query param flag.
+  const updatedParams = qs.stringify({
+    ...qs.parse(params),
+    onboarding: true,
+  })
+
+  const updatedRedirectTo = redirectToWithoutParams + "?" + updatedParams
+  return updatedRedirectTo
+}
+
 export const maybeUpdateRedirectTo = (
   type: ModalType,
   redirectTo: string = "/",
@@ -156,17 +170,8 @@ export const maybeUpdateRedirectTo = (
   if (COMMERCIAL_AUTH_INTENTS.includes(intent)) {
     return redirectTo
   } else {
-    const [redirectToWithoutParams, params] = redirectTo.split("?")
-
-    // For all non-commercial intents, update the redirectTo url with an
-    // onboarding query param flag.
-    const updatedParams = qs.stringify({
-      ...qs.parse(params),
-      onboarding: true,
-    })
-
-    const updatedRedirectTo = redirectToWithoutParams + "?" + updatedParams
-    return updatedRedirectTo
+    const url = updateURLWithOnboardingParam(redirectTo)
+    return url
   }
 }
 
@@ -239,7 +244,8 @@ export function getRedirect(type): URL {
         return new URL(location.href, appBaseURL)
       }
     case "signup":
-      return new URL("/", appBaseURL)
+      const url = new URL(updateURLWithOnboardingParam("/"), appBaseURL)
+      return url
     default:
       return new URL(window.location.href, appBaseURL)
   }

--- a/src/Apps/Authentication/Utils/useAuthForm.ts
+++ b/src/Apps/Authentication/Utils/useAuthForm.ts
@@ -32,7 +32,7 @@ export function useAuthForm({ canonical, pageTitle, type }: UseAuthFormProps) {
     pageTitle,
   })
 
-  const redirectTo = getENV("AUTHENTICATION_REDIRECT_TO") ?? "/"
+  const redirectTo = getENV("AUTHENTICATION_REDIRECT_TO")
   const signupReferer = getENV("AUTHENTICATION_REFERER")
 
   if (action) {


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This updates how we handle onboarding redirects from the static `artsy.net/signup` page, instead relying on internal auth form logic rather than setting a fallback on `AUTHENTICATION_REDIRECT_TO` (which broke a few integrity tests). 

Something that we very much need to follow up on once things have settled is refactoring the onboarding auth flow logic to have a formalized onboarding launch mechanism, versus us piggy-backing on `redirectTo` which is brittle and opaque. It works well enough right now, but the case in this PR illustrates why it won't scale: as soon as we have a signup example that _doesn't_ use `redirectTo` things break; a future dev will certainly not know why. (Filed a ticket [here](https://artsyproduct.atlassian.net/browse/GRO-1239).)

cc @artsy/grow-devs 