### PR TITLE
fix: Suppress fair banner when not full featured fair GRO-1171

### DIFF
--- a/src/Apps/Show/ShowApp.tsx
+++ b/src/Apps/Show/ShowApp.tsx
@@ -53,7 +53,9 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
             contextPageOwnerType,
           }}
         >
-          {isFairBooth && <BackToFairBanner show={show} />}
+          {show.fair?.hasFullFeature && isFairBooth && (
+            <BackToFairBanner show={show} />
+          )}
 
           <Spacer mt={4} />
 

--- a/src/Apps/Show/__tests__/ShowApp.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowApp.jest.tsx
@@ -87,12 +87,24 @@ describe("ShowApp", () => {
     expect(wrapper.find(ShowViewingRoom)).toHaveLength(1)
   })
 
-  it("do not render `Back to Fair` banner by default", () => {
+  it("does not render `Back to Fair` banner by default", () => {
     const wrapper = getWrapper({
       Show: () => ({
         isFairBooth: false,
         name: "Example Show",
-        fair: { name: "Example Fair", href: "example" },
+        fair: { name: "Example Fair", href: "example", hasFullFeature: true },
+      }),
+    })
+
+    expect(wrapper.find("BackToFairBanner").length).toEqual(0)
+  })
+
+  it("does not render `Back to Fair` banner without full featured fair", () => {
+    const wrapper = getWrapper({
+      Show: () => ({
+        isFairBooth: true,
+        name: "Example Show",
+        fair: { name: "Example Fair", href: "example", hasFullFeature: false },
       }),
     })
 
@@ -104,7 +116,7 @@ describe("ShowApp", () => {
       Show: () => ({
         isFairBooth: true,
         name: "Example Show",
-        fair: { name: "Example Fair", href: "example" },
+        fair: { name: "Example Fair", href: "example", hasFullFeature: true },
       }),
     })
 


### PR DESCRIPTION
The criteria to suppress a link back to the fair wasn't strict enough - this PR updates the logic to include a check on the `hasFullFeature` property.

<details>
<summary>Here's some screenshots</summary>

### broken link!
<img width="1160" alt="Screen Shot 2022-09-09 at 11 37 30 AM" src="https://user-images.githubusercontent.com/79799/189399154-54946b8d-2da8-46ec-91e7-52e57b024209.png">

### no broken link!
<img width="1160" alt="Screen Shot 2022-09-09 at 11 37 36 AM" src="https://user-images.githubusercontent.com/79799/189399165-60183e0a-fe07-4026-b6d9-e3de8a96bd93.png">

### working link
<img width="1160" alt="Screen Shot 2022-09-09 at 11 37 44 AM" src="https://user-images.githubusercontent.com/79799/189399169-8a0d09c9-249a-4dd5-bc98-8979ab6f655b.png">

### no change for this one
<img width="1160" alt="Screen Shot 2022-09-09 at 11 37 40 AM" src="https://user-images.githubusercontent.com/79799/189399167-a217204b-959e-430f-8ce7-1ae838d84698.png">

</details>

https://artsyproduct.atlassian.net/browse/GRO-1171

/cc @artsy/grow-devs