### PR TITLE
feat(CX-2885): Add Insights header

### DIFF
--- a/src/Apps/Settings/Routes/Insights/Components/InsightsHeader.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsHeader.tsx
@@ -1,0 +1,64 @@
+import { Box, Button, DROP_SHADOW, Flex, FullBleed, Text } from "@artsy/palette"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { Sticky } from "Components/Sticky"
+import { RouterLink } from "System/Router/RouterLink"
+import { useFeatureFlag } from "System/useFeatureFlag"
+import { Media } from "Utils/Responsive"
+
+export const InsightsHeader: React.FC = () => {
+  const isMyCollectionPhase3Enabled = useFeatureFlag(
+    "my-collection-web-phase-3"
+  )
+
+  return (
+    <Box mt={[-2, -4]}>
+      <Sticky>
+        {({ stuck }) => {
+          return (
+            <FullBleed
+              backgroundColor="white100"
+              style={stuck ? { boxShadow: DROP_SHADOW } : undefined}
+            >
+              <AppContainer>
+                <HorizontalPadding>
+                  <Flex
+                    backgroundColor="white100"
+                    justifyContent="space-between"
+                    py={2}
+                  >
+                    <Flex flex={1}>
+                      <Media greaterThan="xs">
+                        <Text variant="lg-display">
+                          Gain deeper knowledge of your collection.
+                        </Text>
+
+                        <Text variant="xs" color="black60">
+                          Get insights about the artists you collect from the
+                          Artsy Price Database, drawing on millions of results
+                          from leading auction houses across the globe.
+                        </Text>
+                      </Media>
+                    </Flex>
+
+                    {!!isMyCollectionPhase3Enabled && (
+                      <Button
+                        // @ts-ignore
+                        as={RouterLink}
+                        size={["small", "large"]}
+                        variant="primaryBlack"
+                        to="/my-collection/artworks/new"
+                      >
+                        Upload Artwork
+                      </Button>
+                    )}
+                  </Flex>
+                </HorizontalPadding>
+              </AppContainer>
+            </FullBleed>
+          )
+        }}
+      </Sticky>
+    </Box>
+  )
+}

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsHeader.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsHeader.jest.tsx
@@ -1,0 +1,56 @@
+import { screen } from "@testing-library/react"
+import { MockBoot } from "DevTools"
+import { render } from "DevTools/setupTestWrapper"
+import { useSystemContext } from "System"
+import { Breakpoint } from "Utils/Responsive"
+import { InsightsHeader } from "../InsightsHeader"
+
+jest.mock("System/useSystemContext")
+jest.mock("Utils/Hooks/useMatchMedia", () => ({
+  __internal__useMatchMedia: () => false,
+}))
+
+describe("InsightsHeader", () => {
+  const renderComponent = (breakpoint: Breakpoint) =>
+    render(
+      <MockBoot breakpoint={breakpoint}>
+        <InsightsHeader />
+      </MockBoot>
+    )
+
+  beforeAll(() => {
+    ;(useSystemContext as jest.Mock).mockImplementation(() => ({
+      featureFlags: {
+        "my-collection-web-phase-7-insights": { flagEnabled: true },
+        "my-collection-web-phase-3": { flagEnabled: true },
+      },
+    }))
+  })
+
+  describe("In mobile view", () => {
+    it("renders only the Upload artwork CTA", () => {
+      renderComponent("xs")
+
+      expect(
+        screen.queryByText("Gain deeper knowledge of your collection.")
+      ).not.toBeInTheDocument()
+      expect(screen.getByText("Upload Artwork")).toBeInTheDocument()
+    })
+  })
+
+  describe("In desktop view", () => {
+    it("renders the Upload artwork CTA and the textual content", () => {
+      renderComponent("lg")
+
+      expect(
+        screen.getByText("Gain deeper knowledge of your collection.")
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          "Get insights about the artists you collect from the Artsy Price Database, drawing on millions of results from leading auction houses across the globe."
+        )
+      ).toBeInTheDocument()
+      expect(screen.getByText("Upload Artwork")).toBeInTheDocument()
+    })
+  })
+})

--- a/src/Apps/Settings/Routes/Insights/InsightsRoute.tsx
+++ b/src/Apps/Settings/Routes/Insights/InsightsRoute.tsx
@@ -1,6 +1,7 @@
 import { createFragmentContainer, graphql } from "react-relay"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { InsightsRoute_me } from "__generated__/InsightsRoute_me.graphql"
+import { InsightsHeader } from "./Components/InsightsHeader"
 import { InsightsOverviewFragmentContainer } from "./Components/InsightsOverview"
 
 interface InsightsRouteProps {
@@ -13,7 +14,10 @@ const InsightsRoute: React.FC<InsightsRouteProps> = ({ me }) => {
   return (
     <>
       {isInsightsEnabled && (
-        <InsightsOverviewFragmentContainer info={me?.myCollectionInfo!} />
+        <>
+          <InsightsHeader />
+          <InsightsOverviewFragmentContainer info={me?.myCollectionInfo!} />
+        </>
       )}
     </>
   )


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2885]

### Description

This PR adds the insights header to the insights page

### Screenshots
 | | Mobile | Desktop |
| --- | --- | --- |
| normal | <img width="389" alt="image" src="https://user-images.githubusercontent.com/20655703/189614351-51656f99-e077-4254-b68b-55fdc16fd525.png"> | <img width="1739" alt="image" src="https://user-images.githubusercontent.com/20655703/189614333-f83323a6-0dec-4887-930e-32419f90b954.png"> |
| sticky | <img width="389" alt="image" src="https://user-images.githubusercontent.com/20655703/189585091-a5766f38-8d33-4537-a630-976cbe5a2a1d.png"> | <img width="1744" alt="image" src="https://user-images.githubusercontent.com/20655703/189585017-2ab01175-fbf3-4266-b4c0-b6715d12096d.png"> |



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2885]: https://artsyproduct.atlassian.net/browse/CX-2885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ