### PR TITLE
fix(TX-618) - analytics unknown schema errors

### DIFF
--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -227,8 +227,6 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     }
   }
 
-  console.log()
-
   // fired when balance check is done: either sets error state or moves to /review
   const handleBalanceCheckComplete = (
     displayInsufficientFundsError: boolean,

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -4,7 +4,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import type { Stripe, StripeElements } from "@stripe/stripe-js"
 import { Router } from "found"
 import { Box, Flex, Spacer } from "@artsy/palette"
-import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { useTracking } from "react-tracking"
 
 // relay generated
@@ -227,19 +227,22 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     }
   }
 
+  console.log()
+
   // fired when balance check is done: either sets error state or moves to /review
   const handleBalanceCheckComplete = (
     displayInsufficientFundsError: boolean,
     checkResult: BalanceCheckResult
   ) => {
     const event = {
-      subject: "checked_account_balance",
+      subject: "balance_account_check",
       outcome: checkResult,
       payment_method: selectedPaymentMethod,
       currency: order.currencyCode,
       amount: order.buyerTotalCents,
       order_id: order.internalID,
       context_page_owner_type: OwnerType.ordersPayment,
+      action: ActionType.checkedAccountBalance,
       flow: order.mode!,
     }
 

--- a/src/Components/BankDebitForm/BankDebitForm.tsx
+++ b/src/Components/BankDebitForm/BankDebitForm.tsx
@@ -1,5 +1,6 @@
 import { FC, useState } from "react"
 import { PaymentElement, useStripe, useElements } from "@stripe/react-stripe-js"
+import { ActionType, OwnerType } from "@artsy/cohesion"
 import {
   Box,
   Checkbox,
@@ -46,7 +47,9 @@ export const BankDebitForm: FC<Props> = ({
       tracking.trackEvent({
         flow: order.mode,
         order_id: order.internalID,
-        subject: "bank_account_selected",
+        subject: "link_account",
+        context_page_owner_type: OwnerType.ordersPayment,
+        action: ActionType.clickedPaymentDetails,
       })
     }
   }

--- a/src/Components/BankDebitForm/__tests__/BankDebitForm.jest.tsx
+++ b/src/Components/BankDebitForm/__tests__/BankDebitForm.jest.tsx
@@ -65,7 +65,9 @@ describe("BankDebitForm", () => {
     expect(trackEvent).toHaveBeenCalledWith({
       flow: "BUY",
       order_id: "1234",
-      subject: "bank_account_selected",
+      subject: "link_account",
+      context_page_owner_type: "orders-payment",
+      action: "clickedPaymentDetails",
     })
   })
 


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [TX-618]

### Description

This PR fixes the error seen in console when 2 events are tracked: 'unknown analytics schema is used'. The reason for the problem was that the correct `ActionType` property was missing in the event bodies. 


[TX-618]: https://artsyproduct.atlassian.net/browse/TX-618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ