### PR TITLE
fix(misc-tickets): Debounce pageview tracking and hypenate partner badges 

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -9,7 +9,6 @@ import { screen, fireEvent, within, act } from "@testing-library/react"
 
 jest.unmock("react-relay")
 jest.mock("react-tracking")
-jest.mock("lodash/debounce", () => jest.fn(e => e))
 jest.mock("Utils/openAuthModal")
 jest.mock("Components/Pagination/useComputeHref")
 jest.mock("System/Router/Utils/catchLinks", () => ({

--- a/src/Apps/Partner/PartnerApp.tsx
+++ b/src/Apps/Partner/PartnerApp.tsx
@@ -54,7 +54,10 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
 
         <FullBleed mb={[2, 4]}>
           {firstEligibleBadgeName ? (
-            <Marquee speed="static" marqueeText={firstEligibleBadgeName} />
+            <Marquee
+              speed="static"
+              marqueeText={firstEligibleBadgeName.replace(" ", "-")} // hypenate gallery badges
+            />
           ) : (
             <Separator />
           )}

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/KeywordFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/KeywordFilter.jest.tsx
@@ -19,8 +19,6 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
 }))
 
-jest.mock("lodash/debounce", () => jest.fn(e => e))
-
 const render = (ui: ReactElement, options: RenderOptions = {}) =>
   originalRender(ui, { wrapper: Wrapper, ...options })
 

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilterNew.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilterNew.jest.tsx
@@ -19,7 +19,6 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
 }))
 jest.mock("Utils/getENV")
-jest.mock("lodash/debounce", () => jest.fn(e => e))
 
 describe("PriceRangeFilterNew", () => {
   let context: ArtworkFilterContextProps

--- a/src/System/Analytics/trackingMiddleware.ts
+++ b/src/System/Analytics/trackingMiddleware.ts
@@ -1,7 +1,8 @@
 import { ActionTypes } from "farce"
-import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import { match } from "path-to-regexp"
+import { debounce } from "lodash"
+import { getENV } from "Utils/getENV"
 
 /**
  * PageView tracking middleware for use in our router apps. Middleware conforms
@@ -16,6 +17,8 @@ interface TrackingMiddlewareOptions {
 }
 
 export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
+  const trackPageview = debounce(window.analytics?.page!, 30)
+
   return store => next => action => {
     const { excludePaths = [] } = options
     const { type, payload } = action
@@ -34,7 +37,7 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
         )
 
         const getFullReferrerUrl = () => {
-          const fullReferrerUrl = sd.APP_URL + clientSideRoutingReferrer
+          const fullReferrerUrl = getENV("APP_URL") + clientSideRoutingReferrer
           return fullReferrerUrl
         }
 
@@ -69,7 +72,7 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
           })
 
           if (!foundExcludedPath) {
-            const url = sd.APP_URL + pathname
+            const url = getENV("APP_URL") + pathname
             const trackingData: {
               path: string
               referrer?: string
@@ -83,7 +86,7 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
               trackingData.referrer = getFullReferrerUrl()
             }
 
-            analytics.page(trackingData, {
+            trackPageview(trackingData, {
               integrations: {
                 Marketo: false,
               },

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -12,6 +12,7 @@ const useTracking = _useTracking as jest.Mock
 track.mockImplementation(() => x => x as any)
 useTracking.mockImplementation(() => ({ trackEvent: jest.fn() }))
 
+jest.mock("lodash/debounce", () => jest.fn(e => e))
 jest.mock("react-sizeme", () => jest.fn(() => d => d))
 jest.mock("Utils/logger")
 


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves
- https://artsyproduct.atlassian.net/browse/GRO-1242 (onboarding events firing more than once)
- https://artsyproduct.atlassian.net/browse/GRO-1210 (hyphenate gallery ownership badges) 

### Description

Fixes the first ticket by adding a debounce to our analytics middleware. This is good protection (just in general) but more specific to the ticket, we were getting three page view calls because we 
- create account and then
- redirect back to page where user was (page view)
- and trigger onboarding by updating url bar with query param (page view)
- then replace url by stripping `onboarding=true` query param (page view)

which is three routing events (push, push, replace), which all tap into our analytics middleware. So this adds some protection against that by ensuring we can never fire these rapid fire page view events (which should never even be possible from a UX perspective)

The second ticket just hyphenates the display of our categories. Quick fix vs needing to update a few dbs and old rails app vibrations haml UI. Doesn't seem like that big of a deal but happy to go through the hoops there. 

<img width="257" alt="Screen Shot 2022-08-26 at 2 16 02 PM" src="https://user-images.githubusercontent.com/236943/186993879-c40b278e-c15c-40a3-9ce9-bcf970a4e7b5.png">

<img width="507" alt="Screen Shot 2022-08-26 at 2 15 20 PM" src="https://user-images.githubusercontent.com/236943/186993868-e3f89c07-bb62-4c1f-a26d-3a2af954751a.png">



cc @artsy/grow-devs 