### PR TITLE
fix: use fill: currentColor + wrapper color for icon color

### DIFF
--- a/src/Apps/Conversation/Components/OrderUpdate.tsx
+++ b/src/Apps/Conversation/Components/OrderUpdate.tsx
@@ -9,7 +9,6 @@ import {
   MoneyFillIcon,
   Spacer,
   Text,
-  THEME_V3,
 } from "@artsy/palette"
 
 import { TimeSince } from "./TimeSince"

--- a/src/Apps/Conversation/Components/OrderUpdate.tsx
+++ b/src/Apps/Conversation/Components/OrderUpdate.tsx
@@ -62,7 +62,7 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({
     const reasonRejected = stateReason?.includes("_rejected")
     if (state === "PROCESSING_APPROVAL") {
       Icon = AlertCircleFillIcon
-      color = THEME_V3.colors.yellow100 as Color
+      color = "yellow100"
       textColor = "black100"
       message = "Offer accepted. Payment processing"
     } else if (state === "APPROVED") {
@@ -97,8 +97,8 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({
         mb={1}
       />
       <Flex px={2} justifyContent="center" flexDirection="row">
-        <Flex flexDirection="row">
-          <Icon fill={color} />
+        <Flex flexDirection="row" color={color}>
+          <Icon fill="currentColor" />
           <Flex flexDirection="column" pl={1}>
             <Text color={textColor || color} variant="xs">
               {message}


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

This PR offers a solution to [GRO-1151] where out-of-date theme colors were applied to icon components.

#minor

### Description

The fix, discussed with @damassi and @dzucconi , was to use `fill: currentColor` + applying the color to a component that handles it better:
![image](https://user-images.githubusercontent.com/9088720/190242627-9a71ac0d-8ca1-4512-86d8-15a81130fc77.png)

<!-- Implementation description -->


[GRO-1151]: https://artsyproduct.atlassian.net/browse/GRO-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ