### PR TITLE
fix: return null when results (comparables) are not available

### DIFF
--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkComparables.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkComparables.tsx
@@ -16,6 +16,11 @@ const MyCollectionArtworkComparables: React.FC<MyCollectionArtworkComparablesPro
     return null
   }
   const results = extractNodes(artwork.auctionResult)
+
+  if (!results.length) {
+    return null
+  }
+
   const titleString = `${artwork.artist?.name!} - Comparable Works on Artsy`
 
   return (


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2802]

### Description

<!-- Implementation description -->
Return null when results (comparables) are not available

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2802]: https://artsyproduct.atlassian.net/browse/CX-2802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ