### PR TITLE
chore: add ErrorBoundary to the setupTestWrapper

### DIFF
--- a/src/DevTools/setupTestWrapper.tsx
+++ b/src/DevTools/setupTestWrapper.tsx
@@ -158,7 +158,11 @@ export const setupTestWrapper = <T extends OperationType>({
       />
     )
 
-    const wrapper = mount(<TestRenderer />)
+    const wrapper = mount(
+      <ErrorBoundary>
+        <TestRenderer />
+      </ErrorBoundary>
+    )
 
     env.mock.resolveMostRecentOperation(operation => {
       return MockPayloadGenerator.generate(operation, mockResolvers)
@@ -170,4 +174,16 @@ export const setupTestWrapper = <T extends OperationType>({
   }
 
   return { getWrapper }
+}
+
+class ErrorBoundary extends React.Component {
+  componentDidCatch(error) {
+    // Print an error to the console for a better debugging experience
+    console.log("Something went wrong while rendering a component")
+    console.log(error)
+  }
+
+  render() {
+    return this.props.children
+  }
 }


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-]

### Description

<!-- Implementation description -->
@MounirDhahri @MrSltun and I have added an `ErrorBoundary` class that prints an error message telling what went wrong if a test fails
**Before** logs:
![IMAGE 2022-09-09 03:28:43](https://user-images.githubusercontent.com/36167539/189253121-f6f639c5-3a18-4770-954e-d7f31119d434.jpg)
**After** logs:
![IMAGE 2022-09-09 03:32:04](https://user-images.githubusercontent.com/36167539/189253551-2f468654-67cf-470c-a966-d1c56d5ec42c.jpg)
![IMAGE 2022-09-09 03:29:09](https://user-images.githubusercontent.com/36167539/189253157-69732716-af45-462b-8bea-2d9ee5fa7608.jpg)


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ