### PR TITLE
feat(FX-4151): Artsy Guarantee section

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
@@ -7,6 +7,7 @@ import { SidebarExpandable } from "Components/Artwork/SidebarExpandable"
 import { useTranslation } from "react-i18next"
 import { ArtworkSidebar2ArtworkTitleFragmentContainer } from "./ArtworkSidebar2ArtworkTitle"
 import { ArtworkSidebar2DetailsFragmentContainer } from "./ArtworkSidebar2Details"
+import { ArtworkSidebar2ArtsyGuarantee } from "./ArtworkSidebar2ArtsyGuarantee"
 
 export interface ArtworkSidebarProps {
   artwork: ArtworkSidebar2_artwork
@@ -41,6 +42,14 @@ export const ArtworkSidebar2: React.FC<ArtworkSidebarProps> = props => {
           </SidebarExpandable>
         </>
       )}
+      <>
+        <Separator />
+        <SidebarExpandable
+          label={t`artworkPage.sidebar.artsyGuarantee.expandableLabel`}
+        >
+          <ArtworkSidebar2ArtsyGuarantee />
+        </SidebarExpandable>
+      </>
     </Flex>
   )
 }

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
@@ -42,14 +42,13 @@ export const ArtworkSidebar2: React.FC<ArtworkSidebarProps> = props => {
           </SidebarExpandable>
         </>
       )}
-      <>
-        <Separator />
-        <SidebarExpandable
-          label={t`artworkPage.sidebar.artsyGuarantee.expandableLabel`}
-        >
-          <ArtworkSidebar2ArtsyGuarantee />
-        </SidebarExpandable>
-      </>
+
+      <Separator />
+      <SidebarExpandable
+        label={t`artworkPage.sidebar.artsyGuarantee.expandableLabel`}
+      >
+        <ArtworkSidebar2ArtsyGuarantee />
+      </SidebarExpandable>
     </Flex>
   )
 }

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2ArtsyGuarantee.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2ArtsyGuarantee.tsx
@@ -26,17 +26,17 @@ export const ArtworkSidebar2ArtsyGuarantee: React.FC<{}> = () => {
           <LockIcon {...iconProps} />
           <Text>{t("artworkPage.sidebar.artsyGuarantee.securePayment")}</Text>
         </Flex>
-        <Spacer mt={10} />
+        <Spacer mt={1} />
         <Flex flexDirection="row" alignItems="center">
           <VerifiedIcon {...iconProps} />
           <Text>{t("artworkPage.sidebar.artsyGuarantee.moneyBack")}</Text>
         </Flex>
-        <Spacer mt={10} />
+        <Spacer mt={1} />
         <Flex flexDirection="row" alignItems="center">
           <CertificateIcon {...iconProps} />
           <Text>{t("artworkPage.sidebar.artsyGuarantee.authenticity")}</Text>
         </Flex>
-        <Spacer mt={10} />
+        <Spacer mt={1} />
       </Text>
       <RouterLink
         to={"/buyer-guarantee"}

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2ArtsyGuarantee.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2ArtsyGuarantee.tsx
@@ -1,0 +1,52 @@
+import {
+  CertificateIcon,
+  Flex,
+  IconProps,
+  LockIcon,
+  Spacer,
+  Text,
+  VerifiedIcon,
+} from "@artsy/palette"
+import { useTranslation } from "react-i18next"
+import { RouterLink } from "System/Router/RouterLink"
+
+export const ArtworkSidebar2ArtsyGuarantee: React.FC<{}> = () => {
+  const { t } = useTranslation()
+
+  const iconProps: IconProps = {
+    height: 24,
+    width: 24,
+    mr: 1,
+  }
+
+  return (
+    <>
+      <Text variant="sm" color="black60">
+        <Flex flexDirection="row" alignItems="center">
+          <LockIcon {...iconProps} />
+          <Text>{t("artworkPage.sidebar.artsyGuarantee.securePayment")}</Text>
+        </Flex>
+        <Spacer mt={10} />
+        <Flex flexDirection="row" alignItems="center">
+          <VerifiedIcon {...iconProps} />
+          <Text>{t("artworkPage.sidebar.artsyGuarantee.moneyBack")}</Text>
+        </Flex>
+        <Spacer mt={10} />
+        <Flex flexDirection="row" alignItems="center">
+          <CertificateIcon {...iconProps} />
+          <Text>{t("artworkPage.sidebar.artsyGuarantee.authenticity")}</Text>
+        </Flex>
+        <Spacer mt={10} />
+      </Text>
+      <RouterLink
+        to={"/buyer-guarantee"}
+        textDecoration="underline"
+        display="block"
+      >
+        <Text variant="xs" color="black60">
+          {t("artworkPage.sidebar.artsyGuarantee.learnMore")}
+        </Text>
+      </RouterLink>
+    </>
+  )
+}

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/__tests__/ArtworkSidebar2ArtsyGuarantee.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/__tests__/ArtworkSidebar2ArtsyGuarantee.jest.tsx
@@ -1,0 +1,15 @@
+import { screen } from "@testing-library/react"
+import { ArtworkSidebar2ArtsyGuarantee } from "../ArtworkSidebar2ArtsyGuarantee"
+import { render } from "DevTools/setupTestWrapper"
+
+describe("ArtworkSidebar2ArtsyGuarantee", () => {
+  it("renders the Artsy Guarantee section", async () => {
+    render(<ArtworkSidebar2ArtsyGuarantee />)
+
+    expect(screen.queryByText("Secure Payment")).toBeInTheDocument()
+    expect(screen.queryByText("Money-Back Guarantee")).toBeInTheDocument()
+    expect(screen.queryByText("Authenticity Guarantee")).toBeInTheDocument()
+
+    expect(screen.queryByText("Learn more")).toBeInTheDocument()
+  })
+})

--- a/src/DevTools/setupTestWrapper.tsx
+++ b/src/DevTools/setupTestWrapper.tsx
@@ -17,7 +17,7 @@ const mount = children =>
   enzMount(<I18nextProvider i18n={i18n}>{children}</I18nextProvider>)
 
 // overide render to provide access to i18n inside the setupTestWrapperTL function
-const render = children =>
+export const render = children =>
   rtlRender(<I18nextProvider i18n={i18n}>{children}</I18nextProvider>)
 
 type SetupTestWrapper<T extends OperationType> = {

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -61,6 +61,13 @@
         "taxInformation": "Taxes may apply at checkout.",
         "taxInformationLearnMore": "Learn more",
         "shipsFrom": "Ships from"
+      },
+      "artsyGuarantee": {
+        "expandableLabel": "Be covered by the Artsy Guarantee",
+        "securePayment": "Secure Payment",
+        "moneyBack": "Money-Back Guarantee",
+        "authenticity": "Authenticity Guarantee",
+        "learnMore": "Learn more"
       }
     }
   }


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4151]

### Description

- adds artsy guarantee section
- hidden behind a featureflag
- exports render with i18n provider from setuptestwrapper file

> :warning: Note that the icons are not the latest updated figma icons, need to resolve the questions/feedback on [this palette pr](https://github.com/artsy/palette/pull/1206) in order to use the newer ones

#### Screenshots

|Desktop expanded|Desktop collapsed|
|---|---|
|<img width="1018" alt="Screenshot 2022-09-09 at 12 52 15" src="https://user-images.githubusercontent.com/21178754/189335398-6fe251f0-1bb7-4ba5-8258-0bf519febb9e.png">|<img width="894" alt="Screenshot 2022-09-09 at 12 53 06" src="https://user-images.githubusercontent.com/21178754/189335386-e9d30727-7a0d-416c-9b56-e77246223f50.png">|
|**mweb expanded**|**mweb collapsed**|
|<img width="392" alt="Screenshot 2022-09-09 at 12 52 55" src="https://user-images.githubusercontent.com/21178754/189335596-f1249e4e-26cd-4bf6-adef-e9298d75601b.png">|<img width="401" alt="Screenshot 2022-09-09 at 12 52 59" src="https://user-images.githubusercontent.com/21178754/189335595-b88ae84a-c118-4e23-baea-fcb24964b4c8.png">|

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4151]: https://artsyproduct.atlassian.net/browse/FX-4151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ