### PR TITLE
fix: remove blue highlight from guarantee icons

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2ArtsyGuarantee.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2ArtsyGuarantee.tsx
@@ -9,24 +9,6 @@ import {
 } from "@artsy/palette"
 import { useTranslation } from "react-i18next"
 import { RouterLink } from "System/Router/RouterLink"
-import { themeGet } from "@styled-system/theme-get"
-import styled from "styled-components"
-
-const GuaranteeIconBlue = styled(GuaranteeIcon)`
-  .guarantee-checkmark {
-    fill: ${themeGet("colors.brand")};
-  }
-`
-const SecureLockIconBlue = styled(SecureLockIcon)`
-  .securelock-opening {
-    fill: ${themeGet("colors.brand")};
-  }
-`
-const VerifiedIconBlue = styled(VerifiedIcon)`
-  .verified-checkmark {
-    fill: ${themeGet("colors.brand")};
-  }
-`
 
 export const ArtworkSidebar2ArtsyGuarantee: React.FC<{}> = () => {
   const { t } = useTranslation()
@@ -41,7 +23,7 @@ export const ArtworkSidebar2ArtsyGuarantee: React.FC<{}> = () => {
     <>
       <Text variant="sm" color="black60">
         <Flex flexDirection="row" alignItems="center">
-          <SecureLockIconBlue {...iconProps} />
+          <SecureLockIcon {...iconProps} />
           <Text>{t("artworkPage.sidebar.artsyGuarantee.securePayment")}</Text>
         </Flex>
         <Spacer mt={1} />
@@ -53,13 +35,13 @@ export const ArtworkSidebar2ArtsyGuarantee: React.FC<{}> = () => {
             height={24}
             width={24}
           >
-            <GuaranteeIconBlue height={18} width={18} />
+            <GuaranteeIcon height={18} width={18} />
           </Flex>
           <Text>{t("artworkPage.sidebar.artsyGuarantee.moneyBack")}</Text>
         </Flex>
         <Spacer mt={1} />
         <Flex flexDirection="row" alignItems="center">
-          <VerifiedIconBlue {...iconProps} />
+          <VerifiedIcon {...iconProps} />
           <Text>{t("artworkPage.sidebar.artsyGuarantee.authenticity")}</Text>
         </Flex>
         <Spacer mt={1} />


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-4335]

### Description

Remove blue highlight from Artsy Guarantee section

[slack thread](https://artsy.slack.com/archives/C9SATFLUU/p1664963285885169) where this was surfaced

|Desktop|mWeb|
|---|---|
|<img width="1510" alt="Screenshot 2022-10-05 at 13 46 27" src="https://user-images.githubusercontent.com/21178754/194053718-5a392ea2-198d-4bd2-9bab-2dce3074ef2d.png">|<img width="385" alt="Screenshot 2022-10-05 at 13 46 53" src="https://user-images.githubusercontent.com/21178754/194053705-eb8e174d-cffa-44dd-9cd3-f95b3aa7b0aa.png">|



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-4335]: https://artsyproduct.atlassian.net/browse/FX-4335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ