### PR TITLE
chore: update company mission

### DIFF
--- a/src/Apps/About/AboutApp.tsx
+++ b/src/Apps/About/AboutApp.tsx
@@ -23,7 +23,7 @@ export const AboutApp: React.FC = () => {
     <>
       <MetaTags
         title="About | Artsy"
-        description="Artsy’s mission is to make all of the world’s art accessible to anyone with an Internet connection."
+        description="Artsy’s mission is to expand the art market to support more artists and art in the world."
         imageURL="https://files.artsy.net/images/00_CVP_About_Hero_og.png"
         pathname="/about"
       />


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

This PR updates the company mission that is included in the `/about` page (as a meta-tag), so that our previous mission no longer appears in Google search results when I search for "artsy mission".

<img width="863" alt="artsy_mission" src="https://user-images.githubusercontent.com/44589599/191570131-6d7183b8-f05b-4191-844b-c0d4e30bcd2f.png">
