### PR TITLE
fix: specify payment method for each Payment Element

### DIFF
--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -154,7 +154,7 @@ export const PaymentContent: FC<Props> = props => {
         <BankAccountPickerFragmentContainer
           me={me}
           order={order}
-          paymentMethod={paymentMethod}
+          paymentMethod="US_BANK_ACCOUNT"
           bankAccountHasInsufficientFunds={bankAccountHasInsufficientFunds}
           onSetBankAccountHasInsufficientFunds={
             onSetBankAccountHasInsufficientFunds
@@ -175,7 +175,7 @@ export const PaymentContent: FC<Props> = props => {
         <Spacer mb={2} />
         <BankDebitProvider
           order={order}
-          paymentMethod={paymentMethod}
+          paymentMethod="SEPA_DEBIT"
           bankAccountHasInsufficientFunds={bankAccountHasInsufficientFunds}
           onSetBankAccountHasInsufficientFunds={
             onSetBankAccountHasInsufficientFunds

--- a/src/Components/BankDebitForm/BankDebitProvider.tsx
+++ b/src/Components/BankDebitForm/BankDebitProvider.tsx
@@ -145,7 +145,7 @@ export const BankDebitProvider: FC<Props> = ({
   }
 
   return (
-    <div data-test="bankTransferSection">
+    <div data-test={`${paymentMethod}_PaymentSection`}>
       <LoadingArea isLoading={isPaymentElementLoading}>
         {isPaymentElementLoading && <Box height={300}></Box>}
         <Spacer mt={2} />


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

We started to see Integrity failure roughly after https://github.com/artsy/force/pull/10859. There seems to be 2 reasons:

- Stripe seemed to change their iframe implementation again, and our [iframe selector in Integrity](https://github.com/artsy/integrity/blob/0cdd676c94025bb0dd40d988031d0da71ec68e0a/cypress/utils/checkAndAddBankAccount.ts#L12) will find 2 matches.

![Screen Shot 2022-08-30 at 1 50 02 PM](https://user-images.githubusercontent.com/796573/187524219-d126d2ca-a87a-45b1-9d85-0741aa45473a.png)

- After https://github.com/artsy/force/pull/10859, we'll render 2 sections with `[data-test="bankTransferSection"]` (one for ACH one for SEPA). The selection then becomes ambiguous.

This PR updates the `data-test` attribute to be payment method specific so our selector in Integrity can be more reliable.