### PR TITLE
chore: use `secondaryBlack` variant for "show more" button

### DIFF
--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -61,7 +61,12 @@ const NotificationsList: React.FC<NotificationsListProps> = ({
 
     return (
       <Box textAlign="center" mt={4}>
-        <Button onClick={handleLoadNext} loading={loading}>
+        <Button
+          onClick={handleLoadNext}
+          loading={loading}
+          size="small"
+          variant="secondaryBlack"
+        >
           Show More
         </Button>
       </Box>


### PR DESCRIPTION
The type of this PR is: **Chore**

### Demo
| Before | After |
| ------------- | ------------- |
| <img width="342" alt="before" src="https://user-images.githubusercontent.com/3513494/192834619-a904d2a1-d4a0-491c-9108-1f6fd43ad930.png"> | <img width="342" alt="after" src="https://user-images.githubusercontent.com/3513494/192834666-887e413a-cb29-4020-9e9b-cacce680b030.png"> | 

<!-- Implementation description -->
