### PR TITLE
fix(CX-2913): rename Size to Dimensions in MyC artwork page

### DIFF
--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
@@ -30,7 +30,7 @@ export const MyCollectionArtworkSidebarMetadata: React.FC<MyCollectionArtworkSid
         value={attributionClass?.shortDescription}
       />
       <MetadataField
-        label="Size"
+        label="Dimensions"
         value={metric === "in" ? dimensions?.in : dimensions?.cm}
       />
 

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/__tests__/MyCollectionArtworkSidebar.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/__tests__/MyCollectionArtworkSidebar.jest.tsx
@@ -74,7 +74,7 @@ describe("MyCollectionArtworkSidebar", () => {
         )
       })
 
-      it("displays size in cm", () => {
+      it("displays dimensions in cm", () => {
         expect(
           screen.getByText("55.9 × 41.9 cm", {
             collapseWhitespace: true,
@@ -113,7 +113,7 @@ describe("MyCollectionArtworkSidebar", () => {
       ).toBeInTheDocument()
 
       // shows labels when no data are available
-      expect(screen.getByText("Size")).toBeInTheDocument()
+      expect(screen.getByText("Dimensions")).toBeInTheDocument()
       expect(screen.getByText("Provenance")).toBeInTheDocument()
       expect(screen.getByText("Rarity")).toBeInTheDocument()
       expect(screen.getByText("Price Paid")).toBeInTheDocument()


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2913]

### Description
This PR updates the label from "Size" to "Dimensions" in My Collection artwork page

| Before | After |
|--|--|
| ![image](https://user-images.githubusercontent.com/20655703/191809566-ba840e91-0a08-4483-80f2-f078b337f832.png) | ![image](https://user-images.githubusercontent.com/20655703/191809574-23682d2d-fce4-48c3-933b-6b2ea8730016.png) |

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2913]: https://artsyproduct.atlassian.net/browse/CX-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ