### PR TITLE
feat: sending a message to eigen on successful order

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -129,24 +129,28 @@ export const ReviewRoute: FC<ReviewProps> = props => {
           o => o.lineItems?.edges?.[0]?.node?.artwork?.slug
         )
 
-        if (
-          order.mode === "OFFER" &&
-          isEigen &&
-          order.source === "artwork_page"
-        ) {
-          window?.ReactNativeWebView?.postMessage(
-            JSON.stringify({
-              key: "goToInboxOnMakeOfferSubmission",
-              orderCode: order.code,
-              message: `The seller will respond to your offer by ${order.stateExpiresAt}. Keep in mind making an offer doesn’t guarantee you the work.`,
-            })
-          )
-          // We cannot expect Eigen to respond all the time to messages sent from the webview
-          // a default fallback page is safer for old/broken Eigen versions
-          setTimeout(() => {
-            router.push(`/orders/${order.internalID}/status`)
-          }, 500)
-          return
+        if (isEigen) {
+          if (order.mode === "OFFER" && order.source === "artwork_page") {
+            window?.ReactNativeWebView?.postMessage(
+              JSON.stringify({
+                key: "goToInboxOnMakeOfferSubmission",
+                orderCode: order.code,
+                message: `The seller will respond to your offer by ${order.stateExpiresAt}. Keep in mind making an offer doesn’t guarantee you the work.`,
+              })
+            )
+            // We cannot expect Eigen to respond all the time to messages sent from the webview
+            // a default fallback page is safer for old/broken Eigen versions
+            setTimeout(() => {
+              router.push(`/orders/${order.internalID}/status`)
+            }, 500)
+            return
+          }
+
+          if (order.mode === "BUY") {
+            window?.ReactNativeWebView?.postMessage(
+              JSON.stringify({ key: "orderSuccessful", orderCode: order.code })
+            )
+          }
         }
 
         // Eigen redirects to the status page for non-Offer orders (must keep the user inside the webview)


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR is part of [MOPLAT-311]

### Description
We need to get a callback so that we know the order was successful. That way we can do some work after that.

https://user-images.githubusercontent.com/100233/187646529-d92b7988-ab9a-4847-b668-ad7f6c3650ac.mov


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOPLAT-311]: https://artsyproduct.atlassian.net/browse/MOPLAT-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ