### PR TITLE
fix(NX-3277): update copy for fraud prevention banner

### DIFF
--- a/src/Apps/Conversation/Components/Conversation.tsx
+++ b/src/Apps/Conversation/Components/Conversation.tsx
@@ -64,8 +64,8 @@ const GuaranteeBanner: React.FC<{ conversationID: string }> = ({
   return showBanner ? (
     <Banner variant="brand">
       <GuaranteeIcon mr={1} fill="white100" />
-      To protect your payment, always communicate and pay through the Artsy
-      platform.
+      To be covered by the Artsy Guarantee, always communicate and pay through
+      the Artsy platform.
     </Banner>
   ) : null
 }


### PR DESCRIPTION
The type of this PR is: Fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [NX-3277](https://artsyproduct.atlassian.net/browse/NX-3277)

### Description

Update fraud prevention banner copy to `To be covered by the Artsy Guarantee, always communicate and pay through the Artsy platform.`

<img width="696" alt="Screenshot 2022-09-16 at 15 27 52" src="https://user-images.githubusercontent.com/17580625/190650034-3ec670ec-fea0-43fc-98d2-d5e36a83aba5.png">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ