### PR TITLE
fix(GRO-1242): prevents triggering analytics on route change

### DIFF
--- a/src/System/Analytics/trackingMiddleware.ts
+++ b/src/System/Analytics/trackingMiddleware.ts
@@ -13,11 +13,12 @@ import { getENV } from "Utils/getENV"
 
 interface TrackingMiddlewareOptions {
   excludePaths?: string[]
+  excludeReferrers?: string[]
 }
 
 export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
   return store => next => action => {
-    const { excludePaths = [] } = options
+    const { excludePaths = [], excludeReferrers = [] } = options
     const { type, payload } = action
 
     switch (type) {
@@ -68,7 +69,17 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
             return foundMatch
           })
 
-          if (!foundExcludedPath) {
+          const foundExcludedReferrer = excludeReferrers.some(
+            excludedReferrer => {
+              const matcher = match(excludedReferrer, {
+                decode: decodeURIComponent,
+              })
+              const foundMatch = !!matcher(clientSideRoutingReferrer)
+              return foundMatch
+            }
+          )
+
+          if (!foundExcludedPath && !foundExcludedReferrer) {
             const url = getENV("APP_URL") + pathname
             const trackingData: {
               path: string

--- a/src/System/Router/buildClientApp.tsx
+++ b/src/System/Router/buildClientApp.tsx
@@ -77,6 +77,7 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
               // @see https://github.com/artsy/force/blob/2c0db041fa6cb50e9f747ea95860ad5c38290653/src/Apps/Artwork/ArtworkApp.tsx#L117-L121
               "/artwork(.*)",
             ],
+            excludeReferrers: ["/\\?(.*)onboarding=true(.*)"],
           }),
         ]
         const resolver = new Resolver(relayEnvironment)

--- a/src/Utils/Hooks/useOnboardingModal.ts
+++ b/src/Utils/Hooks/useOnboardingModal.ts
@@ -1,5 +1,5 @@
 import { omit } from "lodash"
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { useOnboarding } from "Components/Onboarding"
 import { useSystemContext } from "System"
 import { useRouter } from "System/Router/useRouter"
@@ -7,6 +7,7 @@ import { useRouter } from "System/Router/useRouter"
 export const useOnboardingModal = () => {
   const { isLoggedIn } = useSystemContext()
   const { match, router } = useRouter()
+  const initialized = useRef(false)
 
   const { onboardingComponent, showOnboarding, hideOnboarding } = useOnboarding(
     {
@@ -19,7 +20,8 @@ export const useOnboardingModal = () => {
   // Check to see if we should open onboarding (logged in + ?onboarding=true),
   // show it, and then immediately remove the query param
   useEffect(() => {
-    if (!isLoggedIn || !match.location.query.onboarding) return
+    if (!isLoggedIn || !match.location.query.onboarding || initialized.current)
+      return
 
     showOnboarding()
 
@@ -27,6 +29,8 @@ export const useOnboardingModal = () => {
       ...match.location,
       query: omit(match.location.query, "onboarding"),
     })
+
+    initialized.current = true
   }, [isLoggedIn, match.location, router, showOnboarding])
 
   return { onboardingComponent }


### PR DESCRIPTION
Closes: [GRO-1242](https://artsyproduct.atlassian.net/browse/GRO-1242)

Initially: https://github.com/artsy/force/pull/11058

Read that description; which is still valid. The problem with that approach is that manipulating the history state directly does not update anything in the routing store. The data in the routing store is used in triggering the modal in the first place.

Here I've just added an additional argument to exclude referrers from tracking 😵‍💫 — sorry.