### PR TITLE
fix: cannot create SEPA bank account if collector already has saved US bank account

### DIFF
--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -80,6 +80,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
   const CreditCardPicker = createRef<CreditCardPicker>()
 
   const {
+    bankAccountSelection,
     selectedBankAccountId,
     selectedPaymentMethod,
     balanceCheckComplete,
@@ -97,16 +98,19 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     selectedPaymentMethod === "US_BANK_ACCOUNT"
 
   useEffect(() => {
-    const bankAccountsArray =
-      selectedPaymentMethod !== "SEPA_DEBIT"
-        ? extractNodes(me.bankAccounts)
-        : []
+    if (!bankAccountSelection && selectedPaymentMethod) {
+      const bankAccountsArray =
+        selectedPaymentMethod !== "SEPA_DEBIT"
+          ? extractNodes(me.bankAccounts)
+          : []
 
-    setBankAccountSelection(
-      getInitialBankAccountSelection(order, bankAccountsArray)
-    )
+      setBankAccountSelection(
+        getInitialBankAccountSelection(order, bankAccountsArray)
+      )
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [bankAccountSelection, selectedPaymentMethod])
 
   useEffect(() => {
     setSelectedPaymentMethod(getInitialPaymentMethodValue(order))


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-753]

### Description

<!-- Implementation description -->

This PR prevents the initialization of `bankAccountSelection` field when `selectedPaymentMethod` empty. 


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-753]: https://artsyproduct.atlassian.net/browse/TX-753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ