### PR TITLE
fix(onboarding/about): Italics on captions

### DIFF
--- a/src/Apps/About/AboutApp.tsx
+++ b/src/Apps/About/AboutApp.tsx
@@ -47,6 +47,7 @@ export const AboutApp: React.FC = () => {
             textAlign="right"
             p={1}
             color="white100"
+            fontStyle="italic"
           >
             Detail of Cassi Namoda, A Strange Song, 2022. Detail of Alex Katz,
             Day Lily 1, 1969.
@@ -150,6 +151,7 @@ const Section: React.FC<SectionProps & BoxProps> = ({
             right={0}
             p={1}
             color="white100"
+            fontStyle="italic"
           >
             {caption}
           </Text>

--- a/src/Components/Onboarding/Components/OnboardingFigure.tsx
+++ b/src/Components/Onboarding/Components/OnboardingFigure.tsx
@@ -47,6 +47,7 @@ export const OnboardingFigure: ForwardRefExoticComponent<
           position="absolute"
           right={2}
           bottom={2}
+          fontStyle="italic"
         >
           {caption}
         </Text>


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This italicizes the captions on about/onboarding.

<img width="763" alt="Screen Shot 2022-08-23 at 1 43 23 PM" src="https://user-images.githubusercontent.com/236943/186262133-6ce1dfcc-520d-498a-82b7-fdcd22791dd5.png">

<img width="465" alt="Screen Shot 2022-08-23 at 1 45 37 PM" src="https://user-images.githubusercontent.com/236943/186262170-cffd7aac-cf90-45dc-87c4-aabd766aeb6e.png">


cc @artsy/grow-devs 
