### PR TITLE
feat(FX-4182): mark all notifications as read

### DIFF
--- a/src/Apps/Notifications/NotificationsApp.tsx
+++ b/src/Apps/Notifications/NotificationsApp.tsx
@@ -1,15 +1,37 @@
 import { FullBleed } from "@artsy/palette"
 import { MetaTags } from "Components/MetaTags"
 import { Notifications } from "Components/Notifications/Notifications"
+import { createFragmentContainer, graphql } from "react-relay"
+import { NotificationsApp_me } from "__generated__/NotificationsApp_me.graphql"
 
-export const NotificationsApp: React.FC = () => {
+interface NotificationsAppProps {
+  me: NotificationsApp_me
+}
+
+const NotificationsApp: React.FC<NotificationsAppProps> = props => {
+  const { me } = props
+
   return (
     <>
       <MetaTags title="Notifications | Artsy" pathname="/notifications" />
 
       <FullBleed>
-        <Notifications mode="page" />
+        <Notifications
+          mode="page"
+          unreadCounts={me.unreadNotificationsCount ?? 0}
+        />
       </FullBleed>
     </>
   )
 }
+
+export const NotificationsAppFragmentContainer = createFragmentContainer(
+  NotificationsApp,
+  {
+    me: graphql`
+      fragment NotificationsApp_me on Me {
+        unreadNotificationsCount
+      }
+    `,
+  }
+)

--- a/src/Apps/Notifications/notificationsRoutes.ts
+++ b/src/Apps/Notifications/notificationsRoutes.ts
@@ -1,11 +1,12 @@
 import loadable from "@loadable/component"
+import { graphql } from "relay-runtime"
 import { AppRouteConfig } from "System/Router/Route"
 
 const NotificationsApp = loadable(
   () =>
     import(/* webpackChunkName: "notificationsBundle" */ "./NotificationsApp"),
   {
-    resolveComponent: component => component.NotificationsApp,
+    resolveComponent: component => component.NotificationsAppFragmentContainer,
   }
 )
 
@@ -16,5 +17,12 @@ export const notificationsRoutes: AppRouteConfig[] = [
     onClientSideRender: () => {
       NotificationsApp.preload()
     },
+    query: graphql`
+      query notificationsRoutesQuery {
+        me {
+          ...NotificationsApp_me
+        }
+      }
+    `,
   },
 ]

--- a/src/Components/NavBar/Menus/NavBarNewNotifications.tsx
+++ b/src/Components/NavBar/Menus/NavBarNewNotifications.tsx
@@ -3,7 +3,11 @@ import { Notifications } from "Components/Notifications/Notifications"
 import { useEffect } from "react"
 import { useScrollLock } from "Utils/Hooks/useScrollLock"
 
-export const NavBarNewNotifications = () => {
+interface NavBarNewNotificationsProps {
+  unreadCounts: number
+}
+
+export const NavBarNewNotifications: React.FC<NavBarNewNotificationsProps> = props => {
   const { lockScroll, unlockScroll } = useScrollLock()
 
   useEffect(() => {
@@ -27,6 +31,7 @@ export const NavBarNewNotifications = () => {
         mode="dropdown"
         maxDropdownHeight="90vh"
         paginationType="infinite"
+        {...props}
       />
     </Box>
   )

--- a/src/Components/NavBar/NavBarLoggedInActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedInActions.tsx
@@ -30,8 +30,6 @@ export const NavBarLoggedInActions: React.FC<Partial<
   NavBarLoggedInActionsQueryResponse
 >> = ({ me }) => {
   const enableActivityPanel = useFeatureFlag("force-enable-new-activity-panel")
-  console.log("[debug] me", me?.unreadNotificationsCount)
-
   const { hasConversations, hasNotifications } = checkAndSyncIndicatorsCount({
     notifications: me?.unreadNotificationsCount,
     conversations: me?.unreadConversationCount,

--- a/src/Components/NavBar/NavBarLoggedInActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedInActions.tsx
@@ -30,6 +30,7 @@ export const NavBarLoggedInActions: React.FC<Partial<
   NavBarLoggedInActionsQueryResponse
 >> = ({ me }) => {
   const enableActivityPanel = useFeatureFlag("force-enable-new-activity-panel")
+  console.log("[debug] me", me?.unreadNotificationsCount)
 
   const { hasConversations, hasNotifications } = checkAndSyncIndicatorsCount({
     notifications: me?.unreadNotificationsCount,
@@ -42,7 +43,9 @@ export const NavBarLoggedInActions: React.FC<Partial<
         zIndex={Z.dropdown}
         dropdown={
           enableActivityPanel ? (
-            <NavBarNewNotifications />
+            <NavBarNewNotifications
+              unreadCounts={me?.unreadNotificationsCount ?? 0}
+            />
           ) : (
             <NavBarNotificationsQueryRenderer />
           )

--- a/src/Components/Notifications/MarkAllAsReadPanel.tsx
+++ b/src/Components/Notifications/MarkAllAsReadPanel.tsx
@@ -33,7 +33,6 @@ export const MarkAllAsReadPanel: React.FC<MarkAllAsReadPanelProps> = props => {
         throw new Error(errorMessage)
       }
     } catch (error) {
-      console.log("[debug] error", error)
       logger.error(error)
     }
   }

--- a/src/Components/Notifications/MarkAllAsReadPanel.tsx
+++ b/src/Components/Notifications/MarkAllAsReadPanel.tsx
@@ -12,10 +12,11 @@ export interface MarkAllAsReadPanelProps {
   unreadCounts: number
 }
 
-export const MarkAllAsReadPanel: React.FC<MarkAllAsReadPanelProps> = props => {
+export const MarkAllAsReadPanel: React.FC<MarkAllAsReadPanelProps> = ({
+  unreadCounts,
+}) => {
   const { relayEnvironment } = useSystemContext()
   const { t } = useTranslation()
-  const { unreadCounts } = props
   const hasUnreadNotifications = unreadCounts > 0
 
   const markAllAsRead = async () => {

--- a/src/Components/Notifications/MarkAllAsReadPanel.tsx
+++ b/src/Components/Notifications/MarkAllAsReadPanel.tsx
@@ -1,0 +1,24 @@
+import { Clickable, Flex, Text } from "@artsy/palette"
+
+export const MARK_ALL_AS_READ_PANEL_HEIGHT = 40
+
+export const MarkAllAsReadPanel = () => {
+  const handleMarkAsRead = () => {}
+
+  return (
+    <Flex
+      height={MARK_ALL_AS_READ_PANEL_HEIGHT}
+      p={2}
+      alignItems="center"
+      borderBottom="1px solid"
+      borderBottomColor="black15"
+      bg="white100"
+    >
+      <Clickable onClick={handleMarkAsRead}>
+        <Text variant="xs" color="black60">
+          Mark all as read
+        </Text>
+      </Clickable>
+    </Flex>
+  )
+}

--- a/src/Components/Notifications/MarkAllAsReadPanel.tsx
+++ b/src/Components/Notifications/MarkAllAsReadPanel.tsx
@@ -7,8 +7,13 @@ export const MARK_ALL_AS_READ_PANEL_HEIGHT = 40
 
 const logger = createLogger("MarkAllAsReadPanel")
 
-export const MarkAllAsReadPanel = () => {
+export interface MarkAllAsReadPanelProps {
+  unreadCounts: number
+}
+
+export const MarkAllAsReadPanel: React.FC<MarkAllAsReadPanelProps> = props => {
   const { relayEnvironment } = useSystemContext()
+  const { unreadCounts } = props
 
   const markAllAsRead = async () => {
     if (!relayEnvironment) {
@@ -37,8 +42,13 @@ export const MarkAllAsReadPanel = () => {
       alignItems="center"
       borderBottom="1px solid"
       borderBottomColor="black15"
+      flexDirection="row"
+      justifyContent="space-between"
       bg="white100"
     >
+      <Text variant="xs" color="brand">
+        {unreadCounts} New Notifications
+      </Text>
       <Clickable onClick={markAllAsRead}>
         <Text variant="xs" color="black60">
           Mark all as read

--- a/src/Components/Notifications/MarkAllAsReadPanel.tsx
+++ b/src/Components/Notifications/MarkAllAsReadPanel.tsx
@@ -1,4 +1,5 @@
 import { Clickable, Flex, Text } from "@artsy/palette"
+import { useTranslation } from "react-i18next"
 import { useSystemContext } from "System"
 import createLogger from "Utils/logger"
 import { markAllNotificationsAsRead } from "./Mutations/markAllNotificationsAsRead"
@@ -13,7 +14,9 @@ export interface MarkAllAsReadPanelProps {
 
 export const MarkAllAsReadPanel: React.FC<MarkAllAsReadPanelProps> = props => {
   const { relayEnvironment } = useSystemContext()
+  const { t } = useTranslation()
   const { unreadCounts } = props
+  const hasUnreadNotifications = unreadCounts > 0
 
   const markAllAsRead = async () => {
     if (!relayEnvironment) {
@@ -46,12 +49,12 @@ export const MarkAllAsReadPanel: React.FC<MarkAllAsReadPanelProps> = props => {
       justifyContent="space-between"
       bg="white100"
     >
-      <Text variant="xs" color="brand">
-        {unreadCounts} New Notifications
+      <Text variant="xs" color={hasUnreadNotifications ? "brand" : "black60"}>
+        {t(`activityPanel.newNotifications`, { count: unreadCounts })}
       </Text>
-      <Clickable onClick={markAllAsRead}>
+      <Clickable onClick={markAllAsRead} disabled={!hasUnreadNotifications}>
         <Text variant="xs" color="black60">
-          Mark all as read
+          {t`activityPanel.markAllAsRead`}
         </Text>
       </Clickable>
     </Flex>

--- a/src/Components/Notifications/MarkAllAsReadPanel.tsx
+++ b/src/Components/Notifications/MarkAllAsReadPanel.tsx
@@ -1,9 +1,34 @@
 import { Clickable, Flex, Text } from "@artsy/palette"
+import { useSystemContext } from "System"
+import createLogger from "Utils/logger"
+import { markAllNotificationsAsRead } from "./Mutations/markAllNotificationsAsRead"
 
 export const MARK_ALL_AS_READ_PANEL_HEIGHT = 40
 
+const logger = createLogger("MarkAllAsReadPanel")
+
 export const MarkAllAsReadPanel = () => {
-  const handleMarkAsRead = () => {}
+  const { relayEnvironment } = useSystemContext()
+
+  const markAllAsRead = async () => {
+    if (!relayEnvironment) {
+      return
+    }
+
+    try {
+      const response = await markAllNotificationsAsRead(relayEnvironment)
+      const errorMessage =
+        response.markAllNotificationsAsRead?.responseOrError?.mutationError
+          ?.message
+
+      if (errorMessage) {
+        throw new Error(errorMessage)
+      }
+    } catch (error) {
+      console.log("[debug] error", error)
+      logger.error(error)
+    }
+  }
 
   return (
     <Flex
@@ -14,7 +39,7 @@ export const MarkAllAsReadPanel = () => {
       borderBottomColor="black15"
       bg="white100"
     >
-      <Clickable onClick={handleMarkAsRead}>
+      <Clickable onClick={markAllAsRead}>
         <Text variant="xs" color="black60">
           Mark all as read
         </Text>

--- a/src/Components/Notifications/Mutations/markAllNotificationsAsRead.ts
+++ b/src/Components/Notifications/Mutations/markAllNotificationsAsRead.ts
@@ -1,0 +1,64 @@
+import {
+  markAllNotificationsAsReadMutation,
+  markAllNotificationsAsReadMutationResponse,
+} from "__generated__/markAllNotificationsAsReadMutation.graphql"
+import {
+  commitMutation,
+  ConnectionHandler,
+  Environment,
+  graphql,
+} from "relay-runtime"
+
+export const markAllNotificationsAsRead = (
+  environment: Environment
+): Promise<markAllNotificationsAsReadMutationResponse> => {
+  return new Promise((resolve, reject) => {
+    commitMutation<markAllNotificationsAsReadMutation>(environment, {
+      mutation: graphql`
+        mutation markAllNotificationsAsReadMutation {
+          markAllNotificationsAsRead(input: {}) {
+            responseOrError {
+              ... on MarkAllNotificationsAsReadSuccess {
+                success
+              }
+              ... on MarkAllNotificationsAsReadFailure {
+                mutationError {
+                  message
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: {},
+      updater: store => {
+        const root = store.getRoot()
+        const me = root.getLinkedRecord("me")
+        const viewer = root.getLinkedRecord("viewer")
+
+        if (!me || !viewer) {
+          return
+        }
+
+        const key = "NotificationsList_notifications"
+        const connection = ConnectionHandler.getConnection(viewer, key)
+        const edges = connection?.getLinkedRecords("edges")
+
+        // Set unread notifications count to 0
+        me.setValue(0, "unreadNotificationsCount")
+
+        // Mark all notifications as read
+        edges?.forEach(edge => {
+          const node = edge.getLinkedRecord("node")
+          node?.setValue(false, "isUnread")
+        })
+      },
+      onCompleted: response => {
+        resolve(response)
+      },
+      onError: error => {
+        reject(error)
+      },
+    })
+  })
+}

--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -115,7 +115,7 @@ export const NotificationsListFragmentContainer = createPaginationContainer(
           first: $count
           after: $cursor
           notificationTypes: $types
-        ) @connection(key: "NotificationsList_notifications") {
+        ) @connection(key: "NotificationsList_notifications", filters: []) {
           edges {
             node {
               internalID
@@ -128,6 +128,9 @@ export const NotificationsListFragmentContainer = createPaginationContainer(
   },
   {
     query: NOTIFICATIONS_NEXT_QUERY,
+    getConnectionFromProps(props) {
+      return props.viewer.notifications
+    },
     getFragmentVariables(prevVars, totalCount) {
       return {
         ...prevVars,

--- a/src/Components/Notifications/NotificationsTabs.tsx
+++ b/src/Components/Notifications/NotificationsTabs.tsx
@@ -12,12 +12,13 @@ import { Sticky, StickyProvider } from "Components/Sticky"
 import styled from "styled-components"
 import {
   MarkAllAsReadPanel,
+  MarkAllAsReadPanelProps,
   MARK_ALL_AS_READ_PANEL_HEIGHT,
 } from "./MarkAllAsReadPanel"
 
 const TABS_CONTAINER_HEIGHT = 60
 
-export interface NofiticationsTabsProps {
+export interface NofiticationsTabsProps extends MarkAllAsReadPanelProps {
   mode: "dropdown" | "page"
   maxDropdownHeight?: string
 }
@@ -25,6 +26,7 @@ export interface NofiticationsTabsProps {
 export const NofiticationsTabs: React.FC<NofiticationsTabsProps> = ({
   mode,
   maxDropdownHeight,
+  unreadCounts,
   children,
 }) => {
   const { tabs, activeTab, activeTabIndex, handleClick, ref } = useTabs({
@@ -66,7 +68,7 @@ export const NofiticationsTabs: React.FC<NofiticationsTabsProps> = ({
             <CloseIcon display="block" />
           </Clickable>
         </HeaderContainer>
-        <MarkAllAsReadPanel />
+        <MarkAllAsReadPanel unreadCounts={unreadCounts} />
 
         <Box
           maxHeight={`calc(${maxDropdownHeight} - ${headerTotalHeight}px)`}
@@ -82,7 +84,7 @@ export const NofiticationsTabs: React.FC<NofiticationsTabsProps> = ({
     <StickyProvider>
       <Sticky>
         <HeaderContainer>{Tabs}</HeaderContainer>
-        <MarkAllAsReadPanel />
+        <MarkAllAsReadPanel unreadCounts={unreadCounts} />
       </Sticky>
       {activeTab.current.child}
     </StickyProvider>

--- a/src/Components/Notifications/NotificationsTabs.tsx
+++ b/src/Components/Notifications/NotificationsTabs.tsx
@@ -10,6 +10,10 @@ import {
 import { themeGet } from "@styled-system/theme-get"
 import { Sticky, StickyProvider } from "Components/Sticky"
 import styled from "styled-components"
+import {
+  MarkAllAsReadPanel,
+  MARK_ALL_AS_READ_PANEL_HEIGHT,
+} from "./MarkAllAsReadPanel"
 
 const TABS_CONTAINER_HEIGHT = 60
 
@@ -48,6 +52,9 @@ export const NofiticationsTabs: React.FC<NofiticationsTabsProps> = ({
   )
 
   if (mode === "dropdown") {
+    const headerTotalHeight =
+      TABS_CONTAINER_HEIGHT - MARK_ALL_AS_READ_PANEL_HEIGHT
+
     return (
       <>
         <HeaderContainer display="flex" flexDirection="row" alignItems="center">
@@ -59,9 +66,10 @@ export const NofiticationsTabs: React.FC<NofiticationsTabsProps> = ({
             <CloseIcon display="block" />
           </Clickable>
         </HeaderContainer>
+        <MarkAllAsReadPanel />
 
         <Box
-          maxHeight={`calc(${maxDropdownHeight} - ${TABS_CONTAINER_HEIGHT}px)`}
+          maxHeight={`calc(${maxDropdownHeight} - ${headerTotalHeight}px)`}
           overflowY="scroll"
         >
           {activeTab.current.child}
@@ -74,6 +82,7 @@ export const NofiticationsTabs: React.FC<NofiticationsTabsProps> = ({
     <StickyProvider>
       <Sticky>
         <HeaderContainer>{Tabs}</HeaderContainer>
+        <MarkAllAsReadPanel />
       </Sticky>
       {activeTab.current.child}
     </StickyProvider>

--- a/src/Components/Notifications/__tests__/MarkAllAsReadPanel.jest.tsx
+++ b/src/Components/Notifications/__tests__/MarkAllAsReadPanel.jest.tsx
@@ -6,15 +6,20 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => false,
 }))
 
-describe("Notifications", () => {
-  it("should render tabs", () => {
+describe("MarkAllAsReadPanel", () => {
+  it("should the empty state", () => {
     render(<Notifications mode="page" unreadCounts={0} />)
 
-    expect(screen.getByText("All")).toBeInTheDocument()
-    expect(screen.getByText("Alerts")).toBeInTheDocument()
+    expect(screen.getByText("No new notifications")).toBeInTheDocument()
   })
 
-  it("should display the count of unread notifications", () => {
+  it("should the single state", () => {
+    render(<Notifications mode="page" unreadCounts={1} />)
+
+    expect(screen.getByText("1 new notification")).toBeInTheDocument()
+  })
+
+  it("should the multiple state", () => {
     render(<Notifications mode="page" unreadCounts={5} />)
 
     expect(screen.getByText("5 new notifications")).toBeInTheDocument()

--- a/src/Components/Notifications/__tests__/Notifications.jest.tsx
+++ b/src/Components/Notifications/__tests__/Notifications.jest.tsx
@@ -7,7 +7,7 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
 
 describe("Notifications", () => {
   it("should render tabs", () => {
-    render(<Notifications mode="page" />)
+    render(<Notifications mode="page" unreadCounts={0} />)
 
     expect(screen.getByText("All")).toBeInTheDocument()
     expect(screen.getByText("Alerts")).toBeInTheDocument()

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -86,5 +86,11 @@
     "resultsCount_zero": "No results found for",
     "resultsCount_one": "1 result for",
     "resultsCount_other": "{{count}} results for"
+  },
+  "activityPanel": {
+    "newNotifications_zero": "No new notifications",
+    "newNotifications_one": "{{count}} new notification",
+    "newNotifications_other": "{{count}} new notifications",
+    "markAllAsRead": "Mark all as read"
   }
 }

--- a/src/__generated__/NotificationsApp_me.graphql.ts
+++ b/src/__generated__/NotificationsApp_me.graphql.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type NotificationsApp_me = {
+    readonly unreadNotificationsCount: number;
+    readonly " $refType": "NotificationsApp_me";
+};
+export type NotificationsApp_me$data = NotificationsApp_me;
+export type NotificationsApp_me$key = {
+    readonly " $data"?: NotificationsApp_me$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"NotificationsApp_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "NotificationsApp_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "unreadNotificationsCount",
+      "storageKey": null
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+(node as any).hash = '14dbb767eaa152c635acc649e417f853';
+export default node;

--- a/src/__generated__/NotificationsListNextQuery.graphql.ts
+++ b/src/__generated__/NotificationsListNextQuery.graphql.ts
@@ -399,9 +399,7 @@ return {
           {
             "alias": "notifications",
             "args": (v1/*: any*/),
-            "filters": [
-              "notificationTypes"
-            ],
+            "filters": [],
             "handle": "connection",
             "key": "NotificationsList_notifications",
             "kind": "LinkedHandle",

--- a/src/__generated__/NotificationsListQuery.graphql.ts
+++ b/src/__generated__/NotificationsListQuery.graphql.ts
@@ -370,9 +370,7 @@ return {
           {
             "alias": "notifications",
             "args": (v1/*: any*/),
-            "filters": [
-              "notificationTypes"
-            ],
+            "filters": [],
             "handle": "connection",
             "key": "NotificationsList_notifications",
             "kind": "LinkedHandle",

--- a/src/__generated__/NotificationsList_test_Query.graphql.ts
+++ b/src/__generated__/NotificationsList_test_Query.graphql.ts
@@ -371,9 +371,7 @@ return {
           {
             "alias": "notifications",
             "args": (v0/*: any*/),
-            "filters": [
-              "notificationTypes"
-            ],
+            "filters": [],
             "handle": "connection",
             "key": "NotificationsList_notifications",
             "kind": "LinkedHandle",

--- a/src/__generated__/NotificationsList_viewer.graphql.ts
+++ b/src/__generated__/NotificationsList_viewer.graphql.ts
@@ -58,13 +58,7 @@ const node: ReaderFragment = {
   "selections": [
     {
       "alias": "notifications",
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "notificationTypes",
-          "variableName": "types"
-        }
-      ],
+      "args": null,
       "concreteType": "NotificationConnection",
       "kind": "LinkedField",
       "name": "__NotificationsList_notifications_connection",
@@ -150,5 +144,5 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
-(node as any).hash = '2665432172af659075afecd662ae8a2d';
+(node as any).hash = '24853e1171ff783f11859741da1be54e';
 export default node;

--- a/src/__generated__/markAllNotificationsAsReadMutation.graphql.ts
+++ b/src/__generated__/markAllNotificationsAsReadMutation.graphql.ts
@@ -1,0 +1,174 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+export type markAllNotificationsAsReadMutationVariables = {};
+export type markAllNotificationsAsReadMutationResponse = {
+    readonly markAllNotificationsAsRead: {
+        readonly responseOrError: {
+            readonly success?: boolean | null | undefined;
+            readonly mutationError?: {
+                readonly message: string;
+            } | null | undefined;
+        } | null;
+    } | null;
+};
+export type markAllNotificationsAsReadMutation = {
+    readonly response: markAllNotificationsAsReadMutationResponse;
+    readonly variables: markAllNotificationsAsReadMutationVariables;
+};
+
+
+
+/*
+mutation markAllNotificationsAsReadMutation {
+  markAllNotificationsAsRead(input: {}) {
+    responseOrError {
+      __typename
+      ... on MarkAllNotificationsAsReadSuccess {
+        success
+      }
+      ... on MarkAllNotificationsAsReadFailure {
+        mutationError {
+          message
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "input",
+    "value": {}
+  }
+],
+v1 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "success",
+      "storageKey": null
+    }
+  ],
+  "type": "MarkAllNotificationsAsReadSuccess",
+  "abstractKey": null
+},
+v2 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GravityMutationError",
+      "kind": "LinkedField",
+      "name": "mutationError",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "message",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "MarkAllNotificationsAsReadFailure",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "markAllNotificationsAsReadMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "MarkAllNotificationsAsReadPayload",
+        "kind": "LinkedField",
+        "name": "markAllNotificationsAsRead",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "responseOrError",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "markAllNotificationsAsRead(input:{})"
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "markAllNotificationsAsReadMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "MarkAllNotificationsAsReadPayload",
+        "kind": "LinkedField",
+        "name": "markAllNotificationsAsRead",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "responseOrError",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              (v1/*: any*/),
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "markAllNotificationsAsRead(input:{})"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "aa5b00343c9084c3ae1b6777a79b85a9",
+    "id": null,
+    "metadata": {},
+    "name": "markAllNotificationsAsReadMutation",
+    "operationKind": "mutation",
+    "text": "mutation markAllNotificationsAsReadMutation {\n  markAllNotificationsAsRead(input: {}) {\n    responseOrError {\n      __typename\n      ... on MarkAllNotificationsAsReadSuccess {\n        success\n      }\n      ... on MarkAllNotificationsAsReadFailure {\n        mutationError {\n          message\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '69f2b3bf625a94023e88f559683ecd66';
+export default node;

--- a/src/__generated__/notificationsRoutesQuery.graphql.ts
+++ b/src/__generated__/notificationsRoutesQuery.graphql.ts
@@ -1,0 +1,103 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type notificationsRoutesQueryVariables = {};
+export type notificationsRoutesQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"NotificationsApp_me">;
+    } | null;
+};
+export type notificationsRoutesQuery = {
+    readonly response: notificationsRoutesQueryResponse;
+    readonly variables: notificationsRoutesQueryVariables;
+};
+
+
+
+/*
+query notificationsRoutesQuery {
+  me {
+    ...NotificationsApp_me
+    id
+  }
+}
+
+fragment NotificationsApp_me on Me {
+  unreadNotificationsCount
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "notificationsRoutesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "NotificationsApp_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "notificationsRoutesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "unreadNotificationsCount",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ab5d7db55ce1042593c953f1b52ff6be",
+    "id": null,
+    "metadata": {},
+    "name": "notificationsRoutesQuery",
+    "operationKind": "query",
+    "text": "query notificationsRoutesQuery {\n  me {\n    ...NotificationsApp_me\n    id\n  }\n}\n\nfragment NotificationsApp_me on Me {\n  unreadNotificationsCount\n}\n"
+  }
+};
+(node as any).hash = '186bea32415fd2b3c522c5bebe874558';
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

This PR solves [FX-4182]

Review app: [mark-all-notifications-as-read](https://mark-all-notifications-as-read.artsy.net/)

> **Warning**
> Please note that there are some problems on the backend side (e.g. [FX-4271](https://artsyproduct.atlassian.net/browse/FX-4271), [FX-4205](https://artsyproduct.atlassian.net/browse/FX-4205)) and for this reason not all notifications can be marked as read

### Demo
#### Dropdown Mode
https://user-images.githubusercontent.com/3513494/191791689-840d36b0-a52b-494a-b525-a46fa008aa46.mp4

#### Standalone Mode
https://user-images.githubusercontent.com/3513494/191791752-bdae2b20-428b-47da-a13e-3aa869ba9bc9.mp4

<!-- Implementation description -->


[FX-4182]: https://artsyproduct.atlassian.net/browse/FX-4182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ