### PR TITLE
[Review App] Scale images by area in artwork shelves

### DIFF
--- a/src/Apps/About/AboutArtworksRail.tsx
+++ b/src/Apps/About/AboutArtworksRail.tsx
@@ -4,14 +4,11 @@ import { AboutArtworksRailQuery } from "__generated__/AboutArtworksRailQuery.gra
 import { AboutArtworksRail_viewer$data } from "__generated__/AboutArtworksRail_viewer.graphql"
 import { Rail } from "Components/Rail"
 import { extractNodes } from "Utils/extractNodes"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
 import {
-  Box,
-  Skeleton,
-  SkeletonBox,
-  SkeletonText,
-  Spacer,
-} from "@artsy/palette"
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
+import { Skeleton } from "@artsy/palette"
 
 interface AboutArtworksRailProps {
   viewer: AboutArtworksRail_viewer$data
@@ -77,7 +74,6 @@ export const AboutArtworksRailQueryRenderer: React.FC = () => {
           return PLACEHOLDER
         }
 
-        // @ts-ignore RELAY UPGRDE 13
         return <AboutArtworksRailFragmentContainer viewer={props.viewer} />
       }}
     />
@@ -92,16 +88,7 @@ const PLACEHOLDER = (
       viewAllHref="/gene/trending-this-week"
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
-          return (
-            <Box width={200} key={i}>
-              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-              <Spacer mt={1} />
-              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-              <SkeletonText variant="xs">Partner</SkeletonText>
-              <SkeletonText variant="xs">Price</SkeletonText>
-            </Box>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
@@ -3,20 +3,17 @@ import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { useAnalyticsContext, useSystemContext } from "System"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import { extractNodes } from "Utils/extractNodes"
 import { ArtistNotableWorksRail_artist$data } from "__generated__/ArtistNotableWorksRail_artist.graphql"
 import { ArtistNotableWorksRailQuery } from "__generated__/ArtistNotableWorksRailQuery.graphql"
 import { scrollToTop } from "Apps/Artist/Routes/Overview/Utils/scrollToTop"
 import { Rail } from "Components/Rail"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import {
-  Box,
-  Skeleton,
-  SkeletonBox,
-  SkeletonText,
-  Spacer,
-} from "@artsy/palette"
+import { Box, Skeleton } from "@artsy/palette"
 
 interface ArtistNotableWorksRailProps {
   artist: ArtistNotableWorksRail_artist$data
@@ -66,7 +63,6 @@ const ArtistNotableWorksRail: React.FC<ArtistNotableWorksRailProps> = ({
               artwork={node}
               contextModule={ContextModule.topWorksRail}
               key={index}
-              showMetadata
               lazyLoad
               onClick={() => {
                 tracking.trackEvent(
@@ -119,16 +115,7 @@ const PLACEHOLDER = (
       viewAllLabel="View All Works"
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
-          return (
-            <Box width={200} key={i}>
-              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-              <Spacer mt={1} />
-              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-              <SkeletonText variant="xs">Partner</SkeletonText>
-              <SkeletonText variant="xs">Price</SkeletonText>
-            </Box>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
@@ -3,13 +3,16 @@ import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { useAnalyticsContext, useSystemContext } from "System"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import { extractNodes } from "Utils/extractNodes"
 import { ArtistWorksForSaleRail_artist$data } from "__generated__/ArtistWorksForSaleRail_artist.graphql"
 import { ArtistWorksForSaleRailQuery } from "__generated__/ArtistWorksForSaleRailQuery.graphql"
 import { scrollToTop } from "Apps/Artist/Routes/Overview/Utils/scrollToTop"
 import { Rail } from "Components/Rail"
-import { Box, Skeleton, SkeletonBox, SkeletonText } from "@artsy/palette"
+import { Box, Skeleton } from "@artsy/palette"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 
 interface ArtistWorksForSaleRailProps {
@@ -61,7 +64,6 @@ const ArtistWorksForSaleRail: React.FC<ArtistWorksForSaleRailProps> = ({
                 artwork={node}
                 contextModule={ContextModule.worksForSaleRail}
                 key={index}
-                showMetadata
                 lazyLoad
                 onClick={() => {
                   tracking.trackEvent(
@@ -115,13 +117,7 @@ const PLACEHOLDER = (
       viewAllLabel="View All Works"
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
-          return (
-            <React.Fragment key={i}>
-              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-              <SkeletonText variant="lg-display">Some Artist</SkeletonText>
-              <SkeletonText variant="sm-display">Location</SkeletonText>
-            </React.Fragment>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/SoldRecentlyOnArtsy.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/SoldRecentlyOnArtsy.tsx
@@ -1,17 +1,11 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import {
-  Box,
-  Flex,
-  Skeleton,
-  SkeletonBox,
-  SkeletonText,
-  Spacer,
-  Text,
-} from "@artsy/palette"
+import { Flex, Skeleton, SkeletonText, Spacer, Text } from "@artsy/palette"
 import { shuffle } from "lodash"
-import { Fragment } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import { Rail } from "Components/Rail"
 import { useTracking } from "react-tracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
@@ -58,29 +52,32 @@ export const SoldRecentlyOnArtsy: React.FC<SoldRecentlyOnArtsyProps> = ({
             if (!artwork) return <></>
 
             return (
-              <Fragment key={artwork.internalID}>
-                <ShelfArtworkFragmentContainer
-                  artwork={artwork}
-                  hideSaleInfo
-                  lazyLoad
-                  width={[325]}
-                  data-testid="soldRecentlyItem"
-                  onClick={trackArtworkItemClick(artwork, i)}
-                  // FIXME:
-                  contextModule={ContextModule.artworkRecentlySoldGrid as any}
-                />
+              <ShelfArtworkFragmentContainer
+                key={artwork.internalID}
+                artwork={artwork}
+                hideSaleInfo
+                lazyLoad
+                area={60000}
+                maxImageHeight={300}
+                data-testid="soldRecentlyItem"
+                onClick={trackArtworkItemClick(artwork, i)}
+                // FIXME:
+                contextModule={ContextModule.artworkRecentlySoldGrid as any}
+              >
+                <Spacer mt={4} />
 
                 <Flex
-                  mt={4}
                   flexDirection="row"
                   alignItems="center"
                   justifyContent="space-between"
                   color="black60"
                 >
-                  <Text variant="xs">Estimate</Text>
+                  <Text variant="xs" overflowEllipsis>
+                    Estimate
+                  </Text>
 
-                  <Text variant="xs">
-                    {lowEstimate?.display}—{highEstimate?.display}
+                  <Text variant="xs" overflowEllipsis>
+                    {lowEstimate?.display}–{highEstimate?.display}
                   </Text>
                 </Flex>
 
@@ -90,11 +87,15 @@ export const SoldRecentlyOnArtsy: React.FC<SoldRecentlyOnArtsyProps> = ({
                   justifyContent="space-between"
                   color="blue100"
                 >
-                  <Text variant="xs">Sold for (incl. premium)</Text>
+                  <Text variant="xs" overflowEllipsis>
+                    Sold for (incl. premium)
+                  </Text>
 
-                  <Text variant="xs">{priceRealized?.display}</Text>
+                  <Text variant="xs" overflowEllipsis>
+                    {priceRealized?.display}
+                  </Text>
                 </Flex>
-              </Fragment>
+              </ShelfArtworkFragmentContainer>
             )
           }
         )
@@ -139,11 +140,12 @@ const PLACEHOLDER = (
       getItems={() => {
         return [...new Array(20)].map((_, i) => {
           return (
-            <Box width={325} key={i}>
-              <SkeletonBox width={325} height={[200, 300, 250, 275][i % 4]} />
-              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-
+            <ShelfArtworkPlaceholder
+              index={i}
+              area={60000}
+              maxImageHeight={300}
+              hideSaleInfo
+            >
               <Spacer mt={4} />
 
               <Flex
@@ -151,9 +153,13 @@ const PLACEHOLDER = (
                 alignItems="center"
                 justifyContent="space-between"
               >
-                <SkeletonText variant="xs">Estimate</SkeletonText>
+                <SkeletonText variant="xs" overflowEllipsis>
+                  Estimate
+                </SkeletonText>
 
-                <SkeletonText variant="xs">USD 100,000 - 100,000</SkeletonText>
+                <SkeletonText variant="xs" overflowEllipsis>
+                  USD 100,000–100,000
+                </SkeletonText>
               </Flex>
 
               <Flex
@@ -161,13 +167,15 @@ const PLACEHOLDER = (
                 alignItems="center"
                 justifyContent="space-between"
               >
-                <SkeletonText variant="xs">
+                <SkeletonText variant="xs" overflowEllipsis>
                   Sold for (incl. premium)
                 </SkeletonText>
 
-                <SkeletonText variant="xs">USD 100,000</SkeletonText>
+                <SkeletonText variant="xs" overflowEllipsis>
+                  USD 100,000
+                </SkeletonText>
               </Flex>
-            </Box>
+            </ShelfArtworkPlaceholder>
           )
         })
       }}

--- a/src/Apps/Home/Components/HomeAuctionLotsRail.tsx
+++ b/src/Apps/Home/Components/HomeAuctionLotsRail.tsx
@@ -1,10 +1,4 @@
-import {
-  Box,
-  Spacer,
-  Skeleton,
-  SkeletonText,
-  SkeletonBox,
-} from "@artsy/palette"
+import { Skeleton } from "@artsy/palette"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "System"
@@ -12,7 +6,10 @@ import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { HomeAuctionLotsRail_viewer$data } from "__generated__/HomeAuctionLotsRail_viewer.graphql"
 import { HomeAuctionLotsRailQuery } from "__generated__/HomeAuctionLotsRailQuery.graphql"
 import { extractNodes } from "Utils/extractNodes"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import {
   ActionType,
   ClickedArtworkGroup,
@@ -89,16 +86,7 @@ const PLACEHOLDER = (
       viewAllHref="/auctions"
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
-          return (
-            <Box width={200} key={i}>
-              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-              <Spacer mt={1} />
-              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-              <SkeletonText variant="xs">Partner</SkeletonText>
-              <SkeletonText variant="xs">Price</SkeletonText>
-            </Box>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />

--- a/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
+++ b/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Shelf,
-  Skeleton,
-  SkeletonText,
-  SkeletonBox,
-  Spacer,
-} from "@artsy/palette"
+import { Shelf, Skeleton } from "@artsy/palette"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "System"
@@ -13,7 +6,10 @@ import { useTracking } from "react-tracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { HomeNewWorksForYouRail_artworksForUser$data } from "__generated__/HomeNewWorksForYouRail_artworksForUser.graphql"
 import { HomeNewWorksForYouRailQuery } from "__generated__/HomeNewWorksForYouRailQuery.graphql"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import { extractNodes } from "Utils/extractNodes"
 import {
   ActionType,
@@ -73,18 +69,7 @@ const PLACEHOLDER = (
   <Skeleton>
     <Shelf>
       {[...new Array(8)].map((_, i) => {
-        return (
-          <Box width={200} key={i}>
-            <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-
-            <Spacer mt={1} />
-
-            <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-            <SkeletonText variant="xs">Partner</SkeletonText>
-            <SkeletonText variant="xs">Price</SkeletonText>
-          </Box>
-        )
+        return <ShelfArtworkPlaceholder key={i} index={i} />
       })}
     </Shelf>
   </Skeleton>

--- a/src/Apps/Home/Components/HomeRecentlyViewedRail.tsx
+++ b/src/Apps/Home/Components/HomeRecentlyViewedRail.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Shelf,
-  Skeleton,
-  SkeletonText,
-  SkeletonBox,
-  Spacer,
-} from "@artsy/palette"
+import { Shelf, Skeleton } from "@artsy/palette"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "System"
@@ -13,7 +6,10 @@ import { useTracking } from "react-tracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { HomeRecentlyViewedRail_homePage$data } from "__generated__/HomeRecentlyViewedRail_homePage.graphql"
 import { HomeRecentlyViewedRailQuery } from "__generated__/HomeRecentlyViewedRailQuery.graphql"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import {
   ActionType,
   ClickedArtworkGroup,
@@ -72,18 +68,7 @@ const PLACEHOLDER = (
   <Skeleton>
     <Shelf>
       {[...new Array(8)].map((_, i) => {
-        return (
-          <Box width={200} key={i}>
-            <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-
-            <Spacer mt={1} />
-
-            <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-            <SkeletonText variant="xs">Partner</SkeletonText>
-            <SkeletonText variant="xs">Price</SkeletonText>
-          </Box>
-        )
+        return <ShelfArtworkPlaceholder key={i} index={i} />
       })}
     </Shelf>
   </Skeleton>

--- a/src/Apps/Home/Components/HomeTroveArtworksRail.tsx
+++ b/src/Apps/Home/Components/HomeTroveArtworksRail.tsx
@@ -4,15 +4,12 @@ import {
   ContextModule,
   OwnerType,
 } from "@artsy/cohesion"
-import {
-  Box,
-  Skeleton,
-  SkeletonBox,
-  SkeletonText,
-  Spacer,
-} from "@artsy/palette"
+import { Skeleton } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import { Rail } from "Components/Rail/Rail"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { extractNodes } from "Utils/extractNodes"
@@ -136,16 +133,7 @@ const PLACEHOLDER = (
       subTitle="A weekly curated selection of the best works on Artsy by emerging and sought after artists."
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
-          return (
-            <Box width={200} key={i}>
-              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-              <Spacer mt={1} />
-              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-              <SkeletonText variant="xs">Partner</SkeletonText>
-              <SkeletonText variant="xs">Price</SkeletonText>
-            </Box>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />

--- a/src/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
+++ b/src/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Shelf,
-  Skeleton,
-  SkeletonText,
-  SkeletonBox,
-  Spacer,
-} from "@artsy/palette"
+import { Shelf, Skeleton } from "@artsy/palette"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "System"
@@ -13,7 +6,10 @@ import { useTracking } from "react-tracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { HomeWorksByArtistsYouFollowRail_homePage$data } from "__generated__/HomeWorksByArtistsYouFollowRail_homePage.graphql"
 import { HomeWorksByArtistsYouFollowRailQuery } from "__generated__/HomeWorksByArtistsYouFollowRailQuery.graphql"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import {
   ActionType,
   ClickedArtworkGroup,
@@ -72,18 +68,7 @@ const PLACEHOLDER = (
   <Skeleton>
     <Shelf>
       {[...new Array(8)].map((_, i) => {
-        return (
-          <Box width={200} key={i}>
-            <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-
-            <Spacer mt={1} />
-
-            <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-            <SkeletonText variant="xs">Partner</SkeletonText>
-            <SkeletonText variant="xs">Price</SkeletonText>
-          </Box>
-        )
+        return <ShelfArtworkPlaceholder key={i} index={i} />
       })}
     </Shelf>
   </Skeleton>

--- a/src/Components/ArtistRail.tsx
+++ b/src/Components/ArtistRail.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment } from "react"
+import { FC } from "react"
 import {
   Box,
   Flex,
@@ -13,7 +13,10 @@ import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { extractNodes } from "Utils/extractNodes"
 import { ArtistRailQuery } from "__generated__/ArtistRailQuery.graphql"
 import { ArtistRail_artist$data } from "__generated__/ArtistRail_artist.graphql"
-import { ShelfArtworkFragmentContainer } from "./Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "./Artwork/ShelfArtwork"
 import { EntityHeaderArtistFragmentContainer } from "./EntityHeaders/EntityHeaderArtist"
 
 interface ArtistRailProps {
@@ -63,23 +66,7 @@ export const ARTIST_RAIL_PLACEHOLDER = (
 
     <Shelf>
       {[...new Array(10)].map((_, i) => {
-        return (
-          <Fragment key={i}>
-            <SkeletonBox
-              width={200}
-              height={[
-                [100, 150, 200, 250][i % 4],
-                [100, 320, 200, 250][i % 4],
-              ]}
-              mb={1}
-            />
-
-            <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-            <SkeletonText variant="xs">Partner</SkeletonText>
-            <SkeletonText variant="xs">US$0,000</SkeletonText>
-          </Fragment>
-        )
+        return <ShelfArtworkPlaceholder key={i} index={i} />
       })}
     </Shelf>
   </Skeleton>

--- a/src/Components/Artwork/__stories__/Shelf.story.tsx
+++ b/src/Components/Artwork/__stories__/Shelf.story.tsx
@@ -1,0 +1,77 @@
+import { Shelf } from "@artsy/palette"
+import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import { graphql } from "react-relay"
+import { States } from "storybook-states"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import { extractNodes } from "Utils/extractNodes"
+import { ShelfStoryQuery } from "__generated__/ShelfStoryQuery.graphql"
+
+export default {
+  title: "Components/Shelf",
+}
+
+export const Example = () => {
+  return (
+    <States<{ id: string }>
+      states={[
+        { id: "roni-horn" },
+        { id: "andy-warhol" },
+        { id: "cy-twombly" },
+        { id: "john-m-armleder" },
+        { id: "chris-ofili" },
+      ]}
+    >
+      {({ id }) => {
+        return (
+          <SystemQueryRenderer<ShelfStoryQuery>
+            variables={{ id }}
+            query={graphql`
+              query ShelfStoryQuery($id: String!) {
+                artist(id: $id) {
+                  filterArtworksConnection(
+                    first: 15
+                    sort: "-weighted_iconicity"
+                  ) {
+                    edges {
+                      node {
+                        ...ShelfArtwork_artwork
+                        internalID
+                      }
+                    }
+                  }
+                }
+              }
+            `}
+            render={({ error, props }) => {
+              if (error) {
+                console.error(error)
+                return null
+              }
+
+              if (!props?.artist) {
+                return <div>loading</div>
+              }
+
+              const arworks = extractNodes(
+                props.artist.filterArtworksConnection
+              )
+
+              return (
+                <Shelf>
+                  {arworks.map(artwork => {
+                    return (
+                      <ShelfArtworkFragmentContainer
+                        key={artwork.internalID}
+                        artwork={artwork}
+                      />
+                    )
+                  })}
+                </Shelf>
+              )
+            }}
+          />
+        )
+      }}
+    </States>
+  )
+}

--- a/src/Components/Artwork/__stories__/ShelfArtwork.story.tsx
+++ b/src/Components/Artwork/__stories__/ShelfArtwork.story.tsx
@@ -6,6 +6,8 @@ import {
 } from "Components/Artwork/ShelfArtwork"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { graphql } from "react-relay"
+import { maxWidthByArea } from "Utils/resized"
+import { SkeletonBox } from "@artsy/palette"
 
 export default {
   title: "Components/ShelfArtwork",
@@ -16,23 +18,7 @@ export const Default = () => {
     <States<Partial<ShelfArtworkProps>>
       states={[
         { id: "morris-louis-gamma-delta" },
-        {
-          id: "morris-louis-gamma-delta",
-          width: [100],
-        },
-        {
-          id: "morris-louis-gamma-delta",
-          width: [400],
-        },
         { id: "roni-horn-best-witchcraft-is-geometry" },
-        {
-          id: "roni-horn-best-witchcraft-is-geometry",
-          width: [100],
-        },
-        {
-          id: "roni-horn-best-witchcraft-is-geometry",
-          width: [400],
-        },
         // Very tall + narrow
         { id: "barnett-newman-the-moment-from-four-on-plexiglas" },
         // No sale message
@@ -70,6 +56,31 @@ export const Default = () => {
             }}
           />
         )
+      }}
+    </States>
+  )
+}
+
+export const MaxWidthByArea = () => {
+  return (
+    <States
+      states={[
+        { width: 160, height: 90, area: 10000 },
+        { width: 90, height: 160, area: 40000 },
+        { width: 400, height: 400, area: 10000 },
+        { width: 200, height: 400, area: 10000 },
+        { width: 400, height: 200, area: 10000 },
+        { width: 400, height: 100, area: 10000 },
+        { width: 100, height: 400, area: 10000 },
+        { width: 10, height: 400, area: 10000 },
+        { width: 400, height: 10, area: 10000 },
+      ]}
+    >
+      {({ width, height, area }) => {
+        const maxWidth = maxWidthByArea({ area, height, width })
+        const scaledHeight = Math.round((height / width) * maxWidth)
+
+        return <SkeletonBox width={maxWidth} height={scaledHeight} />
       }}
     </States>
   )

--- a/src/Components/CategoryRail.tsx
+++ b/src/Components/CategoryRail.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment } from "react"
+import { FC } from "react"
 import {
   Box,
   Flex,
@@ -13,7 +13,10 @@ import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { extractNodes } from "Utils/extractNodes"
 import { CategoryRailQuery } from "__generated__/CategoryRailQuery.graphql"
 import { CategoryRail_category$data } from "__generated__/CategoryRail_category.graphql"
-import { ShelfArtworkFragmentContainer } from "./Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "./Artwork/ShelfArtwork"
 import { EntityHeaderGeneFragmentContainer } from "./EntityHeaders/EntityHeaderGene"
 
 interface CategoryRailProps {
@@ -62,23 +65,7 @@ export const CATEGORY_RAIL_PLACEHOLDER = (
 
     <Shelf>
       {[...new Array(10)].map((_, i) => {
-        return (
-          <Fragment key={i}>
-            <SkeletonBox
-              width={200}
-              height={[
-                [100, 150, 200, 250][i % 4],
-                [100, 320, 200, 250][i % 4],
-              ]}
-              mb={1}
-            />
-
-            <SkeletonText variant="sm-display">Category Name</SkeletonText>
-            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-            <SkeletonText variant="xs">Partner</SkeletonText>
-            <SkeletonText variant="xs">US$0,000</SkeletonText>
-          </Fragment>
-        )
+        return <ShelfArtworkPlaceholder key={i} index={i} />
       })}
     </Shelf>
   </Skeleton>

--- a/src/Utils/__tests__/resized.jest.ts
+++ b/src/Utils/__tests__/resized.jest.ts
@@ -1,4 +1,4 @@
-import { cropped, resized } from "../resized"
+import { cropped, resized, maxWidthByArea } from "Utils/resized"
 
 jest.mock("sharify", () => ({
   data: {
@@ -50,5 +50,41 @@ describe("#resized", () => {
     expect(srcSet).toContain("&height=100&quality=80")
     expect(srcSet).toContain("2x")
     expect(srcSet).toContain("&height=200&quality=80")
+  })
+})
+
+describe("maxWidthByArea", () => {
+  it("sets a max width for a proportional box", () => {
+    expect(
+      maxWidthByArea({
+        width: 100,
+        height: 100,
+        area: 10000,
+      })
+    ).toEqual(100)
+
+    expect(
+      maxWidthByArea({
+        width: 200,
+        height: 100,
+        area: 10000,
+      })
+    ).toEqual(141)
+
+    expect(
+      maxWidthByArea({
+        width: 100,
+        height: 200,
+        area: 10000,
+      })
+    ).toEqual(71)
+
+    expect(
+      maxWidthByArea({
+        width: 10,
+        height: 200,
+        area: 10000,
+      })
+    ).toEqual(22)
   })
 })

--- a/src/Utils/resized.ts
+++ b/src/Utils/resized.ts
@@ -94,3 +94,15 @@ export const cropped = (
     srcSet: `${_1x} 1x, ${_2x} 2x`,
   }
 }
+
+export const maxWidthByArea = ({
+  width,
+  height,
+  area,
+}: {
+  width: number
+  height: number
+  area: number
+}) => {
+  return Math.round(width * Math.sqrt(area / (width * height)))
+}

--- a/src/__generated__/ShelfStoryQuery.graphql.ts
+++ b/src/__generated__/ShelfStoryQuery.graphql.ts
@@ -1,0 +1,523 @@
+/**
+ * @generated SignedSource<<a9876f7bd44fb7e7a1fdbe81400498a6>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ShelfStoryQuery$variables = {
+  id: string;
+};
+export type ShelfStoryQuery$data = {
+  readonly artist: {
+    readonly filterArtworksConnection: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly internalID: string;
+          readonly " $fragmentSpreads": FragmentRefs<"ShelfArtwork_artwork">;
+        } | null;
+      } | null> | null;
+    } | null;
+  } | null;
+};
+export type ShelfStoryQuery = {
+  response: ShelfStoryQuery$data;
+  variables: ShelfStoryQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 15
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "-weighted_iconicity"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v9 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v10 = [
+  (v7/*: any*/),
+  (v6/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ShelfStoryQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "ShelfArtwork_artwork"
+                      },
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "filterArtworksConnection(first:15,sort:\"-weighted_iconicity\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ShelfStoryQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v5/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v6/*: any*/),
+                          (v4/*: any*/),
+                          (v7/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v5/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v7/*: any*/),
+                          (v4/*: any*/),
+                          (v6/*: any*/)
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          (v8/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "cascadingEndTimeIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "startAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotID",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotLabel",
+                            "storageKey": null
+                          },
+                          (v8/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingEndAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "formattedEndDateTime",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v9/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v9/*: any*/),
+                            "storageKey": null
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v6/*: any*/),
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "AttributionClass",
+                        "kind": "LinkedField",
+                        "name": "attributionClass",
+                        "plural": false,
+                        "selections": (v10/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkMedium",
+                        "kind": "LinkedField",
+                        "name": "mediumType",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Gene",
+                            "kind": "LinkedField",
+                            "name": "filterGene",
+                            "plural": false,
+                            "selections": (v10/*: any*/),
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "normalized",
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "height",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v6/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:15,sort:\"-weighted_iconicity\")"
+          },
+          (v6/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "9abd14fe4224d923abcf83503eb085e9",
+    "id": null,
+    "metadata": {},
+    "name": "ShelfStoryQuery",
+    "operationKind": "query",
+    "text": "query ShelfStoryQuery(\n  $id: String!\n) {\n  artist(id: $id) {\n    filterArtworksConnection(first: 15, sort: \"-weighted_iconicity\") {\n      edges {\n        node {\n          ...ShelfArtwork_artwork\n          internalID\n          id\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "ea6081fc75393212731f35be87d60bc4";
+
+export default node;


### PR DESCRIPTION
This converts the artwork shelf to target an area (default 40,000) when coming up with a width to resize to. This allows for a more visually balanced shelf component. Previously we were just constraining everything by a specific width (default 200px), which would lead to large portrait oriented images and small landscape ones (the artwork brick columns still suffer from this problem).

![](https://static.damonzucconi.com/_capture/pAPRXcEx.png)

----

Additionally I've gone around and replaced all of the bespoke skeletons with a single placeholder type which should prevent layout shifting for these components.