### PR TITLE
chore(FX-4178): cleanup trending sort AB test

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2376,6 +2376,9 @@ type ArtworkPriceInsights {
     format: String = ""
   ): String
   demandRank: Float
+
+  # The demand rank display text of the artist and medium
+  demandRankDisplayText: String
   lastAuctionResultDate: String
   liquidityRankDisplayText(
     # Return the liquidity rank in a formatted way (Low, medium, high or very high)

--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -6,7 +6,6 @@ import {
   SharedArtworkFilterContextProps,
 } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { Match } from "found"
-import { useEffect } from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { useRouter } from "System/Router/useRouter"
 import {
@@ -15,10 +14,6 @@ import {
 } from "Components/SavedSearchAlert/types"
 import { OwnerType } from "@artsy/cohesion"
 import { ZeroState } from "./ZeroState"
-import {
-  useFeatureVariant,
-  useTrackFeatureVariant,
-} from "System/useFeatureFlag"
 import { ArtistArtworkFilters } from "./ArtistArtworkFilters"
 import { ActiveFilterPillsAndCreateAlert } from "Components/SavedSearchAlert/Components/ActiveFilterPillsAndCreateAlert"
 import { useSystemContext } from "System"
@@ -36,17 +31,6 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
   const { relay, aggregations, artist } = props
   const { filtered_artworks } = artist
   const hasFilter = filtered_artworks && filtered_artworks.id
-  const trendingSortVariant = useFeatureVariant(
-    "trending-sort-for-artist-artwork-grids"
-  )
-  const { trackFeatureVariant } = useTrackFeatureVariant({
-    experimentName: "trending-sort-for-artist-artwork-grids",
-    variantName: trendingSortVariant?.name!,
-  })
-
-  useEffect(() => {
-    trackFeatureVariant()
-  })
 
   if (!hasFilter) {
     return null
@@ -78,19 +62,13 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
     },
   ]
 
-  let defaultSortValue = "-decayed_merch"
-
-  if (trendingSortVariant?.name === "experiment") {
-    defaultSortValue = "-default_trending_score"
-  }
-
   return (
     <ArtworkFilterContextProvider
       aggregations={aggregations}
       counts={artist.counts as Counts}
       filters={match.location.query}
       sortOptions={[
-        { value: defaultSortValue, text: "Default" },
+        { value: "-decayed_merch", text: "Default" },
         { value: "-has_price,-prices", text: "Price (desc.)" },
         { value: "-has_price,prices", text: "Price (asc.)" },
         { value: "-partner_updated_at", text: "Recently updated" },

--- a/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilter.jest.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilter.jest.tsx
@@ -117,7 +117,7 @@ describe("ArtistArtworkFilter", () => {
       const option = screen.getByRole("option", { name: "Default" })
 
       expect(option).toBeInTheDocument()
-      expect(option).toHaveValue("-default_trending_score")
+      expect(option).toHaveValue("-decayed_merch")
     })
   })
 })

--- a/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilter.jest.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilter.jest.tsx
@@ -74,50 +74,25 @@ describe("ArtistArtworkFilter", () => {
     expect(option).toHaveValue("-decayed_merch")
   })
 
-  // TODO: Remove when trending sort experiment ends
-  describe("Trending sort experiment", () => {
-    it("should display default sort for control variant", () => {
-      const { renderWithRelay } = getWrapper({
-        context: {
-          featureFlags: {
-            "trending-sort-for-artist-artwork-grids": {
-              flagEnabled: true,
-              variant: {
-                enabled: true,
-                name: "control",
-              },
+  it("should display trending sort for experiment variant", () => {
+    const { renderWithRelay } = getWrapper({
+      context: {
+        featureFlags: {
+          "trending-sort-for-artist-artwork-grids": {
+            flagEnabled: true,
+            variant: {
+              enabled: true,
+              name: "experiment",
             },
           },
         },
-      })
-
-      renderWithRelay()
-      const option = screen.getByRole("option", { name: "Default" })
-
-      expect(option).toBeInTheDocument()
-      expect(option).toHaveValue("-decayed_merch")
+      },
     })
 
-    it("should display trending sort for experiment variant", () => {
-      const { renderWithRelay } = getWrapper({
-        context: {
-          featureFlags: {
-            "trending-sort-for-artist-artwork-grids": {
-              flagEnabled: true,
-              variant: {
-                enabled: true,
-                name: "experiment",
-              },
-            },
-          },
-        },
-      })
+    renderWithRelay()
+    const option = screen.getByRole("option", { name: "Default" })
 
-      renderWithRelay()
-      const option = screen.getByRole("option", { name: "Default" })
-
-      expect(option).toBeInTheDocument()
-      expect(option).toHaveValue("-decayed_merch")
-    })
+    expect(option).toBeInTheDocument()
+    expect(option).toHaveValue("-decayed_merch")
   })
 })

--- a/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
+++ b/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
@@ -16,14 +16,6 @@ export function getWorksForSaleRouteVariables(
     ...initialFilterState,
   }
 
-  const trendingScoreSortFlag =
-    featureFlags["trending-sort-for-artist-artwork-grids"]
-  const variantName = trendingScoreSortFlag?.variant?.name
-
-  if (filterParams.sort === "-decayed_merch" && variantName === "experiment") {
-    filterParams.sort = "-default_trending_score"
-  }
-
   const aggregations = [
     "MEDIUM",
     "TOTAL",


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4178]

### Description

- [x] Cleans up trending sort experiment

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4178]: https://artsyproduct.atlassian.net/browse/FX-4178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ