### PR TITLE
fix: Scroll to Market Signals when opening MyC auction results

### DIFF
--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkAuctionResults.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkAuctionResults.tsx
@@ -1,10 +1,10 @@
 import { Column, Flex, Join, Spacer, Text } from "@artsy/palette"
-import { createFragmentContainer, graphql } from "react-relay"
-import { MetaTags } from "Components/MetaTags"
 import { ArtistAuctionResultItemFragmentContainer } from "Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem"
+import { MetaTags } from "Components/MetaTags"
+import { createFragmentContainer, graphql } from "react-relay"
+import { RouterLink } from "System/Router/RouterLink"
 import { extractNodes } from "Utils/extractNodes"
 import { MyCollectionArtworkAuctionResults_artist } from "__generated__/MyCollectionArtworkAuctionResults_artist.graphql"
-import { RouterLink } from "System/Router/RouterLink"
 
 interface MyColectionArtworkAuctionResultsProps {
   artist: MyCollectionArtworkAuctionResults_artist
@@ -34,7 +34,10 @@ const AuctionResultsContainer: React.FC<MyColectionArtworkAuctionResultsProps> =
         <Text variant={["sm-display", "lg-display"]} textAlign="left">
           Auction Results
         </Text>
-        <RouterLink textAlign="right" to={`/artist/${slug}/auction-results`}>
+        <RouterLink
+          textAlign="right"
+          to={`/artist/${slug}/auction-results?scroll_to_market_signals`}
+        >
           View All
         </RouterLink>
       </Flex>

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkAuctionResults.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkAuctionResults.tsx
@@ -36,7 +36,7 @@ const AuctionResultsContainer: React.FC<MyColectionArtworkAuctionResultsProps> =
         </Text>
         <RouterLink
           textAlign="right"
-          to={`/artist/${slug}/auction-results?scroll_to_market_signals`}
+          to={`/artist/${slug}/auction-results?scroll_to_market_signals=true`}
         >
           View All
         </RouterLink>


### PR DESCRIPTION
Addresses [CX-2740]

## Description

Scroll to Market Signals when opening MyC auction results.

See https://artsyproduct.atlassian.net/browse/CX-2740?focusedCommentId=50540 for more context.
[CX-2740]: https://artsyproduct.atlassian.net/browse/CX-2740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ