### PR TITLE
fix: reverted changes made to SWA ThankYou screen

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYou.tsx
@@ -1,48 +1,106 @@
-import { Button, Flex, Text } from "@artsy/palette"
-import { useSystemContext } from "System"
+import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
+import { Button, Flex, Text, Spacer, Box } from "@artsy/palette"
 import { RouterLink } from "System/Router/RouterLink"
+import { DownloadApps } from "./Components/DownloadApps"
+import { useSystemContext } from "System"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { useRouter } from "System/Router/useRouter"
+import {
+  SoldRecentlyOnArtsyQueryRenderer,
+  FAQ,
+} from "../../MarketingLanding/Components"
+import { useTracking } from "react-tracking"
 
 export const ThankYou: React.FC = () => {
-  const { isLoggedIn } = useSystemContext()
+  const { user, isLoggedIn } = useSystemContext()
+  const { match } = useRouter()
+  const { trackEvent } = useTracking()
+
+  const trackSubmitAnotherWorkClick = () =>
+    trackEvent({
+      action_type: DeprecatedAnalyticsSchema.ActionType.SubmitAnotherArtwork,
+      context_module: ContextModule.consignSubmissionFlow,
+      context_owner_type: OwnerType.consignmentSubmission,
+      submission_id: match.params.id,
+      user_email: isLoggedIn ? user?.email : undefined,
+      user_id: isLoggedIn ? user?.id : undefined,
+    })
 
   return (
     <>
-      <Text variant="xl" mt={4}>
-        Your artwork has been submitted
-      </Text>
-      <Text variant="md" color="black60" mt={1} mb={[4, 6]}>
-        We will email you within 1-3 days to confirm if your artwork has been
-        accepted or not.
-      </Text>
+      {isLoggedIn ? (
+        <>
+          <Text variant="xxl" mt={4}>
+            Your artwork has been submitted
+          </Text>
+          <Box maxWidth="720px" mt={4}>
+            <Text variant="lg-display" color="black60">
+              We will email you within 1-3 days to confirm if your artwork has
+              been accepted or not. In the meantime your submission will appear
+              in the feature, My Collection, on the Artsy app.
+            </Text>
+            <Text variant="lg-display" mt={2} color="black60">
+              With low fees, informed pricing, and multiple sales options, why
+              not submit another piece with Artsy.
+            </Text>
+          </Box>
+        </>
+      ) : (
+        <>
+          <Text variant="xxl" mt={4}>
+            Thank you for submitting a work
+          </Text>
+          <Box maxWidth="720px" mt={4}>
+            <Text variant="lg-display">
+              We’ll email you within 1–3 business days to let you know the
+              status of your submission.
+            </Text>
+            <Text variant="lg-display" mt={2}>
+              In the meantime, feel free to submit another work—and benefit from
+              Artsy’s low fees, informed pricing, and multiple selling options.
+            </Text>
+          </Box>
+        </>
+      )}
 
       <Flex
+        py={2}
+        my={4}
+        mb={0}
         flexDirection={["column", "row"]}
         alignItems={["stretch", "center"]}
       >
-        {isLoggedIn ? (
-          <RouterLink to="/my-collection">
-            <Button
-              width={["100%", "auto"]}
-              data-test-id="back-to-my-collection"
-              size="large"
-              variant="primaryBlack"
-            >
-              Back to My Collection
-            </Button>
-          </RouterLink>
-        ) : (
-          <RouterLink to="/">
-            <Button
-              width={["100%", "auto"]}
-              data-test-id="back-to-artsy-homepage"
-              size="large"
-              variant="primaryBlack"
-            >
-              Back to Artsy Homepage
-            </Button>
-          </RouterLink>
-        )}
+        <RouterLink to="/sell/submission/artwork-details">
+          <Button
+            mr={[0, 150]}
+            width={["100%", "auto"]}
+            data-test-id="submit-another-work"
+            size="large"
+            variant="primaryBlack"
+            onClick={trackSubmitAnotherWorkClick}
+          >
+            Submit Another Work
+          </Button>
+        </RouterLink>
+
+        <RouterLink to="/">
+          <Button
+            mt={[4, 0]}
+            width={["100%", "auto"]}
+            data-test-id="go-to-artsy-homepage"
+            size="large"
+            variant="tertiary"
+          >
+            Back to Artsy Homepage
+          </Button>
+        </RouterLink>
       </Flex>
+
+      <DownloadApps mb={[2, 6]} />
+
+      <SoldRecentlyOnArtsyQueryRenderer />
+      <Spacer mt={6} />
+      <FAQ shouldTrackClickEvent />
     </>
   )
 }

--- a/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYouWhenFromMyCollection.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYouWhenFromMyCollection.tsx
@@ -1,0 +1,48 @@
+import { Button, Flex, Text } from "@artsy/palette"
+import { useSystemContext } from "System"
+import { RouterLink } from "System/Router/RouterLink"
+
+export const ThankYouWhenFromMyCollection: React.FC = () => {
+  const { isLoggedIn } = useSystemContext()
+
+  return (
+    <>
+      <Text variant="xl" mt={4}>
+        Your artwork has been submitted
+      </Text>
+      <Text variant="md" color="black60" mt={1} mb={[4, 6]}>
+        We will email you within 1-3 days to confirm if your artwork has been
+        accepted or not.
+      </Text>
+
+      <Flex
+        flexDirection={["column", "row"]}
+        alignItems={["stretch", "center"]}
+      >
+        {isLoggedIn ? (
+          <RouterLink to="/my-collection">
+            <Button
+              width={["100%", "auto"]}
+              data-test-id="back-to-my-collection"
+              size="large"
+              variant="primaryBlack"
+            >
+              Back to My Collection
+            </Button>
+          </RouterLink>
+        ) : (
+          <RouterLink to="/">
+            <Button
+              width={["100%", "auto"]}
+              data-test-id="back-to-artsy-homepage"
+              size="large"
+              variant="primaryBlack"
+            >
+              Back to Artsy Homepage
+            </Button>
+          </RouterLink>
+        )}
+      </Flex>
+    </>
+  )
+}

--- a/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYouWhenFromMyCollection.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/ThankYouWhenFromMyCollection.tsx
@@ -1,10 +1,7 @@
 import { Button, Flex, Text } from "@artsy/palette"
-import { useSystemContext } from "System"
 import { RouterLink } from "System/Router/RouterLink"
 
 export const ThankYouWhenFromMyCollection: React.FC = () => {
-  const { isLoggedIn } = useSystemContext()
-
   return (
     <>
       <Text variant="xl" mt={4}>
@@ -19,29 +16,16 @@ export const ThankYouWhenFromMyCollection: React.FC = () => {
         flexDirection={["column", "row"]}
         alignItems={["stretch", "center"]}
       >
-        {isLoggedIn ? (
-          <RouterLink to="/my-collection">
-            <Button
-              width={["100%", "auto"]}
-              data-test-id="back-to-my-collection"
-              size="large"
-              variant="primaryBlack"
-            >
-              Back to My Collection
-            </Button>
-          </RouterLink>
-        ) : (
-          <RouterLink to="/">
-            <Button
-              width={["100%", "auto"]}
-              data-test-id="back-to-artsy-homepage"
-              size="large"
-              variant="primaryBlack"
-            >
-              Back to Artsy Homepage
-            </Button>
-          </RouterLink>
-        )}
+        <RouterLink to="/my-collection">
+          <Button
+            width={["100%", "auto"]}
+            data-test-id="back-to-my-collection"
+            size="large"
+            variant="primaryBlack"
+          >
+            Back to My Collection
+          </Button>
+        </RouterLink>
       </Flex>
     </>
   )

--- a/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYou.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYou.jest.tsx
@@ -1,54 +1,175 @@
+import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { mount } from "enzyme"
-import { useSystemContext } from "System/useSystemContext"
 import { ThankYou } from "../ThankYou"
+import { useSystemContext } from "System"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { useRouter } from "System/Router/useRouter"
+import { useTracking } from "react-tracking"
+
+jest.mock("react-tracking")
+
+jest.mock("System/Router/useRouter")
 
 jest.mock("System/useSystemContext")
 
-const mockContext = useSystemContext as jest.Mock
+jest.mock("../../../MarketingLanding/Components/SoldRecentlyOnArtsy", () => ({
+  SoldRecentlyOnArtsyQueryRenderer: () => <div />,
+}))
+jest.mock("../../../MarketingLanding/Components/FAQ", () => ({
+  FAQ: () => <div />,
+}))
+
+const trackEvent = useTracking as jest.Mock
 
 describe("ThankYou page", () => {
-  describe("when the user is logged in", () => {
-    beforeAll(() => {
-      mockContext.mockImplementation(() => ({ isLoggedIn: true }))
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
     })
+    ;(useRouter as jest.Mock).mockImplementation(() => {
+      return {
+        match: {
+          params: {
+            id: "12345",
+          },
+        },
+      }
+    })
+    ;(useSystemContext as jest.Mock).mockImplementation(() => {
+      return {
+        isLoggedIn: true,
+        user: {
+          id: "123",
+          email: "d@e.f",
+        },
+      }
+    })
+  })
 
+  describe("when user is logged in", () => {
+    beforeEach(() => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => {
+        return {
+          isLoggedIn: true,
+        }
+      })
+    })
     it("renders correctly", () => {
       const wrapper = mount(<ThankYou />)
       const text = wrapper.text()
 
       expect(text).toContain("Your artwork has been submitted")
       expect(text).toContain(
-        "We will email you within 1-3 days to confirm if your artwork has been accepted or not."
+        "We will email you within 1-3 days to confirm if your artwork has been accepted or not. In the meantime your submission will appear in the feature, My Collection, on the Artsy app."
+      )
+      expect(text).toContain(
+        "With low fees, informed pricing, and multiple sales options, why not submit another piece with Artsy."
       )
 
       expect(
-        wrapper.find("button[data-test-id='back-to-my-collection']").text()
-      ).toContain("Back to My Collection")
-      // /my-collection
-      expect(wrapper.find("RouterLink").at(0).props().to).toContain(
-        "/my-collection"
-      )
+        wrapper.find("button[data-test-id='submit-another-work']").text()
+      ).toContain("Submit Another Work")
+
+      expect(
+        wrapper.find("button[data-test-id='go-to-artsy-homepage']").text()
+      ).toContain("Back to Artsy Homepage")
+
+      expect(text).toContain("View My Collection on the Artsy App")
+
+      expect(wrapper.find("SoldRecentlyOnArtsyQueryRenderer").length).toBe(1)
+      expect(wrapper.find("FAQ").length).toBe(1)
     })
   })
 
-  describe("when the user is not logged in", () => {
-    beforeAll(() => {
-      mockContext.mockImplementation(() => ({ isLoggedIn: false }))
+  describe("when user is not logged in", () => {
+    beforeEach(() => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => {
+        return {
+          isLoggedIn: false,
+        }
+      })
     })
-
-    it("renders the contents correctly", () => {
+    it("renders correctly", () => {
       const wrapper = mount(<ThankYou />)
       const text = wrapper.text()
 
-      expect(text).toContain("Your artwork has been submitted")
+      expect(text).toContain("Thank you for submitting a work")
       expect(text).toContain(
-        "We will email you within 1-3 days to confirm if your artwork has been accepted or not."
+        "We’ll email you within 1–3 business days to let you know the status of your submission."
+      )
+      expect(text).toContain(
+        "In the meantime, feel free to submit another work—and benefit from Artsy’s low fees, informed pricing, and multiple selling options."
       )
 
       expect(
-        wrapper.find("button[data-test-id='back-to-artsy-homepage']").text()
+        wrapper.find("button[data-test-id='submit-another-work']").text()
+      ).toContain("Submit Another Work")
+
+      expect(
+        wrapper.find("button[data-test-id='go-to-artsy-homepage']").text()
       ).toContain("Back to Artsy Homepage")
-      expect(wrapper.find("RouterLink").at(0).props().to).toContain("/")
+
+      expect(text).toContain("View My Collection on the Artsy App")
+
+      expect(wrapper.find("SoldRecentlyOnArtsyQueryRenderer").length).toBe(1)
+      expect(wrapper.find("FAQ").length).toBe(1)
+    })
+  })
+
+  describe("when user logged in", () => {
+    it("tracks submit another artwork click with user email and ID", async () => {
+      const wrapper = mount(<ThankYou />)
+
+      const submitAnotherButton = wrapper.find(
+        "button[data-test-id='submit-another-work']"
+      )
+
+      submitAnotherButton.simulate("click")
+
+      expect(trackEvent).toHaveBeenCalled()
+      expect(trackEvent).toHaveBeenCalledWith({
+        action_type: DeprecatedAnalyticsSchema.ActionType.SubmitAnotherArtwork,
+        context_module: ContextModule.consignSubmissionFlow,
+        context_owner_type: OwnerType.consignmentSubmission,
+        submission_id: "12345",
+        user_email: "d@e.f",
+        user_id: "123",
+      })
+    })
+  })
+  describe("when user is notlogged in", () => {
+    beforeEach(() => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => {
+        return {
+          isLoggedIn: false,
+          user: {
+            id: "",
+            email: "",
+          },
+        }
+      })
+    })
+
+    it("tracks submit another artwork click without user email", async () => {
+      const wrapper = mount(<ThankYou />)
+
+      const submitAnotherButton = wrapper.find(
+        "button[data-test-id='submit-another-work']"
+      )
+
+      submitAnotherButton.simulate("click")
+
+      expect(trackEvent).toHaveBeenCalled()
+      expect(trackEvent).toHaveBeenCalledWith({
+        action_type: DeprecatedAnalyticsSchema.ActionType.SubmitAnotherArtwork,
+        context_module: ContextModule.consignSubmissionFlow,
+        context_owner_type: OwnerType.consignmentSubmission,
+        submission_id: "12345",
+        user_email: undefined,
+        user_id: undefined,
+      })
     })
   })
 })

--- a/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYouWhenFromMyCollection.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYouWhenFromMyCollection.jest.tsx
@@ -1,0 +1,54 @@
+import { mount } from "enzyme"
+import { useSystemContext } from "System/useSystemContext"
+import { ThankYouWhenFromMyCollection } from "../ThankYouWhenFromMyCollection"
+
+jest.mock("System/useSystemContext")
+
+const mockContext = useSystemContext as jest.Mock
+
+describe("ThankYou page when artwork is submitted from My Collection", () => {
+  describe("when the user is logged in", () => {
+    beforeAll(() => {
+      mockContext.mockImplementation(() => ({ isLoggedIn: true }))
+    })
+
+    it("renders correctly", () => {
+      const wrapper = mount(<ThankYouWhenFromMyCollection />)
+      const text = wrapper.text()
+
+      expect(text).toContain("Your artwork has been submitted")
+      expect(text).toContain(
+        "We will email you within 1-3 days to confirm if your artwork has been accepted or not."
+      )
+
+      expect(
+        wrapper.find("button[data-test-id='back-to-my-collection']").text()
+      ).toContain("Back to My Collection")
+      // /my-collection
+      expect(wrapper.find("RouterLink").at(0).props().to).toContain(
+        "/my-collection"
+      )
+    })
+  })
+
+  describe("when the user is not logged in", () => {
+    beforeAll(() => {
+      mockContext.mockImplementation(() => ({ isLoggedIn: false }))
+    })
+
+    it("renders the contents correctly", () => {
+      const wrapper = mount(<ThankYouWhenFromMyCollection />)
+      const text = wrapper.text()
+
+      expect(text).toContain("Your artwork has been submitted")
+      expect(text).toContain(
+        "We will email you within 1-3 days to confirm if your artwork has been accepted or not."
+      )
+
+      expect(
+        wrapper.find("button[data-test-id='back-to-artsy-homepage']").text()
+      ).toContain("Back to Artsy Homepage")
+      expect(wrapper.find("RouterLink").at(0).props().to).toContain("/")
+    })
+  })
+})

--- a/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYouWhenFromMyCollection.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ThankYou/__tests__/ThankYouWhenFromMyCollection.jest.tsx
@@ -7,48 +7,25 @@ jest.mock("System/useSystemContext")
 const mockContext = useSystemContext as jest.Mock
 
 describe("ThankYou page when artwork is submitted from My Collection", () => {
-  describe("when the user is logged in", () => {
-    beforeAll(() => {
-      mockContext.mockImplementation(() => ({ isLoggedIn: true }))
-    })
-
-    it("renders correctly", () => {
-      const wrapper = mount(<ThankYouWhenFromMyCollection />)
-      const text = wrapper.text()
-
-      expect(text).toContain("Your artwork has been submitted")
-      expect(text).toContain(
-        "We will email you within 1-3 days to confirm if your artwork has been accepted or not."
-      )
-
-      expect(
-        wrapper.find("button[data-test-id='back-to-my-collection']").text()
-      ).toContain("Back to My Collection")
-      // /my-collection
-      expect(wrapper.find("RouterLink").at(0).props().to).toContain(
-        "/my-collection"
-      )
-    })
+  beforeAll(() => {
+    mockContext.mockImplementation(() => ({ isLoggedIn: true }))
   })
 
-  describe("when the user is not logged in", () => {
-    beforeAll(() => {
-      mockContext.mockImplementation(() => ({ isLoggedIn: false }))
-    })
+  it("renders correctly", () => {
+    const wrapper = mount(<ThankYouWhenFromMyCollection />)
+    const text = wrapper.text()
 
-    it("renders the contents correctly", () => {
-      const wrapper = mount(<ThankYouWhenFromMyCollection />)
-      const text = wrapper.text()
+    expect(text).toContain("Your artwork has been submitted")
+    expect(text).toContain(
+      "We will email you within 1-3 days to confirm if your artwork has been accepted or not."
+    )
 
-      expect(text).toContain("Your artwork has been submitted")
-      expect(text).toContain(
-        "We will email you within 1-3 days to confirm if your artwork has been accepted or not."
-      )
-
-      expect(
-        wrapper.find("button[data-test-id='back-to-artsy-homepage']").text()
-      ).toContain("Back to Artsy Homepage")
-      expect(wrapper.find("RouterLink").at(0).props().to).toContain("/")
-    })
+    expect(
+      wrapper.find("button[data-test-id='back-to-my-collection']").text()
+    ).toContain("Back to My Collection")
+    // /my-collection
+    expect(wrapper.find("RouterLink").at(0).props().to).toContain(
+      "/my-collection"
+    )
   })
 })


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2883]

### Description

<!-- Implementation description -->
Reverted changes made to the Thank you page that is shown after successful submission to sell (ThankYou.tsx)
Renamed the file with the component that will be used for the same purposes, but when the artwork is submitted from My Collection (ThankYouWhenFromMyCollection.tsx)
To test the standard SWA ThankYou screen you can use the link: http://localhost:5000/sell/submission/ed0c7181-ceb3-47c0-96cb-cea66f28b608/thank-you

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2883]: https://artsyproduct.atlassian.net/browse/CX-2883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ