### PR TITLE
fix(TX-619)- Do not send bankAccountId as null

### DIFF
--- a/src/Apps/Order/Components/PollAccountBalance.tsx
+++ b/src/Apps/Order/Components/PollAccountBalance.tsx
@@ -125,7 +125,9 @@ export const PollAccountBalanceQueryRenderer: FC<PollAccountBalanceQueryRenderer
     <SystemQueryRenderer<PollAccountBalanceQuery>
       environment={relayEnvironment}
       placeholder={<SavingPaymentSpinner />}
-      variables={bankAccountId ? { bankAccountId } : { setupIntentId }}
+      variables={
+        bankAccountId ? { bankAccountId } : { setupIntentId, bankAccountId: "" }
+      }
       query={BALANCE_QUERY}
       render={({ props }) => {
         if (!props?.commerceBankAccountBalance) {
@@ -134,7 +136,7 @@ export const PollAccountBalanceQueryRenderer: FC<PollAccountBalanceQueryRenderer
 
         return (
           <PollAccountBalanceRefetchContainer
-            commerceBankAccountBalance={props?.commerceBankAccountBalance}
+            commerceBankAccountBalance={props.commerceBankAccountBalance}
             setupIntentId={setupIntentId}
             bankAccountId={bankAccountId}
             {...rest}


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [TX-619]

### Description

This PR fixes the problem that when account balance check polling receives null initially and then the actual balance value, it still allows users to proceed to the review step, even though the received value is less than the order value. 

The fix is to send bankAccountId as a string explicitly instead of defaulting to null, even when we are using setupIntentId for a newly added bank account. 

Note that this problem is surfaced only since yesterday, when we added bankAccountId to the query for already saved bank account. 

#### Video
https://user-images.githubusercontent.com/42584148/186608637-45dc30d6-9809-4fca-ada7-06e60dc1423c.mov

[TX-619]: https://artsyproduct.atlassian.net/browse/TX-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ