### PR TITLE
feat(TX-655): adjust transaction details text size and spacing

### DIFF
--- a/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -70,7 +70,7 @@ export class TransactionDetailsSummaryItem extends React.Component<
           data-test="buyerTotalDisplayAmount"
         />
         <Spacer mb={2} />
-        <Text variant={["xs", "sm"]} color="black60">
+        <Text variant="xs" color="black60">
           *Additional duties and taxes{" "}
           <a
             href="https://support.artsy.net/hc/en-us/articles/4413546314647-Will-my-order-be-subject-to-customs-fees-"
@@ -80,12 +80,14 @@ export class TransactionDetailsSummaryItem extends React.Component<
             may apply at import.
           </a>
         </Text>
-        <Spacer mb={2} />
         {this.shippingNotCalculated() && (
-          <Text variant={["xs", "sm"]} color="black60">
-            **Shipping costs to be confirmed by gallery. You will be able to
-            review the total price before payment.
-          </Text>
+          <>
+            <Spacer mb={2} />
+            <Text variant="xs" color="black60">
+              **Shipping costs to be confirmed by gallery. You will be able to
+              review the total price before payment.
+            </Text>
+          </>
         )}
         {showOfferNote && order.mode === "OFFER" && this.renderNoteEntry()}
         {showCongratulationMessage && (
@@ -98,7 +100,7 @@ export class TransactionDetailsSummaryItem extends React.Component<
             justifyContent="center"
             order={[2, 1]}
             p={2}
-            mt={4}
+            mt={2}
           >
             <Flex flexDirection="column" mr="auto">
               <Text variant="sm" color="blue100">
@@ -281,11 +283,11 @@ export class TransactionDetailsSummaryItem extends React.Component<
     if (offer?.note) {
       return (
         <>
-          <Spacer mb={[2, 4]} />
-          <Text variant={["xs", "sm"]} fontWeight="bold" color="black100">
+          <Spacer mt={2} />
+          <Text variant="sm" fontWeight="bold" color="black100">
             Your note
           </Text>
-          <Text size={["xs", "sm"]} color="black60">
+          <Text size="sm" color="black60">
             {offer.note}
           </Text>
         </>
@@ -306,13 +308,13 @@ interface EntryProps extends SecondaryEntryProps {
 const Entry: React.FC<EntryProps> = ({ label, value, final }) => (
   <Flex justifyContent="space-between" alignItems="baseline">
     <div>
-      <Text variant={["xs", "sm"]} color={final ? "black100" : "black60"}>
+      <Text variant="sm" color={final ? "black100" : "black60"}>
         {label}
       </Text>
     </div>
     <div>
       <Text
-        variant={["xs", "sm"]}
+        variant="sm"
         color={final ? "black100" : "black60"}
         fontWeight={final ? "semibold" : "regular"}
       >

--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -217,6 +217,7 @@ const USBankOnlyLabel = styled(Text)`
 `
 
 const RadioWithLabel = styled(BorderedRadio)`
+  padding-right: 0px !important;
   div {
     flex-direction: row;
     flex-grow: 0;


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-655]

### Description
This PR adjusts the transaction details text size and spacing. 

Fixes a small bug in the ACH custom radio label. 

<!-- Implementation description -->

### Screenshots
<img width="354" alt="Screenshot 2022-09-16 at 12 33 28 PM" src="https://user-images.githubusercontent.com/50849237/190624273-b8f95ac5-fcf9-4198-a5be-bde38615542a.png">

<img width="352" alt="Screenshot 2022-09-16 at 12 47 03 PM" src="https://user-images.githubusercontent.com/50849237/190624250-eaf565bd-1380-400f-b195-c5ab8dce8e46.png">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-655]: https://artsyproduct.atlassian.net/browse/TX-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ