### PR TITLE
fix: make staging preStop sleep interval agree with prod

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -78,7 +78,7 @@ spec:
               command:
               - sh
               - -c
-              - sleep 35
+              - sleep 10
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:


### PR DESCRIPTION
The type of this PR is: Fix

This PR solves the issue discussed in this [thread](https://artsy.slack.com/archives/CA8SANW3W/p1661368748053139).

### Description

Reduce Staging web deployment's `preStop` sleep interval. It's currently 35 seconds, longer than Kubernetes' default termination grace period of 30 seconds, such that k8s [kills the pods before their preStop runs to completion](https://app.datadoghq.com/event/explorer?query=failedprestophook%20force-web%20env%3Astaging&cols=&messageDisplay=expanded-lg&options=&sort=DESC&from_ts=1661281020625&to_ts=1661367420625&live=true).

We observe that for Prod it is just 10 seconds which seems fine. So let's make Staging agree with Prod. There will be less noise in k8s events, and Staging k8s rollout will be faster, since k8s will wait 25 seconds less between killing pods.

