### PR TITLE
fix: Just dismiss modal when skipping onboarding GRO-1241

### DIFF
--- a/src/Components/Onboarding/Views/OnboardingWelcome.tsx
+++ b/src/Components/Onboarding/Views/OnboardingWelcome.tsx
@@ -59,7 +59,6 @@ export const OnboardingWelcome = () => {
               width="100%"
               // @ts-ignore
               as={RouterLink}
-              to="/"
               onClick={onClose}
               data-test="onboarding-skip-button"
             >


### PR DESCRIPTION
A quick PR to remove the bit that was sending users to the homepage when they skip onboarding. This should fix some integrity failures and is a better user experience!

https://artsyproduct.atlassian.net/browse/GRO-1241

/cc @artsy/grow-devs