### PR TITLE
feat: Add Get in Touch CTA

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/Components/Header.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/Header.tsx
@@ -50,7 +50,7 @@ export const Header: React.FC = () => {
               auction, private sale, or direct listing on Artsy.
             </Text>
 
-            {!showGetInTouchCTA ? (
+            {showGetInTouchCTA ? (
               <Flex flexDirection={["column", "row"]} maxWidth="450px">
                 <Flex flex={1}>
                   <Button

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/Header.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/Header.tsx
@@ -1,12 +1,14 @@
-import { RouterLink } from "System/Router/RouterLink"
-import { FullBleedHeader } from "Components/FullBleedHeader"
-import { Box, Button, Flex, Text } from "@artsy/palette"
+import { Box, Button, Flex, Spacer, Text } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
-import { useAnalyticsContext, useSystemContext } from "System"
+import { FullBleedHeader } from "Components/FullBleedHeader"
 import { useTracking } from "react-tracking"
+import { useAnalyticsContext, useSystemContext } from "System"
+import { RouterLink } from "System/Router/RouterLink"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 export const Header: React.FC = () => {
   const { trackEvent } = useTracking()
+  const showGetInTouchCTA = useFeatureFlag("get-in-touch-flow-web")
   const { user } = useSystemContext()
   const { contextPageOwnerType } = useAnalyticsContext()
 
@@ -48,16 +50,48 @@ export const Header: React.FC = () => {
               auction, private sale, or direct listing on Artsy.
             </Text>
 
-            <Button
-              // @ts-ignore
-              as={RouterLink}
-              variant="primaryWhite"
-              to="/sell/submission/artwork-details"
-              onClick={trackSubmitClick}
-              mb={[4, 0]}
-            >
-              Submit an Artwork
-            </Button>
+            {!showGetInTouchCTA ? (
+              <Flex flexDirection={["column", "row"]} maxWidth="450px">
+                <Flex flex={1}>
+                  <Button
+                    // @ts-ignore
+                    as={RouterLink}
+                    variant="primaryWhite"
+                    to="/sell/submission/artwork-details"
+                    onClick={trackSubmitClick}
+                    mb={[2, 0]}
+                    width={"100%"}
+                  >
+                    Submit an Artwork
+                  </Button>
+                </Flex>
+
+                <Spacer ml={[0, 2]} />
+                <Flex flex={1}>
+                  <Button
+                    // @ts-ignore
+                    as={RouterLink}
+                    variant="secondaryWhite"
+                    onClick={trackSubmitClick}
+                    mb={[4, 0]}
+                    width={"100%"}
+                  >
+                    Get in Touch
+                  </Button>
+                </Flex>
+              </Flex>
+            ) : (
+              <Button
+                // @ts-ignore
+                as={RouterLink}
+                variant="primaryWhite"
+                to="/sell/submission/artwork-details"
+                onClick={trackSubmitClick}
+                mb={[4, 0]}
+              >
+                Submit an Artwork
+              </Button>
+            )}
           </Box>
         </AppContainer>
       </Flex>

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/Header.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/Header.tsx
@@ -61,6 +61,7 @@ export const Header: React.FC = () => {
                     onClick={trackSubmitClick}
                     mb={[2, 0]}
                     width={"100%"}
+                    data-testid="submit-artwork-button"
                   >
                     Submit an Artwork
                   </Button>
@@ -75,6 +76,7 @@ export const Header: React.FC = () => {
                     onClick={trackSubmitClick}
                     mb={[4, 0]}
                     width={"100%"}
+                    data-testid="get-in-touch-button"
                   >
                     Get in Touch
                   </Button>
@@ -88,6 +90,7 @@ export const Header: React.FC = () => {
                 to="/sell/submission/artwork-details"
                 onClick={trackSubmitClick}
                 mb={[4, 0]}
+                data-testid="submit-artwork-button"
               >
                 Submit an Artwork
               </Button>

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/Header.jest.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/Header.jest.tsx
@@ -1,15 +1,16 @@
-import { Header } from "../Header"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { useTracking } from "react-tracking"
+import { useSystemContext } from "System"
+import { Header } from "../Header"
 
 jest.mock("react-tracking")
-
+// TODO: Remove feature flag mock when feature flag is removed
+jest.mock("System/useSystemContext")
 jest.mock("System/Analytics/AnalyticsContext", () => ({
   useAnalyticsContext: jest.fn(() => ({
     contextPageOwnerType: "sell",
   })),
 }))
-
 jest.mock("System/Router/useRouter", () => ({
   useRouter: jest.fn(() => ({
     match: { params: { id: "1" } },
@@ -25,12 +26,17 @@ describe("Header", () => {
         trackEvent,
       }
     })
+    ;(useSystemContext as jest.Mock).mockImplementation(() => ({
+      featureFlags: {
+        "get-in-touch-flow-web": { flagEnabled: true },
+      },
+    }))
   })
 
   it("links out to submission flow", () => {
     render(<Header />)
 
-    const link = screen.getByRole("link")
+    const link = screen.getByTestId("submit-artwork-button")
 
     expect(link).toBeInTheDocument()
     expect(link).toHaveTextContent("Submit an Artwork")
@@ -40,7 +46,7 @@ describe("Header", () => {
   it("tracks click", () => {
     render(<Header />)
 
-    fireEvent.click(screen.getByRole("link"))
+    fireEvent.click(screen.getByTestId("submit-artwork-button"))
 
     expect(trackEvent).toHaveBeenCalled()
     expect(trackEvent).toHaveBeenCalledWith({
@@ -49,6 +55,25 @@ describe("Header", () => {
       context_page_owner_type: "sell",
       label: "Submit an Artwork",
       destination_path: "/sell/submission/artwork-details",
+    })
+  })
+
+  describe("when get-in-touch-flow-web feature is turned on", () => {
+    beforeAll(() => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => ({
+        featureFlags: {
+          "get-in-touch-flow-web": { flagEnabled: true },
+        },
+      }))
+    })
+
+    it("links out to get in touch flow", () => {
+      render(<Header />)
+
+      const link = screen.getByTestId("get-in-touch-button")
+
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveTextContent("Get in Touch")
     })
   })
 })


### PR DESCRIPTION
Addresses [CX-2937]

## Description

Adding the "Get in Touch" CTA on **Sell** page behind feature flag.

| mWeb | Web |
| --- | --- |
|![Screenshot 2022-09-19 at 11 40 11](https://user-images.githubusercontent.com/4691889/190994705-5e74f498-d1d1-4862-9dc3-38c702a9ae0c.png) |![Screenshot 2022-09-19 at 12 02 21](https://user-images.githubusercontent.com/4691889/190994716-0447b316-157c-4a6b-82e5-ad45f18f4c85.png) |




[CX-2937]: https://artsyproduct.atlassian.net/browse/CX-2937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ