### PR TITLE
fix: Hide auction results section title when results are not available

### DIFF
--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkAuctionResults.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkAuctionResults.tsx
@@ -20,6 +20,10 @@ const MyCollectionAuctionResultsContainer: React.FC<MyCollectionArtworkAuctionRe
   }
   const results = extractNodes(auctionResultsConnection)
 
+  if (!results.length) {
+    return null
+  }
+
   const titleString = `${name} - Artwork Auction Results on Artsy`
 
   return (


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2823]

### Description

<!-- Implementation description -->
Hide auction results section title when results are not available

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2823]: https://artsyproduct.atlassian.net/browse/CX-2823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ