### PR TITLE
feat(art-quiz) add art quiz app routes

### DIFF
--- a/src/Apps/ArtQuiz/ArtQuizApp.tsx
+++ b/src/Apps/ArtQuiz/ArtQuizApp.tsx
@@ -1,0 +1,7 @@
+export const ArtQuizApp = () => {
+  return (
+    <div>
+      <h1>ArtQuiz</h1>
+    </div>
+  )
+}

--- a/src/Apps/ArtQuiz/artQuizRoutes.ts
+++ b/src/Apps/ArtQuiz/artQuizRoutes.ts
@@ -1,0 +1,27 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "System/Router/Route"
+
+const ArtQuizApp = loadable(
+  () => import(/* webpackChunkName: "artQuizBundle" */ "./ArtQuizApp"),
+
+  {
+    resolveComponent: component => component.ArtQuizApp,
+  }
+)
+
+export const artQuizRoutes: AppRouteConfig[] = [
+  {
+    path: "/art-quiz",
+    displayFullPage: true,
+    hideFooter: true,
+    onServerSideRender: ({ req, res }) => {
+      if (!res.locals.sd.FEATURE_FLAGS["art-quiz"].flagEnabled) {
+        res.redirect("/")
+      }
+    },
+    getComponent: () => ArtQuizApp,
+    onClientSideRender: () => {
+      ArtQuizApp.preload()
+    },
+  },
+]

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,6 +6,7 @@ import { articlesRoutes } from "Apps/Articles/articlesRoutes"
 import { artistRoutes } from "Apps/Artist/artistRoutes"
 import { artistsRoutes } from "Apps/Artists/artistsRoutes"
 import { artistSeriesRoutes } from "Apps/ArtistSeries/artistSeriesRoutes"
+import { artQuizRoutes } from "./Apps/ArtQuiz/artQuizRoutes"
 import { artworkRoutes } from "Apps/Artwork/artworkRoutes"
 import { auctionsRoutes } from "Apps/Auctions/auctionsRoutes"
 import { authenticationRoutes } from "Apps/Authentication/authenticationRoutes"
@@ -60,6 +61,7 @@ export const getAppRoutes = (): AppRouteConfig[] => {
     { routes: artistRoutes },
     { routes: artistSeriesRoutes },
     { routes: artistsRoutes },
+    { routes: artQuizRoutes },
     { routes: artworkRoutes },
     { routes: auctionRoutes },
     { routes: auctionsRoutes },


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1282]

### Description

<!-- Implementation description -->
This code is to create the routing for the new Art Quiz app. @laurabeth and I have added a feature flag to prevent the app from rendering in production as well. 

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1282]: https://artsyproduct.atlassian.net/browse/GRO-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ