### PR TITLE
fix: Block text injection on settings page GRO-1172

### DIFF
--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
@@ -24,6 +24,8 @@ interface SettingsEditSettingsLinkedAccountsProps {
   me: SettingsEditSettingsLinkedAccounts_me
 }
 
+const providerNames = ["Apple", "Facebook", "Google"]
+
 export const SettingsEditSettingsLinkedAccounts: FC<SettingsEditSettingsLinkedAccountsProps> = ({
   me,
 }) => {
@@ -31,20 +33,26 @@ export const SettingsEditSettingsLinkedAccounts: FC<SettingsEditSettingsLinkedAc
   const { sendToast } = useToasts()
 
   const authenticationPaths = getENV("AP")
-
-  // Errors from authentication providers are handled by routing back to
-  // this page with an `error` query string.
   const query = match?.location?.query ?? {}
 
   useEffect(() => {
-    if (query.error) {
-      sendToast({
-        variant: "error",
-        message: query.error,
-        ttl: Infinity,
-      })
+    if (query.error === "already-linked") {
+      const providerName = query.provider
+
+      if (providerNames.includes(providerName)) {
+        const message =
+          `${providerName} account already linked to another Artsy account. ` +
+          `Try logging out and back in with ${providerName}. Then consider ` +
+          `deleting that user account and re-linking ${providerName}. `
+
+        sendToast({
+          variant: "error",
+          message,
+          ttl: Infinity,
+        })
+      }
     }
-  }, [query.error, sendToast])
+  }, [query.error, query.provider, sendToast])
 
   return (
     <>

--- a/src/Server/passport/lib/app/lifecycle.js
+++ b/src/Server/passport/lib/app/lifecycle.js
@@ -156,11 +156,8 @@ module.exports.afterSocialAuth = provider =>
         err.response.body &&
         err.response.body.error === "Another Account Already Linked"
       ) {
-        msg =
-          `${providerName} account already linked to another Artsy account. ` +
-          `Try logging out and back in with ${providerName}. Then consider ` +
-          `deleting that user account and re-linking ${providerName}. `
-        return res.redirect(opts.settingsPagePath + "?error=" + msg)
+        alreadyLinkedParams = `?error=already-linked&provider=${providerName}`
+        return res.redirect(opts.settingsPagePath + alreadyLinkedParams)
       } else if (
         err &&
         err.message &&


### PR DESCRIPTION
This PR adds a layer of text injection protection that we were lacking. It updates two sides of a handshake so that a bad actor can't populate our error toast via the URL. Here's an example of the intended usage:

<img width="1289" alt="Screen Shot 2022-09-08 at 3 19 54 PM" src="https://user-images.githubusercontent.com/79799/189218219-71cc0294-499c-44af-9c52-de852ace8222.png">

Examples of abuses:

```
http://localhost:4000/settings/edit-settings?error=Please%20contact%20support%20at%20bad-actor@example.com
http://localhost:4000/settings/edit-settings?error=already-linked&provider=Please%20contact%20bad-actor@example.com
http://localhost:4000/settings/edit-settings?error=already-linked&provider=Google%20Please%20contact%20bad-actor@example.com
```

I have verified each of these does nothing with this new blocking approach. 👍 

Shout out to @joeyAghion for helping me see that this was an easy way to solve the problem! 🤗 

https://artsyproduct.atlassian.net/browse/GRO-1172

/cc @artsy/grow-devs