### PR TITLE
fix (PX-5256): Remove duplicated call to setShipping mutation on address changes

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -492,10 +492,6 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       setSelectedAddressID(value)
       setShippingQuotes(null)
       setShippingQuoteId(undefined)
-
-      if (checkIfArtsyShipping()) {
-        selectShipping()
-      }
     }
   }
 


### PR DESCRIPTION
The type of this PR is: Fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PX-5256](PX-5256)

### Description
Seeing the following error on checkout plus the "something went wrong" modal if:
- Order is Artsy Shipping
- on any address changes (addition of new address or selecting between multiple saved addresses)

<img width="1918" alt="Screen Shot 2022-09-28 at 3 48 56 PM" src="https://user-images.githubusercontent.com/12748344/192893872-8639b516-560c-450f-8cca-0b840f0f9ec6.png">


The error in console reads as:
```
instrument.js:109 Order/Routes/Shipping/index.tsx | Error: Mutliple simulataneous mutations is not currently supported
```



Looks like this started with the new use of `useEffect` [that calls setShipping mutation](https://github.com/artsy/force/blob/main/src/Apps/Order/Routes/Shipping/index.tsx#L165-L170)

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ