### PR TITLE
chore(tooling): add no-relative-path-imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,17 +8,18 @@ module.exports = {
     "jest",
     "jest-dom",
     "testing-library",
+    "no-relative-import-paths",
   ],
   extends: [
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier",
     "plugin:styled-components-a11y/recommended",
     "plugin:jest/recommended",
     "plugin:jest-dom/recommended",
     "plugin:testing-library/react",
+    "prettier", // prettier should always be last
   ],
   parserOptions: {
     ecmaFeatures: {
@@ -113,6 +114,10 @@ module.exports = {
         name: "react-waypoint",
         message: "Please use `useIntersectionObserver`",
       },
+    ],
+    "no-relative-import-paths/no-relative-import-paths": [
+      "error",
+      { allowSameFolder: true },
     ],
   },
   overrides: [

--- a/package.json
+++ b/package.json
@@ -289,6 +289,7 @@
     "eslint-plugin-graphql": "^4.0.0",
     "eslint-plugin-jest": "24.1.3",
     "eslint-plugin-jest-dom": "^3.9.0",
+    "eslint-plugin-no-relative-import-paths": "^1.4.0",
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "4.0.4",
     "eslint-plugin-styled-components-a11y": "0.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9585,6 +9585,11 @@ eslint-plugin-jsx-a11y@^6.2.3:
     jsx-ast-utils "^2.4.1"
     language-tags "^1.0.5"
 
+eslint-plugin-no-relative-import-paths@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.4.0.tgz#59489ebc19688d1398bfe53d3ad320b3ed42ca17"
+  integrity sha512-J/ok26KqJM+20VsxNEcHc9kyW0dcFHBlihOO5FFv/GQqwcW+G1UngbHLpnPAdOQ1dJg5Ljk/40csqfZ3mnneUw==
+
 eslint-plugin-react-hooks@4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.4.tgz#aed33b4254a41b045818cacb047b81e6df27fa58"


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/WP-116

The type of this PR is: **Chore**

### Description

<!-- Implementation description -->

Add eslint plugin & rule to disallow the use of relative paths, with an exception for same folder.
