### PR TITLE
chore: remove COVID-19 message from review step of checkout flow

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Join, Message, Spacer } from "@artsy/palette"
+import { Box, Button, Flex, Join, Spacer } from "@artsy/palette"
 import { Review_order } from "__generated__/Review_order.graphql"
 import { ReviewSubmitOfferOrderWithConversationMutation } from "__generated__/ReviewSubmitOfferOrderWithConversationMutation.graphql"
 import { ReviewSubmitOrderMutation } from "__generated__/ReviewSubmitOrderMutation.graphql"
@@ -385,10 +385,6 @@ export const ReviewRoute: FC<ReviewProps> = props => {
         content={
           <Join separator={<Spacer mb={4} />}>
             <Flex flexDirection="column" mb={[2, 4]}>
-              <Message mb={[2, 4]}>
-                Disruptions caused by COVID-19 may cause delays — we appreciate
-                your understanding.
-              </Message>
               {isEigen && (
                 <>
                   <SubmitButton />


### PR DESCRIPTION
This PR removes the first of two COVID-19 messages that is displayed to collectors when they place a BNMO order. This message informs users that response times may be impacted by COVID-19, and is displayed on both the review step and the confirmation page.

We are removing this message from the review step to free up real estate for the submit button that can be hidden below the fold for some collectors.

Review step:

<img width="960" alt="Screen Shot 2022-09-08 at 11 15 37 PM" src="https://user-images.githubusercontent.com/44589599/189264832-9ae1b9cf-c392-4ae2-9666-65c4bffa6592.png">

Confirmation page:

<img width="959" alt="Screen Shot 2022-09-08 at 11 14 37 PM" src="https://user-images.githubusercontent.com/44589599/189264818-c024dc54-ff4d-4630-98c6-0a6b382d3d74.png">