### PR TITLE
fix: Adjust My Collection artwork form Leave Without Saving behaviour

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx",
         "hashed_secret": "dc312ec7ed341804d6911ecdcf18eea1858f6091",
         "is_verified": false,
-        "line_number": 450
+        "line_number": 456
       }
     ],
     "src/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx": [
@@ -1389,5 +1389,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-26T09:32:24Z"
+  "generated_at": "2022-08-26T10:11:14Z"
 }

--- a/src/Apps/MyCollection/Routes/EditArtwork/ConfirmationModalBack.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/ConfirmationModalBack.tsx
@@ -1,15 +1,14 @@
 import { Button, ModalDialog, Text } from "@artsy/palette"
-import { RouterLink } from "System/Router/RouterLink"
 
 interface ConfirmationModalProps {
-  onClose: () => void
-  handleSubmit: string
   isEditing: boolean
+  onClose: () => void
+  onLeave: () => void
 }
 export const ConfirmationModalBack: React.FC<ConfirmationModalProps> = ({
-  onClose,
   isEditing,
-  handleSubmit,
+  onClose,
+  onLeave,
 }) => {
   return (
     <ModalDialog
@@ -18,13 +17,7 @@ export const ConfirmationModalBack: React.FC<ConfirmationModalProps> = ({
       width={["100%", 600]}
       footer={
         <>
-          <Button
-            // @ts-ignore
-            as={RouterLink}
-            to={handleSubmit}
-            width="100%"
-            data-testid="leave-button"
-          >
+          <Button onClick={onLeave} width="100%" data-testid="leave-button">
             Leave Without Saving
           </Button>
           <Button

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -206,11 +206,14 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                   <ConfirmationModalBack
                     onClose={() => setShouldShowBackModal(false)}
                     isEditing={isEditing}
-                    handleSubmit={
-                      isEditing
-                        ? `/my-collection/artwork/${artwork.internalID}`
-                        : "/my-collection"
-                    }
+                    onLeave={() => {
+                      router.replace({ pathname: "/my-collection" })
+                      router.push({
+                        pathname: isEditing
+                          ? `/my-collection/artwork/${artwork.internalID}`
+                          : "/settings/my-collection",
+                      })
+                    }}
                   />
                 )}
                 {shouldShowDeletionModal && (

--- a/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
@@ -142,11 +142,14 @@ describe("Edit artwork", () => {
       })
 
       fireEvent.click(screen.getByText("Back"))
+      fireEvent.click(screen.getByText("Leave Without Saving"))
 
-      expect(screen.getByTestId("leave-button")).toHaveAttribute(
-        "href",
-        `/my-collection/artwork/${mockArtwork.internalID}`
-      )
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        pathname: "/my-collection/artwork/62fc96c48d3ff8000b556c3a",
+      })
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        pathname: "/my-collection",
+      })
     })
   })
 
@@ -409,11 +412,14 @@ describe("Create artwork", () => {
       getWrapper()
 
       fireEvent.click(screen.getByText("Back"))
+      fireEvent.click(screen.getByText("Leave Without Saving"))
 
-      expect(screen.getByTestId("leave-button")).toHaveAttribute(
-        "href",
-        "/my-collection"
-      )
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        pathname: "/my-collection/artwork/62fc96c48d3ff8000b556c3a",
+      })
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        pathname: "/my-collection",
+      })
     })
   })
 })


### PR DESCRIPTION
## Description

Same logic as https://github.com/artsy/force/pull/10835, just resolves the merge conflicts.

Adjust MyC artwork form "Leave Without Saving" behavior. Before it wasn't possible to navigate back from the artwork detail page once the user clicked on  "Leave Without Saving" because this would cause the browser to navigate back to the edit page again.