### PR TITLE
feat(TX-611): Allow unsaved SEPA account to be re-used during checkout 

### DIFF
--- a/src/Apps/Order/Components/BankAccountPicker.tsx
+++ b/src/Apps/Order/Components/BankAccountPicker.tsx
@@ -49,8 +49,8 @@ export const BankAccountPicker: FC<Props> = props => {
     onSetClientSecret,
     clientSecret,
   } = props
-
-  const bankAccountsArray: BankAccountRecord[] = extractNodes(bankAccounts)
+  const bankAccountsArray: BankAccountRecord[] =
+    paymentMethod === "US_BANK_ACCOUNT" ? extractNodes(bankAccounts) : []
 
   if (order?.paymentMethodDetails?.internalID) {
     // if account on order is not saved on user's profile
@@ -76,7 +76,7 @@ export const BankAccountPicker: FC<Props> = props => {
           variables: {
             input: {
               id: order.internalID,
-              paymentMethod: "US_BANK_ACCOUNT",
+              paymentMethod,
               paymentMethodId: bankAccountSelection.id,
             },
           },

--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -32,7 +32,6 @@ import {
 } from "Apps/Order/Components/CreditCardPicker"
 import { BankAccountPickerFragmentContainer } from "Apps/Order/Components/BankAccountPicker"
 import { SaveAndContinueButton } from "Apps/Order/Components/SaveAndContinueButton"
-import { BankDebitProvider } from "Components/BankDebitForm/BankDebitProvider"
 
 export interface Props {
   order: Payment_order
@@ -151,39 +150,48 @@ export const PaymentContent: FC<Props> = props => {
       <Collapse open={paymentMethod === "US_BANK_ACCOUNT"}>
         {getPaymentMethodInfo(paymentMethod)}
         <Spacer mb={2} />
-        <BankAccountPickerFragmentContainer
-          me={me}
-          order={order}
-          paymentMethod="US_BANK_ACCOUNT"
-          bankAccountHasInsufficientFunds={bankAccountHasInsufficientFunds}
-          onSetBankAccountHasInsufficientFunds={
-            onSetBankAccountHasInsufficientFunds
-          }
-          onSetIsSavingPayment={onSetIsSavingPayment}
-          onSetBalanceCheckComplete={onSetBalanceCheckComplete}
-          onSetSelectedBankAccountId={onSetSelectedBankAccountId}
-          bankAccountSelection={bankAccountSelection}
-          onSetBankAccountSelection={onSetBankAccountSelection}
-          clientSecret={clientSecret}
-          onSetClientSecret={setClientSecret}
-        />
+        {paymentMethod === "US_BANK_ACCOUNT" && (
+          <BankAccountPickerFragmentContainer
+            me={me}
+            order={order}
+            paymentMethod="US_BANK_ACCOUNT"
+            bankAccountHasInsufficientFunds={bankAccountHasInsufficientFunds}
+            onSetBankAccountHasInsufficientFunds={
+              onSetBankAccountHasInsufficientFunds
+            }
+            onSetIsSavingPayment={onSetIsSavingPayment}
+            onSetBalanceCheckComplete={onSetBalanceCheckComplete}
+            onSetSelectedBankAccountId={onSetSelectedBankAccountId}
+            bankAccountSelection={bankAccountSelection}
+            onSetBankAccountSelection={onSetBankAccountSelection}
+            clientSecret={clientSecret}
+            onSetClientSecret={setClientSecret}
+          />
+        )}
       </Collapse>
 
       {/* SEPA bank transfer */}
       <Collapse open={paymentMethod === "SEPA_DEBIT"}>
         {getPaymentMethodInfo(paymentMethod)}
         <Spacer mb={2} />
-        <BankDebitProvider
-          order={order}
-          paymentMethod="SEPA_DEBIT"
-          bankAccountHasInsufficientFunds={bankAccountHasInsufficientFunds}
-          onSetBankAccountHasInsufficientFunds={
-            onSetBankAccountHasInsufficientFunds
-          }
-          onSetIsSavingPayment={onSetIsSavingPayment}
-          clientSecret={clientSecret}
-          onSetClientSecret={setClientSecret}
-        />
+        {paymentMethod === "SEPA_DEBIT" && (
+          <BankAccountPickerFragmentContainer
+            me={me}
+            order={order}
+            paymentMethod="SEPA_DEBIT"
+            bankAccountHasInsufficientFunds={bankAccountHasInsufficientFunds}
+            onSetBankAccountHasInsufficientFunds={
+              onSetBankAccountHasInsufficientFunds
+            }
+            onSetIsSavingPayment={onSetIsSavingPayment}
+            onSetBalanceCheckComplete={onSetBalanceCheckComplete}
+            onSetSelectedBankAccountId={onSetSelectedBankAccountId}
+            bankAccountSelection={bankAccountSelection}
+            onSetBankAccountSelection={onSetBankAccountSelection}
+            clientSecret={clientSecret}
+            onSetClientSecret={setClientSecret}
+          />
+        )}
       </Collapse>
 
       {/* Wire transfer */}

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -114,8 +114,11 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
   // an existing bank account's ID, used to query account balance
   const [selectedBankAccountId, setSelectedBankAccountId] = useState("")
 
-  // user's existing bank accounts, if any
-  const bankAccountsArray = extractNodes(me.bankAccounts)
+  // user's existing ACH bank accounts, if any
+  const bankAccountsArray =
+    selectedPaymentMethod === "US_BANK_ACCOUNT"
+      ? extractNodes(me.bankAccounts)
+      : []
 
   const getInitialBankAccountSelection = (): BankAccountSelection => {
     if (order.bankAccountId) {

--- a/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -322,10 +322,6 @@ describe("Payment", () => {
         .find(CreditCardPickerFragmentContainer)
         .closest(Collapse)
       expect(creditCardCollapse.first().props().open).toBe(true)
-      const bankDebitCollapse = page
-        .find(BankAccountPickerFragmentContainer)
-        .closest(Collapse)
-      expect(bankDebitCollapse.first().props().open).toBe(false)
     })
 
     it("renders bank element when bank transfer is chosen as payment method", async () => {


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [TX-611]

### Description
This PR allows buyers in EUR to re-use their unsaved SEPA bank account when they come back to the payment step in the checkout flow. 

https://user-images.githubusercontent.com/42584148/189081572-ee8b1e86-fca6-42de-a1d9-87cd82343d86.mov


[TX-611]: https://artsyproduct.atlassian.net/browse/TX-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ