### PR TITLE
fix(FX-4317): artsy guarantee learn more link opens new tab

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2ArtsyGuarantee.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2ArtsyGuarantee.tsx
@@ -8,7 +8,6 @@ import {
   VerifiedIcon,
 } from "@artsy/palette"
 import { useTranslation } from "react-i18next"
-import { RouterLink } from "System/Router/RouterLink"
 
 export const ArtworkSidebar2ArtsyGuarantee: React.FC<{}> = () => {
   const { t } = useTranslation()
@@ -46,15 +45,15 @@ export const ArtworkSidebar2ArtsyGuarantee: React.FC<{}> = () => {
         </Flex>
         <Spacer mt={1} />
       </Text>
-      <RouterLink
-        to={"/buyer-guarantee"}
-        textDecoration="underline"
-        display="block"
+      <a
+        href="https://artsy.net/buyer-guarantee"
+        target="_blank"
+        rel="noopener noreferrer"
       >
         <Text variant="xs" color="black60">
           {t("artworkPage.sidebar.artsyGuarantee.learnMore")}
         </Text>
-      </RouterLink>
+      </a>
     </>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4317]

### Description

When pressing artsy guarantee learn more link a new tab opens

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4317]: https://artsyproduct.atlassian.net/browse/FX-4317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ