### PR TITLE
fix(FX-4233): encode search term for tabs

### DIFF
--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -97,8 +97,12 @@ export const NavigationTabs: React.FC<NavigationTabsProps> = ({
     tracking.trackEvent(trackingData)
   }
 
-  const route = (tab: string) =>
-    `/search${tab.replace(/\s/g, "_")}?term=${term}`
+  const route = (tab: string) => {
+    const encodedTerm = encodeURIComponent(term)
+    const formattedTab = tab.replace(/\s/g, "_")
+
+    return `/search${formattedTab}?term=${encodedTerm}`
+  }
 
   const renderTab = (
     text: string,


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4233]

### Steps to Reproduce
* In the global search bar, enter a search term that contains an ampersand e.g. art sales & research 
* Disregard the dropdown and press Enter for full-page search results
* Note that the Artworks tab should be highlighted by default but isn’t
* Select any other tab
* Note that the # of results has changed, and that there is an un-escaped ampersand in the URL bar

### Current Outcome
* Tab highlighting is inconsistent
* Total hit counts is inconsistent between tabs

### Expected Outcome
* Artworks tab is always highlighted initially
* Hit counts is stable between tabs

<!-- Implementation description -->
