### PR TITLE
refactor(shelfartwork): optimizes ShelfArtwork

### DIFF
--- a/src/Apps/About/AboutArtworksRail.tsx
+++ b/src/Apps/About/AboutArtworksRail.tsx
@@ -44,7 +44,7 @@ export const AboutArtworksRailFragmentContainer = createFragmentContainer(
         artworksConnection(first: 50, geneIDs: "trending-this-week") {
           edges {
             node {
-              ...ShelfArtwork_artwork @arguments(width: 210)
+              ...ShelfArtwork_artwork
               internalID
               slug
               href

--- a/src/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
+++ b/src/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
@@ -35,7 +35,6 @@ export const ArtistConsignRecentlySold: React.FC<ArtistConsignRecentlySoldProps>
             <ShelfArtworkFragmentContainer
               key={artwork.internalID}
               artwork={artwork}
-              showExtended={false}
               contextModule={ContextModule.artistRecentlySold}
             />
 

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
@@ -66,7 +66,6 @@ const ArtistNotableWorksRail: React.FC<ArtistNotableWorksRailProps> = ({
               artwork={node}
               contextModule={ContextModule.topWorksRail}
               key={index}
-              showExtended={false}
               showMetadata
               lazyLoad
               onClick={() => {
@@ -102,9 +101,9 @@ export const ArtistNotableWorksRailFragmentContainer = createFragmentContainer(
         filterArtworksConnection(sort: "-weighted_iconicity", first: 10) {
           edges {
             node {
+              ...ShelfArtwork_artwork
               internalID
               slug
-              ...ShelfArtwork_artwork @arguments(width: 200)
             }
           }
         }

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
@@ -61,7 +61,6 @@ const ArtistWorksForSaleRail: React.FC<ArtistWorksForSaleRailProps> = ({
                 artwork={node}
                 contextModule={ContextModule.worksForSaleRail}
                 key={index}
-                showExtended={false}
                 showMetadata
                 lazyLoad
                 onClick={() => {
@@ -98,7 +97,7 @@ export const ArtistWorksForSaleRailFragmentContainer = createFragmentContainer(
             node {
               internalID
               slug
-              ...ShelfArtwork_artwork @arguments(width: 200)
+              ...ShelfArtwork_artwork
             }
           }
         }

--- a/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistNotableWorksRail.jest.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistNotableWorksRail.jest.tsx
@@ -45,13 +45,13 @@ describe("ArtistNotableWorksRail", () => {
       }),
     })
     expect(wrapper.text()).toContain("Notable Works")
-    expect(wrapper.find("RouterLink").length).toBe(4)
-    expect(wrapper.find("RouterLink").at(0).props().to).toContain(
+    expect(wrapper.find("RouterLink").length).toBe(3)
+    expect(wrapper.find("RouterLink").first().props().to).toContain(
       "/artist/artistSlug/works-for-sale"
     )
     expect(wrapper.text()).toContain("View All Works")
     expect(wrapper.find("Shelf").length).toBe(1)
-    expect(wrapper.find("Image").length).toBe(2)
+    expect(wrapper.find("Image").length).toBe(1)
     expect(wrapper.text()).toContain("title")
     expect(wrapper.text()).toContain("date")
   })
@@ -73,13 +73,13 @@ describe("ArtistNotableWorksRail", () => {
 
   it("tracks work click", () => {
     const wrapper = getWrapper()
-    wrapper.find("RouterLink").at(2).simulate("click")
+    wrapper.find("RouterLink").last().simulate("click")
     expect(trackingSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "clickedArtworkGroup",
         context_module: "topWorksRail",
-        destination_page_owner_id: "<Artwork-mock-id-3>",
-        destination_page_owner_slug: "<Artwork-mock-id-4>",
+        destination_page_owner_id: "<Artwork-mock-id-8>",
+        destination_page_owner_slug: "<Artwork-mock-id-9>",
         destination_page_owner_type: "artwork",
         horizontal_slide_position: 1,
         type: "thumbnail",

--- a/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistWorksForSaleRail.jest.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistWorksForSaleRail.jest.tsx
@@ -45,13 +45,13 @@ describe("ArtistWorksForSaleRail", () => {
       }),
     })
     expect(wrapper.text()).toContain("Works For Sale")
-    expect(wrapper.find("RouterLink").length).toBe(4)
+    expect(wrapper.find("RouterLink").length).toBe(3)
     expect(wrapper.find("RouterLink").at(0).props().to).toContain(
       "/artist/artistSlug/works-for-sale"
     )
     expect(wrapper.text()).toContain("View All Works")
     expect(wrapper.find("Shelf").length).toBe(1)
-    expect(wrapper.find("Image").length).toBe(2)
+    expect(wrapper.find("Image").length).toBe(1)
     expect(wrapper.text()).toContain("title")
     expect(wrapper.text()).toContain("date")
   })

--- a/src/Apps/Auctions/Components/AuctionArtworksRail.tsx
+++ b/src/Apps/Auctions/Components/AuctionArtworksRail.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { BoxProps, Skeleton, SkeletonBox, SkeletonText } from "@artsy/palette"
+import { BoxProps, Skeleton } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { AuctionArtworksRail_sale$data } from "__generated__/AuctionArtworksRail_sale.graphql"
 import { tabTypeToContextModuleMap } from "Apps/Auctions/Utils/tabTypeToContextModuleMap"
@@ -17,7 +17,7 @@ import { Rail } from "Components/Rail"
 import { extractNodes } from "Utils/extractNodes"
 import {
   ShelfArtworkFragmentContainer,
-  IMG_HEIGHT,
+  ShelfArtworkPlaceholder,
 } from "Components/Artwork/ShelfArtwork"
 import { trackHelpers } from "Utils/cohesionHelpers"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
@@ -96,20 +96,7 @@ const PLACEHOLDER = (
       subTitle="Some subtitle"
       getItems={() => {
         return [...new Array(10)].map((_, i) => {
-          return (
-            <React.Fragment key={i}>
-              <SkeletonBox
-                width={200}
-                height={[IMG_HEIGHT.mobile, IMG_HEIGHT.desktop]}
-                mb={1}
-              />
-              <SkeletonText variant="sm" fontWeight="bold">
-                Artist Name
-              </SkeletonText>
-              <SkeletonText variant="sm">Artwork Title</SkeletonText>
-              <SkeletonText variant="sm">Price</SkeletonText>
-            </React.Fragment>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />
@@ -124,9 +111,9 @@ export const AuctionArtworksRailFragmentContainer = createFragmentContainer(
         artworksConnection(first: 20) {
           edges {
             node {
+              ...ShelfArtwork_artwork
               internalID
               slug
-              ...ShelfArtwork_artwork @arguments(width: 200)
             }
           }
         }

--- a/src/Apps/Auctions/Components/StandoutLotsRail.tsx
+++ b/src/Apps/Auctions/Components/StandoutLotsRail.tsx
@@ -9,7 +9,7 @@ import { trackHelpers } from "Utils/cohesionHelpers"
 import { extractNodes } from "Utils/extractNodes"
 import { StandoutLotsRail_viewer$data } from "__generated__/StandoutLotsRail_viewer.graphql"
 import { tabTypeToContextModuleMap } from "Apps/Auctions/Utils/tabTypeToContextModuleMap"
-import { CuratorialRailsZeroState } from "./CuritorialRailsTabBar"
+import { CuratorialRailsZeroState } from "Apps/Auctions/Components/CuritorialRailsTabBar"
 
 export interface StandoutLotsRailProps {
   viewer: StandoutLotsRail_viewer$data
@@ -70,7 +70,7 @@ export const StandoutLotsRailFragmentContainer = createFragmentContainer(
             node {
               internalID
               slug
-              ...ShelfArtwork_artwork @arguments(width: 325)
+              ...ShelfArtwork_artwork
             }
           }
         }

--- a/src/Apps/Auctions/Components/TrendingLotsRail.tsx
+++ b/src/Apps/Auctions/Components/TrendingLotsRail.tsx
@@ -78,7 +78,7 @@ export const TrendingLotsRailFragmentContainer = createFragmentContainer(
               sale {
                 isClosed
               }
-              ...ShelfArtwork_artwork @arguments(width: 325)
+              ...ShelfArtwork_artwork
             }
           }
         }

--- a/src/Apps/Auctions/Components/WorksByArtistsYouFollowRail.tsx
+++ b/src/Apps/Auctions/Components/WorksByArtistsYouFollowRail.tsx
@@ -73,7 +73,7 @@ export const WorksByArtistsYouFollowRailFragmentContainer = createFragmentContai
             node {
               internalID
               slug
-              ...ShelfArtwork_artwork @arguments(width: 325)
+              ...ShelfArtwork_artwork
             }
           }
         }

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/SoldRecentlyOnArtsy.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/SoldRecentlyOnArtsy.tsx
@@ -13,10 +13,8 @@ import { Fragment } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
 import { Rail } from "Components/Rail"
-import { useSystemContext } from "System"
 import { useTracking } from "react-tracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { RouterLink } from "System/Router/RouterLink"
 import { trackHelpers } from "Utils/cohesionHelpers"
 import { extractNodes } from "Utils/extractNodes"
 import { SoldRecentlyOnArtsyQuery } from "__generated__/SoldRecentlyOnArtsyQuery.graphql"
@@ -56,50 +54,46 @@ export const SoldRecentlyOnArtsy: React.FC<SoldRecentlyOnArtsyProps> = ({
       title="Sold Recently on Artsy"
       getItems={() => {
         return artworks.map(
-          ({ artwork, highEstimate, lowEstimate, priceRealized }, index) => {
+          ({ artwork, highEstimate, lowEstimate, priceRealized }, i) => {
+            if (!artwork) return <></>
+
             return (
-              <Fragment key={artwork!.internalID}>
-                <RouterLink
-                  to={artwork!.href}
+              <Fragment key={artwork.internalID}>
+                <ShelfArtworkFragmentContainer
+                  artwork={artwork}
+                  hideSaleInfo
+                  lazyLoad
+                  width={[325]}
                   data-testid="soldRecentlyItem"
-                  display="block"
-                  textDecoration="none"
-                  onClick={trackArtworkItemClick(artwork, index)}
+                  onClick={trackArtworkItemClick(artwork, i)}
+                  // FIXME:
+                  contextModule={ContextModule.artworkRecentlySoldGrid as any}
+                />
+
+                <Flex
+                  mt={4}
+                  flexDirection="row"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  color="black60"
                 >
-                  <ShelfArtworkFragmentContainer
-                    artwork={artwork!}
-                    key={artwork!.internalID}
-                    hideSaleInfo
-                    lazyLoad
-                    // @ts-ignore
-                    contextModule={ContextModule.artworkRecentlySoldGrid}
-                  />
+                  <Text variant="xs">Estimate</Text>
 
-                  <Flex
-                    mt={4}
-                    flexDirection="row"
-                    alignItems="center"
-                    justifyContent="space-between"
-                    color="black60"
-                  >
-                    <Text variant="xs">Estimate</Text>
+                  <Text variant="xs">
+                    {lowEstimate?.display}—{highEstimate?.display}
+                  </Text>
+                </Flex>
 
-                    <Text variant="xs">
-                      {lowEstimate?.display}—{highEstimate?.display}
-                    </Text>
-                  </Flex>
+                <Flex
+                  flexDirection="row"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  color="blue100"
+                >
+                  <Text variant="xs">Sold for (incl. premium)</Text>
 
-                  <Flex
-                    flexDirection="row"
-                    alignItems="center"
-                    justifyContent="space-between"
-                    color="blue100"
-                  >
-                    <Text variant="xs">Sold for (incl. premium)</Text>
-
-                    <Text variant="xs">{priceRealized?.display}</Text>
-                  </Flex>
-                </RouterLink>
+                  <Text variant="xs">{priceRealized?.display}</Text>
+                </Flex>
               </Fragment>
             )
           }
@@ -117,7 +111,7 @@ export const SoldRecentlyOnArtsyFragmentContainer = createFragmentContainer(
         edges {
           node {
             artwork {
-              ...ShelfArtwork_artwork @arguments(width: 325)
+              ...ShelfArtwork_artwork
               slug
               href
               internalID
@@ -182,12 +176,9 @@ const PLACEHOLDER = (
 )
 
 export const SoldRecentlyOnArtsyQueryRenderer: React.FC = () => {
-  const { relayEnvironment } = useSystemContext()
-
   return (
     <SystemQueryRenderer<SoldRecentlyOnArtsyQuery>
       lazyLoad
-      environment={relayEnvironment}
       query={graphql`
         query SoldRecentlyOnArtsyQuery {
           recentlySoldArtworks {

--- a/src/Apps/Fair/Components/FairBoothRail/FairBoothRailArtworks.tsx
+++ b/src/Apps/Fair/Components/FairBoothRail/FairBoothRailArtworks.tsx
@@ -12,11 +12,13 @@ import {
 } from "@artsy/cohesion"
 import { useTracking } from "react-tracking"
 import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
-import { Box, Shelf, SkeletonBox, SkeletonText } from "@artsy/palette"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import { Shelf } from "@artsy/palette"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import { extractNodes } from "Utils/extractNodes"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { IMG_HEIGHT } from "Components/Artwork/ShelfArtwork"
 
 export interface FairBoothRailArtworksProps {
   show: FairBoothRailArtworks_show$data
@@ -82,18 +84,7 @@ const FairBoothRailArtworks: React.FC<FairBoothRailArtworksProps> = ({
 const PLACEHOLDER = (
   <Shelf>
     {[...new Array(10)].map((_, i) => {
-      return (
-        <Box key={i}>
-          <SkeletonBox
-            width={200}
-            height={[IMG_HEIGHT.mobile, IMG_HEIGHT.desktop]}
-            mb={1}
-          />
-          <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-          <SkeletonText>Artwork Title</SkeletonText>
-          <SkeletonText>Price</SkeletonText>
-        </Box>
-      )
+      return <ShelfArtworkPlaceholder key={i} index={i} />
     })}
   </Shelf>
 )
@@ -106,9 +97,9 @@ export const FairBoothRailArtworksFragmentContainer = createFragmentContainer(
         artworksConnection(first: 20) {
           edges {
             node {
+              ...ShelfArtwork_artwork
               internalID
               slug
-              ...ShelfArtwork_artwork @arguments(width: 200)
             }
           }
         }

--- a/src/Apps/Home/Components/HomeAuctionLotsRail.tsx
+++ b/src/Apps/Home/Components/HomeAuctionLotsRail.tsx
@@ -117,7 +117,7 @@ export const HomeAuctionLotsRailFragmentContainer = createFragmentContainer(
         ) {
           edges {
             node {
-              ...ShelfArtwork_artwork @arguments(width: 210)
+              ...ShelfArtwork_artwork
               internalID
               slug
               href

--- a/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
+++ b/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
@@ -99,7 +99,7 @@ export const HomeNewWorksForYouRailFragmentContainer = createFragmentContainer(
           node {
             internalID
             slug
-            ...ShelfArtwork_artwork @arguments(width: 210)
+            ...ShelfArtwork_artwork
           }
         }
       }

--- a/src/Apps/Home/Components/HomeRecentlyViewedRail.tsx
+++ b/src/Apps/Home/Components/HomeRecentlyViewedRail.tsx
@@ -98,7 +98,7 @@ export const HomeRecentlyViewedRailFragmentContainer = createFragmentContainer(
           results {
             internalID
             slug
-            ...ShelfArtwork_artwork @arguments(width: 210)
+            ...ShelfArtwork_artwork
           }
         }
       }

--- a/src/Apps/Home/Components/HomeTroveArtworksRail.tsx
+++ b/src/Apps/Home/Components/HomeTroveArtworksRail.tsx
@@ -89,7 +89,7 @@ export const HomeTroveArtworksRailFragmentContainer = createFragmentContainer(
         artworksConnection(first: 12, geneIDs: "trove") {
           edges {
             node {
-              ...ShelfArtwork_artwork @arguments(width: 210)
+              ...ShelfArtwork_artwork
               internalID
               slug
               href

--- a/src/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
+++ b/src/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
@@ -98,7 +98,7 @@ export const HomeWorksByArtistsYouFollowRailFragmentContainer = createFragmentCo
           results {
             internalID
             slug
-            ...ShelfArtwork_artwork @arguments(width: 210)
+            ...ShelfArtwork_artwork
           }
         }
       }

--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -1,11 +1,19 @@
-import { Link, Text, LinkProps, Flex, Spacer, Box, Join } from "@artsy/palette"
+import {
+  Link,
+  Text,
+  LinkProps,
+  Flex,
+  Spacer,
+  Box,
+  Join,
+  SkeletonText,
+} from "@artsy/palette"
 import { Details_artwork$data } from "__generated__/Details_artwork.graphql"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useArtworkGridContext } from "Components/ArtworkGrid/ArtworkGridContext"
 import { useTimer } from "Utils/Hooks/useTimer"
 import { HoverDetailsFragmentContainer } from "./HoverDetails"
-
 import { AuthContextModule } from "@artsy/cohesion"
 import { NewSaveButtonFragmentContainer } from "./SaveButton"
 import { getSaleOrLotTimerInfo } from "Utils/getSaleOrLotTimerInfo"
@@ -124,6 +132,8 @@ const SaleInfoLine: React.FC<DetailsProps> = props => {
   )
 }
 
+const NBSP = " "
+
 const SaleMessage: React.FC<DetailsProps> = ({
   artwork: { sale, sale_message, sale_artwork },
 }) => {
@@ -142,7 +152,8 @@ const SaleMessage: React.FC<DetailsProps> = ({
     return <>Price on request</>
   }
 
-  return <>{sale_message}</>
+  // NBSP is used to prevent un-aligned carousels
+  return <>{sale_message ?? NBSP}</>
 }
 
 const BidInfo: React.FC<DetailsProps> = ({
@@ -349,3 +360,28 @@ export const DetailsFragmentContainer = createFragmentContainer(Details, {
     }
   `,
 })
+
+type DetailsPlaceholderProps = Pick<
+  DetailsProps,
+  "hidePartnerName" | "hideArtistName" | "hideSaleInfo"
+>
+
+export const DetailsPlaceholder: React.FC<DetailsPlaceholderProps> = ({
+  hideArtistName,
+  hidePartnerName,
+  hideSaleInfo,
+}) => {
+  return (
+    <>
+      {!hideArtistName && (
+        <SkeletonText variant="sm-display">Artist Name</SkeletonText>
+      )}
+
+      <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
+
+      {!hidePartnerName && <SkeletonText variant="xs">Partner</SkeletonText>}
+
+      {!hideSaleInfo && <SkeletonText variant="xs">Price</SkeletonText>}
+    </>
+  )
+}

--- a/src/Components/Artwork/FillwidthItem.tsx
+++ b/src/Components/Artwork/FillwidthItem.tsx
@@ -112,7 +112,6 @@ export const FillwidthItem: React.FC<FillwidthItemProps> = ({
       {showMetadata && (
         <Metadata
           artwork={artwork}
-          extended={showExtended}
           hidePartnerName={hidePartnerName}
           hideArtistName={hideArtistName}
           hideSaleInfo={hideSaleInfo}

--- a/src/Components/Artwork/Metadata.tsx
+++ b/src/Components/Artwork/Metadata.tsx
@@ -5,13 +5,15 @@ import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { RouterLink } from "System/Router/RouterLink"
 import { Metadata_artwork$data } from "__generated__/Metadata_artwork.graphql"
-import { DetailsFragmentContainer as Details } from "./Details"
+import {
+  DetailsFragmentContainer,
+  DetailsPlaceholder,
+} from "Components/Artwork/Details"
 
 export interface MetadataProps
   extends BoxProps,
     React.AnchorHTMLAttributes<HTMLAnchorElement> {
   artwork: Metadata_artwork$data
-  extended?: boolean
   contextModule?: AuthContextModule
   disableRouterLinking?: boolean
   hidePartnerName?: boolean
@@ -27,7 +29,6 @@ export const Metadata: React.FC<MetadataProps> = ({
   artwork,
   contextModule,
   disableRouterLinking,
-  extended = true,
   hidePartnerName,
   hideArtistName,
   hideSaleInfo,
@@ -46,7 +47,7 @@ export const Metadata: React.FC<MetadataProps> = ({
       isMyCollectionArtwork={isMyCollectionArtwork}
       {...rest}
     >
-      <Details
+      <DetailsFragmentContainer
         includeLinks={false}
         artwork={artwork}
         hideSaleInfo={hideSaleInfo}
@@ -97,7 +98,6 @@ const DisabledLink = styled(Box)`
   display: block;
   text-decoration: none;
   text-align: left;
-  cursor: default;
 `
 
 export default createFragmentContainer(Metadata, {
@@ -109,3 +109,27 @@ export default createFragmentContainer(Metadata, {
     }
   `,
 })
+
+type MetadataPlaceholderProps = Pick<
+  MetadataProps,
+  "hidePartnerName" | "hideArtistName" | "hideSaleInfo"
+> &
+  BoxProps
+
+export const MetadataPlaceholder: React.FC<MetadataPlaceholderProps> = ({
+  mt = 1,
+  hidePartnerName,
+  hideArtistName,
+  hideSaleInfo,
+  ...rest
+}) => {
+  return (
+    <Box mt={mt} {...rest}>
+      <DetailsPlaceholder
+        hidePartnerName={hidePartnerName}
+        hideArtistName={hideArtistName}
+        hideSaleInfo={hideSaleInfo}
+      />
+    </Box>
+  )
+}

--- a/src/Components/Artwork/ShelfArtwork.tsx
+++ b/src/Components/Artwork/ShelfArtwork.tsx
@@ -1,30 +1,22 @@
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { RouterLink } from "System/Router/RouterLink"
+import { RouterLink, RouterLinkProps } from "System/Router/RouterLink"
 import { ShelfArtwork_artwork$data } from "__generated__/ShelfArtwork_artwork.graphql"
-import Metadata from "./Metadata"
+import Metadata, { MetadataPlaceholder } from "Components/Artwork/Metadata"
 import { AuthContextModule } from "@artsy/cohesion"
-import styled from "styled-components"
-import { Image, Flex } from "@artsy/palette"
-import { Media } from "Utils/Responsive"
-import { useHoverMetadata } from "./useHoverMetadata"
+import { Box, Image, SkeletonBox } from "@artsy/palette"
+import { useHoverMetadata } from "Components/Artwork/useHoverMetadata"
+import { resized } from "Utils/resized"
 
-/**
- * The max height for an image in the carousel
- */
-export const IMG_HEIGHT = {
-  mobile: 250,
-  desktop: 320,
-}
-
-interface ShelfArtworkProps {
+export interface ShelfArtworkProps
+  extends Omit<RouterLinkProps, "to" | "width"> {
   artwork: ShelfArtwork_artwork$data
   contextModule?: AuthContextModule
   hideSaleInfo?: boolean
   lazyLoad?: boolean
-  showExtended?: boolean
   showMetadata?: boolean
   onClick?: () => void
+  width?: number[]
 }
 
 const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
@@ -33,115 +25,112 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
   hideSaleInfo,
   lazyLoad,
   onClick,
-  showExtended,
   showMetadata = true,
+  width = [150, 175, 200],
+  ...rest
 }) => {
   const { isHovered, onMouseEnter, onMouseLeave } = useHoverMetadata()
 
+  // Resize image to largest width expected
+  const image = artwork.image?.src
+    ? resized(artwork.image.src, { width: width[width.length - 1] })
+    : null
+
   return (
-    <div
-      data-test="artworkShelfArtwork"
-      data-testid="ShelfArtwork"
+    <RouterLink
+      to={artwork?.href}
+      onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      display="flex"
+      flexDirection="column"
+      justifyContent="flex-end"
+      textDecoration="none"
+      data-test="artworkShelfArtwork"
+      data-testid="ShelfArtwork"
+      aria-label={artwork.title ?? "Artwork"}
+      width={width}
+      {...rest}
     >
-      <RouterLink
-        to={artwork?.href}
-        display="block"
-        textDecoration="none"
-        onClick={onClick}
-      >
-        <ResponsiveContainer artwork={artwork}>
+      {image ? (
+        <Box
+          maxHeight={[250, 320]}
+          maxWidth="100%"
+          style={{
+            aspectRatio: `${artwork.image?.width ?? 1} / ${
+              artwork.image?.height ?? 1
+            }`,
+          }}
+          bg="black10"
+        >
           <Image
-            src={artwork.image?.resized?.src!}
-            srcSet={artwork.image?.resized?.srcSet}
-            width={artwork.image?.resized?.width}
-            maxHeight={[IMG_HEIGHT.mobile, IMG_HEIGHT.desktop]}
+            src={image.src}
+            srcSet={image.srcSet}
+            width="100%"
+            height="100%"
             lazyLoad={lazyLoad}
-            style={{ objectFit: "contain", display: "block" }}
+            style={{ objectFit: "contain" }}
+            alt=""
           />
-        </ResponsiveContainer>
-      </RouterLink>
+        </Box>
+      ) : (
+        <Box style={{ aspectRatio: "1 / 1" }} maxWidth="100%" bg="black10" />
+      )}
 
       {showMetadata && (
         <Metadata
           artwork={artwork}
-          extended={showExtended}
           hideSaleInfo={hideSaleInfo}
-          maxWidth={artwork.image?.resized?.width}
           isHovered={isHovered}
           contextModule={contextModule}
           showSaveButton
+          disableRouterLinking
+          maxWidth="100%"
         />
       )}
-    </div>
+    </RouterLink>
   )
 }
-
-const getHeight = (
-  artwork: ShelfArtwork_artwork$data,
-  size: keyof typeof IMG_HEIGHT
-) => {
-  return (artwork.image?.resized?.height ?? 0) > IMG_HEIGHT[size]
-    ? IMG_HEIGHT[size]
-    : artwork?.image?.resized?.height
-}
-
-const ResponsiveContainer: React.FC<{ artwork: ShelfArtwork_artwork$data }> = ({
-  artwork,
-  children,
-}) => {
-  // FIXME: Replace with <picture> and specific sizes for different platforms
-  return (
-    <>
-      <Media at="xs">
-        <Container
-          width={artwork.image?.resized?.width}
-          height={getHeight(artwork, "mobile")}
-        >
-          {children}
-        </Container>
-      </Media>
-
-      <Media greaterThan="xs">
-        <Container
-          width={artwork.image?.resized?.width}
-          height={getHeight(artwork, "desktop")}
-        >
-          {children}
-        </Container>
-      </Media>
-    </>
-  )
-}
-
-const Container = styled(Flex)`
-  position: relative;
-`
 
 export const ShelfArtworkFragmentContainer = createFragmentContainer(
   ShelfArtwork,
   {
     artwork: graphql`
-      fragment ShelfArtwork_artwork on Artwork
-        @argumentDefinitions(width: { type: "Int", defaultValue: 200 }) {
-        image {
-          resized(width: $width) {
-            src
-            srcSet
-            width
-            height
-          }
-          aspectRatio
-          height
-        }
-        imageTitle
-        title
-        href
+      fragment ShelfArtwork_artwork on Artwork {
         ...Metadata_artwork
         ...SaveButton_artwork
-        ...Badge_artwork
+        title
+        href
+        image {
+          src: url(version: ["normalized", "larger", "large"])
+          width
+          height
+        }
       }
     `,
   }
 )
+
+interface ShelfArtworkPlaceholderProps {
+  // Used to cycle through a set of placeholder heights
+  index: number
+  width?: number[]
+}
+
+export const ShelfArtworkPlaceholder: React.FC<ShelfArtworkPlaceholderProps> = ({
+  index,
+  width = [150, 175, 200],
+}) => {
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      justifyContent="flex-end"
+      width={width}
+    >
+      <SkeletonBox width="100W%" height={[200, 300, 250, 275][index % 4]} />
+
+      <MetadataPlaceholder />
+    </Box>
+  )
+}

--- a/src/Components/Artwork/__stories__/ShelfArtwork.story.tsx
+++ b/src/Components/Artwork/__stories__/ShelfArtwork.story.tsx
@@ -63,7 +63,6 @@ export const Default = () => {
 
               return (
                 <ShelfArtworkFragmentContainer
-                  // @ts-ignore RELAY UPGRADE 13
                   artwork={props.artwork}
                   {...rest}
                 />

--- a/src/Components/Artwork/__stories__/ShelfArtwork.story.tsx
+++ b/src/Components/Artwork/__stories__/ShelfArtwork.story.tsx
@@ -1,0 +1,77 @@
+import { States } from "storybook-states"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+  ShelfArtworkProps,
+} from "Components/Artwork/ShelfArtwork"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import { graphql } from "react-relay"
+
+export default {
+  title: "Components/ShelfArtwork",
+}
+
+export const Default = () => {
+  return (
+    <States<Partial<ShelfArtworkProps>>
+      states={[
+        { id: "morris-louis-gamma-delta" },
+        {
+          id: "morris-louis-gamma-delta",
+          width: [100],
+        },
+        {
+          id: "morris-louis-gamma-delta",
+          width: [400],
+        },
+        { id: "roni-horn-best-witchcraft-is-geometry" },
+        {
+          id: "roni-horn-best-witchcraft-is-geometry",
+          width: [100],
+        },
+        {
+          id: "roni-horn-best-witchcraft-is-geometry",
+          width: [400],
+        },
+        // Very tall + narrow
+        { id: "barnett-newman-the-moment-from-four-on-plexiglas" },
+        // No sale message
+        { id: "clyfford-still-ph-950-1" },
+      ]}
+    >
+      {({ id, ...rest }) => {
+        return (
+          <SystemQueryRenderer<any>
+            variables={{ id }}
+            placeholder={<ShelfArtworkPlaceholder index={1} {...rest} />}
+            query={graphql`
+              query ShelfArtworkStoryQuery($id: String!) {
+                artwork(id: $id) {
+                  ...ShelfArtwork_artwork
+                }
+              }
+            `}
+            render={({ error, props }) => {
+              if (error) {
+                console.error(error)
+                return null
+              }
+
+              if (!props?.artwork) {
+                return <ShelfArtworkPlaceholder index={1} {...rest} />
+              }
+
+              return (
+                <ShelfArtworkFragmentContainer
+                  // @ts-ignore RELAY UPGRADE 13
+                  artwork={props.artwork}
+                  {...rest}
+                />
+              )
+            }}
+          />
+        )
+      }}
+    </States>
+  )
+}

--- a/src/Components/RecentlyViewed/RecentlyViewedPlaceholder.tsx
+++ b/src/Components/RecentlyViewed/RecentlyViewedPlaceholder.tsx
@@ -1,7 +1,6 @@
-import { SkeletonBox, SkeletonText } from "@artsy/palette"
 import * as React from "react"
-import { IMG_HEIGHT } from "../Artwork/ShelfArtwork"
-import { Rail } from "../Rail"
+import { ShelfArtworkPlaceholder } from "Components/Artwork/ShelfArtwork"
+import { Rail } from "Components/Rail"
 
 export const RecentlyViewedPlaceholder: React.FC = () => {
   return (
@@ -9,37 +8,7 @@ export const RecentlyViewedPlaceholder: React.FC = () => {
       title="Recently Viewed"
       getItems={() => {
         return [...new Array(10)].map((_, i) => {
-          return (
-            <React.Fragment key={i}>
-              <SkeletonBox
-                width={200}
-                height={[
-                  // Cycle through random-ish looking heights bounded by the
-                  // max IMG_HEIGHT for both mobile and desktop.
-                  [
-                    IMG_HEIGHT.mobile - 150,
-                    IMG_HEIGHT.mobile - 100,
-                    IMG_HEIGHT.mobile - 50,
-                    IMG_HEIGHT.mobile,
-                    IMG_HEIGHT.mobile - 33,
-                  ][i % 5],
-                  [
-                    IMG_HEIGHT.desktop - 150,
-                    IMG_HEIGHT.desktop - 100,
-                    IMG_HEIGHT.desktop - 50,
-                    IMG_HEIGHT.desktop,
-                    IMG_HEIGHT.desktop - 33,
-                  ][i % 5],
-                ]}
-                mb={1}
-              />
-
-              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-              <SkeletonText variant="xs">Partner Name</SkeletonText>
-              <SkeletonText variant="xs">Price</SkeletonText>
-            </React.Fragment>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />

--- a/src/__generated__/AboutArtworksRailQuery.graphql.ts
+++ b/src/__generated__/AboutArtworksRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1b0bfc983ccc40e8ae5219f51b4471d8>>
+ * @generated SignedSource<<310b311149855cd210d8750c56d0d724>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,9 +66,9 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -153,71 +146,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 210
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v0/*: any*/)
-                            ],
-                            "storageKey": "resized(width:210)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v0/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -225,7 +154,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -249,15 +177,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v1/*: any*/),
-                          (v4/*: any*/)
+                          (v2/*: any*/),
+                          (v0/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -270,15 +198,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v1/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v0/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -290,7 +218,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -326,21 +254,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -366,7 +280,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -406,7 +320,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -416,14 +330,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -452,7 +366,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -470,17 +384,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -489,7 +438,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "storageKey": "artworksConnection(first:50,geneIDs:\"trending-this-week\")"
           }
@@ -499,12 +448,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "813748392fdd075a7cedee41c406372c",
+    "cacheID": "cef60a8805342e0327563a520fa3960a",
     "id": null,
     "metadata": {},
     "name": "AboutArtworksRailQuery",
     "operationKind": "query",
-    "text": "query AboutArtworksRailQuery {\n  viewer {\n    ...AboutArtworksRail_viewer\n  }\n}\n\nfragment AboutArtworksRail_viewer on Viewer {\n  artworksConnection(first: 50, geneIDs: \"trending-this-week\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork_1s6r3G\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query AboutArtworksRailQuery {\n  viewer {\n    ...AboutArtworksRail_viewer\n  }\n}\n\nfragment AboutArtworksRail_viewer on Viewer {\n  artworksConnection(first: 50, geneIDs: \"trending-this-week\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/AboutArtworksRail_viewer.graphql.ts
+++ b/src/__generated__/AboutArtworksRail_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<989da61d7ed690028780ab6f84645bd2>>
+ * @generated SignedSource<<a4900e6de81f05acb7ad9d13cc948fee>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -70,13 +70,7 @@ const node: ReaderFragment = {
               "plural": false,
               "selections": [
                 {
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 210
-                    }
-                  ],
+                  "args": null,
                   "kind": "FragmentSpread",
                   "name": "ShelfArtwork_artwork"
                 },
@@ -115,6 +109,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "0e6c0414bf142041bb098e61ae42b1cf";
+(node as any).hash = "3bf221d89a60f3c43509868c6ad1e23b";
 
 export default node;

--- a/src/__generated__/ArtistConsignRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistConsignRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<dafee44ca603a4a40bc6095c5d51051a>>
+ * @generated SignedSource<<883dac3706b1d6df0fdd8146338de538>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -61,38 +61,24 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = [
+v6 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v9 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v10 = [
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -101,9 +87,9 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = [
+v9 = [
   (v1/*: any*/),
-  (v7/*: any*/)
+  (v5/*: any*/)
 ];
 return {
   "fragment": {
@@ -230,8 +216,20 @@ return {
                                     "selections": [
                                       (v3/*: any*/),
                                       (v4/*: any*/),
-                                      (v5/*: any*/),
-                                      (v6/*: any*/)
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "src",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "srcSet",
+                                        "storageKey": null
+                                      }
                                     ],
                                     "storageKey": "cropped(height:300,width:300)"
                                   },
@@ -256,31 +254,28 @@ return {
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": null,
+                                    "alias": "src",
                                     "args": [
                                       {
                                         "kind": "Literal",
-                                        "name": "width",
-                                        "value": 200
+                                        "name": "version",
+                                        "value": [
+                                          "normalized",
+                                          "larger",
+                                          "large"
+                                        ]
                                       }
                                     ],
-                                    "concreteType": "ResizedImageUrl",
-                                    "kind": "LinkedField",
-                                    "name": "resized",
-                                    "plural": false,
-                                    "selections": [
-                                      (v5/*: any*/),
-                                      (v6/*: any*/),
-                                      (v3/*: any*/),
-                                      (v4/*: any*/)
-                                    ],
-                                    "storageKey": "resized(width:200)"
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
                                   },
+                                  (v3/*: any*/),
                                   (v4/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v7/*: any*/),
+                              (v5/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -326,13 +321,13 @@ return {
                               },
                               {
                                 "alias": null,
-                                "args": (v8/*: any*/),
+                                "args": (v6/*: any*/),
                                 "concreteType": "Artist",
                                 "kind": "LinkedField",
                                 "name": "artists",
                                 "plural": true,
                                 "selections": [
-                                  (v7/*: any*/),
+                                  (v5/*: any*/),
                                   (v2/*: any*/),
                                   (v1/*: any*/)
                                 ],
@@ -347,7 +342,7 @@ return {
                               },
                               {
                                 "alias": null,
-                                "args": (v8/*: any*/),
+                                "args": (v6/*: any*/),
                                 "concreteType": "Partner",
                                 "kind": "LinkedField",
                                 "name": "partner",
@@ -355,7 +350,7 @@ return {
                                 "selections": [
                                   (v1/*: any*/),
                                   (v2/*: any*/),
-                                  (v7/*: any*/)
+                                  (v5/*: any*/)
                                 ],
                                 "storageKey": "partner(shallow:true)"
                               },
@@ -367,7 +362,7 @@ return {
                                 "name": "sale",
                                 "plural": false,
                                 "selections": [
-                                  (v9/*: any*/),
+                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -403,7 +398,7 @@ return {
                                     "name": "isClosed",
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/),
+                                  (v5/*: any*/),
                                   {
                                     "alias": "is_preview",
                                     "args": null,
@@ -443,7 +438,7 @@ return {
                                     "name": "lotLabel",
                                     "storageKey": null
                                   },
-                                  (v9/*: any*/),
+                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -483,7 +478,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "highestBid",
                                     "plural": false,
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v8/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -493,10 +488,10 @@ return {
                                     "kind": "LinkedField",
                                     "name": "openingBid",
                                     "plural": false,
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v8/*: any*/),
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/)
+                                  (v5/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -521,7 +516,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "attributionClass",
                                 "plural": false,
-                                "selections": (v11/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -539,7 +534,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "filterGene",
                                     "plural": false,
-                                    "selections": (v11/*: any*/),
+                                    "selections": (v9/*: any*/),
                                     "storageKey": null
                                   }
                                 ],
@@ -620,19 +615,19 @@ return {
             ],
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "artist(id:\"example\")"
       }
     ]
   },
   "params": {
-    "cacheID": "a71f6b55d2981b870e4ce0cc39e7fe33",
+    "cacheID": "32e1e541e3432b993b59e5f6376f9454",
     "id": null,
     "metadata": {},
     "name": "ArtistConsignRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistConsignRoute_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistConsignRoute_artist\n    id\n  }\n}\n\nfragment ArtistConsignFAQ_artist on Artist {\n  href\n}\n\nfragment ArtistConsignHeader_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              cropped(width: 300, height: 300) {\n                width\n                height\n                src\n                srcSet\n              }\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignHowToSell_artist on Artist {\n  href\n}\n\nfragment ArtistConsignMarketTrends_artist on Artist {\n  href\n  targetSupply {\n    microfunnel {\n      metadata {\n        highestRealized\n        str\n        realized\n      }\n    }\n  }\n}\n\nfragment ArtistConsignMeta_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              imageURL: url(version: \"medium\")\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignPageViews_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      metadata {\n        roundedViews\n        roundedUniqueVisitors\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRecentlySold_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            ...FillwidthItem_artwork\n            ...ShelfArtwork_artwork\n            internalID\n            realizedPrice\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRoute_artist on Artist {\n  ...ArtistConsignMeta_artist\n  ...ArtistConsignHeader_artist\n  ...ArtistConsignRecentlySold_artist\n  ...ArtistConsignPageViews_artist\n  ...ArtistConsignMarketTrends_artist\n  ...ArtistConsignHowToSell_artist\n  ...ArtistConsignFAQ_artist\n  ...ArtistConsignSellArt_artist\n}\n\nfragment ArtistConsignSellArt_artist on Artist {\n  href\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query ArtistConsignRoute_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistConsignRoute_artist\n    id\n  }\n}\n\nfragment ArtistConsignFAQ_artist on Artist {\n  href\n}\n\nfragment ArtistConsignHeader_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              cropped(width: 300, height: 300) {\n                width\n                height\n                src\n                srcSet\n              }\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignHowToSell_artist on Artist {\n  href\n}\n\nfragment ArtistConsignMarketTrends_artist on Artist {\n  href\n  targetSupply {\n    microfunnel {\n      metadata {\n        highestRealized\n        str\n        realized\n      }\n    }\n  }\n}\n\nfragment ArtistConsignMeta_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              imageURL: url(version: \"medium\")\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignPageViews_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      metadata {\n        roundedViews\n        roundedUniqueVisitors\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRecentlySold_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            ...FillwidthItem_artwork\n            ...ShelfArtwork_artwork\n            internalID\n            realizedPrice\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRoute_artist on Artist {\n  ...ArtistConsignMeta_artist\n  ...ArtistConsignHeader_artist\n  ...ArtistConsignRecentlySold_artist\n  ...ArtistConsignPageViews_artist\n  ...ArtistConsignMarketTrends_artist\n  ...ArtistConsignHowToSell_artist\n  ...ArtistConsignFAQ_artist\n  ...ArtistConsignSellArt_artist\n}\n\nfragment ArtistConsignSellArt_artist on Artist {\n  href\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistNotableWorksRailQuery.graphql.ts
+++ b/src/__generated__/ArtistNotableWorksRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<acb1b69c103ad579f42cc6c8a60496f1>>
+ * @generated SignedSource<<8ef5ba2597e1d0e5d84a5c741c1dc82d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,45 +56,38 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v9 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v10 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -103,9 +96,9 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = [
-  (v8/*: any*/),
-  (v7/*: any*/)
+v10 = [
+  (v7/*: any*/),
+  (v6/*: any*/)
 ];
 return {
   "fragment": {
@@ -185,73 +178,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 200
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v4/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v4/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -259,7 +186,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -283,15 +209,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v5/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v7/*: any*/),
-                          (v5/*: any*/),
-                          (v8/*: any*/)
+                          (v6/*: any*/),
+                          (v4/*: any*/),
+                          (v7/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -304,15 +230,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v5/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
-                          (v5/*: any*/),
-                          (v7/*: any*/)
+                          (v7/*: any*/),
+                          (v4/*: any*/),
+                          (v6/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -324,7 +250,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -360,21 +286,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -400,7 +312,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v9/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -440,7 +352,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -450,14 +362,16 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           },
-                          (v7/*: any*/)
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v6/*: any*/),
+                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -472,7 +386,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v11/*: any*/),
+                        "selections": (v10/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -490,17 +404,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v10/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -509,23 +458,23 @@ return {
                 ],
                 "storageKey": null
               },
-              (v7/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")"
           },
-          (v7/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "6b439442e95d60a9642ad799cfa408fe",
+    "cacheID": "5f07607952341d5f35bfb829c4dba011",
     "id": null,
     "metadata": {},
     "name": "ArtistNotableWorksRailQuery",
     "operationKind": "query",
-    "text": "query ArtistNotableWorksRailQuery(\n  $slug: String!\n) {\n  artist(id: $slug) {\n    ...ArtistNotableWorksRail_artist\n    id\n  }\n}\n\nfragment ArtistNotableWorksRail_artist on Artist {\n  slug\n  internalID\n  filterArtworksConnection(sort: \"-weighted_iconicity\", first: 10) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query ArtistNotableWorksRailQuery(\n  $slug: String!\n) {\n  artist(id: $slug) {\n    ...ArtistNotableWorksRail_artist\n    id\n  }\n}\n\nfragment ArtistNotableWorksRail_artist on Artist {\n  slug\n  internalID\n  filterArtworksConnection(sort: \"-weighted_iconicity\", first: 10) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistNotableWorksRail_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistNotableWorksRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<37128305237e4fee2f0b84c909fafec4>>
+ * @generated SignedSource<<4177bb68f4ca7c0cc43c4cf3a6b8cdb9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -47,45 +47,38 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v5 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v9 = [
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -94,35 +87,29 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = [
-  (v7/*: any*/),
-  (v6/*: any*/)
+v9 = [
+  (v6/*: any*/),
+  (v5/*: any*/)
 ],
-v11 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v12 = {
+v11 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v13 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v14 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v15 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -206,73 +193,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
-                      (v1/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 200
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v3/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v3/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -280,7 +201,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -304,15 +224,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v4/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v6/*: any*/),
-                          (v4/*: any*/),
-                          (v7/*: any*/)
+                          (v5/*: any*/),
+                          (v3/*: any*/),
+                          (v6/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -325,15 +245,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v4/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
-                          (v4/*: any*/),
-                          (v6/*: any*/)
+                          (v6/*: any*/),
+                          (v3/*: any*/),
+                          (v5/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -345,7 +265,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -381,21 +301,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -421,7 +327,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v8/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -461,7 +367,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -471,14 +377,16 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      (v1/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -493,7 +401,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v10/*: any*/),
+                        "selections": (v9/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -511,17 +419,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -530,18 +473,18 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")"
           },
-          (v6/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "artist(id:\"test\")"
       }
     ]
   },
   "params": {
-    "cacheID": "72129de062f22a4069421651e6ebfab3",
+    "cacheID": "3c42a254e2186f745186487840bc12b4",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -575,49 +518,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "artist.filterArtworksConnection.edges.node.artists.href": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.artists.id": (v12/*: any*/),
-        "artist.filterArtworksConnection.edges.node.artists.name": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.artists.href": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.artists.id": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.artists.name": (v10/*: any*/),
         "artist.filterArtworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "artist.filterArtworksConnection.edges.node.attributionClass.id": (v12/*: any*/),
-        "artist.filterArtworksConnection.edges.node.attributionClass.name": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.collecting_institution": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.cultural_maker": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.date": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.href": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.id": (v12/*: any*/),
+        "artist.filterArtworksConnection.edges.node.attributionClass.id": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.attributionClass.name": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.collecting_institution": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.cultural_maker": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.date": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.href": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.id": (v11/*: any*/),
         "artist.filterArtworksConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "artist.filterArtworksConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "artist.filterArtworksConnection.edges.node.image.height": (v13/*: any*/),
-        "artist.filterArtworksConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "artist.filterArtworksConnection.edges.node.image.resized.height": (v13/*: any*/),
-        "artist.filterArtworksConnection.edges.node.image.resized.src": (v14/*: any*/),
-        "artist.filterArtworksConnection.edges.node.image.resized.srcSet": (v14/*: any*/),
-        "artist.filterArtworksConnection.edges.node.image.resized.width": (v13/*: any*/),
-        "artist.filterArtworksConnection.edges.node.imageTitle": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.internalID": (v12/*: any*/),
-        "artist.filterArtworksConnection.edges.node.is_biddable": (v15/*: any*/),
-        "artist.filterArtworksConnection.edges.node.is_saved": (v15/*: any*/),
+        "artist.filterArtworksConnection.edges.node.image.height": (v12/*: any*/),
+        "artist.filterArtworksConnection.edges.node.image.src": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.image.width": (v12/*: any*/),
+        "artist.filterArtworksConnection.edges.node.internalID": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.is_saved": (v13/*: any*/),
         "artist.filterArtworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -630,32 +557,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "artist.filterArtworksConnection.edges.node.mediumType.filterGene.id": (v12/*: any*/),
-        "artist.filterArtworksConnection.edges.node.mediumType.filterGene.name": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.mediumType.filterGene.id": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.mediumType.filterGene.name": (v10/*: any*/),
         "artist.filterArtworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "artist.filterArtworksConnection.edges.node.partner.href": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.partner.id": (v12/*: any*/),
-        "artist.filterArtworksConnection.edges.node.partner.name": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.partner.href": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.partner.id": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.partner.name": (v10/*: any*/),
         "artist.filterArtworksConnection.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "artist.filterArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v13/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale.display_timely_at": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale.endAt": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v13/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale.id": (v12/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale.is_auction": (v15/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale.is_closed": (v15/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale.is_preview": (v15/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale.startAt": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v12/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale.endAt": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v12/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale.id": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale.is_auction": (v13/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale.is_closed": (v13/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale.startAt": (v10/*: any*/),
         "artist.filterArtworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -674,38 +599,38 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "artist.filterArtworksConnection.edges.node.sale_artwork.endAt": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale_artwork.endAt": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v10/*: any*/),
         "artist.filterArtworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "artist.filterArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale_artwork.id": (v12/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale_artwork.lotID": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale_artwork.lotLabel": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale_artwork.id": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale_artwork.lotID": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale_artwork.lotLabel": (v10/*: any*/),
         "artist.filterArtworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "artist.filterArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.sale_message": (v11/*: any*/),
-        "artist.filterArtworksConnection.edges.node.slug": (v12/*: any*/),
-        "artist.filterArtworksConnection.edges.node.title": (v11/*: any*/),
-        "artist.filterArtworksConnection.id": (v12/*: any*/),
-        "artist.id": (v12/*: any*/),
-        "artist.internalID": (v12/*: any*/),
-        "artist.slug": (v12/*: any*/)
+        "artist.filterArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale_message": (v10/*: any*/),
+        "artist.filterArtworksConnection.edges.node.slug": (v11/*: any*/),
+        "artist.filterArtworksConnection.edges.node.title": (v10/*: any*/),
+        "artist.filterArtworksConnection.id": (v11/*: any*/),
+        "artist.id": (v11/*: any*/),
+        "artist.internalID": (v11/*: any*/),
+        "artist.slug": (v11/*: any*/)
       }
     },
     "name": "ArtistNotableWorksRail_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistNotableWorksRail_Test_Query {\n  artist(id: \"test\") {\n    ...ArtistNotableWorksRail_artist\n    id\n  }\n}\n\nfragment ArtistNotableWorksRail_artist on Artist {\n  slug\n  internalID\n  filterArtworksConnection(sort: \"-weighted_iconicity\", first: 10) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query ArtistNotableWorksRail_Test_Query {\n  artist(id: \"test\") {\n    ...ArtistNotableWorksRail_artist\n    id\n  }\n}\n\nfragment ArtistNotableWorksRail_artist on Artist {\n  slug\n  internalID\n  filterArtworksConnection(sort: \"-weighted_iconicity\", first: 10) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistNotableWorksRail_artist.graphql.ts
+++ b/src/__generated__/ArtistNotableWorksRail_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f1f9917f9c382f60bb471f25b01f64c6>>
+ * @generated SignedSource<<f6ea4acba80067d2d5b7aa69d91d0d0d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -87,19 +87,13 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                (v1/*: any*/),
-                (v0/*: any*/),
                 {
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 200
-                    }
-                  ],
+                  "args": null,
                   "kind": "FragmentSpread",
                   "name": "ShelfArtwork_artwork"
-                }
+                },
+                (v1/*: any*/),
+                (v0/*: any*/)
               ],
               "storageKey": null
             }
@@ -115,6 +109,6 @@ return {
 };
 })();
 
-(node as any).hash = "9424578a44deb286d040731faadd7dca";
+(node as any).hash = "3144f9efddcbac85711328e9ad6f1949";
 
 export default node;

--- a/src/__generated__/ArtistRailQuery.graphql.ts
+++ b/src/__generated__/ArtistRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<180cf17296d126ffcf6531b08d9b44dc>>
+ * @generated SignedSource<<dba0ab54b850c2bed837f78219ce9e4a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -66,49 +66,28 @@ v5 = {
   "name": "name",
   "storageKey": null
 },
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "src",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v9 = [
+v6 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v10 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v11 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -117,9 +96,9 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v10 = [
   (v5/*: any*/),
-  (v10/*: any*/)
+  (v7/*: any*/)
 ];
 return {
   "fragment": {
@@ -232,8 +211,20 @@ return {
                 "name": "cropped",
                 "plural": false,
                 "selections": [
-                  (v6/*: any*/),
-                  (v7/*: any*/)
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "src",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "srcSet",
+                    "storageKey": null
+                  }
                 ],
                 "storageKey": "cropped(height:45,width:45)"
               }
@@ -271,59 +262,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 200
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              (v6/*: any*/),
-                              (v7/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v8/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v8/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -331,7 +270,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -355,13 +293,13 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v9/*: any*/),
+                        "args": (v6/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v10/*: any*/),
+                          (v7/*: any*/),
                           (v3/*: any*/),
                           (v5/*: any*/)
                         ],
@@ -376,7 +314,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v9/*: any*/),
+                        "args": (v6/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
@@ -384,7 +322,7 @@ return {
                         "selections": [
                           (v5/*: any*/),
                           (v3/*: any*/),
-                          (v10/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -396,7 +334,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v11/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -432,21 +370,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v10/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v7/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -472,7 +396,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v11/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -512,7 +436,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -522,14 +446,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           },
-                          (v10/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v10/*: any*/),
+                      (v7/*: any*/),
                       (v4/*: any*/),
                       {
                         "alias": "is_saved",
@@ -545,7 +469,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v13/*: any*/),
+                        "selections": (v10/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -563,17 +487,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v13/*: any*/),
+                            "selections": (v10/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -585,19 +544,19 @@ return {
             ],
             "storageKey": "artworksConnection(first:10)"
           },
-          (v10/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "9d027971b9db3a1e427c7392977d7d7f",
+    "cacheID": "fd0f9940b1ad36932087336ca89d4a09",
     "id": null,
     "metadata": {},
     "name": "ArtistRailQuery",
     "operationKind": "query",
-    "text": "query ArtistRailQuery(\n  $id: String!\n) {\n  artist(id: $id) {\n    ...ArtistRail_artist\n    id\n  }\n}\n\nfragment ArtistRail_artist on Artist {\n  ...EntityHeaderArtist_artist\n  name\n  artworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query ArtistRailQuery(\n  $id: String!\n) {\n  artist(id: $id) {\n    ...ArtistRail_artist\n    id\n  }\n}\n\nfragment ArtistRail_artist on Artist {\n  ...EntityHeaderArtist_artist\n  name\n  artworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistWorksForSaleRailQuery.graphql.ts
+++ b/src/__generated__/ArtistWorksForSaleRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<17828bc38f8c4a54c92708ed908bdf19>>
+ * @generated SignedSource<<a302de47f07915e301baf2006527721f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,45 +56,38 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v9 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v10 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -103,9 +96,9 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = [
-  (v8/*: any*/),
-  (v7/*: any*/)
+v10 = [
+  (v7/*: any*/),
+  (v6/*: any*/)
 ];
 return {
   "fragment": {
@@ -185,71 +178,7 @@ return {
                     "selections": [
                       (v2/*: any*/),
                       (v3/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 200
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v4/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v4/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -257,7 +186,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -281,15 +209,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v5/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v7/*: any*/),
-                          (v5/*: any*/),
-                          (v8/*: any*/)
+                          (v6/*: any*/),
+                          (v4/*: any*/),
+                          (v7/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -302,15 +230,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v5/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
-                          (v5/*: any*/),
-                          (v7/*: any*/)
+                          (v7/*: any*/),
+                          (v4/*: any*/),
+                          (v6/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -322,7 +250,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -358,21 +286,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -398,7 +312,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v9/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -438,7 +352,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -448,14 +362,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           },
-                          (v7/*: any*/)
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -470,7 +384,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v11/*: any*/),
+                        "selections": (v10/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -488,17 +402,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v10/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -512,19 +461,19 @@ return {
           },
           (v2/*: any*/),
           (v3/*: any*/),
-          (v7/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "3749a8c3874cbc86da14aa448947ccc1",
+    "cacheID": "b13ebc87e8ed2654ef9a665bbd9299eb",
     "id": null,
     "metadata": {},
     "name": "ArtistWorksForSaleRailQuery",
     "operationKind": "query",
-    "text": "query ArtistWorksForSaleRailQuery(\n  $slug: String!\n) {\n  artist(id: $slug) {\n    ...ArtistWorksForSaleRail_artist\n    id\n  }\n}\n\nfragment ArtistWorksForSaleRail_artist on Artist {\n  artworksConnection(first: 20, sort: AVAILABILITY_ASC) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query ArtistWorksForSaleRailQuery(\n  $slug: String!\n) {\n  artist(id: $slug) {\n    ...ArtistWorksForSaleRail_artist\n    id\n  }\n}\n\nfragment ArtistWorksForSaleRail_artist on Artist {\n  artworksConnection(first: 20, sort: AVAILABILITY_ASC) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n  }\n  internalID\n  slug\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistWorksForSaleRail_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistWorksForSaleRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4e93e82a9bd35ce78f02982812514656>>
+ * @generated SignedSource<<db5dfd33881f003262ab3fa005dc4bb4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -47,45 +47,38 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v5 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v9 = [
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -94,35 +87,29 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = [
-  (v7/*: any*/),
-  (v6/*: any*/)
+v9 = [
+  (v6/*: any*/),
+  (v5/*: any*/)
 ],
-v11 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v12 = {
+v11 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v13 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v14 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v15 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -206,71 +193,7 @@ return {
                     "selections": [
                       (v1/*: any*/),
                       (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 200
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v3/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v3/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -278,7 +201,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -302,15 +224,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v4/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v6/*: any*/),
-                          (v4/*: any*/),
-                          (v7/*: any*/)
+                          (v5/*: any*/),
+                          (v3/*: any*/),
+                          (v6/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -323,15 +245,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v4/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
-                          (v4/*: any*/),
-                          (v6/*: any*/)
+                          (v6/*: any*/),
+                          (v3/*: any*/),
+                          (v5/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -343,7 +265,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -379,21 +301,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -419,7 +327,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v8/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -459,7 +367,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -469,14 +377,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -491,7 +399,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v10/*: any*/),
+                        "selections": (v9/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -509,17 +417,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -533,14 +476,14 @@ return {
           },
           (v1/*: any*/),
           (v2/*: any*/),
-          (v6/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "artist(id:\"test\")"
       }
     ]
   },
   "params": {
-    "cacheID": "89b008de74e8ff5f046f7a26658ae115",
+    "cacheID": "6e507515a0b0089b84ec0d92e41a79c4",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -574,49 +517,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "artist.artworksConnection.edges.node.artists.href": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.artists.id": (v12/*: any*/),
-        "artist.artworksConnection.edges.node.artists.name": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.artists.href": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.artists.id": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.artists.name": (v10/*: any*/),
         "artist.artworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "artist.artworksConnection.edges.node.attributionClass.id": (v12/*: any*/),
-        "artist.artworksConnection.edges.node.attributionClass.name": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.collecting_institution": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.cultural_maker": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.date": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.href": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.id": (v12/*: any*/),
+        "artist.artworksConnection.edges.node.attributionClass.id": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.attributionClass.name": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.collecting_institution": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.cultural_maker": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.date": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.href": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.id": (v11/*: any*/),
         "artist.artworksConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "artist.artworksConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "artist.artworksConnection.edges.node.image.height": (v13/*: any*/),
-        "artist.artworksConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "artist.artworksConnection.edges.node.image.resized.height": (v13/*: any*/),
-        "artist.artworksConnection.edges.node.image.resized.src": (v14/*: any*/),
-        "artist.artworksConnection.edges.node.image.resized.srcSet": (v14/*: any*/),
-        "artist.artworksConnection.edges.node.image.resized.width": (v13/*: any*/),
-        "artist.artworksConnection.edges.node.imageTitle": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.internalID": (v12/*: any*/),
-        "artist.artworksConnection.edges.node.is_biddable": (v15/*: any*/),
-        "artist.artworksConnection.edges.node.is_saved": (v15/*: any*/),
+        "artist.artworksConnection.edges.node.image.height": (v12/*: any*/),
+        "artist.artworksConnection.edges.node.image.src": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.image.width": (v12/*: any*/),
+        "artist.artworksConnection.edges.node.internalID": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.is_saved": (v13/*: any*/),
         "artist.artworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -629,32 +556,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "artist.artworksConnection.edges.node.mediumType.filterGene.id": (v12/*: any*/),
-        "artist.artworksConnection.edges.node.mediumType.filterGene.name": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.mediumType.filterGene.id": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.mediumType.filterGene.name": (v10/*: any*/),
         "artist.artworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "artist.artworksConnection.edges.node.partner.href": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.partner.id": (v12/*: any*/),
-        "artist.artworksConnection.edges.node.partner.name": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.partner.href": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.partner.id": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.partner.name": (v10/*: any*/),
         "artist.artworksConnection.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "artist.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v13/*: any*/),
-        "artist.artworksConnection.edges.node.sale.display_timely_at": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.sale.endAt": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v13/*: any*/),
-        "artist.artworksConnection.edges.node.sale.id": (v12/*: any*/),
-        "artist.artworksConnection.edges.node.sale.is_auction": (v15/*: any*/),
-        "artist.artworksConnection.edges.node.sale.is_closed": (v15/*: any*/),
-        "artist.artworksConnection.edges.node.sale.is_preview": (v15/*: any*/),
-        "artist.artworksConnection.edges.node.sale.startAt": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v12/*: any*/),
+        "artist.artworksConnection.edges.node.sale.endAt": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v12/*: any*/),
+        "artist.artworksConnection.edges.node.sale.id": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.sale.is_auction": (v13/*: any*/),
+        "artist.artworksConnection.edges.node.sale.is_closed": (v13/*: any*/),
+        "artist.artworksConnection.edges.node.sale.startAt": (v10/*: any*/),
         "artist.artworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -673,37 +598,37 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "artist.artworksConnection.edges.node.sale_artwork.endAt": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.sale_artwork.endAt": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v10/*: any*/),
         "artist.artworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "artist.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.sale_artwork.id": (v12/*: any*/),
-        "artist.artworksConnection.edges.node.sale_artwork.lotID": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.sale_artwork.lotLabel": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.sale_artwork.id": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.sale_artwork.lotID": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.sale_artwork.lotLabel": (v10/*: any*/),
         "artist.artworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "artist.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.sale_message": (v11/*: any*/),
-        "artist.artworksConnection.edges.node.slug": (v12/*: any*/),
-        "artist.artworksConnection.edges.node.title": (v11/*: any*/),
-        "artist.id": (v12/*: any*/),
-        "artist.internalID": (v12/*: any*/),
-        "artist.slug": (v12/*: any*/)
+        "artist.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.sale_message": (v10/*: any*/),
+        "artist.artworksConnection.edges.node.slug": (v11/*: any*/),
+        "artist.artworksConnection.edges.node.title": (v10/*: any*/),
+        "artist.id": (v11/*: any*/),
+        "artist.internalID": (v11/*: any*/),
+        "artist.slug": (v11/*: any*/)
       }
     },
     "name": "ArtistWorksForSaleRail_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistWorksForSaleRail_Test_Query {\n  artist(id: \"test\") {\n    ...ArtistWorksForSaleRail_artist\n    id\n  }\n}\n\nfragment ArtistWorksForSaleRail_artist on Artist {\n  artworksConnection(first: 20, sort: AVAILABILITY_ASC) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query ArtistWorksForSaleRail_Test_Query {\n  artist(id: \"test\") {\n    ...ArtistWorksForSaleRail_artist\n    id\n  }\n}\n\nfragment ArtistWorksForSaleRail_artist on Artist {\n  artworksConnection(first: 20, sort: AVAILABILITY_ASC) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n  }\n  internalID\n  slug\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistWorksForSaleRail_artist.graphql.ts
+++ b/src/__generated__/ArtistWorksForSaleRail_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<02dfcd4e23ebe9d490948f43b8a39129>>
+ * @generated SignedSource<<c2d687cecf4772a5ced2e3967d84406e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -88,13 +88,7 @@ return {
                 (v0/*: any*/),
                 (v1/*: any*/),
                 {
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 200
-                    }
-                  ],
+                  "args": null,
                   "kind": "FragmentSpread",
                   "name": "ShelfArtwork_artwork"
                 }
@@ -115,6 +109,6 @@ return {
 };
 })();
 
-(node as any).hash = "9b55c55367bdc0d1a2e6d05e14534f3f";
+(node as any).hash = "67f0c44c49040adff0455f06b2ec214d";
 
 export default node;

--- a/src/__generated__/ArtworkArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtworkArtistSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<224e625dc1a8b5967eefaf757c429fe6>>
+ * @generated SignedSource<<191c3c6921e430afb0e754d90c5012ea>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -63,73 +63,45 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
+  "name": "href",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "width",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v10 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v11 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v12 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v13 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v14 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v15 = [
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -138,10 +110,24 @@ v15 = [
     "storageKey": null
   }
 ],
-v16 = [
-  (v13/*: any*/),
-  (v12/*: any*/)
-];
+v12 = [
+  (v9/*: any*/),
+  (v8/*: any*/)
+],
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "width",
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -248,55 +234,8 @@ return {
                                 "selections": [
                                   (v3/*: any*/),
                                   (v2/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          (v5/*: any*/),
-                                          (v6/*: any*/),
-                                          (v7/*: any*/),
-                                          (v8/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v8/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
-                                  (v9/*: any*/),
-                                  (v10/*: any*/),
+                                  (v5/*: any*/),
+                                  (v6/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -320,15 +259,15 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v11/*: any*/),
+                                    "args": (v7/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v12/*: any*/),
-                                      (v10/*: any*/),
-                                      (v13/*: any*/)
+                                      (v8/*: any*/),
+                                      (v5/*: any*/),
+                                      (v9/*: any*/)
                                     ],
                                     "storageKey": "artists(shallow:true)"
                                   },
@@ -341,15 +280,15 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v11/*: any*/),
+                                    "args": (v7/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
                                     "plural": false,
                                     "selections": [
-                                      (v13/*: any*/),
-                                      (v10/*: any*/),
-                                      (v12/*: any*/)
+                                      (v9/*: any*/),
+                                      (v5/*: any*/),
+                                      (v8/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -361,7 +300,7 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v14/*: any*/),
+                                      (v10/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -397,21 +336,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v12/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v8/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -437,7 +362,7 @@ return {
                                         "name": "lotLabel",
                                         "storageKey": null
                                       },
-                                      (v14/*: any*/),
+                                      (v10/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -477,7 +402,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v15/*: any*/),
+                                        "selections": (v11/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -487,14 +412,14 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v15/*: any*/),
+                                        "selections": (v11/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v12/*: any*/)
+                                      (v8/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v12/*: any*/),
+                                  (v8/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -509,7 +434,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v16/*: any*/),
+                                    "selections": (v12/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -527,17 +452,40 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v16/*: any*/),
+                                        "selections": (v12/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      (v13/*: any*/),
+                                      (v14/*: any*/)
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -546,7 +494,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v12/*: any*/)
+                          (v8/*: any*/)
                         ],
                         "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")"
                       }
@@ -561,7 +509,7 @@ return {
           },
           {
             "alias": "seriesArtist",
-            "args": (v11/*: any*/),
+            "args": (v7/*: any*/),
             "concreteType": "Artist",
             "kind": "LinkedField",
             "name": "artist",
@@ -598,7 +546,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v9/*: any*/),
+                          (v6/*: any*/),
                           (v3/*: any*/),
                           {
                             "alias": null,
@@ -641,10 +589,22 @@ return {
                                 "name": "cropped",
                                 "plural": false,
                                 "selections": [
-                                  (v7/*: any*/),
-                                  (v8/*: any*/),
-                                  (v5/*: any*/),
-                                  (v6/*: any*/)
+                                  (v13/*: any*/),
+                                  (v14/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "src",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "srcSet",
+                                    "storageKey": null
+                                  }
                                 ],
                                 "storageKey": "cropped(height:244,width:325)"
                               }
@@ -660,7 +620,7 @@ return {
                 ],
                 "storageKey": "artistSeriesConnection(first:50)"
               },
-              (v12/*: any*/)
+              (v8/*: any*/)
             ],
             "storageKey": "artist(shallow:true)"
           },
@@ -704,19 +664,19 @@ return {
             ],
             "storageKey": "artistSeriesConnection(first:1)"
           },
-          (v12/*: any*/)
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "b270e9e6ea5b21947997cb30ec1eed22",
+    "cacheID": "66c7b9a3aa5cc8661ddcc5f4329af568",
     "id": null,
     "metadata": {},
     "name": "ArtworkArtistSeriesQuery",
     "operationKind": "query",
-    "text": "query ArtworkArtistSeriesQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...ArtworkArtistSeries_artwork\n    id\n  }\n}\n\nfragment ArtistSeriesArtworkRail_artwork on Artwork {\n  internalID\n  slug\n  artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        slug\n        internalID\n        filterArtworksConnection(sort: \"-decayed_merch\", first: 20) {\n          edges {\n            node {\n              slug\n              internalID\n              ...ShelfArtwork_artwork\n              id\n            }\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  featured\n  internalID\n  artworksCountMessage\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n\nfragment ArtworkArtistSeries_artwork on Artwork {\n  ...ArtistSeriesArtworkRail_artwork\n  internalID\n  slug\n  seriesArtist: artist(shallow: true) {\n    artistSeriesConnection(first: 50) {\n      edges {\n        node {\n          internalID\n        }\n      }\n    }\n    ...ArtistSeriesRail_artist\n    id\n  }\n  seriesForCounts: artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        artworksCount\n      }\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query ArtworkArtistSeriesQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...ArtworkArtistSeries_artwork\n    id\n  }\n}\n\nfragment ArtistSeriesArtworkRail_artwork on Artwork {\n  internalID\n  slug\n  artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        slug\n        internalID\n        filterArtworksConnection(sort: \"-decayed_merch\", first: 20) {\n          edges {\n            node {\n              slug\n              internalID\n              ...ShelfArtwork_artwork\n              id\n            }\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  featured\n  internalID\n  artworksCountMessage\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n\nfragment ArtworkArtistSeries_artwork on Artwork {\n  ...ArtistSeriesArtworkRail_artwork\n  internalID\n  slug\n  seriesArtist: artist(shallow: true) {\n    artistSeriesConnection(first: 50) {\n      edges {\n        node {\n          internalID\n        }\n      }\n    }\n    ...ArtistSeriesRail_artist\n    id\n  }\n  seriesForCounts: artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        artworksCount\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtworkArtistSeries_Query.graphql.ts
+++ b/src/__generated__/ArtworkArtistSeries_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fc4248d4f4b2bdc48e4ced9393eb4ce1>>
+ * @generated SignedSource<<3d2499281eaae37e4dcebe16a91d04e4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,137 +10,13 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type ArtworkArtistSeries_Query$variables = {
-  slug: string;
-};
+export type ArtworkArtistSeries_Query$variables = {};
 export type ArtworkArtistSeries_Query$data = {
   readonly artwork: {
     readonly " $fragmentSpreads": FragmentRefs<"ArtworkArtistSeries_artwork">;
   } | null;
 };
-export type ArtworkArtistSeries_Query$rawResponse = {
-  readonly artwork: {
-    readonly artistSeriesConnection: {
-      readonly edges: ReadonlyArray<{
-        readonly node: {
-          readonly filterArtworksConnection: {
-            readonly edges: ReadonlyArray<{
-              readonly node: {
-                readonly artists: ReadonlyArray<{
-                  readonly href: string | null;
-                  readonly id: string;
-                  readonly name: string | null;
-                } | null> | null;
-                readonly attributionClass: {
-                  readonly id: string;
-                  readonly name: string | null;
-                } | null;
-                readonly collecting_institution: string | null;
-                readonly cultural_maker: string | null;
-                readonly date: string | null;
-                readonly href: string | null;
-                readonly id: string;
-                readonly image: {
-                  readonly aspectRatio: number;
-                  readonly height: number | null;
-                  readonly resized: {
-                    readonly height: number | null;
-                    readonly src: string;
-                    readonly srcSet: string;
-                    readonly width: number | null;
-                  } | null;
-                } | null;
-                readonly imageTitle: string | null;
-                readonly internalID: string;
-                readonly is_biddable: boolean | null;
-                readonly is_saved: boolean | null;
-                readonly mediumType: {
-                  readonly filterGene: {
-                    readonly id: string;
-                    readonly name: string | null;
-                  } | null;
-                } | null;
-                readonly partner: {
-                  readonly href: string | null;
-                  readonly id: string;
-                  readonly name: string | null;
-                } | null;
-                readonly sale: {
-                  readonly cascadingEndTimeIntervalMinutes: number | null;
-                  readonly display_timely_at: string | null;
-                  readonly endAt: string | null;
-                  readonly extendedBiddingIntervalMinutes: number | null;
-                  readonly id: string;
-                  readonly is_auction: boolean | null;
-                  readonly is_closed: boolean | null;
-                  readonly is_preview: boolean | null;
-                  readonly startAt: string | null;
-                } | null;
-                readonly sale_artwork: {
-                  readonly counts: {
-                    readonly bidder_positions: any | null;
-                  } | null;
-                  readonly endAt: string | null;
-                  readonly extendedBiddingEndAt: string | null;
-                  readonly formattedEndDateTime: string | null;
-                  readonly highest_bid: {
-                    readonly display: string | null;
-                  } | null;
-                  readonly id: string;
-                  readonly lotID: string | null;
-                  readonly lotLabel: string | null;
-                  readonly opening_bid: {
-                    readonly display: string | null;
-                  } | null;
-                } | null;
-                readonly sale_message: string | null;
-                readonly slug: string;
-                readonly title: string | null;
-              } | null;
-            } | null> | null;
-            readonly id: string;
-          } | null;
-          readonly internalID: string;
-          readonly slug: string;
-        } | null;
-      } | null> | null;
-    } | null;
-    readonly id: string;
-    readonly internalID: string;
-    readonly seriesArtist: {
-      readonly artistSeriesConnection: {
-        readonly edges: ReadonlyArray<{
-          readonly node: {
-            readonly artworksCountMessage: string | null;
-            readonly featured: boolean;
-            readonly image: {
-              readonly cropped: {
-                readonly height: number;
-                readonly src: string;
-                readonly srcSet: string;
-                readonly width: number;
-              } | null;
-            } | null;
-            readonly internalID: string;
-            readonly slug: string;
-            readonly title: string;
-          } | null;
-        } | null> | null;
-      } | null;
-      readonly id: string;
-    } | null;
-    readonly seriesForCounts: {
-      readonly edges: ReadonlyArray<{
-        readonly node: {
-          readonly artworksCount: number;
-        } | null;
-      } | null> | null;
-    } | null;
-    readonly slug: string;
-  } | null;
-};
 export type ArtworkArtistSeries_Query = {
-  rawResponse: ArtworkArtistSeries_Query$rawResponse;
   response: ArtworkArtistSeries_Query$data;
   variables: ArtworkArtistSeries_Query$variables;
 };
@@ -148,110 +24,75 @@ export type ArtworkArtistSeries_Query = {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "slug"
-  }
-],
-v1 = [
-  {
-    "kind": "Variable",
+    "kind": "Literal",
     "name": "id",
-    "variableName": "slug"
+    "value": "example"
   }
 ],
-v2 = {
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v4 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 1
   }
 ],
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "src",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "width",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "title",
-  "storageKey": null
-},
-v10 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v11 = [
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v6 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v12 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v13 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v14 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v15 = [
+v10 = [
   {
     "alias": null,
     "args": null,
@@ -260,71 +101,85 @@ v15 = [
     "storageKey": null
   }
 ],
-v16 = [
-  (v13/*: any*/),
-  (v12/*: any*/)
+v11 = [
+  (v8/*: any*/),
+  (v7/*: any*/)
 ],
-v17 = {
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "width",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artwork"
 },
-v18 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ArtistSeriesConnection"
 },
-v19 = {
+v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "ArtistSeriesEdge"
 },
-v20 = {
+v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ArtistSeries"
 },
-v21 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v22 = {
+v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v23 = {
+v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v24 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v25 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v26 = {
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v27 = {
+v23 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v24 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -332,14 +187,14 @@ v27 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
     "name": "ArtworkArtistSeries_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Artwork",
         "kind": "LinkedField",
         "name": "artwork",
@@ -351,7 +206,7 @@ return {
             "name": "ArtworkArtistSeries_artwork"
           }
         ],
-        "storageKey": null
+        "storageKey": "artwork(id:\"example\")"
       }
     ],
     "type": "Query",
@@ -359,23 +214,23 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Operation",
     "name": "ArtworkArtistSeries_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Artwork",
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
         "selections": [
+          (v1/*: any*/),
           (v2/*: any*/),
-          (v3/*: any*/),
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v3/*: any*/),
             "concreteType": "ArtistSeriesConnection",
             "kind": "LinkedField",
             "name": "artistSeriesConnection",
@@ -397,8 +252,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
                       (v2/*: any*/),
+                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -434,57 +289,10 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v3/*: any*/),
                                   (v2/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          (v5/*: any*/),
-                                          (v6/*: any*/),
-                                          (v7/*: any*/),
-                                          (v8/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v8/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
-                                  (v9/*: any*/),
-                                  (v10/*: any*/),
+                                  (v1/*: any*/),
+                                  (v4/*: any*/),
+                                  (v5/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -508,15 +316,15 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v11/*: any*/),
+                                    "args": (v6/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v12/*: any*/),
-                                      (v10/*: any*/),
-                                      (v13/*: any*/)
+                                      (v7/*: any*/),
+                                      (v4/*: any*/),
+                                      (v8/*: any*/)
                                     ],
                                     "storageKey": "artists(shallow:true)"
                                   },
@@ -529,15 +337,15 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v11/*: any*/),
+                                    "args": (v6/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
                                     "plural": false,
                                     "selections": [
-                                      (v13/*: any*/),
-                                      (v10/*: any*/),
-                                      (v12/*: any*/)
+                                      (v8/*: any*/),
+                                      (v4/*: any*/),
+                                      (v7/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -549,7 +357,7 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v14/*: any*/),
+                                      (v9/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -585,21 +393,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v12/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v7/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -625,7 +419,7 @@ return {
                                         "name": "lotLabel",
                                         "storageKey": null
                                       },
-                                      (v14/*: any*/),
+                                      (v9/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -665,7 +459,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v15/*: any*/),
+                                        "selections": (v10/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -675,14 +469,14 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v15/*: any*/),
+                                        "selections": (v10/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v12/*: any*/)
+                                      (v7/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v12/*: any*/),
+                                  (v7/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -697,7 +491,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v16/*: any*/),
+                                    "selections": (v11/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -715,17 +509,40 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v16/*: any*/),
+                                        "selections": (v11/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      (v12/*: any*/),
+                                      (v13/*: any*/)
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -734,7 +551,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v12/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")"
                       }
@@ -749,7 +566,7 @@ return {
           },
           {
             "alias": "seriesArtist",
-            "args": (v11/*: any*/),
+            "args": (v6/*: any*/),
             "concreteType": "Artist",
             "kind": "LinkedField",
             "name": "artist",
@@ -785,9 +602,9 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
+                          (v1/*: any*/),
+                          (v5/*: any*/),
                           (v2/*: any*/),
-                          (v9/*: any*/),
-                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -829,10 +646,22 @@ return {
                                 "name": "cropped",
                                 "plural": false,
                                 "selections": [
-                                  (v7/*: any*/),
-                                  (v8/*: any*/),
-                                  (v5/*: any*/),
-                                  (v6/*: any*/)
+                                  (v12/*: any*/),
+                                  (v13/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "src",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "srcSet",
+                                    "storageKey": null
+                                  }
                                 ],
                                 "storageKey": "cropped(height:244,width:325)"
                               }
@@ -848,13 +677,13 @@ return {
                 ],
                 "storageKey": "artistSeriesConnection(first:50)"
               },
-              (v12/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": "artist(shallow:true)"
           },
           {
             "alias": "seriesForCounts",
-            "args": (v4/*: any*/),
+            "args": (v3/*: any*/),
             "concreteType": "ArtistSeriesConnection",
             "kind": "LinkedField",
             "name": "artistSeriesConnection",
@@ -892,21 +721,21 @@ return {
             ],
             "storageKey": "artistSeriesConnection(first:1)"
           },
-          (v12/*: any*/)
+          (v7/*: any*/)
         ],
-        "storageKey": null
+        "storageKey": "artwork(id:\"example\")"
       }
     ]
   },
   "params": {
-    "cacheID": "4c71a6def2755c7fef97df5d5105f38d",
+    "cacheID": "1764a5517668dcbacafc6af823cb9430",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "artwork": (v17/*: any*/),
-        "artwork.artistSeriesConnection": (v18/*: any*/),
-        "artwork.artistSeriesConnection.edges": (v19/*: any*/),
-        "artwork.artistSeriesConnection.edges.node": (v20/*: any*/),
+        "artwork": (v14/*: any*/),
+        "artwork.artistSeriesConnection": (v15/*: any*/),
+        "artwork.artistSeriesConnection.edges": (v16/*: any*/),
+        "artwork.artistSeriesConnection.edges.node": (v17/*: any*/),
         "artwork.artistSeriesConnection.edges.node.filterArtworksConnection": {
           "enumValues": null,
           "nullable": true,
@@ -919,51 +748,35 @@ return {
           "plural": true,
           "type": "FilterArtworksEdge"
         },
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node": (v17/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node": (v14/*: any*/),
         "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.artists.href": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.artists.id": (v22/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.artists.name": (v21/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.artists.href": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.artists.id": (v19/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.artists.name": (v18/*: any*/),
         "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.attributionClass.id": (v22/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.attributionClass.name": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.collecting_institution": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.cultural_maker": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.date": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.href": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.id": (v22/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image": (v23/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image.height": (v24/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image.resized.height": (v24/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image.resized.src": (v25/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image.resized.srcSet": (v25/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image.resized.width": (v24/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.imageTitle": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.internalID": (v22/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.is_biddable": (v26/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.is_saved": (v26/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.attributionClass.id": (v19/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.attributionClass.name": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.collecting_institution": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.cultural_maker": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.date": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.href": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.id": (v19/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image": (v20/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image.height": (v21/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image.src": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.image.width": (v21/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.internalID": (v19/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.is_saved": (v22/*: any*/),
         "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -976,32 +789,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.mediumType.filterGene.id": (v22/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.mediumType.filterGene.name": (v21/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.mediumType.filterGene.id": (v19/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.mediumType.filterGene.name": (v18/*: any*/),
         "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.partner.href": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.partner.id": (v22/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.partner.name": (v21/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.partner.href": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.partner.id": (v19/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.partner.name": (v18/*: any*/),
         "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v24/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.display_timely_at": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.endAt": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v24/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.id": (v22/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.is_auction": (v26/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.is_closed": (v26/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.is_preview": (v26/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.startAt": (v21/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v21/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.endAt": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v21/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.id": (v19/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.is_auction": (v22/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.is_closed": (v22/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale.startAt": (v18/*: any*/),
         "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -1020,79 +831,79 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.endAt": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v21/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.endAt": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v18/*: any*/),
         "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.id": (v22/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.lotID": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.lotLabel": (v21/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.id": (v19/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.lotID": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.lotLabel": (v18/*: any*/),
         "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_message": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.slug": (v22/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.title": (v21/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.id": (v22/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.internalID": (v22/*: any*/),
-        "artwork.artistSeriesConnection.edges.node.slug": (v25/*: any*/),
-        "artwork.id": (v22/*: any*/),
-        "artwork.internalID": (v22/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.sale_message": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.slug": (v19/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.edges.node.title": (v18/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.filterArtworksConnection.id": (v19/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.internalID": (v19/*: any*/),
+        "artwork.artistSeriesConnection.edges.node.slug": (v23/*: any*/),
+        "artwork.id": (v19/*: any*/),
+        "artwork.internalID": (v19/*: any*/),
         "artwork.seriesArtist": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Artist"
         },
-        "artwork.seriesArtist.artistSeriesConnection": (v18/*: any*/),
-        "artwork.seriesArtist.artistSeriesConnection.edges": (v19/*: any*/),
-        "artwork.seriesArtist.artistSeriesConnection.edges.node": (v20/*: any*/),
-        "artwork.seriesArtist.artistSeriesConnection.edges.node.artworksCountMessage": (v21/*: any*/),
+        "artwork.seriesArtist.artistSeriesConnection": (v15/*: any*/),
+        "artwork.seriesArtist.artistSeriesConnection.edges": (v16/*: any*/),
+        "artwork.seriesArtist.artistSeriesConnection.edges.node": (v17/*: any*/),
+        "artwork.seriesArtist.artistSeriesConnection.edges.node.artworksCountMessage": (v18/*: any*/),
         "artwork.seriesArtist.artistSeriesConnection.edges.node.featured": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "artwork.seriesArtist.artistSeriesConnection.edges.node.image": (v23/*: any*/),
+        "artwork.seriesArtist.artistSeriesConnection.edges.node.image": (v20/*: any*/),
         "artwork.seriesArtist.artistSeriesConnection.edges.node.image.cropped": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "artwork.seriesArtist.artistSeriesConnection.edges.node.image.cropped.height": (v27/*: any*/),
-        "artwork.seriesArtist.artistSeriesConnection.edges.node.image.cropped.src": (v25/*: any*/),
-        "artwork.seriesArtist.artistSeriesConnection.edges.node.image.cropped.srcSet": (v25/*: any*/),
-        "artwork.seriesArtist.artistSeriesConnection.edges.node.image.cropped.width": (v27/*: any*/),
-        "artwork.seriesArtist.artistSeriesConnection.edges.node.internalID": (v22/*: any*/),
-        "artwork.seriesArtist.artistSeriesConnection.edges.node.slug": (v25/*: any*/),
-        "artwork.seriesArtist.artistSeriesConnection.edges.node.title": (v25/*: any*/),
-        "artwork.seriesArtist.id": (v22/*: any*/),
-        "artwork.seriesForCounts": (v18/*: any*/),
-        "artwork.seriesForCounts.edges": (v19/*: any*/),
-        "artwork.seriesForCounts.edges.node": (v20/*: any*/),
-        "artwork.seriesForCounts.edges.node.artworksCount": (v27/*: any*/),
-        "artwork.slug": (v22/*: any*/)
+        "artwork.seriesArtist.artistSeriesConnection.edges.node.image.cropped.height": (v24/*: any*/),
+        "artwork.seriesArtist.artistSeriesConnection.edges.node.image.cropped.src": (v23/*: any*/),
+        "artwork.seriesArtist.artistSeriesConnection.edges.node.image.cropped.srcSet": (v23/*: any*/),
+        "artwork.seriesArtist.artistSeriesConnection.edges.node.image.cropped.width": (v24/*: any*/),
+        "artwork.seriesArtist.artistSeriesConnection.edges.node.internalID": (v19/*: any*/),
+        "artwork.seriesArtist.artistSeriesConnection.edges.node.slug": (v23/*: any*/),
+        "artwork.seriesArtist.artistSeriesConnection.edges.node.title": (v23/*: any*/),
+        "artwork.seriesArtist.id": (v19/*: any*/),
+        "artwork.seriesForCounts": (v15/*: any*/),
+        "artwork.seriesForCounts.edges": (v16/*: any*/),
+        "artwork.seriesForCounts.edges.node": (v17/*: any*/),
+        "artwork.seriesForCounts.edges.node.artworksCount": (v24/*: any*/),
+        "artwork.slug": (v19/*: any*/)
       }
     },
     "name": "ArtworkArtistSeries_Query",
     "operationKind": "query",
-    "text": "query ArtworkArtistSeries_Query(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...ArtworkArtistSeries_artwork\n    id\n  }\n}\n\nfragment ArtistSeriesArtworkRail_artwork on Artwork {\n  internalID\n  slug\n  artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        slug\n        internalID\n        filterArtworksConnection(sort: \"-decayed_merch\", first: 20) {\n          edges {\n            node {\n              slug\n              internalID\n              ...ShelfArtwork_artwork\n              id\n            }\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  featured\n  internalID\n  artworksCountMessage\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n\nfragment ArtworkArtistSeries_artwork on Artwork {\n  ...ArtistSeriesArtworkRail_artwork\n  internalID\n  slug\n  seriesArtist: artist(shallow: true) {\n    artistSeriesConnection(first: 50) {\n      edges {\n        node {\n          internalID\n        }\n      }\n    }\n    ...ArtistSeriesRail_artist\n    id\n  }\n  seriesForCounts: artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        artworksCount\n      }\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query ArtworkArtistSeries_Query {\n  artwork(id: \"example\") {\n    ...ArtworkArtistSeries_artwork\n    id\n  }\n}\n\nfragment ArtistSeriesArtworkRail_artwork on Artwork {\n  internalID\n  slug\n  artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        slug\n        internalID\n        filterArtworksConnection(sort: \"-decayed_merch\", first: 20) {\n          edges {\n            node {\n              slug\n              internalID\n              ...ShelfArtwork_artwork\n              id\n            }\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  featured\n  internalID\n  artworksCountMessage\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n\nfragment ArtworkArtistSeries_artwork on Artwork {\n  ...ArtistSeriesArtworkRail_artwork\n  internalID\n  slug\n  seriesArtist: artist(shallow: true) {\n    artistSeriesConnection(first: 50) {\n      edges {\n        node {\n          internalID\n        }\n      }\n    }\n    ...ArtistSeriesRail_artist\n    id\n  }\n  seriesForCounts: artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        artworksCount\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2c6458f0f50c16b9e3322b48d09967db";
+(node as any).hash = "0baf6c1d6cace923944b236c96b1253f";
 
 export default node;

--- a/src/__generated__/AuctionAppTestQuery.graphql.ts
+++ b/src/__generated__/AuctionAppTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3a92340f445a56370c8e85f7de445e95>>
+ * @generated SignedSource<<370b487d4e4692b8914f3cdc4499cbfd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -183,229 +183,216 @@ v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "width",
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v15 = [
+v16 = [
   (v12/*: any*/),
   (v13/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "width",
-    "storageKey": null
-  },
-  (v14/*: any*/)
+  (v14/*: any*/),
+  (v15/*: any*/)
 ],
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artistNames",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endedAt",
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "liveStartAt",
   "storageKey": null
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isLiveOpen",
   "storageKey": null
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v24 = [
+v25 = [
   (v4/*: any*/),
-  (v18/*: any*/)
+  (v19/*: any*/)
 ],
-v25 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v26 = {
+v27 = {
   "kind": "Literal",
   "name": "width",
   "value": 445
 },
-v27 = [
+v28 = [
   (v12/*: any*/),
   (v13/*: any*/)
 ],
-v28 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v29 = {
+v30 = {
   "kind": "Literal",
   "name": "first",
   "value": 99
 },
-v30 = {
+v31 = {
   "alias": "sale_message",
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v31 = {
+v32 = {
   "alias": "cultural_maker",
   "args": null,
   "kind": "ScalarField",
   "name": "culturalMaker",
   "storageKey": null
 },
-v32 = [
+v33 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v33 = {
+v34 = {
   "alias": null,
-  "args": (v32/*: any*/),
+  "args": (v33/*: any*/),
   "concreteType": "Artist",
   "kind": "LinkedField",
   "name": "artists",
   "plural": true,
   "selections": [
-    (v18/*: any*/),
-    (v28/*: any*/),
-    (v25/*: any*/)
+    (v19/*: any*/),
+    (v29/*: any*/),
+    (v26/*: any*/)
   ],
   "storageKey": "artists(shallow:true)"
 },
-v34 = {
+v35 = {
   "alias": "collecting_institution",
   "args": null,
   "kind": "ScalarField",
   "name": "collectingInstitution",
   "storageKey": null
 },
-v35 = {
+v36 = {
   "alias": null,
-  "args": (v32/*: any*/),
+  "args": (v33/*: any*/),
   "concreteType": "Partner",
   "kind": "LinkedField",
   "name": "partner",
   "plural": false,
   "selections": [
-    (v25/*: any*/),
-    (v28/*: any*/),
-    (v18/*: any*/)
+    (v26/*: any*/),
+    (v29/*: any*/),
+    (v19/*: any*/)
   ],
   "storageKey": "partner(shallow:true)"
 },
-v36 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cascadingEndTimeIntervalMinutes",
   "storageKey": null
 },
-v37 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingIntervalMinutes",
   "storageKey": null
 },
-v38 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startAt",
   "storageKey": null
 },
-v39 = {
+v40 = {
   "alias": "is_auction",
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v40 = {
+v41 = {
   "alias": "is_closed",
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v41 = {
-  "alias": "is_preview",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isPreview",
-  "storageKey": null
-},
 v42 = {
-  "alias": "display_timely_at",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "displayTimelyAt",
-  "storageKey": null
-},
-v43 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v44 = {
+v43 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v45 = {
+v44 = {
   "alias": "sale_artwork",
   "args": null,
   "concreteType": "SaleArtwork",
@@ -413,10 +400,10 @@ v45 = {
   "name": "saleArtwork",
   "plural": false,
   "selections": [
-    (v43/*: any*/),
+    (v42/*: any*/),
     (v7/*: any*/),
-    (v21/*: any*/),
-    (v44/*: any*/),
+    (v22/*: any*/),
+    (v43/*: any*/),
     (v9/*: any*/),
     {
       "alias": null,
@@ -456,32 +443,32 @@ v45 = {
       "selections": (v8/*: any*/),
       "storageKey": null
     },
-    (v18/*: any*/)
+    (v19/*: any*/)
   ],
   "storageKey": null
 },
-v46 = {
+v45 = {
   "alias": "is_saved",
   "args": null,
   "kind": "ScalarField",
   "name": "isSaved",
   "storageKey": null
 },
-v47 = [
-  (v25/*: any*/),
-  (v18/*: any*/)
+v46 = [
+  (v26/*: any*/),
+  (v19/*: any*/)
 ],
-v48 = {
+v47 = {
   "alias": null,
   "args": null,
   "concreteType": "AttributionClass",
   "kind": "LinkedField",
   "name": "attributionClass",
   "plural": false,
-  "selections": (v47/*: any*/),
+  "selections": (v46/*: any*/),
   "storageKey": null
 },
-v49 = {
+v48 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworkMedium",
@@ -496,20 +483,55 @@ v49 = {
       "kind": "LinkedField",
       "name": "filterGene",
       "plural": false,
-      "selections": (v47/*: any*/),
+      "selections": (v46/*: any*/),
       "storageKey": null
     }
   ],
   "storageKey": null
 },
-v50 = {
-  "alias": "is_biddable",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isBiddable",
-  "storageKey": null
+v49 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": [
+    "normalized",
+    "larger",
+    "large"
+  ]
 },
-v51 = [
+v50 = [
+  (v29/*: any*/),
+  (v11/*: any*/),
+  (v10/*: any*/),
+  (v31/*: any*/),
+  (v32/*: any*/),
+  (v34/*: any*/),
+  (v35/*: any*/),
+  (v36/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Sale",
+    "kind": "LinkedField",
+    "name": "sale",
+    "plural": false,
+    "selections": [
+      (v22/*: any*/),
+      (v37/*: any*/),
+      (v38/*: any*/),
+      (v39/*: any*/),
+      (v40/*: any*/),
+      (v41/*: any*/),
+      (v19/*: any*/)
+    ],
+    "storageKey": null
+  },
+  (v44/*: any*/),
+  (v19/*: any*/),
+  (v4/*: any*/),
+  (v18/*: any*/),
+  (v45/*: any*/),
+  (v47/*: any*/),
+  (v48/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -519,93 +541,37 @@ v51 = [
     "plural": false,
     "selections": [
       {
-        "alias": null,
+        "alias": "src",
         "args": [
-          {
-            "kind": "Literal",
-            "name": "width",
-            "value": 200
-          }
+          (v49/*: any*/)
         ],
-        "concreteType": "ResizedImageUrl",
-        "kind": "LinkedField",
-        "name": "resized",
-        "plural": false,
-        "selections": (v15/*: any*/),
-        "storageKey": "resized(width:200)"
-      },
-      {
-        "alias": null,
-        "args": null,
         "kind": "ScalarField",
-        "name": "aspectRatio",
-        "storageKey": null
+        "name": "url",
+        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
       },
-      (v14/*: any*/)
+      (v14/*: any*/),
+      (v15/*: any*/)
     ],
     "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "imageTitle",
-    "storageKey": null
-  },
-  (v11/*: any*/),
-  (v28/*: any*/),
-  (v10/*: any*/),
-  (v30/*: any*/),
-  (v31/*: any*/),
-  (v33/*: any*/),
-  (v34/*: any*/),
-  (v35/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Sale",
-    "kind": "LinkedField",
-    "name": "sale",
-    "plural": false,
-    "selections": [
-      (v21/*: any*/),
-      (v36/*: any*/),
-      (v37/*: any*/),
-      (v38/*: any*/),
-      (v39/*: any*/),
-      (v40/*: any*/),
-      (v18/*: any*/),
-      (v41/*: any*/),
-      (v42/*: any*/)
-    ],
-    "storageKey": null
-  },
-  (v45/*: any*/),
-  (v18/*: any*/),
-  (v4/*: any*/),
-  (v17/*: any*/),
-  (v46/*: any*/),
-  (v48/*: any*/),
-  (v49/*: any*/),
-  (v50/*: any*/)
+  }
 ],
-v52 = {
+v51 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v53 = {
+v52 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v54 = [
+v53 = [
+  (v51/*: any*/),
   (v52/*: any*/),
-  (v53/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -614,36 +580,27 @@ v54 = [
     "storageKey": null
   }
 ],
-v55 = [
-  (v18/*: any*/)
+v54 = [
+  (v19/*: any*/)
 ],
-v56 = {
-  "kind": "Literal",
-  "name": "version",
-  "value": [
-    "normalized",
-    "larger",
-    "large"
-  ]
-},
-v57 = {
+v55 = {
   "kind": "Literal",
   "name": "first",
   "value": 1
 },
-v58 = {
+v56 = {
   "kind": "Literal",
   "name": "aggregations",
   "value": [
     "TOTAL"
   ]
 },
-v59 = {
+v57 = {
   "kind": "Literal",
   "name": "includeArtworksByFollowedArtists",
   "value": true
 },
-v60 = {
+v58 = {
   "kind": "Variable",
   "name": "saleSlug",
   "variableName": "slug"
@@ -822,7 +779,7 @@ return {
                             "kind": "LinkedField",
                             "name": "resized",
                             "plural": false,
-                            "selections": (v15/*: any*/),
+                            "selections": (v16/*: any*/),
                             "storageKey": "resized(height:100,version:\"medium\",width:100)"
                           }
                         ],
@@ -835,13 +792,13 @@ return {
                         "name": "imageUrl",
                         "storageKey": null
                       },
-                      (v16/*: any*/),
                       (v17/*: any*/),
-                      (v18/*: any*/)
+                      (v18/*: any*/),
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v17/*: any*/),
+                  (v18/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -866,7 +823,7 @@ return {
                     "selections": (v8/*: any*/),
                     "storageKey": null
                   },
-                  (v19/*: any*/),
+                  (v20/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -875,16 +832,16 @@ return {
                     "name": "sale",
                     "plural": false,
                     "selections": [
-                      (v17/*: any*/),
-                      (v20/*: any*/),
+                      (v18/*: any*/),
                       (v21/*: any*/),
                       (v22/*: any*/),
                       (v23/*: any*/),
-                      (v18/*: any*/)
+                      (v24/*: any*/),
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v18/*: any*/)
+                  (v19/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -912,7 +869,7 @@ return {
             "kind": "LinkedField",
             "name": "pendingIdentityVerification",
             "plural": false,
-            "selections": (v24/*: any*/),
+            "selections": (v25/*: any*/),
             "storageKey": null
           },
           {
@@ -930,13 +887,13 @@ return {
                 "kind": "LinkedField",
                 "name": "activeBid",
                 "plural": false,
-                "selections": (v24/*: any*/),
+                "selections": (v25/*: any*/),
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v18/*: any*/)
+          (v19/*: any*/)
         ],
         "storageKey": null
       },
@@ -948,7 +905,7 @@ return {
         "name": "sale",
         "plural": false,
         "selections": [
-          (v25/*: any*/),
+          (v26/*: any*/),
           {
             "alias": null,
             "args": [
@@ -962,7 +919,7 @@ return {
             "name": "description",
             "storageKey": "description(format:\"HTML\")"
           },
-          (v17/*: any*/),
+          (v18/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -987,13 +944,13 @@ return {
                         "name": "height",
                         "value": 250
                       },
-                      (v26/*: any*/)
+                      (v27/*: any*/)
                     ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v27/*: any*/),
+                    "selections": (v28/*: any*/),
                     "storageKey": "cropped(height:250,width:445)"
                   }
                 ],
@@ -1006,10 +963,10 @@ return {
                 "name": "displayTimelyAt",
                 "storageKey": null
               },
-              (v28/*: any*/),
-              (v17/*: any*/),
-              (v25/*: any*/),
-              (v18/*: any*/)
+              (v29/*: any*/),
+              (v18/*: any*/),
+              (v26/*: any*/),
+              (v19/*: any*/)
             ],
             "storageKey": null
           },
@@ -1021,13 +978,13 @@ return {
             "name": "promotedSale",
             "plural": false,
             "selections": [
-              (v28/*: any*/),
+              (v29/*: any*/),
               (v4/*: any*/),
-              (v25/*: any*/),
+              (v26/*: any*/),
               {
                 "alias": null,
                 "args": [
-                  (v29/*: any*/)
+                  (v30/*: any*/)
                 ],
                 "concreteType": "SaleArtworkConnection",
                 "kind": "LinkedField",
@@ -1057,10 +1014,10 @@ return {
                             "kind": "LinkedField",
                             "name": "artwork",
                             "plural": false,
-                            "selections": (v51/*: any*/),
+                            "selections": (v50/*: any*/),
                             "storageKey": null
                           },
-                          (v18/*: any*/)
+                          (v19/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -1070,7 +1027,7 @@ return {
                 ],
                 "storageKey": "saleArtworksConnection(first:99)"
               },
-              (v18/*: any*/)
+              (v19/*: any*/)
             ],
             "storageKey": null
           },
@@ -1089,7 +1046,7 @@ return {
                 "name": "qualifiedForBidding",
                 "storageKey": null
               },
-              (v18/*: any*/)
+              (v19/*: any*/)
             ],
             "storageKey": null
           },
@@ -1100,8 +1057,8 @@ return {
             "name": "isAuction",
             "storageKey": null
           },
+          (v24/*: any*/),
           (v23/*: any*/),
-          (v22/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1137,7 +1094,7 @@ return {
             "kind": "LinkedField",
             "name": "registrationStatus",
             "plural": false,
-            "selections": (v24/*: any*/),
+            "selections": (v25/*: any*/),
             "storageKey": null
           },
           {
@@ -1147,14 +1104,14 @@ return {
             "name": "status",
             "storageKey": null
           },
-          (v20/*: any*/),
           (v21/*: any*/),
-          (v19/*: any*/),
-          (v38/*: any*/),
+          (v22/*: any*/),
+          (v20/*: any*/),
+          (v39/*: any*/),
           (v4/*: any*/),
-          (v28/*: any*/),
-          (v36/*: any*/),
+          (v29/*: any*/),
           (v37/*: any*/),
+          (v38/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1197,7 +1154,7 @@ return {
             "kind": "LinkedField",
             "name": "associatedSale",
             "plural": false,
-            "selections": (v24/*: any*/),
+            "selections": (v25/*: any*/),
             "storageKey": null
           },
           {
@@ -1207,10 +1164,10 @@ return {
             "kind": "LinkedField",
             "name": "promotedSale",
             "plural": false,
-            "selections": (v24/*: any*/),
+            "selections": (v25/*: any*/),
             "storageKey": null
           },
-          (v18/*: any*/)
+          (v19/*: any*/)
         ],
         "storageKey": null
       },
@@ -1232,7 +1189,7 @@ return {
             "name": "artworksConnection",
             "plural": false,
             "selections": [
-              (v18/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1273,7 +1230,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v54/*: any*/),
+                    "selections": (v53/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1283,7 +1240,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v54/*: any*/),
+                    "selections": (v53/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1293,7 +1250,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v54/*: any*/),
+                    "selections": (v53/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1304,8 +1261,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v52/*: any*/),
-                      (v53/*: any*/)
+                      (v51/*: any*/),
+                      (v52/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1327,7 +1284,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": (v55/*: any*/),
+                    "selections": (v54/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -1383,8 +1340,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v17/*: any*/),
-                          (v28/*: any*/),
+                          (v18/*: any*/),
+                          (v29/*: any*/),
                           (v4/*: any*/),
                           {
                             "alias": null,
@@ -1424,14 +1381,14 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v56/*: any*/),
-                                  (v26/*: any*/)
+                                  (v49/*: any*/),
+                                  (v27/*: any*/)
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "kind": "LinkedField",
                                 "name": "resized",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:445)"
                               }
                             ],
@@ -1445,13 +1402,13 @@ return {
                             "name": "imageTitle",
                             "storageKey": null
                           },
-                          (v16/*: any*/),
+                          (v17/*: any*/),
                           (v10/*: any*/),
-                          (v30/*: any*/),
                           (v31/*: any*/),
-                          (v33/*: any*/),
+                          (v32/*: any*/),
                           (v34/*: any*/),
                           (v35/*: any*/),
+                          (v36/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1460,15 +1417,27 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
-                              (v36/*: any*/),
+                              (v22/*: any*/),
                               (v37/*: any*/),
                               (v38/*: any*/),
                               (v39/*: any*/),
                               (v40/*: any*/),
-                              (v18/*: any*/),
                               (v41/*: any*/),
-                              (v42/*: any*/),
+                              (v19/*: any*/),
+                              {
+                                "alias": "is_preview",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isPreview",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "display_timely_at",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "displayTimelyAt",
+                                "storageKey": null
+                              },
                               {
                                 "alias": null,
                                 "args": null,
@@ -1479,11 +1448,17 @@ return {
                             ],
                             "storageKey": null
                           },
+                          (v44/*: any*/),
                           (v45/*: any*/),
-                          (v46/*: any*/),
+                          (v47/*: any*/),
                           (v48/*: any*/),
-                          (v49/*: any*/),
-                          (v50/*: any*/),
+                          {
+                            "alias": "is_biddable",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isBiddable",
+                            "storageKey": null
+                          },
                           {
                             "alias": null,
                             "args": null,
@@ -1492,10 +1467,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
-                              (v44/*: any*/),
+                              (v22/*: any*/),
                               (v43/*: any*/),
-                              (v18/*: any*/)
+                              (v42/*: any*/),
+                              (v19/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -1504,7 +1479,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v55/*: any*/),
+                        "selections": (v54/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1521,7 +1496,7 @@ return {
           {
             "alias": "sidebarAggregations",
             "args": [
-              (v57/*: any*/),
+              (v55/*: any*/),
               (v3/*: any*/)
             ],
             "concreteType": "FilterArtworksConnection",
@@ -1570,7 +1545,7 @@ return {
                     "name": "counts",
                     "plural": true,
                     "selections": [
-                      (v25/*: any*/),
+                      (v26/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1591,17 +1566,17 @@ return {
                 ],
                 "storageKey": null
               },
-              (v18/*: any*/)
+              (v19/*: any*/)
             ],
             "storageKey": null
           },
           {
             "alias": null,
             "args": [
-              (v58/*: any*/),
-              (v29/*: any*/),
-              (v59/*: any*/),
-              (v60/*: any*/)
+              (v56/*: any*/),
+              (v30/*: any*/),
+              (v57/*: any*/),
+              (v58/*: any*/)
             ],
             "concreteType": "SaleArtworksConnection",
             "kind": "LinkedField",
@@ -1623,10 +1598,10 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": (v51/*: any*/),
+                    "selections": (v50/*: any*/),
                     "storageKey": null
                   },
-                  (v18/*: any*/)
+                  (v19/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1636,7 +1611,7 @@ return {
           {
             "alias": null,
             "args": [
-              (v29/*: any*/),
+              (v30/*: any*/),
               (v5/*: any*/),
               {
                 "kind": "Literal",
@@ -1670,7 +1645,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v25/*: any*/),
+                      (v26/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1678,7 +1653,7 @@ return {
                         "name": "formattedStartDateTime",
                         "storageKey": null
                       },
-                      (v28/*: any*/),
+                      (v29/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1695,20 +1670,20 @@ return {
                                 "name": "height",
                                 "value": 334
                               },
-                              (v56/*: any*/),
-                              (v26/*: any*/)
+                              (v49/*: any*/),
+                              (v27/*: any*/)
                             ],
                             "concreteType": "CroppedImageUrl",
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v27/*: any*/),
+                            "selections": (v28/*: any*/),
                             "storageKey": "cropped(height:334,version:[\"normalized\",\"larger\",\"large\"],width:445)"
                           }
                         ],
                         "storageKey": null
                       },
-                      (v18/*: any*/)
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1721,10 +1696,10 @@ return {
           {
             "alias": "showFollowedArtistsTab",
             "args": [
-              (v58/*: any*/),
+              (v56/*: any*/),
+              (v55/*: any*/),
               (v57/*: any*/),
-              (v59/*: any*/),
-              (v60/*: any*/)
+              (v58/*: any*/)
             ],
             "concreteType": "SaleArtworksConnection",
             "kind": "LinkedField",
@@ -1746,10 +1721,10 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": (v24/*: any*/),
+                    "selections": (v25/*: any*/),
                     "storageKey": null
                   },
-                  (v18/*: any*/)
+                  (v19/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1762,12 +1737,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b03d020fafdb538c15a72fee53ce6b6a",
+    "cacheID": "ceb992f99fd8e1d2dfe55bc60591b0e5",
     "id": null,
     "metadata": {},
     "name": "AuctionAppTestQuery",
     "operationKind": "query",
-    "text": "query AuctionAppTestQuery(\n  $input: FilterArtworksInput\n  $slug: String!\n) {\n  me {\n    ...AuctionApp_me_96HcF\n    id\n  }\n  sale(id: $slug) @principalField {\n    ...AuctionApp_sale\n    id\n  }\n  viewer {\n    ...AuctionApp_viewer_YRlPK\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment AuctionActiveBids_me_96HcF on Me {\n  internalID\n  lotStandings(saleID: $slug, live: true) {\n    isHighestBidder\n    saleArtwork {\n      ...AuctionLotInfo_saleArtwork_4oTW5x\n      counts {\n        bidderPositions\n      }\n      currentBid {\n        display\n      }\n      slug\n      lotLabel\n      reserveStatus\n      saleID\n      highestBid {\n        display\n      }\n      endedAt\n      sale {\n        slug\n        liveStartAt\n        endAt\n        isLiveOpen\n        isClosed\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment AuctionApp_me_96HcF on Me {\n  ...AuctionActiveBids_me_96HcF\n  ...AuctionDetails_me\n  internalID\n  showActiveBids: lotStandings(saleID: $slug, live: true) {\n    activeBid {\n      internalID\n      id\n    }\n  }\n}\n\nfragment AuctionApp_sale on Sale {\n  ...AuctionMeta_sale\n  ...AuctionAssociatedSale_sale\n  ...AuctionBuyNowRail_sale\n  ...AuctionDetails_sale\n  ...CascadingEndTimesBanner_sale\n  internalID\n  slug\n  isClosed\n  eligibleSaleArtworksCount\n  coverImage {\n    url(version: [\"wide\", \"source\", \"large_rectangle\"])\n  }\n  showAssociatedSale: associatedSale {\n    internalID\n    id\n  }\n  showBuyNowTab: promotedSale {\n    internalID\n    id\n  }\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n  status\n}\n\nfragment AuctionApp_viewer_YRlPK on Viewer {\n  ...AuctionArtworkFilter_viewer_2VV6jB\n  ...AuctionWorksByFollowedArtistsRail_viewer_96HcF\n  ...AuctionCurrentAuctionsRail_viewer\n  showFollowedArtistsTab: saleArtworksConnection(first: 1, aggregations: [TOTAL], saleSlug: $slug, includeArtworksByFollowedArtists: true) {\n    edges {\n      node {\n        internalID\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment AuctionArtworkFilter_viewer_2VV6jB on Viewer {\n  ...ArtworkFilter_viewer_2VV6jB\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment AuctionAssociatedSale_sale on Sale {\n  associatedSale {\n    coverImage {\n      cropped(width: 445, height: 250) {\n        src\n        srcSet\n      }\n    }\n    displayTimelyAt\n    href\n    slug\n    name\n    id\n  }\n}\n\nfragment AuctionBuyNowRail_sale on Sale {\n  promotedSale {\n    href\n    internalID\n    name\n    saleArtworksConnection(first: 99) {\n      edges {\n        node {\n          artwork {\n            ...ShelfArtwork_artwork\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment AuctionCurrentAuctionsRail_viewer on Viewer {\n  salesConnection(first: 99, published: true, live: true, sort: LICENSED_TIMELY_AT_NAME_DESC) {\n    edges {\n      node {\n        ...CellSale_sale\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionDetails_me on Me {\n  ...RegisterButton_me\n}\n\nfragment AuctionDetails_sale on Sale {\n  ...RegisterButton_sale\n  ...AuctionInfoSidebar_sale\n  ...SaleDetailTimer_sale\n  internalID\n  name\n  slug\n  liveStartAt\n  startAt\n  endAt\n  description(format: HTML)\n  href\n  isClosed\n  cascadingEndTimeIntervalMinutes\n}\n\nfragment AuctionInfoSidebar_sale on Sale {\n  liveStartAt\n}\n\nfragment AuctionLotInfo_saleArtwork_4oTW5x on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  currentBid {\n    display\n  }\n  formattedEndDateTime\n  artwork {\n    internalID\n    date\n    title\n    image {\n      resized(width: 100, height: 100, version: \"medium\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    imageUrl\n    artistNames\n    slug\n    id\n  }\n}\n\nfragment AuctionMeta_sale on Sale {\n  name\n  description(format: HTML)\n  slug\n}\n\nfragment AuctionWorksByFollowedArtistsRail_viewer_96HcF on Viewer {\n  saleArtworksConnection(first: 99, aggregations: [TOTAL], saleSlug: $slug, includeArtworksByFollowedArtists: true) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment CellSale_sale on Sale {\n  name\n  formattedStartDateTime\n  href\n  coverImage {\n    cropped(width: 445, height: 334, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment RegisterButton_me on Me {\n  internalID\n  identityVerified\n  hasCreditCards\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment RegisterButton_sale on Sale {\n  bidder {\n    qualifiedForBidding\n    id\n  }\n  isAuction\n  isClosed\n  isLiveOpen\n  isPreview\n  isRegistrationClosed\n  liveURLIfOpen\n  requireIdentityVerification\n  registrationStatus {\n    internalID\n    id\n  }\n  slug\n  status\n}\n\nfragment SaleDetailTimer_sale on Sale {\n  endAt\n  endedAt\n  startAt\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query AuctionAppTestQuery(\n  $input: FilterArtworksInput\n  $slug: String!\n) {\n  me {\n    ...AuctionApp_me_96HcF\n    id\n  }\n  sale(id: $slug) @principalField {\n    ...AuctionApp_sale\n    id\n  }\n  viewer {\n    ...AuctionApp_viewer_YRlPK\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment AuctionActiveBids_me_96HcF on Me {\n  internalID\n  lotStandings(saleID: $slug, live: true) {\n    isHighestBidder\n    saleArtwork {\n      ...AuctionLotInfo_saleArtwork_4oTW5x\n      counts {\n        bidderPositions\n      }\n      currentBid {\n        display\n      }\n      slug\n      lotLabel\n      reserveStatus\n      saleID\n      highestBid {\n        display\n      }\n      endedAt\n      sale {\n        slug\n        liveStartAt\n        endAt\n        isLiveOpen\n        isClosed\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment AuctionApp_me_96HcF on Me {\n  ...AuctionActiveBids_me_96HcF\n  ...AuctionDetails_me\n  internalID\n  showActiveBids: lotStandings(saleID: $slug, live: true) {\n    activeBid {\n      internalID\n      id\n    }\n  }\n}\n\nfragment AuctionApp_sale on Sale {\n  ...AuctionMeta_sale\n  ...AuctionAssociatedSale_sale\n  ...AuctionBuyNowRail_sale\n  ...AuctionDetails_sale\n  ...CascadingEndTimesBanner_sale\n  internalID\n  slug\n  isClosed\n  eligibleSaleArtworksCount\n  coverImage {\n    url(version: [\"wide\", \"source\", \"large_rectangle\"])\n  }\n  showAssociatedSale: associatedSale {\n    internalID\n    id\n  }\n  showBuyNowTab: promotedSale {\n    internalID\n    id\n  }\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n  status\n}\n\nfragment AuctionApp_viewer_YRlPK on Viewer {\n  ...AuctionArtworkFilter_viewer_2VV6jB\n  ...AuctionWorksByFollowedArtistsRail_viewer_96HcF\n  ...AuctionCurrentAuctionsRail_viewer\n  showFollowedArtistsTab: saleArtworksConnection(first: 1, aggregations: [TOTAL], saleSlug: $slug, includeArtworksByFollowedArtists: true) {\n    edges {\n      node {\n        internalID\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment AuctionArtworkFilter_viewer_2VV6jB on Viewer {\n  ...ArtworkFilter_viewer_2VV6jB\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment AuctionAssociatedSale_sale on Sale {\n  associatedSale {\n    coverImage {\n      cropped(width: 445, height: 250) {\n        src\n        srcSet\n      }\n    }\n    displayTimelyAt\n    href\n    slug\n    name\n    id\n  }\n}\n\nfragment AuctionBuyNowRail_sale on Sale {\n  promotedSale {\n    href\n    internalID\n    name\n    saleArtworksConnection(first: 99) {\n      edges {\n        node {\n          artwork {\n            ...ShelfArtwork_artwork\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment AuctionCurrentAuctionsRail_viewer on Viewer {\n  salesConnection(first: 99, published: true, live: true, sort: LICENSED_TIMELY_AT_NAME_DESC) {\n    edges {\n      node {\n        ...CellSale_sale\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionDetails_me on Me {\n  ...RegisterButton_me\n}\n\nfragment AuctionDetails_sale on Sale {\n  ...RegisterButton_sale\n  ...AuctionInfoSidebar_sale\n  ...SaleDetailTimer_sale\n  internalID\n  name\n  slug\n  liveStartAt\n  startAt\n  endAt\n  description(format: HTML)\n  href\n  isClosed\n  cascadingEndTimeIntervalMinutes\n}\n\nfragment AuctionInfoSidebar_sale on Sale {\n  liveStartAt\n}\n\nfragment AuctionLotInfo_saleArtwork_4oTW5x on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  currentBid {\n    display\n  }\n  formattedEndDateTime\n  artwork {\n    internalID\n    date\n    title\n    image {\n      resized(width: 100, height: 100, version: \"medium\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    imageUrl\n    artistNames\n    slug\n    id\n  }\n}\n\nfragment AuctionMeta_sale on Sale {\n  name\n  description(format: HTML)\n  slug\n}\n\nfragment AuctionWorksByFollowedArtistsRail_viewer_96HcF on Viewer {\n  saleArtworksConnection(first: 99, aggregations: [TOTAL], saleSlug: $slug, includeArtworksByFollowedArtists: true) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment CellSale_sale on Sale {\n  name\n  formattedStartDateTime\n  href\n  coverImage {\n    cropped(width: 445, height: 334, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment RegisterButton_me on Me {\n  internalID\n  identityVerified\n  hasCreditCards\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment RegisterButton_sale on Sale {\n  bidder {\n    qualifiedForBidding\n    id\n  }\n  isAuction\n  isClosed\n  isLiveOpen\n  isPreview\n  isRegistrationClosed\n  liveURLIfOpen\n  requireIdentityVerification\n  registrationStatus {\n    internalID\n    id\n  }\n  slug\n  status\n}\n\nfragment SaleDetailTimer_sale on Sale {\n  endAt\n  endedAt\n  startAt\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/AuctionArtworksRailQuery.graphql.ts
+++ b/src/__generated__/AuctionArtworksRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4764881658ddc2535f3e54120929325e>>
+ * @generated SignedSource<<8acc65a95000982851a9047717f7ca4f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -42,59 +42,38 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v6 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v7 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v9 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v10 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -103,9 +82,23 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = [
-  (v8/*: any*/),
-  (v7/*: any*/)
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v10 = [
+  (v5/*: any*/),
+  (v4/*: any*/)
 ];
 return {
   "fragment": {
@@ -179,72 +172,6 @@ return {
                     "plural": false,
                     "selections": [
                       (v2/*: any*/),
-                      (v3/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 200
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v4/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v4/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
                       {
                         "alias": null,
                         "args": null,
@@ -252,7 +179,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -276,15 +202,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v3/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v7/*: any*/),
-                          (v5/*: any*/),
-                          (v8/*: any*/)
+                          (v4/*: any*/),
+                          (v2/*: any*/),
+                          (v5/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -297,15 +223,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v3/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
                           (v5/*: any*/),
-                          (v7/*: any*/)
+                          (v2/*: any*/),
+                          (v4/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -317,7 +243,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -353,21 +279,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -393,7 +305,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v9/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -433,7 +345,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v7/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -443,14 +355,16 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v7/*: any*/),
                             "storageKey": null
                           },
-                          (v7/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v4/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -465,7 +379,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v11/*: any*/),
+                        "selections": (v10/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -483,17 +397,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v10/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -505,10 +454,10 @@ return {
             ],
             "storageKey": "artworksConnection(first:20)"
           },
-          (v2/*: any*/),
-          (v3/*: any*/),
-          (v5/*: any*/),
           (v8/*: any*/),
+          (v9/*: any*/),
+          (v2/*: any*/),
+          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -516,19 +465,19 @@ return {
             "name": "formattedStartDateTime",
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "ca24457debe22e888029235d94f1e315",
+    "cacheID": "bd593e50cc5d8fece1e3f55c8b9fd562",
     "id": null,
     "metadata": {},
     "name": "AuctionArtworksRailQuery",
     "operationKind": "query",
-    "text": "query AuctionArtworksRailQuery(\n  $slug: String!\n) {\n  sale(id: $slug) {\n    ...AuctionArtworksRail_sale\n    id\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query AuctionArtworksRailQuery(\n  $slug: String!\n) {\n  sale(id: $slug) {\n    ...AuctionArtworksRail_sale\n    id\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/AuctionArtworksRail_Test_Query.graphql.ts
+++ b/src/__generated__/AuctionArtworksRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bd7f27f8bdab82344a5ae0e62bb978a0>>
+ * @generated SignedSource<<f6cd5a834b8444b9c9270f1176fd89cd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,59 +33,38 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v5 = [
+v2 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v6 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v8 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v9 = [
+v6 = [
   {
     "alias": null,
     "args": null,
@@ -94,41 +73,49 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = [
-  (v7/*: any*/),
-  (v6/*: any*/)
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v9 = [
+  (v4/*: any*/),
+  (v3/*: any*/)
 ],
-v11 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Sale"
 },
-v12 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v13 = {
+v12 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v14 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v15 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v16 = {
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -206,72 +193,6 @@ return {
                     "plural": false,
                     "selections": [
                       (v1/*: any*/),
-                      (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 200
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v3/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v3/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
                       {
                         "alias": null,
                         "args": null,
@@ -279,7 +200,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -303,15 +223,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v2/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v6/*: any*/),
-                          (v4/*: any*/),
-                          (v7/*: any*/)
+                          (v3/*: any*/),
+                          (v1/*: any*/),
+                          (v4/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -324,15 +244,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v2/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
                           (v4/*: any*/),
-                          (v6/*: any*/)
+                          (v1/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -344,7 +264,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -380,21 +300,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -420,7 +326,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v8/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -460,7 +366,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -470,14 +376,16 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v3/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -492,7 +400,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v10/*: any*/),
+                        "selections": (v9/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -510,17 +418,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -532,10 +475,10 @@ return {
             ],
             "storageKey": "artworksConnection(first:20)"
           },
-          (v1/*: any*/),
-          (v2/*: any*/),
-          (v4/*: any*/),
           (v7/*: any*/),
+          (v8/*: any*/),
+          (v1/*: any*/),
+          (v4/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -543,18 +486,18 @@ return {
             "name": "formattedStartDateTime",
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": "sale(id:\"xxx\")"
       }
     ]
   },
   "params": {
-    "cacheID": "7b62610709612835dad36c0bf43f5f32",
+    "cacheID": "d148fcaa3802dd2ae44e60bd1883eb71",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "sale": (v11/*: any*/),
+        "sale": (v10/*: any*/),
         "sale.artworksConnection": {
           "enumValues": null,
           "nullable": true,
@@ -579,49 +522,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "sale.artworksConnection.edges.node.artists.href": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.artists.id": (v13/*: any*/),
-        "sale.artworksConnection.edges.node.artists.name": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.artists.href": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.artists.id": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.artists.name": (v11/*: any*/),
         "sale.artworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "sale.artworksConnection.edges.node.attributionClass.id": (v13/*: any*/),
-        "sale.artworksConnection.edges.node.attributionClass.name": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.collecting_institution": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.cultural_maker": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.date": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.href": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.id": (v13/*: any*/),
+        "sale.artworksConnection.edges.node.attributionClass.id": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.attributionClass.name": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.collecting_institution": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.cultural_maker": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.date": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.href": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.id": (v12/*: any*/),
         "sale.artworksConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "sale.artworksConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "sale.artworksConnection.edges.node.image.height": (v14/*: any*/),
-        "sale.artworksConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "sale.artworksConnection.edges.node.image.resized.height": (v14/*: any*/),
-        "sale.artworksConnection.edges.node.image.resized.src": (v15/*: any*/),
-        "sale.artworksConnection.edges.node.image.resized.srcSet": (v15/*: any*/),
-        "sale.artworksConnection.edges.node.image.resized.width": (v14/*: any*/),
-        "sale.artworksConnection.edges.node.imageTitle": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.internalID": (v13/*: any*/),
-        "sale.artworksConnection.edges.node.is_biddable": (v16/*: any*/),
-        "sale.artworksConnection.edges.node.is_saved": (v16/*: any*/),
+        "sale.artworksConnection.edges.node.image.height": (v13/*: any*/),
+        "sale.artworksConnection.edges.node.image.src": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.image.width": (v13/*: any*/),
+        "sale.artworksConnection.edges.node.internalID": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.is_saved": (v14/*: any*/),
         "sale.artworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -634,27 +561,25 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "sale.artworksConnection.edges.node.mediumType.filterGene.id": (v13/*: any*/),
-        "sale.artworksConnection.edges.node.mediumType.filterGene.name": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.mediumType.filterGene.id": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.mediumType.filterGene.name": (v11/*: any*/),
         "sale.artworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "sale.artworksConnection.edges.node.partner.href": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.partner.id": (v13/*: any*/),
-        "sale.artworksConnection.edges.node.partner.name": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.sale": (v11/*: any*/),
-        "sale.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v14/*: any*/),
-        "sale.artworksConnection.edges.node.sale.display_timely_at": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.sale.endAt": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v14/*: any*/),
-        "sale.artworksConnection.edges.node.sale.id": (v13/*: any*/),
-        "sale.artworksConnection.edges.node.sale.is_auction": (v16/*: any*/),
-        "sale.artworksConnection.edges.node.sale.is_closed": (v16/*: any*/),
-        "sale.artworksConnection.edges.node.sale.is_preview": (v16/*: any*/),
-        "sale.artworksConnection.edges.node.sale.startAt": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.partner.href": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.partner.id": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.partner.name": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.sale": (v10/*: any*/),
+        "sale.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v13/*: any*/),
+        "sale.artworksConnection.edges.node.sale.endAt": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v13/*: any*/),
+        "sale.artworksConnection.edges.node.sale.id": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.sale.is_auction": (v14/*: any*/),
+        "sale.artworksConnection.edges.node.sale.is_closed": (v14/*: any*/),
+        "sale.artworksConnection.edges.node.sale.startAt": (v11/*: any*/),
         "sale.artworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -673,40 +598,40 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "sale.artworksConnection.edges.node.sale_artwork.endAt": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.sale_artwork.endAt": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v11/*: any*/),
         "sale.artworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "sale.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.sale_artwork.id": (v13/*: any*/),
-        "sale.artworksConnection.edges.node.sale_artwork.lotID": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.sale_artwork.lotLabel": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.sale_artwork.id": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.sale_artwork.lotID": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.sale_artwork.lotLabel": (v11/*: any*/),
         "sale.artworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "sale.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.sale_message": (v12/*: any*/),
-        "sale.artworksConnection.edges.node.slug": (v13/*: any*/),
-        "sale.artworksConnection.edges.node.title": (v12/*: any*/),
-        "sale.formattedStartDateTime": (v12/*: any*/),
-        "sale.href": (v12/*: any*/),
-        "sale.id": (v13/*: any*/),
-        "sale.internalID": (v13/*: any*/),
-        "sale.name": (v12/*: any*/),
-        "sale.slug": (v13/*: any*/)
+        "sale.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.sale_message": (v11/*: any*/),
+        "sale.artworksConnection.edges.node.slug": (v12/*: any*/),
+        "sale.artworksConnection.edges.node.title": (v11/*: any*/),
+        "sale.formattedStartDateTime": (v11/*: any*/),
+        "sale.href": (v11/*: any*/),
+        "sale.id": (v12/*: any*/),
+        "sale.internalID": (v12/*: any*/),
+        "sale.name": (v11/*: any*/),
+        "sale.slug": (v12/*: any*/)
       }
     },
     "name": "AuctionArtworksRail_Test_Query",
     "operationKind": "query",
-    "text": "query AuctionArtworksRail_Test_Query {\n  sale(id: \"xxx\") {\n    ...AuctionArtworksRail_sale\n    id\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query AuctionArtworksRail_Test_Query {\n  sale(id: \"xxx\") {\n    ...AuctionArtworksRail_sale\n    id\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/AuctionArtworksRail_sale.graphql.ts
+++ b/src/__generated__/AuctionArtworksRail_sale.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d5a11cf6c3dcb41a1e67366c8e3b9ed9>>
+ * @generated SignedSource<<7995350630ef562458042490a636de49>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -83,19 +83,13 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                (v0/*: any*/),
-                (v1/*: any*/),
                 {
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 200
-                    }
-                  ],
+                  "args": null,
                   "kind": "FragmentSpread",
                   "name": "ShelfArtwork_artwork"
-                }
+                },
+                (v0/*: any*/),
+                (v1/*: any*/)
               ],
               "storageKey": null
             }
@@ -134,6 +128,6 @@ return {
 };
 })();
 
-(node as any).hash = "d1fdd98fb47e988738a0af99ccb1f512";
+(node as any).hash = "17ff6099d53e1915651b68d0f6aa4aac";
 
 export default node;

--- a/src/__generated__/AuctionBuyNowRailTestQuery.graphql.ts
+++ b/src/__generated__/AuctionBuyNowRailTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<203e0aa5656c4298d2f78c9b38cfd0bc>>
+ * @generated SignedSource<<a91a896a98fd45275ac8344cb51e18f4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -50,35 +50,28 @@ v3 = {
   "name": "name",
   "storageKey": null
 },
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v5 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v8 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -87,9 +80,9 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = [
+v8 = [
   (v3/*: any*/),
-  (v6/*: any*/)
+  (v5/*: any*/)
 ];
 return {
   "fragment": {
@@ -181,71 +174,7 @@ return {
                             "name": "artwork",
                             "plural": false,
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Image",
-                                "kind": "LinkedField",
-                                "name": "image",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "width",
-                                        "value": 200
-                                      }
-                                    ],
-                                    "concreteType": "ResizedImageUrl",
-                                    "kind": "LinkedField",
-                                    "name": "resized",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "src",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "srcSet",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      (v4/*: any*/)
-                                    ],
-                                    "storageKey": "resized(width:200)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "aspectRatio",
-                                    "storageKey": null
-                                  },
-                                  (v4/*: any*/)
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "imageTitle",
-                                "storageKey": null
-                              },
+                              (v1/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -253,7 +182,6 @@ return {
                                 "name": "title",
                                 "storageKey": null
                               },
-                              (v1/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -277,13 +205,13 @@ return {
                               },
                               {
                                 "alias": null,
-                                "args": (v5/*: any*/),
+                                "args": (v4/*: any*/),
                                 "concreteType": "Artist",
                                 "kind": "LinkedField",
                                 "name": "artists",
                                 "plural": true,
                                 "selections": [
-                                  (v6/*: any*/),
+                                  (v5/*: any*/),
                                   (v1/*: any*/),
                                   (v3/*: any*/)
                                 ],
@@ -298,7 +226,7 @@ return {
                               },
                               {
                                 "alias": null,
-                                "args": (v5/*: any*/),
+                                "args": (v4/*: any*/),
                                 "concreteType": "Partner",
                                 "kind": "LinkedField",
                                 "name": "partner",
@@ -306,7 +234,7 @@ return {
                                 "selections": [
                                   (v3/*: any*/),
                                   (v1/*: any*/),
-                                  (v6/*: any*/)
+                                  (v5/*: any*/)
                                 ],
                                 "storageKey": "partner(shallow:true)"
                               },
@@ -318,7 +246,7 @@ return {
                                 "name": "sale",
                                 "plural": false,
                                 "selections": [
-                                  (v7/*: any*/),
+                                  (v6/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -354,21 +282,7 @@ return {
                                     "name": "isClosed",
                                     "storageKey": null
                                   },
-                                  (v6/*: any*/),
-                                  {
-                                    "alias": "is_preview",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isPreview",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "display_timely_at",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "displayTimelyAt",
-                                    "storageKey": null
-                                  }
+                                  (v5/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -394,7 +308,7 @@ return {
                                     "name": "lotLabel",
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/),
+                                  (v6/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -434,7 +348,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "highestBid",
                                     "plural": false,
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v7/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -444,14 +358,14 @@ return {
                                     "kind": "LinkedField",
                                     "name": "openingBid",
                                     "plural": false,
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v7/*: any*/),
                                     "storageKey": null
                                   },
-                                  (v6/*: any*/)
+                                  (v5/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v6/*: any*/),
+                              (v5/*: any*/),
                               (v2/*: any*/),
                               {
                                 "alias": null,
@@ -474,7 +388,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "attributionClass",
                                 "plural": false,
-                                "selections": (v9/*: any*/),
+                                "selections": (v8/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -492,23 +406,58 @@ return {
                                     "kind": "LinkedField",
                                     "name": "filterGene",
                                     "plural": false,
-                                    "selections": (v9/*: any*/),
+                                    "selections": (v8/*: any*/),
                                     "storageKey": null
                                   }
                                 ],
                                 "storageKey": null
                               },
                               {
-                                "alias": "is_biddable",
+                                "alias": null,
                                 "args": null,
-                                "kind": "ScalarField",
-                                "name": "isBiddable",
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "src",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": [
+                                          "normalized",
+                                          "larger",
+                                          "large"
+                                        ]
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "width",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "height",
+                                    "storageKey": null
+                                  }
+                                ],
                                 "storageKey": null
                               }
                             ],
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -518,23 +467,23 @@ return {
                 ],
                 "storageKey": "saleArtworksConnection(first:99)"
               },
-              (v6/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "sale(id:\"foo\")"
       }
     ]
   },
   "params": {
-    "cacheID": "19e3ec41cb77272ed6383c5dd0e3767a",
+    "cacheID": "1c04221e5ab8858ef7ec053cb76299d6",
     "id": null,
     "metadata": {},
     "name": "AuctionBuyNowRailTestQuery",
     "operationKind": "query",
-    "text": "query AuctionBuyNowRailTestQuery {\n  sale(id: \"foo\") {\n    ...AuctionBuyNowRail_sale\n    id\n  }\n}\n\nfragment AuctionBuyNowRail_sale on Sale {\n  promotedSale {\n    href\n    internalID\n    name\n    saleArtworksConnection(first: 99) {\n      edges {\n        node {\n          artwork {\n            ...ShelfArtwork_artwork\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query AuctionBuyNowRailTestQuery {\n  sale(id: \"foo\") {\n    ...AuctionBuyNowRail_sale\n    id\n  }\n}\n\nfragment AuctionBuyNowRail_sale on Sale {\n  promotedSale {\n    href\n    internalID\n    name\n    saleArtworksConnection(first: 99) {\n      edges {\n        node {\n          artwork {\n            ...ShelfArtwork_artwork\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/AuctionWorksByFollowedArtistsRailTestQuery.graphql.ts
+++ b/src/__generated__/AuctionWorksByFollowedArtistsRailTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c5073993622bb0e0a5cd2a6a88a720de>>
+ * @generated SignedSource<<60724867dddb297a35d416f7e419f5f7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,9 +66,9 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -160,71 +153,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 200
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v0/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v0/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -232,7 +161,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -256,15 +184,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v1/*: any*/),
-                          (v4/*: any*/)
+                          (v2/*: any*/),
+                          (v0/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -277,15 +205,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v1/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v0/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -297,7 +225,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -333,21 +261,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -373,7 +287,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -413,7 +327,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -423,14 +337,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -459,7 +373,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -477,23 +391,58 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v3/*: any*/)
+                  (v2/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -506,12 +455,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "75050a8cf6794435cac9601c3d58ab62",
+    "cacheID": "c860e67a2be3c19f59bb029934ed3c70",
     "id": null,
     "metadata": {},
     "name": "AuctionWorksByFollowedArtistsRailTestQuery",
     "operationKind": "query",
-    "text": "query AuctionWorksByFollowedArtistsRailTestQuery {\n  viewer {\n    ...AuctionWorksByFollowedArtistsRail_viewer\n  }\n}\n\nfragment AuctionWorksByFollowedArtistsRail_viewer on Viewer {\n  saleArtworksConnection(first: 99, aggregations: [TOTAL], includeArtworksByFollowedArtists: true) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query AuctionWorksByFollowedArtistsRailTestQuery {\n  viewer {\n    ...AuctionWorksByFollowedArtistsRail_viewer\n  }\n}\n\nfragment AuctionWorksByFollowedArtistsRail_viewer on Viewer {\n  saleArtworksConnection(first: 99, aggregations: [TOTAL], includeArtworksByFollowedArtists: true) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/AuctionsApp_Test_Query.graphql.ts
+++ b/src/__generated__/AuctionsApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<62c245f3d170ab03d507961265fca95a>>
+ * @generated SignedSource<<f30536b08cd827b43935149fd470bb3b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -60,232 +60,143 @@ v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
+  "name": "href",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "srcSet",
+  "name": "title",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v9 = [
-  (v6/*: any*/),
-  (v7/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "width",
-    "storageKey": null
-  },
-  (v8/*: any*/)
-],
-v10 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Image",
-  "kind": "LinkedField",
-  "name": "image",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "width",
-          "value": 325
-        }
-      ],
-      "concreteType": "ResizedImageUrl",
-      "kind": "LinkedField",
-      "name": "resized",
-      "plural": false,
-      "selections": (v9/*: any*/),
-      "storageKey": "resized(width:325)"
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "aspectRatio",
-      "storageKey": null
-    },
-    (v8/*: any*/)
-  ],
-  "storageKey": null
-},
-v11 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "imageTitle",
-  "storageKey": null
-},
-v12 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "title",
-  "storageKey": null
-},
-v13 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v14 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "date",
   "storageKey": null
 },
-v15 = {
+v9 = {
   "alias": "sale_message",
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v16 = {
+v10 = {
   "alias": "cultural_maker",
   "args": null,
   "kind": "ScalarField",
   "name": "culturalMaker",
   "storageKey": null
 },
-v17 = [
+v11 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v18 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v19 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v20 = {
+v14 = {
   "alias": null,
-  "args": (v17/*: any*/),
+  "args": (v11/*: any*/),
   "concreteType": "Artist",
   "kind": "LinkedField",
   "name": "artists",
   "plural": true,
   "selections": [
-    (v18/*: any*/),
-    (v13/*: any*/),
-    (v19/*: any*/)
+    (v12/*: any*/),
+    (v6/*: any*/),
+    (v13/*: any*/)
   ],
   "storageKey": "artists(shallow:true)"
 },
-v21 = {
+v15 = {
   "alias": "collecting_institution",
   "args": null,
   "kind": "ScalarField",
   "name": "collectingInstitution",
   "storageKey": null
 },
-v22 = {
+v16 = {
   "alias": null,
-  "args": (v17/*: any*/),
+  "args": (v11/*: any*/),
   "concreteType": "Partner",
   "kind": "LinkedField",
   "name": "partner",
   "plural": false,
   "selections": [
-    (v19/*: any*/),
     (v13/*: any*/),
-    (v18/*: any*/)
+    (v6/*: any*/),
+    (v12/*: any*/)
   ],
   "storageKey": "partner(shallow:true)"
 },
-v23 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v24 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cascadingEndTimeIntervalMinutes",
   "storageKey": null
 },
-v25 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingIntervalMinutes",
   "storageKey": null
 },
-v26 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startAt",
   "storageKey": null
 },
-v27 = {
+v21 = {
   "alias": "is_auction",
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v28 = {
+v22 = {
   "alias": "is_closed",
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v29 = {
-  "alias": "is_preview",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isPreview",
-  "storageKey": null
-},
-v30 = {
-  "alias": "display_timely_at",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "displayTimelyAt",
-  "storageKey": null
-},
-v31 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotLabel",
   "storageKey": null
 },
-v32 = [
+v24 = [
   {
     "alias": null,
     "args": null,
@@ -294,7 +205,7 @@ v32 = [
     "storageKey": null
   }
 ],
-v33 = {
+v25 = {
   "alias": "sale_artwork",
   "args": null,
   "concreteType": "SaleArtwork",
@@ -309,8 +220,8 @@ v33 = {
       "name": "lotID",
       "storageKey": null
     },
-    (v31/*: any*/),
     (v23/*: any*/),
+    (v17/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -350,7 +261,7 @@ v33 = {
       "kind": "LinkedField",
       "name": "highestBid",
       "plural": false,
-      "selections": (v32/*: any*/),
+      "selections": (v24/*: any*/),
       "storageKey": null
     },
     {
@@ -360,35 +271,35 @@ v33 = {
       "kind": "LinkedField",
       "name": "openingBid",
       "plural": false,
-      "selections": (v32/*: any*/),
+      "selections": (v24/*: any*/),
       "storageKey": null
     },
-    (v18/*: any*/)
+    (v12/*: any*/)
   ],
   "storageKey": null
 },
-v34 = {
+v26 = {
   "alias": "is_saved",
   "args": null,
   "kind": "ScalarField",
   "name": "isSaved",
   "storageKey": null
 },
-v35 = [
-  (v19/*: any*/),
-  (v18/*: any*/)
+v27 = [
+  (v13/*: any*/),
+  (v12/*: any*/)
 ],
-v36 = {
+v28 = {
   "alias": null,
   "args": null,
   "concreteType": "AttributionClass",
   "kind": "LinkedField",
   "name": "attributionClass",
   "plural": false,
-  "selections": (v35/*: any*/),
+  "selections": (v27/*: any*/),
   "storageKey": null
 },
-v37 = {
+v29 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworkMedium",
@@ -403,20 +314,57 @@ v37 = {
       "kind": "LinkedField",
       "name": "filterGene",
       "plural": false,
-      "selections": (v35/*: any*/),
+      "selections": (v27/*: any*/),
       "storageKey": null
     }
   ],
   "storageKey": null
 },
-v38 = {
-  "alias": "is_biddable",
+v30 = {
+  "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isBiddable",
+  "name": "width",
   "storageKey": null
 },
-v39 = {
+v31 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v32 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": [
+    {
+      "alias": "src",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "version",
+          "value": [
+            "normalized",
+            "larger",
+            "large"
+          ]
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "url",
+      "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+    },
+    (v30/*: any*/),
+    (v31/*: any*/)
+  ],
+  "storageKey": null
+},
+v33 = {
   "alias": null,
   "args": null,
   "concreteType": "Artwork",
@@ -426,16 +374,14 @@ v39 = {
   "selections": [
     (v4/*: any*/),
     (v5/*: any*/),
+    (v6/*: any*/),
+    (v7/*: any*/),
+    (v8/*: any*/),
+    (v9/*: any*/),
     (v10/*: any*/),
-    (v11/*: any*/),
-    (v12/*: any*/),
-    (v13/*: any*/),
     (v14/*: any*/),
     (v15/*: any*/),
     (v16/*: any*/),
-    (v20/*: any*/),
-    (v21/*: any*/),
-    (v22/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -444,166 +390,166 @@ v39 = {
       "name": "sale",
       "plural": false,
       "selections": [
-        (v23/*: any*/),
-        (v24/*: any*/),
-        (v25/*: any*/),
-        (v26/*: any*/),
-        (v27/*: any*/),
-        (v28/*: any*/),
+        (v17/*: any*/),
         (v18/*: any*/),
-        (v29/*: any*/),
-        (v30/*: any*/)
+        (v19/*: any*/),
+        (v20/*: any*/),
+        (v21/*: any*/),
+        (v22/*: any*/),
+        (v12/*: any*/)
       ],
       "storageKey": null
     },
-    (v33/*: any*/),
-    (v18/*: any*/),
-    (v34/*: any*/),
-    (v36/*: any*/),
-    (v37/*: any*/),
-    (v38/*: any*/)
+    (v25/*: any*/),
+    (v12/*: any*/),
+    (v26/*: any*/),
+    (v28/*: any*/),
+    (v29/*: any*/),
+    (v32/*: any*/)
   ],
   "storageKey": null
 },
-v40 = {
+v34 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "src",
+  "storageKey": null
+},
+v35 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "srcSet",
+  "storageKey": null
+},
+v36 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtworksConnection"
 },
-v41 = {
+v37 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v42 = {
+v38 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v43 = {
+v39 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Sale"
 },
-v44 = {
+v40 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v45 = {
+v41 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "CroppedImageUrl"
 },
-v46 = {
+v42 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v47 = {
+v43 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v48 = {
+v44 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Partner"
 },
-v49 = {
+v45 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "SaleArtwork"
 },
-v50 = {
+v46 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artwork"
 },
-v51 = {
+v47 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v52 = {
+v48 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v53 = {
+v49 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v54 = {
+v50 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "Artist"
 },
-v55 = {
+v51 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "AttributionClass"
 },
-v56 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Float"
-},
-v57 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "ResizedImageUrl"
-},
-v58 = {
+v52 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ArtworkMedium"
 },
-v59 = {
+v53 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Gene"
 },
-v60 = {
+v54 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v61 = {
+v55 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtworkCounts"
 },
-v62 = {
+v56 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtworkHighestBid"
 },
-v63 = {
+v57 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -671,8 +617,8 @@ return {
                 "name": "edges",
                 "plural": true,
                 "selections": [
-                  (v39/*: any*/),
-                  (v18/*: any*/)
+                  (v33/*: any*/),
+                  (v12/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -759,38 +705,34 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
+                          (v12/*: any*/),
+                          (v17/*: any*/),
                           (v18/*: any*/),
-                          (v23/*: any*/),
-                          (v24/*: any*/),
-                          (v25/*: any*/),
-                          (v26/*: any*/),
-                          (v27/*: any*/),
-                          (v28/*: any*/),
-                          (v29/*: any*/),
-                          (v30/*: any*/)
+                          (v19/*: any*/),
+                          (v20/*: any*/),
+                          (v21/*: any*/),
+                          (v22/*: any*/)
                         ],
                         "storageKey": null
                       },
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
                       (v10/*: any*/),
-                      (v11/*: any*/),
-                      (v12/*: any*/),
-                      (v13/*: any*/),
                       (v14/*: any*/),
                       (v15/*: any*/),
                       (v16/*: any*/),
-                      (v20/*: any*/),
-                      (v21/*: any*/),
-                      (v22/*: any*/),
-                      (v33/*: any*/),
-                      (v18/*: any*/),
-                      (v34/*: any*/),
-                      (v36/*: any*/),
-                      (v37/*: any*/),
-                      (v38/*: any*/)
+                      (v25/*: any*/),
+                      (v12/*: any*/),
+                      (v26/*: any*/),
+                      (v28/*: any*/),
+                      (v29/*: any*/),
+                      (v32/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v18/*: any*/)
+                  (v12/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -827,11 +769,11 @@ return {
                 "name": "edges",
                 "plural": true,
                 "selections": [
-                  (v39/*: any*/)
+                  (v33/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v18/*: any*/)
+              (v12/*: any*/)
             ],
             "storageKey": "artworksConnection(first:50,forSale:true,geneIDs:[\"our-top-auction-lots\"])"
           },
@@ -942,8 +884,8 @@ return {
                                 "name": "cropped",
                                 "plural": false,
                                 "selections": [
-                                  (v6/*: any*/),
-                                  (v7/*: any*/)
+                                  (v34/*: any*/),
+                                  (v35/*: any*/)
                                 ],
                                 "storageKey": "cropped(height:100,version:[\"source\",\"wide\",\"large_rectangle\"],width:330)"
                               }
@@ -957,7 +899,7 @@ return {
                             "name": "formattedStartDateTime",
                             "storageKey": null
                           },
-                          (v19/*: any*/),
+                          (v13/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -965,10 +907,10 @@ return {
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
-                            "selections": (v35/*: any*/),
+                            "selections": (v27/*: any*/),
                             "storageKey": null
                           },
-                          (v18/*: any*/)
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1021,13 +963,18 @@ return {
                                     "kind": "LinkedField",
                                     "name": "cropped",
                                     "plural": false,
-                                    "selections": (v9/*: any*/),
+                                    "selections": [
+                                      (v34/*: any*/),
+                                      (v35/*: any*/),
+                                      (v30/*: any*/),
+                                      (v31/*: any*/)
+                                    ],
                                     "storageKey": "cropped(height:55,width:55)"
                                   }
                                 ],
                                 "storageKey": null
                               },
-                              (v18/*: any*/)
+                              (v12/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1045,7 +992,7 @@ return {
                             "kind": "LinkedField",
                             "name": "currentBid",
                             "plural": false,
-                            "selections": (v32/*: any*/),
+                            "selections": (v24/*: any*/),
                             "storageKey": null
                           },
                           (v4/*: any*/),
@@ -1085,15 +1032,15 @@ return {
                                 "kind": "LinkedField",
                                 "name": "sellingPrice",
                                 "plural": false,
-                                "selections": (v32/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               }
                             ],
                             "storageKey": null
                           },
-                          (v31/*: any*/),
+                          (v23/*: any*/),
                           (v5/*: any*/),
-                          (v18/*: any*/)
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -1103,7 +1050,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v18/*: any*/)
+              (v12/*: any*/)
             ],
             "storageKey": null
           }
@@ -1113,7 +1060,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0b17bcd4e278e1846d219552aa3193b6",
+    "cacheID": "e748c0971e4dbfea6e03250ee28a26c6",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1123,21 +1070,21 @@ return {
           "plural": false,
           "type": "Viewer"
         },
-        "viewer.followedArtistsInAuction": (v40/*: any*/),
+        "viewer.followedArtistsInAuction": (v36/*: any*/),
         "viewer.followedArtistsInAuction.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterSaleArtworksCounts"
         },
-        "viewer.followedArtistsInAuction.counts.total": (v41/*: any*/),
+        "viewer.followedArtistsInAuction.counts.total": (v37/*: any*/),
         "viewer.me": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Me"
         },
-        "viewer.me.id": (v42/*: any*/),
+        "viewer.me.id": (v38/*: any*/),
         "viewer.me.myBids": {
           "enumValues": null,
           "nullable": true,
@@ -1150,118 +1097,110 @@ return {
           "plural": true,
           "type": "MyBid"
         },
-        "viewer.me.myBids.active.sale": (v43/*: any*/),
-        "viewer.me.myBids.active.sale.coverImage": (v44/*: any*/),
-        "viewer.me.myBids.active.sale.coverImage.cropped": (v45/*: any*/),
-        "viewer.me.myBids.active.sale.coverImage.cropped.src": (v46/*: any*/),
-        "viewer.me.myBids.active.sale.coverImage.cropped.srcSet": (v46/*: any*/),
-        "viewer.me.myBids.active.sale.formattedStartDateTime": (v47/*: any*/),
-        "viewer.me.myBids.active.sale.id": (v42/*: any*/),
-        "viewer.me.myBids.active.sale.name": (v47/*: any*/),
-        "viewer.me.myBids.active.sale.partner": (v48/*: any*/),
-        "viewer.me.myBids.active.sale.partner.id": (v42/*: any*/),
-        "viewer.me.myBids.active.sale.partner.name": (v47/*: any*/),
-        "viewer.me.myBids.active.sale.slug": (v42/*: any*/),
-        "viewer.me.myBids.active.saleArtworks": (v49/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork": (v50/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.artistNames": (v47/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.id": (v42/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image": (v44/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped": (v45/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.height": (v51/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.src": (v46/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.srcSet": (v46/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.width": (v51/*: any*/),
+        "viewer.me.myBids.active.sale": (v39/*: any*/),
+        "viewer.me.myBids.active.sale.coverImage": (v40/*: any*/),
+        "viewer.me.myBids.active.sale.coverImage.cropped": (v41/*: any*/),
+        "viewer.me.myBids.active.sale.coverImage.cropped.src": (v42/*: any*/),
+        "viewer.me.myBids.active.sale.coverImage.cropped.srcSet": (v42/*: any*/),
+        "viewer.me.myBids.active.sale.formattedStartDateTime": (v43/*: any*/),
+        "viewer.me.myBids.active.sale.id": (v38/*: any*/),
+        "viewer.me.myBids.active.sale.name": (v43/*: any*/),
+        "viewer.me.myBids.active.sale.partner": (v44/*: any*/),
+        "viewer.me.myBids.active.sale.partner.id": (v38/*: any*/),
+        "viewer.me.myBids.active.sale.partner.name": (v43/*: any*/),
+        "viewer.me.myBids.active.sale.slug": (v38/*: any*/),
+        "viewer.me.myBids.active.saleArtworks": (v45/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork": (v46/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.artistNames": (v43/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.id": (v38/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image": (v40/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped": (v41/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.height": (v47/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.src": (v42/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.srcSet": (v42/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.width": (v47/*: any*/),
         "viewer.me.myBids.active.saleArtworks.currentBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCurrentBid"
         },
-        "viewer.me.myBids.active.saleArtworks.currentBid.display": (v47/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.estimate": (v47/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.id": (v42/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.internalID": (v42/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.isHighestBidder": (v52/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.isWatching": (v52/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.lotLabel": (v47/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.currentBid.display": (v43/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.estimate": (v43/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.id": (v38/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.internalID": (v38/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.isHighestBidder": (v48/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.isWatching": (v48/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.lotLabel": (v43/*: any*/),
         "viewer.me.myBids.active.saleArtworks.lotState": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CausalityLotState"
         },
-        "viewer.me.myBids.active.saleArtworks.lotState.bidCount": (v53/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.lotState.bidCount": (v49/*: any*/),
         "viewer.me.myBids.active.saleArtworks.lotState.sellingPrice": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "viewer.me.myBids.active.saleArtworks.lotState.sellingPrice.display": (v47/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.slug": (v42/*: any*/),
-        "viewer.saleArtworksConnection": (v40/*: any*/),
-        "viewer.saleArtworksConnection.edges": (v49/*: any*/),
-        "viewer.saleArtworksConnection.edges.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node": (v50/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.artists": (v54/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.artists.href": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.artists.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.artists.name": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.attributionClass": (v55/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.attributionClass.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.attributionClass.name": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.collecting_institution": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.cultural_maker": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.date": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.href": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image": (v44/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.aspectRatio": (v56/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.height": (v53/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized": (v57/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized.height": (v53/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized.src": (v46/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized.srcSet": (v46/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized.width": (v53/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.imageTitle": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.internalID": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.is_biddable": (v52/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.is_saved": (v52/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.mediumType": (v58/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene": (v59/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.name": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.partner": (v48/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.partner.href": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.partner.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.partner.name": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale": (v43/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v53/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.display_timely_at": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.endAt": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v53/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.is_auction": (v52/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.is_closed": (v52/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.is_preview": (v52/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.startAt": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork": (v60/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.counts": (v61/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.counts.bidder_positions": (v41/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.endAt": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid": (v62/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotID": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotLabel": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid": (v63/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_message": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.slug": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.title": (v47/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.lotState.sellingPrice.display": (v43/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.slug": (v38/*: any*/),
+        "viewer.saleArtworksConnection": (v36/*: any*/),
+        "viewer.saleArtworksConnection.edges": (v45/*: any*/),
+        "viewer.saleArtworksConnection.edges.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node": (v46/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists": (v50/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists.href": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists.name": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.attributionClass": (v51/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.attributionClass.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.attributionClass.name": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.collecting_institution": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.cultural_maker": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.date": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.href": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image": (v40/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.height": (v49/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.src": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.width": (v49/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.internalID": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.is_saved": (v48/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.mediumType": (v52/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene": (v53/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.name": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner": (v44/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.href": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.name": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale": (v39/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v49/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.endAt": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v49/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.is_auction": (v48/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.is_closed": (v48/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.startAt": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork": (v54/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.counts": (v55/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.counts.bidder_positions": (v37/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.endAt": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid": (v56/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotID": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotLabel": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid": (v57/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_message": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.slug": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.title": (v43/*: any*/),
         "viewer.standoutLotsRailConnection": {
           "enumValues": null,
           "nullable": true,
@@ -1274,136 +1213,120 @@ return {
           "plural": true,
           "type": "FilterArtworksEdge"
         },
-        "viewer.standoutLotsRailConnection.edges.node": (v50/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.artists": (v54/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.artists.href": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.artists.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.artists.name": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.attributionClass": (v55/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.attributionClass.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.attributionClass.name": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.collecting_institution": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.cultural_maker": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.date": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.href": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image": (v44/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.aspectRatio": (v56/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.height": (v53/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized": (v57/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.height": (v53/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.src": (v46/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.srcSet": (v46/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.width": (v53/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.imageTitle": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.internalID": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.is_biddable": (v52/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.is_saved": (v52/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.mediumType": (v58/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene": (v59/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.name": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.partner": (v48/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.partner.href": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.partner.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.partner.name": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale": (v43/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v53/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.display_timely_at": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.endAt": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v53/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.is_auction": (v52/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.is_closed": (v52/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.is_preview": (v52/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.startAt": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork": (v60/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.counts": (v61/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.counts.bidder_positions": (v41/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.endAt": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.formattedEndDateTime": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.highest_bid": (v62/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.highest_bid.display": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotID": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotLabel": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.opening_bid": (v63/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.opening_bid.display": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_message": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.slug": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.title": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection": (v40/*: any*/),
-        "viewer.trendingLotsConnection.edges": (v49/*: any*/),
-        "viewer.trendingLotsConnection.edges.counts": (v61/*: any*/),
-        "viewer.trendingLotsConnection.edges.counts.bidderPositions": (v41/*: any*/),
-        "viewer.trendingLotsConnection.edges.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node": (v50/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.artists": (v54/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.artists.href": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.artists.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.artists.name": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.attributionClass": (v55/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.attributionClass.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.attributionClass.name": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.collecting_institution": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.cultural_maker": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.date": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.href": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image": (v44/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.aspectRatio": (v56/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.height": (v53/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized": (v57/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized.height": (v53/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized.src": (v46/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized.srcSet": (v46/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized.width": (v53/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.imageTitle": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.internalID": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.is_biddable": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.is_saved": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.mediumType": (v58/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene": (v59/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.name": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.partner": (v48/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.partner.href": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.partner.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.partner.name": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale": (v43/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v53/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.display_timely_at": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.endAt": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v53/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.isClosed": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.is_auction": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.is_closed": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.is_preview": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.startAt": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork": (v60/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts": (v61/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts.bidder_positions": (v41/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.endAt": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.formattedEndDateTime": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.highest_bid": (v62/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.highest_bid.display": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotID": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotLabel": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.opening_bid": (v63/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.opening_bid.display": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_message": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.slug": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.title": (v47/*: any*/)
+        "viewer.standoutLotsRailConnection.edges.node": (v46/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.artists": (v50/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.artists.href": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.artists.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.artists.name": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.attributionClass": (v51/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.attributionClass.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.attributionClass.name": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.collecting_institution": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.cultural_maker": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.date": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.href": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.image": (v40/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.image.height": (v49/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.image.src": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.image.width": (v49/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.internalID": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.is_saved": (v48/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.mediumType": (v52/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene": (v53/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.name": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.partner": (v44/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.partner.href": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.partner.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.partner.name": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale": (v39/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v49/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.endAt": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v49/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.is_auction": (v48/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.is_closed": (v48/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.startAt": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork": (v54/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.counts": (v55/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.counts.bidder_positions": (v37/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.endAt": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.formattedEndDateTime": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.highest_bid": (v56/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.highest_bid.display": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotID": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotLabel": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.opening_bid": (v57/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.opening_bid.display": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_message": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.slug": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.title": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection": (v36/*: any*/),
+        "viewer.trendingLotsConnection.edges": (v45/*: any*/),
+        "viewer.trendingLotsConnection.edges.counts": (v55/*: any*/),
+        "viewer.trendingLotsConnection.edges.counts.bidderPositions": (v37/*: any*/),
+        "viewer.trendingLotsConnection.edges.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node": (v46/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.artists": (v50/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.artists.href": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.artists.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.artists.name": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.attributionClass": (v51/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.attributionClass.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.attributionClass.name": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.collecting_institution": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.cultural_maker": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.date": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.href": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.image": (v40/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.image.height": (v49/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.image.src": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.image.width": (v49/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.internalID": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.is_saved": (v48/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.mediumType": (v52/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene": (v53/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.name": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.partner": (v44/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.partner.href": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.partner.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.partner.name": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale": (v39/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v49/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.endAt": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v49/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.isClosed": (v48/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.is_auction": (v48/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.is_closed": (v48/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.startAt": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork": (v54/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts": (v55/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts.bidder_positions": (v37/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.endAt": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.formattedEndDateTime": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.highest_bid": (v56/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.highest_bid.display": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotID": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotLabel": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.opening_bid": (v57/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.opening_bid.display": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_message": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.slug": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.title": (v43/*: any*/)
       }
     },
     "name": "AuctionsApp_Test_Query",
     "operationKind": "query",
-    "text": "query AuctionsApp_Test_Query {\n  viewer {\n    ...AuctionsApp_viewer\n  }\n}\n\nfragment AuctionsApp_viewer on Viewer {\n  ...CuritorialRailsTabBar_viewer\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CuritorialRailsTabBar_viewer on Viewer {\n  ...WorksByArtistsYouFollowRail_viewer\n  ...TrendingLotsRail_viewer\n  ...StandoutLotsRail_viewer\n  followedArtistsInAuction: saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 1) {\n    counts {\n      total\n    }\n  }\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100, version: [\"source\", \"wide\", \"large_rectangle\"]) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment StandoutLotsRail_viewer on Viewer {\n  standoutLotsRailConnection: artworksConnection(forSale: true, first: 50, geneIDs: [\"our-top-auction-lots\"]) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment TrendingLotsRail_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(biddableSale: true, first: 10, sort: \"-bidder_positions_count\", estimateRange: \"5_000_00-*\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        sale {\n          isClosed\n          id\n        }\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query AuctionsApp_Test_Query {\n  viewer {\n    ...AuctionsApp_viewer\n  }\n}\n\nfragment AuctionsApp_viewer on Viewer {\n  ...CuritorialRailsTabBar_viewer\n}\n\nfragment CuritorialRailsTabBar_viewer on Viewer {\n  ...WorksByArtistsYouFollowRail_viewer\n  ...TrendingLotsRail_viewer\n  ...StandoutLotsRail_viewer\n  followedArtistsInAuction: saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 1) {\n    counts {\n      total\n    }\n  }\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100, version: [\"source\", \"wide\", \"large_rectangle\"]) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n\nfragment StandoutLotsRail_viewer on Viewer {\n  standoutLotsRailConnection: artworksConnection(forSale: true, first: 50, geneIDs: [\"our-top-auction-lots\"]) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment TrendingLotsRail_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(biddableSale: true, first: 10, sort: \"-bidder_positions_count\", estimateRange: \"5_000_00-*\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        sale {\n          isClosed\n          id\n        }\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/CategoryRailQuery.graphql.ts
+++ b/src/__generated__/CategoryRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8470218acb2ac769aa425e637973c750>>
+ * @generated SignedSource<<b1141063699a2be33ba618bf5b341824>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -63,45 +63,24 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v9 = [
+v6 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v10 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v11 = [
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -110,9 +89,9 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = [
+v9 = [
   (v4/*: any*/),
-  (v7/*: any*/)
+  (v5/*: any*/)
 ];
 return {
   "fragment": {
@@ -193,8 +172,20 @@ return {
                 "name": "cropped",
                 "plural": false,
                 "selections": [
-                  (v5/*: any*/),
-                  (v6/*: any*/)
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "src",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "srcSet",
+                    "storageKey": null
+                  }
                 ],
                 "storageKey": "cropped(height:45,version:[\"big_and_tall\",\"tall\"],width:45)"
               }
@@ -233,7 +224,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v7/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(first:1)"
           },
@@ -268,59 +259,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 200
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              (v5/*: any*/),
-                              (v6/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v8/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v8/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -328,7 +267,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -352,13 +290,13 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v9/*: any*/),
+                        "args": (v6/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v7/*: any*/),
+                          (v5/*: any*/),
                           (v3/*: any*/),
                           (v4/*: any*/)
                         ],
@@ -373,7 +311,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v9/*: any*/),
+                        "args": (v6/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
@@ -381,7 +319,7 @@ return {
                         "selections": [
                           (v4/*: any*/),
                           (v3/*: any*/),
-                          (v7/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -393,7 +331,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v10/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -429,21 +367,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -469,7 +393,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v10/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -509,7 +433,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -519,14 +443,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
-                          (v7/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -548,7 +472,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v12/*: any*/),
+                        "selections": (v9/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -566,17 +490,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -585,23 +544,23 @@ return {
                 ],
                 "storageKey": null
               },
-              (v7/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(first:10)"
           },
-          (v7/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "99db619a0d7594049fa6d669af232017",
+    "cacheID": "dc24b881377df560c19cce30034cc68e",
     "id": null,
     "metadata": {},
     "name": "CategoryRailQuery",
     "operationKind": "query",
-    "text": "query CategoryRailQuery(\n  $id: String!\n) {\n  category: gene(id: $id) {\n    ...CategoryRail_category\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CategoryRail_category on Gene {\n  ...EntityHeaderGene_gene\n  name\n  href\n  filterArtworks: filterArtworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderGene_gene on Gene {\n  internalID\n  href\n  name\n  avatar: image {\n    cropped(width: 45, height: 45, version: [\"big_and_tall\", \"tall\"]) {\n      src\n      srcSet\n    }\n  }\n  filterArtworksConnection(first: 1) {\n    counts {\n      total\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query CategoryRailQuery(\n  $id: String!\n) {\n  category: gene(id: $id) {\n    ...CategoryRail_category\n    id\n  }\n}\n\nfragment CategoryRail_category on Gene {\n  ...EntityHeaderGene_gene\n  name\n  href\n  filterArtworks: filterArtworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderGene_gene on Gene {\n  internalID\n  href\n  name\n  avatar: image {\n    cropped(width: 45, height: 45, version: [\"big_and_tall\", \"tall\"]) {\n      src\n      srcSet\n    }\n  }\n  filterArtworksConnection(first: 1) {\n    counts {\n      total\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/CuritorialRailsTabBar_Test_Query.graphql.ts
+++ b/src/__generated__/CuritorialRailsTabBar_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<715cfcc4592a53f23a5f41400e112af3>>
+ * @generated SignedSource<<087a209f4b622719c50e285b9b1ca459>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -60,232 +60,143 @@ v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
+  "name": "href",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "srcSet",
+  "name": "title",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v9 = [
-  (v6/*: any*/),
-  (v7/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "width",
-    "storageKey": null
-  },
-  (v8/*: any*/)
-],
-v10 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Image",
-  "kind": "LinkedField",
-  "name": "image",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "width",
-          "value": 325
-        }
-      ],
-      "concreteType": "ResizedImageUrl",
-      "kind": "LinkedField",
-      "name": "resized",
-      "plural": false,
-      "selections": (v9/*: any*/),
-      "storageKey": "resized(width:325)"
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "aspectRatio",
-      "storageKey": null
-    },
-    (v8/*: any*/)
-  ],
-  "storageKey": null
-},
-v11 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "imageTitle",
-  "storageKey": null
-},
-v12 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "title",
-  "storageKey": null
-},
-v13 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v14 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "date",
   "storageKey": null
 },
-v15 = {
+v9 = {
   "alias": "sale_message",
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v16 = {
+v10 = {
   "alias": "cultural_maker",
   "args": null,
   "kind": "ScalarField",
   "name": "culturalMaker",
   "storageKey": null
 },
-v17 = [
+v11 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v18 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v19 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v20 = {
+v14 = {
   "alias": null,
-  "args": (v17/*: any*/),
+  "args": (v11/*: any*/),
   "concreteType": "Artist",
   "kind": "LinkedField",
   "name": "artists",
   "plural": true,
   "selections": [
-    (v18/*: any*/),
-    (v13/*: any*/),
-    (v19/*: any*/)
+    (v12/*: any*/),
+    (v6/*: any*/),
+    (v13/*: any*/)
   ],
   "storageKey": "artists(shallow:true)"
 },
-v21 = {
+v15 = {
   "alias": "collecting_institution",
   "args": null,
   "kind": "ScalarField",
   "name": "collectingInstitution",
   "storageKey": null
 },
-v22 = {
+v16 = {
   "alias": null,
-  "args": (v17/*: any*/),
+  "args": (v11/*: any*/),
   "concreteType": "Partner",
   "kind": "LinkedField",
   "name": "partner",
   "plural": false,
   "selections": [
-    (v19/*: any*/),
     (v13/*: any*/),
-    (v18/*: any*/)
+    (v6/*: any*/),
+    (v12/*: any*/)
   ],
   "storageKey": "partner(shallow:true)"
 },
-v23 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v24 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cascadingEndTimeIntervalMinutes",
   "storageKey": null
 },
-v25 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingIntervalMinutes",
   "storageKey": null
 },
-v26 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startAt",
   "storageKey": null
 },
-v27 = {
+v21 = {
   "alias": "is_auction",
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v28 = {
+v22 = {
   "alias": "is_closed",
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v29 = {
-  "alias": "is_preview",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isPreview",
-  "storageKey": null
-},
-v30 = {
-  "alias": "display_timely_at",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "displayTimelyAt",
-  "storageKey": null
-},
-v31 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotLabel",
   "storageKey": null
 },
-v32 = [
+v24 = [
   {
     "alias": null,
     "args": null,
@@ -294,7 +205,7 @@ v32 = [
     "storageKey": null
   }
 ],
-v33 = {
+v25 = {
   "alias": "sale_artwork",
   "args": null,
   "concreteType": "SaleArtwork",
@@ -309,8 +220,8 @@ v33 = {
       "name": "lotID",
       "storageKey": null
     },
-    (v31/*: any*/),
     (v23/*: any*/),
+    (v17/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -350,7 +261,7 @@ v33 = {
       "kind": "LinkedField",
       "name": "highestBid",
       "plural": false,
-      "selections": (v32/*: any*/),
+      "selections": (v24/*: any*/),
       "storageKey": null
     },
     {
@@ -360,35 +271,35 @@ v33 = {
       "kind": "LinkedField",
       "name": "openingBid",
       "plural": false,
-      "selections": (v32/*: any*/),
+      "selections": (v24/*: any*/),
       "storageKey": null
     },
-    (v18/*: any*/)
+    (v12/*: any*/)
   ],
   "storageKey": null
 },
-v34 = {
+v26 = {
   "alias": "is_saved",
   "args": null,
   "kind": "ScalarField",
   "name": "isSaved",
   "storageKey": null
 },
-v35 = [
-  (v19/*: any*/),
-  (v18/*: any*/)
+v27 = [
+  (v13/*: any*/),
+  (v12/*: any*/)
 ],
-v36 = {
+v28 = {
   "alias": null,
   "args": null,
   "concreteType": "AttributionClass",
   "kind": "LinkedField",
   "name": "attributionClass",
   "plural": false,
-  "selections": (v35/*: any*/),
+  "selections": (v27/*: any*/),
   "storageKey": null
 },
-v37 = {
+v29 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworkMedium",
@@ -403,20 +314,57 @@ v37 = {
       "kind": "LinkedField",
       "name": "filterGene",
       "plural": false,
-      "selections": (v35/*: any*/),
+      "selections": (v27/*: any*/),
       "storageKey": null
     }
   ],
   "storageKey": null
 },
-v38 = {
-  "alias": "is_biddable",
+v30 = {
+  "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isBiddable",
+  "name": "width",
   "storageKey": null
 },
-v39 = {
+v31 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v32 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": [
+    {
+      "alias": "src",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "version",
+          "value": [
+            "normalized",
+            "larger",
+            "large"
+          ]
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "url",
+      "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+    },
+    (v30/*: any*/),
+    (v31/*: any*/)
+  ],
+  "storageKey": null
+},
+v33 = {
   "alias": null,
   "args": null,
   "concreteType": "Artwork",
@@ -426,16 +374,14 @@ v39 = {
   "selections": [
     (v4/*: any*/),
     (v5/*: any*/),
+    (v6/*: any*/),
+    (v7/*: any*/),
+    (v8/*: any*/),
+    (v9/*: any*/),
     (v10/*: any*/),
-    (v11/*: any*/),
-    (v12/*: any*/),
-    (v13/*: any*/),
     (v14/*: any*/),
     (v15/*: any*/),
     (v16/*: any*/),
-    (v20/*: any*/),
-    (v21/*: any*/),
-    (v22/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -444,166 +390,166 @@ v39 = {
       "name": "sale",
       "plural": false,
       "selections": [
-        (v23/*: any*/),
-        (v24/*: any*/),
-        (v25/*: any*/),
-        (v26/*: any*/),
-        (v27/*: any*/),
-        (v28/*: any*/),
+        (v17/*: any*/),
         (v18/*: any*/),
-        (v29/*: any*/),
-        (v30/*: any*/)
+        (v19/*: any*/),
+        (v20/*: any*/),
+        (v21/*: any*/),
+        (v22/*: any*/),
+        (v12/*: any*/)
       ],
       "storageKey": null
     },
-    (v33/*: any*/),
-    (v18/*: any*/),
-    (v34/*: any*/),
-    (v36/*: any*/),
-    (v37/*: any*/),
-    (v38/*: any*/)
+    (v25/*: any*/),
+    (v12/*: any*/),
+    (v26/*: any*/),
+    (v28/*: any*/),
+    (v29/*: any*/),
+    (v32/*: any*/)
   ],
   "storageKey": null
 },
-v40 = {
+v34 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "src",
+  "storageKey": null
+},
+v35 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "srcSet",
+  "storageKey": null
+},
+v36 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtworksConnection"
 },
-v41 = {
+v37 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v42 = {
+v38 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v43 = {
+v39 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Sale"
 },
-v44 = {
+v40 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v45 = {
+v41 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "CroppedImageUrl"
 },
-v46 = {
+v42 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v47 = {
+v43 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v48 = {
+v44 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Partner"
 },
-v49 = {
+v45 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "SaleArtwork"
 },
-v50 = {
+v46 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artwork"
 },
-v51 = {
+v47 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v52 = {
+v48 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v53 = {
+v49 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v54 = {
+v50 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "Artist"
 },
-v55 = {
+v51 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "AttributionClass"
 },
-v56 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Float"
-},
-v57 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "ResizedImageUrl"
-},
-v58 = {
+v52 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ArtworkMedium"
 },
-v59 = {
+v53 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Gene"
 },
-v60 = {
+v54 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v61 = {
+v55 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtworkCounts"
 },
-v62 = {
+v56 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtworkHighestBid"
 },
-v63 = {
+v57 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -671,8 +617,8 @@ return {
                 "name": "edges",
                 "plural": true,
                 "selections": [
-                  (v39/*: any*/),
-                  (v18/*: any*/)
+                  (v33/*: any*/),
+                  (v12/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -759,38 +705,34 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
+                          (v12/*: any*/),
+                          (v17/*: any*/),
                           (v18/*: any*/),
-                          (v23/*: any*/),
-                          (v24/*: any*/),
-                          (v25/*: any*/),
-                          (v26/*: any*/),
-                          (v27/*: any*/),
-                          (v28/*: any*/),
-                          (v29/*: any*/),
-                          (v30/*: any*/)
+                          (v19/*: any*/),
+                          (v20/*: any*/),
+                          (v21/*: any*/),
+                          (v22/*: any*/)
                         ],
                         "storageKey": null
                       },
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
                       (v10/*: any*/),
-                      (v11/*: any*/),
-                      (v12/*: any*/),
-                      (v13/*: any*/),
                       (v14/*: any*/),
                       (v15/*: any*/),
                       (v16/*: any*/),
-                      (v20/*: any*/),
-                      (v21/*: any*/),
-                      (v22/*: any*/),
-                      (v33/*: any*/),
-                      (v18/*: any*/),
-                      (v34/*: any*/),
-                      (v36/*: any*/),
-                      (v37/*: any*/),
-                      (v38/*: any*/)
+                      (v25/*: any*/),
+                      (v12/*: any*/),
+                      (v26/*: any*/),
+                      (v28/*: any*/),
+                      (v29/*: any*/),
+                      (v32/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v18/*: any*/)
+                  (v12/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -827,11 +769,11 @@ return {
                 "name": "edges",
                 "plural": true,
                 "selections": [
-                  (v39/*: any*/)
+                  (v33/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v18/*: any*/)
+              (v12/*: any*/)
             ],
             "storageKey": "artworksConnection(first:50,forSale:true,geneIDs:[\"our-top-auction-lots\"])"
           },
@@ -942,8 +884,8 @@ return {
                                 "name": "cropped",
                                 "plural": false,
                                 "selections": [
-                                  (v6/*: any*/),
-                                  (v7/*: any*/)
+                                  (v34/*: any*/),
+                                  (v35/*: any*/)
                                 ],
                                 "storageKey": "cropped(height:100,version:[\"source\",\"wide\",\"large_rectangle\"],width:330)"
                               }
@@ -957,7 +899,7 @@ return {
                             "name": "formattedStartDateTime",
                             "storageKey": null
                           },
-                          (v19/*: any*/),
+                          (v13/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -965,10 +907,10 @@ return {
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
-                            "selections": (v35/*: any*/),
+                            "selections": (v27/*: any*/),
                             "storageKey": null
                           },
-                          (v18/*: any*/)
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1021,13 +963,18 @@ return {
                                     "kind": "LinkedField",
                                     "name": "cropped",
                                     "plural": false,
-                                    "selections": (v9/*: any*/),
+                                    "selections": [
+                                      (v34/*: any*/),
+                                      (v35/*: any*/),
+                                      (v30/*: any*/),
+                                      (v31/*: any*/)
+                                    ],
                                     "storageKey": "cropped(height:55,width:55)"
                                   }
                                 ],
                                 "storageKey": null
                               },
-                              (v18/*: any*/)
+                              (v12/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1045,7 +992,7 @@ return {
                             "kind": "LinkedField",
                             "name": "currentBid",
                             "plural": false,
-                            "selections": (v32/*: any*/),
+                            "selections": (v24/*: any*/),
                             "storageKey": null
                           },
                           (v4/*: any*/),
@@ -1085,15 +1032,15 @@ return {
                                 "kind": "LinkedField",
                                 "name": "sellingPrice",
                                 "plural": false,
-                                "selections": (v32/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               }
                             ],
                             "storageKey": null
                           },
-                          (v31/*: any*/),
+                          (v23/*: any*/),
                           (v5/*: any*/),
-                          (v18/*: any*/)
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -1103,7 +1050,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v18/*: any*/)
+              (v12/*: any*/)
             ],
             "storageKey": null
           }
@@ -1113,7 +1060,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "acbecd2f5db37c0c6e99960ed65f502a",
+    "cacheID": "5cc576dc9f9f722c5a6c8cea90051f7a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1123,21 +1070,21 @@ return {
           "plural": false,
           "type": "Viewer"
         },
-        "viewer.followedArtistsInAuction": (v40/*: any*/),
+        "viewer.followedArtistsInAuction": (v36/*: any*/),
         "viewer.followedArtistsInAuction.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterSaleArtworksCounts"
         },
-        "viewer.followedArtistsInAuction.counts.total": (v41/*: any*/),
+        "viewer.followedArtistsInAuction.counts.total": (v37/*: any*/),
         "viewer.me": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Me"
         },
-        "viewer.me.id": (v42/*: any*/),
+        "viewer.me.id": (v38/*: any*/),
         "viewer.me.myBids": {
           "enumValues": null,
           "nullable": true,
@@ -1150,118 +1097,110 @@ return {
           "plural": true,
           "type": "MyBid"
         },
-        "viewer.me.myBids.active.sale": (v43/*: any*/),
-        "viewer.me.myBids.active.sale.coverImage": (v44/*: any*/),
-        "viewer.me.myBids.active.sale.coverImage.cropped": (v45/*: any*/),
-        "viewer.me.myBids.active.sale.coverImage.cropped.src": (v46/*: any*/),
-        "viewer.me.myBids.active.sale.coverImage.cropped.srcSet": (v46/*: any*/),
-        "viewer.me.myBids.active.sale.formattedStartDateTime": (v47/*: any*/),
-        "viewer.me.myBids.active.sale.id": (v42/*: any*/),
-        "viewer.me.myBids.active.sale.name": (v47/*: any*/),
-        "viewer.me.myBids.active.sale.partner": (v48/*: any*/),
-        "viewer.me.myBids.active.sale.partner.id": (v42/*: any*/),
-        "viewer.me.myBids.active.sale.partner.name": (v47/*: any*/),
-        "viewer.me.myBids.active.sale.slug": (v42/*: any*/),
-        "viewer.me.myBids.active.saleArtworks": (v49/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork": (v50/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.artistNames": (v47/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.id": (v42/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image": (v44/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped": (v45/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.height": (v51/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.src": (v46/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.srcSet": (v46/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.width": (v51/*: any*/),
+        "viewer.me.myBids.active.sale": (v39/*: any*/),
+        "viewer.me.myBids.active.sale.coverImage": (v40/*: any*/),
+        "viewer.me.myBids.active.sale.coverImage.cropped": (v41/*: any*/),
+        "viewer.me.myBids.active.sale.coverImage.cropped.src": (v42/*: any*/),
+        "viewer.me.myBids.active.sale.coverImage.cropped.srcSet": (v42/*: any*/),
+        "viewer.me.myBids.active.sale.formattedStartDateTime": (v43/*: any*/),
+        "viewer.me.myBids.active.sale.id": (v38/*: any*/),
+        "viewer.me.myBids.active.sale.name": (v43/*: any*/),
+        "viewer.me.myBids.active.sale.partner": (v44/*: any*/),
+        "viewer.me.myBids.active.sale.partner.id": (v38/*: any*/),
+        "viewer.me.myBids.active.sale.partner.name": (v43/*: any*/),
+        "viewer.me.myBids.active.sale.slug": (v38/*: any*/),
+        "viewer.me.myBids.active.saleArtworks": (v45/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork": (v46/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.artistNames": (v43/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.id": (v38/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image": (v40/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped": (v41/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.height": (v47/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.src": (v42/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.srcSet": (v42/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.artwork.image.cropped.width": (v47/*: any*/),
         "viewer.me.myBids.active.saleArtworks.currentBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCurrentBid"
         },
-        "viewer.me.myBids.active.saleArtworks.currentBid.display": (v47/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.estimate": (v47/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.id": (v42/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.internalID": (v42/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.isHighestBidder": (v52/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.isWatching": (v52/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.lotLabel": (v47/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.currentBid.display": (v43/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.estimate": (v43/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.id": (v38/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.internalID": (v38/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.isHighestBidder": (v48/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.isWatching": (v48/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.lotLabel": (v43/*: any*/),
         "viewer.me.myBids.active.saleArtworks.lotState": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CausalityLotState"
         },
-        "viewer.me.myBids.active.saleArtworks.lotState.bidCount": (v53/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.lotState.bidCount": (v49/*: any*/),
         "viewer.me.myBids.active.saleArtworks.lotState.sellingPrice": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "viewer.me.myBids.active.saleArtworks.lotState.sellingPrice.display": (v47/*: any*/),
-        "viewer.me.myBids.active.saleArtworks.slug": (v42/*: any*/),
-        "viewer.saleArtworksConnection": (v40/*: any*/),
-        "viewer.saleArtworksConnection.edges": (v49/*: any*/),
-        "viewer.saleArtworksConnection.edges.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node": (v50/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.artists": (v54/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.artists.href": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.artists.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.artists.name": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.attributionClass": (v55/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.attributionClass.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.attributionClass.name": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.collecting_institution": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.cultural_maker": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.date": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.href": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image": (v44/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.aspectRatio": (v56/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.height": (v53/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized": (v57/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized.height": (v53/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized.src": (v46/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized.srcSet": (v46/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized.width": (v53/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.imageTitle": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.internalID": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.is_biddable": (v52/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.is_saved": (v52/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.mediumType": (v58/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene": (v59/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.name": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.partner": (v48/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.partner.href": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.partner.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.partner.name": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale": (v43/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v53/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.display_timely_at": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.endAt": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v53/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.is_auction": (v52/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.is_closed": (v52/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.is_preview": (v52/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.startAt": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork": (v60/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.counts": (v61/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.counts.bidder_positions": (v41/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.endAt": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid": (v62/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.id": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotID": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotLabel": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid": (v63/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_message": (v47/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.slug": (v42/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.title": (v47/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.lotState.sellingPrice.display": (v43/*: any*/),
+        "viewer.me.myBids.active.saleArtworks.slug": (v38/*: any*/),
+        "viewer.saleArtworksConnection": (v36/*: any*/),
+        "viewer.saleArtworksConnection.edges": (v45/*: any*/),
+        "viewer.saleArtworksConnection.edges.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node": (v46/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists": (v50/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists.href": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists.name": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.attributionClass": (v51/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.attributionClass.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.attributionClass.name": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.collecting_institution": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.cultural_maker": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.date": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.href": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image": (v40/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.height": (v49/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.src": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.width": (v49/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.internalID": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.is_saved": (v48/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.mediumType": (v52/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene": (v53/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.name": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner": (v44/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.href": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.name": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale": (v39/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v49/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.endAt": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v49/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.is_auction": (v48/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.is_closed": (v48/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.startAt": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork": (v54/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.counts": (v55/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.counts.bidder_positions": (v37/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.endAt": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid": (v56/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.id": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotID": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotLabel": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid": (v57/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_message": (v43/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.slug": (v38/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.title": (v43/*: any*/),
         "viewer.standoutLotsRailConnection": {
           "enumValues": null,
           "nullable": true,
@@ -1274,136 +1213,120 @@ return {
           "plural": true,
           "type": "FilterArtworksEdge"
         },
-        "viewer.standoutLotsRailConnection.edges.node": (v50/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.artists": (v54/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.artists.href": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.artists.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.artists.name": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.attributionClass": (v55/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.attributionClass.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.attributionClass.name": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.collecting_institution": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.cultural_maker": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.date": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.href": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image": (v44/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.aspectRatio": (v56/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.height": (v53/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized": (v57/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.height": (v53/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.src": (v46/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.srcSet": (v46/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.width": (v53/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.imageTitle": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.internalID": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.is_biddable": (v52/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.is_saved": (v52/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.mediumType": (v58/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene": (v59/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.name": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.partner": (v48/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.partner.href": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.partner.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.partner.name": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale": (v43/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v53/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.display_timely_at": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.endAt": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v53/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.is_auction": (v52/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.is_closed": (v52/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.is_preview": (v52/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.startAt": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork": (v60/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.counts": (v61/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.counts.bidder_positions": (v41/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.endAt": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.formattedEndDateTime": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.highest_bid": (v62/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.highest_bid.display": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.id": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotID": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotLabel": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.opening_bid": (v63/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.opening_bid.display": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_message": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.slug": (v42/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.title": (v47/*: any*/),
-        "viewer.standoutLotsRailConnection.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection": (v40/*: any*/),
-        "viewer.trendingLotsConnection.edges": (v49/*: any*/),
-        "viewer.trendingLotsConnection.edges.counts": (v61/*: any*/),
-        "viewer.trendingLotsConnection.edges.counts.bidderPositions": (v41/*: any*/),
-        "viewer.trendingLotsConnection.edges.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node": (v50/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.artists": (v54/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.artists.href": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.artists.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.artists.name": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.attributionClass": (v55/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.attributionClass.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.attributionClass.name": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.collecting_institution": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.cultural_maker": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.date": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.href": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image": (v44/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.aspectRatio": (v56/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.height": (v53/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized": (v57/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized.height": (v53/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized.src": (v46/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized.srcSet": (v46/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized.width": (v53/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.imageTitle": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.internalID": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.is_biddable": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.is_saved": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.mediumType": (v58/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene": (v59/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.name": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.partner": (v48/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.partner.href": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.partner.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.partner.name": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale": (v43/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v53/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.display_timely_at": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.endAt": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v53/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.isClosed": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.is_auction": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.is_closed": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.is_preview": (v52/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.startAt": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork": (v60/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts": (v61/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts.bidder_positions": (v41/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.endAt": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.formattedEndDateTime": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.highest_bid": (v62/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.highest_bid.display": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.id": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotID": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotLabel": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.opening_bid": (v63/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.opening_bid.display": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_message": (v47/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.slug": (v42/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.title": (v47/*: any*/)
+        "viewer.standoutLotsRailConnection.edges.node": (v46/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.artists": (v50/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.artists.href": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.artists.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.artists.name": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.attributionClass": (v51/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.attributionClass.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.attributionClass.name": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.collecting_institution": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.cultural_maker": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.date": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.href": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.image": (v40/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.image.height": (v49/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.image.src": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.image.width": (v49/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.internalID": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.is_saved": (v48/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.mediumType": (v52/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene": (v53/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.name": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.partner": (v44/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.partner.href": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.partner.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.partner.name": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale": (v39/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v49/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.endAt": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v49/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.is_auction": (v48/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.is_closed": (v48/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.startAt": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork": (v54/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.counts": (v55/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.counts.bidder_positions": (v37/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.endAt": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.formattedEndDateTime": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.highest_bid": (v56/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.highest_bid.display": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.id": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotID": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotLabel": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.opening_bid": (v57/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.opening_bid.display": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_message": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.slug": (v38/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.title": (v43/*: any*/),
+        "viewer.standoutLotsRailConnection.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection": (v36/*: any*/),
+        "viewer.trendingLotsConnection.edges": (v45/*: any*/),
+        "viewer.trendingLotsConnection.edges.counts": (v55/*: any*/),
+        "viewer.trendingLotsConnection.edges.counts.bidderPositions": (v37/*: any*/),
+        "viewer.trendingLotsConnection.edges.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node": (v46/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.artists": (v50/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.artists.href": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.artists.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.artists.name": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.attributionClass": (v51/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.attributionClass.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.attributionClass.name": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.collecting_institution": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.cultural_maker": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.date": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.href": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.image": (v40/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.image.height": (v49/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.image.src": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.image.width": (v49/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.internalID": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.is_saved": (v48/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.mediumType": (v52/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene": (v53/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.name": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.partner": (v44/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.partner.href": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.partner.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.partner.name": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale": (v39/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v49/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.endAt": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v49/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.isClosed": (v48/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.is_auction": (v48/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.is_closed": (v48/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.startAt": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork": (v54/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts": (v55/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts.bidder_positions": (v37/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.endAt": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.formattedEndDateTime": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.highest_bid": (v56/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.highest_bid.display": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.id": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotID": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotLabel": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.opening_bid": (v57/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.opening_bid.display": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_message": (v43/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.slug": (v38/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.title": (v43/*: any*/)
       }
     },
     "name": "CuritorialRailsTabBar_Test_Query",
     "operationKind": "query",
-    "text": "query CuritorialRailsTabBar_Test_Query {\n  viewer {\n    ...CuritorialRailsTabBar_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CuritorialRailsTabBar_viewer on Viewer {\n  ...WorksByArtistsYouFollowRail_viewer\n  ...TrendingLotsRail_viewer\n  ...StandoutLotsRail_viewer\n  followedArtistsInAuction: saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 1) {\n    counts {\n      total\n    }\n  }\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100, version: [\"source\", \"wide\", \"large_rectangle\"]) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment StandoutLotsRail_viewer on Viewer {\n  standoutLotsRailConnection: artworksConnection(forSale: true, first: 50, geneIDs: [\"our-top-auction-lots\"]) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment TrendingLotsRail_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(biddableSale: true, first: 10, sort: \"-bidder_positions_count\", estimateRange: \"5_000_00-*\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        sale {\n          isClosed\n          id\n        }\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query CuritorialRailsTabBar_Test_Query {\n  viewer {\n    ...CuritorialRailsTabBar_viewer\n  }\n}\n\nfragment CuritorialRailsTabBar_viewer on Viewer {\n  ...WorksByArtistsYouFollowRail_viewer\n  ...TrendingLotsRail_viewer\n  ...StandoutLotsRail_viewer\n  followedArtistsInAuction: saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 1) {\n    counts {\n      total\n    }\n  }\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100, version: [\"source\", \"wide\", \"large_rectangle\"]) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n\nfragment StandoutLotsRail_viewer on Viewer {\n  standoutLotsRailConnection: artworksConnection(forSale: true, first: 50, geneIDs: [\"our-top-auction-lots\"]) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment TrendingLotsRail_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(biddableSale: true, first: 10, sort: \"-bidder_positions_count\", estimateRange: \"5_000_00-*\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        sale {\n          isClosed\n          id\n        }\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/CurrentAuctionsQuery.graphql.ts
+++ b/src/__generated__/CurrentAuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<821aa5d7b87290b91805f4c0e125077e>>
+ * @generated SignedSource<<2b18a93c95287d87fa275bc49d9dfa44>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -90,42 +90,28 @@ v7 = {
   "name": "href",
   "storageKey": null
 },
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v10 = [
+v8 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v11 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v12 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v13 = [
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -134,9 +120,16 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = [
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v13 = [
   (v6/*: any*/),
-  (v11/*: any*/)
+  (v9/*: any*/)
 ];
 return {
   "fragment": {
@@ -266,73 +259,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v8/*: any*/),
-                                  (v5/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "src",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "srcSet",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "width",
-                                            "storageKey": null
-                                          },
-                                          (v9/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v9/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
+                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -340,7 +267,6 @@ return {
                                     "name": "title",
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -364,13 +290,13 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v10/*: any*/),
+                                    "args": (v8/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v11/*: any*/),
+                                      (v9/*: any*/),
                                       (v7/*: any*/),
                                       (v6/*: any*/)
                                     ],
@@ -385,7 +311,7 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v10/*: any*/),
+                                    "args": (v8/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
@@ -393,7 +319,7 @@ return {
                                     "selections": [
                                       (v6/*: any*/),
                                       (v7/*: any*/),
-                                      (v11/*: any*/)
+                                      (v9/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -405,7 +331,7 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v12/*: any*/),
+                                      (v10/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -441,21 +367,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v11/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v9/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -481,7 +393,7 @@ return {
                                         "name": "lotLabel",
                                         "storageKey": null
                                       },
-                                      (v12/*: any*/),
+                                      (v10/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -521,7 +433,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v13/*: any*/),
+                                        "selections": (v11/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -531,14 +443,16 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v13/*: any*/),
+                                        "selections": (v11/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v11/*: any*/)
+                                      (v9/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v11/*: any*/),
+                                  (v9/*: any*/),
+                                  (v12/*: any*/),
+                                  (v5/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -553,7 +467,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v14/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -571,17 +485,52 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v14/*: any*/),
+                                        "selections": (v13/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -593,7 +542,7 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v8/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -601,7 +550,7 @@ return {
                         "name": "formattedStartDateTime",
                         "storageKey": null
                       },
-                      (v11/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -670,12 +619,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3403de2e21078727ff9784143b1206dc",
+    "cacheID": "d36fed7477065ee38b980ac5a8d031f0",
     "id": null,
     "metadata": {},
     "name": "CurrentAuctionsQuery",
     "operationKind": "query",
-    "text": "query CurrentAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...CurrentAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CurrentAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query CurrentAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...CurrentAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/CurrentAuctions_Test_Query.graphql.ts
+++ b/src/__generated__/CurrentAuctions_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<af113d0e2e4aea9d130e3138b6fcdcdd>>
+ * @generated SignedSource<<3643cc161c7396ea392dcb575b96cb70>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -70,42 +70,28 @@ v3 = {
   "name": "href",
   "storageKey": null
 },
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v6 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v7 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v9 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -114,41 +100,48 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v9 = [
   (v2/*: any*/),
-  (v7/*: any*/)
+  (v5/*: any*/)
 ],
-v11 = {
+v10 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v12 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Sale"
 },
-v13 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v14 = {
+v13 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v15 = {
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v16 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -273,73 +266,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v4/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "src",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "srcSet",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "width",
-                                            "storageKey": null
-                                          },
-                                          (v5/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -347,7 +274,6 @@ return {
                                     "name": "title",
                                     "storageKey": null
                                   },
-                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -371,13 +297,13 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v7/*: any*/),
+                                      (v5/*: any*/),
                                       (v3/*: any*/),
                                       (v2/*: any*/)
                                     ],
@@ -392,7 +318,7 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
@@ -400,7 +326,7 @@ return {
                                     "selections": [
                                       (v2/*: any*/),
                                       (v3/*: any*/),
-                                      (v7/*: any*/)
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -412,7 +338,7 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v8/*: any*/),
+                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -448,21 +374,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v7/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -488,7 +400,7 @@ return {
                                         "name": "lotLabel",
                                         "storageKey": null
                                       },
-                                      (v8/*: any*/),
+                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -528,7 +440,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -538,14 +450,16 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v7/*: any*/)
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/),
+                                  (v5/*: any*/),
+                                  (v8/*: any*/),
+                                  (v1/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -560,7 +474,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v9/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -578,17 +492,52 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v10/*: any*/),
+                                        "selections": (v9/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -600,7 +549,7 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v4/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -608,7 +557,7 @@ return {
                         "name": "formattedStartDateTime",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -677,7 +626,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "986b5d03f3218741e706a88f9a08436f",
+    "cacheID": "736da878e8ada1977ed1d2d3d9c2bb97",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -699,9 +648,9 @@ return {
           "plural": true,
           "type": "SaleEdge"
         },
-        "viewer.salesConnection.edges.cursor": (v11/*: any*/),
-        "viewer.salesConnection.edges.node": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.__typename": (v11/*: any*/),
+        "viewer.salesConnection.edges.cursor": (v10/*: any*/),
+        "viewer.salesConnection.edges.node": (v11/*: any*/),
+        "viewer.salesConnection.edges.node.__typename": (v10/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection": {
           "enumValues": null,
           "nullable": true,
@@ -726,49 +675,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.name": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.name": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.name": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collecting_institution": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.cultural_maker": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.date": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.id": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.name": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collecting_institution": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.cultural_maker": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.date": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.id": (v13/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.height": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.height": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.src": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.srcSet": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.width": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.imageTitle": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.internalID": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.is_biddable": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.is_saved": (v16/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.height": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.src": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.width": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.internalID": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.is_saved": (v15/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -781,27 +714,25 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.name": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.name": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.name": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.display_timely_at": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.endAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_auction": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_closed": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_preview": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.startAt": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.name": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale": (v11/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.endAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_auction": (v15/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_closed": (v15/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.startAt": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -820,56 +751,56 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.endAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.endAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotID": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotLabel": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotID": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotLabel": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_message": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.slug": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.title": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.formattedStartDateTime": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.internalID": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.isLiveOpen": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.liveStartAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.name": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.slug": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_message": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.slug": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.title": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.formattedStartDateTime": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.internalID": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.isLiveOpen": (v15/*: any*/),
+        "viewer.salesConnection.edges.node.liveStartAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.name": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.slug": (v13/*: any*/),
         "viewer.salesConnection.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "viewer.salesConnection.pageInfo.endCursor": (v13/*: any*/),
+        "viewer.salesConnection.pageInfo.endCursor": (v12/*: any*/),
         "viewer.salesConnection.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "viewer.salesConnection.totalCount": (v15/*: any*/)
+        "viewer.salesConnection.totalCount": (v14/*: any*/)
       }
     },
     "name": "CurrentAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query CurrentAuctions_Test_Query {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query CurrentAuctions_Test_Query {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/FairBoothRailArtworksQuery.graphql.ts
+++ b/src/__generated__/FairBoothRailArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d427f51c160c76323d53727250c8eac4>>
+ * @generated SignedSource<<4c3731a78c7997d4c702a1d908d75350>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -42,45 +42,38 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v4 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v8 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -89,9 +82,9 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = [
-  (v6/*: any*/),
-  (v5/*: any*/)
+v8 = [
+  (v5/*: any*/),
+  (v4/*: any*/)
 ];
 return {
   "fragment": {
@@ -164,85 +157,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 200
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v2/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v2/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -250,7 +165,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -274,15 +188,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v4/*: any*/),
+                        "args": (v3/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v5/*: any*/),
-                          (v3/*: any*/),
-                          (v6/*: any*/)
+                          (v4/*: any*/),
+                          (v2/*: any*/),
+                          (v5/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -295,15 +209,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v4/*: any*/),
+                        "args": (v3/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
-                          (v3/*: any*/),
-                          (v5/*: any*/)
+                          (v5/*: any*/),
+                          (v2/*: any*/),
+                          (v4/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -315,7 +229,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -351,21 +265,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -391,7 +291,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -431,7 +331,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v7/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -441,14 +341,28 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v7/*: any*/),
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v5/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -463,7 +377,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v9/*: any*/),
+                        "selections": (v8/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -481,17 +395,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -503,19 +452,19 @@ return {
             ],
             "storageKey": "artworksConnection(first:20)"
           },
-          (v5/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "0c1be7d429838288f8204f931bd488ac",
+    "cacheID": "2afd16b4cd2a5415bae4dba298acc8ff",
     "id": null,
     "metadata": {},
     "name": "FairBoothRailArtworksQuery",
     "operationKind": "query",
-    "text": "query FairBoothRailArtworksQuery(\n  $id: String!\n) {\n  show(id: $id) {\n    ...FairBoothRailArtworks_show\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FairBoothRailArtworks_show on Show {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query FairBoothRailArtworksQuery(\n  $id: String!\n) {\n  show(id: $id) {\n    ...FairBoothRailArtworks_show\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FairBoothRailArtworks_show on Show {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/FairBoothRailArtworks_show.graphql.ts
+++ b/src/__generated__/FairBoothRailArtworks_show.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a766d2aac2f3d99dffd70723db25ada1>>
+ * @generated SignedSource<<c59b58c2f120a02069511ef6800be168>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -64,6 +64,11 @@ const node: ReaderFragment = {
               "plural": false,
               "selections": [
                 {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "ShelfArtwork_artwork"
+                },
+                {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
@@ -76,17 +81,6 @@ const node: ReaderFragment = {
                   "kind": "ScalarField",
                   "name": "slug",
                   "storageKey": null
-                },
-                {
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 200
-                    }
-                  ],
-                  "kind": "FragmentSpread",
-                  "name": "ShelfArtwork_artwork"
                 }
               ],
               "storageKey": null
@@ -102,6 +96,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "c39c78268ad7b633fe073db484642ced";
+(node as any).hash = "d6817dc611224bb68cab87ea49adfa29";
 
 export default node;

--- a/src/__generated__/HomeAuctionLotsRailQuery.graphql.ts
+++ b/src/__generated__/HomeAuctionLotsRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ee1f212e43b018eb47e7afb80753a46e>>
+ * @generated SignedSource<<8f04bd7e22358ccb8643350dcecea08d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,9 +66,9 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -158,71 +151,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 210
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v0/*: any*/)
-                            ],
-                            "storageKey": "resized(width:210)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v0/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -230,7 +159,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -254,15 +182,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v1/*: any*/),
-                          (v4/*: any*/)
+                          (v2/*: any*/),
+                          (v0/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -275,15 +203,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v1/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v0/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -295,7 +223,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -331,21 +259,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -371,7 +285,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -411,7 +325,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -421,14 +335,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -457,7 +371,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -475,17 +389,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -494,7 +443,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "storageKey": "artworksConnection(first:50,forSale:true,geneIDs:\"our-top-auction-lots\")"
           }
@@ -504,12 +453,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3241aab43572f4280573980849137eae",
+    "cacheID": "4ef93a7f9c2decf83920bccafe386a91",
     "id": null,
     "metadata": {},
     "name": "HomeAuctionLotsRailQuery",
     "operationKind": "query",
-    "text": "query HomeAuctionLotsRailQuery {\n  viewer {\n    ...HomeAuctionLotsRail_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeAuctionLotsRail_viewer on Viewer {\n  artworksConnection(forSale: true, first: 50, geneIDs: \"our-top-auction-lots\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork_1s6r3G\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query HomeAuctionLotsRailQuery {\n  viewer {\n    ...HomeAuctionLotsRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeAuctionLotsRail_viewer on Viewer {\n  artworksConnection(forSale: true, first: 50, geneIDs: \"our-top-auction-lots\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeAuctionLotsRail_Test_Query.graphql.ts
+++ b/src/__generated__/HomeAuctionLotsRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6eb8adeb7723f11a5ed0fdab54415c4b>>
+ * @generated SignedSource<<793467ec509885ca953c0e235a4d5b62>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,35 +66,29 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ],
-v8 = {
+v7 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v9 = {
+v8 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v10 = {
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v11 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v12 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -188,71 +175,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 210
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v0/*: any*/)
-                            ],
-                            "storageKey": "resized(width:210)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v0/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -260,7 +183,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -284,15 +206,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v1/*: any*/),
-                          (v4/*: any*/)
+                          (v2/*: any*/),
+                          (v0/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -305,15 +227,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v1/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v0/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -325,7 +247,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -361,21 +283,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -401,7 +309,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -441,7 +349,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -451,14 +359,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -487,7 +395,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -505,17 +413,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -524,7 +467,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "storageKey": "artworksConnection(first:50,forSale:true,geneIDs:\"our-top-auction-lots\")"
           }
@@ -534,7 +477,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b3533726d6080debc045c027c72e362a",
+    "cacheID": "00625e6395e7428ab6f45fe598ad7ba4",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -568,49 +511,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "viewer.artworksConnection.edges.node.artists.href": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.artists.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.artists.name": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.artists.href": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.artists.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.artists.name": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "viewer.artworksConnection.edges.node.attributionClass.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.attributionClass.name": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.collecting_institution": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.cultural_maker": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.date": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.href": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.id": (v9/*: any*/),
+        "viewer.artworksConnection.edges.node.attributionClass.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.attributionClass.name": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.collecting_institution": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.cultural_maker": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.date": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.href": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.id": (v8/*: any*/),
         "viewer.artworksConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "viewer.artworksConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "viewer.artworksConnection.edges.node.image.height": (v10/*: any*/),
-        "viewer.artworksConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "viewer.artworksConnection.edges.node.image.resized.height": (v10/*: any*/),
-        "viewer.artworksConnection.edges.node.image.resized.src": (v11/*: any*/),
-        "viewer.artworksConnection.edges.node.image.resized.srcSet": (v11/*: any*/),
-        "viewer.artworksConnection.edges.node.image.resized.width": (v10/*: any*/),
-        "viewer.artworksConnection.edges.node.imageTitle": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.internalID": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.is_biddable": (v12/*: any*/),
-        "viewer.artworksConnection.edges.node.is_saved": (v12/*: any*/),
+        "viewer.artworksConnection.edges.node.image.height": (v9/*: any*/),
+        "viewer.artworksConnection.edges.node.image.src": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.image.width": (v9/*: any*/),
+        "viewer.artworksConnection.edges.node.internalID": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.is_saved": (v10/*: any*/),
         "viewer.artworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -623,32 +550,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "viewer.artworksConnection.edges.node.mediumType.filterGene.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.mediumType.filterGene.name": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.mediumType.filterGene.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.mediumType.filterGene.name": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewer.artworksConnection.edges.node.partner.href": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.partner.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.partner.name": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.partner.href": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.partner.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.partner.name": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "viewer.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v10/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.display_timely_at": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.endAt": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v10/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.is_auction": (v12/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.is_closed": (v12/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.is_preview": (v12/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.startAt": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v9/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.endAt": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v9/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.is_auction": (v10/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.is_closed": (v10/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.startAt": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -667,35 +592,35 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "viewer.artworksConnection.edges.node.sale_artwork.endAt": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.endAt": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "viewer.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_artwork.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_artwork.lotID": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_artwork.lotLabel": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.lotID": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.lotLabel": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "viewer.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_message": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.slug": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.title": (v8/*: any*/),
-        "viewer.artworksConnection.id": (v9/*: any*/)
+        "viewer.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_message": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.slug": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.title": (v7/*: any*/),
+        "viewer.artworksConnection.id": (v8/*: any*/)
       }
     },
     "name": "HomeAuctionLotsRail_Test_Query",
     "operationKind": "query",
-    "text": "query HomeAuctionLotsRail_Test_Query {\n  viewer {\n    ...HomeAuctionLotsRail_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeAuctionLotsRail_viewer on Viewer {\n  artworksConnection(forSale: true, first: 50, geneIDs: \"our-top-auction-lots\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork_1s6r3G\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query HomeAuctionLotsRail_Test_Query {\n  viewer {\n    ...HomeAuctionLotsRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeAuctionLotsRail_viewer on Viewer {\n  artworksConnection(forSale: true, first: 50, geneIDs: \"our-top-auction-lots\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeAuctionLotsRail_viewer.graphql.ts
+++ b/src/__generated__/HomeAuctionLotsRail_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7d87450642ef67080f4673ab9356a8a2>>
+ * @generated SignedSource<<358903db747b77b2321ecf26e54d6d81>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -75,13 +75,7 @@ const node: ReaderFragment = {
               "plural": false,
               "selections": [
                 {
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 210
-                    }
-                  ],
+                  "args": null,
                   "kind": "FragmentSpread",
                   "name": "ShelfArtwork_artwork"
                 },
@@ -120,6 +114,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "0a78700a9f10a49dc6dc1a2b2ecfc6f7";
+(node as any).hash = "cbd0599e8d0323de9e8db234ae442f6b";
 
 export default node;

--- a/src/__generated__/HomeNewWorksForYouRailQuery.graphql.ts
+++ b/src/__generated__/HomeNewWorksForYouRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b24ac21f88b724f9d94876af960ac079>>
+ * @generated SignedSource<<4ef1a8dffc1c2322a1274cd563f40240>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -43,45 +43,38 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v3 = [
+v2 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v7 = [
+v6 = [
   {
     "alias": null,
     "args": null,
@@ -90,9 +83,9 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = [
-  (v5/*: any*/),
-  (v4/*: any*/)
+v7 = [
+  (v4/*: any*/),
+  (v3/*: any*/)
 ];
 return {
   "fragment": {
@@ -165,71 +158,7 @@ return {
                     "name": "slug",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Image",
-                    "kind": "LinkedField",
-                    "name": "image",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "width",
-                            "value": 210
-                          }
-                        ],
-                        "concreteType": "ResizedImageUrl",
-                        "kind": "LinkedField",
-                        "name": "resized",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "src",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "srcSet",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "width",
-                            "storageKey": null
-                          },
-                          (v1/*: any*/)
-                        ],
-                        "storageKey": "resized(width:210)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "aspectRatio",
-                        "storageKey": null
-                      },
-                      (v1/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "imageTitle",
-                    "storageKey": null
-                  },
+                  (v1/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -237,7 +166,6 @@ return {
                     "name": "title",
                     "storageKey": null
                   },
-                  (v2/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -261,15 +189,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v3/*: any*/),
+                    "args": (v2/*: any*/),
                     "concreteType": "Artist",
                     "kind": "LinkedField",
                     "name": "artists",
                     "plural": true,
                     "selections": [
-                      (v4/*: any*/),
-                      (v2/*: any*/),
-                      (v5/*: any*/)
+                      (v3/*: any*/),
+                      (v1/*: any*/),
+                      (v4/*: any*/)
                     ],
                     "storageKey": "artists(shallow:true)"
                   },
@@ -282,15 +210,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v3/*: any*/),
+                    "args": (v2/*: any*/),
                     "concreteType": "Partner",
                     "kind": "LinkedField",
                     "name": "partner",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
-                      (v2/*: any*/),
-                      (v4/*: any*/)
+                      (v4/*: any*/),
+                      (v1/*: any*/),
+                      (v3/*: any*/)
                     ],
                     "storageKey": "partner(shallow:true)"
                   },
@@ -302,7 +230,7 @@ return {
                     "name": "sale",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -338,21 +266,7 @@ return {
                         "name": "isClosed",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
-                      {
-                        "alias": "is_preview",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isPreview",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "display_timely_at",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "displayTimelyAt",
-                        "storageKey": null
-                      }
+                      (v3/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -378,7 +292,7 @@ return {
                         "name": "lotLabel",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -418,7 +332,7 @@ return {
                         "kind": "LinkedField",
                         "name": "highestBid",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -428,14 +342,14 @@ return {
                         "kind": "LinkedField",
                         "name": "openingBid",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
-                      (v4/*: any*/)
+                      (v3/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v4/*: any*/),
+                  (v3/*: any*/),
                   {
                     "alias": "is_saved",
                     "args": null,
@@ -450,7 +364,7 @@ return {
                     "kind": "LinkedField",
                     "name": "attributionClass",
                     "plural": false,
-                    "selections": (v8/*: any*/),
+                    "selections": (v7/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -468,17 +382,52 @@ return {
                         "kind": "LinkedField",
                         "name": "filterGene",
                         "plural": false,
-                        "selections": (v8/*: any*/),
+                        "selections": (v7/*: any*/),
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
                   {
-                    "alias": "is_biddable",
+                    "alias": null,
                     "args": null,
-                    "kind": "ScalarField",
-                    "name": "isBiddable",
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "src",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": [
+                              "normalized",
+                              "larger",
+                              "large"
+                            ]
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      }
+                    ],
                     "storageKey": null
                   }
                 ],
@@ -493,12 +442,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c33c31a30b0477c51e9acd5e7aa9695f",
+    "cacheID": "887730da23fd10df67f97ca2388fc06a",
     "id": null,
     "metadata": {},
     "name": "HomeNewWorksForYouRailQuery",
     "operationKind": "query",
-    "text": "query HomeNewWorksForYouRailQuery {\n  artworksForUser(includeBackfill: true, first: 20, maxWorksPerArtist: 3) {\n    ...HomeNewWorksForYouRail_artworksForUser\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeNewWorksForYouRail_artworksForUser on ArtworkConnection {\n  edges {\n    node {\n      internalID\n      slug\n      ...ShelfArtwork_artwork_1s6r3G\n      id\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query HomeNewWorksForYouRailQuery {\n  artworksForUser(includeBackfill: true, first: 20, maxWorksPerArtist: 3) {\n    ...HomeNewWorksForYouRail_artworksForUser\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeNewWorksForYouRail_artworksForUser on ArtworkConnection {\n  edges {\n    node {\n      internalID\n      slug\n      ...ShelfArtwork_artwork\n      id\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeNewWorksForYouRail_Test_Query.graphql.ts
+++ b/src/__generated__/HomeNewWorksForYouRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4536cb6666e0176572920180116be585>>
+ * @generated SignedSource<<03248405a82b257ecbfe11ee7a9371de>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -38,45 +38,38 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v3 = [
+v2 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v7 = [
+v6 = [
   {
     "alias": null,
     "args": null,
@@ -85,35 +78,29 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = [
-  (v5/*: any*/),
-  (v4/*: any*/)
+v7 = [
+  (v4/*: any*/),
+  (v3/*: any*/)
 ],
-v9 = {
+v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v10 = {
+v9 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v11 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v12 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v13 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -190,71 +177,7 @@ return {
                     "name": "slug",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Image",
-                    "kind": "LinkedField",
-                    "name": "image",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "width",
-                            "value": 210
-                          }
-                        ],
-                        "concreteType": "ResizedImageUrl",
-                        "kind": "LinkedField",
-                        "name": "resized",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "src",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "srcSet",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "width",
-                            "storageKey": null
-                          },
-                          (v1/*: any*/)
-                        ],
-                        "storageKey": "resized(width:210)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "aspectRatio",
-                        "storageKey": null
-                      },
-                      (v1/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "imageTitle",
-                    "storageKey": null
-                  },
+                  (v1/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -262,7 +185,6 @@ return {
                     "name": "title",
                     "storageKey": null
                   },
-                  (v2/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -286,15 +208,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v3/*: any*/),
+                    "args": (v2/*: any*/),
                     "concreteType": "Artist",
                     "kind": "LinkedField",
                     "name": "artists",
                     "plural": true,
                     "selections": [
-                      (v4/*: any*/),
-                      (v2/*: any*/),
-                      (v5/*: any*/)
+                      (v3/*: any*/),
+                      (v1/*: any*/),
+                      (v4/*: any*/)
                     ],
                     "storageKey": "artists(shallow:true)"
                   },
@@ -307,15 +229,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v3/*: any*/),
+                    "args": (v2/*: any*/),
                     "concreteType": "Partner",
                     "kind": "LinkedField",
                     "name": "partner",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
-                      (v2/*: any*/),
-                      (v4/*: any*/)
+                      (v4/*: any*/),
+                      (v1/*: any*/),
+                      (v3/*: any*/)
                     ],
                     "storageKey": "partner(shallow:true)"
                   },
@@ -327,7 +249,7 @@ return {
                     "name": "sale",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -363,21 +285,7 @@ return {
                         "name": "isClosed",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
-                      {
-                        "alias": "is_preview",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isPreview",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "display_timely_at",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "displayTimelyAt",
-                        "storageKey": null
-                      }
+                      (v3/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -403,7 +311,7 @@ return {
                         "name": "lotLabel",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -443,7 +351,7 @@ return {
                         "kind": "LinkedField",
                         "name": "highestBid",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -453,14 +361,14 @@ return {
                         "kind": "LinkedField",
                         "name": "openingBid",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
-                      (v4/*: any*/)
+                      (v3/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v4/*: any*/),
+                  (v3/*: any*/),
                   {
                     "alias": "is_saved",
                     "args": null,
@@ -475,7 +383,7 @@ return {
                     "kind": "LinkedField",
                     "name": "attributionClass",
                     "plural": false,
-                    "selections": (v8/*: any*/),
+                    "selections": (v7/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -493,17 +401,52 @@ return {
                         "kind": "LinkedField",
                         "name": "filterGene",
                         "plural": false,
-                        "selections": (v8/*: any*/),
+                        "selections": (v7/*: any*/),
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
                   {
-                    "alias": "is_biddable",
+                    "alias": null,
                     "args": null,
-                    "kind": "ScalarField",
-                    "name": "isBiddable",
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "src",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": [
+                              "normalized",
+                              "larger",
+                              "large"
+                            ]
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      }
+                    ],
                     "storageKey": null
                   }
                 ],
@@ -518,7 +461,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e9aab1a9b76a72d06c55d2a3d9d139d6",
+    "cacheID": "b11bda583ce02e0cac7dda6d8b524be5",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -546,49 +489,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "artworksForUser.edges.node.artists.href": (v9/*: any*/),
-        "artworksForUser.edges.node.artists.id": (v10/*: any*/),
-        "artworksForUser.edges.node.artists.name": (v9/*: any*/),
+        "artworksForUser.edges.node.artists.href": (v8/*: any*/),
+        "artworksForUser.edges.node.artists.id": (v9/*: any*/),
+        "artworksForUser.edges.node.artists.name": (v8/*: any*/),
         "artworksForUser.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "artworksForUser.edges.node.attributionClass.id": (v10/*: any*/),
-        "artworksForUser.edges.node.attributionClass.name": (v9/*: any*/),
-        "artworksForUser.edges.node.collecting_institution": (v9/*: any*/),
-        "artworksForUser.edges.node.cultural_maker": (v9/*: any*/),
-        "artworksForUser.edges.node.date": (v9/*: any*/),
-        "artworksForUser.edges.node.href": (v9/*: any*/),
-        "artworksForUser.edges.node.id": (v10/*: any*/),
+        "artworksForUser.edges.node.attributionClass.id": (v9/*: any*/),
+        "artworksForUser.edges.node.attributionClass.name": (v8/*: any*/),
+        "artworksForUser.edges.node.collecting_institution": (v8/*: any*/),
+        "artworksForUser.edges.node.cultural_maker": (v8/*: any*/),
+        "artworksForUser.edges.node.date": (v8/*: any*/),
+        "artworksForUser.edges.node.href": (v8/*: any*/),
+        "artworksForUser.edges.node.id": (v9/*: any*/),
         "artworksForUser.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "artworksForUser.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "artworksForUser.edges.node.image.height": (v11/*: any*/),
-        "artworksForUser.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "artworksForUser.edges.node.image.resized.height": (v11/*: any*/),
-        "artworksForUser.edges.node.image.resized.src": (v12/*: any*/),
-        "artworksForUser.edges.node.image.resized.srcSet": (v12/*: any*/),
-        "artworksForUser.edges.node.image.resized.width": (v11/*: any*/),
-        "artworksForUser.edges.node.imageTitle": (v9/*: any*/),
-        "artworksForUser.edges.node.internalID": (v10/*: any*/),
-        "artworksForUser.edges.node.is_biddable": (v13/*: any*/),
-        "artworksForUser.edges.node.is_saved": (v13/*: any*/),
+        "artworksForUser.edges.node.image.height": (v10/*: any*/),
+        "artworksForUser.edges.node.image.src": (v8/*: any*/),
+        "artworksForUser.edges.node.image.width": (v10/*: any*/),
+        "artworksForUser.edges.node.internalID": (v9/*: any*/),
+        "artworksForUser.edges.node.is_saved": (v11/*: any*/),
         "artworksForUser.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -601,32 +528,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "artworksForUser.edges.node.mediumType.filterGene.id": (v10/*: any*/),
-        "artworksForUser.edges.node.mediumType.filterGene.name": (v9/*: any*/),
+        "artworksForUser.edges.node.mediumType.filterGene.id": (v9/*: any*/),
+        "artworksForUser.edges.node.mediumType.filterGene.name": (v8/*: any*/),
         "artworksForUser.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "artworksForUser.edges.node.partner.href": (v9/*: any*/),
-        "artworksForUser.edges.node.partner.id": (v10/*: any*/),
-        "artworksForUser.edges.node.partner.name": (v9/*: any*/),
+        "artworksForUser.edges.node.partner.href": (v8/*: any*/),
+        "artworksForUser.edges.node.partner.id": (v9/*: any*/),
+        "artworksForUser.edges.node.partner.name": (v8/*: any*/),
         "artworksForUser.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "artworksForUser.edges.node.sale.cascadingEndTimeIntervalMinutes": (v11/*: any*/),
-        "artworksForUser.edges.node.sale.display_timely_at": (v9/*: any*/),
-        "artworksForUser.edges.node.sale.endAt": (v9/*: any*/),
-        "artworksForUser.edges.node.sale.extendedBiddingIntervalMinutes": (v11/*: any*/),
-        "artworksForUser.edges.node.sale.id": (v10/*: any*/),
-        "artworksForUser.edges.node.sale.is_auction": (v13/*: any*/),
-        "artworksForUser.edges.node.sale.is_closed": (v13/*: any*/),
-        "artworksForUser.edges.node.sale.is_preview": (v13/*: any*/),
-        "artworksForUser.edges.node.sale.startAt": (v9/*: any*/),
+        "artworksForUser.edges.node.sale.cascadingEndTimeIntervalMinutes": (v10/*: any*/),
+        "artworksForUser.edges.node.sale.endAt": (v8/*: any*/),
+        "artworksForUser.edges.node.sale.extendedBiddingIntervalMinutes": (v10/*: any*/),
+        "artworksForUser.edges.node.sale.id": (v9/*: any*/),
+        "artworksForUser.edges.node.sale.is_auction": (v11/*: any*/),
+        "artworksForUser.edges.node.sale.is_closed": (v11/*: any*/),
+        "artworksForUser.edges.node.sale.startAt": (v8/*: any*/),
         "artworksForUser.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -645,34 +570,34 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "artworksForUser.edges.node.sale_artwork.endAt": (v9/*: any*/),
-        "artworksForUser.edges.node.sale_artwork.extendedBiddingEndAt": (v9/*: any*/),
-        "artworksForUser.edges.node.sale_artwork.formattedEndDateTime": (v9/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.endAt": (v8/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.extendedBiddingEndAt": (v8/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.formattedEndDateTime": (v8/*: any*/),
         "artworksForUser.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "artworksForUser.edges.node.sale_artwork.highest_bid.display": (v9/*: any*/),
-        "artworksForUser.edges.node.sale_artwork.id": (v10/*: any*/),
-        "artworksForUser.edges.node.sale_artwork.lotID": (v9/*: any*/),
-        "artworksForUser.edges.node.sale_artwork.lotLabel": (v9/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.highest_bid.display": (v8/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.id": (v9/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.lotID": (v8/*: any*/),
+        "artworksForUser.edges.node.sale_artwork.lotLabel": (v8/*: any*/),
         "artworksForUser.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "artworksForUser.edges.node.sale_artwork.opening_bid.display": (v9/*: any*/),
-        "artworksForUser.edges.node.sale_message": (v9/*: any*/),
-        "artworksForUser.edges.node.slug": (v10/*: any*/),
-        "artworksForUser.edges.node.title": (v9/*: any*/)
+        "artworksForUser.edges.node.sale_artwork.opening_bid.display": (v8/*: any*/),
+        "artworksForUser.edges.node.sale_message": (v8/*: any*/),
+        "artworksForUser.edges.node.slug": (v9/*: any*/),
+        "artworksForUser.edges.node.title": (v8/*: any*/)
       }
     },
     "name": "HomeNewWorksForYouRail_Test_Query",
     "operationKind": "query",
-    "text": "query HomeNewWorksForYouRail_Test_Query {\n  artworksForUser(includeBackfill: true, first: 20) {\n    ...HomeNewWorksForYouRail_artworksForUser\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeNewWorksForYouRail_artworksForUser on ArtworkConnection {\n  edges {\n    node {\n      internalID\n      slug\n      ...ShelfArtwork_artwork_1s6r3G\n      id\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query HomeNewWorksForYouRail_Test_Query {\n  artworksForUser(includeBackfill: true, first: 20) {\n    ...HomeNewWorksForYouRail_artworksForUser\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeNewWorksForYouRail_artworksForUser on ArtworkConnection {\n  edges {\n    node {\n      internalID\n      slug\n      ...ShelfArtwork_artwork\n      id\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeNewWorksForYouRail_artworksForUser.graphql.ts
+++ b/src/__generated__/HomeNewWorksForYouRail_artworksForUser.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3dca1ba95609c8dc1e74a888fef04045>>
+ * @generated SignedSource<<79566b72470ab01fb1ee90e0e2661b29>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -62,13 +62,7 @@ const node: ReaderFragment = {
               "storageKey": null
             },
             {
-              "args": [
-                {
-                  "kind": "Literal",
-                  "name": "width",
-                  "value": 210
-                }
-              ],
+              "args": null,
               "kind": "FragmentSpread",
               "name": "ShelfArtwork_artwork"
             }
@@ -83,6 +77,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "c80497b8abf280f4f25d4ab38900546f";
+(node as any).hash = "98d001be0fb3ef2398c6288bb36d5c03";
 
 export default node;

--- a/src/__generated__/HomeRecentlyViewedRailQuery.graphql.ts
+++ b/src/__generated__/HomeRecentlyViewedRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<dc13e431bc350bd6154cd98f834e9154>>
+ * @generated SignedSource<<c90395d2cf5fa531c38561fb302ff1bb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,9 +66,9 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -154,71 +147,7 @@ return {
                     "name": "slug",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Image",
-                    "kind": "LinkedField",
-                    "name": "image",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "width",
-                            "value": 210
-                          }
-                        ],
-                        "concreteType": "ResizedImageUrl",
-                        "kind": "LinkedField",
-                        "name": "resized",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "src",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "srcSet",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "width",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": "resized(width:210)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "aspectRatio",
-                        "storageKey": null
-                      },
-                      (v0/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "imageTitle",
-                    "storageKey": null
-                  },
+                  (v0/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -226,7 +155,6 @@ return {
                     "name": "title",
                     "storageKey": null
                   },
-                  (v1/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -250,15 +178,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v2/*: any*/),
+                    "args": (v1/*: any*/),
                     "concreteType": "Artist",
                     "kind": "LinkedField",
                     "name": "artists",
                     "plural": true,
                     "selections": [
-                      (v3/*: any*/),
-                      (v1/*: any*/),
-                      (v4/*: any*/)
+                      (v2/*: any*/),
+                      (v0/*: any*/),
+                      (v3/*: any*/)
                     ],
                     "storageKey": "artists(shallow:true)"
                   },
@@ -271,15 +199,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v2/*: any*/),
+                    "args": (v1/*: any*/),
                     "concreteType": "Partner",
                     "kind": "LinkedField",
                     "name": "partner",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v1/*: any*/),
-                      (v3/*: any*/)
+                      (v3/*: any*/),
+                      (v0/*: any*/),
+                      (v2/*: any*/)
                     ],
                     "storageKey": "partner(shallow:true)"
                   },
@@ -291,7 +219,7 @@ return {
                     "name": "sale",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -327,21 +255,7 @@ return {
                         "name": "isClosed",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
-                      {
-                        "alias": "is_preview",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isPreview",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "display_timely_at",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "displayTimelyAt",
-                        "storageKey": null
-                      }
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -367,7 +281,7 @@ return {
                         "name": "lotLabel",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -407,7 +321,7 @@ return {
                         "kind": "LinkedField",
                         "name": "highestBid",
                         "plural": false,
-                        "selections": (v6/*: any*/),
+                        "selections": (v5/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -417,14 +331,14 @@ return {
                         "kind": "LinkedField",
                         "name": "openingBid",
                         "plural": false,
-                        "selections": (v6/*: any*/),
+                        "selections": (v5/*: any*/),
                         "storageKey": null
                       },
-                      (v3/*: any*/)
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v3/*: any*/),
+                  (v2/*: any*/),
                   {
                     "alias": "is_saved",
                     "args": null,
@@ -439,7 +353,7 @@ return {
                     "kind": "LinkedField",
                     "name": "attributionClass",
                     "plural": false,
-                    "selections": (v7/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -457,23 +371,58 @@ return {
                         "kind": "LinkedField",
                         "name": "filterGene",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
                   {
-                    "alias": "is_biddable",
+                    "alias": null,
                     "args": null,
-                    "kind": "ScalarField",
-                    "name": "isBiddable",
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "src",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": [
+                              "normalized",
+                              "larger",
+                              "large"
+                            ]
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      }
+                    ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "storageKey": "artworkModule(key:\"RECENTLY_VIEWED_WORKS\")"
           }
@@ -483,12 +432,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e8b3ba3f6a3d3dc2dcfc54fab2205c7e",
+    "cacheID": "305215a988db54412a45c358f71359c4",
     "id": null,
     "metadata": {},
     "name": "HomeRecentlyViewedRailQuery",
     "operationKind": "query",
-    "text": "query HomeRecentlyViewedRailQuery {\n  homePage {\n    ...HomeRecentlyViewedRail_homePage\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeRecentlyViewedRail_homePage on HomePage {\n  artworkModule(key: RECENTLY_VIEWED_WORKS) {\n    results {\n      internalID\n      slug\n      ...ShelfArtwork_artwork_1s6r3G\n      id\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query HomeRecentlyViewedRailQuery {\n  homePage {\n    ...HomeRecentlyViewedRail_homePage\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeRecentlyViewedRail_homePage on HomePage {\n  artworkModule(key: RECENTLY_VIEWED_WORKS) {\n    results {\n      internalID\n      slug\n      ...ShelfArtwork_artwork\n      id\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeRecentlyViewedRail_Test_Query.graphql.ts
+++ b/src/__generated__/HomeRecentlyViewedRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a93d650d34fd9f055e19540e8ddd7e20>>
+ * @generated SignedSource<<7712c2c47a433b3dbd98a9e9e6c5a74c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,9 +66,9 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -154,71 +147,7 @@ return {
                     "name": "slug",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Image",
-                    "kind": "LinkedField",
-                    "name": "image",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "width",
-                            "value": 210
-                          }
-                        ],
-                        "concreteType": "ResizedImageUrl",
-                        "kind": "LinkedField",
-                        "name": "resized",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "src",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "srcSet",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "width",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": "resized(width:210)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "aspectRatio",
-                        "storageKey": null
-                      },
-                      (v0/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "imageTitle",
-                    "storageKey": null
-                  },
+                  (v0/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -226,7 +155,6 @@ return {
                     "name": "title",
                     "storageKey": null
                   },
-                  (v1/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -250,15 +178,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v2/*: any*/),
+                    "args": (v1/*: any*/),
                     "concreteType": "Artist",
                     "kind": "LinkedField",
                     "name": "artists",
                     "plural": true,
                     "selections": [
-                      (v3/*: any*/),
-                      (v1/*: any*/),
-                      (v4/*: any*/)
+                      (v2/*: any*/),
+                      (v0/*: any*/),
+                      (v3/*: any*/)
                     ],
                     "storageKey": "artists(shallow:true)"
                   },
@@ -271,15 +199,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v2/*: any*/),
+                    "args": (v1/*: any*/),
                     "concreteType": "Partner",
                     "kind": "LinkedField",
                     "name": "partner",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v1/*: any*/),
-                      (v3/*: any*/)
+                      (v3/*: any*/),
+                      (v0/*: any*/),
+                      (v2/*: any*/)
                     ],
                     "storageKey": "partner(shallow:true)"
                   },
@@ -291,7 +219,7 @@ return {
                     "name": "sale",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -327,21 +255,7 @@ return {
                         "name": "isClosed",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
-                      {
-                        "alias": "is_preview",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isPreview",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "display_timely_at",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "displayTimelyAt",
-                        "storageKey": null
-                      }
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -367,7 +281,7 @@ return {
                         "name": "lotLabel",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -407,7 +321,7 @@ return {
                         "kind": "LinkedField",
                         "name": "highestBid",
                         "plural": false,
-                        "selections": (v6/*: any*/),
+                        "selections": (v5/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -417,14 +331,14 @@ return {
                         "kind": "LinkedField",
                         "name": "openingBid",
                         "plural": false,
-                        "selections": (v6/*: any*/),
+                        "selections": (v5/*: any*/),
                         "storageKey": null
                       },
-                      (v3/*: any*/)
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v3/*: any*/),
+                  (v2/*: any*/),
                   {
                     "alias": "is_saved",
                     "args": null,
@@ -439,7 +353,7 @@ return {
                     "kind": "LinkedField",
                     "name": "attributionClass",
                     "plural": false,
-                    "selections": (v7/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -457,23 +371,58 @@ return {
                         "kind": "LinkedField",
                         "name": "filterGene",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
                   {
-                    "alias": "is_biddable",
+                    "alias": null,
                     "args": null,
-                    "kind": "ScalarField",
-                    "name": "isBiddable",
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "src",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": [
+                              "normalized",
+                              "larger",
+                              "large"
+                            ]
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      }
+                    ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "storageKey": "artworkModule(key:\"RECENTLY_VIEWED_WORKS\")"
           }
@@ -483,12 +432,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8e2eb8330f3daf70abfb2ffe7f20885c",
+    "cacheID": "cd0f8364e0de23183df6cee2a8da4d0c",
     "id": null,
     "metadata": {},
     "name": "HomeRecentlyViewedRail_Test_Query",
     "operationKind": "query",
-    "text": "query HomeRecentlyViewedRail_Test_Query {\n  homePage {\n    ...HomeRecentlyViewedRail_homePage\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeRecentlyViewedRail_homePage on HomePage {\n  artworkModule(key: RECENTLY_VIEWED_WORKS) {\n    results {\n      internalID\n      slug\n      ...ShelfArtwork_artwork_1s6r3G\n      id\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query HomeRecentlyViewedRail_Test_Query {\n  homePage {\n    ...HomeRecentlyViewedRail_homePage\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeRecentlyViewedRail_homePage on HomePage {\n  artworkModule(key: RECENTLY_VIEWED_WORKS) {\n    results {\n      internalID\n      slug\n      ...ShelfArtwork_artwork\n      id\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeRecentlyViewedRail_homePage.graphql.ts
+++ b/src/__generated__/HomeRecentlyViewedRail_homePage.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<67decb3589baadafdad29b9df8f3f09a>>
+ * @generated SignedSource<<d958bd89526a735a716d30602a2a5b41>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -68,13 +68,7 @@ const node: ReaderFragment = {
               "storageKey": null
             },
             {
-              "args": [
-                {
-                  "kind": "Literal",
-                  "name": "width",
-                  "value": 210
-                }
-              ],
+              "args": null,
               "kind": "FragmentSpread",
               "name": "ShelfArtwork_artwork"
             }
@@ -89,6 +83,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "d634f76b1ad38b0e9b9a866f101dd741";
+(node as any).hash = "5ca2f80b75469ad3c89c9b929518718b";
 
 export default node;

--- a/src/__generated__/HomeTroveArtworksRailQuery.graphql.ts
+++ b/src/__generated__/HomeTroveArtworksRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3f32a3f71b3603544e432df6f58b92c7>>
+ * @generated SignedSource<<dee74b6e9d017b11f6c187740c62209b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,9 +66,9 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -153,71 +146,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 210
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v0/*: any*/)
-                            ],
-                            "storageKey": "resized(width:210)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v0/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -225,7 +154,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -249,15 +177,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v1/*: any*/),
-                          (v4/*: any*/)
+                          (v2/*: any*/),
+                          (v0/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -270,15 +198,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v1/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v0/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -290,7 +218,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -326,21 +254,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -366,7 +280,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -406,7 +320,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -416,14 +330,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -452,7 +366,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -470,17 +384,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -489,7 +438,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "storageKey": "artworksConnection(first:12,geneIDs:\"trove\")"
           }
@@ -499,12 +448,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3019ba899e85ac42a18e3d7a55554c4c",
+    "cacheID": "7aa624d5f0e386b82971cfccdbf86eec",
     "id": null,
     "metadata": {},
     "name": "HomeTroveArtworksRailQuery",
     "operationKind": "query",
-    "text": "query HomeTroveArtworksRailQuery {\n  viewer {\n    ...HomeTroveArtworksRail_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeTroveArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, geneIDs: \"trove\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork_1s6r3G\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query HomeTroveArtworksRailQuery {\n  viewer {\n    ...HomeTroveArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeTroveArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, geneIDs: \"trove\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeTroveArtworksRail_Test_Query.graphql.ts
+++ b/src/__generated__/HomeTroveArtworksRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ea69fc46adc019de2139fba34b815558>>
+ * @generated SignedSource<<08f5ebe6796da8327748b9c8154fe46e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,35 +66,29 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ],
-v8 = {
+v7 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v9 = {
+v8 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v10 = {
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v11 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v12 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -183,71 +170,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 210
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v0/*: any*/)
-                            ],
-                            "storageKey": "resized(width:210)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v0/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -255,7 +178,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -279,15 +201,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v1/*: any*/),
-                          (v4/*: any*/)
+                          (v2/*: any*/),
+                          (v0/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -300,15 +222,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v1/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v0/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -320,7 +242,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -356,21 +278,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -396,7 +304,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -436,7 +344,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -446,14 +354,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -482,7 +390,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -500,17 +408,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -519,7 +462,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "storageKey": "artworksConnection(first:12,geneIDs:\"trove\")"
           }
@@ -529,7 +472,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "07b5add68d92d3bd74fa907d2a869913",
+    "cacheID": "5b4d1815338fde19de0d95f574234f4c",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -563,49 +506,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "viewer.artworksConnection.edges.node.artists.href": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.artists.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.artists.name": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.artists.href": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.artists.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.artists.name": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "viewer.artworksConnection.edges.node.attributionClass.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.attributionClass.name": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.collecting_institution": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.cultural_maker": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.date": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.href": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.id": (v9/*: any*/),
+        "viewer.artworksConnection.edges.node.attributionClass.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.attributionClass.name": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.collecting_institution": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.cultural_maker": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.date": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.href": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.id": (v8/*: any*/),
         "viewer.artworksConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "viewer.artworksConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "viewer.artworksConnection.edges.node.image.height": (v10/*: any*/),
-        "viewer.artworksConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "viewer.artworksConnection.edges.node.image.resized.height": (v10/*: any*/),
-        "viewer.artworksConnection.edges.node.image.resized.src": (v11/*: any*/),
-        "viewer.artworksConnection.edges.node.image.resized.srcSet": (v11/*: any*/),
-        "viewer.artworksConnection.edges.node.image.resized.width": (v10/*: any*/),
-        "viewer.artworksConnection.edges.node.imageTitle": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.internalID": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.is_biddable": (v12/*: any*/),
-        "viewer.artworksConnection.edges.node.is_saved": (v12/*: any*/),
+        "viewer.artworksConnection.edges.node.image.height": (v9/*: any*/),
+        "viewer.artworksConnection.edges.node.image.src": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.image.width": (v9/*: any*/),
+        "viewer.artworksConnection.edges.node.internalID": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.is_saved": (v10/*: any*/),
         "viewer.artworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -618,32 +545,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "viewer.artworksConnection.edges.node.mediumType.filterGene.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.mediumType.filterGene.name": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.mediumType.filterGene.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.mediumType.filterGene.name": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewer.artworksConnection.edges.node.partner.href": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.partner.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.partner.name": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.partner.href": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.partner.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.partner.name": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "viewer.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v10/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.display_timely_at": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.endAt": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v10/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.is_auction": (v12/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.is_closed": (v12/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.is_preview": (v12/*: any*/),
-        "viewer.artworksConnection.edges.node.sale.startAt": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v9/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.endAt": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v9/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.is_auction": (v10/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.is_closed": (v10/*: any*/),
+        "viewer.artworksConnection.edges.node.sale.startAt": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -662,35 +587,35 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "viewer.artworksConnection.edges.node.sale_artwork.endAt": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.endAt": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "viewer.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_artwork.id": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_artwork.lotID": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_artwork.lotLabel": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.id": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.lotID": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_artwork.lotLabel": (v7/*: any*/),
         "viewer.artworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "viewer.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.sale_message": (v8/*: any*/),
-        "viewer.artworksConnection.edges.node.slug": (v9/*: any*/),
-        "viewer.artworksConnection.edges.node.title": (v8/*: any*/),
-        "viewer.artworksConnection.id": (v9/*: any*/)
+        "viewer.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.sale_message": (v7/*: any*/),
+        "viewer.artworksConnection.edges.node.slug": (v8/*: any*/),
+        "viewer.artworksConnection.edges.node.title": (v7/*: any*/),
+        "viewer.artworksConnection.id": (v8/*: any*/)
       }
     },
     "name": "HomeTroveArtworksRail_Test_Query",
     "operationKind": "query",
-    "text": "query HomeTroveArtworksRail_Test_Query {\n  viewer {\n    ...HomeTroveArtworksRail_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeTroveArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, geneIDs: \"trove\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork_1s6r3G\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query HomeTroveArtworksRail_Test_Query {\n  viewer {\n    ...HomeTroveArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeTroveArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, geneIDs: \"trove\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeTroveArtworksRail_viewer.graphql.ts
+++ b/src/__generated__/HomeTroveArtworksRail_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a7a12c312bc4ae607bf0a1000fd6e69b>>
+ * @generated SignedSource<<4e4525bb3d2d774427d94dbd7754e164>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -70,13 +70,7 @@ const node: ReaderFragment = {
               "plural": false,
               "selections": [
                 {
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 210
-                    }
-                  ],
+                  "args": null,
                   "kind": "FragmentSpread",
                   "name": "ShelfArtwork_artwork"
                 },
@@ -115,6 +109,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "a324d42177d1e5ab73ac279f98ed5235";
+(node as any).hash = "aeb4755ff31a7f7acd1803d7daffc06a";
 
 export default node;

--- a/src/__generated__/HomeWorksByArtistsYouFollowRailQuery.graphql.ts
+++ b/src/__generated__/HomeWorksByArtistsYouFollowRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e0a6ee6829ae54791252762f1fbfbd70>>
+ * @generated SignedSource<<c6bf19fb258339a923223cae85441d17>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,9 +66,9 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -154,71 +147,7 @@ return {
                     "name": "slug",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Image",
-                    "kind": "LinkedField",
-                    "name": "image",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "width",
-                            "value": 210
-                          }
-                        ],
-                        "concreteType": "ResizedImageUrl",
-                        "kind": "LinkedField",
-                        "name": "resized",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "src",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "srcSet",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "width",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": "resized(width:210)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "aspectRatio",
-                        "storageKey": null
-                      },
-                      (v0/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "imageTitle",
-                    "storageKey": null
-                  },
+                  (v0/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -226,7 +155,6 @@ return {
                     "name": "title",
                     "storageKey": null
                   },
-                  (v1/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -250,15 +178,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v2/*: any*/),
+                    "args": (v1/*: any*/),
                     "concreteType": "Artist",
                     "kind": "LinkedField",
                     "name": "artists",
                     "plural": true,
                     "selections": [
-                      (v3/*: any*/),
-                      (v1/*: any*/),
-                      (v4/*: any*/)
+                      (v2/*: any*/),
+                      (v0/*: any*/),
+                      (v3/*: any*/)
                     ],
                     "storageKey": "artists(shallow:true)"
                   },
@@ -271,15 +199,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v2/*: any*/),
+                    "args": (v1/*: any*/),
                     "concreteType": "Partner",
                     "kind": "LinkedField",
                     "name": "partner",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v1/*: any*/),
-                      (v3/*: any*/)
+                      (v3/*: any*/),
+                      (v0/*: any*/),
+                      (v2/*: any*/)
                     ],
                     "storageKey": "partner(shallow:true)"
                   },
@@ -291,7 +219,7 @@ return {
                     "name": "sale",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -327,21 +255,7 @@ return {
                         "name": "isClosed",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
-                      {
-                        "alias": "is_preview",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isPreview",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "display_timely_at",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "displayTimelyAt",
-                        "storageKey": null
-                      }
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -367,7 +281,7 @@ return {
                         "name": "lotLabel",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -407,7 +321,7 @@ return {
                         "kind": "LinkedField",
                         "name": "highestBid",
                         "plural": false,
-                        "selections": (v6/*: any*/),
+                        "selections": (v5/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -417,14 +331,14 @@ return {
                         "kind": "LinkedField",
                         "name": "openingBid",
                         "plural": false,
-                        "selections": (v6/*: any*/),
+                        "selections": (v5/*: any*/),
                         "storageKey": null
                       },
-                      (v3/*: any*/)
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v3/*: any*/),
+                  (v2/*: any*/),
                   {
                     "alias": "is_saved",
                     "args": null,
@@ -439,7 +353,7 @@ return {
                     "kind": "LinkedField",
                     "name": "attributionClass",
                     "plural": false,
-                    "selections": (v7/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -457,23 +371,58 @@ return {
                         "kind": "LinkedField",
                         "name": "filterGene",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
                   {
-                    "alias": "is_biddable",
+                    "alias": null,
                     "args": null,
-                    "kind": "ScalarField",
-                    "name": "isBiddable",
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "src",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": [
+                              "normalized",
+                              "larger",
+                              "large"
+                            ]
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      }
+                    ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "storageKey": "artworkModule(key:\"FOLLOWED_ARTISTS\")"
           }
@@ -483,12 +432,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ac5fe031031603e0775710ffc0d42978",
+    "cacheID": "39ef8aeb09a18f16e2b5585a2fcf6ca6",
     "id": null,
     "metadata": {},
     "name": "HomeWorksByArtistsYouFollowRailQuery",
     "operationKind": "query",
-    "text": "query HomeWorksByArtistsYouFollowRailQuery {\n  homePage {\n    ...HomeWorksByArtistsYouFollowRail_homePage\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeWorksByArtistsYouFollowRail_homePage on HomePage {\n  artworkModule(key: FOLLOWED_ARTISTS) {\n    results {\n      internalID\n      slug\n      ...ShelfArtwork_artwork_1s6r3G\n      id\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query HomeWorksByArtistsYouFollowRailQuery {\n  homePage {\n    ...HomeWorksByArtistsYouFollowRail_homePage\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeWorksByArtistsYouFollowRail_homePage on HomePage {\n  artworkModule(key: FOLLOWED_ARTISTS) {\n    results {\n      internalID\n      slug\n      ...ShelfArtwork_artwork\n      id\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeWorksByArtistsYouFollowRail_Test_Query.graphql.ts
+++ b/src/__generated__/HomeWorksByArtistsYouFollowRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f9b604dd64937e7070b1210239aef10e>>
+ * @generated SignedSource<<b74fb5312b9c80268bfee08eae5dbe8d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,35 +66,29 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ],
-v8 = {
+v7 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v9 = {
+v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v10 = {
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v11 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v12 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -184,71 +171,7 @@ return {
                     "name": "slug",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Image",
-                    "kind": "LinkedField",
-                    "name": "image",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "width",
-                            "value": 210
-                          }
-                        ],
-                        "concreteType": "ResizedImageUrl",
-                        "kind": "LinkedField",
-                        "name": "resized",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "src",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "srcSet",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "width",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": "resized(width:210)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "aspectRatio",
-                        "storageKey": null
-                      },
-                      (v0/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "imageTitle",
-                    "storageKey": null
-                  },
+                  (v0/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -256,7 +179,6 @@ return {
                     "name": "title",
                     "storageKey": null
                   },
-                  (v1/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -280,15 +202,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v2/*: any*/),
+                    "args": (v1/*: any*/),
                     "concreteType": "Artist",
                     "kind": "LinkedField",
                     "name": "artists",
                     "plural": true,
                     "selections": [
-                      (v3/*: any*/),
-                      (v1/*: any*/),
-                      (v4/*: any*/)
+                      (v2/*: any*/),
+                      (v0/*: any*/),
+                      (v3/*: any*/)
                     ],
                     "storageKey": "artists(shallow:true)"
                   },
@@ -301,15 +223,15 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v2/*: any*/),
+                    "args": (v1/*: any*/),
                     "concreteType": "Partner",
                     "kind": "LinkedField",
                     "name": "partner",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v1/*: any*/),
-                      (v3/*: any*/)
+                      (v3/*: any*/),
+                      (v0/*: any*/),
+                      (v2/*: any*/)
                     ],
                     "storageKey": "partner(shallow:true)"
                   },
@@ -321,7 +243,7 @@ return {
                     "name": "sale",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -357,21 +279,7 @@ return {
                         "name": "isClosed",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
-                      {
-                        "alias": "is_preview",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isPreview",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "display_timely_at",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "displayTimelyAt",
-                        "storageKey": null
-                      }
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -397,7 +305,7 @@ return {
                         "name": "lotLabel",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -437,7 +345,7 @@ return {
                         "kind": "LinkedField",
                         "name": "highestBid",
                         "plural": false,
-                        "selections": (v6/*: any*/),
+                        "selections": (v5/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -447,14 +355,14 @@ return {
                         "kind": "LinkedField",
                         "name": "openingBid",
                         "plural": false,
-                        "selections": (v6/*: any*/),
+                        "selections": (v5/*: any*/),
                         "storageKey": null
                       },
-                      (v3/*: any*/)
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v3/*: any*/),
+                  (v2/*: any*/),
                   {
                     "alias": "is_saved",
                     "args": null,
@@ -469,7 +377,7 @@ return {
                     "kind": "LinkedField",
                     "name": "attributionClass",
                     "plural": false,
-                    "selections": (v7/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -487,23 +395,58 @@ return {
                         "kind": "LinkedField",
                         "name": "filterGene",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
                   {
-                    "alias": "is_biddable",
+                    "alias": null,
                     "args": null,
-                    "kind": "ScalarField",
-                    "name": "isBiddable",
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "src",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": [
+                              "normalized",
+                              "larger",
+                              "large"
+                            ]
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      }
+                    ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "storageKey": "artworkModule(key:\"FOLLOWED_ARTISTS\")"
           }
@@ -513,7 +456,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "da4b3fe430eccb17495d72eac6117836",
+    "cacheID": "600d85740abec1c60be01165c19f30eb",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -529,7 +472,7 @@ return {
           "plural": false,
           "type": "HomePageArtworkModule"
         },
-        "homePage.artworkModule.id": (v8/*: any*/),
+        "homePage.artworkModule.id": (v7/*: any*/),
         "homePage.artworkModule.results": {
           "enumValues": null,
           "nullable": true,
@@ -542,49 +485,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "homePage.artworkModule.results.artists.href": (v9/*: any*/),
-        "homePage.artworkModule.results.artists.id": (v8/*: any*/),
-        "homePage.artworkModule.results.artists.name": (v9/*: any*/),
+        "homePage.artworkModule.results.artists.href": (v8/*: any*/),
+        "homePage.artworkModule.results.artists.id": (v7/*: any*/),
+        "homePage.artworkModule.results.artists.name": (v8/*: any*/),
         "homePage.artworkModule.results.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "homePage.artworkModule.results.attributionClass.id": (v8/*: any*/),
-        "homePage.artworkModule.results.attributionClass.name": (v9/*: any*/),
-        "homePage.artworkModule.results.collecting_institution": (v9/*: any*/),
-        "homePage.artworkModule.results.cultural_maker": (v9/*: any*/),
-        "homePage.artworkModule.results.date": (v9/*: any*/),
-        "homePage.artworkModule.results.href": (v9/*: any*/),
-        "homePage.artworkModule.results.id": (v8/*: any*/),
+        "homePage.artworkModule.results.attributionClass.id": (v7/*: any*/),
+        "homePage.artworkModule.results.attributionClass.name": (v8/*: any*/),
+        "homePage.artworkModule.results.collecting_institution": (v8/*: any*/),
+        "homePage.artworkModule.results.cultural_maker": (v8/*: any*/),
+        "homePage.artworkModule.results.date": (v8/*: any*/),
+        "homePage.artworkModule.results.href": (v8/*: any*/),
+        "homePage.artworkModule.results.id": (v7/*: any*/),
         "homePage.artworkModule.results.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "homePage.artworkModule.results.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "homePage.artworkModule.results.image.height": (v10/*: any*/),
-        "homePage.artworkModule.results.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "homePage.artworkModule.results.image.resized.height": (v10/*: any*/),
-        "homePage.artworkModule.results.image.resized.src": (v11/*: any*/),
-        "homePage.artworkModule.results.image.resized.srcSet": (v11/*: any*/),
-        "homePage.artworkModule.results.image.resized.width": (v10/*: any*/),
-        "homePage.artworkModule.results.imageTitle": (v9/*: any*/),
-        "homePage.artworkModule.results.internalID": (v8/*: any*/),
-        "homePage.artworkModule.results.is_biddable": (v12/*: any*/),
-        "homePage.artworkModule.results.is_saved": (v12/*: any*/),
+        "homePage.artworkModule.results.image.height": (v9/*: any*/),
+        "homePage.artworkModule.results.image.src": (v8/*: any*/),
+        "homePage.artworkModule.results.image.width": (v9/*: any*/),
+        "homePage.artworkModule.results.internalID": (v7/*: any*/),
+        "homePage.artworkModule.results.is_saved": (v10/*: any*/),
         "homePage.artworkModule.results.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -597,32 +524,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "homePage.artworkModule.results.mediumType.filterGene.id": (v8/*: any*/),
-        "homePage.artworkModule.results.mediumType.filterGene.name": (v9/*: any*/),
+        "homePage.artworkModule.results.mediumType.filterGene.id": (v7/*: any*/),
+        "homePage.artworkModule.results.mediumType.filterGene.name": (v8/*: any*/),
         "homePage.artworkModule.results.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "homePage.artworkModule.results.partner.href": (v9/*: any*/),
-        "homePage.artworkModule.results.partner.id": (v8/*: any*/),
-        "homePage.artworkModule.results.partner.name": (v9/*: any*/),
+        "homePage.artworkModule.results.partner.href": (v8/*: any*/),
+        "homePage.artworkModule.results.partner.id": (v7/*: any*/),
+        "homePage.artworkModule.results.partner.name": (v8/*: any*/),
         "homePage.artworkModule.results.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "homePage.artworkModule.results.sale.cascadingEndTimeIntervalMinutes": (v10/*: any*/),
-        "homePage.artworkModule.results.sale.display_timely_at": (v9/*: any*/),
-        "homePage.artworkModule.results.sale.endAt": (v9/*: any*/),
-        "homePage.artworkModule.results.sale.extendedBiddingIntervalMinutes": (v10/*: any*/),
-        "homePage.artworkModule.results.sale.id": (v8/*: any*/),
-        "homePage.artworkModule.results.sale.is_auction": (v12/*: any*/),
-        "homePage.artworkModule.results.sale.is_closed": (v12/*: any*/),
-        "homePage.artworkModule.results.sale.is_preview": (v12/*: any*/),
-        "homePage.artworkModule.results.sale.startAt": (v9/*: any*/),
+        "homePage.artworkModule.results.sale.cascadingEndTimeIntervalMinutes": (v9/*: any*/),
+        "homePage.artworkModule.results.sale.endAt": (v8/*: any*/),
+        "homePage.artworkModule.results.sale.extendedBiddingIntervalMinutes": (v9/*: any*/),
+        "homePage.artworkModule.results.sale.id": (v7/*: any*/),
+        "homePage.artworkModule.results.sale.is_auction": (v10/*: any*/),
+        "homePage.artworkModule.results.sale.is_closed": (v10/*: any*/),
+        "homePage.artworkModule.results.sale.startAt": (v8/*: any*/),
         "homePage.artworkModule.results.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -641,34 +566,34 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "homePage.artworkModule.results.sale_artwork.endAt": (v9/*: any*/),
-        "homePage.artworkModule.results.sale_artwork.extendedBiddingEndAt": (v9/*: any*/),
-        "homePage.artworkModule.results.sale_artwork.formattedEndDateTime": (v9/*: any*/),
+        "homePage.artworkModule.results.sale_artwork.endAt": (v8/*: any*/),
+        "homePage.artworkModule.results.sale_artwork.extendedBiddingEndAt": (v8/*: any*/),
+        "homePage.artworkModule.results.sale_artwork.formattedEndDateTime": (v8/*: any*/),
         "homePage.artworkModule.results.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "homePage.artworkModule.results.sale_artwork.highest_bid.display": (v9/*: any*/),
-        "homePage.artworkModule.results.sale_artwork.id": (v8/*: any*/),
-        "homePage.artworkModule.results.sale_artwork.lotID": (v9/*: any*/),
-        "homePage.artworkModule.results.sale_artwork.lotLabel": (v9/*: any*/),
+        "homePage.artworkModule.results.sale_artwork.highest_bid.display": (v8/*: any*/),
+        "homePage.artworkModule.results.sale_artwork.id": (v7/*: any*/),
+        "homePage.artworkModule.results.sale_artwork.lotID": (v8/*: any*/),
+        "homePage.artworkModule.results.sale_artwork.lotLabel": (v8/*: any*/),
         "homePage.artworkModule.results.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "homePage.artworkModule.results.sale_artwork.opening_bid.display": (v9/*: any*/),
-        "homePage.artworkModule.results.sale_message": (v9/*: any*/),
-        "homePage.artworkModule.results.slug": (v8/*: any*/),
-        "homePage.artworkModule.results.title": (v9/*: any*/)
+        "homePage.artworkModule.results.sale_artwork.opening_bid.display": (v8/*: any*/),
+        "homePage.artworkModule.results.sale_message": (v8/*: any*/),
+        "homePage.artworkModule.results.slug": (v7/*: any*/),
+        "homePage.artworkModule.results.title": (v8/*: any*/)
       }
     },
     "name": "HomeWorksByArtistsYouFollowRail_Test_Query",
     "operationKind": "query",
-    "text": "query HomeWorksByArtistsYouFollowRail_Test_Query {\n  homePage {\n    ...HomeWorksByArtistsYouFollowRail_homePage\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeWorksByArtistsYouFollowRail_homePage on HomePage {\n  artworkModule(key: FOLLOWED_ARTISTS) {\n    results {\n      internalID\n      slug\n      ...ShelfArtwork_artwork_1s6r3G\n      id\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_1s6r3G on Artwork {\n  image {\n    resized(width: 210) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query HomeWorksByArtistsYouFollowRail_Test_Query {\n  homePage {\n    ...HomeWorksByArtistsYouFollowRail_homePage\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeWorksByArtistsYouFollowRail_homePage on HomePage {\n  artworkModule(key: FOLLOWED_ARTISTS) {\n    results {\n      internalID\n      slug\n      ...ShelfArtwork_artwork\n      id\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeWorksByArtistsYouFollowRail_homePage.graphql.ts
+++ b/src/__generated__/HomeWorksByArtistsYouFollowRail_homePage.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c8740d1804268666d3c21558e9e9cc82>>
+ * @generated SignedSource<<39235e728f0b8bdc9e01ebb6fe6bd4ef>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -68,13 +68,7 @@ const node: ReaderFragment = {
               "storageKey": null
             },
             {
-              "args": [
-                {
-                  "kind": "Literal",
-                  "name": "width",
-                  "value": 210
-                }
-              ],
+              "args": null,
               "kind": "FragmentSpread",
               "name": "ShelfArtwork_artwork"
             }
@@ -89,6 +83,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "67ebfff4507a1f299a511c8f6493e370";
+(node as any).hash = "d64f7d6d4c9d33d55ac3d8b15e1de791";
 
 export default node;

--- a/src/__generated__/OtherWorksQuery.graphql.ts
+++ b/src/__generated__/OtherWorksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<458f931e6a18cb3af88f033382256490>>
+ * @generated SignedSource<<44177ba0b2a39c1106bfb8a4fae53427>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -81,39 +81,42 @@ v7 = {
   "storageKey": null
 },
 v8 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": [
+    "normalized",
+    "larger",
+    "large"
+  ]
+},
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "src",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "srcSet",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v12 = [
-  (v8/*: any*/),
-  (v9/*: any*/),
-  (v10/*: any*/),
-  (v11/*: any*/)
-],
 v13 = {
   "alias": null,
   "args": null,
@@ -227,34 +230,20 @@ v26 = {
   "storageKey": null
 },
 v27 = {
-  "alias": "is_preview",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isPreview",
-  "storageKey": null
-},
-v28 = {
-  "alias": "display_timely_at",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "displayTimelyAt",
-  "storageKey": null
-},
-v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v30 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v31 = [
+v29 = [
   {
     "alias": null,
     "args": null,
@@ -263,7 +252,7 @@ v31 = [
     "storageKey": null
   }
 ],
-v32 = {
+v30 = {
   "alias": "sale_artwork",
   "args": null,
   "concreteType": "SaleArtwork",
@@ -271,7 +260,7 @@ v32 = {
   "name": "saleArtwork",
   "plural": false,
   "selections": [
-    (v29/*: any*/),
+    (v27/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -280,7 +269,7 @@ v32 = {
       "storageKey": null
     },
     (v21/*: any*/),
-    (v30/*: any*/),
+    (v28/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -313,7 +302,7 @@ v32 = {
       "kind": "LinkedField",
       "name": "highestBid",
       "plural": false,
-      "selections": (v31/*: any*/),
+      "selections": (v29/*: any*/),
       "storageKey": null
     },
     {
@@ -323,35 +312,35 @@ v32 = {
       "kind": "LinkedField",
       "name": "openingBid",
       "plural": false,
-      "selections": (v31/*: any*/),
+      "selections": (v29/*: any*/),
       "storageKey": null
     },
     (v5/*: any*/)
   ],
   "storageKey": null
 },
-v33 = {
+v31 = {
   "alias": "is_saved",
   "args": null,
   "kind": "ScalarField",
   "name": "isSaved",
   "storageKey": null
 },
-v34 = [
+v32 = [
   (v17/*: any*/),
   (v5/*: any*/)
 ],
-v35 = {
+v33 = {
   "alias": null,
   "args": null,
   "concreteType": "AttributionClass",
   "kind": "LinkedField",
   "name": "attributionClass",
   "plural": false,
-  "selections": (v34/*: any*/),
+  "selections": (v32/*: any*/),
   "storageKey": null
 },
-v36 = {
+v34 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworkMedium",
@@ -366,20 +355,13 @@ v36 = {
       "kind": "LinkedField",
       "name": "filterGene",
       "plural": false,
-      "selections": (v34/*: any*/),
+      "selections": (v32/*: any*/),
       "storageKey": null
     }
   ],
   "storageKey": null
 },
-v37 = {
-  "alias": "is_biddable",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isBiddable",
-  "storageKey": null
-},
-v38 = {
+v35 = {
   "kind": "InlineFragment",
   "selections": [
     (v5/*: any*/)
@@ -387,7 +369,7 @@ v38 = {
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v39 = {
+v36 = {
   "alias": null,
   "args": [
     {
@@ -485,15 +467,7 @@ v39 = {
                     {
                       "alias": null,
                       "args": [
-                        {
-                          "kind": "Literal",
-                          "name": "version",
-                          "value": [
-                            "normalized",
-                            "larger",
-                            "large"
-                          ]
-                        },
+                        (v8/*: any*/),
                         {
                           "kind": "Literal",
                           "name": "width",
@@ -504,7 +478,12 @@ v39 = {
                       "kind": "LinkedField",
                       "name": "resized",
                       "plural": false,
-                      "selections": (v12/*: any*/),
+                      "selections": [
+                        (v9/*: any*/),
+                        (v10/*: any*/),
+                        (v11/*: any*/),
+                        (v12/*: any*/)
+                      ],
                       "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:445)"
                     }
                   ],
@@ -546,8 +525,20 @@ v39 = {
                     (v25/*: any*/),
                     (v26/*: any*/),
                     (v5/*: any*/),
-                    (v27/*: any*/),
-                    (v28/*: any*/),
+                    {
+                      "alias": "is_preview",
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "isPreview",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": "display_timely_at",
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "displayTimelyAt",
+                      "storageKey": null
+                    },
                     {
                       "alias": null,
                       "args": null,
@@ -558,11 +549,17 @@ v39 = {
                   ],
                   "storageKey": null
                 },
-                (v32/*: any*/),
+                (v30/*: any*/),
+                (v31/*: any*/),
                 (v33/*: any*/),
-                (v35/*: any*/),
-                (v36/*: any*/),
-                (v37/*: any*/),
+                (v34/*: any*/),
+                {
+                  "alias": "is_biddable",
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "isBiddable",
+                  "storageKey": null
+                },
                 {
                   "alias": null,
                   "args": null,
@@ -572,8 +569,8 @@ v39 = {
                   "plural": false,
                   "selections": [
                     (v21/*: any*/),
-                    (v30/*: any*/),
-                    (v29/*: any*/),
+                    (v28/*: any*/),
+                    (v27/*: any*/),
                     (v5/*: any*/)
                   ],
                   "storageKey": null
@@ -581,7 +578,7 @@ v39 = {
               ],
               "storageKey": null
             },
-            (v38/*: any*/)
+            (v35/*: any*/)
           ],
           "storageKey": null
         }
@@ -657,7 +654,7 @@ return {
                 "name": "ctaHref",
                 "storageKey": null
               },
-              (v39/*: any*/)
+              (v36/*: any*/)
             ],
             "storageKey": null
           },
@@ -685,7 +682,7 @@ return {
             "plural": false,
             "selections": [
               (v17/*: any*/),
-              (v39/*: any*/),
+              (v36/*: any*/),
               (v5/*: any*/)
             ],
             "storageKey": null
@@ -760,50 +757,8 @@ return {
                                 "selections": [
                                   (v4/*: any*/),
                                   (v7/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": (v12/*: any*/),
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
-                                  (v3/*: any*/),
                                   (v6/*: any*/),
+                                  (v3/*: any*/),
                                   (v13/*: any*/),
                                   (v14/*: any*/),
                                   (v15/*: any*/),
@@ -824,18 +779,37 @@ return {
                                       (v24/*: any*/),
                                       (v25/*: any*/),
                                       (v26/*: any*/),
-                                      (v5/*: any*/),
-                                      (v27/*: any*/),
-                                      (v28/*: any*/)
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v32/*: any*/),
+                                  (v30/*: any*/),
                                   (v5/*: any*/),
+                                  (v31/*: any*/),
                                   (v33/*: any*/),
-                                  (v35/*: any*/),
-                                  (v36/*: any*/),
-                                  (v37/*: any*/)
+                                  (v34/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          (v8/*: any*/)
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      (v11/*: any*/),
+                                      (v12/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  }
                                 ],
                                 "storageKey": null
                               }
@@ -877,7 +851,7 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
-              (v38/*: any*/)
+              (v35/*: any*/)
             ],
             "storageKey": null
           },
@@ -963,10 +937,10 @@ return {
                                 "name": "cropped",
                                 "plural": false,
                                 "selections": [
-                                  (v10/*: any*/),
                                   (v11/*: any*/),
-                                  (v8/*: any*/),
-                                  (v9/*: any*/)
+                                  (v12/*: any*/),
+                                  (v9/*: any*/),
+                                  (v10/*: any*/)
                                 ],
                                 "storageKey": "cropped(height:244,width:325)"
                               }
@@ -993,12 +967,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8e997ac37ccdb2a3501f20ae4d67ac24",
+    "cacheID": "904f9f7ca2236c8a18bece30c7279710",
     "id": null,
     "metadata": {},
     "name": "OtherWorksQuery",
     "operationKind": "query",
-    "text": "query OtherWorksQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...OtherWorks_artwork\n    id\n  }\n}\n\nfragment ArtistSeriesArtworkRail_artwork on Artwork {\n  internalID\n  slug\n  artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        slug\n        internalID\n        filterArtworksConnection(sort: \"-decayed_merch\", first: 20) {\n          edges {\n            node {\n              slug\n              internalID\n              ...ShelfArtwork_artwork\n              id\n            }\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  featured\n  internalID\n  artworksCountMessage\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OtherWorks_artwork on Artwork {\n  contextGrids {\n    __typename\n    title\n    ctaTitle\n    ctaHref\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  ...RelatedWorksArtworkGrid_artwork\n  ...ArtistSeriesArtworkRail_artwork\n  slug\n  internalID\n  sale {\n    is_closed: isClosed\n    id\n  }\n  context {\n    __typename\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  seriesArtist: artist(shallow: true) {\n    ...ArtistSeriesRail_artist\n    id\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query OtherWorksQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...OtherWorks_artwork\n    id\n  }\n}\n\nfragment ArtistSeriesArtworkRail_artwork on Artwork {\n  internalID\n  slug\n  artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        slug\n        internalID\n        filterArtworksConnection(sort: \"-decayed_merch\", first: 20) {\n          edges {\n            node {\n              slug\n              internalID\n              ...ShelfArtwork_artwork\n              id\n            }\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  featured\n  internalID\n  artworksCountMessage\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection(first: 50) {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment OtherWorks_artwork on Artwork {\n  contextGrids {\n    __typename\n    title\n    ctaTitle\n    ctaHref\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  ...RelatedWorksArtworkGrid_artwork\n  ...ArtistSeriesArtworkRail_artwork\n  slug\n  internalID\n  sale {\n    is_closed: isClosed\n    id\n  }\n  context {\n    __typename\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  seriesArtist: artist(shallow: true) {\n    ...ArtistSeriesRail_artist\n    id\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PastAuctionsQuery.graphql.ts
+++ b/src/__generated__/PastAuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<116608061fc187843117f6e75e95e1b1>>
+ * @generated SignedSource<<90a792ffb2f03dfa8a8430a39ea96b9e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -92,35 +92,21 @@ v8 = {
   "name": "endAt",
   "storageKey": null
 },
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v10 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v11 = [
+v9 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v12 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v13 = [
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -129,9 +115,16 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = [
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v13 = [
   (v6/*: any*/),
-  (v12/*: any*/)
+  (v10/*: any*/)
 ];
 return {
   "fragment": {
@@ -248,73 +241,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v9/*: any*/),
-                                  (v5/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "src",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "srcSet",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "width",
-                                            "storageKey": null
-                                          },
-                                          (v10/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v10/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
+                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -322,7 +249,6 @@ return {
                                     "name": "title",
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -346,13 +272,13 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v11/*: any*/),
+                                    "args": (v9/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v12/*: any*/),
+                                      (v10/*: any*/),
                                       (v7/*: any*/),
                                       (v6/*: any*/)
                                     ],
@@ -367,7 +293,7 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v11/*: any*/),
+                                    "args": (v9/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
@@ -375,7 +301,7 @@ return {
                                     "selections": [
                                       (v6/*: any*/),
                                       (v7/*: any*/),
-                                      (v12/*: any*/)
+                                      (v10/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -423,21 +349,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v12/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v10/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -503,7 +415,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v13/*: any*/),
+                                        "selections": (v11/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -513,14 +425,16 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v13/*: any*/),
+                                        "selections": (v11/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v12/*: any*/)
+                                      (v10/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
+                                  (v10/*: any*/),
                                   (v12/*: any*/),
+                                  (v5/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -535,7 +449,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v14/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -553,17 +467,52 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v14/*: any*/),
+                                        "selections": (v13/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -575,7 +524,7 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v9/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -583,7 +532,7 @@ return {
                         "name": "formattedStartDateTime",
                         "storageKey": null
                       },
-                      (v12/*: any*/),
+                      (v10/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -651,12 +600,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0ab259d7a60f62ac9a893d846009a92e",
+    "cacheID": "258603f3ede4e4b5d46aeebbc7bf50cc",
     "id": null,
     "metadata": {},
     "name": "PastAuctionsQuery",
     "operationKind": "query",
-    "text": "query PastAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...PastAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PastAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query PastAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...PastAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PastAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PastAuctions_Test_Query.graphql.ts
+++ b/src/__generated__/PastAuctions_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<31f0935e0863a8b61b59d800c5f2307c>>
+ * @generated SignedSource<<c07dc16d0c01e5edd27e7b05783bf7a5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -72,35 +72,21 @@ v4 = {
   "name": "endAt",
   "storageKey": null
 },
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v7 = [
+v5 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v8 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v9 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -109,41 +95,48 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v9 = [
   (v2/*: any*/),
-  (v8/*: any*/)
+  (v6/*: any*/)
 ],
-v11 = {
+v10 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v12 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Sale"
 },
-v13 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v14 = {
+v13 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v15 = {
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v16 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -255,73 +248,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v5/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "src",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "srcSet",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "width",
-                                            "storageKey": null
-                                          },
-                                          (v6/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v6/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -329,7 +256,6 @@ return {
                                     "name": "title",
                                     "storageKey": null
                                   },
-                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -353,13 +279,13 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v7/*: any*/),
+                                    "args": (v5/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v8/*: any*/),
+                                      (v6/*: any*/),
                                       (v3/*: any*/),
                                       (v2/*: any*/)
                                     ],
@@ -374,7 +300,7 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v7/*: any*/),
+                                    "args": (v5/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
@@ -382,7 +308,7 @@ return {
                                     "selections": [
                                       (v2/*: any*/),
                                       (v3/*: any*/),
-                                      (v8/*: any*/)
+                                      (v6/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -430,21 +356,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v8/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v6/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -510,7 +422,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -520,14 +432,16 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v8/*: any*/)
+                                      (v6/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
+                                  (v6/*: any*/),
                                   (v8/*: any*/),
+                                  (v1/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -542,7 +456,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v9/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -560,17 +474,52 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v10/*: any*/),
+                                        "selections": (v9/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -582,7 +531,7 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v5/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -590,7 +539,7 @@ return {
                         "name": "formattedStartDateTime",
                         "storageKey": null
                       },
-                      (v8/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -658,7 +607,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "830c7de3064a7ba112be2b5b66e86c6c",
+    "cacheID": "6990a801fe9d34f46b0c7200a23e26dd",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -680,9 +629,9 @@ return {
           "plural": true,
           "type": "SaleEdge"
         },
-        "viewer.salesConnection.edges.cursor": (v11/*: any*/),
-        "viewer.salesConnection.edges.node": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.__typename": (v11/*: any*/),
+        "viewer.salesConnection.edges.cursor": (v10/*: any*/),
+        "viewer.salesConnection.edges.node": (v11/*: any*/),
+        "viewer.salesConnection.edges.node.__typename": (v10/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection": {
           "enumValues": null,
           "nullable": true,
@@ -707,49 +656,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.name": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.name": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.name": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collecting_institution": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.cultural_maker": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.date": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.id": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.name": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collecting_institution": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.cultural_maker": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.date": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.id": (v13/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.height": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.height": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.src": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.srcSet": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.width": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.imageTitle": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.internalID": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.is_biddable": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.is_saved": (v16/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.height": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.src": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.width": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.internalID": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.is_saved": (v15/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -762,27 +695,25 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.name": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.name": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.name": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.display_timely_at": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.endAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_auction": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_closed": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_preview": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.startAt": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.name": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale": (v11/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.endAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_auction": (v15/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_closed": (v15/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.startAt": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -801,55 +732,55 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.endAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.endAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotID": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotLabel": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotID": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotLabel": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_message": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.slug": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.title": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.endAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.formattedStartDateTime": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.internalID": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.name": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.slug": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_message": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.slug": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.title": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.endAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.formattedStartDateTime": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.internalID": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.name": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.slug": (v13/*: any*/),
         "viewer.salesConnection.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "viewer.salesConnection.pageInfo.endCursor": (v13/*: any*/),
+        "viewer.salesConnection.pageInfo.endCursor": (v12/*: any*/),
         "viewer.salesConnection.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "viewer.salesConnection.totalCount": (v15/*: any*/)
+        "viewer.salesConnection.totalCount": (v14/*: any*/)
       }
     },
     "name": "PastAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query PastAuctions_Test_Query {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query PastAuctions_Test_Query {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/RecentlyViewedQuery.graphql.ts
+++ b/src/__generated__/RecentlyViewedQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<793a4e5c0193efb5a93a13bb5db1c969>>
+ * @generated SignedSource<<2a11beb2116251065a5d6a9d130b1f4c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,38 +33,31 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v3 = [
+v2 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,8 +66,8 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
+v6 = [
+  (v3/*: any*/),
   (v0/*: any*/)
 ];
 return {
@@ -149,71 +142,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v0/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 200
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v1/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v1/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -221,7 +150,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -245,15 +173,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v3/*: any*/),
+                        "args": (v2/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
                           (v0/*: any*/),
-                          (v2/*: any*/),
-                          (v4/*: any*/)
+                          (v1/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -266,14 +194,14 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v3/*: any*/),
+                        "args": (v2/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v2/*: any*/),
+                          (v3/*: any*/),
+                          (v1/*: any*/),
                           (v0/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
@@ -286,7 +214,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -322,21 +250,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v0/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v0/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -362,7 +276,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -402,7 +316,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -412,7 +326,7 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           (v0/*: any*/)
@@ -447,7 +361,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -465,17 +379,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -494,12 +443,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e3b22238c0d317f9e69bf3caa105baf9",
+    "cacheID": "e5cffaeb179bf50af53b1cfad7d74ce5",
     "id": null,
     "metadata": {},
     "name": "RecentlyViewedQuery",
     "operationKind": "query",
-    "text": "query RecentlyViewedQuery {\n  me {\n    ...RecentlyViewed_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment RecentlyViewed_me on Me {\n  recentlyViewedArtworksConnection(first: 20) {\n    edges {\n      node {\n        id\n        ...ShelfArtwork_artwork\n      }\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query RecentlyViewedQuery {\n  me {\n    ...RecentlyViewed_me\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment RecentlyViewed_me on Me {\n  recentlyViewedArtworksConnection(first: 20) {\n    edges {\n      node {\n        id\n        ...ShelfArtwork_artwork\n      }\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsSavesArtistsQuery.graphql.ts
+++ b/src/__generated__/SettingsSavesArtistsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a12a6563c124e780b6c69dc46d00c5ca>>
+ * @generated SignedSource<<84ca1fc5f818a1aef77e0d207338d67d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -72,49 +72,28 @@ v6 = {
   "name": "name",
   "storageKey": null
 },
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "src",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v10 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v11 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v12 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v13 = [
+v10 = [
   {
     "alias": null,
     "args": null,
@@ -123,9 +102,9 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = [
+v11 = [
   (v6/*: any*/),
-  (v11/*: any*/)
+  (v8/*: any*/)
 ];
 return {
   "fragment": {
@@ -288,8 +267,20 @@ return {
                                     "name": "cropped",
                                     "plural": false,
                                     "selections": [
-                                      (v7/*: any*/),
-                                      (v8/*: any*/)
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "src",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "srcSet",
+                                        "storageKey": null
+                                      }
                                     ],
                                     "storageKey": "cropped(height:45,width:45)"
                                   }
@@ -327,59 +318,7 @@ return {
                                         "plural": false,
                                         "selections": [
                                           (v3/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Image",
-                                            "kind": "LinkedField",
-                                            "name": "image",
-                                            "plural": false,
-                                            "selections": [
-                                              {
-                                                "alias": null,
-                                                "args": [
-                                                  {
-                                                    "kind": "Literal",
-                                                    "name": "width",
-                                                    "value": 200
-                                                  }
-                                                ],
-                                                "concreteType": "ResizedImageUrl",
-                                                "kind": "LinkedField",
-                                                "name": "resized",
-                                                "plural": false,
-                                                "selections": [
-                                                  (v7/*: any*/),
-                                                  (v8/*: any*/),
-                                                  {
-                                                    "alias": null,
-                                                    "args": null,
-                                                    "kind": "ScalarField",
-                                                    "name": "width",
-                                                    "storageKey": null
-                                                  },
-                                                  (v9/*: any*/)
-                                                ],
-                                                "storageKey": "resized(width:200)"
-                                              },
-                                              {
-                                                "alias": null,
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "aspectRatio",
-                                                "storageKey": null
-                                              },
-                                              (v9/*: any*/)
-                                            ],
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "imageTitle",
-                                            "storageKey": null
-                                          },
+                                          (v4/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -387,7 +326,6 @@ return {
                                             "name": "title",
                                             "storageKey": null
                                           },
-                                          (v4/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -411,13 +349,13 @@ return {
                                           },
                                           {
                                             "alias": null,
-                                            "args": (v10/*: any*/),
+                                            "args": (v7/*: any*/),
                                             "concreteType": "Artist",
                                             "kind": "LinkedField",
                                             "name": "artists",
                                             "plural": true,
                                             "selections": [
-                                              (v11/*: any*/),
+                                              (v8/*: any*/),
                                               (v4/*: any*/),
                                               (v6/*: any*/)
                                             ],
@@ -432,7 +370,7 @@ return {
                                           },
                                           {
                                             "alias": null,
-                                            "args": (v10/*: any*/),
+                                            "args": (v7/*: any*/),
                                             "concreteType": "Partner",
                                             "kind": "LinkedField",
                                             "name": "partner",
@@ -440,7 +378,7 @@ return {
                                             "selections": [
                                               (v6/*: any*/),
                                               (v4/*: any*/),
-                                              (v11/*: any*/)
+                                              (v8/*: any*/)
                                             ],
                                             "storageKey": "partner(shallow:true)"
                                           },
@@ -452,7 +390,7 @@ return {
                                             "name": "sale",
                                             "plural": false,
                                             "selections": [
-                                              (v12/*: any*/),
+                                              (v9/*: any*/),
                                               {
                                                 "alias": null,
                                                 "args": null,
@@ -488,21 +426,7 @@ return {
                                                 "name": "isClosed",
                                                 "storageKey": null
                                               },
-                                              (v11/*: any*/),
-                                              {
-                                                "alias": "is_preview",
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "isPreview",
-                                                "storageKey": null
-                                              },
-                                              {
-                                                "alias": "display_timely_at",
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "displayTimelyAt",
-                                                "storageKey": null
-                                              }
+                                              (v8/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
@@ -528,7 +452,7 @@ return {
                                                 "name": "lotLabel",
                                                 "storageKey": null
                                               },
-                                              (v12/*: any*/),
+                                              (v9/*: any*/),
                                               {
                                                 "alias": null,
                                                 "args": null,
@@ -568,7 +492,7 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "highestBid",
                                                 "plural": false,
-                                                "selections": (v13/*: any*/),
+                                                "selections": (v10/*: any*/),
                                                 "storageKey": null
                                               },
                                               {
@@ -578,14 +502,14 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "openingBid",
                                                 "plural": false,
-                                                "selections": (v13/*: any*/),
+                                                "selections": (v10/*: any*/),
                                                 "storageKey": null
                                               },
-                                              (v11/*: any*/)
+                                              (v8/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
-                                          (v11/*: any*/),
+                                          (v8/*: any*/),
                                           (v5/*: any*/),
                                           {
                                             "alias": "is_saved",
@@ -601,7 +525,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "attributionClass",
                                             "plural": false,
-                                            "selections": (v14/*: any*/),
+                                            "selections": (v11/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -619,17 +543,52 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "filterGene",
                                                 "plural": false,
-                                                "selections": (v14/*: any*/),
+                                                "selections": (v11/*: any*/),
                                                 "storageKey": null
                                               }
                                             ],
                                             "storageKey": null
                                           },
                                           {
-                                            "alias": "is_biddable",
+                                            "alias": null,
                                             "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isBiddable",
+                                            "concreteType": "Image",
+                                            "kind": "LinkedField",
+                                            "name": "image",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": "src",
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": [
+                                                      "normalized",
+                                                      "larger",
+                                                      "large"
+                                                    ]
+                                                  }
+                                                ],
+                                                "kind": "ScalarField",
+                                                "name": "url",
+                                                "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                              },
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "width",
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "height",
+                                                "storageKey": null
+                                              }
+                                            ],
                                             "storageKey": null
                                           }
                                         ],
@@ -641,11 +600,11 @@ return {
                                 ],
                                 "storageKey": "artworksConnection(first:10)"
                               },
-                              (v11/*: any*/)
+                              (v8/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v11/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -706,19 +665,19 @@ return {
             ],
             "storageKey": null
           },
-          (v11/*: any*/)
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "72462ff8c922e2ebf2196787f7554b99",
+    "cacheID": "2b419ddb32c4ec7143c43a7d26d99e2d",
     "id": null,
     "metadata": {},
     "name": "SettingsSavesArtistsQuery",
     "operationKind": "query",
-    "text": "query SettingsSavesArtistsQuery(\n  $after: String\n) {\n  me {\n    ...SettingsSavesArtists_me_WGPvJ\n    id\n  }\n}\n\nfragment ArtistRail_artist on Artist {\n  ...EntityHeaderArtist_artist\n  name\n  artworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SettingsSavesArtists_me_WGPvJ on Me {\n  followsAndSaves {\n    artistsConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          artist {\n            ...ArtistRail_artist\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query SettingsSavesArtistsQuery(\n  $after: String\n) {\n  me {\n    ...SettingsSavesArtists_me_WGPvJ\n    id\n  }\n}\n\nfragment ArtistRail_artist on Artist {\n  ...EntityHeaderArtist_artist\n  name\n  artworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SettingsSavesArtists_me_WGPvJ on Me {\n  followsAndSaves {\n    artistsConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          artist {\n            ...ArtistRail_artist\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsSavesArtists_test_Query.graphql.ts
+++ b/src/__generated__/SettingsSavesArtists_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<01e233074b873be53e6bb59a7acca253>>
+ * @generated SignedSource<<50506630e0be46d2e9b15a7d8a086332>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -72,49 +72,28 @@ v6 = {
   "name": "name",
   "storageKey": null
 },
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "src",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v10 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v11 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v12 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v13 = [
+v10 = [
   {
     "alias": null,
     "args": null,
@@ -123,47 +102,47 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = [
+v11 = [
   (v6/*: any*/),
-  (v11/*: any*/)
+  (v8/*: any*/)
 ],
-v15 = {
+v12 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v16 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v17 = {
+v14 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v18 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v19 = {
+v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v20 = {
+v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v21 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -330,8 +309,20 @@ return {
                                     "name": "cropped",
                                     "plural": false,
                                     "selections": [
-                                      (v7/*: any*/),
-                                      (v8/*: any*/)
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "src",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "srcSet",
+                                        "storageKey": null
+                                      }
                                     ],
                                     "storageKey": "cropped(height:45,width:45)"
                                   }
@@ -369,59 +360,7 @@ return {
                                         "plural": false,
                                         "selections": [
                                           (v3/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Image",
-                                            "kind": "LinkedField",
-                                            "name": "image",
-                                            "plural": false,
-                                            "selections": [
-                                              {
-                                                "alias": null,
-                                                "args": [
-                                                  {
-                                                    "kind": "Literal",
-                                                    "name": "width",
-                                                    "value": 200
-                                                  }
-                                                ],
-                                                "concreteType": "ResizedImageUrl",
-                                                "kind": "LinkedField",
-                                                "name": "resized",
-                                                "plural": false,
-                                                "selections": [
-                                                  (v7/*: any*/),
-                                                  (v8/*: any*/),
-                                                  {
-                                                    "alias": null,
-                                                    "args": null,
-                                                    "kind": "ScalarField",
-                                                    "name": "width",
-                                                    "storageKey": null
-                                                  },
-                                                  (v9/*: any*/)
-                                                ],
-                                                "storageKey": "resized(width:200)"
-                                              },
-                                              {
-                                                "alias": null,
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "aspectRatio",
-                                                "storageKey": null
-                                              },
-                                              (v9/*: any*/)
-                                            ],
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "imageTitle",
-                                            "storageKey": null
-                                          },
+                                          (v4/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -429,7 +368,6 @@ return {
                                             "name": "title",
                                             "storageKey": null
                                           },
-                                          (v4/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -453,13 +391,13 @@ return {
                                           },
                                           {
                                             "alias": null,
-                                            "args": (v10/*: any*/),
+                                            "args": (v7/*: any*/),
                                             "concreteType": "Artist",
                                             "kind": "LinkedField",
                                             "name": "artists",
                                             "plural": true,
                                             "selections": [
-                                              (v11/*: any*/),
+                                              (v8/*: any*/),
                                               (v4/*: any*/),
                                               (v6/*: any*/)
                                             ],
@@ -474,7 +412,7 @@ return {
                                           },
                                           {
                                             "alias": null,
-                                            "args": (v10/*: any*/),
+                                            "args": (v7/*: any*/),
                                             "concreteType": "Partner",
                                             "kind": "LinkedField",
                                             "name": "partner",
@@ -482,7 +420,7 @@ return {
                                             "selections": [
                                               (v6/*: any*/),
                                               (v4/*: any*/),
-                                              (v11/*: any*/)
+                                              (v8/*: any*/)
                                             ],
                                             "storageKey": "partner(shallow:true)"
                                           },
@@ -494,7 +432,7 @@ return {
                                             "name": "sale",
                                             "plural": false,
                                             "selections": [
-                                              (v12/*: any*/),
+                                              (v9/*: any*/),
                                               {
                                                 "alias": null,
                                                 "args": null,
@@ -530,21 +468,7 @@ return {
                                                 "name": "isClosed",
                                                 "storageKey": null
                                               },
-                                              (v11/*: any*/),
-                                              {
-                                                "alias": "is_preview",
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "isPreview",
-                                                "storageKey": null
-                                              },
-                                              {
-                                                "alias": "display_timely_at",
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "displayTimelyAt",
-                                                "storageKey": null
-                                              }
+                                              (v8/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
@@ -570,7 +494,7 @@ return {
                                                 "name": "lotLabel",
                                                 "storageKey": null
                                               },
-                                              (v12/*: any*/),
+                                              (v9/*: any*/),
                                               {
                                                 "alias": null,
                                                 "args": null,
@@ -610,7 +534,7 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "highestBid",
                                                 "plural": false,
-                                                "selections": (v13/*: any*/),
+                                                "selections": (v10/*: any*/),
                                                 "storageKey": null
                                               },
                                               {
@@ -620,14 +544,14 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "openingBid",
                                                 "plural": false,
-                                                "selections": (v13/*: any*/),
+                                                "selections": (v10/*: any*/),
                                                 "storageKey": null
                                               },
-                                              (v11/*: any*/)
+                                              (v8/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
-                                          (v11/*: any*/),
+                                          (v8/*: any*/),
                                           (v5/*: any*/),
                                           {
                                             "alias": "is_saved",
@@ -643,7 +567,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "attributionClass",
                                             "plural": false,
-                                            "selections": (v14/*: any*/),
+                                            "selections": (v11/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -661,17 +585,52 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "filterGene",
                                                 "plural": false,
-                                                "selections": (v14/*: any*/),
+                                                "selections": (v11/*: any*/),
                                                 "storageKey": null
                                               }
                                             ],
                                             "storageKey": null
                                           },
                                           {
-                                            "alias": "is_biddable",
+                                            "alias": null,
                                             "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isBiddable",
+                                            "concreteType": "Image",
+                                            "kind": "LinkedField",
+                                            "name": "image",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": "src",
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": [
+                                                      "normalized",
+                                                      "larger",
+                                                      "large"
+                                                    ]
+                                                  }
+                                                ],
+                                                "kind": "ScalarField",
+                                                "name": "url",
+                                                "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                              },
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "width",
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "height",
+                                                "storageKey": null
+                                              }
+                                            ],
                                             "storageKey": null
                                           }
                                         ],
@@ -683,11 +642,11 @@ return {
                                 ],
                                 "storageKey": "artworksConnection(first:10)"
                               },
-                              (v11/*: any*/)
+                              (v8/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v11/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -748,14 +707,14 @@ return {
             ],
             "storageKey": null
           },
-          (v11/*: any*/)
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "4607b8ebf0cecc16f7035fd1c6a2b560",
+    "cacheID": "205fbfa52beb6864fb13364d02b34ce5",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -783,14 +742,14 @@ return {
           "plural": true,
           "type": "FollowArtistEdge"
         },
-        "me.followsAndSaves.artistsConnection.edges.cursor": (v15/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.cursor": (v12/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FollowArtist"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.__typename": (v15/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.__typename": (v12/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node.artist": {
           "enumValues": null,
           "nullable": true,
@@ -821,44 +780,28 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artists.href": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artists.id": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artists.name": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artists.href": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artists.id": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artists.name": (v13/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.attributionClass.id": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.attributionClass.name": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collecting_institution": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.cultural_maker": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.date": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.href": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.id": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image": (v18/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.height": (v19/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.resized.height": (v19/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.resized.src": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.resized.srcSet": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.resized.width": (v19/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.imageTitle": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.internalID": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.is_biddable": (v20/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.is_saved": (v20/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.attributionClass.id": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.attributionClass.name": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collecting_institution": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.cultural_maker": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.date": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.href": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.id": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image": (v15/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.height": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.src": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.width": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.internalID": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.is_saved": (v17/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -871,32 +814,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.mediumType.filterGene.id": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.mediumType.filterGene.name": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.mediumType.filterGene.id": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.mediumType.filterGene.name": (v13/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.partner.href": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.partner.id": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.partner.name": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.partner.href": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.partner.id": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.partner.name": (v13/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v19/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.display_timely_at": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.endAt": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v19/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.id": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.is_auction": (v20/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.is_closed": (v20/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.is_preview": (v20/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.startAt": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.endAt": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.id": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.is_auction": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.is_closed": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.startAt": (v13/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -909,76 +850,76 @@ return {
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.counts.bidder_positions": (v21/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.endAt": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.counts.bidder_positions": (v18/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.endAt": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v13/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.id": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.lotID": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.lotLabel": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.id": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.lotID": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.lotLabel": (v13/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_message": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.slug": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.title": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.avatar": (v18/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_message": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.slug": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.title": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.avatar": (v15/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node.artist.avatar.cropped": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.avatar.cropped.src": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.avatar.cropped.srcSet": (v15/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.avatar.cropped.src": (v12/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.avatar.cropped.srcSet": (v12/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node.artist.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtistCounts"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.counts.artworks": (v21/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.counts.forSaleArtworks": (v21/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.formattedNationalityAndBirthday": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.href": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.id": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.initials": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.internalID": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.name": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.slug": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.id": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.internalID": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.counts.artworks": (v18/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.counts.forSaleArtworks": (v18/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.formattedNationalityAndBirthday": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.href": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.id": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.initials": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.internalID": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.name": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.slug": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.id": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.internalID": (v14/*: any*/),
         "me.followsAndSaves.artistsConnection.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "me.followsAndSaves.artistsConnection.pageInfo.endCursor": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.pageInfo.endCursor": (v13/*: any*/),
         "me.followsAndSaves.artistsConnection.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "me.followsAndSaves.artistsConnection.totalCount": (v19/*: any*/),
-        "me.id": (v17/*: any*/)
+        "me.followsAndSaves.artistsConnection.totalCount": (v16/*: any*/),
+        "me.id": (v14/*: any*/)
       }
     },
     "name": "SettingsSavesArtists_test_Query",
     "operationKind": "query",
-    "text": "query SettingsSavesArtists_test_Query(\n  $after: String\n) {\n  me {\n    ...SettingsSavesArtists_me_WGPvJ\n    id\n  }\n}\n\nfragment ArtistRail_artist on Artist {\n  ...EntityHeaderArtist_artist\n  name\n  artworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SettingsSavesArtists_me_WGPvJ on Me {\n  followsAndSaves {\n    artistsConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          artist {\n            ...ArtistRail_artist\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query SettingsSavesArtists_test_Query(\n  $after: String\n) {\n  me {\n    ...SettingsSavesArtists_me_WGPvJ\n    id\n  }\n}\n\nfragment ArtistRail_artist on Artist {\n  ...EntityHeaderArtist_artist\n  name\n  artworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SettingsSavesArtists_me_WGPvJ on Me {\n  followsAndSaves {\n    artistsConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          artist {\n            ...ArtistRail_artist\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsSavesCategoriesQuery.graphql.ts
+++ b/src/__generated__/SettingsSavesCategoriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6998f045c6a965c85ae6650ac6cc7e92>>
+ * @generated SignedSource<<a87a6248be570de4239a3bea73b6151e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -69,45 +69,24 @@ v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v10 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v11 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -116,9 +95,9 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v10 = [
   (v5/*: any*/),
-  (v8/*: any*/)
+  (v6/*: any*/)
 ];
 return {
   "fragment": {
@@ -249,8 +228,20 @@ return {
                                     "name": "cropped",
                                     "plural": false,
                                     "selections": [
-                                      (v6/*: any*/),
-                                      (v7/*: any*/)
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "src",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "srcSet",
+                                        "storageKey": null
+                                      }
                                     ],
                                     "storageKey": "cropped(height:45,version:[\"big_and_tall\",\"tall\"],width:45)"
                                   }
@@ -289,7 +280,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v8/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": "filterArtworksConnection(first:1)"
                               },
@@ -324,59 +315,7 @@ return {
                                         "plural": false,
                                         "selections": [
                                           (v3/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Image",
-                                            "kind": "LinkedField",
-                                            "name": "image",
-                                            "plural": false,
-                                            "selections": [
-                                              {
-                                                "alias": null,
-                                                "args": [
-                                                  {
-                                                    "kind": "Literal",
-                                                    "name": "width",
-                                                    "value": 200
-                                                  }
-                                                ],
-                                                "concreteType": "ResizedImageUrl",
-                                                "kind": "LinkedField",
-                                                "name": "resized",
-                                                "plural": false,
-                                                "selections": [
-                                                  (v6/*: any*/),
-                                                  (v7/*: any*/),
-                                                  {
-                                                    "alias": null,
-                                                    "args": null,
-                                                    "kind": "ScalarField",
-                                                    "name": "width",
-                                                    "storageKey": null
-                                                  },
-                                                  (v9/*: any*/)
-                                                ],
-                                                "storageKey": "resized(width:200)"
-                                              },
-                                              {
-                                                "alias": null,
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "aspectRatio",
-                                                "storageKey": null
-                                              },
-                                              (v9/*: any*/)
-                                            ],
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "imageTitle",
-                                            "storageKey": null
-                                          },
+                                          (v4/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -384,7 +323,6 @@ return {
                                             "name": "title",
                                             "storageKey": null
                                           },
-                                          (v4/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -408,13 +346,13 @@ return {
                                           },
                                           {
                                             "alias": null,
-                                            "args": (v10/*: any*/),
+                                            "args": (v7/*: any*/),
                                             "concreteType": "Artist",
                                             "kind": "LinkedField",
                                             "name": "artists",
                                             "plural": true,
                                             "selections": [
-                                              (v8/*: any*/),
+                                              (v6/*: any*/),
                                               (v4/*: any*/),
                                               (v5/*: any*/)
                                             ],
@@ -429,7 +367,7 @@ return {
                                           },
                                           {
                                             "alias": null,
-                                            "args": (v10/*: any*/),
+                                            "args": (v7/*: any*/),
                                             "concreteType": "Partner",
                                             "kind": "LinkedField",
                                             "name": "partner",
@@ -437,7 +375,7 @@ return {
                                             "selections": [
                                               (v5/*: any*/),
                                               (v4/*: any*/),
-                                              (v8/*: any*/)
+                                              (v6/*: any*/)
                                             ],
                                             "storageKey": "partner(shallow:true)"
                                           },
@@ -449,7 +387,7 @@ return {
                                             "name": "sale",
                                             "plural": false,
                                             "selections": [
-                                              (v11/*: any*/),
+                                              (v8/*: any*/),
                                               {
                                                 "alias": null,
                                                 "args": null,
@@ -485,21 +423,7 @@ return {
                                                 "name": "isClosed",
                                                 "storageKey": null
                                               },
-                                              (v8/*: any*/),
-                                              {
-                                                "alias": "is_preview",
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "isPreview",
-                                                "storageKey": null
-                                              },
-                                              {
-                                                "alias": "display_timely_at",
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "displayTimelyAt",
-                                                "storageKey": null
-                                              }
+                                              (v6/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
@@ -525,7 +449,7 @@ return {
                                                 "name": "lotLabel",
                                                 "storageKey": null
                                               },
-                                              (v11/*: any*/),
+                                              (v8/*: any*/),
                                               {
                                                 "alias": null,
                                                 "args": null,
@@ -565,7 +489,7 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "highestBid",
                                                 "plural": false,
-                                                "selections": (v12/*: any*/),
+                                                "selections": (v9/*: any*/),
                                                 "storageKey": null
                                               },
                                               {
@@ -575,14 +499,14 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "openingBid",
                                                 "plural": false,
-                                                "selections": (v12/*: any*/),
+                                                "selections": (v9/*: any*/),
                                                 "storageKey": null
                                               },
-                                              (v8/*: any*/)
+                                              (v6/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
-                                          (v8/*: any*/),
+                                          (v6/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -604,7 +528,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "attributionClass",
                                             "plural": false,
-                                            "selections": (v13/*: any*/),
+                                            "selections": (v10/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -622,17 +546,52 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "filterGene",
                                                 "plural": false,
-                                                "selections": (v13/*: any*/),
+                                                "selections": (v10/*: any*/),
                                                 "storageKey": null
                                               }
                                             ],
                                             "storageKey": null
                                           },
                                           {
-                                            "alias": "is_biddable",
+                                            "alias": null,
                                             "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isBiddable",
+                                            "concreteType": "Image",
+                                            "kind": "LinkedField",
+                                            "name": "image",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": "src",
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": [
+                                                      "normalized",
+                                                      "larger",
+                                                      "large"
+                                                    ]
+                                                  }
+                                                ],
+                                                "kind": "ScalarField",
+                                                "name": "url",
+                                                "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                              },
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "width",
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "height",
+                                                "storageKey": null
+                                              }
+                                            ],
                                             "storageKey": null
                                           }
                                         ],
@@ -641,15 +600,15 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v8/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": "filterArtworksConnection(first:10)"
                               },
-                              (v8/*: any*/)
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v8/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -710,19 +669,19 @@ return {
             ],
             "storageKey": null
           },
-          (v8/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "cf97ead372a3573b167e472ba0e219be",
+    "cacheID": "ee98b2a4d39f89093b9714b7a0515219",
     "id": null,
     "metadata": {},
     "name": "SettingsSavesCategoriesQuery",
     "operationKind": "query",
-    "text": "query SettingsSavesCategoriesQuery(\n  $after: String\n) {\n  me {\n    ...SettingsSavesCategories_me_WGPvJ\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CategoryRail_category on Gene {\n  ...EntityHeaderGene_gene\n  name\n  href\n  filterArtworks: filterArtworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderGene_gene on Gene {\n  internalID\n  href\n  name\n  avatar: image {\n    cropped(width: 45, height: 45, version: [\"big_and_tall\", \"tall\"]) {\n      src\n      srcSet\n    }\n  }\n  filterArtworksConnection(first: 1) {\n    counts {\n      total\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SettingsSavesCategories_me_WGPvJ on Me {\n  followsAndSaves {\n    categoriesConnection: genesConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          category: gene {\n            internalID\n            ...CategoryRail_category\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query SettingsSavesCategoriesQuery(\n  $after: String\n) {\n  me {\n    ...SettingsSavesCategories_me_WGPvJ\n    id\n  }\n}\n\nfragment CategoryRail_category on Gene {\n  ...EntityHeaderGene_gene\n  name\n  href\n  filterArtworks: filterArtworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderGene_gene on Gene {\n  internalID\n  href\n  name\n  avatar: image {\n    cropped(width: 45, height: 45, version: [\"big_and_tall\", \"tall\"]) {\n      src\n      srcSet\n    }\n  }\n  filterArtworksConnection(first: 1) {\n    counts {\n      total\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SettingsSavesCategories_me_WGPvJ on Me {\n  followsAndSaves {\n    categoriesConnection: genesConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          category: gene {\n            internalID\n            ...CategoryRail_category\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsSavesCategories_test_Query.graphql.ts
+++ b/src/__generated__/SettingsSavesCategories_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f3032c02abfcc3edb0887ed133178728>>
+ * @generated SignedSource<<e29ecf029a4002a2c6fa9fff7916d961>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -69,45 +69,24 @@ v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v10 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v11 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -116,59 +95,59 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v10 = [
   (v5/*: any*/),
-  (v8/*: any*/)
+  (v6/*: any*/)
 ],
-v14 = {
+v11 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v15 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Gene"
 },
-v16 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v17 = {
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v18 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v19 = {
+v16 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v20 = {
+v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v21 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v22 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -303,8 +282,20 @@ return {
                                     "name": "cropped",
                                     "plural": false,
                                     "selections": [
-                                      (v6/*: any*/),
-                                      (v7/*: any*/)
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "src",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "srcSet",
+                                        "storageKey": null
+                                      }
                                     ],
                                     "storageKey": "cropped(height:45,version:[\"big_and_tall\",\"tall\"],width:45)"
                                   }
@@ -343,7 +334,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v8/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": "filterArtworksConnection(first:1)"
                               },
@@ -378,59 +369,7 @@ return {
                                         "plural": false,
                                         "selections": [
                                           (v3/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Image",
-                                            "kind": "LinkedField",
-                                            "name": "image",
-                                            "plural": false,
-                                            "selections": [
-                                              {
-                                                "alias": null,
-                                                "args": [
-                                                  {
-                                                    "kind": "Literal",
-                                                    "name": "width",
-                                                    "value": 200
-                                                  }
-                                                ],
-                                                "concreteType": "ResizedImageUrl",
-                                                "kind": "LinkedField",
-                                                "name": "resized",
-                                                "plural": false,
-                                                "selections": [
-                                                  (v6/*: any*/),
-                                                  (v7/*: any*/),
-                                                  {
-                                                    "alias": null,
-                                                    "args": null,
-                                                    "kind": "ScalarField",
-                                                    "name": "width",
-                                                    "storageKey": null
-                                                  },
-                                                  (v9/*: any*/)
-                                                ],
-                                                "storageKey": "resized(width:200)"
-                                              },
-                                              {
-                                                "alias": null,
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "aspectRatio",
-                                                "storageKey": null
-                                              },
-                                              (v9/*: any*/)
-                                            ],
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "imageTitle",
-                                            "storageKey": null
-                                          },
+                                          (v4/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -438,7 +377,6 @@ return {
                                             "name": "title",
                                             "storageKey": null
                                           },
-                                          (v4/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -462,13 +400,13 @@ return {
                                           },
                                           {
                                             "alias": null,
-                                            "args": (v10/*: any*/),
+                                            "args": (v7/*: any*/),
                                             "concreteType": "Artist",
                                             "kind": "LinkedField",
                                             "name": "artists",
                                             "plural": true,
                                             "selections": [
-                                              (v8/*: any*/),
+                                              (v6/*: any*/),
                                               (v4/*: any*/),
                                               (v5/*: any*/)
                                             ],
@@ -483,7 +421,7 @@ return {
                                           },
                                           {
                                             "alias": null,
-                                            "args": (v10/*: any*/),
+                                            "args": (v7/*: any*/),
                                             "concreteType": "Partner",
                                             "kind": "LinkedField",
                                             "name": "partner",
@@ -491,7 +429,7 @@ return {
                                             "selections": [
                                               (v5/*: any*/),
                                               (v4/*: any*/),
-                                              (v8/*: any*/)
+                                              (v6/*: any*/)
                                             ],
                                             "storageKey": "partner(shallow:true)"
                                           },
@@ -503,7 +441,7 @@ return {
                                             "name": "sale",
                                             "plural": false,
                                             "selections": [
-                                              (v11/*: any*/),
+                                              (v8/*: any*/),
                                               {
                                                 "alias": null,
                                                 "args": null,
@@ -539,21 +477,7 @@ return {
                                                 "name": "isClosed",
                                                 "storageKey": null
                                               },
-                                              (v8/*: any*/),
-                                              {
-                                                "alias": "is_preview",
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "isPreview",
-                                                "storageKey": null
-                                              },
-                                              {
-                                                "alias": "display_timely_at",
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "displayTimelyAt",
-                                                "storageKey": null
-                                              }
+                                              (v6/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
@@ -579,7 +503,7 @@ return {
                                                 "name": "lotLabel",
                                                 "storageKey": null
                                               },
-                                              (v11/*: any*/),
+                                              (v8/*: any*/),
                                               {
                                                 "alias": null,
                                                 "args": null,
@@ -619,7 +543,7 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "highestBid",
                                                 "plural": false,
-                                                "selections": (v12/*: any*/),
+                                                "selections": (v9/*: any*/),
                                                 "storageKey": null
                                               },
                                               {
@@ -629,14 +553,14 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "openingBid",
                                                 "plural": false,
-                                                "selections": (v12/*: any*/),
+                                                "selections": (v9/*: any*/),
                                                 "storageKey": null
                                               },
-                                              (v8/*: any*/)
+                                              (v6/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
-                                          (v8/*: any*/),
+                                          (v6/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -658,7 +582,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "attributionClass",
                                             "plural": false,
-                                            "selections": (v13/*: any*/),
+                                            "selections": (v10/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -676,17 +600,52 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "filterGene",
                                                 "plural": false,
-                                                "selections": (v13/*: any*/),
+                                                "selections": (v10/*: any*/),
                                                 "storageKey": null
                                               }
                                             ],
                                             "storageKey": null
                                           },
                                           {
-                                            "alias": "is_biddable",
+                                            "alias": null,
                                             "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isBiddable",
+                                            "concreteType": "Image",
+                                            "kind": "LinkedField",
+                                            "name": "image",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": "src",
+                                                "args": [
+                                                  {
+                                                    "kind": "Literal",
+                                                    "name": "version",
+                                                    "value": [
+                                                      "normalized",
+                                                      "larger",
+                                                      "large"
+                                                    ]
+                                                  }
+                                                ],
+                                                "kind": "ScalarField",
+                                                "name": "url",
+                                                "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                              },
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "width",
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "height",
+                                                "storageKey": null
+                                              }
+                                            ],
                                             "storageKey": null
                                           }
                                         ],
@@ -695,15 +654,15 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v8/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": "filterArtworksConnection(first:10)"
                               },
-                              (v8/*: any*/)
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v8/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -764,14 +723,14 @@ return {
             ],
             "storageKey": null
           },
-          (v8/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "915aad056fea21fba8bc54584cae5979",
+    "cacheID": "6d563bfba6c13a022f4a55118967cae5",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -799,25 +758,25 @@ return {
           "plural": true,
           "type": "FollowGeneEdge"
         },
-        "me.followsAndSaves.categoriesConnection.edges.cursor": (v14/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.cursor": (v11/*: any*/),
         "me.followsAndSaves.categoriesConnection.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FollowGene"
         },
-        "me.followsAndSaves.categoriesConnection.edges.node.__typename": (v14/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category": (v15/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.avatar": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.__typename": (v11/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category": (v12/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.avatar": (v13/*: any*/),
         "me.followsAndSaves.categoriesConnection.edges.node.category.avatar.cropped": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.avatar.cropped.src": (v14/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.avatar.cropped.srcSet": (v14/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks": (v17/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.avatar.cropped.src": (v11/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.avatar.cropped.srcSet": (v11/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks": (v14/*: any*/),
         "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges": {
           "enumValues": null,
           "nullable": true,
@@ -836,77 +795,59 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.artists.href": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.artists.id": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.artists.name": (v18/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.artists.href": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.artists.id": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.artists.name": (v15/*: any*/),
         "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.attributionClass.id": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.attributionClass.name": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.collecting_institution": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.cultural_maker": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.date": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.href": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.id": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image": (v16/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image.height": (v20/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image.resized.height": (v20/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image.resized.src": (v14/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image.resized.srcSet": (v14/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image.resized.width": (v20/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.imageTitle": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.internalID": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.is_biddable": (v21/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.is_saved": (v21/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.attributionClass.id": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.attributionClass.name": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.collecting_institution": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.cultural_maker": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.date": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.href": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.id": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image": (v13/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image.height": (v17/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image.src": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.image.width": (v17/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.internalID": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.is_saved": (v18/*: any*/),
         "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkMedium"
         },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.mediumType.filterGene": (v15/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.mediumType.filterGene.id": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.mediumType.filterGene.name": (v18/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.mediumType.filterGene": (v12/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.mediumType.filterGene.id": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.mediumType.filterGene.name": (v15/*: any*/),
         "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.partner.href": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.partner.id": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.partner.name": (v18/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.partner.href": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.partner.id": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.partner.name": (v15/*: any*/),
         "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v20/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.display_timely_at": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.endAt": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.extendedBiddingIntervalMinutes": (v20/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.id": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.is_auction": (v21/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.is_closed": (v21/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.is_preview": (v21/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.startAt": (v18/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v17/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.endAt": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.extendedBiddingIntervalMinutes": (v17/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.id": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.is_auction": (v18/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.is_closed": (v18/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale.startAt": (v15/*: any*/),
         "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -919,66 +860,66 @@ return {
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.counts.bidder_positions": (v22/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.endAt": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.extendedBiddingEndAt": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.formattedEndDateTime": (v18/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.counts.bidder_positions": (v19/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.endAt": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.extendedBiddingEndAt": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.formattedEndDateTime": (v15/*: any*/),
         "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.highest_bid.display": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.id": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.lotID": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.lotLabel": (v18/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.highest_bid.display": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.id": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.lotID": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.lotLabel": (v15/*: any*/),
         "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.opening_bid.display": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_message": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.slug": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.title": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.id": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworksConnection": (v17/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_artwork.opening_bid.display": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.sale_message": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.slug": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.edges.node.title": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworks.id": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworksConnection": (v14/*: any*/),
         "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworksConnection.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworksConnection.counts.total": (v22/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworksConnection.id": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.href": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.id": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.internalID": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.category.name": (v18/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.id": (v19/*: any*/),
-        "me.followsAndSaves.categoriesConnection.edges.node.internalID": (v19/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworksConnection.counts.total": (v19/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.filterArtworksConnection.id": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.href": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.id": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.internalID": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.category.name": (v15/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.id": (v16/*: any*/),
+        "me.followsAndSaves.categoriesConnection.edges.node.internalID": (v16/*: any*/),
         "me.followsAndSaves.categoriesConnection.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "me.followsAndSaves.categoriesConnection.pageInfo.endCursor": (v18/*: any*/),
+        "me.followsAndSaves.categoriesConnection.pageInfo.endCursor": (v15/*: any*/),
         "me.followsAndSaves.categoriesConnection.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "me.followsAndSaves.categoriesConnection.totalCount": (v20/*: any*/),
-        "me.id": (v19/*: any*/)
+        "me.followsAndSaves.categoriesConnection.totalCount": (v17/*: any*/),
+        "me.id": (v16/*: any*/)
       }
     },
     "name": "SettingsSavesCategories_test_Query",
     "operationKind": "query",
-    "text": "query SettingsSavesCategories_test_Query(\n  $after: String\n) {\n  me {\n    ...SettingsSavesCategories_me_WGPvJ\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CategoryRail_category on Gene {\n  ...EntityHeaderGene_gene\n  name\n  href\n  filterArtworks: filterArtworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderGene_gene on Gene {\n  internalID\n  href\n  name\n  avatar: image {\n    cropped(width: 45, height: 45, version: [\"big_and_tall\", \"tall\"]) {\n      src\n      srcSet\n    }\n  }\n  filterArtworksConnection(first: 1) {\n    counts {\n      total\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SettingsSavesCategories_me_WGPvJ on Me {\n  followsAndSaves {\n    categoriesConnection: genesConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          category: gene {\n            internalID\n            ...CategoryRail_category\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query SettingsSavesCategories_test_Query(\n  $after: String\n) {\n  me {\n    ...SettingsSavesCategories_me_WGPvJ\n    id\n  }\n}\n\nfragment CategoryRail_category on Gene {\n  ...EntityHeaderGene_gene\n  name\n  href\n  filterArtworks: filterArtworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderGene_gene on Gene {\n  internalID\n  href\n  name\n  avatar: image {\n    cropped(width: 45, height: 45, version: [\"big_and_tall\", \"tall\"]) {\n      src\n      srcSet\n    }\n  }\n  filterArtworksConnection(first: 1) {\n    counts {\n      total\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SettingsSavesCategories_me_WGPvJ on Me {\n  followsAndSaves {\n    categoriesConnection: genesConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          category: gene {\n            internalID\n            ...CategoryRail_category\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ShelfArtworkStoryQuery.graphql.ts
+++ b/src/__generated__/ShelfArtworkStoryQuery.graphql.ts
@@ -1,0 +1,434 @@
+/**
+ * @generated SignedSource<<ec254818fd7af95fe3edd194c3c51e57>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ShelfArtworkStoryQuery$variables = {
+  id: string;
+};
+export type ShelfArtworkStoryQuery$data = {
+  readonly artwork: {
+    readonly " $fragmentSpreads": FragmentRefs<"ShelfArtwork_artwork">;
+  } | null;
+};
+export type ShelfArtworkStoryQuery = {
+  response: ShelfArtworkStoryQuery$data;
+  variables: ShelfArtworkStoryQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v8 = [
+  (v5/*: any*/),
+  (v4/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ShelfArtworkStoryQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ShelfArtwork_artwork"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ShelfArtworkStoryQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "date",
+            "storageKey": null
+          },
+          {
+            "alias": "sale_message",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "saleMessage",
+            "storageKey": null
+          },
+          {
+            "alias": "cultural_maker",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "culturalMaker",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v3/*: any*/),
+            "concreteType": "Artist",
+            "kind": "LinkedField",
+            "name": "artists",
+            "plural": true,
+            "selections": [
+              (v4/*: any*/),
+              (v2/*: any*/),
+              (v5/*: any*/)
+            ],
+            "storageKey": "artists(shallow:true)"
+          },
+          {
+            "alias": "collecting_institution",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "collectingInstitution",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v3/*: any*/),
+            "concreteType": "Partner",
+            "kind": "LinkedField",
+            "name": "partner",
+            "plural": false,
+            "selections": [
+              (v5/*: any*/),
+              (v2/*: any*/),
+              (v4/*: any*/)
+            ],
+            "storageKey": "partner(shallow:true)"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Sale",
+            "kind": "LinkedField",
+            "name": "sale",
+            "plural": false,
+            "selections": [
+              (v6/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cascadingEndTimeIntervalMinutes",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "extendedBiddingIntervalMinutes",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "startAt",
+                "storageKey": null
+              },
+              {
+                "alias": "is_auction",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isAuction",
+                "storageKey": null
+              },
+              {
+                "alias": "is_closed",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isClosed",
+                "storageKey": null
+              },
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": "sale_artwork",
+            "args": null,
+            "concreteType": "SaleArtwork",
+            "kind": "LinkedField",
+            "name": "saleArtwork",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "lotID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "lotLabel",
+                "storageKey": null
+              },
+              (v6/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "extendedBiddingEndAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "formattedEndDateTime",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "SaleArtworkCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": "bidder_positions",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "bidderPositions",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": "highest_bid",
+                "args": null,
+                "concreteType": "SaleArtworkHighestBid",
+                "kind": "LinkedField",
+                "name": "highestBid",
+                "plural": false,
+                "selections": (v7/*: any*/),
+                "storageKey": null
+              },
+              {
+                "alias": "opening_bid",
+                "args": null,
+                "concreteType": "SaleArtworkOpeningBid",
+                "kind": "LinkedField",
+                "name": "openingBid",
+                "plural": false,
+                "selections": (v7/*: any*/),
+                "storageKey": null
+              },
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": "is_saved",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isSaved",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "kind": "LinkedField",
+            "name": "attributionClass",
+            "plural": false,
+            "selections": (v8/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkMedium",
+            "kind": "LinkedField",
+            "name": "mediumType",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Gene",
+                "kind": "LinkedField",
+                "name": "filterGene",
+                "plural": false,
+                "selections": (v8/*: any*/),
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": "src",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": [
+                      "normalized",
+                      "larger",
+                      "large"
+                    ]
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "width",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "height",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "977be8dc13765d78929da3637b4facaf",
+    "id": null,
+    "metadata": {},
+    "name": "ShelfArtworkStoryQuery",
+    "operationKind": "query",
+    "text": "query ShelfArtworkStoryQuery(\n  $id: String!\n) {\n  artwork(id: $id) {\n    ...ShelfArtwork_artwork\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "2b561c42fea1a2bd72e8a250c35ad803";
+
+export default node;

--- a/src/__generated__/ShelfArtwork_artwork.graphql.ts
+++ b/src/__generated__/ShelfArtwork_artwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cab57ea7d26a46fa8b7e22af5aa68d1a>>
+ * @generated SignedSource<<7e00bd8bc5b9f363e842334ac8af12fe>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,18 +13,12 @@ import { FragmentRefs } from "relay-runtime";
 export type ShelfArtwork_artwork$data = {
   readonly href: string | null;
   readonly image: {
-    readonly aspectRatio: number;
     readonly height: number | null;
-    readonly resized: {
-      readonly height: number | null;
-      readonly src: string;
-      readonly srcSet: string;
-      readonly width: number | null;
-    } | null;
+    readonly src: string | null;
+    readonly width: number | null;
   } | null;
-  readonly imageTitle: string | null;
   readonly title: string | null;
-  readonly " $fragmentSpreads": FragmentRefs<"Badge_artwork" | "Metadata_artwork" | "SaveButton_artwork">;
+  readonly " $fragmentSpreads": FragmentRefs<"Metadata_artwork" | "SaveButton_artwork">;
   readonly " $fragmentType": "ShelfArtwork_artwork";
 };
 export type ShelfArtwork_artwork$key = {
@@ -32,90 +26,21 @@ export type ShelfArtwork_artwork$key = {
   readonly " $fragmentSpreads": FragmentRefs<"ShelfArtwork_artwork">;
 };
 
-const node: ReaderFragment = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-};
-return {
-  "argumentDefinitions": [
-    {
-      "defaultValue": 200,
-      "kind": "LocalArgument",
-      "name": "width"
-    }
-  ],
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "ShelfArtwork_artwork",
   "selections": [
     {
-      "alias": null,
       "args": null,
-      "concreteType": "Image",
-      "kind": "LinkedField",
-      "name": "image",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": [
-            {
-              "kind": "Variable",
-              "name": "width",
-              "variableName": "width"
-            }
-          ],
-          "concreteType": "ResizedImageUrl",
-          "kind": "LinkedField",
-          "name": "resized",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "src",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "srcSet",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "width",
-              "storageKey": null
-            },
-            (v0/*: any*/)
-          ],
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "aspectRatio",
-          "storageKey": null
-        },
-        (v0/*: any*/)
-      ],
-      "storageKey": null
+      "kind": "FragmentSpread",
+      "name": "Metadata_artwork"
     },
     {
-      "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "imageTitle",
-      "storageKey": null
+      "kind": "FragmentSpread",
+      "name": "SaveButton_artwork"
     },
     {
       "alias": null,
@@ -132,26 +57,52 @@ return {
       "storageKey": null
     },
     {
+      "alias": null,
       "args": null,
-      "kind": "FragmentSpread",
-      "name": "Metadata_artwork"
-    },
-    {
-      "args": null,
-      "kind": "FragmentSpread",
-      "name": "SaveButton_artwork"
-    },
-    {
-      "args": null,
-      "kind": "FragmentSpread",
-      "name": "Badge_artwork"
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": "src",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": [
+                "normalized",
+                "larger",
+                "large"
+              ]
+            }
+          ],
+          "kind": "ScalarField",
+          "name": "url",
+          "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "width",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "height",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
     }
   ],
   "type": "Artwork",
   "abstractKey": null
 };
-})();
 
-(node as any).hash = "d1820313035096f06affbbffddc5b748";
+(node as any).hash = "b21e439bd4b7d6cb70e0113af36b5138";
 
 export default node;

--- a/src/__generated__/SoldRecentlyOnArtsyQuery.graphql.ts
+++ b/src/__generated__/SoldRecentlyOnArtsyQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3f72f912a5a3bbcca2cdf76578f8c755>>
+ * @generated SignedSource<<2f0e30528759989810c388e1bebfc78e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,9 +66,9 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -142,71 +135,7 @@ return {
                     "name": "artwork",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 325
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v0/*: any*/)
-                            ],
-                            "storageKey": "resized(width:325)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v0/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -214,7 +143,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -238,15 +166,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v1/*: any*/),
-                          (v4/*: any*/)
+                          (v2/*: any*/),
+                          (v0/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -259,15 +187,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v1/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v0/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -279,7 +207,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -315,21 +243,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -355,7 +269,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -395,7 +309,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -405,14 +319,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -441,7 +355,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -459,17 +373,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -482,7 +431,7 @@ return {
                     "kind": "LinkedField",
                     "name": "lowEstimate",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -492,7 +441,7 @@ return {
                     "kind": "LinkedField",
                     "name": "highEstimate",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -502,7 +451,7 @@ return {
                     "kind": "LinkedField",
                     "name": "priceRealized",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -517,12 +466,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9cde9a02f6a03cf88d4d4eb8736c39fa",
+    "cacheID": "01a1cc8a9d1ce259ede449bc3f493fc2",
     "id": null,
     "metadata": {},
     "name": "SoldRecentlyOnArtsyQuery",
     "operationKind": "query",
-    "text": "query SoldRecentlyOnArtsyQuery {\n  recentlySoldArtworks {\n    ...SoldRecentlyOnArtsy_recentlySoldArtworks\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment SoldRecentlyOnArtsy_recentlySoldArtworks on RecentlySoldArtworkTypeConnection {\n  edges {\n    node {\n      artwork {\n        ...ShelfArtwork_artwork_20bRBg\n        slug\n        href\n        internalID\n        id\n      }\n      lowEstimate {\n        display\n      }\n      highEstimate {\n        display\n      }\n      priceRealized {\n        display\n      }\n    }\n  }\n}\n"
+    "text": "query SoldRecentlyOnArtsyQuery {\n  recentlySoldArtworks {\n    ...SoldRecentlyOnArtsy_recentlySoldArtworks\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n\nfragment SoldRecentlyOnArtsy_recentlySoldArtworks on RecentlySoldArtworkTypeConnection {\n  edges {\n    node {\n      artwork {\n        ...ShelfArtwork_artwork\n        slug\n        href\n        internalID\n        id\n      }\n      lowEstimate {\n        display\n      }\n      highEstimate {\n        display\n      }\n      priceRealized {\n        display\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SoldRecentlyOnArtsy_recentlySoldArtworks.graphql.ts
+++ b/src/__generated__/SoldRecentlyOnArtsy_recentlySoldArtworks.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9982fdc2365737fe7b2a9aa25ec3c83e>>
+ * @generated SignedSource<<9b2db065de6b67c9e01f65a53f3dbab6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -78,13 +78,7 @@ return {
               "plural": false,
               "selections": [
                 {
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 325
-                    }
-                  ],
+                  "args": null,
                   "kind": "FragmentSpread",
                   "name": "ShelfArtwork_artwork"
                 },
@@ -154,6 +148,6 @@ return {
 };
 })();
 
-(node as any).hash = "3383851e54e381c51407feb8f1525d5c";
+(node as any).hash = "f60bd979112cbf02e6fb9bd4d4a32eb8";
 
 export default node;

--- a/src/__generated__/SoldRecentlyOnArtsy_tests_Query.graphql.ts
+++ b/src/__generated__/SoldRecentlyOnArtsy_tests_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2fc694bb207d3335436bdc0c1b1163ee>>
+ * @generated SignedSource<<2b0147c8e05b836536dd3e6d1268d50e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,41 +66,35 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ],
-v8 = {
+v7 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v9 = {
+v8 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v10 = {
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v11 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v12 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v13 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -178,71 +165,7 @@ return {
                     "name": "artwork",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 325
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v0/*: any*/)
-                            ],
-                            "storageKey": "resized(width:325)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v0/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -250,7 +173,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -274,15 +196,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v1/*: any*/),
-                          (v4/*: any*/)
+                          (v2/*: any*/),
+                          (v0/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -295,15 +217,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v1/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v0/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -315,7 +237,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -351,21 +273,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -391,7 +299,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -431,7 +339,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -441,14 +349,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -477,7 +385,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -495,17 +403,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -518,7 +461,7 @@ return {
                     "kind": "LinkedField",
                     "name": "lowEstimate",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -528,7 +471,7 @@ return {
                     "kind": "LinkedField",
                     "name": "highEstimate",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -538,7 +481,7 @@ return {
                     "kind": "LinkedField",
                     "name": "priceRealized",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -553,7 +496,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "61a6bda5f9cc58308453ea3c7c0f2dec",
+    "cacheID": "0e53d12bf7bafe926f18b27aac3d750b",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -587,49 +530,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "recentlySoldArtworks.edges.node.artwork.artists.href": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.artists.id": (v9/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.artists.name": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.artists.href": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.artists.id": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.artists.name": (v7/*: any*/),
         "recentlySoldArtworks.edges.node.artwork.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "recentlySoldArtworks.edges.node.artwork.attributionClass.id": (v9/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.attributionClass.name": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.collecting_institution": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.cultural_maker": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.date": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.href": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.id": (v9/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.attributionClass.id": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.attributionClass.name": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.collecting_institution": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.cultural_maker": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.date": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.href": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.id": (v8/*: any*/),
         "recentlySoldArtworks.edges.node.artwork.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "recentlySoldArtworks.edges.node.artwork.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "recentlySoldArtworks.edges.node.artwork.image.height": (v10/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "recentlySoldArtworks.edges.node.artwork.image.resized.height": (v10/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.image.resized.src": (v11/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.image.resized.srcSet": (v11/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.image.resized.width": (v10/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.imageTitle": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.internalID": (v9/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.is_biddable": (v12/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.is_saved": (v12/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.image.height": (v9/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.image.src": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.image.width": (v9/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.internalID": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.is_saved": (v10/*: any*/),
         "recentlySoldArtworks.edges.node.artwork.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -642,32 +569,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "recentlySoldArtworks.edges.node.artwork.mediumType.filterGene.id": (v9/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.mediumType.filterGene.name": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.mediumType.filterGene.id": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.mediumType.filterGene.name": (v7/*: any*/),
         "recentlySoldArtworks.edges.node.artwork.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "recentlySoldArtworks.edges.node.artwork.partner.href": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.partner.id": (v9/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.partner.name": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.partner.href": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.partner.id": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.partner.name": (v7/*: any*/),
         "recentlySoldArtworks.edges.node.artwork.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "recentlySoldArtworks.edges.node.artwork.sale.cascadingEndTimeIntervalMinutes": (v10/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale.display_timely_at": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale.endAt": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale.extendedBiddingIntervalMinutes": (v10/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale.id": (v9/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale.is_auction": (v12/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale.is_closed": (v12/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale.is_preview": (v12/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale.startAt": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale.cascadingEndTimeIntervalMinutes": (v9/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale.endAt": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale.extendedBiddingIntervalMinutes": (v9/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale.id": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale.is_auction": (v10/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale.is_closed": (v10/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale.startAt": (v7/*: any*/),
         "recentlySoldArtworks.edges.node.artwork.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -686,40 +611,40 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "recentlySoldArtworks.edges.node.artwork.sale_artwork.endAt": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale_artwork.extendedBiddingEndAt": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale_artwork.formattedEndDateTime": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale_artwork.endAt": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale_artwork.extendedBiddingEndAt": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale_artwork.formattedEndDateTime": (v7/*: any*/),
         "recentlySoldArtworks.edges.node.artwork.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "recentlySoldArtworks.edges.node.artwork.sale_artwork.highest_bid.display": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale_artwork.id": (v9/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale_artwork.lotID": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale_artwork.lotLabel": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale_artwork.highest_bid.display": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale_artwork.id": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale_artwork.lotID": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale_artwork.lotLabel": (v7/*: any*/),
         "recentlySoldArtworks.edges.node.artwork.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "recentlySoldArtworks.edges.node.artwork.sale_artwork.opening_bid.display": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.sale_message": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.slug": (v9/*: any*/),
-        "recentlySoldArtworks.edges.node.artwork.title": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.highEstimate": (v13/*: any*/),
-        "recentlySoldArtworks.edges.node.highEstimate.display": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.lowEstimate": (v13/*: any*/),
-        "recentlySoldArtworks.edges.node.lowEstimate.display": (v8/*: any*/),
-        "recentlySoldArtworks.edges.node.priceRealized": (v13/*: any*/),
-        "recentlySoldArtworks.edges.node.priceRealized.display": (v8/*: any*/)
+        "recentlySoldArtworks.edges.node.artwork.sale_artwork.opening_bid.display": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.sale_message": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.slug": (v8/*: any*/),
+        "recentlySoldArtworks.edges.node.artwork.title": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.highEstimate": (v11/*: any*/),
+        "recentlySoldArtworks.edges.node.highEstimate.display": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.lowEstimate": (v11/*: any*/),
+        "recentlySoldArtworks.edges.node.lowEstimate.display": (v7/*: any*/),
+        "recentlySoldArtworks.edges.node.priceRealized": (v11/*: any*/),
+        "recentlySoldArtworks.edges.node.priceRealized.display": (v7/*: any*/)
       }
     },
     "name": "SoldRecentlyOnArtsy_tests_Query",
     "operationKind": "query",
-    "text": "query SoldRecentlyOnArtsy_tests_Query {\n  recentlySoldArtworks {\n    ...SoldRecentlyOnArtsy_recentlySoldArtworks\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment SoldRecentlyOnArtsy_recentlySoldArtworks on RecentlySoldArtworkTypeConnection {\n  edges {\n    node {\n      artwork {\n        ...ShelfArtwork_artwork_20bRBg\n        slug\n        href\n        internalID\n        id\n      }\n      lowEstimate {\n        display\n      }\n      highEstimate {\n        display\n      }\n      priceRealized {\n        display\n      }\n    }\n  }\n}\n"
+    "text": "query SoldRecentlyOnArtsy_tests_Query {\n  recentlySoldArtworks {\n    ...SoldRecentlyOnArtsy_recentlySoldArtworks\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n\nfragment SoldRecentlyOnArtsy_recentlySoldArtworks on RecentlySoldArtworkTypeConnection {\n  edges {\n    node {\n      artwork {\n        ...ShelfArtwork_artwork\n        slug\n        href\n        internalID\n        id\n      }\n      lowEstimate {\n        display\n      }\n      highEstimate {\n        display\n      }\n      priceRealized {\n        display\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/StandoutLotsRail_Test_Query.graphql.ts
+++ b/src/__generated__/StandoutLotsRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<870a706105df2a92a3befd06895d4002>>
+ * @generated SignedSource<<47ff95450b8d542df1c00156768f3d22>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,35 +66,29 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ],
-v8 = {
+v7 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v9 = {
+v8 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v10 = {
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v11 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v12 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -204,71 +191,7 @@ return {
                         "name": "slug",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 325
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v0/*: any*/)
-                            ],
-                            "storageKey": "resized(width:325)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v0/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -276,7 +199,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -300,15 +222,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v1/*: any*/),
-                          (v4/*: any*/)
+                          (v2/*: any*/),
+                          (v0/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -321,15 +243,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v1/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v0/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -341,7 +263,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -377,21 +299,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -417,7 +325,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -457,7 +365,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -467,14 +375,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -489,7 +397,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -507,17 +415,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -526,7 +469,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "storageKey": "artworksConnection(first:50,forSale:true,geneIDs:[\"our-top-auction-lots\"])"
           }
@@ -536,7 +479,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9bbb476253dd12c5dc352b8266bd11a0",
+    "cacheID": "3e5e63176ac920d5e9998ba7eb22b23e",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -570,49 +513,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "viewer.standoutLotsRailConnection.edges.node.artists.href": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.artists.id": (v9/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.artists.name": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.artists.href": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.artists.id": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.artists.name": (v7/*: any*/),
         "viewer.standoutLotsRailConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "viewer.standoutLotsRailConnection.edges.node.attributionClass.id": (v9/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.attributionClass.name": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.collecting_institution": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.cultural_maker": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.date": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.href": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.id": (v9/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.attributionClass.id": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.attributionClass.name": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.collecting_institution": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.cultural_maker": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.date": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.href": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.id": (v8/*: any*/),
         "viewer.standoutLotsRailConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "viewer.standoutLotsRailConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "viewer.standoutLotsRailConnection.edges.node.image.height": (v10/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.height": (v10/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.src": (v11/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.srcSet": (v11/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.image.resized.width": (v10/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.imageTitle": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.internalID": (v9/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.is_biddable": (v12/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.is_saved": (v12/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.image.height": (v9/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.image.src": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.image.width": (v9/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.internalID": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.is_saved": (v10/*: any*/),
         "viewer.standoutLotsRailConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -625,32 +552,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.id": (v9/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.name": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.id": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.mediumType.filterGene.name": (v7/*: any*/),
         "viewer.standoutLotsRailConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewer.standoutLotsRailConnection.edges.node.partner.href": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.partner.id": (v9/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.partner.name": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.partner.href": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.partner.id": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.partner.name": (v7/*: any*/),
         "viewer.standoutLotsRailConnection.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "viewer.standoutLotsRailConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v10/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.display_timely_at": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.endAt": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v10/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.id": (v9/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.is_auction": (v12/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.is_closed": (v12/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.is_preview": (v12/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale.startAt": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v9/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.endAt": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v9/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.id": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.is_auction": (v10/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.is_closed": (v10/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale.startAt": (v7/*: any*/),
         "viewer.standoutLotsRailConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -669,35 +594,35 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.endAt": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.formattedEndDateTime": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.endAt": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.formattedEndDateTime": (v7/*: any*/),
         "viewer.standoutLotsRailConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.highest_bid.display": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.id": (v9/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotID": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotLabel": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.highest_bid.display": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.id": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotID": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.lotLabel": (v7/*: any*/),
         "viewer.standoutLotsRailConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.opening_bid.display": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.sale_message": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.slug": (v9/*: any*/),
-        "viewer.standoutLotsRailConnection.edges.node.title": (v8/*: any*/),
-        "viewer.standoutLotsRailConnection.id": (v9/*: any*/)
+        "viewer.standoutLotsRailConnection.edges.node.sale_artwork.opening_bid.display": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.sale_message": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.slug": (v8/*: any*/),
+        "viewer.standoutLotsRailConnection.edges.node.title": (v7/*: any*/),
+        "viewer.standoutLotsRailConnection.id": (v8/*: any*/)
       }
     },
     "name": "StandoutLotsRail_Test_Query",
     "operationKind": "query",
-    "text": "query StandoutLotsRail_Test_Query {\n  viewer {\n    ...StandoutLotsRail_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment StandoutLotsRail_viewer on Viewer {\n  standoutLotsRailConnection: artworksConnection(forSale: true, first: 50, geneIDs: [\"our-top-auction-lots\"]) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query StandoutLotsRail_Test_Query {\n  viewer {\n    ...StandoutLotsRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n\nfragment StandoutLotsRail_viewer on Viewer {\n  standoutLotsRailConnection: artworksConnection(forSale: true, first: 50, geneIDs: [\"our-top-auction-lots\"]) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/StandoutLotsRail_viewer.graphql.ts
+++ b/src/__generated__/StandoutLotsRail_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<addf4630fd0e95f6eb1bf549dc4bd418>>
+ * @generated SignedSource<<89b0f6af07b3b50105a769703e18d6cf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -90,13 +90,7 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 325
-                    }
-                  ],
+                  "args": null,
                   "kind": "FragmentSpread",
                   "name": "ShelfArtwork_artwork"
                 }
@@ -114,6 +108,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "627efa328f2de06e4cccd9b7720b4980";
+(node as any).hash = "d8606d7cde2352137b087dc03c069e4a";
 
 export default node;

--- a/src/__generated__/TrendingLotsRail_Test_Query.graphql.ts
+++ b/src/__generated__/TrendingLotsRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c3ece8c33f535ae87a95aa46b1ce6677>>
+ * @generated SignedSource<<8cb8f5f2a0794af93bb60ff1ab1c0f63>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -40,31 +40,24 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v4 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,47 +66,41 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v5/*: any*/),
+v6 = [
+  (v4/*: any*/),
   (v0/*: any*/)
 ],
-v8 = {
+v7 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtworkCounts"
 },
-v9 = {
+v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v10 = {
+v9 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v11 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v12 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v13 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v14 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -288,89 +275,11 @@ return {
                             "kind": "ScalarField",
                             "name": "isClosed",
                             "storageKey": null
-                          },
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 325
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v2/*: any*/)
-                            ],
-                            "storageKey": "resized(width:325)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v2/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -378,7 +287,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -402,15 +310,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v4/*: any*/),
+                        "args": (v3/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
                           (v0/*: any*/),
-                          (v3/*: any*/),
-                          (v5/*: any*/)
+                          (v2/*: any*/),
+                          (v4/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -423,14 +331,14 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v4/*: any*/),
+                        "args": (v3/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
-                          (v3/*: any*/),
+                          (v4/*: any*/),
+                          (v2/*: any*/),
                           (v0/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
@@ -497,7 +405,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -507,7 +415,7 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           (v0/*: any*/)
@@ -529,7 +437,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -547,17 +455,52 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -576,7 +519,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "aa38b2e17fa7b9acd172cdfbc7fd198f",
+    "cacheID": "ee48a24e6a3ebbd99b40a01164b61f4a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -598,9 +541,9 @@ return {
           "plural": true,
           "type": "SaleArtwork"
         },
-        "viewer.trendingLotsConnection.edges.counts": (v8/*: any*/),
-        "viewer.trendingLotsConnection.edges.counts.bidderPositions": (v9/*: any*/),
-        "viewer.trendingLotsConnection.edges.id": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.counts": (v7/*: any*/),
+        "viewer.trendingLotsConnection.edges.counts.bidderPositions": (v8/*: any*/),
+        "viewer.trendingLotsConnection.edges.id": (v9/*: any*/),
         "viewer.trendingLotsConnection.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -613,49 +556,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "viewer.trendingLotsConnection.edges.node.artists.href": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.artists.id": (v10/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.artists.name": (v11/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.artists.href": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.artists.id": (v9/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.artists.name": (v10/*: any*/),
         "viewer.trendingLotsConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "viewer.trendingLotsConnection.edges.node.attributionClass.id": (v10/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.attributionClass.name": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.collecting_institution": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.cultural_maker": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.date": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.href": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.id": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.attributionClass.id": (v9/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.attributionClass.name": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.collecting_institution": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.cultural_maker": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.date": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.href": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.id": (v9/*: any*/),
         "viewer.trendingLotsConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "viewer.trendingLotsConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "viewer.trendingLotsConnection.edges.node.image.height": (v12/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "viewer.trendingLotsConnection.edges.node.image.resized.height": (v12/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized.src": (v13/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized.srcSet": (v13/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.image.resized.width": (v12/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.imageTitle": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.internalID": (v10/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.is_biddable": (v14/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.is_saved": (v14/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.image.height": (v11/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.image.src": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.image.width": (v11/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.internalID": (v9/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.is_saved": (v12/*: any*/),
         "viewer.trendingLotsConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -668,69 +595,67 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.id": (v10/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.name": (v11/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.id": (v9/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.mediumType.filterGene.name": (v10/*: any*/),
         "viewer.trendingLotsConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewer.trendingLotsConnection.edges.node.partner.href": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.partner.id": (v10/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.partner.name": (v11/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.partner.href": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.partner.id": (v9/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.partner.name": (v10/*: any*/),
         "viewer.trendingLotsConnection.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "viewer.trendingLotsConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v12/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.display_timely_at": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.endAt": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v12/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.id": (v10/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.isClosed": (v14/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.is_auction": (v14/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.is_closed": (v14/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.is_preview": (v14/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale.startAt": (v11/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v11/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.endAt": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v11/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.id": (v9/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.isClosed": (v12/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.is_auction": (v12/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.is_closed": (v12/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale.startAt": (v10/*: any*/),
         "viewer.trendingLotsConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtwork"
         },
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts": (v8/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts.bidder_positions": (v9/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.endAt": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.formattedEndDateTime": (v11/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts": (v7/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.counts.bidder_positions": (v8/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.endAt": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.formattedEndDateTime": (v10/*: any*/),
         "viewer.trendingLotsConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.highest_bid.display": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.id": (v10/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotID": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotLabel": (v11/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.highest_bid.display": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.id": (v9/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotID": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.lotLabel": (v10/*: any*/),
         "viewer.trendingLotsConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "viewer.trendingLotsConnection.edges.node.sale_artwork.opening_bid.display": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.sale_message": (v11/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.slug": (v10/*: any*/),
-        "viewer.trendingLotsConnection.edges.node.title": (v11/*: any*/)
+        "viewer.trendingLotsConnection.edges.node.sale_artwork.opening_bid.display": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.sale_message": (v10/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.slug": (v9/*: any*/),
+        "viewer.trendingLotsConnection.edges.node.title": (v10/*: any*/)
       }
     },
     "name": "TrendingLotsRail_Test_Query",
     "operationKind": "query",
-    "text": "query TrendingLotsRail_Test_Query {\n  viewer {\n    ...TrendingLotsRail_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment TrendingLotsRail_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(biddableSale: true, first: 10, sort: \"-bidder_positions_count\", estimateRange: \"5_000_00-*\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        sale {\n          isClosed\n          id\n        }\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query TrendingLotsRail_Test_Query {\n  viewer {\n    ...TrendingLotsRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n\nfragment TrendingLotsRail_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(biddableSale: true, first: 10, sort: \"-bidder_positions_count\", estimateRange: \"5_000_00-*\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        sale {\n          isClosed\n          id\n        }\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/TrendingLotsRail_viewer.graphql.ts
+++ b/src/__generated__/TrendingLotsRail_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b3000920c0c5d4adfefa33a29415022c>>
+ * @generated SignedSource<<48e06333829deb8c57e75cfd793fb3ec>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -135,13 +135,7 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 325
-                    }
-                  ],
+                  "args": null,
                   "kind": "FragmentSpread",
                   "name": "ShelfArtwork_artwork"
                 }
@@ -159,6 +153,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "2f73e7cdd51767d0f7cd4a0a7a0b7e5a";
+(node as any).hash = "8ecb9ab94e93aafd7c16720ee4fb1920";
 
 export default node;

--- a/src/__generated__/UpcomingAuctionsQuery.graphql.ts
+++ b/src/__generated__/UpcomingAuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<246733552429a7e1cb800ddcbaa5c573>>
+ * @generated SignedSource<<95e44e07025cb3cce3b97127525eec0e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -80,42 +80,28 @@ v7 = {
   "name": "href",
   "storageKey": null
 },
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v10 = [
+v8 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v11 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v12 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v13 = [
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -124,9 +110,16 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = [
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v13 = [
   (v6/*: any*/),
-  (v11/*: any*/)
+  (v9/*: any*/)
 ];
 return {
   "fragment": {
@@ -270,73 +263,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v8/*: any*/),
-                                  (v5/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "src",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "srcSet",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "width",
-                                            "storageKey": null
-                                          },
-                                          (v9/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v9/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
+                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -344,7 +271,6 @@ return {
                                     "name": "title",
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -368,13 +294,13 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v10/*: any*/),
+                                    "args": (v8/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v11/*: any*/),
+                                      (v9/*: any*/),
                                       (v7/*: any*/),
                                       (v6/*: any*/)
                                     ],
@@ -389,7 +315,7 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v10/*: any*/),
+                                    "args": (v8/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
@@ -397,7 +323,7 @@ return {
                                     "selections": [
                                       (v6/*: any*/),
                                       (v7/*: any*/),
-                                      (v11/*: any*/)
+                                      (v9/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -409,7 +335,7 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v12/*: any*/),
+                                      (v10/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -445,21 +371,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v11/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v9/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -485,7 +397,7 @@ return {
                                         "name": "lotLabel",
                                         "storageKey": null
                                       },
-                                      (v12/*: any*/),
+                                      (v10/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -525,7 +437,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v13/*: any*/),
+                                        "selections": (v11/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -535,14 +447,16 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v13/*: any*/),
+                                        "selections": (v11/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v11/*: any*/)
+                                      (v9/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v11/*: any*/),
+                                  (v9/*: any*/),
+                                  (v12/*: any*/),
+                                  (v5/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -557,7 +471,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v14/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -575,17 +489,52 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v14/*: any*/),
+                                        "selections": (v13/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -597,8 +546,8 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v8/*: any*/),
-                      (v11/*: any*/),
+                      (v12/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -665,12 +614,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bb09c993b4a2cbcc218f0ac7669f9e66",
+    "cacheID": "0cccad03e51729d1a9598d4f0351f747",
     "id": null,
     "metadata": {},
     "name": "UpcomingAuctionsQuery",
     "operationKind": "query",
-    "text": "query UpcomingAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...UpcomingAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment UpcomingAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query UpcomingAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...UpcomingAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n\nfragment UpcomingAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/UpcomingAuctions_Test_Query.graphql.ts
+++ b/src/__generated__/UpcomingAuctions_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c754f997f3f6a7fa4ef717efcfaea07e>>
+ * @generated SignedSource<<7d0b0a3cf8c5c8790c8b5a7e654b9fff>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -60,42 +60,28 @@ v3 = {
   "name": "href",
   "storageKey": null
 },
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v6 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v7 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v9 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -104,41 +90,48 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v9 = [
   (v2/*: any*/),
-  (v7/*: any*/)
+  (v5/*: any*/)
 ],
-v11 = {
+v10 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v12 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Sale"
 },
-v13 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v14 = {
+v13 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v15 = {
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v16 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -277,73 +270,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v4/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "src",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "srcSet",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "width",
-                                            "storageKey": null
-                                          },
-                                          (v5/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -351,7 +278,6 @@ return {
                                     "name": "title",
                                     "storageKey": null
                                   },
-                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -375,13 +301,13 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v7/*: any*/),
+                                      (v5/*: any*/),
                                       (v3/*: any*/),
                                       (v2/*: any*/)
                                     ],
@@ -396,7 +322,7 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
@@ -404,7 +330,7 @@ return {
                                     "selections": [
                                       (v2/*: any*/),
                                       (v3/*: any*/),
-                                      (v7/*: any*/)
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -416,7 +342,7 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v8/*: any*/),
+                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -452,21 +378,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v7/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -492,7 +404,7 @@ return {
                                         "name": "lotLabel",
                                         "storageKey": null
                                       },
-                                      (v8/*: any*/),
+                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -532,7 +444,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -542,14 +454,16 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v7/*: any*/)
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/),
+                                  (v5/*: any*/),
+                                  (v8/*: any*/),
+                                  (v1/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -564,7 +478,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v9/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -582,17 +496,52 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v10/*: any*/),
+                                        "selections": (v9/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -604,8 +553,8 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v4/*: any*/),
-                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -672,7 +621,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "323c411acaff1b4e79f535da1e6d785a",
+    "cacheID": "e0b782d8d4b6d3838eca1231e38bb18b",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -694,9 +643,9 @@ return {
           "plural": true,
           "type": "SaleEdge"
         },
-        "viewer.salesConnection.edges.cursor": (v11/*: any*/),
-        "viewer.salesConnection.edges.node": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.__typename": (v11/*: any*/),
+        "viewer.salesConnection.edges.cursor": (v10/*: any*/),
+        "viewer.salesConnection.edges.node": (v11/*: any*/),
+        "viewer.salesConnection.edges.node.__typename": (v10/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection": {
           "enumValues": null,
           "nullable": true,
@@ -721,49 +670,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.name": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.name": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.name": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collecting_institution": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.cultural_maker": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.date": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.id": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.name": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collecting_institution": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.cultural_maker": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.date": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.id": (v13/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.height": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.height": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.src": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.srcSet": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.resized.width": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.imageTitle": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.internalID": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.is_biddable": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.is_saved": (v16/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.height": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.src": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.width": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.internalID": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.is_saved": (v15/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -776,27 +709,25 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.name": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.name": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.name": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.display_timely_at": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.endAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_auction": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_closed": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_preview": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.startAt": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.name": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale": (v11/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.endAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_auction": (v15/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_closed": (v15/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.startAt": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -815,57 +746,57 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.endAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.endAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotID": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotLabel": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotID": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotLabel": (v12/*: any*/),
         "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_message": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.slug": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.title": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.eventStartAt": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.formattedStartDateTime": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.href": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.id": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.internalID": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.isLiveOpen": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.name": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.slug": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.status": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_message": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.slug": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.artworksConnection.edges.node.title": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.eventStartAt": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.formattedStartDateTime": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.href": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.id": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.internalID": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.isLiveOpen": (v15/*: any*/),
+        "viewer.salesConnection.edges.node.name": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.slug": (v13/*: any*/),
+        "viewer.salesConnection.edges.node.status": (v12/*: any*/),
         "viewer.salesConnection.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "viewer.salesConnection.pageInfo.endCursor": (v13/*: any*/),
+        "viewer.salesConnection.pageInfo.endCursor": (v12/*: any*/),
         "viewer.salesConnection.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "viewer.salesConnection.totalCount": (v15/*: any*/)
+        "viewer.salesConnection.totalCount": (v14/*: any*/)
       }
     },
     "name": "UpcomingAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query UpcomingAuctions_Test_Query {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query UpcomingAuctions_Test_Query {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/WorksByArtistsYouFollowRail_Test_Query.graphql.ts
+++ b/src/__generated__/WorksByArtistsYouFollowRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<979a91a2b233c9195d6db365819a8686>>
+ * @generated SignedSource<<ac990e015dd3f703d99a293ff70f5b73>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,45 +26,38 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v2 = [
+v1 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,35 +66,29 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
-  (v3/*: any*/)
+v6 = [
+  (v3/*: any*/),
+  (v2/*: any*/)
 ],
-v8 = {
+v7 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v9 = {
+v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v10 = {
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v11 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v12 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -207,71 +194,7 @@ return {
                         "name": "slug",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 325
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v0/*: any*/)
-                            ],
-                            "storageKey": "resized(width:325)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
+                      (v0/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -279,7 +202,6 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -303,15 +225,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v1/*: any*/),
-                          (v4/*: any*/)
+                          (v2/*: any*/),
+                          (v0/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -324,15 +246,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v2/*: any*/),
+                        "args": (v1/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v1/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v0/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -344,7 +266,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -380,21 +302,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -420,7 +328,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -460,7 +368,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -470,14 +378,14 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v5/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -492,7 +400,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v6/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -510,23 +418,58 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
                       {
-                        "alias": "is_biddable",
+                        "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v3/*: any*/)
+                  (v2/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -539,7 +482,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1707ac55fcb1af6b2224c6ade5534fe4",
+    "cacheID": "4505e4d701011b3c7c0d3107952f4bb1",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -561,7 +504,7 @@ return {
           "plural": true,
           "type": "SaleArtwork"
         },
-        "viewer.saleArtworksConnection.edges.id": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.id": (v7/*: any*/),
         "viewer.saleArtworksConnection.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -574,49 +517,33 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "viewer.saleArtworksConnection.edges.node.artists.href": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.artists.id": (v8/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.artists.name": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists.href": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists.id": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.artists.name": (v8/*: any*/),
         "viewer.saleArtworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "viewer.saleArtworksConnection.edges.node.attributionClass.id": (v8/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.attributionClass.name": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.collecting_institution": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.cultural_maker": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.date": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.href": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.id": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.attributionClass.id": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.attributionClass.name": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.collecting_institution": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.cultural_maker": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.date": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.href": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.id": (v7/*: any*/),
         "viewer.saleArtworksConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "viewer.saleArtworksConnection.edges.node.image.aspectRatio": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Float"
-        },
-        "viewer.saleArtworksConnection.edges.node.image.height": (v10/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ResizedImageUrl"
-        },
-        "viewer.saleArtworksConnection.edges.node.image.resized.height": (v10/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized.src": (v11/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized.srcSet": (v11/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.image.resized.width": (v10/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.imageTitle": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.internalID": (v8/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.is_biddable": (v12/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.is_saved": (v12/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.height": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.src": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.image.width": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.internalID": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.is_saved": (v10/*: any*/),
         "viewer.saleArtworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -629,32 +556,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.id": (v8/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.name": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.id": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.mediumType.filterGene.name": (v8/*: any*/),
         "viewer.saleArtworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewer.saleArtworksConnection.edges.node.partner.href": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.partner.id": (v8/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.partner.name": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.href": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.id": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.partner.name": (v8/*: any*/),
         "viewer.saleArtworksConnection.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "viewer.saleArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v10/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.display_timely_at": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.endAt": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v10/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.id": (v8/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.is_auction": (v12/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.is_closed": (v12/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.is_preview": (v12/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale.startAt": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.endAt": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.id": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.is_auction": (v10/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.is_closed": (v10/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale.startAt": (v8/*: any*/),
         "viewer.saleArtworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -673,34 +598,34 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.endAt": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.endAt": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v8/*: any*/),
         "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.id": (v8/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotID": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotLabel": (v9/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.id": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotID": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.lotLabel": (v8/*: any*/),
         "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.sale_message": (v9/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.slug": (v8/*: any*/),
-        "viewer.saleArtworksConnection.edges.node.title": (v9/*: any*/)
+        "viewer.saleArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.sale_message": (v8/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.slug": (v7/*: any*/),
+        "viewer.saleArtworksConnection.edges.node.title": (v8/*: any*/)
       }
     },
     "name": "WorksByArtistsYouFollowRail_Test_Query",
     "operationKind": "query",
-    "text": "query WorksByArtistsYouFollowRail_Test_Query {\n  viewer {\n    ...WorksByArtistsYouFollowRail_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query WorksByArtistsYouFollowRail_Test_Query {\n  viewer {\n    ...WorksByArtistsYouFollowRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/WorksByArtistsYouFollowRail_viewer.graphql.ts
+++ b/src/__generated__/WorksByArtistsYouFollowRail_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3ede7caa35be4ab78905462e56023d8b>>
+ * @generated SignedSource<<bcd14af8fb3d9c127080914b03e02846>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -93,13 +93,7 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "width",
-                      "value": 325
-                    }
-                  ],
+                  "args": null,
                   "kind": "FragmentSpread",
                   "name": "ShelfArtwork_artwork"
                 }
@@ -117,6 +111,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "d057c41c30771c499be6e4c23e3e3c38";
+(node as any).hash = "eb7e8e8e4eca5480745363a7175fa074";
 
 export default node;

--- a/src/__generated__/artistRoutes_ArtistConsignQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_ArtistConsignQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a4e896d7263a06db7fc671186150a67f>>
+ * @generated SignedSource<<74fc30e163680d8ec1a4489d43609446>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -80,38 +80,24 @@ v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v10 = [
+v8 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v11 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v10 = [
   {
     "alias": null,
     "args": null,
@@ -120,9 +106,9 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v11 = [
   (v3/*: any*/),
-  (v9/*: any*/)
+  (v7/*: any*/)
 ];
 return {
   "fragment": {
@@ -261,8 +247,20 @@ return {
                                     "selections": [
                                       (v5/*: any*/),
                                       (v6/*: any*/),
-                                      (v7/*: any*/),
-                                      (v8/*: any*/)
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "src",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "srcSet",
+                                        "storageKey": null
+                                      }
                                     ],
                                     "storageKey": "cropped(height:300,width:300)"
                                   },
@@ -287,31 +285,28 @@ return {
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": null,
+                                    "alias": "src",
                                     "args": [
                                       {
                                         "kind": "Literal",
-                                        "name": "width",
-                                        "value": 200
+                                        "name": "version",
+                                        "value": [
+                                          "normalized",
+                                          "larger",
+                                          "large"
+                                        ]
                                       }
                                     ],
-                                    "concreteType": "ResizedImageUrl",
-                                    "kind": "LinkedField",
-                                    "name": "resized",
-                                    "plural": false,
-                                    "selections": [
-                                      (v7/*: any*/),
-                                      (v8/*: any*/),
-                                      (v5/*: any*/),
-                                      (v6/*: any*/)
-                                    ],
-                                    "storageKey": "resized(width:200)"
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
                                   },
+                                  (v5/*: any*/),
                                   (v6/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v9/*: any*/),
+                              (v7/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -357,13 +352,13 @@ return {
                               },
                               {
                                 "alias": null,
-                                "args": (v10/*: any*/),
+                                "args": (v8/*: any*/),
                                 "concreteType": "Artist",
                                 "kind": "LinkedField",
                                 "name": "artists",
                                 "plural": true,
                                 "selections": [
-                                  (v9/*: any*/),
+                                  (v7/*: any*/),
                                   (v4/*: any*/),
                                   (v3/*: any*/)
                                 ],
@@ -378,7 +373,7 @@ return {
                               },
                               {
                                 "alias": null,
-                                "args": (v10/*: any*/),
+                                "args": (v8/*: any*/),
                                 "concreteType": "Partner",
                                 "kind": "LinkedField",
                                 "name": "partner",
@@ -386,7 +381,7 @@ return {
                                 "selections": [
                                   (v3/*: any*/),
                                   (v4/*: any*/),
-                                  (v9/*: any*/)
+                                  (v7/*: any*/)
                                 ],
                                 "storageKey": "partner(shallow:true)"
                               },
@@ -398,7 +393,7 @@ return {
                                 "name": "sale",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
+                                  (v9/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -434,7 +429,7 @@ return {
                                     "name": "isClosed",
                                     "storageKey": null
                                   },
-                                  (v9/*: any*/),
+                                  (v7/*: any*/),
                                   {
                                     "alias": "is_preview",
                                     "args": null,
@@ -474,7 +469,7 @@ return {
                                     "name": "lotLabel",
                                     "storageKey": null
                                   },
-                                  (v11/*: any*/),
+                                  (v9/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -514,7 +509,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "highestBid",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v10/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -524,10 +519,10 @@ return {
                                     "kind": "LinkedField",
                                     "name": "openingBid",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v10/*: any*/),
                                     "storageKey": null
                                   },
-                                  (v9/*: any*/)
+                                  (v7/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -552,7 +547,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "attributionClass",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v11/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -570,7 +565,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "filterGene",
                                     "plural": false,
-                                    "selections": (v13/*: any*/),
+                                    "selections": (v11/*: any*/),
                                     "storageKey": null
                                   }
                                 ],
@@ -652,19 +647,19 @@ return {
             ],
             "storageKey": null
           },
-          (v9/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "bc6a57eef70e16f7050089498e8f6098",
+    "cacheID": "c26a504844f251a6d28377259673f0d7",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_ArtistConsignQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_ArtistConsignQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistConsignRoute_artist\n    targetSupply {\n      isInMicrofunnel\n    }\n    id\n  }\n}\n\nfragment ArtistConsignFAQ_artist on Artist {\n  href\n}\n\nfragment ArtistConsignHeader_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              cropped(width: 300, height: 300) {\n                width\n                height\n                src\n                srcSet\n              }\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignHowToSell_artist on Artist {\n  href\n}\n\nfragment ArtistConsignMarketTrends_artist on Artist {\n  href\n  targetSupply {\n    microfunnel {\n      metadata {\n        highestRealized\n        str\n        realized\n      }\n    }\n  }\n}\n\nfragment ArtistConsignMeta_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              imageURL: url(version: \"medium\")\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignPageViews_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      metadata {\n        roundedViews\n        roundedUniqueVisitors\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRecentlySold_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            ...FillwidthItem_artwork\n            ...ShelfArtwork_artwork\n            internalID\n            realizedPrice\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRoute_artist on Artist {\n  ...ArtistConsignMeta_artist\n  ...ArtistConsignHeader_artist\n  ...ArtistConsignRecentlySold_artist\n  ...ArtistConsignPageViews_artist\n  ...ArtistConsignMarketTrends_artist\n  ...ArtistConsignHowToSell_artist\n  ...ArtistConsignFAQ_artist\n  ...ArtistConsignSellArt_artist\n}\n\nfragment ArtistConsignSellArt_artist on Artist {\n  href\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query artistRoutes_ArtistConsignQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistConsignRoute_artist\n    targetSupply {\n      isInMicrofunnel\n    }\n    id\n  }\n}\n\nfragment ArtistConsignFAQ_artist on Artist {\n  href\n}\n\nfragment ArtistConsignHeader_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              cropped(width: 300, height: 300) {\n                width\n                height\n                src\n                srcSet\n              }\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignHowToSell_artist on Artist {\n  href\n}\n\nfragment ArtistConsignMarketTrends_artist on Artist {\n  href\n  targetSupply {\n    microfunnel {\n      metadata {\n        highestRealized\n        str\n        realized\n      }\n    }\n  }\n}\n\nfragment ArtistConsignMeta_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              imageURL: url(version: \"medium\")\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignPageViews_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      metadata {\n        roundedViews\n        roundedUniqueVisitors\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRecentlySold_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            ...FillwidthItem_artwork\n            ...ShelfArtwork_artwork\n            internalID\n            realizedPrice\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRoute_artist on Artist {\n  ...ArtistConsignMeta_artist\n  ...ArtistConsignHeader_artist\n  ...ArtistConsignRecentlySold_artist\n  ...ArtistConsignPageViews_artist\n  ...ArtistConsignMarketTrends_artist\n  ...ArtistConsignHowToSell_artist\n  ...ArtistConsignFAQ_artist\n  ...ArtistConsignSellArt_artist\n}\n\nfragment ArtistConsignSellArt_artist on Artist {\n  href\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/auctionRoutes_TopLevelQuery.graphql.ts
+++ b/src/__generated__/auctionRoutes_TopLevelQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cdbb9b2db53486b3d0c4f0c9b4abadb0>>
+ * @generated SignedSource<<d11c1cd02cb3ec24c243a86f19f3e02a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -183,229 +183,216 @@ v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "width",
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v15 = [
+v16 = [
   (v12/*: any*/),
   (v13/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "width",
-    "storageKey": null
-  },
-  (v14/*: any*/)
+  (v14/*: any*/),
+  (v15/*: any*/)
 ],
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artistNames",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endedAt",
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "liveStartAt",
   "storageKey": null
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isLiveOpen",
   "storageKey": null
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v24 = [
+v25 = [
   (v4/*: any*/),
-  (v18/*: any*/)
+  (v19/*: any*/)
 ],
-v25 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v26 = {
+v27 = {
   "kind": "Literal",
   "name": "width",
   "value": 445
 },
-v27 = [
+v28 = [
   (v12/*: any*/),
   (v13/*: any*/)
 ],
-v28 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v29 = {
+v30 = {
   "kind": "Literal",
   "name": "first",
   "value": 99
 },
-v30 = {
+v31 = {
   "alias": "sale_message",
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v31 = {
+v32 = {
   "alias": "cultural_maker",
   "args": null,
   "kind": "ScalarField",
   "name": "culturalMaker",
   "storageKey": null
 },
-v32 = [
+v33 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v33 = {
+v34 = {
   "alias": null,
-  "args": (v32/*: any*/),
+  "args": (v33/*: any*/),
   "concreteType": "Artist",
   "kind": "LinkedField",
   "name": "artists",
   "plural": true,
   "selections": [
-    (v18/*: any*/),
-    (v28/*: any*/),
-    (v25/*: any*/)
+    (v19/*: any*/),
+    (v29/*: any*/),
+    (v26/*: any*/)
   ],
   "storageKey": "artists(shallow:true)"
 },
-v34 = {
+v35 = {
   "alias": "collecting_institution",
   "args": null,
   "kind": "ScalarField",
   "name": "collectingInstitution",
   "storageKey": null
 },
-v35 = {
+v36 = {
   "alias": null,
-  "args": (v32/*: any*/),
+  "args": (v33/*: any*/),
   "concreteType": "Partner",
   "kind": "LinkedField",
   "name": "partner",
   "plural": false,
   "selections": [
-    (v25/*: any*/),
-    (v28/*: any*/),
-    (v18/*: any*/)
+    (v26/*: any*/),
+    (v29/*: any*/),
+    (v19/*: any*/)
   ],
   "storageKey": "partner(shallow:true)"
 },
-v36 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cascadingEndTimeIntervalMinutes",
   "storageKey": null
 },
-v37 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingIntervalMinutes",
   "storageKey": null
 },
-v38 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startAt",
   "storageKey": null
 },
-v39 = {
+v40 = {
   "alias": "is_auction",
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v40 = {
+v41 = {
   "alias": "is_closed",
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v41 = {
-  "alias": "is_preview",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isPreview",
-  "storageKey": null
-},
 v42 = {
-  "alias": "display_timely_at",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "displayTimelyAt",
-  "storageKey": null
-},
-v43 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v44 = {
+v43 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v45 = {
+v44 = {
   "alias": "sale_artwork",
   "args": null,
   "concreteType": "SaleArtwork",
@@ -413,10 +400,10 @@ v45 = {
   "name": "saleArtwork",
   "plural": false,
   "selections": [
-    (v43/*: any*/),
+    (v42/*: any*/),
     (v7/*: any*/),
-    (v21/*: any*/),
-    (v44/*: any*/),
+    (v22/*: any*/),
+    (v43/*: any*/),
     (v9/*: any*/),
     {
       "alias": null,
@@ -456,32 +443,32 @@ v45 = {
       "selections": (v8/*: any*/),
       "storageKey": null
     },
-    (v18/*: any*/)
+    (v19/*: any*/)
   ],
   "storageKey": null
 },
-v46 = {
+v45 = {
   "alias": "is_saved",
   "args": null,
   "kind": "ScalarField",
   "name": "isSaved",
   "storageKey": null
 },
-v47 = [
-  (v25/*: any*/),
-  (v18/*: any*/)
+v46 = [
+  (v26/*: any*/),
+  (v19/*: any*/)
 ],
-v48 = {
+v47 = {
   "alias": null,
   "args": null,
   "concreteType": "AttributionClass",
   "kind": "LinkedField",
   "name": "attributionClass",
   "plural": false,
-  "selections": (v47/*: any*/),
+  "selections": (v46/*: any*/),
   "storageKey": null
 },
-v49 = {
+v48 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworkMedium",
@@ -496,20 +483,55 @@ v49 = {
       "kind": "LinkedField",
       "name": "filterGene",
       "plural": false,
-      "selections": (v47/*: any*/),
+      "selections": (v46/*: any*/),
       "storageKey": null
     }
   ],
   "storageKey": null
 },
-v50 = {
-  "alias": "is_biddable",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isBiddable",
-  "storageKey": null
+v49 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": [
+    "normalized",
+    "larger",
+    "large"
+  ]
 },
-v51 = [
+v50 = [
+  (v29/*: any*/),
+  (v11/*: any*/),
+  (v10/*: any*/),
+  (v31/*: any*/),
+  (v32/*: any*/),
+  (v34/*: any*/),
+  (v35/*: any*/),
+  (v36/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Sale",
+    "kind": "LinkedField",
+    "name": "sale",
+    "plural": false,
+    "selections": [
+      (v22/*: any*/),
+      (v37/*: any*/),
+      (v38/*: any*/),
+      (v39/*: any*/),
+      (v40/*: any*/),
+      (v41/*: any*/),
+      (v19/*: any*/)
+    ],
+    "storageKey": null
+  },
+  (v44/*: any*/),
+  (v19/*: any*/),
+  (v4/*: any*/),
+  (v18/*: any*/),
+  (v45/*: any*/),
+  (v47/*: any*/),
+  (v48/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -519,93 +541,37 @@ v51 = [
     "plural": false,
     "selections": [
       {
-        "alias": null,
+        "alias": "src",
         "args": [
-          {
-            "kind": "Literal",
-            "name": "width",
-            "value": 200
-          }
+          (v49/*: any*/)
         ],
-        "concreteType": "ResizedImageUrl",
-        "kind": "LinkedField",
-        "name": "resized",
-        "plural": false,
-        "selections": (v15/*: any*/),
-        "storageKey": "resized(width:200)"
-      },
-      {
-        "alias": null,
-        "args": null,
         "kind": "ScalarField",
-        "name": "aspectRatio",
-        "storageKey": null
+        "name": "url",
+        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
       },
-      (v14/*: any*/)
+      (v14/*: any*/),
+      (v15/*: any*/)
     ],
     "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "imageTitle",
-    "storageKey": null
-  },
-  (v11/*: any*/),
-  (v28/*: any*/),
-  (v10/*: any*/),
-  (v30/*: any*/),
-  (v31/*: any*/),
-  (v33/*: any*/),
-  (v34/*: any*/),
-  (v35/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Sale",
-    "kind": "LinkedField",
-    "name": "sale",
-    "plural": false,
-    "selections": [
-      (v21/*: any*/),
-      (v36/*: any*/),
-      (v37/*: any*/),
-      (v38/*: any*/),
-      (v39/*: any*/),
-      (v40/*: any*/),
-      (v18/*: any*/),
-      (v41/*: any*/),
-      (v42/*: any*/)
-    ],
-    "storageKey": null
-  },
-  (v45/*: any*/),
-  (v18/*: any*/),
-  (v4/*: any*/),
-  (v17/*: any*/),
-  (v46/*: any*/),
-  (v48/*: any*/),
-  (v49/*: any*/),
-  (v50/*: any*/)
+  }
 ],
-v52 = {
+v51 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v53 = {
+v52 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v54 = [
+v53 = [
+  (v51/*: any*/),
   (v52/*: any*/),
-  (v53/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -614,36 +580,27 @@ v54 = [
     "storageKey": null
   }
 ],
-v55 = [
-  (v18/*: any*/)
+v54 = [
+  (v19/*: any*/)
 ],
-v56 = {
-  "kind": "Literal",
-  "name": "version",
-  "value": [
-    "normalized",
-    "larger",
-    "large"
-  ]
-},
-v57 = {
+v55 = {
   "kind": "Literal",
   "name": "first",
   "value": 1
 },
-v58 = {
+v56 = {
   "kind": "Literal",
   "name": "aggregations",
   "value": [
     "TOTAL"
   ]
 },
-v59 = {
+v57 = {
   "kind": "Literal",
   "name": "includeArtworksByFollowedArtists",
   "value": true
 },
-v60 = {
+v58 = {
   "kind": "Variable",
   "name": "saleSlug",
   "variableName": "slug"
@@ -822,7 +779,7 @@ return {
                             "kind": "LinkedField",
                             "name": "resized",
                             "plural": false,
-                            "selections": (v15/*: any*/),
+                            "selections": (v16/*: any*/),
                             "storageKey": "resized(height:100,version:\"medium\",width:100)"
                           }
                         ],
@@ -835,13 +792,13 @@ return {
                         "name": "imageUrl",
                         "storageKey": null
                       },
-                      (v16/*: any*/),
                       (v17/*: any*/),
-                      (v18/*: any*/)
+                      (v18/*: any*/),
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v17/*: any*/),
+                  (v18/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -866,7 +823,7 @@ return {
                     "selections": (v8/*: any*/),
                     "storageKey": null
                   },
-                  (v19/*: any*/),
+                  (v20/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -875,16 +832,16 @@ return {
                     "name": "sale",
                     "plural": false,
                     "selections": [
-                      (v17/*: any*/),
-                      (v20/*: any*/),
+                      (v18/*: any*/),
                       (v21/*: any*/),
                       (v22/*: any*/),
                       (v23/*: any*/),
-                      (v18/*: any*/)
+                      (v24/*: any*/),
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v18/*: any*/)
+                  (v19/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -912,7 +869,7 @@ return {
             "kind": "LinkedField",
             "name": "pendingIdentityVerification",
             "plural": false,
-            "selections": (v24/*: any*/),
+            "selections": (v25/*: any*/),
             "storageKey": null
           },
           {
@@ -930,13 +887,13 @@ return {
                 "kind": "LinkedField",
                 "name": "activeBid",
                 "plural": false,
-                "selections": (v24/*: any*/),
+                "selections": (v25/*: any*/),
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v18/*: any*/)
+          (v19/*: any*/)
         ],
         "storageKey": null
       },
@@ -948,7 +905,7 @@ return {
         "name": "sale",
         "plural": false,
         "selections": [
-          (v25/*: any*/),
+          (v26/*: any*/),
           {
             "alias": null,
             "args": [
@@ -962,7 +919,7 @@ return {
             "name": "description",
             "storageKey": "description(format:\"HTML\")"
           },
-          (v17/*: any*/),
+          (v18/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -987,13 +944,13 @@ return {
                         "name": "height",
                         "value": 250
                       },
-                      (v26/*: any*/)
+                      (v27/*: any*/)
                     ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v27/*: any*/),
+                    "selections": (v28/*: any*/),
                     "storageKey": "cropped(height:250,width:445)"
                   }
                 ],
@@ -1006,10 +963,10 @@ return {
                 "name": "displayTimelyAt",
                 "storageKey": null
               },
-              (v28/*: any*/),
-              (v17/*: any*/),
-              (v25/*: any*/),
-              (v18/*: any*/)
+              (v29/*: any*/),
+              (v18/*: any*/),
+              (v26/*: any*/),
+              (v19/*: any*/)
             ],
             "storageKey": null
           },
@@ -1021,13 +978,13 @@ return {
             "name": "promotedSale",
             "plural": false,
             "selections": [
-              (v28/*: any*/),
+              (v29/*: any*/),
               (v4/*: any*/),
-              (v25/*: any*/),
+              (v26/*: any*/),
               {
                 "alias": null,
                 "args": [
-                  (v29/*: any*/)
+                  (v30/*: any*/)
                 ],
                 "concreteType": "SaleArtworkConnection",
                 "kind": "LinkedField",
@@ -1057,10 +1014,10 @@ return {
                             "kind": "LinkedField",
                             "name": "artwork",
                             "plural": false,
-                            "selections": (v51/*: any*/),
+                            "selections": (v50/*: any*/),
                             "storageKey": null
                           },
-                          (v18/*: any*/)
+                          (v19/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -1070,7 +1027,7 @@ return {
                 ],
                 "storageKey": "saleArtworksConnection(first:99)"
               },
-              (v18/*: any*/)
+              (v19/*: any*/)
             ],
             "storageKey": null
           },
@@ -1089,7 +1046,7 @@ return {
                 "name": "qualifiedForBidding",
                 "storageKey": null
               },
-              (v18/*: any*/)
+              (v19/*: any*/)
             ],
             "storageKey": null
           },
@@ -1100,8 +1057,8 @@ return {
             "name": "isAuction",
             "storageKey": null
           },
+          (v24/*: any*/),
           (v23/*: any*/),
-          (v22/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1137,7 +1094,7 @@ return {
             "kind": "LinkedField",
             "name": "registrationStatus",
             "plural": false,
-            "selections": (v24/*: any*/),
+            "selections": (v25/*: any*/),
             "storageKey": null
           },
           {
@@ -1147,14 +1104,14 @@ return {
             "name": "status",
             "storageKey": null
           },
-          (v20/*: any*/),
           (v21/*: any*/),
-          (v19/*: any*/),
-          (v38/*: any*/),
+          (v22/*: any*/),
+          (v20/*: any*/),
+          (v39/*: any*/),
           (v4/*: any*/),
-          (v28/*: any*/),
-          (v36/*: any*/),
+          (v29/*: any*/),
           (v37/*: any*/),
+          (v38/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1197,7 +1154,7 @@ return {
             "kind": "LinkedField",
             "name": "associatedSale",
             "plural": false,
-            "selections": (v24/*: any*/),
+            "selections": (v25/*: any*/),
             "storageKey": null
           },
           {
@@ -1207,10 +1164,10 @@ return {
             "kind": "LinkedField",
             "name": "promotedSale",
             "plural": false,
-            "selections": (v24/*: any*/),
+            "selections": (v25/*: any*/),
             "storageKey": null
           },
-          (v18/*: any*/)
+          (v19/*: any*/)
         ],
         "storageKey": null
       },
@@ -1232,7 +1189,7 @@ return {
             "name": "artworksConnection",
             "plural": false,
             "selections": [
-              (v18/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1273,7 +1230,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v54/*: any*/),
+                    "selections": (v53/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1283,7 +1240,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v54/*: any*/),
+                    "selections": (v53/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1293,7 +1250,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v54/*: any*/),
+                    "selections": (v53/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1304,8 +1261,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v52/*: any*/),
-                      (v53/*: any*/)
+                      (v51/*: any*/),
+                      (v52/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1327,7 +1284,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": (v55/*: any*/),
+                    "selections": (v54/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -1383,8 +1340,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v17/*: any*/),
-                          (v28/*: any*/),
+                          (v18/*: any*/),
+                          (v29/*: any*/),
                           (v4/*: any*/),
                           {
                             "alias": null,
@@ -1424,14 +1381,14 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v56/*: any*/),
-                                  (v26/*: any*/)
+                                  (v49/*: any*/),
+                                  (v27/*: any*/)
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "kind": "LinkedField",
                                 "name": "resized",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:445)"
                               }
                             ],
@@ -1445,13 +1402,13 @@ return {
                             "name": "imageTitle",
                             "storageKey": null
                           },
-                          (v16/*: any*/),
+                          (v17/*: any*/),
                           (v10/*: any*/),
-                          (v30/*: any*/),
                           (v31/*: any*/),
-                          (v33/*: any*/),
+                          (v32/*: any*/),
                           (v34/*: any*/),
                           (v35/*: any*/),
+                          (v36/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1460,15 +1417,27 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
-                              (v36/*: any*/),
+                              (v22/*: any*/),
                               (v37/*: any*/),
                               (v38/*: any*/),
                               (v39/*: any*/),
                               (v40/*: any*/),
-                              (v18/*: any*/),
                               (v41/*: any*/),
-                              (v42/*: any*/),
+                              (v19/*: any*/),
+                              {
+                                "alias": "is_preview",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isPreview",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "display_timely_at",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "displayTimelyAt",
+                                "storageKey": null
+                              },
                               {
                                 "alias": null,
                                 "args": null,
@@ -1479,11 +1448,17 @@ return {
                             ],
                             "storageKey": null
                           },
+                          (v44/*: any*/),
                           (v45/*: any*/),
-                          (v46/*: any*/),
+                          (v47/*: any*/),
                           (v48/*: any*/),
-                          (v49/*: any*/),
-                          (v50/*: any*/),
+                          {
+                            "alias": "is_biddable",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isBiddable",
+                            "storageKey": null
+                          },
                           {
                             "alias": null,
                             "args": null,
@@ -1492,10 +1467,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
-                              (v44/*: any*/),
+                              (v22/*: any*/),
                               (v43/*: any*/),
-                              (v18/*: any*/)
+                              (v42/*: any*/),
+                              (v19/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -1504,7 +1479,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v55/*: any*/),
+                        "selections": (v54/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1521,7 +1496,7 @@ return {
           {
             "alias": "sidebarAggregations",
             "args": [
-              (v57/*: any*/),
+              (v55/*: any*/),
               (v3/*: any*/)
             ],
             "concreteType": "FilterArtworksConnection",
@@ -1570,7 +1545,7 @@ return {
                     "name": "counts",
                     "plural": true,
                     "selections": [
-                      (v25/*: any*/),
+                      (v26/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1591,17 +1566,17 @@ return {
                 ],
                 "storageKey": null
               },
-              (v18/*: any*/)
+              (v19/*: any*/)
             ],
             "storageKey": null
           },
           {
             "alias": null,
             "args": [
-              (v58/*: any*/),
-              (v29/*: any*/),
-              (v59/*: any*/),
-              (v60/*: any*/)
+              (v56/*: any*/),
+              (v30/*: any*/),
+              (v57/*: any*/),
+              (v58/*: any*/)
             ],
             "concreteType": "SaleArtworksConnection",
             "kind": "LinkedField",
@@ -1623,10 +1598,10 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": (v51/*: any*/),
+                    "selections": (v50/*: any*/),
                     "storageKey": null
                   },
-                  (v18/*: any*/)
+                  (v19/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1636,7 +1611,7 @@ return {
           {
             "alias": null,
             "args": [
-              (v29/*: any*/),
+              (v30/*: any*/),
               (v5/*: any*/),
               {
                 "kind": "Literal",
@@ -1670,7 +1645,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v25/*: any*/),
+                      (v26/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1678,7 +1653,7 @@ return {
                         "name": "formattedStartDateTime",
                         "storageKey": null
                       },
-                      (v28/*: any*/),
+                      (v29/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1695,20 +1670,20 @@ return {
                                 "name": "height",
                                 "value": 334
                               },
-                              (v56/*: any*/),
-                              (v26/*: any*/)
+                              (v49/*: any*/),
+                              (v27/*: any*/)
                             ],
                             "concreteType": "CroppedImageUrl",
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v27/*: any*/),
+                            "selections": (v28/*: any*/),
                             "storageKey": "cropped(height:334,version:[\"normalized\",\"larger\",\"large\"],width:445)"
                           }
                         ],
                         "storageKey": null
                       },
-                      (v18/*: any*/)
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1721,10 +1696,10 @@ return {
           {
             "alias": "showFollowedArtistsTab",
             "args": [
-              (v58/*: any*/),
+              (v56/*: any*/),
+              (v55/*: any*/),
               (v57/*: any*/),
-              (v59/*: any*/),
-              (v60/*: any*/)
+              (v58/*: any*/)
             ],
             "concreteType": "SaleArtworksConnection",
             "kind": "LinkedField",
@@ -1746,10 +1721,10 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": (v24/*: any*/),
+                    "selections": (v25/*: any*/),
                     "storageKey": null
                   },
-                  (v18/*: any*/)
+                  (v19/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1762,12 +1737,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "af2629bba2011757434508cdaffdda31",
+    "cacheID": "9f9b42d41f99db1ae3bb7f0c517f6562",
     "id": null,
     "metadata": {},
     "name": "auctionRoutes_TopLevelQuery",
     "operationKind": "query",
-    "text": "query auctionRoutes_TopLevelQuery(\n  $input: FilterArtworksInput\n  $slug: String!\n) {\n  me {\n    ...AuctionApp_me_96HcF\n    id\n  }\n  sale(id: $slug) @principalField {\n    ...AuctionApp_sale\n    id\n  }\n  viewer {\n    ...AuctionApp_viewer_YRlPK\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment AuctionActiveBids_me_96HcF on Me {\n  internalID\n  lotStandings(saleID: $slug, live: true) {\n    isHighestBidder\n    saleArtwork {\n      ...AuctionLotInfo_saleArtwork_4oTW5x\n      counts {\n        bidderPositions\n      }\n      currentBid {\n        display\n      }\n      slug\n      lotLabel\n      reserveStatus\n      saleID\n      highestBid {\n        display\n      }\n      endedAt\n      sale {\n        slug\n        liveStartAt\n        endAt\n        isLiveOpen\n        isClosed\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment AuctionApp_me_96HcF on Me {\n  ...AuctionActiveBids_me_96HcF\n  ...AuctionDetails_me\n  internalID\n  showActiveBids: lotStandings(saleID: $slug, live: true) {\n    activeBid {\n      internalID\n      id\n    }\n  }\n}\n\nfragment AuctionApp_sale on Sale {\n  ...AuctionMeta_sale\n  ...AuctionAssociatedSale_sale\n  ...AuctionBuyNowRail_sale\n  ...AuctionDetails_sale\n  ...CascadingEndTimesBanner_sale\n  internalID\n  slug\n  isClosed\n  eligibleSaleArtworksCount\n  coverImage {\n    url(version: [\"wide\", \"source\", \"large_rectangle\"])\n  }\n  showAssociatedSale: associatedSale {\n    internalID\n    id\n  }\n  showBuyNowTab: promotedSale {\n    internalID\n    id\n  }\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n  status\n}\n\nfragment AuctionApp_viewer_YRlPK on Viewer {\n  ...AuctionArtworkFilter_viewer_2VV6jB\n  ...AuctionWorksByFollowedArtistsRail_viewer_96HcF\n  ...AuctionCurrentAuctionsRail_viewer\n  showFollowedArtistsTab: saleArtworksConnection(first: 1, aggregations: [TOTAL], saleSlug: $slug, includeArtworksByFollowedArtists: true) {\n    edges {\n      node {\n        internalID\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment AuctionArtworkFilter_viewer_2VV6jB on Viewer {\n  ...ArtworkFilter_viewer_2VV6jB\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment AuctionAssociatedSale_sale on Sale {\n  associatedSale {\n    coverImage {\n      cropped(width: 445, height: 250) {\n        src\n        srcSet\n      }\n    }\n    displayTimelyAt\n    href\n    slug\n    name\n    id\n  }\n}\n\nfragment AuctionBuyNowRail_sale on Sale {\n  promotedSale {\n    href\n    internalID\n    name\n    saleArtworksConnection(first: 99) {\n      edges {\n        node {\n          artwork {\n            ...ShelfArtwork_artwork\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment AuctionCurrentAuctionsRail_viewer on Viewer {\n  salesConnection(first: 99, published: true, live: true, sort: LICENSED_TIMELY_AT_NAME_DESC) {\n    edges {\n      node {\n        ...CellSale_sale\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionDetails_me on Me {\n  ...RegisterButton_me\n}\n\nfragment AuctionDetails_sale on Sale {\n  ...RegisterButton_sale\n  ...AuctionInfoSidebar_sale\n  ...SaleDetailTimer_sale\n  internalID\n  name\n  slug\n  liveStartAt\n  startAt\n  endAt\n  description(format: HTML)\n  href\n  isClosed\n  cascadingEndTimeIntervalMinutes\n}\n\nfragment AuctionInfoSidebar_sale on Sale {\n  liveStartAt\n}\n\nfragment AuctionLotInfo_saleArtwork_4oTW5x on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  currentBid {\n    display\n  }\n  formattedEndDateTime\n  artwork {\n    internalID\n    date\n    title\n    image {\n      resized(width: 100, height: 100, version: \"medium\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    imageUrl\n    artistNames\n    slug\n    id\n  }\n}\n\nfragment AuctionMeta_sale on Sale {\n  name\n  description(format: HTML)\n  slug\n}\n\nfragment AuctionWorksByFollowedArtistsRail_viewer_96HcF on Viewer {\n  saleArtworksConnection(first: 99, aggregations: [TOTAL], saleSlug: $slug, includeArtworksByFollowedArtists: true) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment CellSale_sale on Sale {\n  name\n  formattedStartDateTime\n  href\n  coverImage {\n    cropped(width: 445, height: 334, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment RegisterButton_me on Me {\n  internalID\n  identityVerified\n  hasCreditCards\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment RegisterButton_sale on Sale {\n  bidder {\n    qualifiedForBidding\n    id\n  }\n  isAuction\n  isClosed\n  isLiveOpen\n  isPreview\n  isRegistrationClosed\n  liveURLIfOpen\n  requireIdentityVerification\n  registrationStatus {\n    internalID\n    id\n  }\n  slug\n  status\n}\n\nfragment SaleDetailTimer_sale on Sale {\n  endAt\n  endedAt\n  startAt\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query auctionRoutes_TopLevelQuery(\n  $input: FilterArtworksInput\n  $slug: String!\n) {\n  me {\n    ...AuctionApp_me_96HcF\n    id\n  }\n  sale(id: $slug) @principalField {\n    ...AuctionApp_sale\n    id\n  }\n  viewer {\n    ...AuctionApp_viewer_YRlPK\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment AuctionActiveBids_me_96HcF on Me {\n  internalID\n  lotStandings(saleID: $slug, live: true) {\n    isHighestBidder\n    saleArtwork {\n      ...AuctionLotInfo_saleArtwork_4oTW5x\n      counts {\n        bidderPositions\n      }\n      currentBid {\n        display\n      }\n      slug\n      lotLabel\n      reserveStatus\n      saleID\n      highestBid {\n        display\n      }\n      endedAt\n      sale {\n        slug\n        liveStartAt\n        endAt\n        isLiveOpen\n        isClosed\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment AuctionApp_me_96HcF on Me {\n  ...AuctionActiveBids_me_96HcF\n  ...AuctionDetails_me\n  internalID\n  showActiveBids: lotStandings(saleID: $slug, live: true) {\n    activeBid {\n      internalID\n      id\n    }\n  }\n}\n\nfragment AuctionApp_sale on Sale {\n  ...AuctionMeta_sale\n  ...AuctionAssociatedSale_sale\n  ...AuctionBuyNowRail_sale\n  ...AuctionDetails_sale\n  ...CascadingEndTimesBanner_sale\n  internalID\n  slug\n  isClosed\n  eligibleSaleArtworksCount\n  coverImage {\n    url(version: [\"wide\", \"source\", \"large_rectangle\"])\n  }\n  showAssociatedSale: associatedSale {\n    internalID\n    id\n  }\n  showBuyNowTab: promotedSale {\n    internalID\n    id\n  }\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n  status\n}\n\nfragment AuctionApp_viewer_YRlPK on Viewer {\n  ...AuctionArtworkFilter_viewer_2VV6jB\n  ...AuctionWorksByFollowedArtistsRail_viewer_96HcF\n  ...AuctionCurrentAuctionsRail_viewer\n  showFollowedArtistsTab: saleArtworksConnection(first: 1, aggregations: [TOTAL], saleSlug: $slug, includeArtworksByFollowedArtists: true) {\n    edges {\n      node {\n        internalID\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment AuctionArtworkFilter_viewer_2VV6jB on Viewer {\n  ...ArtworkFilter_viewer_2VV6jB\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment AuctionAssociatedSale_sale on Sale {\n  associatedSale {\n    coverImage {\n      cropped(width: 445, height: 250) {\n        src\n        srcSet\n      }\n    }\n    displayTimelyAt\n    href\n    slug\n    name\n    id\n  }\n}\n\nfragment AuctionBuyNowRail_sale on Sale {\n  promotedSale {\n    href\n    internalID\n    name\n    saleArtworksConnection(first: 99) {\n      edges {\n        node {\n          artwork {\n            ...ShelfArtwork_artwork\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment AuctionCurrentAuctionsRail_viewer on Viewer {\n  salesConnection(first: 99, published: true, live: true, sort: LICENSED_TIMELY_AT_NAME_DESC) {\n    edges {\n      node {\n        ...CellSale_sale\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionDetails_me on Me {\n  ...RegisterButton_me\n}\n\nfragment AuctionDetails_sale on Sale {\n  ...RegisterButton_sale\n  ...AuctionInfoSidebar_sale\n  ...SaleDetailTimer_sale\n  internalID\n  name\n  slug\n  liveStartAt\n  startAt\n  endAt\n  description(format: HTML)\n  href\n  isClosed\n  cascadingEndTimeIntervalMinutes\n}\n\nfragment AuctionInfoSidebar_sale on Sale {\n  liveStartAt\n}\n\nfragment AuctionLotInfo_saleArtwork_4oTW5x on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  currentBid {\n    display\n  }\n  formattedEndDateTime\n  artwork {\n    internalID\n    date\n    title\n    image {\n      resized(width: 100, height: 100, version: \"medium\") {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    imageUrl\n    artistNames\n    slug\n    id\n  }\n}\n\nfragment AuctionMeta_sale on Sale {\n  name\n  description(format: HTML)\n  slug\n}\n\nfragment AuctionWorksByFollowedArtistsRail_viewer_96HcF on Viewer {\n  saleArtworksConnection(first: 99, aggregations: [TOTAL], saleSlug: $slug, includeArtworksByFollowedArtists: true) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment CellSale_sale on Sale {\n  name\n  formattedStartDateTime\n  href\n  coverImage {\n    cropped(width: 445, height: 334, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    resized(width: 445, version: [\"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment RegisterButton_me on Me {\n  internalID\n  identityVerified\n  hasCreditCards\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment RegisterButton_sale on Sale {\n  bidder {\n    qualifiedForBidding\n    id\n  }\n  isAuction\n  isClosed\n  isLiveOpen\n  isPreview\n  isRegistrationClosed\n  liveURLIfOpen\n  requireIdentityVerification\n  registrationStatus {\n    internalID\n    id\n  }\n  slug\n  status\n}\n\nfragment SaleDetailTimer_sale on Sale {\n  endAt\n  endedAt\n  startAt\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/auctionsRoutes_Artworks_AuctionsQuery.graphql.ts
+++ b/src/__generated__/auctionsRoutes_Artworks_AuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d86df0afd71ac792af3ecf3b2ff95151>>
+ * @generated SignedSource<<45a5c6f75b0ea8378c6bba00bda911cf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -43,42 +43,28 @@ v2 = {
   "name": "href",
   "storageKey": null
 },
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v5 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v6 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v8 = [
+v6 = [
   {
     "alias": null,
     "args": null,
@@ -87,9 +73,16 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = [
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v8 = [
   (v1/*: any*/),
-  (v6/*: any*/)
+  (v4/*: any*/)
 ];
 return {
   "fragment": {
@@ -236,73 +229,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v3/*: any*/),
-                                  (v0/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "src",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "srcSet",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "width",
-                                            "storageKey": null
-                                          },
-                                          (v4/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v4/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
+                                  (v2/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -310,7 +237,6 @@ return {
                                     "name": "title",
                                     "storageKey": null
                                   },
-                                  (v2/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -334,13 +260,13 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v5/*: any*/),
+                                    "args": (v3/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v6/*: any*/),
+                                      (v4/*: any*/),
                                       (v2/*: any*/),
                                       (v1/*: any*/)
                                     ],
@@ -355,7 +281,7 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v5/*: any*/),
+                                    "args": (v3/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
@@ -363,7 +289,7 @@ return {
                                     "selections": [
                                       (v1/*: any*/),
                                       (v2/*: any*/),
-                                      (v6/*: any*/)
+                                      (v4/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -375,7 +301,7 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v7/*: any*/),
+                                      (v5/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -411,21 +337,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v6/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v4/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -451,7 +363,7 @@ return {
                                         "name": "lotLabel",
                                         "storageKey": null
                                       },
-                                      (v7/*: any*/),
+                                      (v5/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -491,7 +403,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v8/*: any*/),
+                                        "selections": (v6/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -501,14 +413,16 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v8/*: any*/),
+                                        "selections": (v6/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v6/*: any*/)
+                                      (v4/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v6/*: any*/),
+                                  (v4/*: any*/),
+                                  (v7/*: any*/),
+                                  (v0/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -523,7 +437,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v9/*: any*/),
+                                    "selections": (v8/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -541,17 +455,52 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v8/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -563,7 +512,7 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v3/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -571,7 +520,7 @@ return {
                         "name": "formattedStartDateTime",
                         "storageKey": null
                       },
-                      (v6/*: any*/)
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -587,12 +536,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d07a99dae8fb0d5adfd74e9a1f7b9c6e",
+    "cacheID": "e6a425218bd0cb1a4637b4c3a21d4cfb",
     "id": null,
     "metadata": {},
     "name": "auctionsRoutes_Artworks_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Artworks_AuctionsQuery {\n  viewer {\n    ...ArtworksRoute_viewer\n  }\n}\n\nfragment ArtworksRoute_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query auctionsRoutes_Artworks_AuctionsQuery {\n  viewer {\n    ...ArtworksRoute_viewer\n  }\n}\n\nfragment ArtworksRoute_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/auctionsRoutes_AuctionsQuery.graphql.ts
+++ b/src/__generated__/auctionsRoutes_AuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2885be3c341bdee59e2cac4d2b25e5a0>>
+ * @generated SignedSource<<45f27e29e69c6b4f9dc9c782cf60a802>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -60,232 +60,143 @@ v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
+  "name": "href",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "srcSet",
+  "name": "title",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v9 = [
-  (v6/*: any*/),
-  (v7/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "width",
-    "storageKey": null
-  },
-  (v8/*: any*/)
-],
-v10 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Image",
-  "kind": "LinkedField",
-  "name": "image",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "width",
-          "value": 325
-        }
-      ],
-      "concreteType": "ResizedImageUrl",
-      "kind": "LinkedField",
-      "name": "resized",
-      "plural": false,
-      "selections": (v9/*: any*/),
-      "storageKey": "resized(width:325)"
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "aspectRatio",
-      "storageKey": null
-    },
-    (v8/*: any*/)
-  ],
-  "storageKey": null
-},
-v11 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "imageTitle",
-  "storageKey": null
-},
-v12 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "title",
-  "storageKey": null
-},
-v13 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v14 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "date",
   "storageKey": null
 },
-v15 = {
+v9 = {
   "alias": "sale_message",
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v16 = {
+v10 = {
   "alias": "cultural_maker",
   "args": null,
   "kind": "ScalarField",
   "name": "culturalMaker",
   "storageKey": null
 },
-v17 = [
+v11 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v18 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v19 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v20 = {
+v14 = {
   "alias": null,
-  "args": (v17/*: any*/),
+  "args": (v11/*: any*/),
   "concreteType": "Artist",
   "kind": "LinkedField",
   "name": "artists",
   "plural": true,
   "selections": [
-    (v18/*: any*/),
-    (v13/*: any*/),
-    (v19/*: any*/)
+    (v12/*: any*/),
+    (v6/*: any*/),
+    (v13/*: any*/)
   ],
   "storageKey": "artists(shallow:true)"
 },
-v21 = {
+v15 = {
   "alias": "collecting_institution",
   "args": null,
   "kind": "ScalarField",
   "name": "collectingInstitution",
   "storageKey": null
 },
-v22 = {
+v16 = {
   "alias": null,
-  "args": (v17/*: any*/),
+  "args": (v11/*: any*/),
   "concreteType": "Partner",
   "kind": "LinkedField",
   "name": "partner",
   "plural": false,
   "selections": [
-    (v19/*: any*/),
     (v13/*: any*/),
-    (v18/*: any*/)
+    (v6/*: any*/),
+    (v12/*: any*/)
   ],
   "storageKey": "partner(shallow:true)"
 },
-v23 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v24 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cascadingEndTimeIntervalMinutes",
   "storageKey": null
 },
-v25 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingIntervalMinutes",
   "storageKey": null
 },
-v26 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startAt",
   "storageKey": null
 },
-v27 = {
+v21 = {
   "alias": "is_auction",
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v28 = {
+v22 = {
   "alias": "is_closed",
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v29 = {
-  "alias": "is_preview",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isPreview",
-  "storageKey": null
-},
-v30 = {
-  "alias": "display_timely_at",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "displayTimelyAt",
-  "storageKey": null
-},
-v31 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotLabel",
   "storageKey": null
 },
-v32 = [
+v24 = [
   {
     "alias": null,
     "args": null,
@@ -294,7 +205,7 @@ v32 = [
     "storageKey": null
   }
 ],
-v33 = {
+v25 = {
   "alias": "sale_artwork",
   "args": null,
   "concreteType": "SaleArtwork",
@@ -309,8 +220,8 @@ v33 = {
       "name": "lotID",
       "storageKey": null
     },
-    (v31/*: any*/),
     (v23/*: any*/),
+    (v17/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -350,7 +261,7 @@ v33 = {
       "kind": "LinkedField",
       "name": "highestBid",
       "plural": false,
-      "selections": (v32/*: any*/),
+      "selections": (v24/*: any*/),
       "storageKey": null
     },
     {
@@ -360,35 +271,35 @@ v33 = {
       "kind": "LinkedField",
       "name": "openingBid",
       "plural": false,
-      "selections": (v32/*: any*/),
+      "selections": (v24/*: any*/),
       "storageKey": null
     },
-    (v18/*: any*/)
+    (v12/*: any*/)
   ],
   "storageKey": null
 },
-v34 = {
+v26 = {
   "alias": "is_saved",
   "args": null,
   "kind": "ScalarField",
   "name": "isSaved",
   "storageKey": null
 },
-v35 = [
-  (v19/*: any*/),
-  (v18/*: any*/)
+v27 = [
+  (v13/*: any*/),
+  (v12/*: any*/)
 ],
-v36 = {
+v28 = {
   "alias": null,
   "args": null,
   "concreteType": "AttributionClass",
   "kind": "LinkedField",
   "name": "attributionClass",
   "plural": false,
-  "selections": (v35/*: any*/),
+  "selections": (v27/*: any*/),
   "storageKey": null
 },
-v37 = {
+v29 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworkMedium",
@@ -403,20 +314,57 @@ v37 = {
       "kind": "LinkedField",
       "name": "filterGene",
       "plural": false,
-      "selections": (v35/*: any*/),
+      "selections": (v27/*: any*/),
       "storageKey": null
     }
   ],
   "storageKey": null
 },
-v38 = {
-  "alias": "is_biddable",
+v30 = {
+  "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isBiddable",
+  "name": "width",
   "storageKey": null
 },
-v39 = {
+v31 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v32 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": [
+    {
+      "alias": "src",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "version",
+          "value": [
+            "normalized",
+            "larger",
+            "large"
+          ]
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "url",
+      "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+    },
+    (v30/*: any*/),
+    (v31/*: any*/)
+  ],
+  "storageKey": null
+},
+v33 = {
   "alias": null,
   "args": null,
   "concreteType": "Artwork",
@@ -426,16 +374,14 @@ v39 = {
   "selections": [
     (v4/*: any*/),
     (v5/*: any*/),
+    (v6/*: any*/),
+    (v7/*: any*/),
+    (v8/*: any*/),
+    (v9/*: any*/),
     (v10/*: any*/),
-    (v11/*: any*/),
-    (v12/*: any*/),
-    (v13/*: any*/),
     (v14/*: any*/),
     (v15/*: any*/),
     (v16/*: any*/),
-    (v20/*: any*/),
-    (v21/*: any*/),
-    (v22/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -444,25 +390,37 @@ v39 = {
       "name": "sale",
       "plural": false,
       "selections": [
-        (v23/*: any*/),
-        (v24/*: any*/),
-        (v25/*: any*/),
-        (v26/*: any*/),
-        (v27/*: any*/),
-        (v28/*: any*/),
+        (v17/*: any*/),
         (v18/*: any*/),
-        (v29/*: any*/),
-        (v30/*: any*/)
+        (v19/*: any*/),
+        (v20/*: any*/),
+        (v21/*: any*/),
+        (v22/*: any*/),
+        (v12/*: any*/)
       ],
       "storageKey": null
     },
-    (v33/*: any*/),
-    (v18/*: any*/),
-    (v34/*: any*/),
-    (v36/*: any*/),
-    (v37/*: any*/),
-    (v38/*: any*/)
+    (v25/*: any*/),
+    (v12/*: any*/),
+    (v26/*: any*/),
+    (v28/*: any*/),
+    (v29/*: any*/),
+    (v32/*: any*/)
   ],
+  "storageKey": null
+},
+v34 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "src",
+  "storageKey": null
+},
+v35 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "srcSet",
   "storageKey": null
 };
 return {
@@ -527,8 +485,8 @@ return {
                 "name": "edges",
                 "plural": true,
                 "selections": [
-                  (v39/*: any*/),
-                  (v18/*: any*/)
+                  (v33/*: any*/),
+                  (v12/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -615,38 +573,34 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
+                          (v12/*: any*/),
+                          (v17/*: any*/),
                           (v18/*: any*/),
-                          (v23/*: any*/),
-                          (v24/*: any*/),
-                          (v25/*: any*/),
-                          (v26/*: any*/),
-                          (v27/*: any*/),
-                          (v28/*: any*/),
-                          (v29/*: any*/),
-                          (v30/*: any*/)
+                          (v19/*: any*/),
+                          (v20/*: any*/),
+                          (v21/*: any*/),
+                          (v22/*: any*/)
                         ],
                         "storageKey": null
                       },
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
                       (v10/*: any*/),
-                      (v11/*: any*/),
-                      (v12/*: any*/),
-                      (v13/*: any*/),
                       (v14/*: any*/),
                       (v15/*: any*/),
                       (v16/*: any*/),
-                      (v20/*: any*/),
-                      (v21/*: any*/),
-                      (v22/*: any*/),
-                      (v33/*: any*/),
-                      (v18/*: any*/),
-                      (v34/*: any*/),
-                      (v36/*: any*/),
-                      (v37/*: any*/),
-                      (v38/*: any*/)
+                      (v25/*: any*/),
+                      (v12/*: any*/),
+                      (v26/*: any*/),
+                      (v28/*: any*/),
+                      (v29/*: any*/),
+                      (v32/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v18/*: any*/)
+                  (v12/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -683,11 +637,11 @@ return {
                 "name": "edges",
                 "plural": true,
                 "selections": [
-                  (v39/*: any*/)
+                  (v33/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v18/*: any*/)
+              (v12/*: any*/)
             ],
             "storageKey": "artworksConnection(first:50,forSale:true,geneIDs:[\"our-top-auction-lots\"])"
           },
@@ -798,8 +752,8 @@ return {
                                 "name": "cropped",
                                 "plural": false,
                                 "selections": [
-                                  (v6/*: any*/),
-                                  (v7/*: any*/)
+                                  (v34/*: any*/),
+                                  (v35/*: any*/)
                                 ],
                                 "storageKey": "cropped(height:100,version:[\"source\",\"wide\",\"large_rectangle\"],width:330)"
                               }
@@ -813,7 +767,7 @@ return {
                             "name": "formattedStartDateTime",
                             "storageKey": null
                           },
-                          (v19/*: any*/),
+                          (v13/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -821,10 +775,10 @@ return {
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
-                            "selections": (v35/*: any*/),
+                            "selections": (v27/*: any*/),
                             "storageKey": null
                           },
-                          (v18/*: any*/)
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -877,13 +831,18 @@ return {
                                     "kind": "LinkedField",
                                     "name": "cropped",
                                     "plural": false,
-                                    "selections": (v9/*: any*/),
+                                    "selections": [
+                                      (v34/*: any*/),
+                                      (v35/*: any*/),
+                                      (v30/*: any*/),
+                                      (v31/*: any*/)
+                                    ],
                                     "storageKey": "cropped(height:55,width:55)"
                                   }
                                 ],
                                 "storageKey": null
                               },
-                              (v18/*: any*/)
+                              (v12/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -901,7 +860,7 @@ return {
                             "kind": "LinkedField",
                             "name": "currentBid",
                             "plural": false,
-                            "selections": (v32/*: any*/),
+                            "selections": (v24/*: any*/),
                             "storageKey": null
                           },
                           (v4/*: any*/),
@@ -941,15 +900,15 @@ return {
                                 "kind": "LinkedField",
                                 "name": "sellingPrice",
                                 "plural": false,
-                                "selections": (v32/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               }
                             ],
                             "storageKey": null
                           },
-                          (v31/*: any*/),
+                          (v23/*: any*/),
                           (v5/*: any*/),
-                          (v18/*: any*/)
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -959,7 +918,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v18/*: any*/)
+              (v12/*: any*/)
             ],
             "storageKey": null
           }
@@ -969,12 +928,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3b546939842c89a68ae0bf1efa8bfd19",
+    "cacheID": "2de1622bf7169517b776eadc6bfef45a",
     "id": null,
     "metadata": {},
     "name": "auctionsRoutes_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_AuctionsQuery {\n  viewer {\n    ...AuctionsApp_viewer\n  }\n}\n\nfragment AuctionsApp_viewer on Viewer {\n  ...CuritorialRailsTabBar_viewer\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CuritorialRailsTabBar_viewer on Viewer {\n  ...WorksByArtistsYouFollowRail_viewer\n  ...TrendingLotsRail_viewer\n  ...StandoutLotsRail_viewer\n  followedArtistsInAuction: saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 1) {\n    counts {\n      total\n    }\n  }\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100, version: [\"source\", \"wide\", \"large_rectangle\"]) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment StandoutLotsRail_viewer on Viewer {\n  standoutLotsRailConnection: artworksConnection(forSale: true, first: 50, geneIDs: [\"our-top-auction-lots\"]) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment TrendingLotsRail_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(biddableSale: true, first: 10, sort: \"-bidder_positions_count\", estimateRange: \"5_000_00-*\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        sale {\n          isClosed\n          id\n        }\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query auctionsRoutes_AuctionsQuery {\n  viewer {\n    ...AuctionsApp_viewer\n  }\n}\n\nfragment AuctionsApp_viewer on Viewer {\n  ...CuritorialRailsTabBar_viewer\n}\n\nfragment CuritorialRailsTabBar_viewer on Viewer {\n  ...WorksByArtistsYouFollowRail_viewer\n  ...TrendingLotsRail_viewer\n  ...StandoutLotsRail_viewer\n  followedArtistsInAuction: saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 1) {\n    counts {\n      total\n    }\n  }\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100, version: [\"source\", \"wide\", \"large_rectangle\"]) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n\nfragment StandoutLotsRail_viewer on Viewer {\n  standoutLotsRailConnection: artworksConnection(forSale: true, first: 50, geneIDs: [\"our-top-auction-lots\"]) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment TrendingLotsRail_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(biddableSale: true, first: 10, sort: \"-bidder_positions_count\", estimateRange: \"5_000_00-*\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        sale {\n          isClosed\n          id\n        }\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/auctionsRoutes_Current_AuctionsQuery.graphql.ts
+++ b/src/__generated__/auctionsRoutes_Current_AuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b27e3c1eae87c13778de600af9a1b1f5>>
+ * @generated SignedSource<<35482ebcdd1b6ba374379d93e419ef06>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -70,42 +70,28 @@ v3 = {
   "name": "href",
   "storageKey": null
 },
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v6 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v7 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v9 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -114,9 +100,16 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v9 = [
   (v2/*: any*/),
-  (v7/*: any*/)
+  (v5/*: any*/)
 ];
 return {
   "fragment": {
@@ -237,73 +230,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v4/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "src",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "srcSet",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "width",
-                                            "storageKey": null
-                                          },
-                                          (v5/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -311,7 +238,6 @@ return {
                                     "name": "title",
                                     "storageKey": null
                                   },
-                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -335,13 +261,13 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v7/*: any*/),
+                                      (v5/*: any*/),
                                       (v3/*: any*/),
                                       (v2/*: any*/)
                                     ],
@@ -356,7 +282,7 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
@@ -364,7 +290,7 @@ return {
                                     "selections": [
                                       (v2/*: any*/),
                                       (v3/*: any*/),
-                                      (v7/*: any*/)
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -376,7 +302,7 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v8/*: any*/),
+                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -412,21 +338,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v7/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -452,7 +364,7 @@ return {
                                         "name": "lotLabel",
                                         "storageKey": null
                                       },
-                                      (v8/*: any*/),
+                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -492,7 +404,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -502,14 +414,16 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v7/*: any*/)
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/),
+                                  (v5/*: any*/),
+                                  (v8/*: any*/),
+                                  (v1/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -524,7 +438,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v9/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -542,17 +456,52 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v10/*: any*/),
+                                        "selections": (v9/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -564,7 +513,7 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v4/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -572,7 +521,7 @@ return {
                         "name": "formattedStartDateTime",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -641,12 +590,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "429e86125392187515aed337a2619964",
+    "cacheID": "b8cfbf04778a194799b9cf12abcfc8d7",
     "id": null,
     "metadata": {},
     "name": "auctionsRoutes_Current_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Current_AuctionsQuery {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query auctionsRoutes_Current_AuctionsQuery {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/auctionsRoutes_Past_AuctionsQuery.graphql.ts
+++ b/src/__generated__/auctionsRoutes_Past_AuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1180c63bee04e273106e96f289d84e3b>>
+ * @generated SignedSource<<d71034bd9f0543d1871e8154dfd72415>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -72,35 +72,21 @@ v4 = {
   "name": "endAt",
   "storageKey": null
 },
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v7 = [
+v5 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v8 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v9 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -109,9 +95,16 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v9 = [
   (v2/*: any*/),
-  (v8/*: any*/)
+  (v6/*: any*/)
 ];
 return {
   "fragment": {
@@ -219,73 +212,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v5/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "src",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "srcSet",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "width",
-                                            "storageKey": null
-                                          },
-                                          (v6/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v6/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -293,7 +220,6 @@ return {
                                     "name": "title",
                                     "storageKey": null
                                   },
-                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -317,13 +243,13 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v7/*: any*/),
+                                    "args": (v5/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v8/*: any*/),
+                                      (v6/*: any*/),
                                       (v3/*: any*/),
                                       (v2/*: any*/)
                                     ],
@@ -338,7 +264,7 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v7/*: any*/),
+                                    "args": (v5/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
@@ -346,7 +272,7 @@ return {
                                     "selections": [
                                       (v2/*: any*/),
                                       (v3/*: any*/),
-                                      (v8/*: any*/)
+                                      (v6/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -394,21 +320,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v8/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v6/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -474,7 +386,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -484,14 +396,16 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v8/*: any*/)
+                                      (v6/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
+                                  (v6/*: any*/),
                                   (v8/*: any*/),
+                                  (v1/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -506,7 +420,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v9/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -524,17 +438,52 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v10/*: any*/),
+                                        "selections": (v9/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -546,7 +495,7 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v5/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -554,7 +503,7 @@ return {
                         "name": "formattedStartDateTime",
                         "storageKey": null
                       },
-                      (v8/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -622,12 +571,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f39260001829034650de704aac7c3ff4",
+    "cacheID": "4f63bdeb676dfc93dc77ba73e7444a84",
     "id": null,
     "metadata": {},
     "name": "auctionsRoutes_Past_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Past_AuctionsQuery {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query auctionsRoutes_Past_AuctionsQuery {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/auctionsRoutes_Upcoming_AuctionsQuery.graphql.ts
+++ b/src/__generated__/auctionsRoutes_Upcoming_AuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<75bcd72548b84540f986e359c6cb3c88>>
+ * @generated SignedSource<<ed1887c001222ca3082fa4628c85da0f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -60,42 +60,28 @@ v3 = {
   "name": "href",
   "storageKey": null
 },
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v6 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v7 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v9 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -104,9 +90,16 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v9 = [
   (v2/*: any*/),
-  (v7/*: any*/)
+  (v5/*: any*/)
 ];
 return {
   "fragment": {
@@ -241,73 +234,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v4/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "width",
-                                            "value": 200
-                                          }
-                                        ],
-                                        "concreteType": "ResizedImageUrl",
-                                        "kind": "LinkedField",
-                                        "name": "resized",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "src",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "srcSet",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "width",
-                                            "storageKey": null
-                                          },
-                                          (v5/*: any*/)
-                                        ],
-                                        "storageKey": "resized(width:200)"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -315,7 +242,6 @@ return {
                                     "name": "title",
                                     "storageKey": null
                                   },
-                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -339,13 +265,13 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "concreteType": "Artist",
                                     "kind": "LinkedField",
                                     "name": "artists",
                                     "plural": true,
                                     "selections": [
-                                      (v7/*: any*/),
+                                      (v5/*: any*/),
                                       (v3/*: any*/),
                                       (v2/*: any*/)
                                     ],
@@ -360,7 +286,7 @@ return {
                                   },
                                   {
                                     "alias": null,
-                                    "args": (v6/*: any*/),
+                                    "args": (v4/*: any*/),
                                     "concreteType": "Partner",
                                     "kind": "LinkedField",
                                     "name": "partner",
@@ -368,7 +294,7 @@ return {
                                     "selections": [
                                       (v2/*: any*/),
                                       (v3/*: any*/),
-                                      (v7/*: any*/)
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": "partner(shallow:true)"
                                   },
@@ -380,7 +306,7 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v8/*: any*/),
+                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -416,21 +342,7 @@ return {
                                         "name": "isClosed",
                                         "storageKey": null
                                       },
-                                      (v7/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -456,7 +368,7 @@ return {
                                         "name": "lotLabel",
                                         "storageKey": null
                                       },
-                                      (v8/*: any*/),
+                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -496,7 +408,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -506,14 +418,16 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v9/*: any*/),
+                                        "selections": (v7/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v7/*: any*/)
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/),
+                                  (v5/*: any*/),
+                                  (v8/*: any*/),
+                                  (v1/*: any*/),
                                   {
                                     "alias": "is_saved",
                                     "args": null,
@@ -528,7 +442,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "attributionClass",
                                     "plural": false,
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v9/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -546,17 +460,52 @@ return {
                                         "kind": "LinkedField",
                                         "name": "filterGene",
                                         "plural": false,
-                                        "selections": (v10/*: any*/),
+                                        "selections": (v9/*: any*/),
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
                                   {
-                                    "alias": "is_biddable",
+                                    "alias": null,
                                     "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "normalized",
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   }
                                 ],
@@ -568,8 +517,8 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v4/*: any*/),
-                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -636,12 +585,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6286fc7be585f62bc0581a7ddd05aa3f",
+    "cacheID": "ca9ca9fba62ab5645cfe3c56afbf098d",
     "id": null,
     "metadata": {},
     "name": "auctionsRoutes_Upcoming_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Upcoming_AuctionsQuery {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_OqwQs\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_OqwQs on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query auctionsRoutes_Upcoming_AuctionsQuery {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/useCreateBidderMutation.graphql.ts
+++ b/src/__generated__/useCreateBidderMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d1d00e94f0a50516087cc0eeefc6776f>>
+ * @generated SignedSource<<dd6b0115b14278e9241b06605d7892ad>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -72,73 +72,52 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
+  "name": "href",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v10 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v11 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cascadingEndTimeIntervalMinutes",
   "storageKey": null
 },
-v13 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingIntervalMinutes",
   "storageKey": null
 },
-v14 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startAt",
   "storageKey": null
 },
-v15 = [
+v12 = [
   {
     "alias": null,
     "args": null,
@@ -147,13 +126,13 @@ v15 = [
     "storageKey": null
   }
 ],
-v16 = [
+v13 = [
   (v3/*: any*/),
-  (v8/*: any*/)
+  (v6/*: any*/)
 ],
-v17 = [
+v14 = [
   (v2/*: any*/),
-  (v8/*: any*/)
+  (v6/*: any*/)
 ];
 return {
   "fragment": {
@@ -286,8 +265,20 @@ return {
                             "name": "cropped",
                             "plural": false,
                             "selections": [
-                              (v5/*: any*/),
-                              (v6/*: any*/)
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              }
                             ],
                             "storageKey": "cropped(height:250,width:445)"
                           }
@@ -301,10 +292,10 @@ return {
                         "name": "displayTimelyAt",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v5/*: any*/),
                       (v4/*: any*/),
                       (v3/*: any*/),
-                      (v8/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -316,7 +307,7 @@ return {
                     "name": "promotedSale",
                     "plural": false,
                     "selections": [
-                      (v7/*: any*/),
+                      (v5/*: any*/),
                       (v2/*: any*/),
                       (v3/*: any*/),
                       {
@@ -357,59 +348,7 @@ return {
                                     "name": "artwork",
                                     "plural": false,
                                     "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Image",
-                                        "kind": "LinkedField",
-                                        "name": "image",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": [
-                                              {
-                                                "kind": "Literal",
-                                                "name": "width",
-                                                "value": 200
-                                              }
-                                            ],
-                                            "concreteType": "ResizedImageUrl",
-                                            "kind": "LinkedField",
-                                            "name": "resized",
-                                            "plural": false,
-                                            "selections": [
-                                              (v5/*: any*/),
-                                              (v6/*: any*/),
-                                              {
-                                                "alias": null,
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "width",
-                                                "storageKey": null
-                                              },
-                                              (v9/*: any*/)
-                                            ],
-                                            "storageKey": "resized(width:200)"
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "aspectRatio",
-                                            "storageKey": null
-                                          },
-                                          (v9/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "imageTitle",
-                                        "storageKey": null
-                                      },
+                                      (v5/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -417,7 +356,6 @@ return {
                                         "name": "title",
                                         "storageKey": null
                                       },
-                                      (v7/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -441,14 +379,14 @@ return {
                                       },
                                       {
                                         "alias": null,
-                                        "args": (v10/*: any*/),
+                                        "args": (v7/*: any*/),
                                         "concreteType": "Artist",
                                         "kind": "LinkedField",
                                         "name": "artists",
                                         "plural": true,
                                         "selections": [
-                                          (v8/*: any*/),
-                                          (v7/*: any*/),
+                                          (v6/*: any*/),
+                                          (v5/*: any*/),
                                           (v3/*: any*/)
                                         ],
                                         "storageKey": "artists(shallow:true)"
@@ -462,15 +400,15 @@ return {
                                       },
                                       {
                                         "alias": null,
-                                        "args": (v10/*: any*/),
+                                        "args": (v7/*: any*/),
                                         "concreteType": "Partner",
                                         "kind": "LinkedField",
                                         "name": "partner",
                                         "plural": false,
                                         "selections": [
                                           (v3/*: any*/),
-                                          (v7/*: any*/),
-                                          (v8/*: any*/)
+                                          (v5/*: any*/),
+                                          (v6/*: any*/)
                                         ],
                                         "storageKey": "partner(shallow:true)"
                                       },
@@ -482,10 +420,10 @@ return {
                                         "name": "sale",
                                         "plural": false,
                                         "selections": [
+                                          (v8/*: any*/),
+                                          (v9/*: any*/),
+                                          (v10/*: any*/),
                                           (v11/*: any*/),
-                                          (v12/*: any*/),
-                                          (v13/*: any*/),
-                                          (v14/*: any*/),
                                           {
                                             "alias": "is_auction",
                                             "args": null,
@@ -500,21 +438,7 @@ return {
                                             "name": "isClosed",
                                             "storageKey": null
                                           },
-                                          (v8/*: any*/),
-                                          {
-                                            "alias": "is_preview",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isPreview",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": "display_timely_at",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "displayTimelyAt",
-                                            "storageKey": null
-                                          }
+                                          (v6/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
@@ -540,7 +464,7 @@ return {
                                             "name": "lotLabel",
                                             "storageKey": null
                                           },
-                                          (v11/*: any*/),
+                                          (v8/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -580,7 +504,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "highestBid",
                                             "plural": false,
-                                            "selections": (v15/*: any*/),
+                                            "selections": (v12/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -590,14 +514,14 @@ return {
                                             "kind": "LinkedField",
                                             "name": "openingBid",
                                             "plural": false,
-                                            "selections": (v15/*: any*/),
+                                            "selections": (v12/*: any*/),
                                             "storageKey": null
                                           },
-                                          (v8/*: any*/)
+                                          (v6/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
-                                      (v8/*: any*/),
+                                      (v6/*: any*/),
                                       (v2/*: any*/),
                                       (v4/*: any*/),
                                       {
@@ -614,7 +538,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "attributionClass",
                                         "plural": false,
-                                        "selections": (v16/*: any*/),
+                                        "selections": (v13/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -632,23 +556,58 @@ return {
                                             "kind": "LinkedField",
                                             "name": "filterGene",
                                             "plural": false,
-                                            "selections": (v16/*: any*/),
+                                            "selections": (v13/*: any*/),
                                             "storageKey": null
                                           }
                                         ],
                                         "storageKey": null
                                       },
                                       {
-                                        "alias": "is_biddable",
+                                        "alias": null,
                                         "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isBiddable",
+                                        "concreteType": "Image",
+                                        "kind": "LinkedField",
+                                        "name": "image",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": "src",
+                                            "args": [
+                                              {
+                                                "kind": "Literal",
+                                                "name": "version",
+                                                "value": [
+                                                  "normalized",
+                                                  "larger",
+                                                  "large"
+                                                ]
+                                              }
+                                            ],
+                                            "kind": "ScalarField",
+                                            "name": "url",
+                                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "width",
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "height",
+                                            "storageKey": null
+                                          }
+                                        ],
                                         "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
                                   },
-                                  (v8/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -658,7 +617,7 @@ return {
                         ],
                         "storageKey": "saleArtworksConnection(first:99)"
                       },
-                      (v8/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -677,7 +636,7 @@ return {
                         "name": "qualifiedForBidding",
                         "storageKey": null
                       },
-                      (v8/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -737,7 +696,7 @@ return {
                     "kind": "LinkedField",
                     "name": "registrationStatus",
                     "plural": false,
-                    "selections": (v17/*: any*/),
+                    "selections": (v14/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -754,7 +713,7 @@ return {
                     "name": "liveStartAt",
                     "storageKey": null
                   },
-                  (v11/*: any*/),
+                  (v8/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -762,11 +721,11 @@ return {
                     "name": "endedAt",
                     "storageKey": null
                   },
-                  (v14/*: any*/),
+                  (v11/*: any*/),
                   (v2/*: any*/),
-                  (v7/*: any*/),
-                  (v12/*: any*/),
-                  (v13/*: any*/),
+                  (v5/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -809,7 +768,7 @@ return {
                     "kind": "LinkedField",
                     "name": "associatedSale",
                     "plural": false,
-                    "selections": (v17/*: any*/),
+                    "selections": (v14/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -819,14 +778,14 @@ return {
                     "kind": "LinkedField",
                     "name": "promotedSale",
                     "plural": false,
-                    "selections": (v17/*: any*/),
+                    "selections": (v14/*: any*/),
                     "storageKey": null
                   },
-                  (v8/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v8/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": null
           }
@@ -836,12 +795,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "50506e93b3198be4bc4713488e08204c",
+    "cacheID": "ec4330e105cbf8a4b60212cbc89449a5",
     "id": null,
     "metadata": {},
     "name": "useCreateBidderMutation",
     "operationKind": "mutation",
-    "text": "mutation useCreateBidderMutation(\n  $input: CreateBidderInput!\n) {\n  createBidder(input: $input) {\n    bidder {\n      internalID\n      sale {\n        ...AuctionApp_sale\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment AuctionApp_sale on Sale {\n  ...AuctionMeta_sale\n  ...AuctionAssociatedSale_sale\n  ...AuctionBuyNowRail_sale\n  ...AuctionDetails_sale\n  ...CascadingEndTimesBanner_sale\n  internalID\n  slug\n  isClosed\n  eligibleSaleArtworksCount\n  coverImage {\n    url(version: [\"wide\", \"source\", \"large_rectangle\"])\n  }\n  showAssociatedSale: associatedSale {\n    internalID\n    id\n  }\n  showBuyNowTab: promotedSale {\n    internalID\n    id\n  }\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n  status\n}\n\nfragment AuctionAssociatedSale_sale on Sale {\n  associatedSale {\n    coverImage {\n      cropped(width: 445, height: 250) {\n        src\n        srcSet\n      }\n    }\n    displayTimelyAt\n    href\n    slug\n    name\n    id\n  }\n}\n\nfragment AuctionBuyNowRail_sale on Sale {\n  promotedSale {\n    href\n    internalID\n    name\n    saleArtworksConnection(first: 99) {\n      edges {\n        node {\n          artwork {\n            ...ShelfArtwork_artwork\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment AuctionDetails_sale on Sale {\n  ...RegisterButton_sale\n  ...AuctionInfoSidebar_sale\n  ...SaleDetailTimer_sale\n  internalID\n  name\n  slug\n  liveStartAt\n  startAt\n  endAt\n  description(format: HTML)\n  href\n  isClosed\n  cascadingEndTimeIntervalMinutes\n}\n\nfragment AuctionInfoSidebar_sale on Sale {\n  liveStartAt\n}\n\nfragment AuctionMeta_sale on Sale {\n  name\n  description(format: HTML)\n  slug\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment RegisterButton_sale on Sale {\n  bidder {\n    qualifiedForBidding\n    id\n  }\n  isAuction\n  isClosed\n  isLiveOpen\n  isPreview\n  isRegistrationClosed\n  liveURLIfOpen\n  requireIdentityVerification\n  registrationStatus {\n    internalID\n    id\n  }\n  slug\n  status\n}\n\nfragment SaleDetailTimer_sale on Sale {\n  endAt\n  endedAt\n  startAt\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "mutation useCreateBidderMutation(\n  $input: CreateBidderInput!\n) {\n  createBidder(input: $input) {\n    bidder {\n      internalID\n      sale {\n        ...AuctionApp_sale\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment AuctionApp_sale on Sale {\n  ...AuctionMeta_sale\n  ...AuctionAssociatedSale_sale\n  ...AuctionBuyNowRail_sale\n  ...AuctionDetails_sale\n  ...CascadingEndTimesBanner_sale\n  internalID\n  slug\n  isClosed\n  eligibleSaleArtworksCount\n  coverImage {\n    url(version: [\"wide\", \"source\", \"large_rectangle\"])\n  }\n  showAssociatedSale: associatedSale {\n    internalID\n    id\n  }\n  showBuyNowTab: promotedSale {\n    internalID\n    id\n  }\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n  status\n}\n\nfragment AuctionAssociatedSale_sale on Sale {\n  associatedSale {\n    coverImage {\n      cropped(width: 445, height: 250) {\n        src\n        srcSet\n      }\n    }\n    displayTimelyAt\n    href\n    slug\n    name\n    id\n  }\n}\n\nfragment AuctionBuyNowRail_sale on Sale {\n  promotedSale {\n    href\n    internalID\n    name\n    saleArtworksConnection(first: 99) {\n      edges {\n        node {\n          artwork {\n            ...ShelfArtwork_artwork\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment AuctionDetails_sale on Sale {\n  ...RegisterButton_sale\n  ...AuctionInfoSidebar_sale\n  ...SaleDetailTimer_sale\n  internalID\n  name\n  slug\n  liveStartAt\n  startAt\n  endAt\n  description(format: HTML)\n  href\n  isClosed\n  cascadingEndTimeIntervalMinutes\n}\n\nfragment AuctionInfoSidebar_sale on Sale {\n  liveStartAt\n}\n\nfragment AuctionMeta_sale on Sale {\n  name\n  description(format: HTML)\n  slug\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment RegisterButton_sale on Sale {\n  bidder {\n    qualifiedForBidding\n    id\n  }\n  isAuction\n  isClosed\n  isLiveOpen\n  isPreview\n  isRegistrationClosed\n  liveURLIfOpen\n  requireIdentityVerification\n  registrationStatus {\n    internalID\n    id\n  }\n  slug\n  status\n}\n\nfragment SaleDetailTimer_sale on Sale {\n  endAt\n  endedAt\n  startAt\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Closes [GRO-1330](https://artsyproduct.atlassian.net/browse/GRO-1330)

Initially I was looking at the DOM size of the shelf artwork and saw some opportunities to improve how it renders and make it easier to use. In particular we get rid of the double tab stop problem where previously there was a link wrapped around the image and then another link wrapped around the details. Now there's a single link wrapped around the entire thing, labelled with the artwork title alone. I also removed the need to use the `Media` component which should help a bit with rendering performance. Also improved how it responsively scales. Also added a consistent placeholder.