### PR TITLE
feat(art-quiz) hook welcome screen to art quiz interface

### DIFF
--- a/src/Apps/ArtQuiz/ArtQuizApp.tsx
+++ b/src/Apps/ArtQuiz/ArtQuizApp.tsx
@@ -1,10 +1,22 @@
 import { ArtQuizContextProvider } from "Apps/ArtQuiz/ArtQuizContext/ArtQuizContext"
+import { ArtQuizWelcome } from "Components/ArtQuiz/Views/ArtQuizWelcome"
+import { useState } from "react"
 import { ArtQuizInterface } from "./ArtQuizInterface/ArtQuizInterface"
 
 export const ArtQuizApp = () => {
+  const [startQuiz, setStartQuiz] = useState(false)
+
+  const handleStartQuiz = () => {
+    setStartQuiz(true)
+  }
+
   return (
     <ArtQuizContextProvider>
-      <ArtQuizInterface />
+      {startQuiz ? (
+        <ArtQuizInterface />
+      ) : (
+        <ArtQuizWelcome onStartQuiz={handleStartQuiz} />
+      )}
     </ArtQuizContextProvider>
   )
 }

--- a/src/Apps/ArtQuiz/ArtQuizContext/ArtQuizContext.tsx
+++ b/src/Apps/ArtQuiz/ArtQuizContext/ArtQuizContext.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react"
 import { extractNodes } from "Utils/extractNodes"
@@ -102,29 +103,41 @@ export const ArtQuizContextProvider: FC = ({ children }) => {
     }
   }, [artworks, quizTemplate])
 
-  const markItemComplete = (
-    artworkSlug: keyof ArtQuizContextValues["quizTemplate"]
-  ) => {
-    setQuizTemplate(prev => ({ ...prev, [artworkSlug]: true }))
-  }
+  const markItemComplete = useCallback(
+    (artworkSlug: keyof ArtQuizContextValues["quizTemplate"]) => {
+      setQuizTemplate(prev => ({ ...prev, [artworkSlug]: true }))
+    },
+    []
+  )
+
+  const value = useMemo(
+    () => ({
+      artworks,
+      artworksTotalCount: artworks.length,
+      currentArtwork: currentArtwork(),
+      currentIndex,
+      markItemComplete,
+      nextArtwork: nextArtwork(),
+      previousArtwork: previousArtwork(),
+      stepBackward,
+      stepForward,
+      quizTemplate,
+    }),
+    [
+      artworks,
+      currentArtwork,
+      currentIndex,
+      markItemComplete,
+      nextArtwork,
+      previousArtwork,
+      stepBackward,
+      stepForward,
+      quizTemplate,
+    ]
+  )
 
   return (
-    <ArtQuizContext.Provider
-      value={{
-        artworks,
-        artworksTotalCount: artworks.length,
-        currentArtwork: currentArtwork(),
-        currentIndex,
-        markItemComplete,
-        nextArtwork: nextArtwork(),
-        previousArtwork: previousArtwork(),
-        stepBackward,
-        stepForward,
-        quizTemplate,
-      }}
-    >
-      {children}
-    </ArtQuizContext.Provider>
+    <ArtQuizContext.Provider value={value}>{children}</ArtQuizContext.Provider>
   )
 }
 

--- a/src/Components/ArtQuiz/Views/ArtQuizWelcome.tsx
+++ b/src/Components/ArtQuiz/Views/ArtQuizWelcome.tsx
@@ -10,9 +10,14 @@ import {
 } from "@artsy/palette"
 import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
 import { SplitLayout } from "Components/SplitLayout"
+import { FC } from "react"
 import { RouterLink } from "System/Router/RouterLink"
 
-export const ArtQuizWelcome = () => {
+interface ArtQuizWelcomeProps {
+  onStartQuiz: () => void
+}
+
+export const ArtQuizWelcome: FC<ArtQuizWelcomeProps> = ({ onStartQuiz }) => {
   const { desktop } = useNavBarHeight()
 
   return (
@@ -50,7 +55,9 @@ export const ArtQuizWelcome = () => {
 
               <Spacer my={1} />
               <Box width="100%">
-                <Button width="100%">Start the Quiz</Button>
+                <Button width="100%" onClick={onStartQuiz}>
+                  Start the Quiz
+                </Button>
                 <Button
                   // @ts-ignore
                   as={RouterLink}


### PR DESCRIPTION
The type of this PR is: **feat w/ a lil refactor** 

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1284]

### Description

<!-- Implementation description -->
The intent of this PR is to hook up the welcome page to the interface after `onClick()` to start the quiz. 



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1284]: https://artsyproduct.atlassian.net/browse/GRO-1284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ