### PR TITLE
fix: Adjust MyC insights sell-through rate formatting

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -1,7 +1,7 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { Box, Column, GridColumns, Select, Text } from "@artsy/palette"
-import { formatSellThroughRate } from "Apps/Artwork/Utils/insightUtils"
+import { formatSellThroughRate } from "Apps/Artwork/Utils/insightHelpers"
 import { rest } from "lodash"
 import * as React from "react"
 import { useEffect, useRef, useState } from "react"

--- a/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -1,9 +1,10 @@
-import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { ContextModule, OwnerType } from "@artsy/cohesion"
+import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { Box, Column, GridColumns, Select, Text } from "@artsy/palette"
+import { formatSellThroughRate } from "Apps/Artwork/Utils/insightUtils"
 import { rest } from "lodash"
-import { useEffect, useRef, useState } from "react"
 import * as React from "react"
+import { useEffect, useRef, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
@@ -67,12 +68,6 @@ export const MarketStats: React.FC<MarketStatsProps> = ({
   const formattedMedianSaleOverEstimatePercentage = Math.abs(
     actualMedianSaleOverEstimatePercentage
   )
-
-  const sellThroughRatePercentage =
-    (selectedPriceInsight.sellThroughRate as number) * 100
-  // show up to 2 decimal places
-  const formattedSellThroughRate =
-    Math.round(sellThroughRatePercentage * 100) / 100
 
   return (
     <Box mb={[4, 12]} mt={[0, 6]}>
@@ -155,7 +150,9 @@ export const MarketStats: React.FC<MarketStatsProps> = ({
                     style={{ whiteSpace: "nowrap" }}
                     textAlign="right"
                   >
-                    {formattedSellThroughRate}%
+                    {formatSellThroughRate(
+                      selectedPriceInsight.sellThroughRate
+                    )}
                   </Text>
                 </Column>
               </GridColumns>

--- a/src/Apps/Artwork/Utils/insightHelpers.ts
+++ b/src/Apps/Artwork/Utils/insightHelpers.ts
@@ -3,7 +3,6 @@ export const formatSellThroughRate = (sellThroughRate: number | null) => {
     return ""
   }
 
-  const sellThroughRatePercentage = (sellThroughRate as number) * 100
   // show up to 2 decimal places
-  return `${Math.round(sellThroughRatePercentage * 100) / 100}%`
+  return `${Math.round(sellThroughRate * 10000) / 100}%`
 }

--- a/src/Apps/Artwork/Utils/insightUtils.ts
+++ b/src/Apps/Artwork/Utils/insightUtils.ts
@@ -1,0 +1,9 @@
+export const formatSellThroughRate = (sellThroughRate: number | null) => {
+  if (sellThroughRate === null) {
+    return ""
+  }
+
+  const sellThroughRatePercentage = (sellThroughRate as number) * 100
+  // show up to 2 decimal places
+  return `${Math.round(sellThroughRatePercentage * 100) / 100}%`
+}

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   Tooltip,
 } from "@artsy/palette"
-import { formatSellThroughRate } from "Apps/Artwork/Utils/insightUtils"
+import { formatSellThroughRate } from "Apps/Artwork/Utils/insightHelpers"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "Utils/Responsive"
 import { MyCollectionArtworkArtistMarket_marketPriceInsights } from "__generated__/MyCollectionArtworkArtistMarket_marketPriceInsights.graphql"

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   Tooltip,
 } from "@artsy/palette"
+import { formatSellThroughRate } from "Apps/Artwork/Utils/insightUtils"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "Utils/Responsive"
 import { MyCollectionArtworkArtistMarket_marketPriceInsights } from "__generated__/MyCollectionArtworkArtistMarket_marketPriceInsights.graphql"
@@ -30,8 +31,6 @@ export const MyCollectionArtworkArtistMarket = ({
     medianSaleOverEstimatePercentage,
     sellThroughRate,
   } = marketPriceInsights
-
-  const formattedSellThroughRate = Number(sellThroughRate).toFixed(3)
 
   return (
     <>
@@ -86,7 +85,7 @@ export const MyCollectionArtworkArtistMarket = ({
         {
           <InsightColumn
             name="Sell-through Rate"
-            value={formattedSellThroughRate + "%"}
+            value={formatSellThroughRate(sellThroughRate)}
           />
         }
 

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkArtistMarket.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkArtistMarket.jest.tsx
@@ -39,7 +39,7 @@ describe("MyCollectionArtworkArtistMarket", () => {
     expect(screen.getByText("Annual Lots Sold")).toBeInTheDocument()
     expect(screen.getByText("123")).toBeInTheDocument()
     expect(screen.getByText("Sell-through Rate")).toBeInTheDocument()
-    expect(screen.getByText("0.134%")).toBeInTheDocument()
+    expect(screen.getByText("13.4%")).toBeInTheDocument()
     expect(screen.getByText("Sale Price to Estimate")).toBeInTheDocument()
     expect(screen.getByText("95%")).toBeInTheDocument()
     expect(screen.getByText("Liquidity")).toBeInTheDocument()


### PR DESCRIPTION
Addresses https://github.com/artsy/force/pull/10880#pullrequestreview-1093488341

## Description

Adjust MyC insights sell-through rate formatting.

| Before | After |
| --- | --- |
| <img width="288" alt="Screenshot 2022-09-01 at 16 28 06" src="https://user-images.githubusercontent.com/4691889/187939216-b4d6f33a-9fc1-456f-87b6-a48bc0fd7b05.png">|<img width="322" alt="Screenshot 2022-09-01 at 16 33 02" src="https://user-images.githubusercontent.com/4691889/187940412-5b88a9dd-f721-4daa-95cf-d21e6d8cac85.png"> |


