### PR TITLE
fix(GRO-1242): prevents triggering analytics on route change

### DIFF
--- a/src/Utils/Hooks/useOnboardingModal.ts
+++ b/src/Utils/Hooks/useOnboardingModal.ts
@@ -3,10 +3,11 @@ import { useEffect } from "react"
 import { useOnboarding } from "Components/Onboarding"
 import { useSystemContext } from "System"
 import { useRouter } from "System/Router/useRouter"
+import { stringify } from "qs"
 
 export const useOnboardingModal = () => {
   const { isLoggedIn } = useSystemContext()
-  const { match, router } = useRouter()
+  const { match } = useRouter()
 
   const { onboardingComponent, showOnboarding, hideOnboarding } = useOnboarding(
     {
@@ -23,11 +24,15 @@ export const useOnboardingModal = () => {
 
     showOnboarding()
 
-    router.replace({
-      ...match.location,
-      query: omit(match.location.query, "onboarding"),
-    })
-  }, [isLoggedIn, match.location, router, showOnboarding])
+    // Manually manipulate URL to avoid triggering analytics with router.replace
+    const search = stringify(omit(match.location.query, "onboarding"))
+
+    window.history.replaceState(
+      null,
+      "",
+      match.location.pathname + (search !== "" ? `?${search}` : "")
+    )
+  }, [isLoggedIn, match.location, showOnboarding])
 
   return { onboardingComponent }
 }


### PR DESCRIPTION
Closes: [GRO-1242](https://artsyproduct.atlassian.net/browse/GRO-1242)

There's definitely a few places in the code that use `router.replace` not expecting it to trigger an analytics pageview. (And a few places where they want `push` or a proper link.)

I don't think this is the _correct_ fix. The correct way would be to switch the analytics tracking middleware to track on the `PUSH` event only. But as far as I can tell, it is never triggered (instead `UPDATE_LOCATION` is).