### PR TITLE
fix(FX-4108): Switching between metrics (cm/in) produces duplicate filter pills when custom size is selected

### DIFF
--- a/src/Components/SavedSearchAlert/Components/SavedSearchAlertPills.tsx
+++ b/src/Components/SavedSearchAlert/Components/SavedSearchAlertPills.tsx
@@ -13,7 +13,7 @@ export const SavedSearchAlertPills: React.FC<SavedSearchAlertPillsProps> = props
   return (
     <>
       {items.map(item => {
-        const key = `filter-label-${item.value}`
+        const key = `filter-label-${item.field}-${item.value}`
 
         if (item.isDefault) {
           return (


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [FX-4108]

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/189921609-d33c9fa7-1c71-44f1-ab19-9c6c021ea984.mp4

#### After
https://user-images.githubusercontent.com/3513494/189921771-6e0bded0-5a3b-4061-aa3c-76cb7db70da1.mp4

<!-- Implementation description -->


[FX-4108]: https://artsyproduct.atlassian.net/browse/FX-4108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ