### PR TITLE
fix: Adjust Settings app title font size on mWeb and tab spacing

### DIFF
--- a/src/Apps/Settings/Routes/Auctions/Components/SectionContainer.tsx
+++ b/src/Apps/Settings/Routes/Auctions/Components/SectionContainer.tsx
@@ -1,4 +1,4 @@
-import { Text, GridColumns, Message } from "@artsy/palette"
+import { GridColumns, Message, Text } from "@artsy/palette"
 import React from "react"
 
 interface SectionContainerProps {
@@ -14,7 +14,7 @@ export const SectionContainer: React.FC<SectionContainerProps> = ({
 
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         {title}
       </Text>
 

--- a/src/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
+++ b/src/Apps/Settings/Routes/DeleteAccount/DeleteAccountRoute.tsx
@@ -9,15 +9,15 @@ import {
   TextArea,
   useToasts,
 } from "@artsy/palette"
-import * as Yup from "yup"
 import { password } from "Components/Authentication/Validators"
+import { Form, Formik } from "formik"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { RouterLink } from "System/Router/RouterLink"
+import { logout } from "Utils/auth"
+import * as Yup from "yup"
 import { DeleteAccountRoute_me } from "__generated__/DeleteAccountRoute_me.graphql"
 import { useDeleteAccount } from "./useDeleteAccount"
-import { RouterLink } from "System/Router/RouterLink"
-import { Formik, Form } from "formik"
-import { logout } from "Utils/auth"
 
 interface DeleteAccountRouteProps {
   me: DeleteAccountRoute_me
@@ -32,7 +32,7 @@ export const DeleteAccountRoute: FC<DeleteAccountRouteProps> = ({
   return (
     <GridColumns>
       <Column span={8}>
-        <Text variant="lg-display" mb={4}>
+        <Text variant={["md", "lg"]} mb={4}>
           Delete My Account
         </Text>
 

--- a/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileAboutYou.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileAboutYou.tsx
@@ -8,13 +8,13 @@ import {
   Text,
   useToasts,
 } from "@artsy/palette"
-import { Formik } from "formik"
-import { FC, useState } from "react"
-import { createFragmentContainer, graphql } from "react-relay"
 import {
   LocationAutocompleteInput,
   normalizePlace,
 } from "Components/LocationAutocompleteInput"
+import { Formik } from "formik"
+import { FC, useState } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
 import { useUpdateMyUserProfile } from "Utils/Hooks/Mutations/useUpdateMyUserProfile"
 import { SettingsEditProfileAboutYou_me } from "__generated__/SettingsEditProfileAboutYou_me.graphql"
 
@@ -32,7 +32,7 @@ const SettingsEditProfileAboutYou: FC<SettingsEditProfileAboutYouProps> = ({
 
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         About You
       </Text>
 

--- a/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileArtistsYouCollect/SettingsEditProfileArtistsYouCollect.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileArtistsYouCollect/SettingsEditProfileArtistsYouCollect.tsx
@@ -1,19 +1,19 @@
-import { FC, useState } from "react"
-import { compact } from "lodash"
 import {
-  Text,
   AutocompleteInput,
-  BoxProps,
   Box,
+  BoxProps,
+  Text,
   useToasts,
 } from "@artsy/palette"
+import { compact } from "lodash"
+import { FC, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { SettingsEditProfileArtistsYouCollectRemoveButton } from "./SettingsEditProfileArtistsYouCollectRemoveButton"
-import { SettingsEditProfileArtistsYouCollect_me } from "__generated__/SettingsEditProfileArtistsYouCollect_me.graphql"
-import { SettingsEditProfileArtistsYouCollectAutocompleteQuery } from "__generated__/SettingsEditProfileArtistsYouCollectAutocompleteQuery.graphql"
-import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { useSystemContext } from "System"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { extractNodes } from "Utils/extractNodes"
+import { SettingsEditProfileArtistsYouCollectAutocompleteQuery } from "__generated__/SettingsEditProfileArtistsYouCollectAutocompleteQuery.graphql"
+import { SettingsEditProfileArtistsYouCollect_me } from "__generated__/SettingsEditProfileArtistsYouCollect_me.graphql"
+import { SettingsEditProfileArtistsYouCollectRemoveButton } from "./SettingsEditProfileArtistsYouCollectRemoveButton"
 import { useAddArtistYouCollect } from "./useAddArtistYouCollect"
 import { useRemoveArtistYouCollect } from "./useRemoveArtistYouCollect"
 
@@ -61,7 +61,7 @@ export const SettingsEditProfileArtistsYouCollect: FC<SettingsEditProfileArtists
 
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         Artists You Collect
       </Text>
 

--- a/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileYourGalleryIntro.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileYourGalleryIntro.tsx
@@ -13,7 +13,7 @@ const SettingsEditProfileYourGalleryIntro: FC<SettingsEditProfileYourGalleryIntr
 }) => {
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         Your Gallery Intro
       </Text>
 
@@ -21,7 +21,7 @@ const SettingsEditProfileYourGalleryIntro: FC<SettingsEditProfileYourGalleryIntr
         Preview
       </Text>
 
-      <Text variant="lg-display" color="black60">
+      <Text variant={["md", "lg"]} color="black60">
         {me.inquiryIntroduction}
       </Text>
     </>

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsEmailPreferences/SettingsEditSettingsEmailPreferences.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsEmailPreferences/SettingsEditSettingsEmailPreferences.tsx
@@ -1,11 +1,11 @@
-import { FC } from "react"
 import { Button, Text } from "@artsy/palette"
+import { FC } from "react"
 import { RouterLink } from "System/Router/RouterLink"
 
 export const SettingsEditSettingsEmailPreferences: FC = () => {
   return (
     <>
-      <Text color="black100" variant="lg-display" mb={4}>
+      <Text color="black100" variant={["md", "lg"]} mb={4}>
         Email Preferences
       </Text>
       <Text color="black60" variant="sm" mb={2}>

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
@@ -1,18 +1,18 @@
-import * as React from "react"
-import * as Yup from "yup"
-import { createFragmentContainer, graphql } from "react-relay"
-import { Form, Formik } from "formik"
-import { SettingsEditSettingsInformation_me } from "__generated__/SettingsEditSettingsInformation_me.graphql"
 import {
   Button,
-  Text,
   Input,
   Join,
-  Spacer,
-  useToasts,
   PasswordInput,
+  Spacer,
+  Text,
+  useToasts,
 } from "@artsy/palette"
-import { email, password, name } from "Components/Authentication/Validators"
+import { email, name, password } from "Components/Authentication/Validators"
+import { Form, Formik } from "formik"
+import * as React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import * as Yup from "yup"
+import { SettingsEditSettingsInformation_me } from "__generated__/SettingsEditSettingsInformation_me.graphql"
 import { useUpdateSettingsInformation } from "./useUpdateSettingsInformation"
 
 interface SettingsEditSettingsInformationProps {
@@ -27,7 +27,7 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
 
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         Information
       </Text>
 

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
@@ -1,24 +1,24 @@
-import { FC, useEffect } from "react"
 import {
   AppleIcon,
+  Button,
   FacebookIcon,
   GoogleIcon,
-  Button,
+  IconProps,
   Join,
   Spacer,
   Text,
   useToasts,
-  IconProps,
 } from "@artsy/palette"
+import { FC, useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import {
-  SettingsEditSettingsLinkedAccounts_me,
-  AuthenticationProvider,
-} from "__generated__/SettingsEditSettingsLinkedAccounts_me.graphql"
 import { useRouter } from "System/Router/useRouter"
-import { useUnlinkSettingsLinkedAccount } from "./useUnlinkSettingsLinkedAccount"
 import { getENV } from "Utils/getENV"
 import { useMode } from "Utils/Hooks/useMode"
+import {
+  AuthenticationProvider,
+  SettingsEditSettingsLinkedAccounts_me,
+} from "__generated__/SettingsEditSettingsLinkedAccounts_me.graphql"
+import { useUnlinkSettingsLinkedAccount } from "./useUnlinkSettingsLinkedAccount"
 
 interface SettingsEditSettingsLinkedAccountsProps {
   me: SettingsEditSettingsLinkedAccounts_me
@@ -48,7 +48,7 @@ export const SettingsEditSettingsLinkedAccounts: FC<SettingsEditSettingsLinkedAc
 
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         Linked Accounts
       </Text>
 

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsPassword.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsPassword.tsx
@@ -1,22 +1,22 @@
-import * as Yup from "yup"
-import { FC } from "react"
-import { createFragmentContainer, graphql } from "react-relay"
 import {
-  Text,
-  Input,
   Button,
   Flex,
-  PasswordInput,
+  Input,
   Join,
+  PasswordInput,
   Spacer,
+  Text,
   useToasts,
 } from "@artsy/palette"
-import { Form, Formik } from "formik"
-import { useUpdateSettingsPassword } from "../useUpdateSettingsPassword"
-import { logout } from "Utils/auth"
-import { SettingsEditSettingsPassword_me } from "__generated__/SettingsEditSettingsPassword_me.graphql"
-import { useMode } from "Utils/Hooks/useMode"
 import { password } from "Components/Authentication/Validators"
+import { Form, Formik } from "formik"
+import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { logout } from "Utils/auth"
+import { useMode } from "Utils/Hooks/useMode"
+import * as Yup from "yup"
+import { SettingsEditSettingsPassword_me } from "__generated__/SettingsEditSettingsPassword_me.graphql"
+import { useUpdateSettingsPassword } from "../useUpdateSettingsPassword"
 
 interface SettingsEditSettingsPasswordProps {
   me: SettingsEditSettingsPassword_me
@@ -41,7 +41,7 @@ export const SettingsEditSettingsPassword: FC<SettingsEditSettingsPasswordProps>
 
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         Password
       </Text>
 

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactor.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactor.tsx
@@ -1,9 +1,9 @@
 import { Join, Spacer, Sup, Text } from "@artsy/palette"
+import { AppSecondFactorRefetchContainer } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor"
+import { SmsSecondFactorRefetchContainer } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/SmsSecondFactor"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SettingsEditSettingsTwoFactor_me } from "__generated__/SettingsEditSettingsTwoFactor_me.graphql"
-import { SmsSecondFactorRefetchContainer } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/SmsSecondFactor"
-import { AppSecondFactorRefetchContainer } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor"
 import { SettingsEditSettingsTwoFactorBackupCodesFragmentContainer } from "./SettingsEditSettingsTwoFactorBackupCodes"
 
 export interface SettingsEditSettingsTwoFactorProps {
@@ -15,7 +15,7 @@ export const SettingsEditSettingsTwoFactor: React.FC<SettingsEditSettingsTwoFact
 }) => {
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         Two-Factor Authentication{" "}
         {me.hasSecondFactorEnabled && <Sup color="green100">Enabled</Sup>}
       </Text>

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodes.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodes.tsx
@@ -8,9 +8,9 @@ import {
   Text,
   useToasts,
 } from "@artsy/palette"
+import { ConfirmPasswordModal } from "Components/ConfirmPasswordModal"
 import { FC, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { ConfirmPasswordModal } from "Components/ConfirmPasswordModal"
 import { useMode } from "Utils/Hooks/useMode"
 import { SettingsEditSettingsTwoFactorBackupCodes_me } from "__generated__/SettingsEditSettingsTwoFactorBackupCodes_me.graphql"
 import { CreateBackupSecondFactorsInput } from "__generated__/useCreateSettingsBackupSecondFactorsMutation.graphql"
@@ -72,7 +72,7 @@ export const SettingsEditSettingsTwoFactorBackupCodes: FC<SettingsEditSettingsTw
         flexDirection={["column", "row"]}
       >
         <Box flexBasis="50%">
-          <Text variant="lg-display" mb={2}>
+          <Text variant={["md", "lg"]} mb={2}>
             Backup Codes
             {me.backupSecondFactors && me.backupSecondFactors.length > 0 && (
               <>

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodesDialog.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/SettingsEditSettingsTwoFactorBackupCodesDialog.tsx
@@ -1,4 +1,3 @@
-import { FC } from "react"
 import {
   Column,
   GridColumns,
@@ -6,10 +5,11 @@ import {
   SkeletonText,
   Text,
 } from "@artsy/palette"
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { SettingsEditSettingsTwoFactorBackupCodesDialog_me } from "__generated__/SettingsEditSettingsTwoFactorBackupCodesDialog_me.graphql"
 import { SettingsEditSettingsTwoFactorBackupCodesDialogQuery } from "__generated__/SettingsEditSettingsTwoFactorBackupCodesDialogQuery.graphql"
+import { SettingsEditSettingsTwoFactorBackupCodesDialog_me } from "__generated__/SettingsEditSettingsTwoFactorBackupCodesDialog_me.graphql"
 import { SettingsEditSettingsTwoFactorBackupCodesActions } from "./SettingsEditSettingsTwoFactorBackupCodesActions"
 
 interface SettingsEditSettingsTwoFactorBackupCodesDialogProps {
@@ -34,7 +34,7 @@ const SettingsEditSettingsTwoFactorBackupCodesDialog: FC<SettingsEditSettingsTwo
 
               return (
                 <Column span={6} key={factor.code}>
-                  <Text variant="lg-display" textAlign="center">
+                  <Text variant={["md", "lg"]} textAlign="center">
                     {factor.code}
                   </Text>
                 </Column>
@@ -54,7 +54,7 @@ const SettingsEditSettingsTwoFactorBackupCodesDialog: FC<SettingsEditSettingsTwo
           <GridColumns mt={2}>
             {[...Array(12)].map((_, i) => (
               <Column key={i} span={6}>
-                <SkeletonText variant="lg-display" textAlign="center">
+                <SkeletonText variant={["md", "lg"]} textAlign="center">
                   Pending Code
                 </SkeletonText>
               </Column>

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -1,25 +1,25 @@
 import {
+  Box,
   Button,
   Flex,
-  Box,
-  Text,
-  Spacer,
   ModalDialog,
+  Spacer,
+  Text,
   useToasts,
 } from "@artsy/palette"
-import { useState } from "react"
 import * as React from "react"
-import { RelayRefetchProp, graphql, createRefetchContainer } from "react-relay"
+import { useState } from "react"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 // eslint-disable-next-line no-restricted-imports
+import { ConfirmPasswordModal } from "Components/ConfirmPasswordModal"
 import request from "superagent"
 import { useSystemContext } from "System"
-import { AppSecondFactorModal, OnCompleteRedirectModal } from "./Modal"
-import { ApiError } from "../../ApiError"
-import { CreateAppSecondFactor } from "./Mutation/CreateAppSecondFactor"
-import { DisableFactorConfirmation } from "../DisableFactorConfirmation"
 import { AppSecondFactor_me } from "__generated__/AppSecondFactor_me.graphql"
-import { ConfirmPasswordModal } from "Components/ConfirmPasswordModal"
 import { CreateAppSecondFactorInput } from "__generated__/CreateAppSecondFactorMutation.graphql"
+import { ApiError } from "../../ApiError"
+import { DisableFactorConfirmation } from "../DisableFactorConfirmation"
+import { AppSecondFactorModal, OnCompleteRedirectModal } from "./Modal"
+import { CreateAppSecondFactor } from "./Mutation/CreateAppSecondFactor"
 
 import { afterUpdateRedirect } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/helpers"
 
@@ -166,10 +166,10 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = ({
         flexDirection={["column", "row"]}
       >
         <Box flexBasis="50%">
-          <Text variant="lg-display">App Authenticator</Text>
+          <Text variant={["md", "lg"]}>App Authenticator</Text>
 
           {enabledSecondFactorLabel && (
-            <Text variant="lg-display" color="black60">
+            <Text variant={["md", "lg"]} color="black60">
               {enabledSecondFactorLabel}
             </Text>
           )}

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
@@ -31,7 +31,7 @@ export const BackupSecondFactorReminder: React.FC<BackupSecondFactorReminderProp
 
           return (
             <Column span={6} key={factor}>
-              <Text variant="lg-display" textAlign="center">
+              <Text variant={["md", "lg"]} textAlign="center">
                 {factor}
               </Text>
             </Column>

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -8,21 +8,21 @@ import {
   Text,
   useToasts,
 } from "@artsy/palette"
-import { useState } from "react"
 import * as React from "react"
-import { RelayRefetchProp, graphql, createRefetchContainer } from "react-relay"
+import { useState } from "react"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 // eslint-disable-next-line no-restricted-imports
+import { afterUpdateRedirect } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/helpers"
+import { ConfirmPasswordModal } from "Components/ConfirmPasswordModal"
 import request from "superagent"
 import { useSystemContext } from "System"
-import { ApiError } from "../../ApiError"
-import { SmsSecondFactorModal, OnCompleteRedirectModal } from "./Modal"
-import { CreateSmsSecondFactor } from "./Mutation/CreateSmsSecondFactor"
 import { CreateSmsSecondFactorInput } from "__generated__/CreateSmsSecondFactorMutation.graphql"
 import { SmsSecondFactor_me } from "__generated__/SmsSecondFactor_me.graphql"
+import { ApiError } from "../../ApiError"
 import { DisableFactorConfirmation } from "../DisableFactorConfirmation"
-import { ConfirmPasswordModal } from "Components/ConfirmPasswordModal"
-import { afterUpdateRedirect } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/helpers"
 import { isArtsyEmail } from "./isArtsyEmail"
+import { OnCompleteRedirectModal, SmsSecondFactorModal } from "./Modal"
+import { CreateSmsSecondFactor } from "./Mutation/CreateSmsSecondFactor"
 
 interface SmsSecondFactorProps {
   me: SmsSecondFactor_me
@@ -181,10 +181,10 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = ({
 
         <Flex p={2} flexDirection={["column", "row"]}>
           <Box flexBasis="50%">
-            <Text variant="lg-display">Use Text Messages</Text>
+            <Text variant={["md", "lg"]}>Use Text Messages</Text>
 
             {enabledSecondFactorLabel && (
-              <Text variant="lg-display" color="black60">
+              <Text variant={["md", "lg"]} color="black60">
                 {enabledSecondFactorLabel}
               </Text>
             )}

--- a/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Button,
   Clickable,
   CloseIcon,
@@ -100,7 +99,6 @@ const MyCollectionRoute: FC<MyCollectionRouteProps> = ({ me, relay }) => {
                 mb={SETTINGS_ROUTE_TABS_MARGIN}
               >
                 <Flex flexDirection="row" justifyContent="space-between">
-                  <Box />
                   <Text mx={1}>
                     Access all the My Collection features on the{" "}
                     <Clickable
@@ -125,7 +123,7 @@ const MyCollectionRoute: FC<MyCollectionRouteProps> = ({ me, relay }) => {
           )}
 
           <Flex justifyContent="space-between" mb={4}>
-            <Text as="h1" variant="lg-display" my="auto">
+            <Text as="h1" variant={["md", "lg"]}>
               My Collection <Sup color="brand">{total}</Sup>
             </Text>
 

--- a/src/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethods.tsx
+++ b/src/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethods.tsx
@@ -1,9 +1,9 @@
-import { Text, Button, Message, GridColumns, Column } from "@artsy/palette"
+import { Button, Column, GridColumns, Message, Text } from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
+import { CreditCardInputProvider } from "Components/CreditCardInput"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
-import { CreditCardInputProvider } from "Components/CreditCardInput"
 import { extractNodes } from "Utils/extractNodes"
 import { useMode } from "Utils/Hooks/useMode"
 import { SettingsPaymentsMethods_me } from "__generated__/SettingsPaymentsMethods_me.graphql"
@@ -39,7 +39,7 @@ const SettingsPaymentsMethods: FC<SettingsPaymentsMethodsProps> = ({ me }) => {
         </CreditCardInputProvider>
       )}
 
-      <Text variant="lg-display" mb={2}>
+      <Text variant={["md", "lg"]} mb={2}>
         Saved Payment Details
       </Text>
 

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormDesktop.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormDesktop.tsx
@@ -11,7 +11,7 @@ export const SavedSearchAlertEditFormDesktop: React.FC<EditAlertFormBase> = ({
   return (
     <Box flex={1} p={4}>
       <Flex justifyContent="space-between" alignItems="center">
-        <Text variant="lg-display" flex={1} mr={1}>
+        <Text variant={["md", "lg"]} flex={1} mr={1}>
           Edit {editAlertEntity.name}
         </Text>
         <Clickable onClick={onCloseClick}>

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertHeader.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertHeader.tsx
@@ -22,7 +22,7 @@ export const SavedSearchAlertHeader: FC<SavedSearchAlertHeaderProps> = ({
       justifyContent="space-between"
       mb={4}
     >
-      <Text variant="lg-display" mb={[4, 0]} mr={[0, 2]}>
+      <Text variant={["md", "lg"]} mb={[4, 0]} mr={[0, 2]}>
         Your Alerts
       </Text>
 

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -1,15 +1,15 @@
 import {
-  Box,
-  Text,
-  Flex,
-  Clickable,
-  Spacer,
-  Pill,
-  IconProps,
   ArrowDownIcon,
   ArrowUpIcon,
-  GridColumns,
+  Box,
+  Clickable,
   Column,
+  Flex,
+  GridColumns,
+  IconProps,
+  Pill,
+  Spacer,
+  Text,
 } from "@artsy/palette"
 import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -59,7 +59,7 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
           alignItems={["stretch", "center"]}
         >
           <Text
-            variant="lg-display"
+            variant={["md", "lg"]}
             color={variant === "active" ? "blue100" : "black100"}
           >
             {item.userAlertSettings.name}

--- a/src/Apps/Settings/Routes/Saves/Components/SettingsSavesArtists.tsx
+++ b/src/Apps/Settings/Routes/Saves/Components/SettingsSavesArtists.tsx
@@ -1,3 +1,17 @@
+import {
+  Box,
+  Button,
+  Join,
+  Skeleton,
+  SkeletonText,
+  Spacer,
+  Sup,
+  Text,
+} from "@artsy/palette"
+import {
+  ArtistRailFragmentContainer,
+  ARTIST_RAIL_PLACEHOLDER,
+} from "Components/ArtistRail"
 import { FC, Fragment, useState } from "react"
 import {
   createPaginationContainer,
@@ -5,23 +19,9 @@ import {
   RelayPaginationProp,
 } from "react-relay"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { SettingsSavesArtists_me } from "__generated__/SettingsSavesArtists_me.graphql"
-import { SettingsSavesArtistsQuery } from "__generated__/SettingsSavesArtistsQuery.graphql"
-import {
-  Box,
-  Button,
-  Join,
-  Spacer,
-  Sup,
-  Text,
-  SkeletonText,
-  Skeleton,
-} from "@artsy/palette"
 import { extractNodes } from "Utils/extractNodes"
-import {
-  ArtistRailFragmentContainer,
-  ARTIST_RAIL_PLACEHOLDER,
-} from "Components/ArtistRail"
+import { SettingsSavesArtistsQuery } from "__generated__/SettingsSavesArtistsQuery.graphql"
+import { SettingsSavesArtists_me } from "__generated__/SettingsSavesArtists_me.graphql"
 
 interface SettingsSavesArtistsProps {
   me: SettingsSavesArtists_me
@@ -48,7 +48,7 @@ const SettingsSavesArtists: FC<SettingsSavesArtistsProps> = ({ me, relay }) => {
 
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         Followed Artists {total > 0 && <Sup color="brand">{total}</Sup>}
       </Text>
 
@@ -73,7 +73,7 @@ const SettingsSavesArtists: FC<SettingsSavesArtistsProps> = ({ me, relay }) => {
           )}
         </>
       ) : (
-        <Text variant="lg-display" color="black60">
+        <Text variant={["md", "lg"]} color="black60">
           Nothing yet.
         </Text>
       )}
@@ -127,7 +127,7 @@ export const SettingsSavesArtistsPaginationContainer = createPaginationContainer
 const SETTINGS_SAVES_ARTISTS_PLACEHOLDER = (
   <>
     <Skeleton>
-      <SkeletonText variant="lg-display" mb={4}>
+      <SkeletonText variant={["md", "lg"]} mb={4}>
         Followed Artists
       </SkeletonText>
     </Skeleton>

--- a/src/Apps/Settings/Routes/Saves/Components/SettingsSavesArtworks.tsx
+++ b/src/Apps/Settings/Routes/Saves/Components/SettingsSavesArtworks.tsx
@@ -1,8 +1,3 @@
-import { FC, Fragment, useState } from "react"
-import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
-import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { SettingsSavesArtworks_me } from "__generated__/SettingsSavesArtworks_me.graphql"
-import { SettingsSavesArtworksQuery } from "__generated__/SettingsSavesArtworksQuery.graphql"
 import {
   ResponsiveBox,
   Skeleton,
@@ -12,11 +7,16 @@ import {
   Sup,
   Text,
 } from "@artsy/palette"
-import { Masonry } from "Components/Masonry"
-import { extractNodes } from "Utils/extractNodes"
 import { ArtworkGridItemFragmentContainer } from "Components/Artwork/GridItem"
+import { Masonry } from "Components/Masonry"
 import { PaginationFragmentContainer } from "Components/Pagination"
+import { FC, Fragment, useState } from "react"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import { extractNodes } from "Utils/extractNodes"
 import { useScrollToElement } from "Utils/Hooks/useScrollTo"
+import { SettingsSavesArtworksQuery } from "__generated__/SettingsSavesArtworksQuery.graphql"
+import { SettingsSavesArtworks_me } from "__generated__/SettingsSavesArtworks_me.graphql"
 
 interface SettingsSavesArtworksProps {
   me: SettingsSavesArtworks_me
@@ -64,7 +64,7 @@ const SettingsSavesArtworks: FC<SettingsSavesArtworksProps> = ({
 
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         Saved Artworks {total > 0 && <Sup color="brand">{total}</Sup>}
       </Text>
 
@@ -94,7 +94,7 @@ const SettingsSavesArtworks: FC<SettingsSavesArtworksProps> = ({
           />
         </>
       ) : (
-        <Text variant="lg-display" color="black60">
+        <Text variant={["md", "lg"]} color="black60">
           Nothing yet.
         </Text>
       )}
@@ -143,7 +143,7 @@ export const SettingsSavesArtworksRefetchContainer = createRefetchContainer(
 
 const SETTINGS_SAVES_ARTWORKS_PLACEHOLDER = (
   <Skeleton>
-    <SkeletonText variant="lg-display" mb={4}>
+    <SkeletonText variant={["md", "lg"]} mb={4}>
       Saved Artworks
     </SkeletonText>
 

--- a/src/Apps/Settings/Routes/Saves/Components/SettingsSavesCategories.tsx
+++ b/src/Apps/Settings/Routes/Saves/Components/SettingsSavesCategories.tsx
@@ -1,3 +1,17 @@
+import {
+  Box,
+  Button,
+  Join,
+  Skeleton,
+  SkeletonText,
+  Spacer,
+  Sup,
+  Text,
+} from "@artsy/palette"
+import {
+  CategoryRailFragmentContainer,
+  CATEGORY_RAIL_PLACEHOLDER,
+} from "Components/CategoryRail"
 import { FC, Fragment, useState } from "react"
 import {
   createPaginationContainer,
@@ -5,23 +19,9 @@ import {
   RelayPaginationProp,
 } from "react-relay"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { SettingsSavesCategories_me } from "__generated__/SettingsSavesCategories_me.graphql"
-import { SettingsSavesCategoriesQuery } from "__generated__/SettingsSavesCategoriesQuery.graphql"
-import {
-  Box,
-  Button,
-  Join,
-  Spacer,
-  Sup,
-  Text,
-  SkeletonText,
-  Skeleton,
-} from "@artsy/palette"
 import { extractNodes } from "Utils/extractNodes"
-import {
-  CategoryRailFragmentContainer,
-  CATEGORY_RAIL_PLACEHOLDER,
-} from "Components/CategoryRail"
+import { SettingsSavesCategoriesQuery } from "__generated__/SettingsSavesCategoriesQuery.graphql"
+import { SettingsSavesCategories_me } from "__generated__/SettingsSavesCategories_me.graphql"
 
 interface SettingsSavesCategoriesProps {
   me: SettingsSavesCategories_me
@@ -53,7 +53,7 @@ const SettingsSavesCategories: FC<SettingsSavesCategoriesProps> = ({
 
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         Followed Categories {total > 0 && <Sup color="brand">{total}</Sup>}
       </Text>
 
@@ -81,7 +81,7 @@ const SettingsSavesCategories: FC<SettingsSavesCategoriesProps> = ({
           )}
         </>
       ) : (
-        <Text variant="lg-display" color="black60">
+        <Text variant={["md", "lg"]} color="black60">
           Nothing yet.
         </Text>
       )}
@@ -136,7 +136,7 @@ export const SettingsSavesCategoriesPaginationContainer = createPaginationContai
 const SETTINGS_SAVES_CATEGORIES_PLACEHOLDER = (
   <>
     <Skeleton>
-      <SkeletonText variant="lg-display" mb={4}>
+      <SkeletonText variant={["md", "lg"]} mb={4}>
         Followed Categories
       </SkeletonText>
     </Skeleton>

--- a/src/Apps/Settings/Routes/Saves/Components/SettingsSavesProfiles.tsx
+++ b/src/Apps/Settings/Routes/Saves/Components/SettingsSavesProfiles.tsx
@@ -1,3 +1,17 @@
+import {
+  Box,
+  Button,
+  Column,
+  GridColumns,
+  Skeleton,
+  SkeletonText,
+  Sup,
+  Text,
+} from "@artsy/palette"
+import { EntityHeaderFairFragmentContainer } from "Components/EntityHeaders/EntityHeaderFair"
+import { EntityHeaderFairOrganizerFragmentContainer } from "Components/EntityHeaders/EntityHeaderFairOrganizer"
+import { EntityHeaderPartnerFragmentContainer } from "Components/EntityHeaders/EntityHeaderPartner"
+import { EntityHeaderPlaceholder } from "Components/EntityHeaders/EntityHeaderPlaceholder"
 import { FC, useState } from "react"
 import {
   createPaginationContainer,
@@ -5,23 +19,9 @@ import {
   RelayPaginationProp,
 } from "react-relay"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { SettingsSavesProfiles_me } from "__generated__/SettingsSavesProfiles_me.graphql"
-import { SettingsSavesProfilesQuery } from "__generated__/SettingsSavesProfilesQuery.graphql"
-import {
-  Box,
-  Button,
-  Sup,
-  Text,
-  SkeletonText,
-  Skeleton,
-  GridColumns,
-  Column,
-} from "@artsy/palette"
 import { extractNodes } from "Utils/extractNodes"
-import { EntityHeaderPartnerFragmentContainer } from "Components/EntityHeaders/EntityHeaderPartner"
-import { EntityHeaderFairOrganizerFragmentContainer } from "Components/EntityHeaders/EntityHeaderFairOrganizer"
-import { EntityHeaderFairFragmentContainer } from "Components/EntityHeaders/EntityHeaderFair"
-import { EntityHeaderPlaceholder } from "Components/EntityHeaders/EntityHeaderPlaceholder"
+import { SettingsSavesProfilesQuery } from "__generated__/SettingsSavesProfilesQuery.graphql"
+import { SettingsSavesProfiles_me } from "__generated__/SettingsSavesProfiles_me.graphql"
 
 interface SettingsSavesProfilesProps {
   me: SettingsSavesProfiles_me
@@ -51,7 +51,7 @@ const SettingsSavesProfiles: FC<SettingsSavesProfilesProps> = ({
 
   return (
     <>
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         Followed Profiles {total > 0 && <Sup color="brand">{total}</Sup>}
       </Text>
 
@@ -104,7 +104,7 @@ const SettingsSavesProfiles: FC<SettingsSavesProfilesProps> = ({
           )}
         </>
       ) : (
-        <Text variant="lg-display" color="black60">
+        <Text variant={["md", "lg"]} color="black60">
           Nothing yet.
         </Text>
       )}
@@ -177,7 +177,7 @@ export const SettingsSavesProfilesPaginationContainer = createPaginationContaine
 const SETTINGS_SAVES_PROFILES_PLACEHOLDER = (
   <>
     <Skeleton>
-      <SkeletonText variant="lg-display" mb={4}>
+      <SkeletonText variant={["md", "lg"]} mb={4}>
         Followed Profiles
       </SkeletonText>
     </Skeleton>

--- a/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddresses.tsx
+++ b/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddresses.tsx
@@ -2,10 +2,10 @@ import { Button, Column, GridColumns, Message, Text } from "@artsy/palette"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { extractNodes } from "Utils/extractNodes"
-import { SettingsShippingAddresses_me } from "__generated__/SettingsShippingAddresses_me.graphql"
-import { SettingsShippingAddressForm } from "./SettingsShippingAddressForm"
-import { SettingsShippingAddressFragmentContainer } from "./SettingsShippingAddress"
 import { useMode } from "Utils/Hooks/useMode"
+import { SettingsShippingAddresses_me } from "__generated__/SettingsShippingAddresses_me.graphql"
+import { SettingsShippingAddressFragmentContainer } from "./SettingsShippingAddress"
+import { SettingsShippingAddressForm } from "./SettingsShippingAddressForm"
 
 interface SettingsShippingAddressesProps {
   me: SettingsShippingAddresses_me
@@ -34,7 +34,7 @@ export const SettingsShippingAddresses: FC<SettingsShippingAddressesProps> = ({
         <SettingsShippingAddressForm onClose={handleClose} />
       )}
 
-      <Text variant="lg-display" mb={4}>
+      <Text variant={["md", "lg"]} mb={4}>
         Saved Addresses
       </Text>
 

--- a/src/Apps/Settings/SettingsApp.tsx
+++ b/src/Apps/Settings/SettingsApp.tsx
@@ -5,7 +5,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SettingsApp_me } from "__generated__/SettingsApp_me.graphql"
 
-export const SETTINGS_ROUTE_TABS_MARGIN = 4
+export const SETTINGS_ROUTE_TABS_MARGIN = [2, 4]
 
 const TABS = [
   { name: "Edit Settings", url: "/settings/edit-settings" },


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

As discussed with Design, this PR changes the titles font size in the settings app from `lg` to `md` on mWeb and adjusts the vertical tabs spacing on mWeb.

**Note for reviewers:**
I've commented on the two relevant changes. Everything else is just import sorting and repeating the font size change.

| Before | After |
| --- | --- |
| <img width="407" alt="Screenshot 2022-08-29 at 12 47 21" src="https://user-images.githubusercontent.com/4691889/187184574-ba4c4f5b-7fc1-4ccb-b1f6-b6d7d6e23685.png">| <img width="409" alt="Screenshot 2022-08-29 at 12 46 34" src="https://user-images.githubusercontent.com/4691889/187184494-1de2e012-3004-4e5c-9523-bfe8ae535e63.png">|





<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ