### PR TITLE
fix(CX-2855): Update sell through rate in MyC Artist Market

### DIFF
--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
@@ -28,7 +28,7 @@ export const MyCollectionArtworkArtistMarket = ({
     sellThroughRate,
   } = marketPriceInsights
 
-  const formattedSellThroughRate = (Number(sellThroughRate) * 100).toFixed(2)
+  const formattedSellThroughRate = Number(sellThroughRate).toFixed(3)
 
   return (
     <>

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkArtistMarket.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkArtistMarket.jest.tsx
@@ -1,8 +1,8 @@
 import { screen } from "@testing-library/react"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
-import { MyCollectionArtworkArtistMarketFragmentContainer } from "../MyCollectionArtworkArtistMarket"
 import { MyCollectionArtworkArtistMarket_Test_Query } from "../../../../../../__generated__/MyCollectionArtworkArtistMarket_Test_Query.graphql"
+import { MyCollectionArtworkArtistMarketFragmentContainer } from "../MyCollectionArtworkArtistMarket"
 
 jest.unmock("react-relay")
 
@@ -39,7 +39,7 @@ describe("MyCollectionArtworkArtistMarket", () => {
     expect(screen.getByText("Annual Lots Sold")).toBeInTheDocument()
     expect(screen.getByText("123")).toBeInTheDocument()
     expect(screen.getByText("Sell-through Rate")).toBeInTheDocument()
-    expect(screen.getByText("13.40%")).toBeInTheDocument()
+    expect(screen.getByText("0.134%")).toBeInTheDocument()
     expect(screen.getByText("Sale Price to Estimate")).toBeInTheDocument()
     expect(screen.getByText("95%")).toBeInTheDocument()
     expect(screen.getByText("Liquidity")).toBeInTheDocument()


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2855]

### Description
This PR updates the Sell Through Rate value in the artist market in My Collection artwork details page

|before|after
|--|--|
|<img width="1301" alt="image" src="https://user-images.githubusercontent.com/20655703/187442127-2d72de9a-eca5-442f-8667-9d0293f9ad18.png"> | <img width="1323" alt="image" src="https://user-images.githubusercontent.com/20655703/187442140-12a28662-e9c1-4ac4-8ac1-acadc86c24d5.png"> |

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2855]: https://artsyproduct.atlassian.net/browse/CX-2855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ