### PR TITLE
fix: Adjust MyC artwork form Leave Without Saving behaviour

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "src/Apps/MyCollection/Routes/EditArtwork/__tests__/ArtworkForm.jest.tsx",
         "hashed_secret": "dc312ec7ed341804d6911ecdcf18eea1858f6091",
         "is_verified": false,
-        "line_number": 259
+        "line_number": 265
       }
     ],
     "src/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx": [
@@ -1398,5 +1398,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-23T15:12:26Z"
+  "generated_at": "2022-08-25T09:36:07Z"
 }

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -8,8 +8,8 @@ import {
   Spacer,
   Step,
   Stepper,
-  useToasts,
   Text,
+  useToasts,
 } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
@@ -140,13 +140,16 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                     footer={
                       <>
                         <Button
-                          // @ts-ignore
-                          as={RouterLink}
-                          to={
-                            isEditing
-                              ? `/my-collection/artwork/${artwork.internalID}`
-                              : "/my-collection"
-                          }
+                          onClick={e => {
+                            e.preventDefault()
+
+                            router.replace({ pathname: "/my-collection" })
+                            router.push({
+                              pathname: isEditing
+                                ? `/my-collection/artwork/${artwork.internalID}`
+                                : "/settings/my-collection",
+                            })
+                          }}
                           mt={4}
                           width="100%"
                           data-testid="leave-button"

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -142,7 +142,6 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                         <Button
                           onClick={e => {
                             e.preventDefault()
-
                             router.replace({ pathname: "/my-collection" })
                             router.push({
                               pathname: isEditing

--- a/src/Apps/MyCollection/Routes/EditArtwork/__tests__/ArtworkForm.jest.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/__tests__/ArtworkForm.jest.tsx
@@ -118,11 +118,14 @@ describe("Edit artwork", () => {
       })
 
       fireEvent.click(screen.getByText("Back"))
+      fireEvent.click(screen.getByText("Leave Without Saving"))
 
-      expect(screen.getByTestId("leave-button")).toHaveAttribute(
-        "href",
-        `/my-collection/artwork/${mockArtwork.internalID}`
-      )
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        pathname: "/my-collection/artwork/62fc96c48d3ff8000b556c3a",
+      })
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        pathname: "/my-collection",
+      })
     })
   })
 
@@ -218,11 +221,14 @@ describe("Create artwork", () => {
       getWrapper()
 
       fireEvent.click(screen.getByText("Back"))
+      fireEvent.click(screen.getByText("Leave Without Saving"))
 
-      expect(screen.getByTestId("leave-button")).toHaveAttribute(
-        "href",
-        "/my-collection"
-      )
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        pathname: "/my-collection/artwork/62fc96c48d3ff8000b556c3a",
+      })
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        pathname: "/my-collection",
+      })
     })
   })
 })


### PR DESCRIPTION
## Description

Adjust MyC artwork form "Leave Without Saving" behavior. Before it wasn't possible to navigate back from the artwork detail page once the user clicked on  "Leave Without Saving" because this would cause the browser to navigate back to the edit page again.