### PR TITLE
fix: show order status on the order history page

### DIFF
--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -33,6 +33,7 @@ const ORDER_LABELS = {
   PROCESSING: "Processing",
   REFUNDED: "Refunded",
   SUBMITTED: "Pending",
+  PROCESSING_APPROVAL: "Payment processing",
 } as const
 
 const ORDER_ICONS = {
@@ -43,6 +44,7 @@ const ORDER_ICONS = {
   PROCESSING: <PendingCircleIcon fill="black60" />,
   REFUNDED: <XCircleIcon fill="red100" />,
   SUBMITTED: <PendingCircleIcon fill="black60" />,
+  PROCESSING_APPROVAL: <PendingCircleIcon fill="black60" />,
 } as const
 
 const ORDER_COLORS = {
@@ -53,6 +55,7 @@ const ORDER_COLORS = {
   PROCESSING: "black60",
   REFUNDED: "red100",
   SUBMITTED: "black60",
+  PROCESSING_APPROVAL: "black60",
 } as const
 
 const getPaymentMethodText = (


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-600]

### Description

This PR shows `PROCESSING_APPROVAL` order status on the order history page 

![Screenshot from 2022-08-30 12-03-00](https://user-images.githubusercontent.com/79979820/187396262-9cb51e68-2fdc-420e-979c-a1c71a403bbd.png)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-600]: https://artsyproduct.atlassian.net/browse/TX-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ