### PR TITLE
fix: spinner when user comes back to the payment step

### DIFF
--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -223,7 +223,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
         throw orderOrError.error
       }
 
-      props.router.push(`/orders/${props.order.internalID}/review`)
+      handlePaymentStepComplete()
     } catch (error) {
       setIsSavingPayment(false)
       logger.error(error)
@@ -247,8 +247,8 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
       ).commerceSetPayment?.orderOrError
 
       if (orderOrError?.error) throw orderOrError.error
-      setIsSavingPayment(false)
-      props.router.push(`/orders/${props.order.internalID}/review`)
+
+      handlePaymentStepComplete()
     } catch (error) {
       setIsSavingPayment(false)
       logger.error(error)


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This PR fixes the bug reported in TX channel recently. More context in the [slack thread](https://artsy.slack.com/archives/C02JHHHKP5K/p1664477051141039). 

The problem is caused by the fact that the flag to render a spinner in the payment context remains true when a user leaves the payment route with Credit Card as the payment method. This PR makes sure that the flag is set to false when leaving the route. 