### PR TITLE
fix(onboarding): move completed onboarding tracking call to end of flow

### DIFF
--- a/src/Components/Onboarding/Components/OnboardingFollows.tsx
+++ b/src/Components/Onboarding/Components/OnboardingFollows.tsx
@@ -14,6 +14,7 @@ import { OnboardingSearchResultsQueryRenderer } from "../Components/OnboardingSe
 import { useDebouncedValue } from "Utils/Hooks/useDebounce"
 import { useOnboardingFadeTransition } from "../Hooks/useOnboardingFadeTransition"
 import { OnboardingFigure } from "../Components/OnboardingFigure"
+import { useOnboardingTracking } from "../Hooks/useOnboardingTracking"
 
 interface OnboardingFollowsProps {
   kind: "artists" | "galleries"
@@ -44,6 +45,8 @@ export const OnboardingFollows: FC<OnboardingFollowsProps> = ({ kind }) => {
   const { debouncedValue } = useDebouncedValue({ value: query, delay: 200 })
 
   const { title, placeholder, entities, setId } = CONFIGURATION[kind]
+
+  const tracking = useOnboardingTracking()
 
   return (
     <OnboardingSplitLayout
@@ -94,7 +97,10 @@ export const OnboardingFollows: FC<OnboardingFollowsProps> = ({ kind }) => {
           <Box p={2}>
             <Button
               width="100%"
-              onClick={handleNext}
+              onClick={() => {
+                tracking.userCompletedOnboarding()
+                handleNext()
+              }}
               loading={loading}
               disabled={state.followedIds.length === 0}
             >

--- a/src/Components/Onboarding/Components/OnboardingGene.tsx
+++ b/src/Components/Onboarding/Components/OnboardingGene.tsx
@@ -11,6 +11,7 @@ import { FollowGeneButtonFragmentContainer } from "Components/FollowButton/Follo
 import { useOnboardingContext } from "../Hooks/useOnboardingContext"
 import { OnboardingThankYou } from "../Views/OnboardingThankYou"
 import { ContextModule } from "@artsy/cohesion"
+import { useOnboardingTracking } from "../Hooks/useOnboardingTracking"
 
 interface OnboardingGeneProps {
   gene: OnboardingGene_gene
@@ -20,14 +21,16 @@ interface OnboardingGeneProps {
 const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
   const artworks = extractNodes(gene.artworks)
   const { onClose } = useOnboardingContext()
+  const tracking = useOnboardingTracking()
 
   useEffect(() => {
     return () => {
       if (onClose) {
+        tracking.userCompletedOnboarding()
         onClose()
       }
     }
-  }, [onClose])
+  }, [onClose, tracking])
 
   return (
     <Box px={[2, 4]} py={6}>

--- a/src/Components/Onboarding/Hooks/useOnboardingContext.tsx
+++ b/src/Components/Onboarding/Hooks/useOnboardingContext.tsx
@@ -10,7 +10,6 @@ import { useSystemContext } from "System"
 import { useUpdateMyUserProfile } from "Utils/Hooks/Mutations/useUpdateMyUserProfile"
 import { WorkflowEngine } from "Utils/WorkflowEngine"
 import { useConfig } from "../config"
-import { useOnboardingTracking } from "../Hooks/useOnboardingTracking"
 
 export type State = {
   questionOne: string | null
@@ -108,8 +107,6 @@ export const OnboardingProvider: FC<OnboardingProviderProps> = ({
     relayEnvironment,
   })
 
-  const tracking = useOnboardingTracking()
-
   const handleComplete = async () => {
     try {
       await submitUpdateMyUserProfile({
@@ -118,8 +115,6 @@ export const OnboardingProvider: FC<OnboardingProviderProps> = ({
     } catch (error) {
       console.error("Onboarding/useOnboardingContext", error)
     }
-
-    tracking.userCompletedOnboarding()
   }
 
   const { workflowEngine, back, current, next, reset: __reset__ } = useConfig({


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1242]

### Description

<!-- Implementation description -->
The goal of this PR is a bug fix to deal with the `userCompletedOnboarding()` tracking function being called multiple times at the end of the flow. My solution is to remove the tracking function call from the async user mutation and into a more stable place like a button click for artist/gallery follow views and whenever the user closes the modal for the gene views. 

artist/gallery follow view
![follow](https://user-images.githubusercontent.com/23108927/186224888-06cd4a49-7fc0-47e6-a3c6-dca6cf250afb.gif)

gene view
![gene](https://user-images.githubusercontent.com/23108927/186225155-a2badd9d-9ede-45cd-b0f8-c8047d9d9f65.gif)


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1242]: https://artsyproduct.atlassian.net/browse/GRO-1242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ