### PR TITLE
feat(FX-4196): render empty states for activity panel

### DIFF
--- a/src/Components/Notifications/Notifications.tsx
+++ b/src/Components/Notifications/Notifications.tsx
@@ -1,9 +1,7 @@
 import { Tab } from "@artsy/palette"
-import {
-  NotificationPaginationType,
-  NotificationsListQueryRenderer,
-} from "./NotificationsList"
 import { NofiticationsTabs, NofiticationsTabsProps } from "./NotificationsTabs"
+import { NotificationsListQueryRenderer } from "./NotificationsList"
+import { NotificationPaginationType } from "./types"
 
 interface NotificationsProps extends NofiticationsTabsProps {
   paginationType?: NotificationPaginationType

--- a/src/Components/Notifications/NotificationsEmptyStateByType.tsx
+++ b/src/Components/Notifications/NotificationsEmptyStateByType.tsx
@@ -30,7 +30,7 @@ export const NotificationsEmptyStateByType: React.FC<NotificationsEmptyStateByTy
   const state = emptyStateByType[type]
 
   return (
-    <Box aria-label="There is nothing to show">
+    <Box p={2} aria-label="There is nothing to show">
       <Text variant="sm-display" textAlign="center">
         {state.title}
       </Text>

--- a/src/Components/Notifications/NotificationsEmptyStateByType.tsx
+++ b/src/Components/Notifications/NotificationsEmptyStateByType.tsx
@@ -1,0 +1,43 @@
+import { Box, Spacer, Text } from "@artsy/palette"
+import { NotificationType } from "./types"
+
+interface NotificationsEmptyStateByTypeProps {
+  type: NotificationType
+}
+
+const emptyStateByType: Record<
+  NotificationType,
+  {
+    title: string
+    message: string
+  }
+> = {
+  all: {
+    title: "You haven't followed any artists, galleries or fairs yet.",
+    message:
+      "Follow artists to keep track of their latest work and career highlights. Following artists helps Artsy to recommend works you might like.",
+  },
+  alerts: {
+    title: "You haven't created any Alerts yet.",
+    message:
+      "Filter for the artworks you love on an Artist Page and tap 'Create Alert' to be notified when new works are added to Artsy.",
+  },
+}
+
+export const NotificationsEmptyStateByType: React.FC<NotificationsEmptyStateByTypeProps> = ({
+  type,
+}) => {
+  const state = emptyStateByType[type]
+
+  return (
+    <Box aria-label="There is nothing to show">
+      <Text variant="sm-display" textAlign="center">
+        {state.title}
+      </Text>
+      <Spacer mt={2} />
+      <Text variant="xs" color="black60" textAlign="center">
+        {state.message}
+      </Text>
+    </Box>
+  )
+}

--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -15,19 +15,23 @@ import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { useContext, useState } from "react"
 import { SystemContext } from "System"
 import { NotificationsListScrollSentinel } from "./NotificationsListScrollSentinel"
+import { NotificationPaginationType, NotificationType } from "./types"
+import { NotificationsEmptyStateByType } from "./NotificationsEmptyStateByType"
 
-export type NotificationType = "all" | "alerts"
-export type NotificationPaginationType = "showMoreButton" | "infinite"
+interface NotificationsListQueryRendererProps {
+  type: NotificationType
+  paginationType?: NotificationPaginationType
+}
 
-interface NotificationsListProps {
+interface NotificationsListProps extends NotificationsListQueryRendererProps {
   viewer: NotificationsList_viewer
   relay: RelayPaginationProp
-  paginationType?: NotificationPaginationType
 }
 
 const NotificationsList: React.FC<NotificationsListProps> = ({
   viewer,
   relay,
+  type,
   paginationType = "showMoreButton",
 }) => {
   const [loading, setLoading] = useState(false)
@@ -62,6 +66,10 @@ const NotificationsList: React.FC<NotificationsListProps> = ({
         </Button>
       </Box>
     )
+  }
+
+  if (nodes.length === 0) {
+    return <NotificationsEmptyStateByType type={type} />
   }
 
   return (
@@ -136,11 +144,6 @@ export const NotificationsListFragmentContainer = createPaginationContainer(
   }
 )
 
-interface NotificationsListQueryRendererProps {
-  type: NotificationType
-  paginationType?: NotificationPaginationType
-}
-
 export const NotificationsListQueryRenderer: React.FC<NotificationsListQueryRendererProps> = ({
   type,
   paginationType,
@@ -185,6 +188,7 @@ export const NotificationsListQueryRenderer: React.FC<NotificationsListQueryRend
           <NotificationsListFragmentContainer
             viewer={props.viewer}
             paginationType={paginationType}
+            type={type}
           />
         )
       }}

--- a/src/Components/Notifications/__tests__/NotificationsEmptyStateByType.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationsEmptyStateByType.jest.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react"
+import { NotificationsEmptyStateByType } from "../NotificationsEmptyStateByType"
+
+describe("NotificationsEmptyStateByType", () => {
+  it("should render correct state when type is 'All'", () => {
+    render(<NotificationsEmptyStateByType type="all" />)
+
+    const title = "You haven't followed any artists, galleries or fairs yet."
+    const message =
+      "Follow artists to keep track of their latest work and career highlights. Following artists helps Artsy to recommend works you might like."
+
+    expect(screen.getByText(title)).toBeInTheDocument()
+    expect(screen.getByText(message)).toBeInTheDocument()
+  })
+
+  it("should render correct state when type is 'Alerts'", () => {
+    render(<NotificationsEmptyStateByType type="alerts" />)
+
+    const title = "You haven't created any Alerts yet."
+    const message =
+      "Filter for the artworks you love on an Artist Page and tap 'Create Alert' to be notified when new works are added to Artsy."
+
+    expect(screen.getByText(title)).toBeInTheDocument()
+    expect(screen.getByText(message)).toBeInTheDocument()
+  })
+})

--- a/src/Components/Notifications/__tests__/NotificationsList.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationsList.jest.tsx
@@ -7,7 +7,15 @@ import { NotificationsList_test_Query } from "__generated__/NotificationsList_te
 jest.unmock("react-relay")
 
 const { renderWithRelay } = setupTestWrapperTL<NotificationsList_test_Query>({
-  Component: NotificationsListFragmentContainer,
+  Component: props => {
+    if (props.viewer) {
+      return (
+        <NotificationsListFragmentContainer type="all" viewer={props.viewer} />
+      )
+    }
+
+    return null
+  },
   query: graphql`
     query NotificationsList_test_Query @relay_test_operation {
       viewer {
@@ -26,6 +34,17 @@ describe("NotificationsList", () => {
     expect(screen.getByText("Notification One")).toBeInTheDocument()
     expect(screen.getByText("Notification Two")).toBeInTheDocument()
     expect(screen.getByText("Notification Three")).toBeInTheDocument()
+  })
+
+  it("should render empty state when there is nothing to show", () => {
+    renderWithRelay({
+      NotificationConnection: () => ({
+        edges: [],
+      }),
+    })
+
+    const element = screen.getByLabelText("There is nothing to show")
+    expect(element).toBeInTheDocument()
   })
 })
 

--- a/src/Components/Notifications/types.ts
+++ b/src/Components/Notifications/types.ts
@@ -1,0 +1,2 @@
+export type NotificationType = "all" | "alerts"
+export type NotificationPaginationType = "showMoreButton" | "infinite"


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [FX-4196]

Review app: [activity-panel-empty-states](https://activity-panel-empty-states.artsy.net/)

### Demo Dropdown
| All tab | Alerts tab |
| ------------- | ------------- |
| <img width="513" alt="demo-1" src="https://user-images.githubusercontent.com/3513494/188926318-774b5d4d-184f-4c7e-a0de-a5313df4d2ce.png"> | <img width="513" alt="demo-2" src="https://user-images.githubusercontent.com/3513494/188926352-4256ab7f-65e5-42dd-82e8-a01a119aae2a.png"> |

https://user-images.githubusercontent.com/3513494/188931252-91d3ea16-1438-458a-ba67-bda9e287033a.mp4

### Demo Standalone
| All tab | Alerts tab |
| ------------- | ------------- |
| <img width="342" alt="demo-3" src="https://user-images.githubusercontent.com/3513494/188926609-a8005557-ef4c-439c-9cd4-c2bcb73d5ba9.png"> | <img width="342" alt="demo-4" src="https://user-images.githubusercontent.com/3513494/188926636-596185dc-78fe-4c0e-b449-8363568c0dec.png"> |

<!-- Implementation description -->


[FX-4196]: https://artsyproduct.atlassian.net/browse/FX-4196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ