### PR TITLE
fix(auth): Update description copy on login

### DIFF
--- a/src/Apps/Authentication/Components/AuthStatic.tsx
+++ b/src/Apps/Authentication/Components/AuthStatic.tsx
@@ -8,13 +8,13 @@ import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 
 interface AuthStaticProps extends BoxProps {
   type: ModalType
-  meta: { title?: string }
+  meta: { description?: string; title?: string }
   options: ModalOptions
 }
 
 export const AuthStatic: React.FC<AuthStaticProps> = ({
   type,
-  meta: { title },
+  meta: { description, title },
   options,
   ...rest
 }) => {
@@ -30,10 +30,11 @@ export const AuthStatic: React.FC<AuthStaticProps> = ({
         maxWidth={440}
       >
         <ModalHeader title={title} hasLogo />
-        <Text textAlign="center" variant="sm-display">
-          Build your personalized profile. Get art market insights. Buy and sell
-          with confidence.
-        </Text>
+        {description && (
+          <Text textAlign="center" variant="sm-display">
+            {description}
+          </Text>
+        )}
         <Spacer my={0.5} />
         <FormSwitcher
           type={type}

--- a/src/Apps/Authentication/Components/__tests__/AuthStatic.jest.js
+++ b/src/Apps/Authentication/Components/__tests__/AuthStatic.jest.js
@@ -1,3 +1,4 @@
+import { merge } from "lodash"
 import { mount } from "enzyme"
 import { ModalHeader } from "Components/Modal/ModalHeader"
 import { FormSwitcher } from "Components/Authentication/FormSwitcher"
@@ -13,7 +14,7 @@ describe("AuthStatic", () => {
     props = {
       type: "login",
       meta: {
-        title: "A sub title",
+        title: "A title",
       },
       handleSubmit: jest.fn(),
       options: {},
@@ -27,6 +28,17 @@ describe("AuthStatic", () => {
 
   it("Renders the DesktopHeader", () => {
     const component = getWrapper(props)
-    expect(component.find(ModalHeader).text()).toMatch("A sub title")
+    expect(component.find(ModalHeader).text()).toMatch("A title")
+  })
+
+  it("shows description on login", () => {
+    const component = getWrapper(
+      merge(props, {
+        meta: {
+          description: "a description",
+        },
+      })
+    )
+    expect(component.find(ModalHeader).text()).toMatch("a description")
   })
 })

--- a/src/Apps/Authentication/Routes/SignupRoute.tsx
+++ b/src/Apps/Authentication/Routes/SignupRoute.tsx
@@ -9,6 +9,8 @@ export const SignupRoute: React.FC = props => {
   const { meta, options, type } = useAuthForm({
     canonical: `${getENV("APP_URL")}/signup`,
     pageTitle: "Sign up for Artsy",
+    description:
+      "Build your personalized profile. Get art market insights. Buy and sell with confidence.",
     type: ModalType.signup,
   })
 

--- a/src/Apps/Authentication/Utils/useAuthForm.ts
+++ b/src/Apps/Authentication/Utils/useAuthForm.ts
@@ -8,10 +8,16 @@ import { computeTitle } from "./computeTitle"
 interface UseAuthFormProps {
   canonical: string
   pageTitle: string
+  description?: string
   type: ModalType
 }
 
-export function useAuthForm({ canonical, pageTitle, type }: UseAuthFormProps) {
+export function useAuthForm({
+  canonical,
+  description,
+  pageTitle,
+  type,
+}: UseAuthFormProps) {
   const { match } = useRouter()
 
   const {
@@ -48,7 +54,7 @@ export function useAuthForm({ canonical, pageTitle, type }: UseAuthFormProps) {
 
   const meta: AuthenticationMetaProps["meta"] = {
     canonical,
-    description: "",
+    description: description ?? "",
     title,
   }
 


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [GRO-1238]

### Description

This updates our static auth pages to only include a description when called for:

<img width="391" alt="Screen Shot 2022-08-26 at 1 07 49 PM" src="https://user-images.githubusercontent.com/236943/186984147-b9141619-7d5c-4bd3-8bb9-d5075daf1bc8.png">

<img width="445" alt="Screen Shot 2022-08-26 at 1 07 54 PM" src="https://user-images.githubusercontent.com/236943/186984148-2d443d76-13a8-4a48-a586-9a09ad681d8f.png">
la

<img width="499" alt="Screen Shot 2022-08-26 at 1 07 43 PM" src="https://user-images.githubusercontent.com/236943/186984143-adaeb1e2-392b-4bc3-be89-f56e55ad5c49.png">

cc @artsy/grow-devs 

[GRO-1238]: https://artsyproduct.atlassian.net/browse/GRO-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ