### PR TITLE
fix(pageview-tracking): Revert debounce on analytics middleware

### DIFF
--- a/src/System/Analytics/trackingMiddleware.ts
+++ b/src/System/Analytics/trackingMiddleware.ts
@@ -1,7 +1,6 @@
 import { ActionTypes } from "farce"
 import { get } from "Utils/get"
 import { match } from "path-to-regexp"
-import { debounce } from "lodash"
 import { getENV } from "Utils/getENV"
 
 /**
@@ -17,8 +16,6 @@ interface TrackingMiddlewareOptions {
 }
 
 export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
-  const trackPageview = debounce(window.analytics?.page!, 30)
-
   return store => next => action => {
     const { excludePaths = [] } = options
     const { type, payload } = action
@@ -86,7 +83,7 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
               trackingData.referrer = getFullReferrerUrl()
             }
 
-            trackPageview(trackingData, {
+            window.analytics?.page(trackingData, {
               integrations: {
                 Marketo: false,
               },


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

@abhitip discovered that page-to-page tracking in the SPA broke from this change, so going to revert it for now and investigate things further. 

cc @artsy/grow-devs 