### PR TITLE
fix: Add my-collection route to history when saving an artwork

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2Artists.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2Artists.tsx
@@ -1,9 +1,9 @@
 import { ShowMore, Text } from "@artsy/palette"
-import { createFragmentContainer, graphql } from "react-relay"
-import { ArtworkSidebar2Artists_artwork } from "__generated__/ArtworkSidebar2Artists_artwork.graphql"
-import { RouterLink } from "System/Router/RouterLink"
-import styled from "styled-components"
 import { themeGet } from "@styled-system/theme-get"
+import { createFragmentContainer, graphql } from "react-relay"
+import styled from "styled-components"
+import { RouterLink } from "System/Router/RouterLink"
+import { ArtworkSidebar2Artists_artwork } from "__generated__/ArtworkSidebar2Artists_artwork.graphql"
 
 const ARTISTS_TO_DISPLAY = 4
 
@@ -33,7 +33,7 @@ export const ArtworkSidebar2Artists: React.FC<ArtistsProps> = ({
     <div>
       <ShowMore
         initial={ARTISTS_TO_DISPLAY}
-        variant={"lg-display"}
+        variant="lg-display"
         textDecoration="underline"
         showMoreText={showMoreText}
         hideText="Show less"

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -142,6 +142,9 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
       }
 
       if (isEditing) {
+        router.replace({
+          pathname: `/settings/my-collection`,
+        })
         router.push({ pathname: `/my-collection/artwork/${artworkId}` })
       } else {
         router.replace({


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Currently, when saving an artwork after editing it, the user will be navigated to the artwork detail page. At this point it's not easy to navigate back to the My Collection overview because pressing the back button would navigate the user again back to the edit page. 

This PR fixes this by replacing the route with the `/my-collection` route after saving the artwork. 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ