### PR TITLE
fix: Decrease "Upload Work" button size on mWeb

### DIFF
--- a/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
@@ -133,6 +133,7 @@ const MyCollectionRoute: FC<MyCollectionRouteProps> = ({ me, relay }) => {
               <Button
                 // @ts-ignore
                 as={RouterLink}
+                size={["small", "large"]}
                 variant="primaryBlack"
                 to="/my-collection/artworks/new"
               >


### PR DESCRIPTION
Addresses [CX-2840]

## Description

Decrease Upload Work button size on mWeb.

| Before | After |
| --- | --- |
|<img width="407" alt="Screenshot 2022-08-26 at 12 51 58" src="https://user-images.githubusercontent.com/4691889/186888406-af55fadc-4eca-4689-84cf-7b354ba9f1fb.png"> | <img width="410" alt="Screenshot 2022-08-26 at 12 51 17" src="https://user-images.githubusercontent.com/4691889/186888358-c7a6b87b-3f79-4b77-9066-ab787aa0c897.png"> |





[CX-2840]: https://artsyproduct.atlassian.net/browse/CX-2840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ