### PR TITLE
feat: update styles of order statuses

### DIFF
--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -37,9 +37,9 @@ const ORDER_LABELS = {
 } as const
 
 const ORDER_ICONS = {
-  APPROVED: <PendingCircleIcon fill="black60" />,
+  APPROVED: <PendingCircleIcon fill="black100" />,
   CANCELED: <XCircleIcon fill="red100" />,
-  FULFILLED: <CheckCircleFillIcon />,
+  FULFILLED: <CheckCircleFillIcon fill="green100" />,
   IN_TRANSIT: <PendingCircleIcon fill="black60" />,
   PROCESSING: <PendingCircleIcon fill="black60" />,
   REFUNDED: <XCircleIcon fill="red100" />,
@@ -48,10 +48,10 @@ const ORDER_ICONS = {
 } as const
 
 const ORDER_COLORS = {
-  APPROVED: "black60",
+  APPROVED: "black100",
   CANCELED: "red100",
-  FULFILLED: "black100",
-  IN_TRANSIT: "black100",
+  FULFILLED: "green100",
+  IN_TRANSIT: "black60",
   PROCESSING: "black60",
   REFUNDED: "red100",
   SUBMITTED: "black60",
@@ -102,7 +102,11 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
         <Flex alignItems="center">
           {ORDER_ICONS[order.displayState]}
 
-          <Text ml={0.5} variant="xs" color={ORDER_COLORS[order.displayState]}>
+          <Text
+            ml={0.5}
+            variant="sm-display"
+            color={ORDER_COLORS[order.displayState]}
+          >
             {ORDER_LABELS[order.displayState]}
           </Text>
 


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-637]

### Description

This PR updates the styles of the order statuses on the order history page.

![Screenshot from 2022-09-07 15-18-59](https://user-images.githubusercontent.com/79979820/188877694-574427be-682b-4006-a4e1-714a2a003ff0.png)
![Screenshot from 2022-09-07 15-14-09](https://user-images.githubusercontent.com/79979820/188877698-beda2162-f628-46df-b416-f3422646b58c.png)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-637]: https://artsyproduct.atlassian.net/browse/TX-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ