### PR TITLE
feat(CX-2738): add artist market insights

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2381,11 +2381,13 @@ type ArtworkPriceInsights {
     # Return the liquidity rank in a formatted way (Low, medium, high or very high)
     format: String = ""
   ): String
+  medianSaleOverEstimatePercentage: Float
   medianSalePriceDisplayText(
     # Passes in to numeral, such as `'0.00'`
     format: String = ""
   ): String
   medium: String
+  sellThroughRate: Float
 }
 
 # The results for one of the requested aggregations

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
@@ -1,0 +1,111 @@
+import {
+  Column,
+  DecreaseIcon,
+  Flex,
+  GridColumns,
+  IncreaseIcon,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { Media } from "Utils/Responsive"
+import { MyCollectionArtworkArtistMarket_marketPriceInsights } from "../../../../../__generated__/MyCollectionArtworkArtistMarket_marketPriceInsights.graphql"
+
+export const MyCollectionArtworkArtistMarket = ({
+  marketPriceInsights,
+}: {
+  marketPriceInsights: MyCollectionArtworkArtistMarket_marketPriceInsights
+}) => {
+  const renderInsight = (name: string, value: string) => {
+    return (
+      <Column span={[6, 4, 2]}>
+        <Flex flexDirection={"column"} justifyContent="flex-start">
+          <Text variant={["xs", "md", "md"]}>{name}</Text>
+          <Text variant={["lg", "xl", "xl"]}>{value}</Text>
+        </Flex>
+      </Column>
+    )
+  }
+
+  const {
+    annualValueSoldDisplayText,
+    liquidityRankDisplayText,
+    annualLotsSold,
+    medianSaleOverEstimatePercentage,
+    sellThroughRate,
+  } = marketPriceInsights
+
+  const formattedSellThroughRate = (Number(sellThroughRate) * 100).toFixed(2)
+
+  return (
+    <>
+      <Text variant="lg-display">Artist Market</Text>
+      <Text variant={["xs", "md"]} color="black60">
+        Based on the last 36 months of auction sale data from top commercial
+        auction houses.
+      </Text>
+
+      <Spacer mt={[2, 6]} />
+
+      <GridColumns>
+        {!!annualValueSoldDisplayText &&
+          renderInsight("Annual Value Sold", annualValueSoldDisplayText)}
+        {annualLotsSold !== null &&
+          renderInsight("Annual Lots Sold", annualLotsSold.toString())}
+        {renderInsight("Sell-through Rate", formattedSellThroughRate + "%")}
+
+        {!!medianSaleOverEstimatePercentage && (
+          <Column span={[6, 4, 2]}>
+            <Flex flexDirection={"column"} justifyContent="flex-start">
+              <Text variant={["xs", "md", "md"]}>Sale Price to Estimate</Text>
+              <SalePriceEstimatePerformance
+                value={medianSaleOverEstimatePercentage}
+              />
+            </Flex>
+          </Column>
+        )}
+
+        {!!liquidityRankDisplayText &&
+          renderInsight("Liquidity", liquidityRankDisplayText)}
+      </GridColumns>
+    </>
+  )
+}
+
+const SalePriceEstimatePerformance = ({ value }: { value: number }) => {
+  const sign = value < 0 ? "down" : "up"
+  const color = sign === "up" ? "green100" : "red100"
+  const Arrow = sign === "up" ? IncreaseIcon : DecreaseIcon
+
+  return (
+    <Flex flexDirection="row" alignItems="baseline">
+      <Media at="xs">
+        <Arrow fill={color} width={15} height={15} />
+      </Media>
+      <Media greaterThan="xs">
+        <Arrow fill={color} width={25} height={25} />
+      </Media>
+
+      <Spacer mr={1} />
+
+      <Text variant={["lg", "xl", "xl"]} fontWeight="medium" color={color}>
+        {Math.abs(value)}%
+      </Text>
+    </Flex>
+  )
+}
+
+export const MyCollectionArtworkArtistMarketFragmentContainer = createFragmentContainer(
+  MyCollectionArtworkArtistMarket,
+  {
+    marketPriceInsights: graphql`
+      fragment MyCollectionArtworkArtistMarket_marketPriceInsights on ArtworkPriceInsights {
+        annualLotsSold
+        annualValueSoldDisplayText
+        medianSaleOverEstimatePercentage
+        liquidityRankDisplayText
+        sellThroughRate
+      }
+    `,
+  }
+)

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
@@ -9,24 +9,13 @@ import {
 } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "Utils/Responsive"
-import { MyCollectionArtworkArtistMarket_marketPriceInsights } from "../../../../../__generated__/MyCollectionArtworkArtistMarket_marketPriceInsights.graphql"
+import { MyCollectionArtworkArtistMarket_marketPriceInsights } from "__generated__/MyCollectionArtworkArtistMarket_marketPriceInsights.graphql"
 
 export const MyCollectionArtworkArtistMarket = ({
   marketPriceInsights,
 }: {
   marketPriceInsights: MyCollectionArtworkArtistMarket_marketPriceInsights
 }) => {
-  const renderInsight = (name: string, value: string) => {
-    return (
-      <Column span={[6, 4, 2]}>
-        <Flex flexDirection={"column"} justifyContent="flex-start">
-          <Text variant={["xs", "md", "md"]}>{name}</Text>
-          <Text variant={["lg", "xl", "xl"]}>{value}</Text>
-        </Flex>
-      </Column>
-    )
-  }
-
   const {
     annualValueSoldDisplayText,
     liquidityRankDisplayText,
@@ -48,11 +37,24 @@ export const MyCollectionArtworkArtistMarket = ({
       <Spacer mt={[2, 6]} />
 
       <GridColumns>
-        {!!annualValueSoldDisplayText &&
-          renderInsight("Annual Value Sold", annualValueSoldDisplayText)}
-        {annualLotsSold !== null &&
-          renderInsight("Annual Lots Sold", annualLotsSold.toString())}
-        {renderInsight("Sell-through Rate", formattedSellThroughRate + "%")}
+        {!!annualValueSoldDisplayText && (
+          <InsightColumn
+            name="Annual Value Sold"
+            value={annualValueSoldDisplayText}
+          />
+        )}
+        {annualLotsSold !== null && (
+          <InsightColumn
+            name="Annual Lots Sold"
+            value={annualLotsSold.toString()}
+          />
+        )}
+        {
+          <InsightColumn
+            name="Sell-through Rate"
+            value={formattedSellThroughRate + "%"}
+          />
+        }
 
         {!!medianSaleOverEstimatePercentage && (
           <Column span={[6, 4, 2]}>
@@ -65,10 +67,22 @@ export const MyCollectionArtworkArtistMarket = ({
           </Column>
         )}
 
-        {!!liquidityRankDisplayText &&
-          renderInsight("Liquidity", liquidityRankDisplayText)}
+        {!!liquidityRankDisplayText && (
+          <InsightColumn name="Liquidity" value={liquidityRankDisplayText} />
+        )}
       </GridColumns>
     </>
+  )
+}
+
+const InsightColumn = ({ name, value }: { name: string; value: string }) => {
+  return (
+    <Column span={[6, 4, 2]}>
+      <Flex flexDirection={"column"} justifyContent="flex-start">
+        <Text variant={["xs", "md", "md"]}>{name}</Text>
+        <Text variant={["lg", "xl", "xl"]}>{value}</Text>
+      </Flex>
+    </Column>
   )
 }
 

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkComparables.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkComparables.tsx
@@ -42,7 +42,6 @@ const MyCollectionArtworkComparables: React.FC<MyCollectionArtworkComparablesPro
           })}
         </Join>
       </Column>
-      <Spacer pb={6} />
     </>
   )
 }

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkArtistMarket.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkArtistMarket.jest.tsx
@@ -1,0 +1,61 @@
+import { screen } from "@testing-library/react"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { graphql } from "react-relay"
+import { MyCollectionArtworkArtistMarketFragmentContainer } from "../MyCollectionArtworkArtistMarket"
+import { MyCollectionArtworkArtistMarket_Test_Query } from "../../../../../../__generated__/MyCollectionArtworkArtistMarket_Test_Query.graphql"
+
+jest.unmock("react-relay")
+
+describe("MyCollectionArtworkArtistMarket", () => {
+  const { renderWithRelay } = setupTestWrapperTL<
+    MyCollectionArtworkArtistMarket_Test_Query
+  >({
+    Component: props => {
+      if (props?.artwork?.marketPriceInsights) {
+        return (
+          <MyCollectionArtworkArtistMarketFragmentContainer
+            marketPriceInsights={props.artwork.marketPriceInsights}
+          />
+        )
+      }
+      return null
+    },
+    query: graphql`
+      query MyCollectionArtworkArtistMarket_Test_Query @relay_test_operation {
+        artwork(id: "foo") {
+          marketPriceInsights {
+            ...MyCollectionArtworkArtistMarket_marketPriceInsights
+          }
+        }
+      }
+    `,
+  })
+
+  it("renders the market price insights for an artwork", () => {
+    renderWithRelay(mockResolvers, false)
+
+    expect(screen.getByText("Annual Value Sold")).toBeInTheDocument()
+    expect(screen.getByText("$13B")).toBeInTheDocument()
+    expect(screen.getByText("Annual Lots Sold")).toBeInTheDocument()
+    expect(screen.getByText("123")).toBeInTheDocument()
+    expect(screen.getByText("Sell-through Rate")).toBeInTheDocument()
+    expect(screen.getByText("13.40%")).toBeInTheDocument()
+    expect(screen.getByText("Sale Price to Estimate")).toBeInTheDocument()
+    expect(screen.getByText("95%")).toBeInTheDocument()
+    expect(screen.getByText("Liquidity")).toBeInTheDocument()
+    expect(screen.getByText("Very High")).toBeInTheDocument()
+  })
+})
+
+const mockResolvers = {
+  Artwork: () => ({
+    internalID: "artwork-id",
+    marketPriceInsights: {
+      annualLotsSold: 123,
+      annualValueSoldDisplayText: "$13B",
+      medianSaleOverEstimatePercentage: 95,
+      liquidityRankDisplayText: "Very High",
+      sellThroughRate: 0.134,
+    },
+  }),
+}

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
@@ -1,4 +1,4 @@
-import { Button, Column, Flex, GridColumns } from "@artsy/palette"
+import { Button, Column, Flex, GridColumns, Join, Spacer } from "@artsy/palette"
 import { ArtistCurrentArticlesRailQueryRenderer } from "Apps/Artist/Routes/Overview/Components/ArtistCurrentArticlesRail"
 import { ArtworkImageBrowserFragmentContainer } from "Apps/Artwork/Components/ArtworkImageBrowser"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -9,6 +9,7 @@ import { MyCollectionArtwork_artwork } from "__generated__/MyCollectionArtwork_a
 import { MyCollectionArtworkComparablesFragmentContainer } from "./Components/MyCollectionArtworkComparables"
 import { MyCollectionArtworkMetaFragmentContainer } from "./Components/MyCollectionArtworkMeta"
 import { MyCollectionArtworkSidebarFragmentContainer } from "./Components/MyCollectionArtworkSidebar"
+import { MyCollectionArtworkArtistMarketFragmentContainer } from "./Components/MyCollectionArtworkArtistMarket"
 
 interface MyCollectionArtworkProps {
   artwork: MyCollectionArtwork_artwork
@@ -22,7 +23,9 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
   const enableMyCollectionPhase4ArticlesRail = useFeatureFlag(
     "my-collection-web-phase-4-articles-rail"
   )
-
+  const enableMyCollectionPhase4ArtistMarket = useFeatureFlag(
+    "my-collection-web-phase-4-artist-market"
+  )
   const enableMyCollectionPhase4Comparables = useFeatureFlag(
     "my-collection-web-phase-4-comparables"
   )
@@ -67,12 +70,22 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
         </Column>
       </GridColumns>
 
-      {!!enableMyCollectionPhase4Comparables && (
-        <MyCollectionArtworkComparablesFragmentContainer artwork={artwork} />
-      )}
-      {!!enableMyCollectionPhase4ArticlesRail && (
-        <ArtistCurrentArticlesRailQueryRenderer slug={slug} />
-      )}
+      <Join separator={<Spacer mt={[2, 6]} />}>
+        {!!enableMyCollectionPhase4ArtistMarket &&
+          artwork.marketPriceInsights && (
+            <MyCollectionArtworkArtistMarketFragmentContainer
+              marketPriceInsights={artwork.marketPriceInsights}
+            />
+          )}
+
+        {!!enableMyCollectionPhase4Comparables && (
+          <MyCollectionArtworkComparablesFragmentContainer artwork={artwork} />
+        )}
+
+        {!!enableMyCollectionPhase4ArticlesRail && (
+          <ArtistCurrentArticlesRailQueryRenderer slug={slug} />
+        )}
+      </Join>
     </>
   )
 }
@@ -89,6 +102,9 @@ export const MyCollectionArtworkFragmentContainer = createFragmentContainer(
         internalID
         artist {
           slug
+        }
+        marketPriceInsights {
+          ...MyCollectionArtworkArtistMarket_marketPriceInsights
         }
       }
     `,

--- a/src/DevTools/setupTestWrapper.tsx
+++ b/src/DevTools/setupTestWrapper.tsx
@@ -96,8 +96,7 @@ export const setupTestWrapperTL = <T extends OperationType>({
         query={query}
         render={({ props, error }) => {
           if (props) {
-            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-            return <Component {...componentProps} {...props} />
+            return <Component {...componentProps} {...(props as {})} />
           } else if (error) {
             console.error(error)
           }
@@ -141,8 +140,7 @@ export const setupTestWrapper = <T extends OperationType>({
         query={query}
         render={({ props, error }) => {
           if (props) {
-            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-            return <Component {...(componentProps || {})} {...props} />
+            return <Component {...(componentProps || {})} {...(props as {})} />
           } else if (error) {
             console.error(error)
           }

--- a/src/__generated__/MyCollectionArtworkArtistMarket_Test_Query.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkArtistMarket_Test_Query.graphql.ts
@@ -1,0 +1,213 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type MyCollectionArtworkArtistMarket_Test_QueryVariables = {};
+export type MyCollectionArtworkArtistMarket_Test_QueryResponse = {
+    readonly artwork: {
+        readonly marketPriceInsights: {
+            readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkArtistMarket_marketPriceInsights">;
+        } | null;
+    } | null;
+};
+export type MyCollectionArtworkArtistMarket_Test_Query = {
+    readonly response: MyCollectionArtworkArtistMarket_Test_QueryResponse;
+    readonly variables: MyCollectionArtworkArtistMarket_Test_QueryVariables;
+};
+
+
+
+/*
+query MyCollectionArtworkArtistMarket_Test_Query {
+  artwork(id: "foo") {
+    marketPriceInsights {
+      ...MyCollectionArtworkArtistMarket_marketPriceInsights
+    }
+    id
+  }
+}
+
+fragment MyCollectionArtworkArtistMarket_marketPriceInsights on ArtworkPriceInsights {
+  annualLotsSold
+  annualValueSoldDisplayText
+  medianSaleOverEstimatePercentage
+  liquidityRankDisplayText
+  sellThroughRate
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "foo"
+  }
+],
+v1 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v2 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Float"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "MyCollectionArtworkArtistMarket_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkPriceInsights",
+            "kind": "LinkedField",
+            "name": "marketPriceInsights",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "MyCollectionArtworkArtistMarket_marketPriceInsights"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "artwork(id:\"foo\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "MyCollectionArtworkArtistMarket_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkPriceInsights",
+            "kind": "LinkedField",
+            "name": "marketPriceInsights",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "annualLotsSold",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "annualValueSoldDisplayText",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "medianSaleOverEstimatePercentage",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "liquidityRankDisplayText",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "sellThroughRate",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "artwork(id:\"foo\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "5b0233d743da651b03e469c7dd09b29d",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "artwork.id": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "ID"
+        },
+        "artwork.marketPriceInsights": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkPriceInsights"
+        },
+        "artwork.marketPriceInsights.annualLotsSold": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Int"
+        },
+        "artwork.marketPriceInsights.annualValueSoldDisplayText": (v1/*: any*/),
+        "artwork.marketPriceInsights.liquidityRankDisplayText": (v1/*: any*/),
+        "artwork.marketPriceInsights.medianSaleOverEstimatePercentage": (v2/*: any*/),
+        "artwork.marketPriceInsights.sellThroughRate": (v2/*: any*/)
+      }
+    },
+    "name": "MyCollectionArtworkArtistMarket_Test_Query",
+    "operationKind": "query",
+    "text": "query MyCollectionArtworkArtistMarket_Test_Query {\n  artwork(id: \"foo\") {\n    marketPriceInsights {\n      ...MyCollectionArtworkArtistMarket_marketPriceInsights\n    }\n    id\n  }\n}\n\nfragment MyCollectionArtworkArtistMarket_marketPriceInsights on ArtworkPriceInsights {\n  annualLotsSold\n  annualValueSoldDisplayText\n  medianSaleOverEstimatePercentage\n  liquidityRankDisplayText\n  sellThroughRate\n}\n"
+  }
+};
+})();
+(node as any).hash = 'd80d43a3006dcfe6a3a879d3556af8e6';
+export default node;

--- a/src/__generated__/MyCollectionArtworkArtistMarket_marketPriceInsights.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkArtistMarket_marketPriceInsights.graphql.ts
@@ -1,0 +1,69 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type MyCollectionArtworkArtistMarket_marketPriceInsights = {
+    readonly annualLotsSold: number | null;
+    readonly annualValueSoldDisplayText: string | null;
+    readonly medianSaleOverEstimatePercentage: number | null;
+    readonly liquidityRankDisplayText: string | null;
+    readonly sellThroughRate: number | null;
+    readonly " $refType": "MyCollectionArtworkArtistMarket_marketPriceInsights";
+};
+export type MyCollectionArtworkArtistMarket_marketPriceInsights$data = MyCollectionArtworkArtistMarket_marketPriceInsights;
+export type MyCollectionArtworkArtistMarket_marketPriceInsights$key = {
+    readonly " $data"?: MyCollectionArtworkArtistMarket_marketPriceInsights$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkArtistMarket_marketPriceInsights">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "MyCollectionArtworkArtistMarket_marketPriceInsights",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "annualLotsSold",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "annualValueSoldDisplayText",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "medianSaleOverEstimatePercentage",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "liquidityRankDisplayText",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "sellThroughRate",
+      "storageKey": null
+    }
+  ],
+  "type": "ArtworkPriceInsights",
+  "abstractKey": null
+};
+(node as any).hash = 'a11e6122ed5ee14d128ef822cf1fa819';
+export default node;

--- a/src/__generated__/MyCollectionArtwork_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtwork_artwork.graphql.ts
@@ -9,6 +9,9 @@ export type MyCollectionArtwork_artwork = {
     readonly artist: {
         readonly slug: string;
     } | null;
+    readonly marketPriceInsights: {
+        readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkArtistMarket_marketPriceInsights">;
+    } | null;
     readonly " $fragmentRefs": FragmentRefs<"MyCollectionArtworkSidebar_artwork" | "MyCollectionArtworkMeta_artwork" | "ArtworkImageBrowser_artwork" | "MyCollectionArtworkComparables_artwork">;
     readonly " $refType": "MyCollectionArtwork_artwork";
 };
@@ -52,6 +55,22 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArtworkPriceInsights",
+      "kind": "LinkedField",
+      "name": "marketPriceInsights",
+      "plural": false,
+      "selections": [
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "MyCollectionArtworkArtistMarket_marketPriceInsights"
+        }
+      ],
+      "storageKey": null
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "MyCollectionArtworkSidebar_artwork"
@@ -75,5 +94,5 @@ const node: ReaderFragment = {
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = '523b9e971835307b3c46a51a702ef430';
+(node as any).hash = '1eee00337241c31e6693b4fbf73cfa68';
 export default node;

--- a/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
@@ -223,6 +223,14 @@ fragment DeepZoom_image on Image {
   }
 }
 
+fragment MyCollectionArtworkArtistMarket_marketPriceInsights on ArtworkPriceInsights {
+  annualLotsSold
+  annualValueSoldDisplayText
+  medianSaleOverEstimatePercentage
+  liquidityRankDisplayText
+  sellThroughRate
+}
+
 fragment MyCollectionArtworkComparables_artwork on Artwork {
   auctionResult: comparableAuctionResults(first: 6) @optionalField {
     edges {
@@ -280,6 +288,9 @@ fragment MyCollectionArtwork_artwork on Artwork {
   artist {
     slug
     id
+  }
+  marketPriceInsights {
+    ...MyCollectionArtworkArtistMarket_marketPriceInsights
   }
 }
 
@@ -1162,6 +1173,52 @@ return {
               (v7/*: any*/)
             ],
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkPriceInsights",
+            "kind": "LinkedField",
+            "name": "marketPriceInsights",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "annualLotsSold",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "annualValueSoldDisplayText",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "medianSaleOverEstimatePercentage",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "liquidityRankDisplayText",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "sellThroughRate",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -1169,12 +1226,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "de32618d4a96e73ad6328c668e3d42bc",
+    "cacheID": "15395b8361ce75022809cd780d6f557c",
     "id": null,
     "metadata": {},
     "name": "myCollectionRoutes_ArtworkQuery",
     "operationKind": "query",
-    "text": "query myCollectionRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    larger {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  internalID\n  id\n  slug\n  title\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkSharePanel_artwork\n  ...ViewInRoom_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  downloadableImageUrl\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkImageBrowserLarge_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  ...ArtworkVideoPlayer_artwork\n  figures {\n    __typename\n    ... on Image {\n      type: __typename\n      internalID\n      isZoomable\n      ...DeepZoom_image\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  ...ArtworkVideoPlayer_artwork\n  figures {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkActions_artwork\n  ...ArtworkImageBrowserSmall_artwork\n  ...ArtworkImageBrowserLarge_artwork\n  internalID\n  images {\n    width\n    height\n  }\n  figures {\n    __typename\n    ... on Image {\n      internalID\n      isDefault\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork on Artwork {\n  formattedMetadata\n  images {\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    fallback: cropped(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork on Artwork {\n  figures {\n    __typename\n    ... on Video {\n      type: __typename\n      url\n      height\n      width\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkComparables_artwork on Artwork {\n  auctionResult: comparableAuctionResults(first: 6) @optionalField {\n    edges {\n      cursor\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        artistID\n        internalID\n        id\n      }\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment MyCollectionArtworkMeta_artwork on Artwork {\n  artistNames\n  title\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  date\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n\nfragment MyCollectionArtworkSidebar_artwork on Artwork {\n  ...MyCollectionArtworkSidebarMetadata_artwork\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkSidebar_artwork\n  ...MyCollectionArtworkMeta_artwork\n  ...ArtworkImageBrowser_artwork\n  ...MyCollectionArtworkComparables_artwork\n  internalID\n  artist {\n    slug\n    id\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
+    "text": "query myCollectionRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    larger {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  internalID\n  id\n  slug\n  title\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkSharePanel_artwork\n  ...ViewInRoom_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  downloadableImageUrl\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkImageBrowserLarge_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  ...ArtworkVideoPlayer_artwork\n  figures {\n    __typename\n    ... on Image {\n      type: __typename\n      internalID\n      isZoomable\n      ...DeepZoom_image\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  ...ArtworkVideoPlayer_artwork\n  figures {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkActions_artwork\n  ...ArtworkImageBrowserSmall_artwork\n  ...ArtworkImageBrowserLarge_artwork\n  internalID\n  images {\n    width\n    height\n  }\n  figures {\n    __typename\n    ... on Image {\n      internalID\n      isDefault\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork on Artwork {\n  formattedMetadata\n  images {\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    fallback: cropped(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork on Artwork {\n  figures {\n    __typename\n    ... on Video {\n      type: __typename\n      url\n      height\n      width\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkArtistMarket_marketPriceInsights on ArtworkPriceInsights {\n  annualLotsSold\n  annualValueSoldDisplayText\n  medianSaleOverEstimatePercentage\n  liquidityRankDisplayText\n  sellThroughRate\n}\n\nfragment MyCollectionArtworkComparables_artwork on Artwork {\n  auctionResult: comparableAuctionResults(first: 6) @optionalField {\n    edges {\n      cursor\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        artistID\n        internalID\n        id\n      }\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment MyCollectionArtworkMeta_artwork on Artwork {\n  artistNames\n  title\n}\n\nfragment MyCollectionArtworkSidebarMetadata_artwork on Artwork {\n  artistNames\n  title\n  date\n  category\n  medium\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  pricePaid {\n    display\n  }\n  artworkLocation\n}\n\nfragment MyCollectionArtworkSidebar_artwork on Artwork {\n  ...MyCollectionArtworkSidebarMetadata_artwork\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkSidebar_artwork\n  ...MyCollectionArtworkMeta_artwork\n  ...ArtworkImageBrowser_artwork\n  ...MyCollectionArtworkComparables_artwork\n  internalID\n  artist {\n    slug\n    id\n  }\n  marketPriceInsights {\n    ...MyCollectionArtworkArtistMarket_marketPriceInsights\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2738]

### Description

This PR adds market insights to my collection artwork page.

![Group 3 (1)](https://user-images.githubusercontent.com/11945712/185737723-d2b097e0-f0d1-4a48-b7bf-354569eb9516.png)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2738]: https://artsyproduct.atlassian.net/browse/CX-2738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ