### PR TITLE
fix: Replacing my-collection routes in redirects to avoid 404s

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -210,7 +210,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                     onClose={() => setShouldShowBackModal(false)}
                     isEditing={isEditing}
                     onLeave={() => {
-                      router.replace({ pathname: "/my-collection" })
+                      router.replace({ pathname: "/settings/my-collection" })
                       router.push({
                         pathname: isEditing
                           ? `/my-collection/artwork/${artwork.internalID}`

--- a/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
@@ -148,7 +148,7 @@ describe("Edit artwork", () => {
         pathname: "/my-collection/artwork/62fc96c48d3ff8000b556c3a",
       })
       expect(mockRouterReplace).toHaveBeenCalledWith({
-        pathname: "/my-collection",
+        pathname: "/settings/my-collection",
       })
     })
   })
@@ -418,7 +418,7 @@ describe("Create artwork", () => {
         pathname: "/my-collection/artwork/62fc96c48d3ff8000b556c3a",
       })
       expect(mockRouterReplace).toHaveBeenCalledWith({
-        pathname: "/my-collection",
+        pathname: "/settings/my-collection",
       })
     })
   })


### PR DESCRIPTION
## Description

Replacing `/my-collection` with `/settings/my-collection` in redirects to avoid 404s. This is probably related to the redirect.