### PR TITLE
fix: My Collection artwork form header 

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -228,7 +228,6 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                       <FullBleed
                         backgroundColor="white100"
                         style={stuck ? { boxShadow: DROP_SHADOW } : undefined}
-                        zIndex={10000}
                       >
                         <AppContainer>
                           <HorizontalPadding>

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -4,9 +4,9 @@ import {
   DROP_SHADOW,
   Flex,
   FullBleed,
+  Separator,
   Spacer,
-  Step,
-  Stepper,
+  Text,
   useToasts,
 } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
@@ -265,14 +265,10 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                 </Sticky>
               </StickyProvider>
 
-              <Stepper
-                initialTabIndex={0}
-                currentStepIndex={0}
-                disableNavigation
-                zIndex={0}
-              >
-                <Step name="Add Artwork Details" />
-              </Stepper>
+              <Text mx={2} mb={1}>
+                Edit Artwork Details
+              </Text>
+              <Separator color="black100" />
 
               <Spacer mb={4} />
 

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -228,6 +228,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                       <FullBleed
                         backgroundColor="white100"
                         style={stuck ? { boxShadow: DROP_SHADOW } : undefined}
+                        zIndex={10000}
                       >
                         <AppContainer>
                           <HorizontalPadding>
@@ -269,6 +270,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                 initialTabIndex={0}
                 currentStepIndex={0}
                 disableNavigation
+                zIndex={0}
               >
                 <Step name="Add Artwork Details" />
               </Stepper>

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -266,7 +266,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
               </StickyProvider>
 
               <Text mx={2} mb={1}>
-                Edit Artwork Details
+                {isEditing ? "Edit Artwork Details" : "Add Artwork Details"}
               </Text>
               <Separator color="black100" />
 

--- a/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
@@ -86,7 +86,7 @@ describe("Edit artwork", () => {
       expect(screen.getByText("Save Artwork")).toBeInTheDocument()
       expect(screen.getByTestId("save-button")).toBeEnabled()
 
-      expect(screen.getByText("Add Artwork Details")).toBeInTheDocument()
+      expect(screen.getByText("Edit Artwork Details")).toBeInTheDocument()
 
       expect(screen.getByPlaceholderText("Enter full name")).toHaveValue(
         "Willem de Kooning"


### PR DESCRIPTION
Resolves [CX-2843](https://artsyproduct.atlassian.net/browse/CX-2843) & [2844](https://artsyproduct.atlassian.net/browse/CX-2844)

## Description

This PR changes the copy of and removes the `Stepper` component from the artwork form header. This solves the following problems:

- Text was overlapping the sticky header
- Chevron Icon was visible at the end of the stepper.