### PR TITLE
feat: don't show confirmation dialog

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx",
         "hashed_secret": "dc312ec7ed341804d6911ecdcf18eea1858f6091",
         "is_verified": false,
-        "line_number": 456
+        "line_number": 498
       }
     ],
     "src/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx": [
@@ -1389,5 +1389,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-26T10:11:14Z"
+  "generated_at": "2022-09-01T21:34:09Z"
 }

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2Artists.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2Artists.tsx
@@ -33,7 +33,7 @@ export const ArtworkSidebar2Artists: React.FC<ArtistsProps> = ({
     <div>
       <ShowMore
         initial={ARTISTS_TO_DISPLAY}
-        variant={"lg-display"}
+        variant="lg-display"
         textDecoration="underline"
         showMoreText={showMoreText}
         hideText="Show less"

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormDetails.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormDetails.tsx
@@ -79,6 +79,7 @@ export const MyCollectionArtworkFormDetails: React.FC = () => {
             onBlur={handleBlur}
             onChange={handleChange}
             value={values.title}
+            data-testid="my-collection-artwork-details-title"
           />
         </Column>
       </GridColumns>

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -15,6 +15,7 @@ import { BackLink } from "Components/Links/BackLink"
 import { MetaTags } from "Components/MetaTags"
 import { Sticky, StickyProvider } from "Components/Sticky"
 import { Form, Formik } from "formik"
+import { isEqual } from "lodash"
 import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { RouterLink } from "System/Router/RouterLink"
@@ -189,6 +190,15 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
     }
   }
 
+  const leaveForm = () => {
+    router.replace({ pathname: "/settings/my-collection" })
+    router.push({
+      pathname: isEditing
+        ? `/my-collection/artwork/${artwork.internalID}`
+        : "/settings/my-collection",
+    })
+  }
+
   return (
     <>
       <MetaTags
@@ -220,14 +230,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                   <ConfirmationModalBack
                     onClose={() => setShouldShowBackModal(false)}
                     isEditing={isEditing}
-                    onLeave={() => {
-                      router.replace({ pathname: "/settings/my-collection" })
-                      router.push({
-                        pathname: isEditing
-                          ? `/my-collection/artwork/${artwork.internalID}`
-                          : "/settings/my-collection",
-                      })
-                    }}
+                    onLeave={() => leaveForm()}
                   />
                 )}
                 {shouldShowDeletionModal && (
@@ -253,7 +256,16 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                               <BackLink
                                 // @ts-ignore
                                 as={RouterLink}
-                                onClick={() => setShouldShowBackModal(true)}
+                                onClick={() => {
+                                  const formIsDirty = !isEqual(
+                                    initialValues,
+                                    values
+                                  )
+
+                                  return formIsDirty
+                                    ? setShouldShowBackModal(true)
+                                    : leaveForm()
+                                }}
                                 width="min-content"
                               >
                                 Back

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -15,7 +15,6 @@ import { BackLink } from "Components/Links/BackLink"
 import { MetaTags } from "Components/MetaTags"
 import { Sticky, StickyProvider } from "Components/Sticky"
 import { Form, Formik } from "formik"
-import { isEqual } from "lodash"
 import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { RouterLink } from "System/Router/RouterLink"
@@ -57,7 +56,10 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
     MyCollectionArtworkDetailsValidationSchema
   )
 
-  const [shouldShowBackModal, setShouldShowBackModal] = useState<boolean>(false)
+  const [
+    showLeaveWithoutSavingModal,
+    setShowLeaveWithoutSavingModal,
+  ] = useState<boolean>(false)
   const [shouldShowDeletionModal, setShouldShowDeletionModal] = useState<
     boolean
   >(false)
@@ -219,16 +221,16 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
           validationSchema={MyCollectionArtworkDetailsValidationSchema}
           initialErrors={initialErrors}
         >
-          {({ isSubmitting, isValid, values }) => (
+          {({ isSubmitting, isValid, values, dirty }) => (
             <Form>
               <RouterLink to="/my-collection" display="block">
                 <ArtsyLogoBlackIcon display="block" />
               </RouterLink>
 
               <StickyProvider>
-                {shouldShowBackModal && (
+                {showLeaveWithoutSavingModal && (
                   <ConfirmationModalBack
-                    onClose={() => setShouldShowBackModal(false)}
+                    onClose={() => setShowLeaveWithoutSavingModal(false)}
                     isEditing={isEditing}
                     onLeave={() => leaveForm()}
                   />
@@ -257,13 +259,8 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                                 // @ts-ignore
                                 as={RouterLink}
                                 onClick={() => {
-                                  const formIsDirty = !isEqual(
-                                    initialValues,
-                                    values
-                                  )
-
-                                  return formIsDirty
-                                    ? setShouldShowBackModal(true)
+                                  dirty
+                                    ? setShowLeaveWithoutSavingModal(true)
                                     : leaveForm()
                                 }}
                                 width="min-content"

--- a/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
@@ -136,13 +136,35 @@ describe("Edit artwork", () => {
   })
 
   describe("Back Link behavior", () => {
-    it("opens modal on press", async () => {
+    it("opens modal on press when the form has been changed", async () => {
+      getWrapper().renderWithRelay({
+        Artwork: () => mockArtwork,
+      })
+
+      fireEvent.change(
+        screen.getByTestId("my-collection-artwork-details-title"),
+        {
+          target: { value: "Some new value" },
+        }
+      )
+
+      fireEvent.click(screen.getByText("Back"))
+      fireEvent.click(screen.getByText("Leave Without Saving"))
+
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        pathname: "/my-collection/artwork/62fc96c48d3ff8000b556c3a",
+      })
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        pathname: "/settings/my-collection",
+      })
+    })
+
+    it("navigates to the previous screen when the form has not been changed", async () => {
       getWrapper().renderWithRelay({
         Artwork: () => mockArtwork,
       })
 
       fireEvent.click(screen.getByText("Back"))
-      fireEvent.click(screen.getByText("Leave Without Saving"))
 
       expect(mockRouterPush).toHaveBeenCalledWith({
         pathname: "/my-collection/artwork/62fc96c48d3ff8000b556c3a",
@@ -408,11 +430,31 @@ describe("Create artwork", () => {
   })
 
   describe("Back Link behavior", () => {
-    it("opens modal on press", async () => {
+    it("opens modal on press when the form has been changed", async () => {
       getWrapper()
+
+      fireEvent.change(
+        screen.getByTestId("my-collection-artwork-details-title"),
+        {
+          target: { value: "Some new value" },
+        }
+      )
 
       fireEvent.click(screen.getByText("Back"))
       fireEvent.click(screen.getByText("Leave Without Saving"))
+
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        pathname: "/my-collection/artwork/62fc96c48d3ff8000b556c3a",
+      })
+      expect(mockRouterReplace).toHaveBeenCalledWith({
+        pathname: "/settings/my-collection",
+      })
+    })
+
+    it("navigates to the previous screen when the form has not been changed", async () => {
+      getWrapper()
+
+      fireEvent.click(screen.getByText("Back"))
 
       expect(mockRouterPush).toHaveBeenCalledWith({
         pathname: "/my-collection/artwork/62fc96c48d3ff8000b556c3a",


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2870]

### Description

<!-- Implementation description -->
Don't show confirmation dialog when the user has not made any changes | edit/create artwork flow

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2870]: https://artsyproduct.atlassian.net/browse/CX-2870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ