### PR TITLE
feat: User sees show events on the info page GRO-1024

### DIFF
--- a/src/Apps/Show/Routes/ShowInfo.tsx
+++ b/src/Apps/Show/Routes/ShowInfo.tsx
@@ -24,6 +24,8 @@ export const ShowInfo: React.FC<ShowInfoProps> = ({
   show,
   show: { about, pressRelease, partner, hasLocation },
 }) => {
+  const events = show.events || []
+
   return (
     <>
       <Text as="h1" variant="xl" my={4}>
@@ -62,6 +64,8 @@ export const ShowInfo: React.FC<ShowInfoProps> = ({
                 </HTML>
               </Box>
             )}
+
+            {events.length > 0 && <EventList events={events} />}
           </Join>
         </Column>
 
@@ -95,6 +99,40 @@ export const ShowInfo: React.FC<ShowInfoProps> = ({
   )
 }
 
+const EventList: React.FC<{ events: ShowInfoProps["show"]["events"] }> = ({
+  events,
+}) => {
+  if (!events?.length) return null
+
+  return (
+    <Box>
+      <Text as="h2" variant="xl" mb="2">
+        Events
+      </Text>
+
+      <Join separator={<Spacer mt="2" />}>
+        {events.map((event, index) => {
+          if (!event) return null
+
+          const eventHeading = event.title || event.eventType
+
+          return (
+            <Box key={index}>
+              <Text as="h3" variant="lg">
+                {eventHeading}
+              </Text>
+              <Text color="black60" mb="1">
+                {event.dateTimeRange}
+              </Text>
+              <Text>{event.description}</Text>
+            </Box>
+          )
+        })}
+      </Join>
+    </Box>
+  )
+}
+
 export const ShowInfoFragmentContainer = createFragmentContainer(ShowInfo, {
   show: graphql`
     fragment ShowInfo_show on Show {
@@ -104,6 +142,12 @@ export const ShowInfoFragmentContainer = createFragmentContainer(ShowInfo, {
       about: description
       pressRelease(format: HTML)
       hasLocation
+      events {
+        dateTimeRange
+        description
+        eventType
+        title
+      }
       partner {
         __typename
         ... on Partner {

--- a/src/Apps/Show/__tests__/ShowInfo.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowInfo.jest.tsx
@@ -16,11 +16,80 @@ const { getWrapper } = setupTestWrapper({
 })
 
 describe("ShowInfo", () => {
-  it("renders the info page", () => {
-    const wrapper = getWrapper({ Partner: () => ({ type: "Gallery" }) })
+  describe("default rendering", () => {
+    it("renders the basic page", () => {
+      const events = []
 
-    expect(wrapper.find("h1")).toHaveLength(1)
-    expect(wrapper.find("h1").text()).toEqual("About")
-    expect(wrapper.find("h2").text()).toEqual("Gallery")
+      const wrapper = getWrapper({
+        Show: () => ({ events }),
+        Partner: () => ({ type: "Gallery" }),
+      })
+
+      expect(wrapper.find("h1")).toHaveLength(1)
+      expect(wrapper.find("h1").text()).toEqual("About")
+      expect(wrapper.find("EventList")).toHaveLength(0)
+      expect(wrapper.find("h2").text()).toEqual("Gallery")
+    })
+  })
+
+  describe("with an event", () => {
+    it("renders that event", () => {
+      const event = {
+        title: "Number one best event",
+        dateTimeRange: "noon to 1:00",
+        description: "This is going to be a fun event!",
+      }
+
+      const events = [event]
+
+      const wrapper = getWrapper({
+        Show: () => ({ events }),
+        Partner: () => ({ type: "Gallery" }),
+      })
+
+      expect(wrapper.find("EventList")).toHaveLength(1)
+      const eventList = wrapper.find("EventList")
+
+      expect(eventList.find("h3").text()).toEqual("Number one best event")
+      expect(eventList.text()).toContain("noon to 1:00")
+      expect(eventList.text()).toContain("This is going to be a fun event!")
+    })
+  })
+
+  describe("with an event that has no title", () => {
+    it("renders the event type instead", () => {
+      const event = {
+        title: null,
+        eventType: "Opening Ceremony",
+        dateTimeRange: "noon to 1:00",
+        description: "This is going to be a fun event!",
+      }
+
+      const events = [event]
+
+      const wrapper = getWrapper({
+        Show: () => ({ events }),
+        Partner: () => ({ type: "Gallery" }),
+      })
+
+      expect(wrapper.text()).toContain("Opening Ceremony")
+    })
+  })
+
+  describe("with a null event", () => {
+    it("skips rendering that event", () => {
+      const event = null
+
+      const events = [event]
+
+      const wrapper = getWrapper({
+        Show: () => ({ events }),
+        Partner: () => ({ type: "Gallery" }),
+      })
+
+      expect(wrapper.find("EventList")).toHaveLength(1)
+      const eventList = wrapper.find("EventList")
+      expect(eventList.find("h3")).toHaveLength(0)
+    })
   })
 })

--- a/src/__generated__/ShowInfo_Test_Query.graphql.ts
+++ b/src/__generated__/ShowInfo_Test_Query.graphql.ts
@@ -118,6 +118,12 @@ fragment ShowInfo_show on Show {
   about: description
   pressRelease(format: HTML)
   hasLocation
+  events {
+    dateTimeRange
+    description
+    eventType
+    title
+  }
   partner {
     __typename
     ... on Partner {
@@ -428,6 +434,45 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "ShowEventType",
+            "kind": "LinkedField",
+            "name": "events",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "dateTimeRange",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "description",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "eventType",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": null,
             "kind": "LinkedField",
             "name": "partner",
@@ -621,12 +666,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2e595a9aeb431bde804131d69cf20160",
+    "cacheID": "c604a4ba2ebaab6a838e1abcb5e8e2e6",
     "id": null,
     "metadata": {},
     "name": "ShowInfo_Test_Query",
     "operationKind": "query",
-    "text": "query ShowInfo_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment ShowHours_show on Show {\n  location {\n    ...ShowLocationHours_location\n    id\n  }\n  fair {\n    location {\n      ...ShowLocationHours_location\n      id\n    }\n    id\n  }\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      display\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  ...ShowHours_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  partner {\n    __typename\n    ... on Partner {\n      ...EntityHeaderPartner_partner\n      type\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowLocationHours_location on Location {\n  openingHours {\n    __typename\n    ... on OpeningHoursArray {\n      schedules {\n        days\n        hours\n      }\n    }\n    ... on OpeningHoursText {\n      text\n    }\n  }\n}\n"
+    "text": "query ShowInfo_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment ShowHours_show on Show {\n  location {\n    ...ShowLocationHours_location\n    id\n  }\n  fair {\n    location {\n      ...ShowLocationHours_location\n      id\n    }\n    id\n  }\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      display\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  ...ShowHours_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  events {\n    dateTimeRange\n    description\n    eventType\n    title\n  }\n  partner {\n    __typename\n    ... on Partner {\n      ...EntityHeaderPartner_partner\n      type\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowLocationHours_location on Location {\n  openingHours {\n    __typename\n    ... on OpeningHoursArray {\n      schedules {\n        days\n        hours\n      }\n    }\n    ... on OpeningHoursText {\n      text\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ShowInfo_show.graphql.ts
+++ b/src/__generated__/ShowInfo_show.graphql.ts
@@ -9,6 +9,12 @@ export type ShowInfo_show = {
     readonly about: string | null;
     readonly pressRelease: string | null;
     readonly hasLocation: boolean | null;
+    readonly events: ReadonlyArray<{
+        readonly dateTimeRange: string | null;
+        readonly description: string | null;
+        readonly eventType: string | null;
+        readonly title: string | null;
+    } | null> | null;
     readonly partner: ({
         readonly __typename: "Partner";
         readonly type: string | null;
@@ -72,6 +78,45 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
+      "concreteType": "ShowEventType",
+      "kind": "LinkedField",
+      "name": "events",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "dateTimeRange",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "description",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "eventType",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "title",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": null,
       "kind": "LinkedField",
       "name": "partner",
@@ -120,5 +165,5 @@ const node: ReaderFragment = {
   "type": "Show",
   "abstractKey": null
 };
-(node as any).hash = '093a8b1f2819b7cb2556cbb3352decda';
+(node as any).hash = 'fec6d5d1a6d802b0be2ddd9e4b3f4630';
 export default node;

--- a/src/__generated__/showRoutes_ShowInfoQuery.graphql.ts
+++ b/src/__generated__/showRoutes_ShowInfoQuery.graphql.ts
@@ -122,6 +122,12 @@ fragment ShowInfo_show on Show {
   about: description
   pressRelease(format: HTML)
   hasLocation
+  events {
+    dateTimeRange
+    description
+    eventType
+    title
+  }
   partner {
     __typename
     ... on Partner {
@@ -439,6 +445,45 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "ShowEventType",
+            "kind": "LinkedField",
+            "name": "events",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "dateTimeRange",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "description",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "eventType",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": null,
             "kind": "LinkedField",
             "name": "partner",
@@ -632,12 +677,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "05d02da32e161e66bf5bbd2d56813aaf",
+    "cacheID": "e5c77788e8fed5833db0e3fd3aa75bdd",
     "id": null,
     "metadata": {},
     "name": "showRoutes_ShowInfoQuery",
     "operationKind": "query",
-    "text": "query showRoutes_ShowInfoQuery(\n  $slug: String!\n) {\n  show(id: $slug) @principalField {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment ShowHours_show on Show {\n  location {\n    ...ShowLocationHours_location\n    id\n  }\n  fair {\n    location {\n      ...ShowLocationHours_location\n      id\n    }\n    id\n  }\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      display\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  ...ShowHours_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  partner {\n    __typename\n    ... on Partner {\n      ...EntityHeaderPartner_partner\n      type\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowLocationHours_location on Location {\n  openingHours {\n    __typename\n    ... on OpeningHoursArray {\n      schedules {\n        days\n        hours\n      }\n    }\n    ... on OpeningHoursText {\n      text\n    }\n  }\n}\n"
+    "text": "query showRoutes_ShowInfoQuery(\n  $slug: String!\n) {\n  show(id: $slug) @principalField {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    ...FollowProfileButton_profile\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n}\n\nfragment ShowHours_show on Show {\n  location {\n    ...ShowLocationHours_location\n    id\n  }\n  fair {\n    location {\n      ...ShowLocationHours_location\n      id\n    }\n    id\n  }\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      display\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  ...ShowHours_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  events {\n    dateTimeRange\n    description\n    eventType\n    title\n  }\n  partner {\n    __typename\n    ... on Partner {\n      ...EntityHeaderPartner_partner\n      type\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowLocationHours_location on Location {\n  openingHours {\n    __typename\n    ... on OpeningHoursArray {\n      schedules {\n        days\n        hours\n      }\n    }\n    ... on OpeningHoursText {\n      text\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This PR adds back something that was removed when we re-built the more info page for shows: `PartnerShowEvent` records. Here's the Figma I was following:

https://www.figma.com/file/k465puwy6YQOcEESEkppni/Smaller-Tasks-2022?node-id=24%3A952

What I did here was update the GQL to include the `events` array and then I broke out an `EventList` component. I didn't start with that component extracted but then when it came time to test it was handy to have a way to filter down to that part of the page.

<details>

<summary>Heres some screenshots</summary>

<img width="1080" alt="Screen Shot 2022-09-14 at 10 53 36 AM" src="https://user-images.githubusercontent.com/79799/190189294-cdffacb0-fb9b-4d69-8ebd-a0aaff8a1480.png">
<img width="1080" alt="Screen Shot 2022-09-14 at 10 53 10 AM" src="https://user-images.githubusercontent.com/79799/190189316-759bee7d-99c4-4f96-a0f5-0adc3445edb9.png">

</details>

https://artsyproduct.atlassian.net/browse/GRO-1024

/cc @artsy/grow-devs @starsirius 