### PR TITLE
feat: abandoned flow confirmation | uploading flow & edit flow

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "src/Apps/MyCollection/Routes/EditArtwork/__tests__/ArtworkForm.jest.tsx",
         "hashed_secret": "dc312ec7ed341804d6911ecdcf18eea1858f6091",
         "is_verified": false,
-        "line_number": 242
+        "line_number": 264
       }
     ],
     "src/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx": [
@@ -1398,5 +1398,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-18T08:31:49Z"
+  "generated_at": "2022-08-23T15:05:45Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "src/Apps/MyCollection/Routes/EditArtwork/__tests__/ArtworkForm.jest.tsx",
         "hashed_secret": "dc312ec7ed341804d6911ecdcf18eea1858f6091",
         "is_verified": false,
-        "line_number": 264
+        "line_number": 259
       }
     ],
     "src/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx": [
@@ -1398,5 +1398,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-23T15:05:45Z"
+  "generated_at": "2022-08-23T15:12:26Z"
 }

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -138,7 +138,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                     onClose={() => setShouldShowModal(false)}
                     width={["100%", 600]}
                     footer={
-                      <Flex flexGrow={1} flexDirection={"column"}>
+                      <>
                         <Button
                           // @ts-ignore
                           as={RouterLink}
@@ -162,7 +162,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                             ? "Continue Editing"
                             : "Continue Uploading Artwork"}
                         </Button>
-                      </Flex>
+                      </>
                     }
                   >
                     <Text mt={4}>

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -4,10 +4,12 @@ import {
   DROP_SHADOW,
   Flex,
   FullBleed,
+  ModalDialog,
   Spacer,
   Step,
   Stepper,
   useToasts,
+  Text,
 } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
@@ -15,6 +17,7 @@ import { BackLink } from "Components/Links/BackLink"
 import { MetaTags } from "Components/MetaTags"
 import { Sticky, StickyProvider } from "Components/Sticky"
 import { Form, Formik } from "formik"
+import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { RouterLink } from "System/Router/RouterLink"
 import { useRouter } from "System/Router/useRouter"
@@ -42,6 +45,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
   const { router } = useRouter()
   const { sendToast } = useToasts()
   const initialValues = getMyCollectionArtworkFormInitialValues(artwork)
+  const [shouldShowModal, setShouldShowModal] = useState<boolean>(false)
 
   const initialErrors = validateArtwork(
     initialValues,
@@ -128,6 +132,46 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
               </RouterLink>
 
               <StickyProvider>
+                {shouldShowModal && (
+                  <ModalDialog
+                    title="Leave without saving?"
+                    onClose={() => setShouldShowModal(false)}
+                    width={["100%", 600]}
+                    footer={
+                      <Flex flexGrow={1} flexDirection={"column"}>
+                        <Button
+                          // @ts-ignore
+                          as={RouterLink}
+                          to={
+                            isEditing
+                              ? `/my-collection/artwork/${artwork.internalID}`
+                              : "/my-collection"
+                          }
+                          mt={4}
+                          width="100%"
+                        >
+                          Leave Without Saving
+                        </Button>
+                        <Button
+                          onClick={() => setShouldShowModal(false)}
+                          variant="secondaryNeutral"
+                          mt={2}
+                          width="100%"
+                        >
+                          {isEditing
+                            ? "Continue Editing"
+                            : "Continue Uploading Artwork"}
+                        </Button>
+                      </Flex>
+                    }
+                  >
+                    <Text mt={4}>
+                      {isEditing
+                        ? "Changes you have made so far will not be saved."
+                        : "Your artwork will not be added to My Collection."}
+                    </Text>
+                  </ModalDialog>
+                )}
                 <Sticky withoutHeaderOffset>
                   {({ stuck }) => {
                     return (
@@ -143,11 +187,9 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                               py={2}
                             >
                               <BackLink
-                                to={
-                                  isEditing
-                                    ? `/my-collection/artwork/${artwork.internalID}`
-                                    : "/my-collection"
-                                }
+                                // @ts-ignore
+                                as={RouterLink}
+                                onClick={() => setShouldShowModal(true)}
                                 width="min-content"
                               >
                                 Back

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -149,6 +149,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                           }
                           mt={4}
                           width="100%"
+                          data-testid="leave-button"
                         >
                           Leave Without Saving
                         </Button>

--- a/src/Apps/MyCollection/Routes/EditArtwork/__tests__/ArtworkForm.jest.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/__tests__/ArtworkForm.jest.tsx
@@ -17,6 +17,11 @@ const mockSubmitArtwork = jest.fn().mockResolvedValue({
   },
 })
 
+const setHookState = state =>
+  jest.fn().mockImplementation(() => [state, () => {}])
+
+const reactMock = require("react")
+
 jest.mock("System/Router/useRouter", () => ({
   useRouter: jest.fn(() => ({
     router: { push: mockRouterPush, replace: mockRouterReplace },
@@ -64,13 +69,6 @@ describe("Edit artwork", () => {
 
       expect(screen.getByText("Add Artwork Details")).toBeInTheDocument()
 
-      expect(
-        screen.getAllByRole("link").find(c => c.textContent?.includes("Back"))
-      ).toHaveAttribute(
-        "href",
-        `/my-collection/artwork/${mockArtwork.internalID}`
-      )
-
       expect(screen.getByPlaceholderText("Enter full name")).toHaveValue(
         "Willem de Kooning"
       )
@@ -115,6 +113,21 @@ describe("Edit artwork", () => {
       expect(
         screen.getByPlaceholderText("City where artwork is located")
       ).toHaveValue("Berlin")
+    })
+  })
+
+  describe("Back Link behavior", () => {
+    it("opens modal on press", async () => {
+      getWrapper().renderWithRelay({
+        Artwork: () => mockArtwork,
+      })
+
+      fireEvent.click(screen.getByText("Back"))
+
+      expect(screen.getByTestId("leave-button")).toHaveAttribute(
+        "href",
+        `/my-collection/artwork/${mockArtwork.internalID}`
+      )
     })
   })
 
@@ -193,7 +206,7 @@ describe("Create artwork", () => {
   }
 
   describe("Initial render", () => {
-    it("doesn't populates inputs", async () => {
+    it("doesn't populate inputs", async () => {
       getWrapper()
 
       expect(screen.getByText("Upload Artwork")).toBeInTheDocument()
@@ -201,11 +214,20 @@ describe("Create artwork", () => {
 
       expect(screen.getByText("Add Artwork Details")).toBeInTheDocument()
 
-      expect(
-        screen.getAllByRole("link").find(c => c.textContent?.includes("Back"))
-      ).toHaveAttribute("href", "/my-collection")
-
       expect(screen.getByPlaceholderText("Enter full name")).toHaveValue("")
+    })
+  })
+
+  describe("Back Link behavior", () => {
+    it("opens modal on press", async () => {
+      getWrapper()
+
+      fireEvent.click(screen.getByText("Back"))
+
+      expect(screen.getByTestId("leave-button")).toHaveAttribute(
+        "href",
+        "/my-collection"
+      )
     })
   })
 })

--- a/src/Apps/MyCollection/Routes/EditArtwork/__tests__/ArtworkForm.jest.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/__tests__/ArtworkForm.jest.tsx
@@ -17,11 +17,6 @@ const mockSubmitArtwork = jest.fn().mockResolvedValue({
   },
 })
 
-const setHookState = state =>
-  jest.fn().mockImplementation(() => [state, () => {}])
-
-const reactMock = require("react")
-
 jest.mock("System/Router/useRouter", () => ({
   useRouter: jest.fn(() => ({
     router: { push: mockRouterPush, replace: mockRouterReplace },


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2755]

### Description

<!-- Implementation description -->
On back button press opens the confirmation modal.

| Upload web | Upload Mobile | Edit Web | Edit Mobile |
| --- | --- | --- | --- |
| <img width="1784" alt="image" src="https://user-images.githubusercontent.com/36167539/186168368-aa75ecf1-ff82-4123-ab6e-a60cac6a733a.png"> | <img width="431" alt="image" src="https://user-images.githubusercontent.com/36167539/186168483-5b171f08-b4f7-43a2-870b-943981a03f74.png"> | <img width="1792" alt="image" src="https://user-images.githubusercontent.com/36167539/186168808-9e77948a-c3fc-485e-aae0-9930d3460ce6.png"> | <img width="386" alt="image" src="https://user-images.githubusercontent.com/36167539/186168928-95cd1eda-a82b-4355-afad-9d7d1bfb1cf5.png"> |


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2755]: https://artsyproduct.atlassian.net/browse/CX-2755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ