### PR TITLE
fix(onboarding): Cap max height

### DIFF
--- a/src/Components/Onboarding/Hooks/useOnboarding.tsx
+++ b/src/Components/Onboarding/Hooks/useOnboarding.tsx
@@ -15,7 +15,7 @@ export const useOnboarding = ({ onClose }: UseOnboarding) => {
           <OnboardingModal
             onClose={hideDialog}
             height={["100%", "90%"]}
-            dialogProps={{ height: ["100%", "90%"] }}
+            dialogProps={{ height: ["100%", "90%"], maxHeight: 800 }}
           >
             <OnboardingSteps />
           </OnboardingModal>


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This fixes the issue where the modal was always expanding to fill 90% of the height on desktop: 

<img width="679" alt="Screen Shot 2022-09-26 at 6 15 23 PM" src="https://user-images.githubusercontent.com/236943/192409017-77fc34fb-408e-4238-bdd5-17d6a2c85333.png">

cc @artsy/grow-devs 
