### PR TITLE
fix(TX-593): saving payment loader ignoring error validation

### DIFF
--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -99,7 +99,6 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
 
   // fired when save and continue is clicked for CC and Wire payment methods
   const setPayment = () => {
-    setIsSavingPayment(true)
     switch (selectedPaymentMethod) {
       case "CREDIT_CARD":
         onCreditCardContinue()
@@ -136,6 +135,8 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
         return
       }
 
+      setIsSavingPayment(true)
+
       const orderOrError = (
         await setOrderPayment({
           input: {
@@ -146,7 +147,11 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
         })
       ).commerceSetPayment?.orderOrError
 
-      if (orderOrError?.error) throw orderOrError.error
+      if (orderOrError?.error) {
+        setIsSavingPayment(false)
+        throw orderOrError.error
+      }
+
       props.router.push(`/orders/${props.order.internalID}/review`)
     } catch (error) {
       setIsSavingPayment(false)
@@ -157,6 +162,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
 
   // sets payment with Wire Transfer
   const onWireTransferContinue = async () => {
+    setIsSavingPayment(true)
     try {
       const orderOrError = (
         await setPaymentMutation({

--- a/src/Components/BankDebitForm/BankDebitForm.tsx
+++ b/src/Components/BankDebitForm/BankDebitForm.tsx
@@ -52,7 +52,6 @@ export const BankDebitForm: FC<Props> = ({
   }
 
   const handleSubmit = async event => {
-    setIsSavingPayment(true)
     event.preventDefault()
 
     if (!stripe || !elements || !user) {
@@ -67,6 +66,8 @@ export const BankDebitForm: FC<Props> = ({
     // confirm Stripe payment setup which leaves and redirects back.
     window.removeEventListener("beforeunload", preventHardReload)
 
+    setIsSavingPayment(true)
+
     const { error } = await stripe.confirmSetup({
       elements,
       confirmParams: {
@@ -75,7 +76,8 @@ export const BankDebitForm: FC<Props> = ({
     })
 
     if (error) {
-      console.log("error", error)
+      setIsSavingPayment(false)
+      throw error
     }
   }
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-593]

### Description
This PR fixes the saving payment loader from ignoring form error validation for incomplete forms on CC and bank accounts.
 
**To test:** Submit CC payment without CVC or without billing address details filled out. 
For bank transfers, submit without adding a bank account. 

In both cases, we should still be getting validation errors. 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-593]: https://artsyproduct.atlassian.net/browse/TX-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ