### PR TITLE
feat(art-quiz): create results page structure

### DIFF
--- a/src/Apps/ArtQuiz/ArtQuizResults.tsx
+++ b/src/Apps/ArtQuiz/ArtQuizResults.tsx
@@ -1,18 +1,14 @@
 import { Box, Button, Spacer, Tab, Tabs, Text } from "@artsy/palette"
 import { FC } from "react"
 import { useTranslation } from "react-i18next"
-import { getENV } from "Utils/getENV"
 
 export const ArtQuizResults: FC = () => {
   const { t } = useTranslation()
-  const name: string | undefined = getENV("CURRENT_USER")?.name
-  const customGreeting: string = `${name}'s ${t("artQuizPage.results.title")}`
-  const defaultGreeting: string = `Your ${t("artQuizPage.results.title")}`
 
   return (
     <Box>
       <Text mt={6} variant="xl">
-        {name ? customGreeting : defaultGreeting}
+        {t("artQuizPage.results.title")}
       </Text>
       <Text color="black60">{t("artQuizPage.results.subtitle")}</Text>
       <Spacer mt={2} />
@@ -20,7 +16,7 @@ export const ArtQuizResults: FC = () => {
         {t("artQuizPage.results.emailButton")}
       </Button>
       <Spacer mt={6} />
-      <Tabs>
+      <Tabs justifyContent="fill">
         <Tab name={t("artQuizPage.results.tabs.worksYouLiked")} />
         <Tab name={t("artQuizPage.results.tabs.recommendedCollections")} />
         <Tab name={t("artQuizPage.results.tabs.recommendedArtists")} />

--- a/src/Apps/ArtQuiz/ArtQuizResults.tsx
+++ b/src/Apps/ArtQuiz/ArtQuizResults.tsx
@@ -16,7 +16,7 @@ export const ArtQuizResults: FC = () => {
         {t("artQuizPage.results.emailButton")}
       </Button>
       <Spacer mt={6} />
-      <Tabs justifyContent="fill">
+      <Tabs fill>
         <Tab name={t("artQuizPage.results.tabs.worksYouLiked")} />
         <Tab name={t("artQuizPage.results.tabs.recommendedCollections")} />
         <Tab name={t("artQuizPage.results.tabs.recommendedArtists")} />

--- a/src/Apps/ArtQuiz/ArtQuizResults.tsx
+++ b/src/Apps/ArtQuiz/ArtQuizResults.tsx
@@ -1,0 +1,30 @@
+import { Box, Button, Spacer, Tab, Tabs, Text } from "@artsy/palette"
+import { FC } from "react"
+import { useTranslation } from "react-i18next"
+import { getENV } from "Utils/getENV"
+
+export const ArtQuizResults: FC = () => {
+  const { t } = useTranslation()
+  const name: string | undefined = getENV("CURRENT_USER")?.name
+  const customGreeting: string = `${name}'s ${t("artQuizPage.results.title")}`
+  const defaultGreeting: string = `Your ${t("artQuizPage.results.title")}`
+
+  return (
+    <Box>
+      <Text mt={6} variant="xl">
+        {name ? customGreeting : defaultGreeting}
+      </Text>
+      <Text color="black60">{t("artQuizPage.results.subtitle")}</Text>
+      <Spacer mt={2} />
+      <Button variant="secondaryBlack">
+        {t("artQuizPage.results.emailButton")}
+      </Button>
+      <Spacer mt={6} />
+      <Tabs>
+        <Tab name={t("artQuizPage.results.tabs.worksYouLiked")} />
+        <Tab name={t("artQuizPage.results.tabs.recommendedCollections")} />
+        <Tab name={t("artQuizPage.results.tabs.recommendedArtists")} />
+      </Tabs>
+    </Box>
+  )
+}

--- a/src/Apps/ArtQuiz/ArtQuizResults.tsx
+++ b/src/Apps/ArtQuiz/ArtQuizResults.tsx
@@ -7,11 +7,14 @@ export const ArtQuizResults: FC = () => {
 
   return (
     <Box>
-      <Text mt={6} variant="xl">
+      <Text mt={6} variant={["lg", "xl"]}>
         {t("artQuizPage.results.title")}
       </Text>
-      <Text color="black60">{t("artQuizPage.results.subtitle")}</Text>
-      <Spacer mt={2} />
+      <Spacer mt={1} />
+      <Text color="black60" variant={["sm", "md"]}>
+        {t("artQuizPage.results.subtitle")}
+      </Text>
+      <Spacer mt={4} />
       <Button variant="secondaryBlack">
         {t("artQuizPage.results.emailButton")}
       </Button>

--- a/src/Apps/ArtQuiz/ArtQuizWelcome.tsx
+++ b/src/Apps/ArtQuiz/ArtQuizWelcome.tsx
@@ -19,11 +19,13 @@ interface ArtQuizWelcomeProps {
 }
 
 export const ArtQuizWelcome: FC<ArtQuizWelcomeProps> = ({ onStartQuiz }) => {
-  const { desktop } = useNavBarHeight()
+  const { desktop, mobile } = useNavBarHeight()
   const { t } = useTranslation()
 
   return (
-    <FullBleed height={`calc(100vh - ${desktop}px)`}>
+    <FullBleed
+      height={[`calc(100vh - ${mobile}px)`, `calc(100vh - ${desktop}px)`]}
+    >
       <Box height="100%" padding={0}>
         <SplitLayout
           hideLogo
@@ -34,28 +36,27 @@ export const ArtQuizWelcome: FC<ArtQuizWelcomeProps> = ({ onStartQuiz }) => {
           }
           leftProps={{ display: ["none", "block"] }}
           right={
-            <Flex
-              flexDirection="column"
-              justifyContent="space-between"
-              p={[2, 4]}
-            >
-              {/* Vertically centers next Box */}
-              <Box />
-              <Box width="100%">
+            <Flex flexDirection="column" justifyContent="center" p={[2, 4]}>
+              <Box width="100%" my={6}>
                 <ArtsyLogoIcon mb={2} />
                 <Text variant={["xl", "xxl"]}>{t("artQuizPage.title")}</Text>
 
                 <Spacer my={6} />
 
-                <Text variant={["md", "lg-display"]}>
+                <Text variant={["md", "lg"]}>
                   {t("artQuizPage.welcomeScreen.subtitle1")}
-                  <Spacer my={4} />
+                </Text>
+
+                <Spacer my={2} />
+
+                <Text variant={["md", "lg-display"]}>
                   {t("artQuizPage.welcomeScreen.subtitle2")}
                 </Text>
               </Box>
 
-              <Spacer my={1} />
-              <Box width="100%">
+              <Spacer my={6} />
+
+              <Box width="100%" my={6}>
                 <Button width="100%" onClick={onStartQuiz}>
                   {t("artQuizPage.welcomeScreen.getStartedButton")}
                 </Button>

--- a/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
+++ b/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
@@ -1,0 +1,53 @@
+import { ArtQuizResults } from "Apps/ArtQuiz/ArtQuizResults"
+import { render, screen } from "@testing-library/react"
+
+const translationFileMock = {
+  artQuizPage: {
+    results: {
+      emailButton: "Email My Results",
+      title: "Explore Your Quiz Results",
+      subtitle:
+        "Explore these collections and artists recommended for you based on your saved works. Follow them to see their latest works on your Artsy home.",
+      tabs: {
+        worksYouLiked: "Works You Liked",
+        recommendedCollections: "Recommended Collections",
+        recommendedArtists: "Recommended Artists",
+      },
+    },
+  },
+}
+
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => ({
+      t: (dotNotation: string) => {
+        const [page, ...nestedKeys] = dotNotation.split(".")
+
+        let temp: Record<string, any> = { ...translationFileMock[page] }
+
+        nestedKeys.forEach(key => {
+          temp = temp[key]
+        })
+
+        return (temp as unknown) as string
+      },
+    }),
+  }
+})
+
+describe("ArtQuizResults", () => {
+  it.each([
+    ["title", "Explore Your Quiz Results"],
+    [
+      "subtitle",
+      "Explore these collections and artists recommended for you based on your saved works. Follow them to see their latest works on your Artsy home.",
+    ],
+    ["email button", "Email My Results"],
+    ["tab", "Works You Liked"],
+    ["tab", "Recommended Collections"],
+    ["tab", "Recommended Artists"],
+  ])("displays the expected %s text", (_key, text) => {
+    render(<ArtQuizResults />)
+    expect(screen.getByText(text)).toBeInTheDocument()
+  })
+})

--- a/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
+++ b/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
@@ -1,6 +1,5 @@
 import { ArtQuizResults } from "Apps/ArtQuiz/ArtQuizResults"
-import { screen } from "@testing-library/react"
-import { render } from "DevTools/setupTestWrapper"
+import { render, screen } from "@testing-library/react"
 
 describe("ArtQuizResults", () => {
   it("displays the expected text", () => {

--- a/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
+++ b/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
@@ -1,39 +1,6 @@
 import { ArtQuizResults } from "Apps/ArtQuiz/ArtQuizResults"
-import { render, screen } from "@testing-library/react"
-
-const translationFileMock = {
-  artQuizPage: {
-    results: {
-      emailButton: "Email My Results",
-      title: "Explore Your Quiz Results",
-      subtitle:
-        "Explore these collections and artists recommended for you based on your saved works. Follow them to see their latest works on your Artsy home.",
-      tabs: {
-        worksYouLiked: "Works You Liked",
-        recommendedCollections: "Recommended Collections",
-        recommendedArtists: "Recommended Artists",
-      },
-    },
-  },
-}
-
-jest.mock("react-i18next", () => {
-  return {
-    useTranslation: () => ({
-      t: (dotNotation: string) => {
-        const [page, ...nestedKeys] = dotNotation.split(".")
-
-        let temp: Record<string, any> = { ...translationFileMock[page] }
-
-        nestedKeys.forEach(key => {
-          temp = temp[key]
-        })
-
-        return (temp as unknown) as string
-      },
-    }),
-  }
-})
+import { screen } from "@testing-library/react"
+import { render } from "DevTools/setupTestWrapper"
 
 describe("ArtQuizResults", () => {
   it.each([

--- a/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
+++ b/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
@@ -3,18 +3,17 @@ import { screen } from "@testing-library/react"
 import { render } from "DevTools/setupTestWrapper"
 
 describe("ArtQuizResults", () => {
-  it.each([
-    ["title", "Explore Your Quiz Results"],
-    [
-      "subtitle",
-      "Explore these collections and artists recommended for you based on your saved works. Follow them to see their latest works on your Artsy home.",
-    ],
-    ["email button", "Email My Results"],
-    ["tab", "Works You Liked"],
-    ["tab", "Recommended Collections"],
-    ["tab", "Recommended Artists"],
-  ])("displays the expected %s text", (_key, text) => {
+  it("displays the expected text", () => {
     render(<ArtQuizResults />)
-    expect(screen.getByText(text)).toBeInTheDocument()
+    expect(screen.getByText("Explore Your Quiz Results")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Explore these collections and artists recommended for you based on your saved works. Follow them to see their latest works on your Artsy home."
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByText("Email My Results")).toBeInTheDocument()
+    expect(screen.getByText("Works You Liked")).toBeInTheDocument()
+    expect(screen.getByText("Recommended Collections")).toBeInTheDocument()
+    expect(screen.getByText("Recommended Artists")).toBeInTheDocument()
   })
 })

--- a/src/Apps/ArtQuiz/__tests__/ArtQuizResultsLoader.jest.tsx
+++ b/src/Apps/ArtQuiz/__tests__/ArtQuizResultsLoader.jest.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render } from "DevTools/setupTestWrapper"
+import { screen } from "@testing-library/react"
 import {
   ArtQuizResultsLoader,
   waitTime,
@@ -7,9 +8,9 @@ import {
 import { act } from "react-dom/test-utils"
 
 describe("Art Quiz Results Loader", () => {
-  it("displays correct copy text when whatever", () => {
+  it("displays title text", () => {
     render(<ArtQuizResultsLoader />)
-    expect(screen.getByText("Art Taste Quiz")).toBeInTheDocument()
+    expect(screen.queryByText("Art Taste Quiz")).toBeInTheDocument()
   })
 
   it("displays 'Calculating Results...' while results are loading", () => {

--- a/src/Apps/ArtQuiz/__tests__/ArtQuizResultsLoader.jest.tsx
+++ b/src/Apps/ArtQuiz/__tests__/ArtQuizResultsLoader.jest.tsx
@@ -1,6 +1,5 @@
 import React from "react"
-import { render } from "DevTools/setupTestWrapper"
-import { screen } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import {
   ArtQuizResultsLoader,
   waitTime,

--- a/src/Apps/ArtQuiz/artQuizRoutes.ts
+++ b/src/Apps/ArtQuiz/artQuizRoutes.ts
@@ -1,13 +1,13 @@
 import loadable from "@loadable/component"
 import { AppRouteConfig } from "System/Router/Route"
 
-const ArtQuizApp = loadable(
-  () => import(/* webpackChunkName: "artQuizBundle" */ "./ArtQuizApp"),
+const ArtQuizApp = loadable(() => import("./ArtQuizApp"), {
+  resolveComponent: component => component.ArtQuizApp,
+})
 
-  {
-    resolveComponent: component => component.ArtQuizApp,
-  }
-)
+const ArtQuizResults = loadable(() => import("./ArtQuizResults"), {
+  resolveComponent: component => component.ArtQuizResults,
+})
 
 // TODO: Add query to check for quiz template
 export const artQuizRoutes: AppRouteConfig[] = [
@@ -20,9 +20,24 @@ export const artQuizRoutes: AppRouteConfig[] = [
         res.redirect("/")
       }
     },
-    getComponent: () => ArtQuizApp,
     onClientSideRender: () => {
       ArtQuizApp.preload()
+      ArtQuizResults.preload()
     },
+    children: [
+      {
+        path: "/",
+        getComponent: () => ArtQuizApp,
+      },
+      {
+        path: "results",
+        displayFullPage: true,
+        hideFooter: true,
+        getComponent: () => ArtQuizResults,
+        onClientSideRender: () => {
+          ArtQuizResults.preload()
+        },
+      },
+    ],
   },
 ]

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -115,9 +115,15 @@
       "getStartedButton": "Start the Quiz",
       "skipButton": "Skip"
     },
-    "loadingScreen": {
-      "calculatingResults": "Calculating Results...",
-      "resultsComplete": "Results Complete"
+    "results": {
+      "emailButton": "Email My Results",
+      "title": "Taste Profile",
+      "subtitle": "Explore these collections and artists recommended for you based on your saved works. Follow them to see their latest works on your Artsy home.",
+      "tabs": {
+        "worksYouLiked": "Works You Liked",
+        "recommendedCollections": "Recommended Collections",
+        "recommendedArtists": "Recommended Artists"
+      }
     }
   },
   "onboarding": {

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -108,22 +108,26 @@
     "markAllAsRead": "Mark all as read"
   },
   "artQuizPage": {
-    "title": "Art Taste Quiz",
-    "welcomeScreen": {
-      "subtitle1": "See more of what you love.",
-      "subtitle2": "Rate artworks to discover your taste profile and get recommendations tailored to you.",
-      "getStartedButton": "Start the Quiz",
-      "skipButton": "Skip"
+    "loadingScreen": {
+      "calculatingResults": "Calculating Results...",
+      "resultsComplete": "Results Complete"
     },
+    "title": "Art Taste Quiz",
     "results": {
       "emailButton": "Email My Results",
-      "title": "Taste Profile",
+      "title": "Explore Your Quiz Results",
       "subtitle": "Explore these collections and artists recommended for you based on your saved works. Follow them to see their latest works on your Artsy home.",
       "tabs": {
         "worksYouLiked": "Works You Liked",
         "recommendedCollections": "Recommended Collections",
         "recommendedArtists": "Recommended Artists"
       }
+    },
+    "welcomeScreen": {
+      "subtitle1": "See more of what you love.",
+      "subtitle2": "Rate artworks to discover your taste profile and get recommendations tailored to you.",
+      "getStartedButton": "Start the Quiz",
+      "skipButton": "Skip"
     }
   },
   "onboarding": {


### PR DESCRIPTION
The type of this PR is: **feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1258]

### Description
This PR creates a basic structure for the user's art quiz results.

![Screen Shot 2022-10-21 at 12 04 33 PM](https://user-images.githubusercontent.com/14044896/197240094-325aaebb-31f1-4621-96fd-ec53af96e2dc.png)

🚧Still to-do🚧
 - [ ] Remove context and lift logic into ArtQuizApp
 - [ ] Finalize ☝🏽 logic
 - [ ] Add animations
 - [ ] Add tooltips
 - [ ] Add mutation to dislike button
 - [ ] Add mutation to back button
 - [ ] Replace fixture data w/ query
 - [ ] Write integration tests
 - [ ] Finalize folder structure
 - [ ] Add tab content

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1258]: https://artsyproduct.atlassian.net/browse/GRO-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ