### PR TITLE
feat: allow prod to run on spot

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -86,6 +86,15 @@ spec:
                 operator: In
                 values:
                 - foreground
+                - foreground-spot
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                      - foreground
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -87,14 +87,6 @@ spec:
                 values:
                 - foreground
                 - foreground-spot
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: tier
-                    operator: In
-                    values:
-                      - foreground
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -99,15 +99,14 @@ spec:
                 values:
                 - foreground
                 - foreground-spot
-      topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: tier
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            app: force
-            layer: application
-            component: web
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                      - foreground
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -99,14 +99,6 @@ spec:
                 values:
                 - foreground
                 - foreground-spot
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: tier
-                    operator: In
-                    values:
-                      - foreground
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR supports [PLATFORM-4571]

### Description

Staging [has been partly run on Spot nodes](https://github.com/artsy/force/pull/10846) for a while. I haven't heard of any problems. This PR spikes Prod on Spot.

- Allow pods in Prod to run on Spot nodes.

And (as [done for Gravity](https://github.com/artsy/gravity/pull/15646)):

- Remove topologySpreadConstraints in Staging.

[PLATFORM-4571]: https://artsyproduct.atlassian.net/browse/PLATFORM-4571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ