### PR TITLE
feat: Add Sell with Artsy FAQ page

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/FAQApp.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/FAQApp.tsx
@@ -1,0 +1,10 @@
+import { Box } from "@artsy/palette"
+import { FAQ } from "./Components"
+
+export const FAQApp = () => {
+  return (
+    <Box mt={2} mb={4}>
+      <FAQ />
+    </Box>
+  )
+}

--- a/src/Apps/Consign/consignRoutes.tsx
+++ b/src/Apps/Consign/consignRoutes.tsx
@@ -15,6 +15,16 @@ const MarketingLandingApp = loadable(
   }
 )
 
+const FAQApp = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "consignBundle" */ "./Routes/MarketingLanding/FAQApp"
+    ),
+  {
+    resolveComponent: component => component.FAQApp,
+  }
+)
+
 const SubmissionLayout = loadable(
   () =>
     import(
@@ -116,11 +126,25 @@ const prepareSubmissionFlowStepVariables = data => {
 export const consignRoutes: AppRouteConfig[] = [
   {
     path: "/sell",
-    getComponent: () => MarketingLandingApp,
-    onClientSideRender: () => {
-      MarketingLandingApp.preload()
-    },
+    children: [
+      {
+        path: "/",
+        getComponent: () => MarketingLandingApp,
+        onClientSideRender: () => {
+          MarketingLandingApp.preload()
+        },
+      },
+      {
+        path: "faq",
+        hideFooter: true,
+        getComponent: () => FAQApp,
+        onClientSideRender: () => {
+          FAQApp.preload()
+        },
+      },
+    ],
   },
+
   {
     path: "/consign",
     children: [


### PR DESCRIPTION
Addresses [CX-2950]

## Description

This PR adds the new Sell with Artsy FAQ page to be displayed in a web view in the app.

| with Eigen's user agent |normal | 
| --- | --- |
|<img width="375" alt="Screenshot 2022-09-20 at 10 21 35" src="https://user-images.githubusercontent.com/4691889/191213717-ede5c96a-354e-4716-96d5-95b3bd69ca1f.png"> |<img width="375" alt="Screenshot 2022-09-20 at 10 21 51" src="https://user-images.githubusercontent.com/4691889/191213740-029b3cc2-7c5c-495f-8a66-4e65ebdb71ca.png"> |




[CX-2950]: https://artsyproduct.atlassian.net/browse/CX-2950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ