### PR TITLE
fix: Remove subtitle from Insights Header

### DIFF
--- a/src/Apps/Settings/Routes/Insights/Components/InsightsHeader.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsHeader.tsx
@@ -31,16 +31,10 @@ export const InsightsHeader: React.FC = () => {
                     justifyContent="space-between"
                     py={2}
                   >
-                    <Flex flex={1}>
+                    <Flex flex={1} alignItems="center">
                       <Media greaterThan="xs">
                         <Text variant="lg-display">
                           Gain deeper knowledge of your collection.
-                        </Text>
-
-                        <Text variant="xs" color="black60">
-                          Get insights about the artists you collect from the
-                          Artsy Price Database, drawing on millions of results
-                          from leading auction houses across the globe.
                         </Text>
                       </Media>
                     </Flex>

--- a/src/Apps/Settings/Routes/Insights/Components/InsightsHeader.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsHeader.tsx
@@ -29,7 +29,7 @@ export const InsightsHeader: React.FC = () => {
                   <Flex
                     backgroundColor="white100"
                     justifyContent="space-between"
-                    py={2}
+                    py={[1, 2]}
                   >
                     <Flex flex={1} alignItems="center">
                       <Media greaterThan="xs">

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsHeader.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsHeader.jest.tsx
@@ -45,11 +45,6 @@ describe("InsightsHeader", () => {
       expect(
         screen.getByText("Gain deeper knowledge of your collection.")
       ).toBeInTheDocument()
-      expect(
-        screen.getByText(
-          "Get insights about the artists you collect from the Artsy Price Database, drawing on millions of results from leading auction houses across the globe."
-        )
-      ).toBeInTheDocument()
       expect(screen.getByText("Upload Artwork")).toBeInTheDocument()
     })
   })


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves []

### Description
This PR removes the subtitle from the Insights header to match the design
Also updates the padding for the sticky header in the mobile view

|Before|After|
|--|--|
| ![image](https://user-images.githubusercontent.com/20655703/192752434-8661bbee-a570-4813-b0f1-a8bdddee8073.png) | ![image](https://user-images.githubusercontent.com/20655703/192752456-6c2674a7-dd48-4c8e-bdd5-99889186cf63.png) |
| ![image](https://user-images.githubusercontent.com/20655703/192754107-944a7c4d-4d41-4d60-8f45-6b1deecf2283.png) | ![image](https://user-images.githubusercontent.com/20655703/192754124-1cb907e2-50e7-48d9-89b1-3fe5f47cf40a.png) |
<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ