### PR TITLE
feat: User sees complete rules for password and better validations GRO-1277

### DIFF
--- a/src/Apps/Authentication/Routes/__tests__/ResetPasswordRoute.jest.tsx
+++ b/src/Apps/Authentication/Routes/__tests__/ResetPasswordRoute.jest.tsx
@@ -49,11 +49,11 @@ describe("ResetPasswordRoute", () => {
 
   it("resets the password and redirects", async () => {
     fireEvent.change(screen.getByPlaceholderText("New password"), {
-      target: { name: "password", value: "secretsecret" },
+      target: { name: "password", value: "Secretsecret1" },
     })
 
     fireEvent.change(screen.getByPlaceholderText("Confirm new password"), {
-      target: { name: "passwordConfirmation", value: "secretsecret" },
+      target: { name: "passwordConfirmation", value: "Secretsecret1" },
     })
 
     fireEvent.submit(screen.getByText("Change My Password"))
@@ -62,8 +62,8 @@ describe("ResetPasswordRoute", () => {
       expect(screen.getByText("Password Updated")).toBeInTheDocument()
 
       expect(mockResetPassword).toBeCalledWith({
-        password: "secretsecret",
-        passwordConfirmation: "secretsecret",
+        password: "Secretsecret1",
+        passwordConfirmation: "Secretsecret1",
         resetPasswordToken: "token", // pragma: allowlist secret
       })
 

--- a/src/Components/Authentication/Validators.tsx
+++ b/src/Components/Authentication/Validators.tsx
@@ -8,7 +8,10 @@ export const name = Yup.string().required("Name is required.")
 
 export const password = Yup.string()
   .required("Password required")
-  .min(8, "Your password must be at least 8 characters")
+  .min(8, "Your password must be at least 8 characters.")
+  .matches(/\d{1}/, "Your password must have at least 1 digit.")
+  .matches(/[a-z]{1}/, "Your password must have at least 1 lowercase letter.")
+  .matches(/[A-Z]{1}/, "Your password must have at least 1 uppercase letter.")
 
 export const loginPassword = Yup.string().required("Password required")
 
@@ -22,9 +25,7 @@ export const SignUpValidator = Yup.object().shape({
   accepted_terms_of_service,
   email,
   name,
-  password: Yup.string()
-    .required("Password required")
-    .min(8, "Password must be at least 8 characters."),
+  password,
 })
 
 export const ForgotPasswordValidator = Yup.object().shape({ email })

--- a/src/Components/Authentication/Views/SignUpForm.tsx
+++ b/src/Components/Authentication/Views/SignUpForm.tsx
@@ -168,7 +168,8 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
 
                   {!passwordErrorMessage && (
                     <Text variant="xs" color="black60" mt={0.5}>
-                      Password must be at least 8 characters.
+                      Password must be at least 8 characters and include a
+                      lowercase letter, uppercase letter, and digit.
                     </Text>
                   )}
                 </Box>

--- a/src/Components/Authentication/__tests__/helpers.jest.ts
+++ b/src/Components/Authentication/__tests__/helpers.jest.ts
@@ -1,5 +1,6 @@
 import { fetchQuery } from "relay-runtime"
 import { checkEmail } from "../helpers"
+import { password } from "../Validators"
 
 jest.mock("relay-runtime", () => ({ fetchQuery: jest.fn() }))
 const mockFetchQuery = fetchQuery as jest.Mock<any>
@@ -115,6 +116,41 @@ describe("Authentication Helpers", () => {
         expect(result).toBeFalsy()
         done()
       })
+    })
+  })
+
+  describe("password validation", () => {
+    it("rejects passwords that are too short", async () => {
+      const candidate = "short"
+      await expect(password.validate(candidate)).rejects.toThrow(
+        "must be at least 8"
+      )
+    })
+
+    it("rejects passwords that have no digits", async () => {
+      const candidate = "longenough"
+      await expect(password.validate(candidate)).rejects.toThrow(
+        "must have at least 1 digit"
+      )
+    })
+
+    it("rejects passwords that have no lowercase letters", async () => {
+      const candidate = "LONGENOUGH1"
+      await expect(password.validate(candidate)).rejects.toThrow(
+        "must have at least 1 lowercase letter"
+      )
+    })
+
+    it("rejects passwords that have no uppercase letters", async () => {
+      const candidate = "longenough1"
+      await expect(password.validate(candidate)).rejects.toThrow(
+        "must have at least 1 uppercase letter"
+      )
+    })
+
+    it("resolves passwords that are valid", async () => {
+      const candidate = "Longenough1"
+      await expect(password.validate(candidate)).resolves.toEqual(candidate)
     })
   })
 })


### PR DESCRIPTION
This PR started with a simply copy change so that users see all the rules for a valid password. Then I also update the Yup schema for the password field to throw errors when those rules are violated and provide better error messages to the user. This happens client-side so the user doesn't have to wait for the server to tell them something was wrong.

I then wrote unit tests that use this Yup schema to demonstrates the various ways a password can be invalid and finally a case for a password that follows the rules.

<details>

<summary>Here's some screenshots</summary>

<img width="1079" alt="Screen Shot 2022-09-14 at 3 33 00 PM" src="https://user-images.githubusercontent.com/79799/190246068-0149c35b-c5ee-42f7-9fea-cdb38bc08865.png">
<img width="1079" alt="Screen Shot 2022-09-14 at 3 33 30 PM" src="https://user-images.githubusercontent.com/79799/190246071-64c2e182-cca2-4361-aace-34da84d8a273.png">
<img width="1079" alt="Screen Shot 2022-09-14 at 3 33 37 PM" src="https://user-images.githubusercontent.com/79799/190246072-c0a38564-409b-4c22-9594-e52eaade519e.png">
<img width="1079" alt="Screen Shot 2022-09-14 at 3 33 40 PM" src="https://user-images.githubusercontent.com/79799/190246074-aedd9b96-7903-4831-88cb-909969bca3a6.png">
<img width="1079" alt="Screen Shot 2022-09-14 at 3 33 47 PM" src="https://user-images.githubusercontent.com/79799/190246075-a7e8f674-ba6e-474c-aaa4-0af812d1e26d.png">


</details>

https://artsyproduct.atlassian.net/browse/GRO-1277

/cc @artsy/grow-devs