### PR TITLE
feat: unlock parent scroll when activity panel menu is closed

### DIFF
--- a/src/Components/NavBar/Menus/NavBarNewNotifications.tsx
+++ b/src/Components/NavBar/Menus/NavBarNewNotifications.tsx
@@ -1,9 +1,20 @@
 import { Box } from "@artsy/palette"
 import { Notifications } from "Components/Notifications/Notifications"
+import { useEffect } from "react"
 import { useScrollLock } from "Utils/Hooks/useScrollLock"
 
 export const NavBarNewNotifications = () => {
   const { lockScroll, unlockScroll } = useScrollLock()
+
+  useEffect(() => {
+    return () => {
+      /**
+       * unlock parent scroll when component unmounted
+       * for example, when the user clicked on the notification and the dropdown menu was closed
+       */
+      unlockScroll()
+    }
+  }, [unlockScroll])
 
   return (
     <Box


### PR DESCRIPTION
The type of this PR is: **Fix**

Review app: [unlock-parent-scroll](https://unlock-parent-scroll.artsy.net/)

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/189310246-bc34a271-2ccd-4cd2-a397-202e20b6a39c.mp4

#### After
https://user-images.githubusercontent.com/3513494/189310338-1582b373-72f2-4a23-be64-c021f495c6bc.mp4

<!-- Implementation description -->
