### PR TITLE
feat: Increase the max number of works per artist for new for you GRO-1297

### DIFF
--- a/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
+++ b/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
@@ -116,7 +116,11 @@ export const HomeNewWorksForYouRailQueryRenderer: React.FC = () => {
       environment={relayEnvironment}
       query={graphql`
         query HomeNewWorksForYouRailQuery {
-          artworksForUser(includeBackfill: true, first: 20) {
+          artworksForUser(
+            includeBackfill: true
+            first: 20
+            maxWorksPerArtist: 3
+          ) {
             ...HomeNewWorksForYouRail_artworksForUser
           }
         }

--- a/src/Apps/NewForYou/newForYouRoutes.tsx
+++ b/src/Apps/NewForYou/newForYouRoutes.tsx
@@ -17,7 +17,7 @@ export const newForYouRoutes: AppRouteConfig[] = [
       const first = parseInt(props.location.query.first, 10) || 20
       const includeBackfill = props.location.query.includeBackfill ?? true
       const version = props.location.query.version?.toUpperCase()
-      const maxWorksPerArtist = props.location.query.maxWorksPerArtist ?? 1
+      const maxWorksPerArtist = props.location.query.maxWorksPerArtist ?? 3
 
       return {
         ...params,


### PR DESCRIPTION
This PR updates both the rail on the homepage and the actual /new-for-you page so that they will show more works per artist. I considered extracting a constant for this but then changed my mind. 🤷 

https://artsyproduct.atlassian.net/browse/GRO-1297

/cc @artsy/grow-devs @shaq31415926 @isakelaris 