### PR TITLE
fix: hide the insights title/tab behind the feature flags

### DIFF
--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
@@ -47,6 +47,18 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
   const enableMyCollectionPhase4ArticlesRail = useFeatureFlag(
     "my-collection-web-phase-4-articles-rail"
   )
+  const enableMyCollectionPhase4ArtistMarket = useFeatureFlag(
+    "my-collection-web-phase-4-artist-market"
+  )
+  const enableMyCollectionPhase4Comparables = useFeatureFlag(
+    "my-collection-web-phase-4-comparables"
+  )
+  const enableMyCollectionPhase4DemandIndex = useFeatureFlag(
+    "my-collection-web-phase-4-demand-index"
+  )
+  const enableMyCollectionPhase4AuctionResults = useFeatureFlag(
+    "my-collection-web-phase-4-auction-results"
+  )
 
   const isMyCollectionPhase5Enabled = useFeatureFlag(
     "my-collection-web-phase-5"
@@ -69,10 +81,21 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
 
   const slug = artwork?.artist?.slug!
 
+  const showComparables =
+    !!artwork.comparables?.totalCount && enableMyCollectionPhase4Comparables
+
+  const showAuctionResults =
+    !!artwork.artist?.auctionResults?.totalCount &&
+    enableMyCollectionPhase4AuctionResults
+
+  const showDemandIndex =
+    !!artwork.hasMarketPriceInsights && enableMyCollectionPhase4DemandIndex
+
+  const showArtistMarket =
+    !!artwork.hasMarketPriceInsights && enableMyCollectionPhase4ArtistMarket
+
   const hasInsights =
-    !!artwork.comparables?.totalCount ||
-    !!artwork.artist?.auctionResults?.totalCount ||
-    !!artwork.hasMarketPriceInsights
+    showComparables || showAuctionResults || showDemandIndex || showArtistMarket
 
   return (
     <>

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/__tests__/MyCollectionArtwork.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/__tests__/MyCollectionArtwork.jest.tsx
@@ -3,9 +3,11 @@ import { screen } from "@testing-library/react"
 import { MockBoot } from "DevTools"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { graphql } from "relay-runtime"
+import { useSystemContext } from "System/useSystemContext"
 import { MyCollectionArtworkTestQuery } from "__generated__/MyCollectionArtworkTestQuery.graphql"
 import { MyCollectionArtworkFragmentContainer } from "../MyCollectionArtwork"
 
+jest.mock("System/useSystemContext")
 jest.unmock("react-relay")
 
 describe("MyCollectionArtwork", () => {
@@ -25,6 +27,14 @@ describe("MyCollectionArtwork", () => {
       `,
     })
   }
+
+  beforeAll(() => {
+    ;(useSystemContext as jest.Mock).mockImplementation(() => ({
+      featureFlags: {
+        "my-collection-web-phase-4-demand-index": { flagEnabled: true },
+      },
+    }))
+  })
 
   describe("In a mobile view", () => {
     describe("When the artwork has insights", () => {
@@ -74,9 +84,7 @@ const mockResolversWithInsights = {
     title: "Morons",
     date: "2007",
     artistNames: "Banksy",
-    priceInsights: {
-      artistId: "4dd1584de0091e000100207c",
-    },
+    hasMarketPriceInsights: true,
   }),
 }
 
@@ -86,7 +94,7 @@ const mockResolversWithoutInsights = {
     title: "Morons",
     date: "2007",
     artistNames: "Banksy",
-    priceInsights: null,
+    hasMarketPriceInsights: false,
     comparables: null,
     artist: {
       auctionResults: null,


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves []

### Description
This PR hides the Insights title and tabs behind the phase4 feature flags
<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ