### PR TITLE
feat(CX-2780): add back button to MyC Artwork details page

### DIFF
--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkBackButton.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkBackButton.tsx
@@ -1,0 +1,18 @@
+import { ChevronIcon, Flex, Text } from "@artsy/palette"
+import { RouterLink } from "System/Router/RouterLink"
+import { Media } from "Utils/Responsive"
+
+export const MyCollectionArtworkBackButton = () => {
+  return (
+    <RouterLink textDecoration="none" to="/settings/my-collection">
+      <Flex alignItems="center">
+        <ChevronIcon height={14} width={14} direction="left" />
+        <Media greaterThanOrEqual="sm">
+          <Text variant="xs" pl={1}>
+            Back to My Collection
+          </Text>
+        </Media>
+      </Flex>
+    </RouterLink>
+  )
+}

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
@@ -16,6 +16,7 @@ import { useFeatureFlag } from "System/useFeatureFlag"
 import { Media } from "Utils/Responsive"
 import { MyCollectionArtwork_artwork } from "__generated__/MyCollectionArtwork_artwork.graphql"
 import { useMyCollectionTracking } from "../Hooks/useMyCollectionTracking"
+import { MyCollectionArtworkBackButton } from "./Components/MyCollectionArtworkBackButton"
 import { MyCollectionArtworkImageBrowserFragmentContainer } from "./Components/MyCollectionArtworkImageBrowser/MyCollectionArtworkImageBrowser"
 import { MyCollectionArtworkInsightsFragmentContainer } from "./Components/MyCollectionArtworkInsights"
 import { MyCollectionArtworkMetaFragmentContainer } from "./Components/MyCollectionArtworkMeta"
@@ -65,21 +66,20 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
   )
 
   const EditArtworkButton = () => (
-    <Flex justifyContent="flex-end" pb={[1, 2]}>
-      <Button
-        // @ts-ignore
-        as={RouterLink}
-        variant="secondaryNeutral"
-        size="small"
-        to={`/my-collection/artworks/${artwork.internalID}/edit`}
-        onClick={() =>
-          trackEditCollectedArtwork(artwork.internalID, artwork.slug)
-        }
-        alignSelf="flex-end"
-      >
-        Edit Artwork Details
-      </Button>
-    </Flex>
+    <Button
+      // @ts-ignore
+      as={RouterLink}
+      variant="secondaryNeutral"
+      size="small"
+      to={`/my-collection/artworks/${artwork.internalID}/edit`}
+      onClick={() =>
+        trackEditCollectedArtwork(artwork.internalID, artwork.slug)
+      }
+      alignSelf="flex-end"
+    >
+      <Media greaterThanOrEqual="sm">Edit Artwork Details</Media>
+      <Media lessThan="sm">Edit</Media>
+    </Button>
   )
 
   const slug = artwork?.artist?.slug!
@@ -114,18 +114,19 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
         />
       )}
 
-      <GridColumns gridRowGap={[2, null]} py={[2, 6]}>
+      <Flex py={[2, 1]} justifyContent="space-between" alignItems="center">
+        <MyCollectionArtworkBackButton />
+
+        {!!isMyCollectionPhase3Enabled && <EditArtworkButton />}
+      </Flex>
+
+      <GridColumns gridRowGap={[2, null]}>
         <Column span={8}>
-          <Media lessThan="sm">
-            {!!isMyCollectionPhase3Enabled && <EditArtworkButton />}
-          </Media>
           <MyCollectionArtworkImageBrowserFragmentContainer artwork={artwork} />
         </Column>
 
         <Column span={4}>
           <Media greaterThanOrEqual="sm">
-            {!!isMyCollectionPhase3Enabled && <EditArtworkButton />}
-
             <MyCollectionArtworkSidebarFragmentContainer artwork={artwork} />
             {isMyCollectionPhase5Enabled && isP1Artist && (
               <Media greaterThanOrEqual="sm">


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2780]

### Description
This PR adds the back button to My Collection inside MyC Artwork Details page

### Screenshots
| Viewport | Before | After |
|--|--|--|
| Desktop | <img width="1280" alt="image" src="https://user-images.githubusercontent.com/20655703/192596885-800b731f-30ba-45c4-93d7-7cee04b91650.png"> | <img width="1280" alt="image" src="https://user-images.githubusercontent.com/20655703/192596958-6ce898dc-8d18-4bd1-a9c7-6212d42f4ef6.png"> |
| Mobile | <img width="390" alt="image" src="https://user-images.githubusercontent.com/20655703/192596999-bbb41aac-3087-486d-b8fa-2ccb6efeaec5.png"> | <img width="390" alt="image" src="https://user-images.githubusercontent.com/20655703/192597025-3743f730-cbad-4c85-b5d0-1a5906122b32.png"> |



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2780]: https://artsyproduct.atlassian.net/browse/CX-2780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ