### PR TITLE
feat(FX-4174): add Activity link to navbar menu

### DIFF
--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
@@ -14,6 +14,7 @@ import { NavBarMobileMenuAuthentication_me } from "__generated__/NavBarMobileMen
 import { getConversationCount, updateConversationCache } from "../helpers"
 import { NavBarMobileMenuItemLink } from "./NavBarMobileMenuItem"
 import { NavBarMobileSubMenu } from "./NavBarMobileSubMenu"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface NavBarMobileMenuLoggedInProps {
   me?: NavBarMobileMenuAuthentication_me | null
@@ -23,6 +24,7 @@ export const NavBarMobileMenuLoggedIn: React.FC<NavBarMobileMenuLoggedInProps> =
   me,
 }) => {
   const { mediator } = useSystemContext()
+  const enableActivityPanel = useFeatureFlag("force-enable-new-activity-panel")
 
   const menu = {
     title: "Account",
@@ -97,6 +99,12 @@ export const NavBarMobileMenuLoggedIn: React.FC<NavBarMobileMenuLoggedInProps> =
       </NavBarMobileMenuItemLink>
 
       <NavBarMobileSubMenu menu={menu}>{menu.title}</NavBarMobileSubMenu>
+
+      {enableActivityPanel && (
+        <NavBarMobileMenuItemLink to="/notifications">
+          Activity
+        </NavBarMobileMenuItemLink>
+      )}
     </>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [FX-4174]

Unleash flag: [force-enable-new-activity-panel](https://unleash.artsy.net/projects/default/features/force-enable-new-activity-panel)

Review app: [activity-menu-item](https://activity-menu-item.artsy.net/)

### Acceptance Criteria
* Add the "Activity" link to the menu below "Account"
* Render the "Activity" link only for mWeb
* Render the "Activity" link only for logged in users
* Render the "Activity" link only when feature flag is enabled

### Demo
| NOT logged in user | Feature Flag is disabled | Feature Flag is enabled and logged in user |
| ------------- | ------------- | ------------- |
| <img width="344" alt="1" src="https://user-images.githubusercontent.com/3513494/186404140-8b15aaa0-3bcc-4e0b-8f92-29f221faf2a6.png"> | <img width="344" alt="2" src="https://user-images.githubusercontent.com/3513494/186404334-36171970-d037-422c-a72b-28de4019d76e.png"> | <img width="344" alt="3" src="https://user-images.githubusercontent.com/3513494/186404177-16478684-3d8b-4826-99bd-67e92b6bb7a7.png"> |

<!-- Implementation description -->


[FX-4174]: https://artsyproduct.atlassian.net/browse/FX-4174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ