### PR TITLE
fix: fix admin/clear-cache route

### DIFF
--- a/src/Apps/Admin/adminRoutes.tsx
+++ b/src/Apps/Admin/adminRoutes.tsx
@@ -1,6 +1,7 @@
 import loadable from "@loadable/component"
 import { HttpError } from "found"
 import { AppRouteConfig } from "System/Router/Route"
+import { getUser } from "Utils/user"
 
 const AdminClearCacheApp = loadable(
   () => import(/* webpackChunkName: "adminBundle" */ "./AdminClearCacheApp"),
@@ -16,7 +17,8 @@ export const adminRoutes: AppRouteConfig[] = [
         path: "clear-cache",
         Component: AdminClearCacheApp,
         onServerSideRender: ({ req }) => {
-          if (req.user?.get("type") !== "Admin") {
+          const user = getUser(req.user)
+          if (user?.type !== "Admin") {
             throw new HttpError(403)
           }
         },

--- a/src/Apps/Admin/adminServerRoutes.tsx
+++ b/src/Apps/Admin/adminServerRoutes.tsx
@@ -1,11 +1,14 @@
 import { Router } from "express"
 import { cache } from "Server/cache"
 import { ArtsyRequest } from "Server/middleware/artsyExpress"
+import { getUser } from "Utils/user"
 
 const adminServerRoutes = Router()
 
 adminServerRoutes.post("/admin/clear-cache", (req: ArtsyRequest, res) => {
-  if (req.user?.get("type") !== "Admin") {
+  const user = getUser(req.user)
+
+  if (user?.type !== "Admin") {
     res.status(403).send({
       status: 403,
       message: "You must be logged in as an admin to clear the cache.",


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

While [investigating](https://artsy.slack.com/archives/CCS8TMQ0K/p1662478073254789) a shortcut that had been updated and is seemingly very cached, discovered that the `/admin/clear-cache` route & functionality was broken. 

This fixed it when running locally, though I will freely admit that I'm not sure if it's the "correct" way to fetch a user in Force nowadays. LMK if I goofed!


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ