### PR TITLE
chore: switch to CI specific tag for detect-secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ jobs:
 
   detect-secrets:
     docker:
-      - image: artsy/detect-secrets:1.3.0
+      - image: artsy/detect-secrets:ci # pragma: allowlist secret
     working_directory: /usr/src/app
     steps:
       - checkout


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PLATFORM-4375](https://artsyproduct.atlassian.net/browse/PLATFORM-4375)

### Description

<!-- Implementation description -->

- using a dedicated tag makes rolling out new versions of this tool easier across multiple projects
- adds inline exclusion as the new pattern is a false positive


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ