### PR TITLE
fix: Add delay to artwork form for image processing

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -75,6 +75,10 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
       values.editionSize = ""
     }
 
+    const externalImageUrls = values.newPhotos.flatMap(
+      photo => photo.url || null
+    )
+
     // Create or update artwork
 
     try {
@@ -94,7 +98,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
         width: String(values.width),
         depth: String(values.depth),
         metric: values.metric,
-        externalImageUrls: values.newPhotos.flatMap(photo => photo.url || null),
+        externalImageUrls,
         pricePaidCents:
           !values.pricePaidDollars || isNaN(Number(values.pricePaidDollars))
             ? undefined
@@ -133,7 +137,9 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
 
       // Waiting for a few seconds to make sure the new images are processed
       // and ready to be displayed
-      await wait(5000)
+      if (externalImageUrls.length) {
+        await wait(3000)
+      }
 
       if (isEditing) {
         router.push({ pathname: `/my-collection/artwork/${artworkId}` })

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -133,7 +133,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
 
       // Waiting for a few seconds to make sure the new images are processed
       // and ready to be displayed
-      await wait(3000)
+      await wait(5000)
 
       if (isEditing) {
         router.push({ pathname: `/my-collection/artwork/${artworkId}` })

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -20,6 +20,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { RouterLink } from "System/Router/RouterLink"
 import { useRouter } from "System/Router/useRouter"
 import createLogger from "Utils/logger"
+import { wait } from "Utils/wait"
 import { MyCollectionArtworkForm_artwork } from "__generated__/MyCollectionArtworkForm_artwork.graphql"
 import { ArtworkAttributionClassType } from "__generated__/useCreateArtworkMutation.graphql"
 import { MyCollectionArtworkFormDetails } from "./Components/MyCollectionArtworkFormDetails"
@@ -129,6 +130,10 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
           }
         })
       )
+
+      // Waiting for a few seconds to make sure the new images are processed
+      // and ready to be displayed
+      await wait(3000)
 
       if (isEditing) {
         router.push({ pathname: `/my-collection/artwork/${artworkId}` })

--- a/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
@@ -213,7 +213,7 @@ describe("Edit artwork", () => {
       )
 
       expect(mockRouterPush).toHaveBeenCalledWith({
-        pathname: "/my-collection/artwork/internal-id",
+        pathname: "/my-collection/artwork/62fc96c48d3ff8000b556c3a",
       })
     })
   })

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -36,7 +36,6 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
   showSaveButton = true,
   ...rest
 }) => {
-  console.log({ artwork })
   const { user } = useSystemContext()
   const isTeam = userIsTeam(user)
   const { isHovered, onMouseEnter, onMouseLeave } = useHoverMetadata()

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -36,6 +36,7 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
   showSaveButton = true,
   ...rest
 }) => {
+  console.log({ artwork })
   const { user } = useSystemContext()
   const isTeam = userIsTeam(user)
   const { isHovered, onMouseEnter, onMouseLeave } = useHoverMetadata()


### PR DESCRIPTION
Addresses [CX-2854]

## Description

This PR adds a delay to the artwork form before navigating the user to the My Collection overview. This should add enough time to make sure all new images have started being processed and can be displayed.

The reason is that when immediately navigating to the artwork detail page or the My Collection overview, images are either not present on the artwork or have not been processed and can't be displayed correctly.

The only issue that is left is `GridItem` not correctly rendering the image when getting the `square`-version, which is the first version of the image that gets processed.

[CX-2854]: https://artsyproduct.atlassian.net/browse/CX-2854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ