### PR TITLE
fix(partners): Hyphenate categories on /partners page

### DIFF
--- a/src/Components/EntityHeaders/EntityHeaderPartner.tsx
+++ b/src/Components/EntityHeaders/EntityHeaderPartner.tsx
@@ -72,7 +72,7 @@ const EntityHeaderPartner: FC<EntityHeaderPartnerProps> = ({
           <Text variant="sm-display">
             {badges.map(badge => (
               <Fragment key={badge.slug}>
-                <Label>{badge.name}</Label>{" "}
+                <Label>{badge.name?.replace(" ", "-")}</Label>{" "}
               </Fragment>
             ))}
           </Text>

--- a/src/Components/EntityHeaders/__tests__/EntityHeaderPartner.jest.tsx
+++ b/src/Components/EntityHeaders/__tests__/EntityHeaderPartner.jest.tsx
@@ -36,7 +36,7 @@ describe("EntityHeaderPartner", () => {
 
     expect(screen.getByText("Example Partner")).toBeInTheDocument()
     expect(screen.getByText("New York")).toBeInTheDocument()
-    expect(screen.getByText("Black Owned")).toBeInTheDocument()
+    expect(screen.getByText("Black-Owned")).toBeInTheDocument()
     expect(screen.queryByText("Example Category")).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

We covered the partner badge hyphenation on the /partner/id page, but never handled it on the main partners page. Fixing that here: 

<img width="364" alt="Screen Shot 2022-08-29 at 11 30 52 AM" src="https://user-images.githubusercontent.com/236943/187272894-18f5e555-8905-45e4-a290-7a62e6eb4aa7.png">

cc @artsy/grow-devs 
