### PR TITLE
feat[FX-4095]: use curated collection pages instead of genes

### DIFF
--- a/src/Apps/Gene/Server/__tests__ /redirectGeneToCollection.jest.ts
+++ b/src/Apps/Gene/Server/__tests__ /redirectGeneToCollection.jest.ts
@@ -1,0 +1,35 @@
+import { redirectGeneToCollection } from "../redirectGeneToCollection"
+
+describe("redirectGeneToCollection", () => {
+  it("does not redirect for a non-migrated gene", () => {
+    const req = {
+      params: {
+        slug: "contemporary",
+      },
+    }
+    const res = {
+      redirect: jest.fn(),
+      locals: { sd: {} },
+    }
+    redirectGeneToCollection({ req, res })
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+
+  it("redirects for a migrated gene", () => {
+    const spy = jest.fn()
+    const req = {
+      params: {
+        slug: "trove",
+      },
+    }
+    const res = {
+      redirect: spy,
+      locals: {
+        sd: {},
+      },
+    }
+
+    redirectGeneToCollection({ req, res })
+    expect(spy).toHaveBeenCalledWith(301, "/collection/trove-editors-picks")
+  })
+})

--- a/src/Apps/Gene/Server/redirectGeneToCollection.ts
+++ b/src/Apps/Gene/Server/redirectGeneToCollection.ts
@@ -1,0 +1,11 @@
+import { geneToCollectionMap } from "../Utils/geneToCollectionMap"
+
+export function redirectGeneToCollection({ req, res }) {
+  const geneSlug: string = req.params.slug
+  const collectionSlug: string = geneToCollectionMap[geneSlug]
+
+  if (collectionSlug) {
+    const collectionPath = `/collection/${collectionSlug}`
+    res.redirect(301, collectionPath)
+  }
+}

--- a/src/Apps/Gene/Utils/geneToCollectionMap.ts
+++ b/src/Apps/Gene/Utils/geneToCollectionMap.ts
@@ -1,0 +1,17 @@
+export const geneToCollectionMap = {
+  "trending-this-week": "trending-this-week",
+  "black-painters-on-our-radar": "black-painters-on-our-radar",
+  "street-art-now-1": "street-art-highlights",
+  "artists-on-the-rise": "artists-on-the-rise",
+  "contemporary-now": "contemporary-now",
+  "women-artists-now": "women-artists-now",
+  trove: "trove-editors-picks",
+  "our-top-auction-lots": "top-auction-lots",
+  "iconic-prints": "iconic-prints",
+  "the-collectibles-shop": "the-collectibles-shop",
+  "finds-under-50000": "finds-under-50000-dollars",
+  "finds-under-10000": "finds-under-10000-dollars",
+  "finds-under-5000": "finds-under-5000-dollars",
+  "finds-under-2500": "finds-under-2500-dollars",
+  "finds-under-1000": "finds-under-1000-dollars",
+}

--- a/src/Apps/Gene/geneRoutes.tsx
+++ b/src/Apps/Gene/geneRoutes.tsx
@@ -5,6 +5,7 @@ import { allowedFilters } from "Components/ArtworkFilter/Utils/allowedFilters"
 import { paramsToCamelCase } from "Components/ArtworkFilter/Utils/urlBuilder"
 import { initialArtworkFilterState } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { AppRouteConfig } from "System/Router/Route"
+import { redirectGeneToCollection } from "./Server/redirectGeneToCollection"
 
 const GeneApp = loadable(
   () => import(/* webpackChunkName: "geneBundle" */ "./GeneApp"),
@@ -24,6 +25,7 @@ export const geneRoutes: AppRouteConfig[] = [
   {
     path: "/gene/:slug",
     getComponent: () => GeneApp,
+    onServerSideRender: redirectGeneToCollection,
     onClientSideRender: () => {
       return GeneApp.preload()
     },

--- a/src/Apps/Home/Components/HomeTroveArtworksRail.tsx
+++ b/src/Apps/Home/Components/HomeTroveArtworksRail.tsx
@@ -37,15 +37,15 @@ export const HomeTroveArtworksRail: React.FC<HomeTroveArtworksRailProps> = ({
       title="Trove"
       subTitle="A weekly curated selection of the best works on Artsy by emerging and sought after artists."
       viewAllLabel="View All Works"
-      viewAllHref="/gene/trove"
+      viewAllHref="/collection/trove-editors-picks"
       viewAllOnClick={() => {
         const trackingEvent: ClickedArtworkGroup = {
           action: ActionType.clickedArtworkGroup,
           context_module: ContextModule.troveArtworksRail,
           context_page_owner_type: OwnerType.home,
-          destination_page_owner_type: OwnerType.gene,
-          destination_page_owner_id: "60a6b70fa7025f0012fdf5df",
-          destination_page_owner_slug: "trove",
+          destination_page_owner_type: OwnerType.collection,
+          destination_page_owner_id: "932d0b13-3cf1-46d1-8e49-18b186230347",
+          destination_page_owner_slug: "trove-editors-picks",
           type: "viewAll",
         }
         trackEvent(trackingEvent)
@@ -83,7 +83,10 @@ export const HomeTroveArtworksRailFragmentContainer = createFragmentContainer(
   {
     viewer: graphql`
       fragment HomeTroveArtworksRail_viewer on Viewer {
-        artworksConnection(first: 12, geneIDs: "trove") {
+        artworksConnection(
+          first: 12
+          marketingCollectionID: "trove-editors-picks"
+        ) {
           edges {
             node {
               ...ShelfArtwork_artwork

--- a/src/Apps/Home/__tests__/HomeTroveArtworksRail.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeTroveArtworksRail.jest.tsx
@@ -81,9 +81,9 @@ describe("HomeTroveArtworksRail", () => {
         action: "clickedArtworkGroup",
         context_module: "troveArtworksRail",
         context_page_owner_type: "home",
-        destination_page_owner_id: "60a6b70fa7025f0012fdf5df",
-        destination_page_owner_slug: "trove",
-        destination_page_owner_type: "gene",
+        destination_page_owner_id: "932d0b13-3cf1-46d1-8e49-18b186230347",
+        destination_page_owner_slug: "trove-editors-picks",
+        destination_page_owner_type: "collection",
         type: "viewAll",
       })
     })

--- a/src/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
+++ b/src/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
@@ -32,21 +32,24 @@ describe("NavBarSubMenu", () => {
     const wrapper = getWrapper()
     const linkMenuItems = wrapper.find("a")
 
-    // expect(linkMenuItems.length).toBe(5)
     expect(linkMenuItems.at(0).text()).toContain("Trove: Editor's Picks")
-    expect(linkMenuItems.at(0).prop("href")).toEqual("/gene/trove")
+    expect(linkMenuItems.at(0).prop("href")).toEqual(
+      "/collection/trove-editors-picks"
+    )
 
     expect(linkMenuItems.at(1).text()).toContain("Top Auction Lots")
     expect(linkMenuItems.at(1).prop("href")).toEqual(
-      "/gene/our-top-auction-lots"
+      "/collection/top-auction-lots"
     )
 
     expect(linkMenuItems.at(2).text()).toContain("Iconic Prints")
-    expect(linkMenuItems.at(2).prop("href")).toEqual("/gene/iconic-prints")
+    expect(linkMenuItems.at(2).prop("href")).toEqual(
+      "/collection/iconic-prints"
+    )
 
     expect(linkMenuItems.at(3).text()).toContain("The Collectibles Shop")
     expect(linkMenuItems.at(3).prop("href")).toEqual(
-      "/gene/the-collectibles-shop"
+      "/collection/the-collectibles-shop"
     )
 
     expect(linkMenuItems.at(4).text()).toContain("View All Artworks")

--- a/src/Components/NavBar/menuData.ts
+++ b/src/Components/NavBar/menuData.ts
@@ -33,15 +33,15 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
     links: [
       {
         text: "Trending This Week",
-        href: "/gene/trending-this-week",
+        href: "/collection/trending-this-week",
       },
       {
         text: "Black Painters On Our Radar",
-        href: "/gene/black-painters-on-our-radar",
+        href: "/collection/black-painters-on-our-radar",
       },
       {
         text: "Street Art Highlights",
-        href: "/gene/street-art-now-1",
+        href: "/collection/street-art-highlights",
         dividerBelow: true,
       },
       {
@@ -51,7 +51,7 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
           links: [
             {
               text: "Artists On The Rise",
-              href: "/gene/artists-on-the-rise",
+              href: "/collection/artists-on-the-rise",
             },
             {
               text: "Contemporary Now",
@@ -152,19 +152,19 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
     links: [
       {
         text: "Trove: Editor's Picks",
-        href: "/gene/trove",
+        href: "/collection/trove-editors-picks",
       },
       {
         text: "Top Auction Lots",
-        href: "/gene/our-top-auction-lots",
+        href: "/collection/top-auction-lots",
       },
       {
         text: "Iconic Prints",
-        href: "/gene/iconic-prints",
+        href: "/collection/iconic-prints",
       },
       {
         text: "The Collectibles Shop",
-        href: "/gene/the-collectibles-shop",
+        href: "/collection/the-collectibles-shop",
       },
       {
         text: "Price",
@@ -185,11 +185,11 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
             },
             {
               text: "Finds Under $2,500",
-              href: "/gene/finds-under-2500",
+              href: "/collection/finds-under-2500-dollars",
             },
             {
               text: "Finds Under $1,000",
-              href: "/gene/finds-under-1000",
+              href: "/collection/finds-under-1000-dollars",
             },
           ],
         },

--- a/src/Components/Onboarding/Components/OnboardingMarketingCollection.tsx
+++ b/src/Components/Onboarding/Components/OnboardingMarketingCollection.tsx
@@ -1,25 +1,26 @@
 import { FC, Fragment, useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { OnboardingGene_gene$data } from "__generated__/OnboardingGene_gene.graphql"
-import { OnboardingGeneQuery } from "__generated__/OnboardingGeneQuery.graphql"
+import { OnboardingMarketingCollection_marketingCollection$data } from "__generated__/OnboardingMarketingCollection_marketingCollection.graphql"
+import { OnboardingMarketingCollectionQuery } from "__generated__/OnboardingMarketingCollectionQuery.graphql"
 import { ArtworkGridItemFragmentContainer } from "Components/Artwork/GridItem"
 import { Masonry } from "Components/Masonry"
 import { extractNodes } from "Utils/extractNodes"
 import { Box, Flex, Message, Spacer, Text } from "@artsy/palette"
-import { FollowGeneButtonQueryRenderer } from "Components/FollowButton/FollowGeneButton"
-import { useOnboardingContext } from "Components/Onboarding/Hooks/useOnboardingContext"
-import { OnboardingThankYou } from "Components/Onboarding/Views/OnboardingThankYou"
-import { ContextModule } from "@artsy/cohesion"
-import { useOnboardingTracking } from "Components/Onboarding/Hooks/useOnboardingTracking"
+import { useOnboardingContext } from "../Hooks/useOnboardingContext"
+import { OnboardingThankYou } from "../Views/OnboardingThankYou"
+import { useOnboardingTracking } from "../Hooks/useOnboardingTracking"
 
-interface OnboardingGeneProps {
-  gene: OnboardingGene_gene$data
+interface OnboardingMarketingCollectionProps {
+  marketingCollection: OnboardingMarketingCollection_marketingCollection$data
   description: JSX.Element
 }
 
-const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
-  const artworks = extractNodes(gene.artworks)
+const OnboardingMarketingCollection: FC<OnboardingMarketingCollectionProps> = ({
+  marketingCollection,
+  description,
+}) => {
+  const artworks = extractNodes(marketingCollection.artworks)
   const { onClose } = useOnboardingContext()
   const tracking = useOnboardingTracking()
 
@@ -36,27 +37,13 @@ const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
     <Box px={[2, 4]} py={6}>
       <Flex justifyContent="space-between">
         <Box>
-          <Text variant="xl">{gene.name}</Text>
+          <Text variant="xl">{marketingCollection.title}</Text>
 
           <Text variant={["sm", "md"]} color="black60" mt={2}>
             {description}
           </Text>
         </Box>
-
-        <FollowGeneButtonQueryRenderer
-          id={gene.internalID}
-          display={["none", "block"]}
-          contextModule={ContextModule.onboardingFlow}
-        />
       </Flex>
-
-      <FollowGeneButtonQueryRenderer
-        id={gene.internalID}
-        mt={2}
-        display={["block", "none"]}
-        size="small"
-        contextModule={ContextModule.onboardingFlow}
-      />
 
       <Spacer mb={4} />
 
@@ -79,24 +66,16 @@ const OnboardingGene: FC<OnboardingGeneProps> = ({ gene, description }) => {
   )
 }
 
-export const OnboardingGeneFragmentContainer = createFragmentContainer(
-  OnboardingGene,
+export const OnboardingMarketingCollectionFragmentContainer = createFragmentContainer(
+  OnboardingMarketingCollection,
   {
-    gene: graphql`
-      fragment OnboardingGene_gene on Gene {
-        internalID
-        name
-        artworks: filterArtworksConnection(
+    marketingCollection: graphql`
+      fragment OnboardingMarketingCollection_marketingCollection on MarketingCollection {
+        title
+        artworks: artworksConnection(
           first: 50
           page: 1
           sort: "-decayed_merch"
-          height: "*-*"
-          width: "*-*"
-          priceRange: "*-*"
-          marketable: true
-          offerable: true
-          inquireableOnly: true
-          forSale: true
         ) {
           edges {
             node {
@@ -110,19 +89,19 @@ export const OnboardingGeneFragmentContainer = createFragmentContainer(
   }
 )
 
-interface OnboardingGeneQueryRendererProps {
-  id: string
+interface OnboardingMarketingCollectionQueryRendererProps {
+  slug: string
   description: JSX.Element
 }
 
-export const OnboardingGeneQueryRenderer: FC<OnboardingGeneQueryRendererProps> = ({
-  id,
+export const OnboardingMarketingCollectionQueryRenderer: FC<OnboardingMarketingCollectionQueryRendererProps> = ({
+  slug,
   description,
 }) => {
   const { onComplete } = useOnboardingContext()
 
-  // If a user has arrived to the gene artwork grid page, they've completed a
-  // path within the artwork flow.
+  // If a user has arrived to the marketing collection artwork grid page,
+  // they've completed a path within the artwork flow.
   useEffect(() => {
     onComplete()
   }, [onComplete])
@@ -136,28 +115,28 @@ export const OnboardingGeneQueryRenderer: FC<OnboardingGeneQueryRendererProps> =
   )
 
   return (
-    <SystemQueryRenderer<OnboardingGeneQuery>
+    <SystemQueryRenderer<OnboardingMarketingCollectionQuery>
       query={graphql`
-        query OnboardingGeneQuery($id: String!) {
-          gene(id: $id) {
-            ...OnboardingGene_gene
+        query OnboardingMarketingCollectionQuery($slug: String!) {
+          marketingCollection(slug: $slug) {
+            ...OnboardingMarketingCollection_marketingCollection
           }
         }
       `}
-      variables={{ id }}
+      variables={{ slug }}
       render={({ error, props }) => {
         if (error) {
           console.error(error)
           return null
         }
 
-        if (!props?.gene) {
+        if (!props?.marketingCollection) {
           return <OnboardingThankYou message={ThankYouMessage} />
         }
 
         return (
-          <OnboardingGeneFragmentContainer
-            gene={props.gene}
+          <OnboardingMarketingCollectionFragmentContainer
+            marketingCollection={props.marketingCollection}
             description={description}
           />
         )

--- a/src/Components/Onboarding/Components/__tests__/OnboardingMarketingCollection.jest.tsx
+++ b/src/Components/Onboarding/Components/__tests__/OnboardingMarketingCollection.jest.tsx
@@ -1,7 +1,7 @@
 import { graphql } from "react-relay"
 import { screen } from "@testing-library/react"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { OnboardingGeneFragmentContainer } from "../OnboardingGene"
+import { OnboardingMarketingCollectionFragmentContainer } from "../OnboardingMarketingCollection"
 
 jest.unmock("react-relay")
 
@@ -9,36 +9,36 @@ const { renderWithRelay } = setupTestWrapperTL({
   Component: props => {
     return (
       // @ts-ignore
-      <OnboardingGeneFragmentContainer
+      <OnboardingMarketingCollectionFragmentContainer
         {...props}
         description={<>Example description</>}
       />
     )
   },
   query: graphql`
-    query OnboardingGene_Test_Query @relay_test_operation {
-      gene(id: "example") {
-        ...OnboardingGene_gene
+    query OnboardingMarketingCollection_Test_Query @relay_test_operation {
+      marketingCollection(slug: "example") {
+        ...OnboardingMarketingCollection_marketingCollection
       }
     }
   `,
 })
 
-describe("OnboardingGene", () => {
+describe("OnboardingMarketingCollection", () => {
   it("renders correctly", () => {
     renderWithRelay({
-      Gene: () => ({
-        name: "Example Gene",
+      MarketingCollection: () => ({
+        title: "Example Collection",
       }),
     })
 
-    expect(screen.getByText("Example Gene")).toBeInTheDocument()
+    expect(screen.getByText("Example Collection")).toBeInTheDocument()
     expect(screen.getByText("Example description")).toBeInTheDocument()
   })
 
   it("shows no results if none found", () => {
     renderWithRelay({
-      Gene: () => ({
+      MarketingCollection: () => ({
         artworks: { edges: [] },
       }),
     })

--- a/src/Components/Onboarding/Views/OnboardingArtistsOnTheRise.tsx
+++ b/src/Components/Onboarding/Views/OnboardingArtistsOnTheRise.tsx
@@ -1,10 +1,10 @@
 import { FC } from "react"
-import { OnboardingGeneQueryRenderer } from "../Components/OnboardingGene"
+import { OnboardingMarketingCollectionQueryRenderer } from "../Components/OnboardingMarketingCollection"
 
 export const OnboardingArtistsOnTheRise: FC = () => {
   return (
-    <OnboardingGeneQueryRenderer
-      id="artists-on-the-rise"
+    <OnboardingMarketingCollectionQueryRenderer
+      slug="artists-on-the-rise"
       description={
         <>
           Follow to see fresh works from the studios of up-and-coming artists in

--- a/src/Components/Onboarding/Views/OnboardingArtistsOnTheRise.tsx
+++ b/src/Components/Onboarding/Views/OnboardingArtistsOnTheRise.tsx
@@ -7,8 +7,8 @@ export const OnboardingArtistsOnTheRise: FC = () => {
       slug="artists-on-the-rise"
       description={
         <>
-          Follow to see fresh works from the studios of up-and-coming artists in
-          your home feed. Click the heart to save artworks you love.
+          Fresh works from the studios of up-and-coming artists in your home
+          feed. Click the heart to save artworks you love.
         </>
       }
     />

--- a/src/Components/Onboarding/Views/OnboardingCuratedArtworks.tsx
+++ b/src/Components/Onboarding/Views/OnboardingCuratedArtworks.tsx
@@ -1,10 +1,10 @@
 import { FC } from "react"
-import { OnboardingGeneQueryRenderer } from "../Components/OnboardingGene"
+import { OnboardingMarketingCollectionQueryRenderer } from "../Components/OnboardingMarketingCollection"
 
 export const OnboardingCuratedArtworks: FC = () => {
   return (
-    <OnboardingGeneQueryRenderer
-      id="trove"
+    <OnboardingMarketingCollectionQueryRenderer
+      slug="trove-editors-picks"
       description={
         <>
           Follow to see the best works on Artsy each week, all available now.

--- a/src/Components/Onboarding/Views/OnboardingCuratedArtworks.tsx
+++ b/src/Components/Onboarding/Views/OnboardingCuratedArtworks.tsx
@@ -7,8 +7,8 @@ export const OnboardingCuratedArtworks: FC = () => {
       slug="trove-editors-picks"
       description={
         <>
-          Follow to see the best works on Artsy each week, all available now.
-          Click the heart to save artworks you love.
+          The best works on Artsy each week, all available now. Click the heart
+          to save artworks you love.
         </>
       }
     />

--- a/src/Components/Onboarding/Views/OnboardingTopAuctionLots.tsx
+++ b/src/Components/Onboarding/Views/OnboardingTopAuctionLots.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react"
-import { OnboardingMarketingCollectionQueryRenderer } from "Components/Onboarding/Components/OnboardingMarketingCollection"
+import { OnboardingMarketingCollectionQueryRenderer } from "../Components/OnboardingMarketingCollection"
 
 export const OnboardingTopAuctionLots: FC = () => {
   return (
@@ -7,8 +7,8 @@ export const OnboardingTopAuctionLots: FC = () => {
       slug="top-auction-lots"
       description={
         <>
-          Follow for works by emerging and established market stars—now open for
-          bidding. Click the heart to save artworks you love.
+          Works by emerging and established market stars—now open for bidding.
+          Click the heart to save artworks you love.
         </>
       }
     />

--- a/src/Components/Onboarding/Views/OnboardingTopAuctionLots.tsx
+++ b/src/Components/Onboarding/Views/OnboardingTopAuctionLots.tsx
@@ -1,10 +1,10 @@
 import { FC } from "react"
-import { OnboardingGeneQueryRenderer } from "Components/Onboarding/Components/OnboardingGene"
+import { OnboardingMarketingCollectionQueryRenderer } from "Components/Onboarding/Components/OnboardingMarketingCollection"
 
 export const OnboardingTopAuctionLots: FC = () => {
   return (
-    <OnboardingGeneQueryRenderer
-      id="our-top-auction-lots"
+    <OnboardingMarketingCollectionQueryRenderer
+      slug="top-auction-lots"
       description={
         <>
           Follow for works by emerging and established market stars—now open for

--- a/src/Server/analytics/__tests__/brazeMessagingIntegration.jest.ts
+++ b/src/Server/analytics/__tests__/brazeMessagingIntegration.jest.ts
@@ -10,7 +10,7 @@ describe("isMatchingRoute", () => {
     "/artists",
     "/auctions",
     "/collect",
-    "/collection/trove",
+    "/collection/trove-editors-picks",
     "/fair/outside-tent-thingy",
     "/galleries",
     "/gene/works-on-paper",

--- a/src/__generated__/HomeTroveArtworksRailQuery.graphql.ts
+++ b/src/__generated__/HomeTroveArtworksRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5783e5cf0be8f1469898e92794b13aca>>
+ * @generated SignedSource<<cd465ebebfbca150a94384f88b2b4af3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -121,8 +121,8 @@ return {
               },
               {
                 "kind": "Literal",
-                "name": "geneIDs",
-                "value": "trove"
+                "name": "marketingCollectionID",
+                "value": "trove-editors-picks"
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -488,7 +488,7 @@ return {
               },
               (v1/*: any*/)
             ],
-            "storageKey": "artworksConnection(first:12,geneIDs:\"trove\")"
+            "storageKey": "artworksConnection(first:12,marketingCollectionID:\"trove-editors-picks\")"
           }
         ],
         "storageKey": null
@@ -496,12 +496,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b277edc663695ea3e15cc91c2617f87e",
+    "cacheID": "0082266232b5a2f823af29ddcece667c",
     "id": null,
     "metadata": {},
     "name": "HomeTroveArtworksRailQuery",
     "operationKind": "query",
-    "text": "query HomeTroveArtworksRailQuery {\n  viewer {\n    ...HomeTroveArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeTroveArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, geneIDs: \"trove\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+    "text": "query HomeTroveArtworksRailQuery {\n  viewer {\n    ...HomeTroveArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeTroveArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, marketingCollectionID: \"trove-editors-picks\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeTroveArtworksRail_Test_Query.graphql.ts
+++ b/src/__generated__/HomeTroveArtworksRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<775d6e38bee6cb197fcd0baf9b683927>>
+ * @generated SignedSource<<96889377cfa77b64ad0bf7b3b904e47a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -145,8 +145,8 @@ return {
               },
               {
                 "kind": "Literal",
-                "name": "geneIDs",
-                "value": "trove"
+                "name": "marketingCollectionID",
+                "value": "trove-editors-picks"
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -512,7 +512,7 @@ return {
               },
               (v1/*: any*/)
             ],
-            "storageKey": "artworksConnection(first:12,geneIDs:\"trove\")"
+            "storageKey": "artworksConnection(first:12,marketingCollectionID:\"trove-editors-picks\")"
           }
         ],
         "storageKey": null
@@ -520,7 +520,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "97a68df476e08c6b107d31987bb6def2",
+    "cacheID": "e39302a2dc1c3acd4b9b099663f0a2d9",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -689,7 +689,7 @@ return {
     },
     "name": "HomeTroveArtworksRail_Test_Query",
     "operationKind": "query",
-    "text": "query HomeTroveArtworksRail_Test_Query {\n  viewer {\n    ...HomeTroveArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeTroveArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, geneIDs: \"trove\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+    "text": "query HomeTroveArtworksRail_Test_Query {\n  viewer {\n    ...HomeTroveArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeTroveArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, marketingCollectionID: \"trove-editors-picks\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeTroveArtworksRail_viewer.graphql.ts
+++ b/src/__generated__/HomeTroveArtworksRail_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4e4525bb3d2d774427d94dbd7754e164>>
+ * @generated SignedSource<<4e3e2d4d1a9a56e146549187f9ac1fd8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -44,8 +44,8 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Literal",
-          "name": "geneIDs",
-          "value": "trove"
+          "name": "marketingCollectionID",
+          "value": "trove-editors-picks"
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -102,13 +102,13 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "artworksConnection(first:12,geneIDs:\"trove\")"
+      "storageKey": "artworksConnection(first:12,marketingCollectionID:\"trove-editors-picks\")"
     }
   ],
   "type": "Viewer",
   "abstractKey": null
 };
 
-(node as any).hash = "aeb4755ff31a7f7acd1803d7daffc06a";
+(node as any).hash = "d3ba6a95604757356fd7f0426f0c17fb";
 
 export default node;

--- a/src/__generated__/OnboardingMarketingCollectionQuery.graphql.ts
+++ b/src/__generated__/OnboardingMarketingCollectionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2573464a68e7ef9e89abfbc3f264042a>>
+ * @generated SignedSource<<8f9656204a41b4339281521decb0e6a6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,17 +10,17 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type OnboardingGeneQuery$variables = {
-  id: string;
+export type OnboardingMarketingCollectionQuery$variables = {
+  slug: string;
 };
-export type OnboardingGeneQuery$data = {
-  readonly gene: {
-    readonly " $fragmentSpreads": FragmentRefs<"OnboardingGene_gene">;
+export type OnboardingMarketingCollectionQuery$data = {
+  readonly marketingCollection: {
+    readonly " $fragmentSpreads": FragmentRefs<"OnboardingMarketingCollection_marketingCollection">;
   } | null;
 };
-export type OnboardingGeneQuery = {
-  response: OnboardingGeneQuery$data;
-  variables: OnboardingGeneQuery$variables;
+export type OnboardingMarketingCollectionQuery = {
+  response: OnboardingMarketingCollectionQuery$data;
+  variables: OnboardingMarketingCollectionQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -28,51 +28,51 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "id"
+    "name": "slug"
   }
 ],
 v1 = [
   {
     "kind": "Variable",
-    "name": "id",
-    "variableName": "id"
+    "name": "slug",
+    "variableName": "slug"
   }
 ],
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "title",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "href",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
 v7 = {
   "alias": null,
   "args": null,
@@ -90,28 +90,28 @@ v8 = [
   }
 ],
 v9 = [
-  (v3/*: any*/),
-  (v5/*: any*/)
+  (v6/*: any*/),
+  (v4/*: any*/)
 ];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "OnboardingGeneQuery",
+    "name": "OnboardingMarketingCollectionQuery",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "Gene",
+        "concreteType": "MarketingCollection",
         "kind": "LinkedField",
-        "name": "gene",
+        "name": "marketingCollection",
         "plural": false,
         "selections": [
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "OnboardingGene_gene"
+            "name": "OnboardingMarketingCollection_marketingCollection"
           }
         ],
         "storageKey": null
@@ -124,18 +124,17 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "OnboardingGeneQuery",
+    "name": "OnboardingMarketingCollectionQuery",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "Gene",
+        "concreteType": "MarketingCollection",
         "kind": "LinkedField",
-        "name": "gene",
+        "name": "marketingCollection",
         "plural": false,
         "selections": [
           (v2/*: any*/),
-          (v3/*: any*/),
           {
             "alias": "artworks",
             "args": [
@@ -146,53 +145,18 @@ return {
               },
               {
                 "kind": "Literal",
-                "name": "forSale",
-                "value": true
-              },
-              {
-                "kind": "Literal",
-                "name": "height",
-                "value": "*-*"
-              },
-              {
-                "kind": "Literal",
-                "name": "inquireableOnly",
-                "value": true
-              },
-              {
-                "kind": "Literal",
-                "name": "marketable",
-                "value": true
-              },
-              {
-                "kind": "Literal",
-                "name": "offerable",
-                "value": true
-              },
-              {
-                "kind": "Literal",
                 "name": "page",
                 "value": 1
               },
               {
                 "kind": "Literal",
-                "name": "priceRange",
-                "value": "*-*"
-              },
-              {
-                "kind": "Literal",
                 "name": "sort",
                 "value": "-decayed_merch"
-              },
-              {
-                "kind": "Literal",
-                "name": "width",
-                "value": "*-*"
               }
             ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
-            "name": "filterArtworksConnection",
+            "name": "artworksConnection",
             "plural": false,
             "selections": [
               {
@@ -211,14 +175,14 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "title",
+                        "name": "internalID",
                         "storageKey": null
                       },
+                      (v2/*: any*/),
                       {
                         "alias": "image_title",
                         "args": null,
@@ -271,7 +235,7 @@ return {
                         "name": "artistNames",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -319,7 +283,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -343,15 +307,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v5/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v5/*: any*/),
                           (v4/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v6/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -364,15 +328,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v5/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
+                          (v6/*: any*/),
                           (v3/*: any*/),
-                          (v4/*: any*/),
-                          (v5/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -420,7 +384,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": "is_preview",
                             "args": null,
@@ -513,11 +477,11 @@ return {
                             "selections": (v8/*: any*/),
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -576,27 +540,27 @@ return {
                 ],
                 "storageKey": null
               },
-              (v5/*: any*/)
+              (v4/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:50,forSale:true,height:\"*-*\",inquireableOnly:true,marketable:true,offerable:true,page:1,priceRange:\"*-*\",sort:\"-decayed_merch\",width:\"*-*\")"
+            "storageKey": "artworksConnection(first:50,page:1,sort:\"-decayed_merch\")"
           },
-          (v5/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "2121c905a8be0c317c9ac505c61caa57",
+    "cacheID": "4643c84410d518c7132e232068aaffa4",
     "id": null,
     "metadata": {},
-    "name": "OnboardingGeneQuery",
+    "name": "OnboardingMarketingCollectionQuery",
     "operationKind": "query",
-    "text": "query OnboardingGeneQuery(\n  $id: String!\n) {\n  gene(id: $id) {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  internalID\n  name\n  artworks: filterArtworksConnection(first: 50, page: 1, sort: \"-decayed_merch\", height: \"*-*\", width: \"*-*\", priceRange: \"*-*\", marketable: true, offerable: true, inquireableOnly: true, forSale: true) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query OnboardingMarketingCollectionQuery(\n  $slug: String!\n) {\n  marketingCollection(slug: $slug) {\n    ...OnboardingMarketingCollection_marketingCollection\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingMarketingCollection_marketingCollection on MarketingCollection {\n  title\n  artworks: artworksConnection(first: 50, page: 1, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "12d0a4f322ee457beee90abcfe58cceb";
+(node as any).hash = "b5f74b9addb941fa84aad7b4898f36ce";
 
 export default node;

--- a/src/__generated__/OnboardingMarketingCollection_Test_Query.graphql.ts
+++ b/src/__generated__/OnboardingMarketingCollection_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5e299e3414559d762d3c8590a26a6c2d>>
+ * @generated SignedSource<<0307af2c5b14a9372d4b7f9760cbe9e8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,22 +10,22 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type OnboardingGene_Test_Query$variables = {};
-export type OnboardingGene_Test_Query$data = {
-  readonly gene: {
-    readonly " $fragmentSpreads": FragmentRefs<"OnboardingGene_gene">;
+export type OnboardingMarketingCollection_Test_Query$variables = {};
+export type OnboardingMarketingCollection_Test_Query$data = {
+  readonly marketingCollection: {
+    readonly " $fragmentSpreads": FragmentRefs<"OnboardingMarketingCollection_marketingCollection">;
   } | null;
 };
-export type OnboardingGene_Test_Query = {
-  response: OnboardingGene_Test_Query$data;
-  variables: OnboardingGene_Test_Query$variables;
+export type OnboardingMarketingCollection_Test_Query = {
+  response: OnboardingMarketingCollection_Test_Query$data;
+  variables: OnboardingMarketingCollection_Test_Query$variables;
 };
 
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
     "kind": "Literal",
-    "name": "id",
+    "name": "slug",
     "value": "example"
   }
 ],
@@ -33,37 +33,37 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "title",
   "storageKey": null
 },
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "href",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
 v6 = {
   "alias": null,
   "args": null,
@@ -81,34 +81,28 @@ v7 = [
   }
 ],
 v8 = [
-  (v2/*: any*/),
-  (v4/*: any*/)
+  (v5/*: any*/),
+  (v3/*: any*/)
 ],
 v9 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Gene"
-},
-v10 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v11 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v12 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v13 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -119,23 +113,23 @@ return {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "OnboardingGene_Test_Query",
+    "name": "OnboardingMarketingCollection_Test_Query",
     "selections": [
       {
         "alias": null,
         "args": (v0/*: any*/),
-        "concreteType": "Gene",
+        "concreteType": "MarketingCollection",
         "kind": "LinkedField",
-        "name": "gene",
+        "name": "marketingCollection",
         "plural": false,
         "selections": [
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "OnboardingGene_gene"
+            "name": "OnboardingMarketingCollection_marketingCollection"
           }
         ],
-        "storageKey": "gene(id:\"example\")"
+        "storageKey": "marketingCollection(slug:\"example\")"
       }
     ],
     "type": "Query",
@@ -145,18 +139,17 @@ return {
   "operation": {
     "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "OnboardingGene_Test_Query",
+    "name": "OnboardingMarketingCollection_Test_Query",
     "selections": [
       {
         "alias": null,
         "args": (v0/*: any*/),
-        "concreteType": "Gene",
+        "concreteType": "MarketingCollection",
         "kind": "LinkedField",
-        "name": "gene",
+        "name": "marketingCollection",
         "plural": false,
         "selections": [
           (v1/*: any*/),
-          (v2/*: any*/),
           {
             "alias": "artworks",
             "args": [
@@ -167,53 +160,18 @@ return {
               },
               {
                 "kind": "Literal",
-                "name": "forSale",
-                "value": true
-              },
-              {
-                "kind": "Literal",
-                "name": "height",
-                "value": "*-*"
-              },
-              {
-                "kind": "Literal",
-                "name": "inquireableOnly",
-                "value": true
-              },
-              {
-                "kind": "Literal",
-                "name": "marketable",
-                "value": true
-              },
-              {
-                "kind": "Literal",
-                "name": "offerable",
-                "value": true
-              },
-              {
-                "kind": "Literal",
                 "name": "page",
                 "value": 1
               },
               {
                 "kind": "Literal",
-                "name": "priceRange",
-                "value": "*-*"
-              },
-              {
-                "kind": "Literal",
                 "name": "sort",
                 "value": "-decayed_merch"
-              },
-              {
-                "kind": "Literal",
-                "name": "width",
-                "value": "*-*"
               }
             ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
-            "name": "filterArtworksConnection",
+            "name": "artworksConnection",
             "plural": false,
             "selections": [
               {
@@ -232,14 +190,14 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "title",
+                        "name": "internalID",
                         "storageKey": null
                       },
+                      (v1/*: any*/),
                       {
                         "alias": "image_title",
                         "args": null,
@@ -292,7 +250,7 @@ return {
                         "name": "artistNames",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -340,7 +298,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v4/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -364,15 +322,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v4/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v4/*: any*/),
                           (v3/*: any*/),
-                          (v2/*: any*/)
+                          (v2/*: any*/),
+                          (v5/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -385,15 +343,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v4/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
+                          (v5/*: any*/),
                           (v2/*: any*/),
-                          (v3/*: any*/),
-                          (v4/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -441,7 +399,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v4/*: any*/),
+                          (v3/*: any*/),
                           {
                             "alias": "is_preview",
                             "args": null,
@@ -534,11 +492,11 @@ return {
                             "selections": (v7/*: any*/),
                             "storageKey": null
                           },
-                          (v4/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -597,194 +555,208 @@ return {
                 ],
                 "storageKey": null
               },
-              (v4/*: any*/)
+              (v3/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:50,forSale:true,height:\"*-*\",inquireableOnly:true,marketable:true,offerable:true,page:1,priceRange:\"*-*\",sort:\"-decayed_merch\",width:\"*-*\")"
+            "storageKey": "artworksConnection(first:50,page:1,sort:\"-decayed_merch\")"
           },
-          (v4/*: any*/)
+          (v3/*: any*/)
         ],
-        "storageKey": "gene(id:\"example\")"
+        "storageKey": "marketingCollection(slug:\"example\")"
       }
     ]
   },
   "params": {
-    "cacheID": "678cdfb0b937e45d9f772ed5aa8f4d7c",
+    "cacheID": "9fd06f7ca0497ea98d609e779e931dc3",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "gene": (v9/*: any*/),
-        "gene.artworks": {
+        "marketingCollection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "MarketingCollection"
+        },
+        "marketingCollection.artworks": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksConnection"
         },
-        "gene.artworks.edges": {
+        "marketingCollection.artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "FilterArtworksEdge"
         },
-        "gene.artworks.edges.node": {
+        "marketingCollection.artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Artwork"
         },
-        "gene.artworks.edges.node.artist": {
+        "marketingCollection.artworks.edges.node.artist": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Artist"
         },
-        "gene.artworks.edges.node.artist.id": (v10/*: any*/),
-        "gene.artworks.edges.node.artist.targetSupply": {
+        "marketingCollection.artworks.edges.node.artist.id": (v9/*: any*/),
+        "marketingCollection.artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "gene.artworks.edges.node.artist.targetSupply.isP1": (v11/*: any*/),
-        "gene.artworks.edges.node.artistNames": (v12/*: any*/),
-        "gene.artworks.edges.node.artists": {
+        "marketingCollection.artworks.edges.node.artist.targetSupply.isP1": (v10/*: any*/),
+        "marketingCollection.artworks.edges.node.artistNames": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "gene.artworks.edges.node.artists.href": (v12/*: any*/),
-        "gene.artworks.edges.node.artists.id": (v10/*: any*/),
-        "gene.artworks.edges.node.artists.name": (v12/*: any*/),
-        "gene.artworks.edges.node.attributionClass": {
+        "marketingCollection.artworks.edges.node.artists.href": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.artists.id": (v9/*: any*/),
+        "marketingCollection.artworks.edges.node.artists.name": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "gene.artworks.edges.node.attributionClass.id": (v10/*: any*/),
-        "gene.artworks.edges.node.attributionClass.name": (v12/*: any*/),
-        "gene.artworks.edges.node.collecting_institution": (v12/*: any*/),
-        "gene.artworks.edges.node.cultural_maker": (v12/*: any*/),
-        "gene.artworks.edges.node.date": (v12/*: any*/),
-        "gene.artworks.edges.node.href": (v12/*: any*/),
-        "gene.artworks.edges.node.id": (v10/*: any*/),
-        "gene.artworks.edges.node.image": {
+        "marketingCollection.artworks.edges.node.attributionClass.id": (v9/*: any*/),
+        "marketingCollection.artworks.edges.node.attributionClass.name": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.collecting_institution": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.cultural_maker": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.date": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.href": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.id": (v9/*: any*/),
+        "marketingCollection.artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "gene.artworks.edges.node.image.aspect_ratio": {
+        "marketingCollection.artworks.edges.node.image.aspect_ratio": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Float"
         },
-        "gene.artworks.edges.node.image.placeholder": (v12/*: any*/),
-        "gene.artworks.edges.node.image.url": (v12/*: any*/),
-        "gene.artworks.edges.node.image_title": (v12/*: any*/),
-        "gene.artworks.edges.node.internalID": (v10/*: any*/),
-        "gene.artworks.edges.node.is_biddable": (v11/*: any*/),
-        "gene.artworks.edges.node.is_saved": (v11/*: any*/),
-        "gene.artworks.edges.node.marketPriceInsights": {
+        "marketingCollection.artworks.edges.node.image.placeholder": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.image.url": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.image_title": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.internalID": (v9/*: any*/),
+        "marketingCollection.artworks.edges.node.is_biddable": (v10/*: any*/),
+        "marketingCollection.artworks.edges.node.is_saved": (v10/*: any*/),
+        "marketingCollection.artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkPriceInsights"
         },
-        "gene.artworks.edges.node.marketPriceInsights.demandRank": {
+        "marketingCollection.artworks.edges.node.marketPriceInsights.demandRank": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Float"
         },
-        "gene.artworks.edges.node.mediumType": {
+        "marketingCollection.artworks.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkMedium"
         },
-        "gene.artworks.edges.node.mediumType.filterGene": (v9/*: any*/),
-        "gene.artworks.edges.node.mediumType.filterGene.id": (v10/*: any*/),
-        "gene.artworks.edges.node.mediumType.filterGene.name": (v12/*: any*/),
-        "gene.artworks.edges.node.partner": {
+        "marketingCollection.artworks.edges.node.mediumType.filterGene": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Gene"
+        },
+        "marketingCollection.artworks.edges.node.mediumType.filterGene.id": (v9/*: any*/),
+        "marketingCollection.artworks.edges.node.mediumType.filterGene.name": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "gene.artworks.edges.node.partner.href": (v12/*: any*/),
-        "gene.artworks.edges.node.partner.id": (v10/*: any*/),
-        "gene.artworks.edges.node.partner.name": (v12/*: any*/),
-        "gene.artworks.edges.node.sale": {
+        "marketingCollection.artworks.edges.node.partner.href": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.partner.id": (v9/*: any*/),
+        "marketingCollection.artworks.edges.node.partner.name": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "gene.artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v13/*: any*/),
-        "gene.artworks.edges.node.sale.display_timely_at": (v12/*: any*/),
-        "gene.artworks.edges.node.sale.endAt": (v12/*: any*/),
-        "gene.artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v13/*: any*/),
-        "gene.artworks.edges.node.sale.id": (v10/*: any*/),
-        "gene.artworks.edges.node.sale.is_auction": (v11/*: any*/),
-        "gene.artworks.edges.node.sale.is_closed": (v11/*: any*/),
-        "gene.artworks.edges.node.sale.is_preview": (v11/*: any*/),
-        "gene.artworks.edges.node.sale.startAt": (v12/*: any*/),
-        "gene.artworks.edges.node.sale_artwork": {
+        "marketingCollection.artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v12/*: any*/),
+        "marketingCollection.artworks.edges.node.sale.display_timely_at": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.sale.endAt": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v12/*: any*/),
+        "marketingCollection.artworks.edges.node.sale.id": (v9/*: any*/),
+        "marketingCollection.artworks.edges.node.sale.is_auction": (v10/*: any*/),
+        "marketingCollection.artworks.edges.node.sale.is_closed": (v10/*: any*/),
+        "marketingCollection.artworks.edges.node.sale.is_preview": (v10/*: any*/),
+        "marketingCollection.artworks.edges.node.sale.startAt": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtwork"
         },
-        "gene.artworks.edges.node.sale_artwork.counts": {
+        "marketingCollection.artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "gene.artworks.edges.node.sale_artwork.counts.bidder_positions": {
+        "marketingCollection.artworks.edges.node.sale_artwork.counts.bidder_positions": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FormattedNumber"
         },
-        "gene.artworks.edges.node.sale_artwork.endAt": (v12/*: any*/),
-        "gene.artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v12/*: any*/),
-        "gene.artworks.edges.node.sale_artwork.formattedEndDateTime": (v12/*: any*/),
-        "gene.artworks.edges.node.sale_artwork.highest_bid": {
+        "marketingCollection.artworks.edges.node.sale_artwork.endAt": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.sale_artwork.formattedEndDateTime": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "gene.artworks.edges.node.sale_artwork.highest_bid.display": (v12/*: any*/),
-        "gene.artworks.edges.node.sale_artwork.id": (v10/*: any*/),
-        "gene.artworks.edges.node.sale_artwork.lotID": (v12/*: any*/),
-        "gene.artworks.edges.node.sale_artwork.lotLabel": (v12/*: any*/),
-        "gene.artworks.edges.node.sale_artwork.opening_bid": {
+        "marketingCollection.artworks.edges.node.sale_artwork.highest_bid.display": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.sale_artwork.id": (v9/*: any*/),
+        "marketingCollection.artworks.edges.node.sale_artwork.lotID": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.sale_artwork.lotLabel": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "gene.artworks.edges.node.sale_artwork.opening_bid.display": (v12/*: any*/),
-        "gene.artworks.edges.node.sale_message": (v12/*: any*/),
-        "gene.artworks.edges.node.slug": (v10/*: any*/),
-        "gene.artworks.edges.node.title": (v12/*: any*/),
-        "gene.artworks.id": (v10/*: any*/),
-        "gene.id": (v10/*: any*/),
-        "gene.internalID": (v10/*: any*/),
-        "gene.name": (v12/*: any*/)
+        "marketingCollection.artworks.edges.node.sale_artwork.opening_bid.display": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.sale_message": (v11/*: any*/),
+        "marketingCollection.artworks.edges.node.slug": (v9/*: any*/),
+        "marketingCollection.artworks.edges.node.title": (v11/*: any*/),
+        "marketingCollection.artworks.id": (v9/*: any*/),
+        "marketingCollection.id": (v9/*: any*/),
+        "marketingCollection.title": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "String"
+        }
       }
     },
-    "name": "OnboardingGene_Test_Query",
+    "name": "OnboardingMarketingCollection_Test_Query",
     "operationKind": "query",
-    "text": "query OnboardingGene_Test_Query {\n  gene(id: \"example\") {\n    ...OnboardingGene_gene\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingGene_gene on Gene {\n  internalID\n  name\n  artworks: filterArtworksConnection(first: 50, page: 1, sort: \"-decayed_merch\", height: \"*-*\", width: \"*-*\", priceRange: \"*-*\", marketable: true, offerable: true, inquireableOnly: true, forSale: true) {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query OnboardingMarketingCollection_Test_Query {\n  marketingCollection(slug: \"example\") {\n    ...OnboardingMarketingCollection_marketingCollection\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OnboardingMarketingCollection_marketingCollection on MarketingCollection {\n  title\n  artworks: artworksConnection(first: 50, page: 1, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "712839d653d2a3e80adb4cef64ec6aec";
+(node as any).hash = "6aab673af643bc3695f69202af510add";
 
 export default node;

--- a/src/__generated__/OnboardingMarketingCollection_marketingCollection.graphql.ts
+++ b/src/__generated__/OnboardingMarketingCollection_marketingCollection.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ff10f17f0d421a768c85c137fbd5fd8a>>
+ * @generated SignedSource<<d2aec914ba152a4e4d14081ca727ffdf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type OnboardingGene_gene$data = {
+export type OnboardingMarketingCollection_marketingCollection$data = {
   readonly artworks: {
     readonly edges: ReadonlyArray<{
       readonly node: {
@@ -19,35 +19,25 @@ export type OnboardingGene_gene$data = {
       } | null;
     } | null> | null;
   } | null;
-  readonly internalID: string;
-  readonly name: string | null;
-  readonly " $fragmentType": "OnboardingGene_gene";
+  readonly title: string;
+  readonly " $fragmentType": "OnboardingMarketingCollection_marketingCollection";
 };
-export type OnboardingGene_gene$key = {
-  readonly " $data"?: OnboardingGene_gene$data;
-  readonly " $fragmentSpreads": FragmentRefs<"OnboardingGene_gene">;
+export type OnboardingMarketingCollection_marketingCollection$key = {
+  readonly " $data"?: OnboardingMarketingCollection_marketingCollection$data;
+  readonly " $fragmentSpreads": FragmentRefs<"OnboardingMarketingCollection_marketingCollection">;
 };
 
-const node: ReaderFragment = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-};
-return {
+const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
-  "name": "OnboardingGene_gene",
+  "name": "OnboardingMarketingCollection_marketingCollection",
   "selections": [
-    (v0/*: any*/),
     {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "name",
+      "name": "title",
       "storageKey": null
     },
     {
@@ -60,53 +50,18 @@ return {
         },
         {
           "kind": "Literal",
-          "name": "forSale",
-          "value": true
-        },
-        {
-          "kind": "Literal",
-          "name": "height",
-          "value": "*-*"
-        },
-        {
-          "kind": "Literal",
-          "name": "inquireableOnly",
-          "value": true
-        },
-        {
-          "kind": "Literal",
-          "name": "marketable",
-          "value": true
-        },
-        {
-          "kind": "Literal",
-          "name": "offerable",
-          "value": true
-        },
-        {
-          "kind": "Literal",
           "name": "page",
           "value": 1
         },
         {
           "kind": "Literal",
-          "name": "priceRange",
-          "value": "*-*"
-        },
-        {
-          "kind": "Literal",
           "name": "sort",
           "value": "-decayed_merch"
-        },
-        {
-          "kind": "Literal",
-          "name": "width",
-          "value": "*-*"
         }
       ],
       "concreteType": "FilterArtworksConnection",
       "kind": "LinkedField",
-      "name": "filterArtworksConnection",
+      "name": "artworksConnection",
       "plural": false,
       "selections": [
         {
@@ -125,7 +80,13 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
                 {
                   "args": null,
                   "kind": "FragmentSpread",
@@ -138,14 +99,13 @@ return {
           "storageKey": null
         }
       ],
-      "storageKey": "filterArtworksConnection(first:50,forSale:true,height:\"*-*\",inquireableOnly:true,marketable:true,offerable:true,page:1,priceRange:\"*-*\",sort:\"-decayed_merch\",width:\"*-*\")"
+      "storageKey": "artworksConnection(first:50,page:1,sort:\"-decayed_merch\")"
     }
   ],
-  "type": "Gene",
+  "type": "MarketingCollection",
   "abstractKey": null
 };
-})();
 
-(node as any).hash = "3e738a263393a1812162d68c8845a834";
+(node as any).hash = "e8392b6fc42af68d5aeb3d3b693865d5";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [FX-4095]

### Description

This PR accomplishes a few things:
- Update navigation links to point to collections instead of gene pages (e.g. `/collection/trove-editors-picks` instead of `/gene/trove`)
- Update "curated genes" to redirect to curated collections (e.g. navigating to `/gene/trove` will redirect you to `/collection/trove-editors-picks`)
- Replace genes in onboarding with collections (Paired with Eigen version [here](https://github.com/artsy/eigen/pull/7396))
- Update homepage Trove rail to pull works from a collection and direct clicks to the collection instead of to the gene


[FX-4095]: https://artsyproduct.atlassian.net/browse/FX-4095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

For the full plan for launching these changes, see [Notion](https://www.notion.so/artsy/Curated-collections-launch-plan-8181a3ef06884b66a6b71664e65e5598#ecc09d24f7744e1ba990e8a938bc1400)