### PR TITLE
feat(FX-4152): position account above inbox in mweb nav

### DIFF
--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
@@ -84,6 +84,8 @@ export const NavBarMobileMenuLoggedIn: React.FC<NavBarMobileMenuLoggedInProps> =
 
   return (
     <>
+      <NavBarMobileSubMenu menu={menu}>{menu.title}</NavBarMobileSubMenu>
+
       <NavBarMobileMenuItemLink
         to="/user/conversations"
         justifyContent="space-between"
@@ -97,8 +99,6 @@ export const NavBarMobileMenuLoggedIn: React.FC<NavBarMobileMenuLoggedInProps> =
       <NavBarMobileMenuItemLink to="/works-for-you">
         Works for you
       </NavBarMobileMenuItemLink>
-
-      <NavBarMobileSubMenu menu={menu}>{menu.title}</NavBarMobileSubMenu>
 
       {enableActivityPanel && (
         <NavBarMobileMenuItemLink to="/notifications">

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
@@ -86,6 +86,12 @@ export const NavBarMobileMenuLoggedIn: React.FC<NavBarMobileMenuLoggedInProps> =
     <>
       <NavBarMobileSubMenu menu={menu}>{menu.title}</NavBarMobileSubMenu>
 
+      {enableActivityPanel && (
+        <NavBarMobileMenuItemLink to="/notifications">
+          Activity
+        </NavBarMobileMenuItemLink>
+      )}
+
       <NavBarMobileMenuItemLink
         to="/user/conversations"
         justifyContent="space-between"
@@ -99,12 +105,6 @@ export const NavBarMobileMenuLoggedIn: React.FC<NavBarMobileMenuLoggedInProps> =
       <NavBarMobileMenuItemLink to="/works-for-you">
         Works for you
       </NavBarMobileMenuItemLink>
-
-      {enableActivityPanel && (
-        <NavBarMobileMenuItemLink to="/notifications">
-          Activity
-        </NavBarMobileMenuItemLink>
-      )}
     </>
   )
 }

--- a/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
@@ -53,7 +53,7 @@ describe("NavBarMobileMenu", () => {
 
     wrapper
       .find("a")
-      .at(length - 2)
+      .at(length - 4)
       .simulate("click")
 
     expect(mediator.trigger).toBeCalledWith("auth:logout")


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4152]

### Description

- [x] Moves account before inbox on mweb navbar
- [x] moves activity under account on mweb navbar

<img width="442" alt="Screenshot 2022-09-07 at 10 08 27" src="https://user-images.githubusercontent.com/21178754/188825866-378ee1a0-ab64-4746-81b9-62600c44fb51.png">


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4152]: https://artsyproduct.atlassian.net/browse/FX-4152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ