### PR TITLE
fix: Decrease Consign FAQ page top spacing for mobile

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/FAQApp.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/FAQApp.tsx
@@ -3,7 +3,7 @@ import { FAQ } from "./Components"
 
 export const FAQApp = () => {
   return (
-    <Box mt={2} mb={4}>
+    <Box mb={4}>
       <FAQ />
     </Box>
   )

--- a/src/Apps/Consign/Routes/MarketingLanding/FAQApp.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/FAQApp.tsx
@@ -1,9 +1,14 @@
 import { Box } from "@artsy/palette"
+import { useSystemContext } from "System"
 import { FAQ } from "./Components"
 
 export const FAQApp = () => {
+  const { isEigen } = useSystemContext()
+
+  const marginTop = isEigen ? -2 : 4
+
   return (
-    <Box mb={4}>
+    <Box mt={marginTop} mb={4}>
       <FAQ />
     </Box>
   )


### PR DESCRIPTION

## Description

Decrease Consign FAQ page top spacing for Eigen only.

[Slack Thread for context](https://artsy.slack.com/archives/C01B2P6LJUU/p1664353989135969?thread_ts=1664268146.882799&cid=C01B2P6LJUU)