### PR TITLE
chore: Let react-i18next handle pluralization on Search results

### DIFF
--- a/src/Apps/Search/Components/ZeroState.tsx
+++ b/src/Apps/Search/Components/ZeroState.tsx
@@ -2,6 +2,7 @@ import { Box, Separator, Text } from "@artsy/palette"
 import { SendFeedback } from "Apps/Search/Components/SendFeedback"
 import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { FC } from "react"
+import { useTranslation } from "react-i18next"
 
 interface ZeroStateProps {
   term: string
@@ -9,17 +10,18 @@ interface ZeroStateProps {
 
 export const ZeroState: FC<ZeroStateProps> = ({ term }) => {
   const { hasFilters, filters } = useArtworkFilterContext()
+  const { t } = useTranslation()
 
   return (
     <>
       <Text variant={["lg-display", "xl"]}>
         {hasFilters ? (
-          "No results found."
+          t`searchApp.noResultsFound`
         ) : (
           <>
-            No results found for{" "}
+            {t(`searchApp.resultsCount`, { count: 0 })}
             <Box as="span" color="blue100">
-              “{filters?.term ?? term}”
+              “ {filters?.term ?? term}”
             </Box>
           </>
         )}

--- a/src/Apps/Search/SearchApp.tsx
+++ b/src/Apps/Search/SearchApp.tsx
@@ -16,6 +16,7 @@ import { ZeroState } from "./Components/ZeroState"
 import { useRouter } from "System/Router/useRouter"
 import { Sticky, StickyProvider } from "Components/Sticky"
 import { AppContainer } from "../Components/AppContainer"
+import { useTranslation } from "react-i18next"
 
 export interface SearchAppProps {
   viewer: SearchApp_viewer
@@ -25,10 +26,12 @@ const TotalResults: React.FC<{ count: number; term: string }> = ({
   count,
   term,
 }) => {
+  const { t } = useTranslation()
+
   return (
     <>
       <Text variant={["lg-display", "xl"]} display="inline">
-        {count.toLocaleString()} result{count > 1 ? "s" : ""} for
+        {t(`searchApp.resultsCount`, { count: count })}
       </Text>
       <Text variant={["lg-display", "xl"]} color="blue100" display="inline">
         {` \u201C${term}\u201D`}

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -76,5 +76,11 @@
         "description": "Get notifications for similar works"
       }
     }
+  },
+  "searchApp" : {
+    "noResultsFound": "No results found.",
+    "resultsCount_zero": "No results found for",
+    "resultsCount_one": "1 result for",
+    "resultsCount_other": "{{count}} results for"
   }
 }


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->
Remove the logic responsible for defining if the sentence that's displayed on the search results should use singular or plural form and replace it with i18n keys.

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ