### PR TITLE
feat:(FX-4219): edition selection artwork screen

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
@@ -14,6 +14,7 @@ import { useTimer } from "Utils/Hooks/useTimer"
 import { useState } from "react"
 import { lotIsClosed } from "Apps/Artwork/Utils/lotIsClosed"
 import { useAuctionWebsocket } from "Components/useAuctionWebsocket"
+import { ArtworkSidebar2EditionSetFragmentContainer } from "./ArtworkSidebar2EditionSets"
 
 export interface ArtworkSidebarProps {
   artwork: ArtworkSidebar2_artwork
@@ -74,6 +75,9 @@ export const ArtworkSidebar2: React.FC<ArtworkSidebarProps> = props => {
 
       <Spacer mt={2} />
       <ArtworkSidebar2DetailsFragmentContainer artwork={artwork} />
+      <Separator />
+
+      <ArtworkSidebar2EditionSetFragmentContainer artwork={artwork} />
 
       {!isSold && artworkEcommerceAvailable && (
         <>
@@ -123,6 +127,7 @@ export const ArtworkSidebar2FragmentContainer = createFragmentContainer(
         ...ArtworkSidebar2ArtworkTitle_artwork
         ...ArtworkSidebar2Artists_artwork
         ...ArtworkSidebar2Details_artwork
+        ...ArtworkSidebar2EditionSets_artwork
         ...ArtworkSidebar2ShippingInformation_artwork
         ...ArtworkSidebar2PartnerInfo_artwork
         ...ArtworkSidebar2CreateArtworkAlert_artwork

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
@@ -74,7 +74,6 @@ export const ArtworkSidebar2: React.FC<ArtworkSidebarProps> = props => {
 
       <Spacer mt={2} />
       <ArtworkSidebar2DetailsFragmentContainer artwork={artwork} />
-      <Spacer mt={2} />
 
       {!isSold && artworkEcommerceAvailable && (
         <>

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2EditionSets.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2EditionSets.tsx
@@ -1,0 +1,111 @@
+import {
+  Box,
+  Flex,
+  RadioGroup,
+  Radio,
+  Separator,
+  Text,
+  FlexProps,
+} from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+
+import { ArtworkSidebar2EditionSets_artwork } from "__generated__/ArtworkSidebar2EditionSets_artwork.graphql"
+import React from "react"
+import { ArtworkSidebar2SizeInfoFragmentContainer } from "./ArtworkSidebar2SizeInfo"
+
+const Row: React.FC<FlexProps> = ({ children, ...others }) => (
+  <Flex justifyContent="left" {...others}>
+    {children}
+  </Flex>
+)
+
+type EditionSet = NonNullable<
+  ArtworkSidebar2EditionSets_artwork["editionSets"]
+>[0]
+
+interface ArtworkSidebar2EditionSetsProps {
+  artwork: ArtworkSidebar2EditionSets_artwork
+  selectedEditionSet?: EditionSet
+  onSelectEditionSet?: (editionSet: EditionSet) => void
+}
+
+const ArtworkSidebar2EditionSets: React.FC<ArtworkSidebar2EditionSetsProps> = ({
+  artwork,
+}) => {
+  const { editionSets, isInquireable, isOfferable, isAcquireable } = artwork
+
+  const renderEditionSet = (editionSet: EditionSet) => {
+    const editionEcommerceAvailable =
+      editionSet?.isAcquireable || editionSet?.isOfferable || isInquireable
+
+    const editionFragment = (
+      <Flex justifyContent="space-between" flex={1}>
+        <ArtworkSidebar2SizeInfoFragmentContainer piece={editionSet!} />
+
+        <Text
+          ml={1}
+          variant="sm-display"
+          color="black100"
+          data-test="SaleMessage"
+        >
+          {editionSet?.saleMessage}
+        </Text>
+      </Flex>
+    )
+
+    if (!!(isOfferable || isAcquireable || isInquireable)) {
+      return (
+        <Row>
+          <Radio
+            flex={1}
+            onSelect={() => {
+              // TODO: will be added in the next pr
+              // this.setState({ selectedEditionSet: editionSet })
+            }}
+            selected={
+              // TODO: will be added in the next pr
+              false
+            }
+            disabled={!editionEcommerceAvailable}
+            label={editionFragment}
+          />
+        </Row>
+      )
+    } else {
+      return <Row>{editionFragment}</Row>
+    }
+  }
+
+  return (
+    <RadioGroup>
+      {
+        editionSets?.map((editionSet, index) => (
+          <React.Fragment key={editionSet?.id}>
+            <Box py={2}>{renderEditionSet(editionSet)}</Box>
+            {index !== editionSets.length - 1 && <Separator />}
+          </React.Fragment>
+        ))!
+      }
+    </RadioGroup>
+  )
+}
+
+export const ArtworkSidebar2EditionSetFragmentContainer = createFragmentContainer(
+  ArtworkSidebar2EditionSets,
+  {
+    artwork: graphql`
+      fragment ArtworkSidebar2EditionSets_artwork on Artwork {
+        isInquireable
+        isOfferable
+        isAcquireable
+        editionSets {
+          id
+          isOfferable
+          isAcquireable
+          saleMessage
+          ...ArtworkSidebar2SizeInfo_piece
+        }
+      }
+    `,
+  }
+)

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2SizeInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2SizeInfo.tsx
@@ -1,0 +1,65 @@
+import { Box, Text } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { Media } from "Utils/Responsive"
+import { ArtworkSidebar2SizeInfo_piece } from "__generated__/ArtworkSidebar2SizeInfo_piece.graphql"
+
+interface ArtworkSidebar2SizeInfoProps {
+  piece: ArtworkSidebar2SizeInfo_piece
+}
+
+const ArtworkSidebar2SizeInfo: React.FC<ArtworkSidebar2SizeInfoProps> = ({
+  piece,
+}) => {
+  const { dimensions, editionOf } = piece
+
+  const hasInDimensions = !!dimensions?.in
+  const hasCmDimensions = !!dimensions?.cm
+
+  const sizeInfoMissing = (dimensions, editionOf) => {
+    const dimensionsPresent =
+      /\d/.test(dimensions?.in) || /\d/.test(dimensions?.cm)
+
+    return !editionOf?.length && !dimensionsPresent
+  }
+
+  if (sizeInfoMissing(dimensions, editionOf)) {
+    return null
+  }
+
+  return (
+    <>
+      <Media greaterThan="sm">
+        <Box color="black60">
+          <Text variant="sm-display">
+            {hasInDimensions && dimensions.in}{" "}
+            {hasInDimensions && hasCmDimensions && "|"}{" "}
+            {hasCmDimensions && dimensions.cm}
+          </Text>
+          {editionOf && <Text variant="sm-display">{editionOf}</Text>}
+        </Box>
+      </Media>
+      <Media at="sm">
+        <Box color="black60">
+          {hasInDimensions && <Text variant="sm-display">{dimensions.in}</Text>}
+          {hasCmDimensions && <Text variant="sm-display">{dimensions.cm}</Text>}
+          {editionOf && <Text variant="sm-display">{editionOf}</Text>}
+        </Box>
+      </Media>
+    </>
+  )
+}
+
+export const ArtworkSidebar2SizeInfoFragmentContainer = createFragmentContainer(
+  ArtworkSidebar2SizeInfo,
+  {
+    piece: graphql`
+      fragment ArtworkSidebar2SizeInfo_piece on Sellable {
+        dimensions {
+          in
+          cm
+        }
+        editionOf
+      }
+    `,
+  }
+)

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2SizeInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2SizeInfo.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from "@artsy/palette"
+import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "Utils/Responsive"
 import { ArtworkSidebar2SizeInfo_piece } from "__generated__/ArtworkSidebar2SizeInfo_piece.graphql"
@@ -27,8 +28,8 @@ const ArtworkSidebar2SizeInfo: React.FC<ArtworkSidebar2SizeInfoProps> = ({
   }
 
   return (
-    <>
-      <Media greaterThan="sm">
+    <React.Fragment data-testid="size-info">
+      <Media greaterThanOrEqual="md">
         <Box color="black60">
           <Text variant="sm-display">
             {hasInDimensions && dimensions.in}{" "}
@@ -38,14 +39,14 @@ const ArtworkSidebar2SizeInfo: React.FC<ArtworkSidebar2SizeInfoProps> = ({
           {editionOf && <Text variant="sm-display">{editionOf}</Text>}
         </Box>
       </Media>
-      <Media at="sm">
+      <Media lessThan="md">
         <Box color="black60">
           {hasInDimensions && <Text variant="sm-display">{dimensions.in}</Text>}
           {hasCmDimensions && <Text variant="sm-display">{dimensions.cm}</Text>}
           {editionOf && <Text variant="sm-display">{editionOf}</Text>}
         </Box>
       </Media>
-    </>
+    </React.Fragment>
   )
 }
 

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2SizeInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2SizeInfo.tsx
@@ -16,6 +16,16 @@ const ArtworkSidebar2SizeInfo: React.FC<ArtworkSidebar2SizeInfoProps> = ({
   const hasInDimensions = !!dimensions?.in
   const hasCmDimensions = !!dimensions?.cm
 
+  const renderDimensions = () => {
+    if (hasInDimensions && hasCmDimensions) {
+      return `${dimensions.in} | ${dimensions.cm}`
+    }
+
+    return dimensions?.in ?? dimensions?.cm
+  }
+
+  const label = renderDimensions()
+
   const sizeInfoMissing = (dimensions, editionOf) => {
     const dimensionsPresent =
       /\d/.test(dimensions?.in) || /\d/.test(dimensions?.cm)
@@ -31,14 +41,11 @@ const ArtworkSidebar2SizeInfo: React.FC<ArtworkSidebar2SizeInfoProps> = ({
     <React.Fragment data-testid="size-info">
       <Media greaterThanOrEqual="md">
         <Box color="black60">
-          <Text variant="sm-display">
-            {hasInDimensions && dimensions.in}{" "}
-            {hasInDimensions && hasCmDimensions && "|"}{" "}
-            {hasCmDimensions && dimensions.cm}
-          </Text>
+          {!!label && <Text variant="sm-display">{label}</Text>}
           {editionOf && <Text variant="sm-display">{editionOf}</Text>}
         </Box>
       </Media>
+
       <Media lessThan="md">
         <Box color="black60">
           {hasInDimensions && <Text variant="sm-display">{dimensions.in}</Text>}

--- a/src/__generated__/ArtworkSidebar2EditionSets_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebar2EditionSets_artwork.graphql.ts
@@ -1,0 +1,96 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtworkSidebar2EditionSets_artwork = {
+    readonly isInquireable: boolean | null;
+    readonly isOfferable: boolean | null;
+    readonly isAcquireable: boolean | null;
+    readonly editionSets: ReadonlyArray<{
+        readonly id: string;
+        readonly isOfferable: boolean | null;
+        readonly isAcquireable: boolean | null;
+        readonly saleMessage: string | null;
+        readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebar2SizeInfo_piece">;
+    } | null> | null;
+    readonly " $refType": "ArtworkSidebar2EditionSets_artwork";
+};
+export type ArtworkSidebar2EditionSets_artwork$data = ArtworkSidebar2EditionSets_artwork;
+export type ArtworkSidebar2EditionSets_artwork$key = {
+    readonly " $data"?: ArtworkSidebar2EditionSets_artwork$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebar2EditionSets_artwork">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isOfferable",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isAcquireable",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArtworkSidebar2EditionSets_artwork",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isInquireable",
+      "storageKey": null
+    },
+    (v0/*: any*/),
+    (v1/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "EditionSet",
+      "kind": "LinkedField",
+      "name": "editionSets",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        (v0/*: any*/),
+        (v1/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "saleMessage",
+          "storageKey": null
+        },
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "ArtworkSidebar2SizeInfo_piece"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Artwork",
+  "abstractKey": null
+};
+})();
+(node as any).hash = '7caa0d9ba122d91eaf4ccef5c6ec2741';
+export default node;

--- a/src/__generated__/ArtworkSidebar2SizeInfo_piece.graphql.ts
+++ b/src/__generated__/ArtworkSidebar2SizeInfo_piece.graphql.ts
@@ -1,0 +1,66 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtworkSidebar2SizeInfo_piece = {
+    readonly dimensions: {
+        readonly in: string | null;
+        readonly cm: string | null;
+    } | null;
+    readonly editionOf: string | null;
+    readonly " $refType": "ArtworkSidebar2SizeInfo_piece";
+};
+export type ArtworkSidebar2SizeInfo_piece$data = ArtworkSidebar2SizeInfo_piece;
+export type ArtworkSidebar2SizeInfo_piece$key = {
+    readonly " $data"?: ArtworkSidebar2SizeInfo_piece$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebar2SizeInfo_piece">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArtworkSidebar2SizeInfo_piece",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "dimensions",
+      "kind": "LinkedField",
+      "name": "dimensions",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "in",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "cm",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "editionOf",
+      "storageKey": null
+    }
+  ],
+  "type": "Sellable",
+  "abstractKey": "__isSellable"
+};
+(node as any).hash = 'd279249e1cd0b50923969a85224b0200';
+export default node;

--- a/src/__generated__/ArtworkSidebar2_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkSidebar2_Test_Query.graphql.ts
@@ -88,6 +88,19 @@ fragment ArtworkSidebar2Details_artwork on Artwork {
   ...ArtworkSidebar2AuthenticityCertificate_artwork
 }
 
+fragment ArtworkSidebar2EditionSets_artwork on Artwork {
+  isInquireable
+  isOfferable
+  isAcquireable
+  editionSets {
+    id
+    isOfferable
+    isAcquireable
+    saleMessage
+    ...ArtworkSidebar2SizeInfo_piece
+  }
+}
+
 fragment ArtworkSidebar2PartnerInfo_artwork on Artwork {
   internalID
   slug
@@ -111,6 +124,15 @@ fragment ArtworkSidebar2ShippingInformation_artwork on Artwork {
   shippingInfo
 }
 
+fragment ArtworkSidebar2SizeInfo_piece on Sellable {
+  __isSellable: __typename
+  dimensions {
+    in
+    cm
+  }
+  editionOf
+}
+
 fragment ArtworkSidebar2_artwork on Artwork {
   slug
   isSold
@@ -121,6 +143,7 @@ fragment ArtworkSidebar2_artwork on Artwork {
   ...ArtworkSidebar2ArtworkTitle_artwork
   ...ArtworkSidebar2Artists_artwork
   ...ArtworkSidebar2Details_artwork
+  ...ArtworkSidebar2EditionSets_artwork
   ...ArtworkSidebar2ShippingInformation_artwork
   ...ArtworkSidebar2PartnerInfo_artwork
   ...ArtworkSidebar2CreateArtworkAlert_artwork
@@ -160,49 +183,108 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "isAcquireable",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "isOfferable",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "saleMessage",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
+  "name": "name",
   "storageKey": null
 },
 v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "dimensions",
+  "kind": "LinkedField",
+  "name": "dimensions",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "in",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "cm",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "editionOf",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v11 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v7 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v8 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "String"
 },
-v9 = {
+v14 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "dimensions"
+},
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -257,20 +339,8 @@ return {
             "name": "isSold",
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "isAcquireable",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "isOfferable",
-            "storageKey": null
-          },
+          (v2/*: any*/),
+          (v3/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -278,13 +348,7 @@ return {
             "name": "isInAuction",
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "saleMessage",
-            "storageKey": null
-          },
+          (v4/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -315,9 +379,9 @@ return {
             "plural": true,
             "selections": [
               (v1/*: any*/),
-              (v2/*: any*/),
-              (v3/*: any*/),
-              (v4/*: any*/)
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
@@ -328,31 +392,7 @@ return {
             "name": "medium",
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "dimensions",
-            "kind": "LinkedField",
-            "name": "dimensions",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "in",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "cm",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
+          (v8/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -371,13 +411,7 @@ return {
             ],
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "editionOf",
-            "storageKey": null
-          },
+          (v9/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -393,8 +427,8 @@ return {
                 "name": "shortArrayDescription",
                 "storageKey": null
               },
-              (v3/*: any*/),
-              (v4/*: any*/)
+              (v6/*: any*/),
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
@@ -416,6 +450,37 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "isInquireable",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "EditionSet",
+            "kind": "LinkedField",
+            "name": "editionSets",
+            "plural": true,
+            "selections": [
+              (v6/*: any*/),
+              (v3/*: any*/),
+              (v2/*: any*/),
+              (v4/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v8/*: any*/),
+                  (v9/*: any*/)
+                ],
+                "type": "Sellable",
+                "abstractKey": "__isSellable"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "shippingOrigin",
             "storageKey": null
           },
@@ -426,14 +491,7 @@ return {
             "name": "shippingInfo",
             "storageKey": null
           },
-          (v4/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "isInquireable",
-            "storageKey": null
-          },
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -442,8 +500,8 @@ return {
             "name": "partner",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
               (v5/*: any*/),
+              (v10/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -451,7 +509,7 @@ return {
                 "name": "cities",
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": null
           },
@@ -463,9 +521,9 @@ return {
             "name": "sale",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
               (v5/*: any*/),
-              (v3/*: any*/),
+              (v10/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -493,8 +551,8 @@ return {
                 "plural": false,
                 "selections": [
                   (v1/*: any*/),
-                  (v2/*: any*/),
-                  (v3/*: any*/)
+                  (v5/*: any*/),
+                  (v6/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -530,18 +588,18 @@ return {
                 "name": "endAt",
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": null
           },
-          (v3/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": "artwork(id:\"josef-albers-homage-to-the-square-85\")"
       }
     ]
   },
   "params": {
-    "cacheID": "d8cc3b6dc9def69f270e940327610c5a",
+    "cacheID": "c7224f7fea0ec3709725d0981f05cfe4",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -557,47 +615,62 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "artwork.artists.id": (v6/*: any*/),
-        "artwork.artists.internalID": (v6/*: any*/),
-        "artwork.artists.name": (v7/*: any*/),
-        "artwork.artists.slug": (v6/*: any*/),
+        "artwork.artists.id": (v11/*: any*/),
+        "artwork.artists.internalID": (v11/*: any*/),
+        "artwork.artists.name": (v12/*: any*/),
+        "artwork.artists.slug": (v11/*: any*/),
         "artwork.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "artwork.attributionClass.id": (v6/*: any*/),
-        "artwork.attributionClass.internalID": (v6/*: any*/),
-        "artwork.attributionClass.shortArrayDescription": (v8/*: any*/),
-        "artwork.culturalMaker": (v7/*: any*/),
-        "artwork.date": (v7/*: any*/),
-        "artwork.dimensions": {
+        "artwork.attributionClass.id": (v11/*: any*/),
+        "artwork.attributionClass.internalID": (v11/*: any*/),
+        "artwork.attributionClass.shortArrayDescription": (v13/*: any*/),
+        "artwork.culturalMaker": (v12/*: any*/),
+        "artwork.date": (v12/*: any*/),
+        "artwork.dimensions": (v14/*: any*/),
+        "artwork.dimensions.cm": (v12/*: any*/),
+        "artwork.dimensions.in": (v12/*: any*/),
+        "artwork.editionOf": (v12/*: any*/),
+        "artwork.editionSets": {
           "enumValues": null,
           "nullable": true,
-          "plural": false,
-          "type": "dimensions"
+          "plural": true,
+          "type": "EditionSet"
         },
-        "artwork.dimensions.cm": (v7/*: any*/),
-        "artwork.dimensions.in": (v7/*: any*/),
-        "artwork.editionOf": (v7/*: any*/),
+        "artwork.editionSets.__isSellable": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "String"
+        },
+        "artwork.editionSets.dimensions": (v14/*: any*/),
+        "artwork.editionSets.dimensions.cm": (v12/*: any*/),
+        "artwork.editionSets.dimensions.in": (v12/*: any*/),
+        "artwork.editionSets.editionOf": (v12/*: any*/),
+        "artwork.editionSets.id": (v11/*: any*/),
+        "artwork.editionSets.isAcquireable": (v15/*: any*/),
+        "artwork.editionSets.isOfferable": (v15/*: any*/),
+        "artwork.editionSets.saleMessage": (v12/*: any*/),
         "artwork.framed": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkInfoRow"
         },
-        "artwork.framed.details": (v7/*: any*/),
-        "artwork.hasCertificateOfAuthenticity": (v9/*: any*/),
-        "artwork.id": (v6/*: any*/),
-        "artwork.internalID": (v6/*: any*/),
-        "artwork.isAcquireable": (v9/*: any*/),
-        "artwork.isBiddable": (v9/*: any*/),
-        "artwork.isInAuction": (v9/*: any*/),
-        "artwork.isInquireable": (v9/*: any*/),
-        "artwork.isOfferable": (v9/*: any*/),
-        "artwork.isSold": (v9/*: any*/),
-        "artwork.medium": (v7/*: any*/),
+        "artwork.framed.details": (v12/*: any*/),
+        "artwork.hasCertificateOfAuthenticity": (v15/*: any*/),
+        "artwork.id": (v11/*: any*/),
+        "artwork.internalID": (v11/*: any*/),
+        "artwork.isAcquireable": (v15/*: any*/),
+        "artwork.isBiddable": (v15/*: any*/),
+        "artwork.isInAuction": (v15/*: any*/),
+        "artwork.isInquireable": (v15/*: any*/),
+        "artwork.isOfferable": (v15/*: any*/),
+        "artwork.isSold": (v15/*: any*/),
+        "artwork.medium": (v12/*: any*/),
         "artwork.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -610,49 +683,49 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "artwork.mediumType.filterGene.id": (v6/*: any*/),
-        "artwork.mediumType.filterGene.name": (v7/*: any*/),
-        "artwork.mediumType.filterGene.slug": (v6/*: any*/),
+        "artwork.mediumType.filterGene.id": (v11/*: any*/),
+        "artwork.mediumType.filterGene.name": (v12/*: any*/),
+        "artwork.mediumType.filterGene.slug": (v11/*: any*/),
         "artwork.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "artwork.partner.cities": (v8/*: any*/),
-        "artwork.partner.href": (v7/*: any*/),
-        "artwork.partner.id": (v6/*: any*/),
-        "artwork.partner.name": (v7/*: any*/),
+        "artwork.partner.cities": (v13/*: any*/),
+        "artwork.partner.href": (v12/*: any*/),
+        "artwork.partner.id": (v11/*: any*/),
+        "artwork.partner.name": (v12/*: any*/),
         "artwork.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "artwork.sale.href": (v7/*: any*/),
-        "artwork.sale.id": (v6/*: any*/),
-        "artwork.sale.name": (v7/*: any*/),
-        "artwork.sale.startAt": (v7/*: any*/),
+        "artwork.sale.href": (v12/*: any*/),
+        "artwork.sale.id": (v11/*: any*/),
+        "artwork.sale.name": (v12/*: any*/),
+        "artwork.sale.startAt": (v12/*: any*/),
         "artwork.saleArtwork": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtwork"
         },
-        "artwork.saleArtwork.endAt": (v7/*: any*/),
-        "artwork.saleArtwork.extendedBiddingEndAt": (v7/*: any*/),
-        "artwork.saleArtwork.id": (v6/*: any*/),
-        "artwork.saleArtwork.lotID": (v7/*: any*/),
-        "artwork.saleMessage": (v7/*: any*/),
-        "artwork.shippingInfo": (v7/*: any*/),
-        "artwork.shippingOrigin": (v7/*: any*/),
-        "artwork.slug": (v6/*: any*/),
-        "artwork.title": (v7/*: any*/)
+        "artwork.saleArtwork.endAt": (v12/*: any*/),
+        "artwork.saleArtwork.extendedBiddingEndAt": (v12/*: any*/),
+        "artwork.saleArtwork.id": (v11/*: any*/),
+        "artwork.saleArtwork.lotID": (v12/*: any*/),
+        "artwork.saleMessage": (v12/*: any*/),
+        "artwork.shippingInfo": (v12/*: any*/),
+        "artwork.shippingOrigin": (v12/*: any*/),
+        "artwork.slug": (v11/*: any*/),
+        "artwork.title": (v12/*: any*/)
       }
     },
     "name": "ArtworkSidebar2_Test_Query",
     "operationKind": "query",
-    "text": "query ArtworkSidebar2_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebar2_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebar2Artists_artwork on Artwork {\n  culturalMaker\n  artists {\n    slug\n    name\n    id\n  }\n}\n\nfragment ArtworkSidebar2ArtworkTitle_artwork on Artwork {\n  date\n  title\n}\n\nfragment ArtworkSidebar2AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  isBiddable\n}\n\nfragment ArtworkSidebar2Classification_artwork on Artwork {\n  attributionClass {\n    shortArrayDescription\n    id\n  }\n}\n\nfragment ArtworkSidebar2CreateArtworkAlert_artwork on Artwork {\n  internalID\n  title\n  slug\n  artists {\n    internalID\n    name\n    slug\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebar2Details_artwork on Artwork {\n  medium\n  dimensions {\n    in\n    cm\n  }\n  framed {\n    details\n  }\n  editionOf\n  ...ArtworkSidebar2Classification_artwork\n  ...ArtworkSidebar2AuthenticityCertificate_artwork\n}\n\nfragment ArtworkSidebar2PartnerInfo_artwork on Artwork {\n  internalID\n  slug\n  isInquireable\n  isInAuction\n  partner {\n    name\n    href\n    cities\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkSidebar2ShippingInformation_artwork on Artwork {\n  shippingOrigin\n  shippingInfo\n}\n\nfragment ArtworkSidebar2_artwork on Artwork {\n  slug\n  isSold\n  isAcquireable\n  isOfferable\n  isInAuction\n  saleMessage\n  ...ArtworkSidebar2ArtworkTitle_artwork\n  ...ArtworkSidebar2Artists_artwork\n  ...ArtworkSidebar2Details_artwork\n  ...ArtworkSidebar2ShippingInformation_artwork\n  ...ArtworkSidebar2PartnerInfo_artwork\n  ...ArtworkSidebar2CreateArtworkAlert_artwork\n  sale {\n    startAt\n    id\n  }\n  saleArtwork {\n    lotID\n    extendedBiddingEndAt\n    endAt\n    id\n  }\n  artists {\n    internalID\n    id\n  }\n}\n"
+    "text": "query ArtworkSidebar2_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebar2_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebar2Artists_artwork on Artwork {\n  culturalMaker\n  artists {\n    slug\n    name\n    id\n  }\n}\n\nfragment ArtworkSidebar2ArtworkTitle_artwork on Artwork {\n  date\n  title\n}\n\nfragment ArtworkSidebar2AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  isBiddable\n}\n\nfragment ArtworkSidebar2Classification_artwork on Artwork {\n  attributionClass {\n    shortArrayDescription\n    id\n  }\n}\n\nfragment ArtworkSidebar2CreateArtworkAlert_artwork on Artwork {\n  internalID\n  title\n  slug\n  artists {\n    internalID\n    name\n    slug\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebar2Details_artwork on Artwork {\n  medium\n  dimensions {\n    in\n    cm\n  }\n  framed {\n    details\n  }\n  editionOf\n  ...ArtworkSidebar2Classification_artwork\n  ...ArtworkSidebar2AuthenticityCertificate_artwork\n}\n\nfragment ArtworkSidebar2EditionSets_artwork on Artwork {\n  isInquireable\n  isOfferable\n  isAcquireable\n  editionSets {\n    id\n    isOfferable\n    isAcquireable\n    saleMessage\n    ...ArtworkSidebar2SizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebar2PartnerInfo_artwork on Artwork {\n  internalID\n  slug\n  isInquireable\n  isInAuction\n  partner {\n    name\n    href\n    cities\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkSidebar2ShippingInformation_artwork on Artwork {\n  shippingOrigin\n  shippingInfo\n}\n\nfragment ArtworkSidebar2SizeInfo_piece on Sellable {\n  __isSellable: __typename\n  dimensions {\n    in\n    cm\n  }\n  editionOf\n}\n\nfragment ArtworkSidebar2_artwork on Artwork {\n  slug\n  isSold\n  isAcquireable\n  isOfferable\n  isInAuction\n  saleMessage\n  ...ArtworkSidebar2ArtworkTitle_artwork\n  ...ArtworkSidebar2Artists_artwork\n  ...ArtworkSidebar2Details_artwork\n  ...ArtworkSidebar2EditionSets_artwork\n  ...ArtworkSidebar2ShippingInformation_artwork\n  ...ArtworkSidebar2PartnerInfo_artwork\n  ...ArtworkSidebar2CreateArtworkAlert_artwork\n  sale {\n    startAt\n    id\n  }\n  saleArtwork {\n    lotID\n    extendedBiddingEndAt\n    endAt\n    id\n  }\n  artists {\n    internalID\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtworkSidebar2_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebar2_artwork.graphql.ts
@@ -22,7 +22,7 @@ export type ArtworkSidebar2_artwork = {
     readonly artists: ReadonlyArray<{
         readonly internalID: string;
     } | null> | null;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebar2ArtworkTitle_artwork" | "ArtworkSidebar2Artists_artwork" | "ArtworkSidebar2Details_artwork" | "ArtworkSidebar2ShippingInformation_artwork" | "ArtworkSidebar2PartnerInfo_artwork" | "ArtworkSidebar2CreateArtworkAlert_artwork">;
+    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebar2ArtworkTitle_artwork" | "ArtworkSidebar2Artists_artwork" | "ArtworkSidebar2Details_artwork" | "ArtworkSidebar2EditionSets_artwork" | "ArtworkSidebar2ShippingInformation_artwork" | "ArtworkSidebar2PartnerInfo_artwork" | "ArtworkSidebar2CreateArtworkAlert_artwork">;
     readonly " $refType": "ArtworkSidebar2_artwork";
 };
 export type ArtworkSidebar2_artwork$data = ArtworkSidebar2_artwork;
@@ -167,6 +167,11 @@ const node: ReaderFragment = {
     {
       "args": null,
       "kind": "FragmentSpread",
+      "name": "ArtworkSidebar2EditionSets_artwork"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
       "name": "ArtworkSidebar2ShippingInformation_artwork"
     },
     {
@@ -183,5 +188,5 @@ const node: ReaderFragment = {
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = '8f1066fa7dbd91bad4e5679d85e02e99';
+(node as any).hash = '889c3073a35499eb969b6ea8399cb86e';
 export default node;

--- a/src/__generated__/artworkRoutes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/artworkRoutes_ArtworkQuery.graphql.ts
@@ -405,6 +405,19 @@ fragment ArtworkSidebar2Details_artwork on Artwork {
   ...ArtworkSidebar2AuthenticityCertificate_artwork
 }
 
+fragment ArtworkSidebar2EditionSets_artwork on Artwork {
+  isInquireable
+  isOfferable
+  isAcquireable
+  editionSets {
+    id
+    isOfferable
+    isAcquireable
+    saleMessage
+    ...ArtworkSidebar2SizeInfo_piece
+  }
+}
+
 fragment ArtworkSidebar2PartnerInfo_artwork on Artwork {
   internalID
   slug
@@ -428,6 +441,15 @@ fragment ArtworkSidebar2ShippingInformation_artwork on Artwork {
   shippingInfo
 }
 
+fragment ArtworkSidebar2SizeInfo_piece on Sellable {
+  __isSellable: __typename
+  dimensions {
+    in
+    cm
+  }
+  editionOf
+}
+
 fragment ArtworkSidebar2_artwork on Artwork {
   slug
   isSold
@@ -438,6 +460,7 @@ fragment ArtworkSidebar2_artwork on Artwork {
   ...ArtworkSidebar2ArtworkTitle_artwork
   ...ArtworkSidebar2Artists_artwork
   ...ArtworkSidebar2Details_artwork
+  ...ArtworkSidebar2EditionSets_artwork
   ...ArtworkSidebar2ShippingInformation_artwork
   ...ArtworkSidebar2PartnerInfo_artwork
   ...ArtworkSidebar2CreateArtworkAlert_artwork
@@ -1827,44 +1850,58 @@ v49 = {
   "storageKey": null
 },
 v50 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isAcquireable",
+  "storageKey": null
+},
+v51 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isOfferable",
+  "storageKey": null
+},
+v52 = {
   "alias": "sale_message",
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v51 = {
+v53 = {
   "alias": "edition_of",
   "args": null,
   "kind": "ScalarField",
   "name": "editionOf",
   "storageKey": null
 },
-v52 = {
+v54 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endedAt",
   "storageKey": null
 },
-v53 = [
+v55 = [
   (v7/*: any*/)
 ],
-v54 = {
+v56 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cents",
   "storageKey": null
 },
-v55 = {
+v57 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDefault",
   "storageKey": null
 },
-v56 = [
+v58 = [
   {
     "kind": "Literal",
     "name": "height",
@@ -1881,17 +1918,31 @@ v56 = [
   },
   (v32/*: any*/)
 ],
-v57 = [
+v59 = [
   (v45/*: any*/),
   (v46/*: any*/),
   (v21/*: any*/),
   (v22/*: any*/)
 ],
-v58 = {
+v60 = {
   "alias": "type",
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
+  "storageKey": null
+},
+v61 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "saleMessage",
+  "storageKey": null
+},
+v62 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "editionOf",
   "storageKey": null
 };
 return {
@@ -2628,13 +2679,7 @@ return {
             "storageKey": null
           },
           (v49/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "isAcquireable",
-            "storageKey": null
-          },
+          (v50/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -2642,13 +2687,7 @@ return {
             "name": "isInquireable",
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "isOfferable",
-            "storageKey": null
-          },
+          (v51/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -2793,12 +2832,12 @@ return {
               (v3/*: any*/),
               (v4/*: any*/),
               (v5/*: any*/),
-              (v50/*: any*/),
+              (v52/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
                   (v49/*: any*/),
-                  (v51/*: any*/)
+                  (v53/*: any*/)
                 ],
                 "type": "Sellable",
                 "abstractKey": "__isSellable"
@@ -2850,7 +2889,7 @@ return {
                 "name": "reserveStatus",
                 "storageKey": null
               },
-              (v52/*: any*/),
+              (v54/*: any*/),
               {
                 "alias": "current_bid",
                 "args": null,
@@ -2858,7 +2897,7 @@ return {
                 "kind": "LinkedField",
                 "name": "currentBid",
                 "plural": false,
-                "selections": (v53/*: any*/),
+                "selections": (v55/*: any*/),
                 "storageKey": null
               },
               {
@@ -2887,7 +2926,7 @@ return {
                 "name": "increments",
                 "plural": true,
                 "selections": [
-                  (v54/*: any*/),
+                  (v56/*: any*/),
                   (v7/*: any*/)
                 ],
                 "storageKey": null
@@ -2938,7 +2977,7 @@ return {
                 "kind": "LinkedField",
                 "name": "currentBid",
                 "plural": false,
-                "selections": (v53/*: any*/),
+                "selections": (v55/*: any*/),
                 "storageKey": null
               },
               (v12/*: any*/),
@@ -2986,7 +3025,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v52/*: any*/)
+              (v54/*: any*/)
             ],
             "storageKey": null
           },
@@ -3040,7 +3079,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v7/*: any*/),
-                      (v54/*: any*/)
+                      (v56/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -3111,7 +3150,7 @@ return {
             "name": "priceIncludesTaxDisplay",
             "storageKey": null
           },
-          (v50/*: any*/),
+          (v52/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -3143,7 +3182,7 @@ return {
             "plural": true,
             "selections": [
               (v13/*: any*/),
-              (v55/*: any*/),
+              (v57/*: any*/),
               {
                 "alias": "placeholder",
                 "args": [
@@ -3162,22 +3201,22 @@ return {
               },
               {
                 "alias": "fallback",
-                "args": (v56/*: any*/),
+                "args": (v58/*: any*/),
                 "concreteType": "CroppedImageUrl",
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v57/*: any*/),
+                "selections": (v59/*: any*/),
                 "storageKey": "cropped(height:800,version:[\"normalized\",\"larger\",\"large\"],width:800)"
               },
               {
                 "alias": null,
-                "args": (v56/*: any*/),
+                "args": (v58/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v57/*: any*/),
+                "selections": (v59/*: any*/),
                 "storageKey": "resized(height:800,version:[\"normalized\",\"larger\",\"large\"],width:800)"
               },
               (v45/*: any*/),
@@ -3227,7 +3266,7 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": (v56/*: any*/),
+                "args": (v58/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
@@ -3299,7 +3338,7 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v58/*: any*/),
+                  (v60/*: any*/),
                   (v13/*: any*/),
                   (v46/*: any*/),
                   (v45/*: any*/)
@@ -3400,8 +3439,8 @@ return {
                     "name": "isZoomable",
                     "storageKey": null
                   },
-                  (v58/*: any*/),
-                  (v55/*: any*/)
+                  (v60/*: any*/),
+                  (v57/*: any*/)
                 ],
                 "type": "Image",
                 "abstractKey": null
@@ -3416,13 +3455,7 @@ return {
             "name": "isSold",
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "saleMessage",
-            "storageKey": null
-          },
+          (v61/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -3448,13 +3481,7 @@ return {
             ],
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "editionOf",
-            "storageKey": null
-          },
+          (v62/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -3463,9 +3490,33 @@ return {
             "storageKey": null
           },
           {
+            "alias": null,
+            "args": null,
+            "concreteType": "EditionSet",
+            "kind": "LinkedField",
+            "name": "editionSets",
+            "plural": true,
+            "selections": [
+              (v12/*: any*/),
+              (v51/*: any*/),
+              (v50/*: any*/),
+              (v61/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v49/*: any*/),
+                  (v62/*: any*/)
+                ],
+                "type": "Sellable",
+                "abstractKey": "__isSellable"
+              }
+            ],
+            "storageKey": null
+          },
+          {
             "kind": "InlineFragment",
             "selections": [
-              (v51/*: any*/)
+              (v53/*: any*/)
             ],
             "type": "Sellable",
             "abstractKey": "__isSellable"
@@ -3619,12 +3670,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "592931253b2c0ea984284045a75b1b07",
+    "cacheID": "83d6ebf6a03587b690a1bc65982c759d",
     "id": null,
     "metadata": {},
     "name": "artworkRoutes_ArtworkQuery",
     "operationKind": "query",
-    "text": "query artworkRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...ArtworkApp_artwork\n    id\n  }\n  me {\n    ...ArtworkApp_me\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML, partnerBio: false) {\n    credit\n    partnerID\n    text\n  }\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  internalID\n  id\n  slug\n  title\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkSharePanel_artwork\n  ...ViewInRoom_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  downloadableImageUrl\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  slug\n  internalID\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  availability\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  is_in_auction: isInAuction\n  sale {\n    ...CascadingEndTimesBanner_sale\n    internalID\n    slug\n    extendedBiddingIntervalMinutes\n    id\n  }\n  artists {\n    id\n    slug\n    ...ArtistInfo_artist\n  }\n  artist {\n    ...ArtistInfo_artist\n    id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkTopContextBar_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkImageBrowser_artwork\n  ...ArtworkSidebar2_artwork\n}\n\nfragment ArtworkApp_me on Me {\n  ...ArtworkSidebar_me\n  ...SubmittedOrderModal_me\n}\n\nfragment ArtworkImageBrowserLarge_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  ...ArtworkVideoPlayer_artwork\n  figures {\n    __typename\n    ... on Image {\n      type: __typename\n      internalID\n      isZoomable\n      ...DeepZoom_image\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  ...ArtworkVideoPlayer_artwork\n  figures {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkActions_artwork\n  ...ArtworkImageBrowserSmall_artwork\n  ...ArtworkImageBrowserLarge_artwork\n  internalID\n  images {\n    width\n    height\n  }\n  figures {\n    __typename\n    ... on Image {\n      internalID\n      isDefault\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork on Artwork {\n  formattedMetadata\n  images {\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    fallback: cropped(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  ...SeoDataForArtwork_artwork\n  ...ArtworkZendesk_artwork\n  href\n  isShareable\n  metaImage: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    longDescription: description(limit: 200)\n  }\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  slug\n  artist {\n    href\n    related {\n      artistsConnection(kind: MAIN, first: 6, after: \"\") {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            ...EntityHeaderArtist_artist\n            id\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkSidebar2Artists_artwork on Artwork {\n  culturalMaker\n  artists {\n    slug\n    name\n    id\n  }\n}\n\nfragment ArtworkSidebar2ArtworkTitle_artwork on Artwork {\n  date\n  title\n}\n\nfragment ArtworkSidebar2AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  isBiddable\n}\n\nfragment ArtworkSidebar2Classification_artwork on Artwork {\n  attributionClass {\n    shortArrayDescription\n    id\n  }\n}\n\nfragment ArtworkSidebar2CreateArtworkAlert_artwork on Artwork {\n  internalID\n  title\n  slug\n  artists {\n    internalID\n    name\n    slug\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebar2Details_artwork on Artwork {\n  medium\n  dimensions {\n    in\n    cm\n  }\n  framed {\n    details\n  }\n  editionOf\n  ...ArtworkSidebar2Classification_artwork\n  ...ArtworkSidebar2AuthenticityCertificate_artwork\n}\n\nfragment ArtworkSidebar2PartnerInfo_artwork on Artwork {\n  internalID\n  slug\n  isInquireable\n  isInAuction\n  partner {\n    name\n    href\n    cities\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkSidebar2ShippingInformation_artwork on Artwork {\n  shippingOrigin\n  shippingInfo\n}\n\nfragment ArtworkSidebar2_artwork on Artwork {\n  slug\n  isSold\n  isAcquireable\n  isOfferable\n  isInAuction\n  saleMessage\n  ...ArtworkSidebar2ArtworkTitle_artwork\n  ...ArtworkSidebar2Artists_artwork\n  ...ArtworkSidebar2Details_artwork\n  ...ArtworkSidebar2ShippingInformation_artwork\n  ...ArtworkSidebar2PartnerInfo_artwork\n  ...ArtworkSidebar2CreateArtworkAlert_artwork\n  sale {\n    startAt\n    id\n  }\n  saleArtwork {\n    lotID\n    extendedBiddingEndAt\n    endAt\n    id\n  }\n  artists {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    ...EntityHeaderArtist_artist\n    internalID\n    slug\n    name\n    ...FollowArtistButton_artist_2eN9lh\n    id\n  }\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_artwork on Artwork {\n  internalID\n  sale {\n    isClosed\n    id\n  }\n  saleArtwork {\n    currentBid {\n      display\n    }\n    id\n  }\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_me on Me {\n  ...ArtworkSidebarBidAction_me\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarAuctionTimer_artwork on Artwork {\n  internalID\n  sale {\n    cascadingEndTimeIntervalMinutes\n    isClosed\n    ...AuctionTimer_sale\n    startAt\n    id\n  }\n  saleArtwork {\n    ...LotTimer_saleArtwork\n    endAt\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    requireIdentityVerification\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    endedAt\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_me on Me {\n  identityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebarBiddingClosedMessage_artwork on Artwork {\n  artists {\n    internalID\n    id\n  }\n  ...ArtworkSidebarCreateAlertButton_artwork\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attributionClass {\n    shortArrayDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n  artists {\n    internalID\n    id\n  }\n  internalID\n  isOfferableFromInquiry\n  isPriceHidden\n  is_acquireable: isAcquireable\n  is_for_sale: isForSale\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  is_sold: isSold\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  slug\n  ...ArtworkSidebarCreateAlertButton_artwork\n}\n\nfragment ArtworkSidebarCreateAlertButton_artwork on Artwork {\n  slug\n  internalID\n  title\n  artists {\n    internalID\n    name\n    slug\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    endedAt\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    isBenefit\n    partner {\n      name\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  internalID\n  slug\n  isInquireable\n  is_in_auction: isInAuction\n  partner {\n    name\n    href\n    cities\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  __isSellable: __typename\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  is_sold: isSold\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  hasCertificateOfAuthenticity\n  partner {\n    isVerifiedSeller\n    id\n  }\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarAuctionInfoPolling_artwork\n  ...ArtworkSidebarAuctionTimer_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  ...BuyerGuarantee_artwork\n  ...CreateArtworkAlertSection_artwork\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n  sale {\n    is_closed: isClosed\n    startAt\n    internalID\n    extendedBiddingIntervalMinutes\n    id\n  }\n  saleArtwork {\n    endAt\n    endedAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  artists {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebar_me on Me {\n  ...ArtworkSidebarAuctionInfoPolling_me\n}\n\nfragment ArtworkTopContextBar_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale {\n    isAuction\n    isBenefit\n    isGalleryAuction\n    coverImage {\n      url\n    }\n    id\n  }\n  context {\n    __typename\n    ... on Sale {\n      name\n      href\n    }\n    ... on Fair {\n      name\n      href\n      profile {\n        icon {\n          url\n        }\n        id\n      }\n    }\n    ... on Show {\n      name\n      href\n      status\n      thumbnail: coverImage {\n        url\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork on Artwork {\n  figures {\n    __typename\n    ... on Video {\n      type: __typename\n      url\n      height\n      width\n    }\n  }\n}\n\nfragment ArtworkZendesk_artwork on Artwork {\n  isAcquireable\n  isInquireable\n  isOfferable\n  isInAuction\n  listPrice {\n    __typename\n    ... on Money {\n      currencyCode\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        currencyCode\n        major\n      }\n    }\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  liveStartAt\n  endAt\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment BuyerGuarantee_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment CreateArtworkAlertSection_artwork on Artwork {\n  internalID\n  title\n  slug\n  artists {\n    internalID\n    name\n    slug\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  ...FollowArtistPopover_artist\n  id\n  slug\n  name\n  internalID\n  isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  slug\n  internalID\n  name\n  formattedNationalityAndBirthday\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true, includeFallbackArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment LotTimer_saleArtwork on SaleArtwork {\n  endAt\n  formattedStartDateTime\n  extendedBiddingEndAt\n  lotID\n  sale {\n    startAt\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    internalID\n    id\n  }\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      minPrice {\n        major\n        currencyCode\n      }\n      maxPrice {\n        major\n      }\n    }\n    ... on Money {\n      major\n      currencyCode\n    }\n  }\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment SubmittedOrderModal_me on Me {\n  orders(states: [SUBMITTED], mode: OFFER, first: 1, sort: UPDATED_AT_DESC) {\n    edges {\n      node {\n        __typename\n        stateExpiresAt(format: \"MMM D\")\n        lineItems {\n          edges {\n            node {\n              artwork {\n                slug\n                id\n              }\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
+    "text": "query artworkRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...ArtworkApp_artwork\n    id\n  }\n  me {\n    ...ArtworkApp_me\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML, partnerBio: false) {\n    credit\n    partnerID\n    text\n  }\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  internalID\n  id\n  slug\n  title\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkSharePanel_artwork\n  ...ViewInRoom_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  downloadableImageUrl\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n  is_saved: isSaved\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  slug\n  internalID\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  availability\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  is_in_auction: isInAuction\n  sale {\n    ...CascadingEndTimesBanner_sale\n    internalID\n    slug\n    extendedBiddingIntervalMinutes\n    id\n  }\n  artists {\n    id\n    slug\n    ...ArtistInfo_artist\n  }\n  artist {\n    ...ArtistInfo_artist\n    id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkTopContextBar_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkImageBrowser_artwork\n  ...ArtworkSidebar2_artwork\n}\n\nfragment ArtworkApp_me on Me {\n  ...ArtworkSidebar_me\n  ...SubmittedOrderModal_me\n}\n\nfragment ArtworkImageBrowserLarge_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  ...ArtworkVideoPlayer_artwork\n  figures {\n    __typename\n    ... on Image {\n      type: __typename\n      internalID\n      isZoomable\n      ...DeepZoom_image\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork on Artwork {\n  ...ArtworkLightbox_artwork\n  ...ArtworkVideoPlayer_artwork\n  figures {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkActions_artwork\n  ...ArtworkImageBrowserSmall_artwork\n  ...ArtworkImageBrowserLarge_artwork\n  internalID\n  images {\n    width\n    height\n  }\n  figures {\n    __typename\n    ... on Image {\n      internalID\n      isDefault\n    }\n    ... on Video {\n      type: __typename\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork on Artwork {\n  formattedMetadata\n  images {\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    fallback: cropped(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  ...SeoDataForArtwork_artwork\n  ...ArtworkZendesk_artwork\n  href\n  isShareable\n  metaImage: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    longDescription: description(limit: 200)\n  }\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  slug\n  artist {\n    href\n    related {\n      artistsConnection(kind: MAIN, first: 6, after: \"\") {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            ...EntityHeaderArtist_artist\n            id\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkSidebar2Artists_artwork on Artwork {\n  culturalMaker\n  artists {\n    slug\n    name\n    id\n  }\n}\n\nfragment ArtworkSidebar2ArtworkTitle_artwork on Artwork {\n  date\n  title\n}\n\nfragment ArtworkSidebar2AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  isBiddable\n}\n\nfragment ArtworkSidebar2Classification_artwork on Artwork {\n  attributionClass {\n    shortArrayDescription\n    id\n  }\n}\n\nfragment ArtworkSidebar2CreateArtworkAlert_artwork on Artwork {\n  internalID\n  title\n  slug\n  artists {\n    internalID\n    name\n    slug\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebar2Details_artwork on Artwork {\n  medium\n  dimensions {\n    in\n    cm\n  }\n  framed {\n    details\n  }\n  editionOf\n  ...ArtworkSidebar2Classification_artwork\n  ...ArtworkSidebar2AuthenticityCertificate_artwork\n}\n\nfragment ArtworkSidebar2EditionSets_artwork on Artwork {\n  isInquireable\n  isOfferable\n  isAcquireable\n  editionSets {\n    id\n    isOfferable\n    isAcquireable\n    saleMessage\n    ...ArtworkSidebar2SizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebar2PartnerInfo_artwork on Artwork {\n  internalID\n  slug\n  isInquireable\n  isInAuction\n  partner {\n    name\n    href\n    cities\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkSidebar2ShippingInformation_artwork on Artwork {\n  shippingOrigin\n  shippingInfo\n}\n\nfragment ArtworkSidebar2SizeInfo_piece on Sellable {\n  __isSellable: __typename\n  dimensions {\n    in\n    cm\n  }\n  editionOf\n}\n\nfragment ArtworkSidebar2_artwork on Artwork {\n  slug\n  isSold\n  isAcquireable\n  isOfferable\n  isInAuction\n  saleMessage\n  ...ArtworkSidebar2ArtworkTitle_artwork\n  ...ArtworkSidebar2Artists_artwork\n  ...ArtworkSidebar2Details_artwork\n  ...ArtworkSidebar2EditionSets_artwork\n  ...ArtworkSidebar2ShippingInformation_artwork\n  ...ArtworkSidebar2PartnerInfo_artwork\n  ...ArtworkSidebar2CreateArtworkAlert_artwork\n  sale {\n    startAt\n    id\n  }\n  saleArtwork {\n    lotID\n    extendedBiddingEndAt\n    endAt\n    id\n  }\n  artists {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    ...EntityHeaderArtist_artist\n    internalID\n    slug\n    name\n    ...FollowArtistButton_artist_2eN9lh\n    id\n  }\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_artwork on Artwork {\n  internalID\n  sale {\n    isClosed\n    id\n  }\n  saleArtwork {\n    currentBid {\n      display\n    }\n    id\n  }\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_me on Me {\n  ...ArtworkSidebarBidAction_me\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarAuctionTimer_artwork on Artwork {\n  internalID\n  sale {\n    cascadingEndTimeIntervalMinutes\n    isClosed\n    ...AuctionTimer_sale\n    startAt\n    id\n  }\n  saleArtwork {\n    ...LotTimer_saleArtwork\n    endAt\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    requireIdentityVerification\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    endedAt\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_me on Me {\n  identityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebarBiddingClosedMessage_artwork on Artwork {\n  artists {\n    internalID\n    id\n  }\n  ...ArtworkSidebarCreateAlertButton_artwork\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attributionClass {\n    shortArrayDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n  artists {\n    internalID\n    id\n  }\n  internalID\n  isOfferableFromInquiry\n  isPriceHidden\n  is_acquireable: isAcquireable\n  is_for_sale: isForSale\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  is_sold: isSold\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  slug\n  ...ArtworkSidebarCreateAlertButton_artwork\n}\n\nfragment ArtworkSidebarCreateAlertButton_artwork on Artwork {\n  slug\n  internalID\n  title\n  artists {\n    internalID\n    name\n    slug\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    endedAt\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    isBenefit\n    partner {\n      name\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  internalID\n  slug\n  isInquireable\n  is_in_auction: isInAuction\n  partner {\n    name\n    href\n    cities\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  __isSellable: __typename\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  is_sold: isSold\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  hasCertificateOfAuthenticity\n  partner {\n    isVerifiedSeller\n    id\n  }\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarAuctionInfoPolling_artwork\n  ...ArtworkSidebarAuctionTimer_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  ...BuyerGuarantee_artwork\n  ...CreateArtworkAlertSection_artwork\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n  sale {\n    is_closed: isClosed\n    startAt\n    internalID\n    extendedBiddingIntervalMinutes\n    id\n  }\n  saleArtwork {\n    endAt\n    endedAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  artists {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebar_me on Me {\n  ...ArtworkSidebarAuctionInfoPolling_me\n}\n\nfragment ArtworkTopContextBar_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale {\n    isAuction\n    isBenefit\n    isGalleryAuction\n    coverImage {\n      url\n    }\n    id\n  }\n  context {\n    __typename\n    ... on Sale {\n      name\n      href\n    }\n    ... on Fair {\n      name\n      href\n      profile {\n        icon {\n          url\n        }\n        id\n      }\n    }\n    ... on Show {\n      name\n      href\n      status\n      thumbnail: coverImage {\n        url\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork on Artwork {\n  figures {\n    __typename\n    ... on Video {\n      type: __typename\n      url\n      height\n      width\n    }\n  }\n}\n\nfragment ArtworkZendesk_artwork on Artwork {\n  isAcquireable\n  isInquireable\n  isOfferable\n  isInAuction\n  listPrice {\n    __typename\n    ... on Money {\n      currencyCode\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        currencyCode\n        major\n      }\n    }\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  liveStartAt\n  endAt\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment BuyerGuarantee_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment CreateArtworkAlertSection_artwork on Artwork {\n  internalID\n  title\n  slug\n  artists {\n    internalID\n    name\n    slug\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  ...FollowArtistPopover_artist\n  id\n  slug\n  name\n  internalID\n  isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  slug\n  internalID\n  name\n  formattedNationalityAndBirthday\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true, includeFallbackArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment LotTimer_saleArtwork on SaleArtwork {\n  endAt\n  formattedStartDateTime\n  extendedBiddingEndAt\n  lotID\n  sale {\n    startAt\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    internalID\n    id\n  }\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      minPrice {\n        major\n        currencyCode\n      }\n      maxPrice {\n        major\n      }\n    }\n    ... on Money {\n      major\n      currencyCode\n    }\n  }\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment SubmittedOrderModal_me on Me {\n  orders(states: [SUBMITTED], mode: OFFER, first: 1, sort: UPDATED_AT_DESC) {\n    edges {\n      node {\n        __typename\n        stateExpiresAt(format: \"MMM D\")\n        lineItems {\n          edges {\n            node {\n              artwork {\n                slug\n                id\n              }\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4219]

### Description

> ⚠️ Feature is behind a feature flag

Adds Edition selection in artwork screen, functionality and tests will be added on next ticket ([FX-4149](https://artsyproduct.atlassian.net/browse/FX-4149))

#### Screenshots

|Desktop| mWeb|
|---|---|
|<img width="1512" alt="Screenshot 2022-09-14 at 17 22 48" src="https://user-images.githubusercontent.com/21178754/190196608-0d80ef91-e5fd-404f-8d0f-3ffc0777c13e.png">|<img width="378" alt="Screenshot 2022-09-14 at 17 23 26" src="https://user-images.githubusercontent.com/21178754/190196604-4312597b-4deb-4d63-82b5-f4881459b901.png">|



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4219]: https://artsyproduct.atlassian.net/browse/FX-4219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ