### PR TITLE
feat(FX-4201): display indicator for hamburger menu icon and Activity link when user has unread notifications

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -44,6 +44,8 @@ import { RouterLink } from "System/Router/RouterLink"
 import { useTracking } from "react-tracking"
 import { Z } from "Apps/Components/constants"
 import { useTranslation } from "react-i18next"
+import { useFeatureFlag } from "System/useFeatureFlag"
+import { NavBarMobileMenuNotificationsIndicatorQueryRenderer } from "./NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator"
 
 /**
  * Old Force pages have the navbar height hardcoded in several places. If
@@ -74,6 +76,7 @@ export const NavBar: React.FC = track(
   }
   const { trackEvent } = useTracking()
   const { t } = useTranslation()
+  const enableActivityPanel = useFeatureFlag("force-enable-new-activity-panel")
   const [showMobileMenu, toggleMobileNav] = useState(false)
   const xs = __internal__useMatchMedia(themeProps.mediaQueries.xs)
   const sm = __internal__useMatchMedia(themeProps.mediaQueries.sm)
@@ -121,6 +124,18 @@ export const NavBar: React.FC = track(
   }
 
   const { height } = useNavBarHeight()
+
+  const renderNotificationsIndicator = () => {
+    if (!showNotificationCount) {
+      return null
+    }
+
+    if (enableActivityPanel) {
+      return <NavBarMobileMenuNotificationsIndicatorQueryRenderer />
+    }
+
+    return <NavBarMobileMenuInboxNotificationCountQueryRenderer />
+  }
 
   return (
     <ThemeProviderV3>
@@ -290,9 +305,7 @@ export const NavBar: React.FC = track(
                 >
                   <NavBarMobileMenuIcon open={showMobileMenu} />
 
-                  {showNotificationCount && (
-                    <NavBarMobileMenuInboxNotificationCountQueryRenderer />
-                  )}
+                  {renderNotificationsIndicator()}
                 </NavBarItemButton>
               </Flex>
             </Flex>

--- a/src/Components/NavBar/NavBarLoggedInActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedInActions.tsx
@@ -16,12 +16,7 @@ import {
   NavBarLoggedInActionsQueryResponse,
 } from "__generated__/NavBarLoggedInActionsQuery.graphql"
 import { isServer } from "Server/isServer"
-import {
-  getConversationCount,
-  getNotificationCount,
-  updateConversationCache,
-  updateNotificationCache,
-} from "./helpers"
+import { checkAndSyncIndicatorsCount } from "./helpers"
 import styled from "styled-components"
 import { themeGet } from "@styled-system/theme-get"
 import { NavBarItemButton, NavBarItemLink } from "./NavBarItem"
@@ -34,13 +29,11 @@ export const NavBarLoggedInActions: React.FC<Partial<
   NavBarLoggedInActionsQueryResponse
 >> = ({ me }) => {
   const enableActivityPanel = useFeatureFlag("force-enable-new-activity-panel")
-  const hasUnreadNotifications =
-    (me?.unreadNotificationsCount ?? 0) > 0 || getNotificationCount() > 0
-  const hasUnreadConversations =
-    (me?.unreadConversationCount ?? 0) > 0 || getConversationCount() > 0
 
-  updateNotificationCache(me?.unreadNotificationsCount)
-  updateConversationCache(me?.unreadConversationCount)
+  const { hasConversations, hasNotifications } = checkAndSyncIndicatorsCount({
+    notifications: me?.unreadNotificationsCount,
+    conversations: me?.unreadConversationCount,
+  })
 
   return (
     <>
@@ -69,9 +62,7 @@ export const NavBarLoggedInActions: React.FC<Partial<
               fill="currentColor"
             />
 
-            {hasUnreadNotifications && (
-              <NavBarLoggedInActionsNotificationIndicator />
-            )}
+            {hasNotifications && <NavBarLoggedInActionsNotificationIndicator />}
           </NavBarItemButton>
         )}
       </Dropdown>
@@ -83,9 +74,7 @@ export const NavBarLoggedInActions: React.FC<Partial<
           fill="currentColor"
         />
 
-        {hasUnreadConversations && (
-          <NavBarLoggedInActionsNotificationIndicator />
-        )}
+        {hasConversations && <NavBarLoggedInActionsNotificationIndicator />}
       </NavBarItemLink>
 
       <Dropdown

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
@@ -11,10 +11,17 @@ import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { getMobileAuthLink } from "Utils/openAuthModal"
 import { NavBarMobileMenuAuthenticationQuery } from "__generated__/NavBarMobileMenuAuthenticationQuery.graphql"
 import { NavBarMobileMenuAuthentication_me } from "__generated__/NavBarMobileMenuAuthentication_me.graphql"
-import { getConversationCount, updateConversationCache } from "../helpers"
+import {
+  getConversationCount,
+  getNotificationCount,
+  updateConversationCache,
+  updateNotificationCache,
+} from "../helpers"
 import { NavBarMobileMenuItemLink } from "./NavBarMobileMenuItem"
 import { NavBarMobileSubMenu } from "./NavBarMobileSubMenu"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { NavBarNotificationIndicator } from "../NavBarNotificationIndicator"
+import styled from "styled-components"
 
 interface NavBarMobileMenuLoggedInProps {
   me?: NavBarMobileMenuAuthentication_me | null
@@ -77,10 +84,19 @@ export const NavBarMobileMenuLoggedIn: React.FC<NavBarMobileMenuLoggedInProps> =
     ],
   }
 
-  const conversationCount =
-    me?.unreadConversationCount || getConversationCount()
+  const { unreadConversationCount, unreadNotificationsCount } = me ?? {}
+  const conversationCount = unreadConversationCount || getConversationCount()
+  let hasUnreadNotifications = false
 
   updateConversationCache(me?.unreadConversationCount)
+
+  if (enableActivityPanel) {
+    const notificationsCount =
+      unreadNotificationsCount || getNotificationCount()
+    hasUnreadNotifications = notificationsCount > 0
+
+    updateNotificationCache(unreadNotificationsCount)
+  }
 
   return (
     <>
@@ -89,6 +105,7 @@ export const NavBarMobileMenuLoggedIn: React.FC<NavBarMobileMenuLoggedInProps> =
       {enableActivityPanel && (
         <NavBarMobileMenuItemLink to="/notifications">
           Activity
+          {hasUnreadNotifications && <Indicator />}
         </NavBarMobileMenuItemLink>
       )}
 
@@ -182,3 +199,8 @@ export const NavBarMobileMenuAuthentication: React.FC = () => {
     <NavBarMobileMenuLoggedOut />
   )
 }
+
+const Indicator = styled(NavBarNotificationIndicator)`
+  margin-left: 5px;
+  margin-top: -15px;
+`

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
@@ -1,0 +1,89 @@
+import { useContext } from "react"
+import * as React from "react"
+import { graphql } from "relay-runtime"
+import { isServer } from "Server/isServer"
+import { NavBarMobileMenuNotificationsIndicatorQuery } from "__generated__/NavBarMobileMenuNotificationsIndicatorQuery.graphql"
+import { SystemContext } from "System/SystemContext"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import {
+  getConversationCount,
+  getNotificationCount,
+  updateConversationCache,
+  updateNotificationCache,
+} from "../helpers"
+import { createFragmentContainer } from "react-relay"
+import { NavBarMobileMenuNotificationsIndicator_me } from "__generated__/NavBarMobileMenuNotificationsIndicator_me.graphql"
+import { NavBarNotificationIndicator } from "../NavBarNotificationIndicator"
+
+interface NavBarMobileMenuNotificationsIndicatorProps {
+  me?: NavBarMobileMenuNotificationsIndicator_me | null
+}
+
+export const NavBarMobileMenuNotificationsIndicator: React.FC<NavBarMobileMenuNotificationsIndicatorProps> = ({
+  me,
+}) => {
+  const { unreadConversationCount, unreadNotificationsCount } = me ?? {}
+  const conversationCount = unreadConversationCount || getConversationCount()
+  const notificationsCount = unreadNotificationsCount || getNotificationCount()
+  const hasNotifications = conversationCount > 0 || notificationsCount > 0
+
+  updateConversationCache(unreadConversationCount)
+  updateNotificationCache(unreadNotificationsCount)
+
+  if (hasNotifications) {
+    return (
+      <NavBarNotificationIndicator position="absolute" top="7px" right="4px" />
+    )
+  }
+
+  return null
+}
+
+export const NavBarMobileMenuNotificationsIndicatorFragmentContainer = createFragmentContainer(
+  NavBarMobileMenuNotificationsIndicator,
+  {
+    me: graphql`
+      fragment NavBarMobileMenuNotificationsIndicator_me on Me {
+        unreadConversationCount
+        unreadNotificationsCount
+      }
+    `,
+  }
+)
+
+export const NavBarMobileMenuNotificationsIndicatorQueryRenderer: React.FC<{}> = () => {
+  const { relayEnvironment } = useContext(SystemContext)
+
+  if (isServer) {
+    return <NavBarMobileMenuNotificationsIndicator />
+  }
+
+  return (
+    <SystemQueryRenderer<NavBarMobileMenuNotificationsIndicatorQuery>
+      environment={relayEnvironment}
+      query={graphql`
+        query NavBarMobileMenuNotificationsIndicatorQuery {
+          me {
+            ...NavBarMobileMenuNotificationsIndicator_me
+          }
+        }
+      `}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (props?.me) {
+          return (
+            <NavBarMobileMenuNotificationsIndicatorFragmentContainer
+              me={props.me}
+            />
+          )
+        }
+
+        return <NavBarMobileMenuNotificationsIndicator />
+      }}
+    />
+  )
+}

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
@@ -25,7 +25,7 @@ export const NavBarMobileMenuNotificationsIndicator: React.FC<NavBarMobileMenuNo
 
   if (shouldDisplayIndicator) {
     return (
-      <NavBarNotificationIndicator position="absolute" top="7px" right="4px" />
+      <NavBarNotificationIndicator position="absolute" top="5px" right="5px" />
     )
   }
 

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
@@ -23,13 +23,13 @@ export const NavBarMobileMenuNotificationsIndicator: React.FC<NavBarMobileMenuNo
   })
   const shouldDisplayIndicator = hasConversations || hasNotifications
 
-  if (shouldDisplayIndicator) {
-    return (
-      <NavBarNotificationIndicator position="absolute" top="5px" right="5px" />
-    )
+  if (!shouldDisplayIndicator) {
+    return null
   }
 
-  return null
+  return (
+    <NavBarNotificationIndicator position="absolute" top="5px" right="5px" />
+  )
 }
 
 export const NavBarMobileMenuNotificationsIndicatorFragmentContainer = createFragmentContainer(

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
@@ -5,12 +5,7 @@ import { isServer } from "Server/isServer"
 import { NavBarMobileMenuNotificationsIndicatorQuery } from "__generated__/NavBarMobileMenuNotificationsIndicatorQuery.graphql"
 import { SystemContext } from "System/SystemContext"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import {
-  getConversationCount,
-  getNotificationCount,
-  updateConversationCache,
-  updateNotificationCache,
-} from "../helpers"
+import { checkAndSyncIndicatorsCount } from "../helpers"
 import { createFragmentContainer } from "react-relay"
 import { NavBarMobileMenuNotificationsIndicator_me } from "__generated__/NavBarMobileMenuNotificationsIndicator_me.graphql"
 import { NavBarNotificationIndicator } from "../NavBarNotificationIndicator"
@@ -22,15 +17,13 @@ interface NavBarMobileMenuNotificationsIndicatorProps {
 export const NavBarMobileMenuNotificationsIndicator: React.FC<NavBarMobileMenuNotificationsIndicatorProps> = ({
   me,
 }) => {
-  const { unreadConversationCount, unreadNotificationsCount } = me ?? {}
-  const conversationCount = unreadConversationCount || getConversationCount()
-  const notificationsCount = unreadNotificationsCount || getNotificationCount()
-  const hasNotifications = conversationCount > 0 || notificationsCount > 0
+  const { hasConversations, hasNotifications } = checkAndSyncIndicatorsCount({
+    notifications: me?.unreadNotificationsCount,
+    conversations: me?.unreadConversationCount,
+  })
+  const shouldDisplayIndicator = hasConversations || hasNotifications
 
-  updateConversationCache(unreadConversationCount)
-  updateNotificationCache(unreadNotificationsCount)
-
-  if (hasNotifications) {
+  if (shouldDisplayIndicator) {
     return (
       <NavBarNotificationIndicator position="absolute" top="7px" right="4px" />
     )

--- a/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenuNotificationsIndicator.jest.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenuNotificationsIndicator.jest.tsx
@@ -1,0 +1,56 @@
+import { screen } from "@testing-library/react"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { graphql } from "relay-runtime"
+import { NavBarMobileMenuNotificationsIndicatorFragmentContainer } from "../NavBarMobileMenuNotificationsIndicator"
+
+jest.unmock("react-relay")
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: NavBarMobileMenuNotificationsIndicatorFragmentContainer,
+  query: graphql`
+    query NavBarMobileMenuNotificationsIndicator_test_Query
+      @relay_test_operation {
+      me {
+        ...NavBarMobileMenuNotificationsIndicator_me
+      }
+    }
+  `,
+})
+
+describe("NavBarMobileMenuNotificationsIndicator", () => {
+  it("should NOT render indicator by default", () => {
+    renderWithRelay({
+      Me: () => ({
+        unreadConversationCount: 0,
+        unreadNotificationsCount: 0,
+      }),
+    })
+
+    const indicator = screen.queryByLabelText("Unread notifications indicator")
+    expect(indicator).not.toBeInTheDocument()
+  })
+
+  it("should render indicator when there are unread conversations", () => {
+    renderWithRelay({
+      Me: () => ({
+        unreadConversationCount: 5,
+        unreadNotificationsCount: 0,
+      }),
+    })
+
+    const indicator = screen.getByLabelText("Unread notifications indicator")
+    expect(indicator).toBeInTheDocument()
+  })
+
+  it("should render indicator when there are unread notifications", () => {
+    renderWithRelay({
+      Me: () => ({
+        unreadConversationCount: 0,
+        unreadNotificationsCount: 5,
+      }),
+    })
+
+    const indicator = screen.getByLabelText("Unread notifications indicator")
+    expect(indicator).toBeInTheDocument()
+  })
+})

--- a/src/Components/NavBar/NavBarNotificationIndicator.tsx
+++ b/src/Components/NavBar/NavBarNotificationIndicator.tsx
@@ -1,0 +1,14 @@
+import { Box } from "@artsy/palette"
+import { themeGet } from "@styled-system/theme-get"
+import styled from "styled-components"
+
+export const NavBarNotificationIndicator = styled(Box)`
+  width: 4px;
+  height: 4px;
+  background-color: ${themeGet("colors.brand")};
+  border-radius: 50%;
+`
+
+NavBarNotificationIndicator.defaultProps = {
+  "aria-label": "Unread notifications indicator",
+}

--- a/src/Components/NavBar/helpers.ts
+++ b/src/Components/NavBar/helpers.ts
@@ -2,8 +2,8 @@ import cookie from "cookies-js"
 import { isServer } from "Server/isServer"
 
 interface Counts {
-  conversations: number | undefined
-  notifications: number | undefined
+  conversations?: number
+  notifications?: number
 }
 
 export const getNotificationCount = () =>

--- a/src/Components/NavBar/helpers.ts
+++ b/src/Components/NavBar/helpers.ts
@@ -1,6 +1,11 @@
 import cookie from "cookies-js"
 import { isServer } from "Server/isServer"
 
+interface Counts {
+  conversations: number | undefined
+  notifications: number | undefined
+}
+
 export const getNotificationCount = () =>
   (!isServer && cookie.get("notification-count")) || 0
 
@@ -20,5 +25,25 @@ export const updateConversationCache = (conversationCount?: number) => {
     conversationCount === 0
       ? cookie.expire("conversation-count")
       : cookie.set("conversation-count", conversationCount)
+  }
+}
+
+export const checkAndSyncIndicatorsCount = (counts: Counts) => {
+  const { conversations, notifications } = counts
+  const conversationCount = conversations ?? getConversationCount()
+  const notificationsCount = notifications ?? getNotificationCount()
+  const hasConversations = conversationCount > 0
+  const hasNotifications = notificationsCount > 0
+
+  updateConversationCache(conversations)
+  updateNotificationCache(notifications)
+
+  return {
+    hasConversations,
+    hasNotifications,
+    counts: {
+      conversations: conversationCount,
+      notifications: notificationsCount,
+    },
   }
 }

--- a/src/__generated__/NavBarMobileMenuNotificationsIndicatorQuery.graphql.ts
+++ b/src/__generated__/NavBarMobileMenuNotificationsIndicatorQuery.graphql.ts
@@ -1,0 +1,111 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type NavBarMobileMenuNotificationsIndicatorQueryVariables = {};
+export type NavBarMobileMenuNotificationsIndicatorQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"NavBarMobileMenuNotificationsIndicator_me">;
+    } | null;
+};
+export type NavBarMobileMenuNotificationsIndicatorQuery = {
+    readonly response: NavBarMobileMenuNotificationsIndicatorQueryResponse;
+    readonly variables: NavBarMobileMenuNotificationsIndicatorQueryVariables;
+};
+
+
+
+/*
+query NavBarMobileMenuNotificationsIndicatorQuery {
+  me {
+    ...NavBarMobileMenuNotificationsIndicator_me
+    id
+  }
+}
+
+fragment NavBarMobileMenuNotificationsIndicator_me on Me {
+  unreadConversationCount
+  unreadNotificationsCount
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NavBarMobileMenuNotificationsIndicatorQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "NavBarMobileMenuNotificationsIndicator_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "NavBarMobileMenuNotificationsIndicatorQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "unreadConversationCount",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "unreadNotificationsCount",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "fcad35569728dba5274eae66eabbcd8d",
+    "id": null,
+    "metadata": {},
+    "name": "NavBarMobileMenuNotificationsIndicatorQuery",
+    "operationKind": "query",
+    "text": "query NavBarMobileMenuNotificationsIndicatorQuery {\n  me {\n    ...NavBarMobileMenuNotificationsIndicator_me\n    id\n  }\n}\n\nfragment NavBarMobileMenuNotificationsIndicator_me on Me {\n  unreadConversationCount\n  unreadNotificationsCount\n}\n"
+  }
+};
+(node as any).hash = '75cfde809b93933d8d91d345599013f7';
+export default node;

--- a/src/__generated__/NavBarMobileMenuNotificationsIndicator_me.graphql.ts
+++ b/src/__generated__/NavBarMobileMenuNotificationsIndicator_me.graphql.ts
@@ -1,0 +1,45 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type NavBarMobileMenuNotificationsIndicator_me = {
+    readonly unreadConversationCount: number;
+    readonly unreadNotificationsCount: number;
+    readonly " $refType": "NavBarMobileMenuNotificationsIndicator_me";
+};
+export type NavBarMobileMenuNotificationsIndicator_me$data = NavBarMobileMenuNotificationsIndicator_me;
+export type NavBarMobileMenuNotificationsIndicator_me$key = {
+    readonly " $data"?: NavBarMobileMenuNotificationsIndicator_me$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"NavBarMobileMenuNotificationsIndicator_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "NavBarMobileMenuNotificationsIndicator_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "unreadConversationCount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "unreadNotificationsCount",
+      "storageKey": null
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+(node as any).hash = '8bfb3627d6825178d58a6ad8c2836d2d';
+export default node;

--- a/src/__generated__/NavBarMobileMenuNotificationsIndicator_test_Query.graphql.ts
+++ b/src/__generated__/NavBarMobileMenuNotificationsIndicator_test_Query.graphql.ts
@@ -1,0 +1,136 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type NavBarMobileMenuNotificationsIndicator_test_QueryVariables = {};
+export type NavBarMobileMenuNotificationsIndicator_test_QueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"NavBarMobileMenuNotificationsIndicator_me">;
+    } | null;
+};
+export type NavBarMobileMenuNotificationsIndicator_test_Query = {
+    readonly response: NavBarMobileMenuNotificationsIndicator_test_QueryResponse;
+    readonly variables: NavBarMobileMenuNotificationsIndicator_test_QueryVariables;
+};
+
+
+
+/*
+query NavBarMobileMenuNotificationsIndicator_test_Query {
+  me {
+    ...NavBarMobileMenuNotificationsIndicator_me
+    id
+  }
+}
+
+fragment NavBarMobileMenuNotificationsIndicator_me on Me {
+  unreadConversationCount
+  unreadNotificationsCount
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NavBarMobileMenuNotificationsIndicator_test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "NavBarMobileMenuNotificationsIndicator_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "NavBarMobileMenuNotificationsIndicator_test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "unreadConversationCount",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "unreadNotificationsCount",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "37ccc0b48e759e445c0c355569c560bd",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.id": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "ID"
+        },
+        "me.unreadConversationCount": (v0/*: any*/),
+        "me.unreadNotificationsCount": (v0/*: any*/)
+      }
+    },
+    "name": "NavBarMobileMenuNotificationsIndicator_test_Query",
+    "operationKind": "query",
+    "text": "query NavBarMobileMenuNotificationsIndicator_test_Query {\n  me {\n    ...NavBarMobileMenuNotificationsIndicator_me\n    id\n  }\n}\n\nfragment NavBarMobileMenuNotificationsIndicator_me on Me {\n  unreadConversationCount\n  unreadNotificationsCount\n}\n"
+  }
+};
+})();
+(node as any).hash = '26ec2da0ab6233adec36923fad6a1536';
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

This PR solves [FX-4201]

[Figma link](https://www.figma.com/file/SlzmAJV6zqJDmAO8GoSjiC/Activity-%2F-Save-%2F-Follow-%2F-Create?node-id=1336%3A81444)

Review app: https://add-blue-dot-indicator.artsy.net/

### Acceptance criteria
* Add a blue dot on the hamburger menu icon if user has unread notifications (ignore Inbox for now)
* Add blue dot on Activity link if user has unread notifications
* Use the same query which is used on Desktop

### Demo
| Menu | Activity item |
| ------------- | ------------- |
| <img width="344" alt="demo-1" src="https://user-images.githubusercontent.com/3513494/188670728-89e753fe-b794-4ece-ab3d-f6eacfab7e0e.png"> | <img width="344" alt="demo-2" src="https://user-images.githubusercontent.com/3513494/188670765-a5b95941-9680-4043-9a19-3528ad71d023.png"> |

<!-- Implementation description -->


[FX-4201]: https://artsyproduct.atlassian.net/browse/FX-4201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ