### PR TITLE
feat: preconnect webfonts and preload font css

### DIFF
--- a/src/html.ejs
+++ b/src/html.ejs
@@ -18,6 +18,8 @@
   <meta charset='utf-8' />
 
   <!-- Create preload tags for most common fonts -->
+  <link rel="preconnect" href="<%%= fontUrl %>" crossorigin />
+  <link rel="preload" href="<%%= fontUrl %>/all-webfonts.css" as="style" />
   <link rel="preload" href="<%%= fontUrl %>/ll-unica77_regular.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="<%%= fontUrl %>/ll-unica77_medium.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="<%%= fontUrl %>/ll-unica77_italic.woff2" as="font" type="font/woff2" crossorigin />


### PR DESCRIPTION
A minor thing but in my [non-scientific] testing this removed webfonts from being a factor in holding up the LCP.

The domain preconnect is incase we're on a page that has another font (mainly medium-italic, though it's rare). And preload the CSS because that's an obvious critical one we need.