### PR TITLE
fix: Artist autocomplete validation

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
@@ -39,8 +39,9 @@ interface ArtistAutocompleteOption extends AutocompleteInputOptionType {
 
 export const ArtistAutoComplete: React.FC<{
   onError: () => void
+  onSelect: ({ artistId: string }) => void
   required?: boolean
-}> = ({ onError, required }) => {
+}> = ({ onError, onSelect, required }) => {
   const [suggestions, setSuggestions] = useState<
     Array<ArtistAutocompleteOption>
   >([])
@@ -111,11 +112,13 @@ export const ArtistAutoComplete: React.FC<{
     setSuggestions([])
     setFieldValue("artistId", "")
     setFieldValue("artistName", "")
+    onSelect({ artistId: "" })
   }
 
   const handleSelect = ({ text, value }: ArtistAutocompleteOption) => {
     setFieldValue("artistId", value)
     setFieldValue("artistName", text)
+    onSelect({ artistId: value })
   }
 
   const handleClose = () => {

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtworkDetailsForm.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtworkDetailsForm.tsx
@@ -149,7 +149,10 @@ export const ArtworkDetailsForm: React.FC = () => {
 
       <GridColumns>
         <Column span={6}>
-          <ArtistAutoComplete onError={() => handleAutosuggestError(true)} />
+          <ArtistAutoComplete
+            onSelect={({ artistId }) => setFieldValue("artistId", artistId)}
+            onError={() => handleAutosuggestError(true)}
+          />
         </Column>
         <Column span={6} mt={[4, 0]}>
           <Input

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
@@ -1,13 +1,13 @@
+import { Input } from "@artsy/palette"
+import { flushPromiseQueue } from "DevTools"
 import { mount, ReactWrapper } from "enzyme"
+import { Form, Formik } from "formik"
+import { SystemContextProvider } from "System"
+import { ArtistAutoComplete } from "../Components/ArtistAutocomplete"
 import {
   ArtworkDetailsFormModel,
   getArtworkDetailsFormInitialValues,
 } from "../Components/ArtworkDetailsForm"
-import { ArtistAutoComplete } from "../Components/ArtistAutocomplete"
-import { Form, Formik } from "formik"
-import { Input } from "@artsy/palette"
-import { SystemContextProvider } from "System"
-import { flushPromiseQueue } from "DevTools"
 
 jest.mock("System/Router/useRouter", () => ({
   useRouter: jest.fn(() => ({ match: { params: { id: null } } })),
@@ -57,7 +57,10 @@ const renderArtistAutosuggest = (values: ArtworkDetailsFormModel) =>
           formikValues = values
           return (
             <Form>
-              <ArtistAutoComplete onError={() => mockErrorHandler(true)} />
+              <ArtistAutoComplete
+                onSelect={() => {}}
+                onError={() => mockErrorHandler(true)}
+              />
             </Form>
           )
         }}

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormDetails.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormDetails.tsx
@@ -64,6 +64,7 @@ export const MyCollectionArtworkFormDetails: React.FC = () => {
         <Column span={6}>
           <ArtistAutoComplete
             onError={() => handleAutosuggestError(true)}
+            onSelect={({ artistId }) => setFieldValue("artistId", artistId)}
             required
           />
         </Column>


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2836]

### Description

This PR fixes the validation for the artist autocomplete by adding a `onSelect` callback. Before this change selecting an artist or clearing the input didn't revalidate the form. 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2836]: https://artsyproduct.atlassian.net/browse/CX-2836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ