### PR TITLE
chore: move shortcut redirect middleware to last, and also account for new MP behavior when shortcut doesn't exist

### DIFF
--- a/src/Apps/Redirects/redirectsServerRoutes.tsx
+++ b/src/Apps/Redirects/redirectsServerRoutes.tsx
@@ -34,7 +34,9 @@ export const handleShort = async (
       { id: short }
     )
 
-    res.redirect(301, shortcut.long)
+    if (shortcut) return res.redirect(301, shortcut.long)
+
+    next()
   } catch {
     next()
   }
@@ -183,9 +185,6 @@ export const handleFairOrganizer = (
 }
 
 redirectsServerRoutes
-  // Shortcuts
-  .get("/:short", handleShort)
-
   // Fetch profile for remaining routes
   .get(["/:id", "/:id/:tab*"], handleProfile)
 
@@ -256,5 +255,8 @@ redirectsServerRoutes
 
   // Fair Organziers
   .get("/:id", handleFairOrganizer)
+
+  // Shortcuts
+  .get("/:short", handleShort)
 
 export { redirectsServerRoutes }


### PR DESCRIPTION
I think it's more optimal to have this shortcut redirect handler at the bottom of our middleware stack - it'll save looking up a shortcut for all the legacy partner, fair, other root-level pages.

Additionally, with https://github.com/artsy/metaphysics/pull/4342 , `shortcut` could be `null` so deserves a guard (although the `try/catch` would have swallowed that anyway). Prior to the MP PR, `shortcut` could not be `null` and MP would actually return a 500 for shortcuts that aren't found, which gets caught by the `try/catch`.