### PR TITLE
feat(article): allows unpublished artworks to be viewed within articles

### DIFF
--- a/src/Apps/Article/Components/ArticleZoomGallery/ArticleZoomGallery.tsx
+++ b/src/Apps/Article/Components/ArticleZoomGallery/ArticleZoomGallery.tsx
@@ -53,7 +53,8 @@ const ArticleZoomGallery: FC<ArticleZoomGalleryProps> = ({
   const initialCursor = figures.findIndex(figure => {
     if (
       figure.__typename === "Artwork" ||
-      figure.__typename === "ArticleImageSection"
+      figure.__typename === "ArticleImageSection" ||
+      figure.__typename === "ArticleUnpublishedArtwork"
     ) {
       return figure.id === figureId
     }
@@ -177,6 +178,9 @@ export const ArticleZoomGalleryFragmentContainer = createFragmentContainer(
                 id
               }
               ... on ArticleImageSection {
+                id
+              }
+              ... on ArticleUnpublishedArtwork {
                 id
               }
             }

--- a/src/Apps/Article/Components/ArticleZoomGallery/ArticleZoomGalleryCaption.tsx
+++ b/src/Apps/Article/Components/ArticleZoomGallery/ArticleZoomGalleryCaption.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, HTML } from "@artsy/palette"
+import { Box, Button, Flex, HTML, Text } from "@artsy/palette"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import Metadata from "Components/Artwork/Metadata"
@@ -42,6 +42,30 @@ const ArticleZoomGalleryCaption: FC<ArticleZoomGalleryCaptionProps> = ({
 
       return <HTML variant="sm" html={figure.caption} />
 
+    case "ArticleUnpublishedArtwork":
+      return (
+        <Box>
+          {figure.artist && (
+            <Text variant="sm-display" overflowEllipsis>
+              {figure.artist.name}
+            </Text>
+          )}
+
+          {figure.title && (
+            <Text variant="sm-display" color="black60" overflowEllipsis>
+              <i>{figure.title}</i>
+              {figure.date && `, ${figure.date}`}
+            </Text>
+          )}
+
+          {figure.partner && (
+            <Text variant="xs" color="black60" overflowEllipsis>
+              {figure.partner.name}
+            </Text>
+          )}
+        </Box>
+      )
+
     default:
       return <div />
   }
@@ -59,6 +83,16 @@ export const ArticleZoomGalleryCaptionFragmentContainer = createFragmentContaine
         }
         ... on ArticleImageSection {
           caption
+        }
+        ... on ArticleUnpublishedArtwork {
+          title
+          date
+          artist {
+            name
+          }
+          partner {
+            name
+          }
         }
       }
     `,

--- a/src/Apps/Article/Components/ArticleZoomGallery/ArticleZoomGalleryFigure.tsx
+++ b/src/Apps/Article/Components/ArticleZoomGallery/ArticleZoomGalleryFigure.tsx
@@ -24,7 +24,8 @@ const ArticleZoomGalleryFigure: FC<ArticleZoomGalleryFigureProps> = ({
 }) => {
   if (
     figure.__typename !== "Artwork" &&
-    figure.__typename !== "ArticleImageSection"
+    figure.__typename !== "ArticleImageSection" &&
+    figure.__typename !== "ArticleUnpublishedArtwork"
   ) {
     return null
   }
@@ -141,6 +142,13 @@ export const ArticleZoomGalleryFigureFragmentContainer = createFragmentContainer
           }
         }
         ... on ArticleImageSection {
+          image {
+            width
+            height
+            url(version: ["normalized", "larger", "large"])
+          }
+        }
+        ... on ArticleUnpublishedArtwork {
           image {
             width
             height

--- a/src/Apps/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionCaption.tsx
+++ b/src/Apps/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionCaption.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react"
-import { HTML } from "@artsy/palette"
+import { HTML, Text } from "@artsy/palette"
 import Metadata from "Components/Artwork/Metadata"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArticleSectionImageCollectionCaption_figure$data } from "__generated__/ArticleSectionImageCollectionCaption_figure.graphql"
@@ -19,6 +19,31 @@ const ArticleSectionImageCollectionCaption: FC<ArticleSectionImageCollectionCapt
     return <HTML variant="xs" color="black60" html={figure.caption} />
   }
 
+  if (figure.__typename === "ArticleUnpublishedArtwork") {
+    return (
+      <>
+        {figure.artist && (
+          <Text variant="sm-display" overflowEllipsis>
+            {figure.artist.name}
+          </Text>
+        )}
+
+        {figure.title && (
+          <Text variant="sm-display" color="black60" overflowEllipsis>
+            <i>{figure.title}</i>
+            {figure.date && `, ${figure.date}`}
+          </Text>
+        )}
+
+        {figure.partner && (
+          <Text variant="xs" color="black60" overflowEllipsis>
+            {figure.partner.name}
+          </Text>
+        )}
+      </>
+    )
+  }
+
   return null
 }
 
@@ -31,6 +56,16 @@ export const ArticleSectionImageCollectionCaptionFragmentContainer = createFragm
         ...Metadata_artwork
         ... on ArticleImageSection {
           caption
+        }
+        ... on ArticleUnpublishedArtwork {
+          title
+          date
+          artist {
+            name
+          }
+          partner {
+            name
+          }
         }
       }
     `,

--- a/src/Apps/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionImage.tsx
+++ b/src/Apps/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionImage.tsx
@@ -1,8 +1,8 @@
 import { ResponsiveBox, Image } from "@artsy/palette"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { ArticleZoomButton } from "../../ArticleZoomButton"
-import { useArticleZoomGallery } from "../../ArticleZoomGallery"
+import { ArticleZoomButton } from "Apps/Article/Components/ArticleZoomButton"
+import { useArticleZoomGallery } from "Apps/Article/Components/ArticleZoomGallery"
 import { ArticleSectionImageCollectionImage_figure$data } from "__generated__/ArticleSectionImageCollectionImage_figure.graphql"
 import { resized } from "Utils/resized"
 
@@ -69,6 +69,14 @@ export const ArticleSectionImageCollectionImageFragmentContainer = createFragmen
           }
         }
         ... on Artwork {
+          id
+          image {
+            url(version: ["normalized", "larger", "large"])
+            width
+            height
+          }
+        }
+        ... on ArticleUnpublishedArtwork {
           id
           image {
             url(version: ["normalized", "larger", "large"])

--- a/src/__generated__/ArticleBody_test_Query.graphql.ts
+++ b/src/__generated__/ArticleBody_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<796693426fa96c9f64ce47ea0ecd053c>>
+ * @generated SignedSource<<751625b1304630080463ec48f1fdfcd6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -162,21 +162,28 @@ v17 = {
   ],
   "storageKey": null
 },
-v18 = [
+v18 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "date",
+  "storageKey": null
+},
+v19 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v20 = [
+v21 = [
   {
     "alias": null,
     "args": null,
@@ -185,33 +192,35 @@ v20 = [
     "storageKey": null
   }
 ],
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v22 = [
+v23 = [
   (v12/*: any*/),
   (v13/*: any*/)
 ],
-v23 = [
-  (v13/*: any*/)
+v24 = [
+  (v12/*: any*/)
 ],
-v24 = {
+v25 = {
   "kind": "InlineFragment",
-  "selections": (v23/*: any*/),
+  "selections": [
+    (v13/*: any*/)
+  ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v25 = [
+v26 = [
   (v8/*: any*/),
   (v9/*: any*/),
   (v16/*: any*/),
   (v15/*: any*/)
 ],
-v26 = [
+v27 = [
   (v13/*: any*/),
   {
     "alias": null,
@@ -240,7 +249,7 @@ v26 = [
         "kind": "LinkedField",
         "name": "cropped",
         "plural": false,
-        "selections": (v25/*: any*/),
+        "selections": (v26/*: any*/),
         "storageKey": "cropped(height:80,version:[\"normalized\",\"larger\",\"large\"],width:80)"
       },
       {
@@ -257,68 +266,68 @@ v26 = [
         "kind": "LinkedField",
         "name": "resized",
         "plural": false,
-        "selections": (v25/*: any*/),
+        "selections": (v26/*: any*/),
         "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:1220)"
       }
     ],
     "storageKey": null
   }
 ],
-v27 = {
+v28 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Article"
 },
-v28 = {
+v29 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v29 = {
+v30 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v30 = {
+v31 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v31 = {
+v32 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "CroppedImageUrl"
 },
-v32 = {
+v33 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v33 = {
+v34 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ResizedImageUrl"
 },
-v34 = {
+v35 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v35 = {
+v36 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v36 = {
+v37 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -580,13 +589,7 @@ return {
                           (v17/*: any*/),
                           (v2/*: any*/),
                           (v1/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "date",
-                            "storageKey": null
-                          },
+                          (v18/*: any*/),
                           {
                             "alias": "sale_message",
                             "args": null,
@@ -603,7 +606,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
@@ -624,7 +627,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
@@ -644,7 +647,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v19/*: any*/),
+                              (v20/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -706,7 +709,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v19/*: any*/),
+                              (v20/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -746,7 +749,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v20/*: any*/),
+                                "selections": (v21/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -756,7 +759,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v20/*: any*/),
+                                "selections": (v21/*: any*/),
                                 "storageKey": null
                               },
                               (v13/*: any*/)
@@ -764,7 +767,7 @@ return {
                             "storageKey": null
                           },
                           (v11/*: any*/),
-                          (v21/*: any*/),
+                          (v22/*: any*/),
                           {
                             "alias": "is_saved",
                             "args": null,
@@ -779,7 +782,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v22/*: any*/),
+                            "selections": (v23/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -797,7 +800,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v22/*: any*/),
+                                "selections": (v23/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -807,13 +810,38 @@ return {
                         "type": "Artwork",
                         "abstractKey": null
                       },
-                      (v24/*: any*/),
                       {
                         "kind": "InlineFragment",
-                        "selections": (v23/*: any*/),
+                        "selections": [
+                          (v13/*: any*/),
+                          (v17/*: any*/),
+                          (v1/*: any*/),
+                          (v18/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArticleUnpublishedArtworkArtist",
+                            "kind": "LinkedField",
+                            "name": "artist",
+                            "plural": false,
+                            "selections": (v24/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArticleUnpublishedArtworkPartner",
+                            "kind": "LinkedField",
+                            "name": "partner",
+                            "plural": false,
+                            "selections": (v24/*: any*/),
+                            "storageKey": null
+                          }
+                        ],
                         "type": "ArticleUnpublishedArtwork",
                         "abstractKey": null
-                      }
+                      },
+                      (v25/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -861,17 +889,17 @@ return {
                       (v4/*: any*/),
                       {
                         "kind": "InlineFragment",
-                        "selections": (v26/*: any*/),
+                        "selections": (v27/*: any*/),
                         "type": "ArticleImageSection",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v26/*: any*/),
+                        "selections": (v27/*: any*/),
                         "type": "Artwork",
                         "abstractKey": null
                       },
-                      (v24/*: any*/)
+                      (v25/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1013,7 +1041,7 @@ return {
             "storageKey": null
           },
           (v11/*: any*/),
-          (v21/*: any*/),
+          (v22/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1090,43 +1118,43 @@ return {
     ]
   },
   "params": {
-    "cacheID": "602672c74ce384422e62f21a191a5be9",
+    "cacheID": "35a9bb1db23fc4711c62d9ed5e4cca57",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "article": (v27/*: any*/),
+        "article": (v28/*: any*/),
         "article.authors": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "Author"
         },
-        "article.authors.bio": (v28/*: any*/),
-        "article.authors.id": (v29/*: any*/),
-        "article.authors.image": (v30/*: any*/),
-        "article.authors.image.cropped": (v31/*: any*/),
-        "article.authors.image.cropped.src": (v32/*: any*/),
-        "article.authors.image.cropped.srcSet": (v32/*: any*/),
-        "article.authors.initials": (v28/*: any*/),
-        "article.authors.internalID": (v29/*: any*/),
-        "article.authors.name": (v28/*: any*/),
-        "article.byline": (v28/*: any*/),
+        "article.authors.bio": (v29/*: any*/),
+        "article.authors.id": (v30/*: any*/),
+        "article.authors.image": (v31/*: any*/),
+        "article.authors.image.cropped": (v32/*: any*/),
+        "article.authors.image.cropped.src": (v33/*: any*/),
+        "article.authors.image.cropped.srcSet": (v33/*: any*/),
+        "article.authors.initials": (v29/*: any*/),
+        "article.authors.internalID": (v30/*: any*/),
+        "article.authors.name": (v29/*: any*/),
+        "article.byline": (v29/*: any*/),
         "article.hero": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArticleHero"
         },
-        "article.hero.__typename": (v32/*: any*/),
-        "article.hero.embed": (v28/*: any*/),
-        "article.hero.image": (v30/*: any*/),
-        "article.hero.image.split": (v33/*: any*/),
-        "article.hero.image.split.src": (v32/*: any*/),
-        "article.hero.image.split.srcSet": (v32/*: any*/),
-        "article.hero.image.text": (v31/*: any*/),
-        "article.hero.image.text.src": (v32/*: any*/),
-        "article.hero.image.text.srcSet": (v32/*: any*/),
-        "article.hero.image.url": (v28/*: any*/),
+        "article.hero.__typename": (v33/*: any*/),
+        "article.hero.embed": (v29/*: any*/),
+        "article.hero.image": (v31/*: any*/),
+        "article.hero.image.split": (v34/*: any*/),
+        "article.hero.image.split.src": (v33/*: any*/),
+        "article.hero.image.split.srcSet": (v33/*: any*/),
+        "article.hero.image.text": (v32/*: any*/),
+        "article.hero.image.text.src": (v33/*: any*/),
+        "article.hero.image.text.srcSet": (v33/*: any*/),
+        "article.hero.image.url": (v29/*: any*/),
         "article.hero.layout": {
           "enumValues": [
             "BASIC",
@@ -1138,10 +1166,10 @@ return {
           "plural": false,
           "type": "ArticleFeatureSectionType"
         },
-        "article.hero.media": (v28/*: any*/),
-        "article.href": (v28/*: any*/),
-        "article.id": (v29/*: any*/),
-        "article.internalID": (v29/*: any*/),
+        "article.hero.media": (v29/*: any*/),
+        "article.href": (v29/*: any*/),
+        "article.id": (v30/*: any*/),
+        "article.internalID": (v30/*: any*/),
         "article.layout": {
           "enumValues": [
             "CLASSIC",
@@ -1155,40 +1183,40 @@ return {
           "plural": false,
           "type": "ArticleLayout"
         },
-        "article.leadParagraph": (v28/*: any*/),
+        "article.leadParagraph": (v29/*: any*/),
         "article.newsSource": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArticleNewsSource"
         },
-        "article.newsSource.title": (v28/*: any*/),
-        "article.newsSource.url": (v28/*: any*/),
-        "article.postscript": (v28/*: any*/),
-        "article.publishedAt": (v28/*: any*/),
+        "article.newsSource.title": (v29/*: any*/),
+        "article.newsSource.url": (v29/*: any*/),
+        "article.postscript": (v29/*: any*/),
+        "article.publishedAt": (v29/*: any*/),
         "article.relatedArticles": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "Article"
         },
-        "article.relatedArticles.byline": (v28/*: any*/),
-        "article.relatedArticles.href": (v28/*: any*/),
-        "article.relatedArticles.id": (v29/*: any*/),
-        "article.relatedArticles.internalID": (v29/*: any*/),
-        "article.relatedArticles.thumbnailImage": (v30/*: any*/),
-        "article.relatedArticles.thumbnailImage.cropped": (v31/*: any*/),
-        "article.relatedArticles.thumbnailImage.cropped.src": (v32/*: any*/),
-        "article.relatedArticles.thumbnailImage.cropped.srcSet": (v32/*: any*/),
-        "article.relatedArticles.title": (v28/*: any*/),
+        "article.relatedArticles.byline": (v29/*: any*/),
+        "article.relatedArticles.href": (v29/*: any*/),
+        "article.relatedArticles.id": (v30/*: any*/),
+        "article.relatedArticles.internalID": (v30/*: any*/),
+        "article.relatedArticles.thumbnailImage": (v31/*: any*/),
+        "article.relatedArticles.thumbnailImage.cropped": (v32/*: any*/),
+        "article.relatedArticles.thumbnailImage.cropped.src": (v33/*: any*/),
+        "article.relatedArticles.thumbnailImage.cropped.srcSet": (v33/*: any*/),
+        "article.relatedArticles.title": (v29/*: any*/),
         "article.sections": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "ArticleSections"
         },
-        "article.sections.__isArticleSections": (v32/*: any*/),
-        "article.sections.__typename": (v32/*: any*/),
+        "article.sections.__isArticleSections": (v33/*: any*/),
+        "article.sections.__typename": (v33/*: any*/),
         "article.sections._layout": {
           "enumValues": [
             "COLUMN_WIDTH",
@@ -1200,74 +1228,81 @@ return {
           "plural": false,
           "type": "ArticleSectionEmbedLayout"
         },
-        "article.sections.body": (v28/*: any*/),
+        "article.sections.body": (v29/*: any*/),
         "article.sections.counts": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArticleSectionImageSetCounts"
         },
-        "article.sections.counts.figures": (v34/*: any*/),
+        "article.sections.counts.figures": (v35/*: any*/),
         "article.sections.cover": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArticleSectionImageSetFigure"
         },
-        "article.sections.cover.__isNode": (v32/*: any*/),
-        "article.sections.cover.__typename": (v32/*: any*/),
-        "article.sections.cover.id": (v29/*: any*/),
-        "article.sections.cover.image": (v30/*: any*/),
-        "article.sections.cover.image.large": (v33/*: any*/),
-        "article.sections.cover.image.large.height": (v35/*: any*/),
-        "article.sections.cover.image.large.src": (v32/*: any*/),
-        "article.sections.cover.image.large.srcSet": (v32/*: any*/),
-        "article.sections.cover.image.large.width": (v35/*: any*/),
-        "article.sections.cover.image.small": (v31/*: any*/),
-        "article.sections.cover.image.small.height": (v34/*: any*/),
-        "article.sections.cover.image.small.src": (v32/*: any*/),
-        "article.sections.cover.image.small.srcSet": (v32/*: any*/),
-        "article.sections.cover.image.small.width": (v34/*: any*/),
-        "article.sections.embed": (v28/*: any*/),
-        "article.sections.fallbackEmbed": (v28/*: any*/),
+        "article.sections.cover.__isNode": (v33/*: any*/),
+        "article.sections.cover.__typename": (v33/*: any*/),
+        "article.sections.cover.id": (v30/*: any*/),
+        "article.sections.cover.image": (v31/*: any*/),
+        "article.sections.cover.image.large": (v34/*: any*/),
+        "article.sections.cover.image.large.height": (v36/*: any*/),
+        "article.sections.cover.image.large.src": (v33/*: any*/),
+        "article.sections.cover.image.large.srcSet": (v33/*: any*/),
+        "article.sections.cover.image.large.width": (v36/*: any*/),
+        "article.sections.cover.image.small": (v32/*: any*/),
+        "article.sections.cover.image.small.height": (v35/*: any*/),
+        "article.sections.cover.image.small.src": (v33/*: any*/),
+        "article.sections.cover.image.small.srcSet": (v33/*: any*/),
+        "article.sections.cover.image.small.width": (v35/*: any*/),
+        "article.sections.embed": (v29/*: any*/),
+        "article.sections.fallbackEmbed": (v29/*: any*/),
         "article.sections.figures": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "ArticleSectionImageCollectionFigure"
         },
-        "article.sections.figures.__isArticleSectionImageCollectionFigure": (v32/*: any*/),
-        "article.sections.figures.__isNode": (v32/*: any*/),
-        "article.sections.figures.__typename": (v32/*: any*/),
+        "article.sections.figures.__isArticleSectionImageCollectionFigure": (v33/*: any*/),
+        "article.sections.figures.__isNode": (v33/*: any*/),
+        "article.sections.figures.__typename": (v33/*: any*/),
+        "article.sections.figures.artist": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArticleUnpublishedArtworkArtist"
+        },
+        "article.sections.figures.artist.name": (v29/*: any*/),
         "article.sections.figures.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "article.sections.figures.artists.href": (v28/*: any*/),
-        "article.sections.figures.artists.id": (v29/*: any*/),
-        "article.sections.figures.artists.name": (v28/*: any*/),
+        "article.sections.figures.artists.href": (v29/*: any*/),
+        "article.sections.figures.artists.id": (v30/*: any*/),
+        "article.sections.figures.artists.name": (v29/*: any*/),
         "article.sections.figures.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "article.sections.figures.attributionClass.id": (v29/*: any*/),
-        "article.sections.figures.attributionClass.name": (v28/*: any*/),
-        "article.sections.figures.caption": (v28/*: any*/),
-        "article.sections.figures.collecting_institution": (v28/*: any*/),
-        "article.sections.figures.cultural_maker": (v28/*: any*/),
-        "article.sections.figures.date": (v28/*: any*/),
-        "article.sections.figures.href": (v28/*: any*/),
-        "article.sections.figures.id": (v29/*: any*/),
-        "article.sections.figures.image": (v30/*: any*/),
-        "article.sections.figures.image.height": (v35/*: any*/),
-        "article.sections.figures.image.url": (v28/*: any*/),
-        "article.sections.figures.image.width": (v35/*: any*/),
-        "article.sections.figures.internalID": (v29/*: any*/),
-        "article.sections.figures.is_saved": (v36/*: any*/),
+        "article.sections.figures.attributionClass.id": (v30/*: any*/),
+        "article.sections.figures.attributionClass.name": (v29/*: any*/),
+        "article.sections.figures.caption": (v29/*: any*/),
+        "article.sections.figures.collecting_institution": (v29/*: any*/),
+        "article.sections.figures.cultural_maker": (v29/*: any*/),
+        "article.sections.figures.date": (v29/*: any*/),
+        "article.sections.figures.href": (v29/*: any*/),
+        "article.sections.figures.id": (v30/*: any*/),
+        "article.sections.figures.image": (v31/*: any*/),
+        "article.sections.figures.image.height": (v36/*: any*/),
+        "article.sections.figures.image.url": (v29/*: any*/),
+        "article.sections.figures.image.width": (v36/*: any*/),
+        "article.sections.figures.internalID": (v30/*: any*/),
+        "article.sections.figures.is_saved": (v37/*: any*/),
         "article.sections.figures.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -1280,30 +1315,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "article.sections.figures.mediumType.filterGene.id": (v29/*: any*/),
-        "article.sections.figures.mediumType.filterGene.name": (v28/*: any*/),
+        "article.sections.figures.mediumType.filterGene.id": (v30/*: any*/),
+        "article.sections.figures.mediumType.filterGene.name": (v29/*: any*/),
         "article.sections.figures.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "article.sections.figures.partner.href": (v28/*: any*/),
-        "article.sections.figures.partner.id": (v29/*: any*/),
-        "article.sections.figures.partner.name": (v28/*: any*/),
+        "article.sections.figures.partner.href": (v29/*: any*/),
+        "article.sections.figures.partner.id": (v30/*: any*/),
+        "article.sections.figures.partner.name": (v29/*: any*/),
         "article.sections.figures.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "article.sections.figures.sale.cascadingEndTimeIntervalMinutes": (v35/*: any*/),
-        "article.sections.figures.sale.endAt": (v28/*: any*/),
-        "article.sections.figures.sale.extendedBiddingIntervalMinutes": (v35/*: any*/),
-        "article.sections.figures.sale.id": (v29/*: any*/),
-        "article.sections.figures.sale.is_auction": (v36/*: any*/),
-        "article.sections.figures.sale.is_closed": (v36/*: any*/),
-        "article.sections.figures.sale.startAt": (v28/*: any*/),
+        "article.sections.figures.sale.cascadingEndTimeIntervalMinutes": (v36/*: any*/),
+        "article.sections.figures.sale.endAt": (v29/*: any*/),
+        "article.sections.figures.sale.extendedBiddingIntervalMinutes": (v36/*: any*/),
+        "article.sections.figures.sale.id": (v30/*: any*/),
+        "article.sections.figures.sale.is_auction": (v37/*: any*/),
+        "article.sections.figures.sale.is_closed": (v37/*: any*/),
+        "article.sections.figures.sale.startAt": (v29/*: any*/),
         "article.sections.figures.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -1322,34 +1357,34 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "article.sections.figures.sale_artwork.endAt": (v28/*: any*/),
-        "article.sections.figures.sale_artwork.extendedBiddingEndAt": (v28/*: any*/),
-        "article.sections.figures.sale_artwork.formattedEndDateTime": (v28/*: any*/),
+        "article.sections.figures.sale_artwork.endAt": (v29/*: any*/),
+        "article.sections.figures.sale_artwork.extendedBiddingEndAt": (v29/*: any*/),
+        "article.sections.figures.sale_artwork.formattedEndDateTime": (v29/*: any*/),
         "article.sections.figures.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "article.sections.figures.sale_artwork.highest_bid.display": (v28/*: any*/),
-        "article.sections.figures.sale_artwork.id": (v29/*: any*/),
-        "article.sections.figures.sale_artwork.lotID": (v28/*: any*/),
-        "article.sections.figures.sale_artwork.lotLabel": (v28/*: any*/),
+        "article.sections.figures.sale_artwork.highest_bid.display": (v29/*: any*/),
+        "article.sections.figures.sale_artwork.id": (v30/*: any*/),
+        "article.sections.figures.sale_artwork.lotID": (v29/*: any*/),
+        "article.sections.figures.sale_artwork.lotLabel": (v29/*: any*/),
         "article.sections.figures.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "article.sections.figures.sale_artwork.opening_bid.display": (v28/*: any*/),
-        "article.sections.figures.sale_message": (v28/*: any*/),
-        "article.sections.figures.slug": (v29/*: any*/),
-        "article.sections.figures.title": (v28/*: any*/),
-        "article.sections.height": (v35/*: any*/),
-        "article.sections.image": (v30/*: any*/),
-        "article.sections.image.cropped": (v31/*: any*/),
-        "article.sections.image.cropped.src": (v32/*: any*/),
-        "article.sections.image.cropped.srcSet": (v32/*: any*/),
+        "article.sections.figures.sale_artwork.opening_bid.display": (v29/*: any*/),
+        "article.sections.figures.sale_message": (v29/*: any*/),
+        "article.sections.figures.slug": (v30/*: any*/),
+        "article.sections.figures.title": (v29/*: any*/),
+        "article.sections.height": (v36/*: any*/),
+        "article.sections.image": (v31/*: any*/),
+        "article.sections.image.cropped": (v32/*: any*/),
+        "article.sections.image.cropped.src": (v33/*: any*/),
+        "article.sections.image.cropped.srcSet": (v33/*: any*/),
         "article.sections.layout": {
           "enumValues": [
             "COLUMN_WIDTH",
@@ -1360,7 +1395,7 @@ return {
           "plural": false,
           "type": "ArticleSectionImageCollectionLayout"
         },
-        "article.sections.mobileHeight": (v35/*: any*/),
+        "article.sections.mobileHeight": (v36/*: any*/),
         "article.sections.setLayout": {
           "enumValues": [
             "FULL",
@@ -1370,20 +1405,20 @@ return {
           "plural": false,
           "type": "ArticleSectionImageSetLayout"
         },
-        "article.sections.title": (v28/*: any*/),
-        "article.sections.url": (v28/*: any*/),
-        "article.seriesArticle": (v27/*: any*/),
-        "article.seriesArticle.href": (v28/*: any*/),
-        "article.seriesArticle.id": (v29/*: any*/),
-        "article.seriesArticle.thumbnailTitle": (v28/*: any*/),
-        "article.slug": (v28/*: any*/),
-        "article.title": (v28/*: any*/),
-        "article.vertical": (v28/*: any*/)
+        "article.sections.title": (v29/*: any*/),
+        "article.sections.url": (v29/*: any*/),
+        "article.seriesArticle": (v28/*: any*/),
+        "article.seriesArticle.href": (v29/*: any*/),
+        "article.seriesArticle.id": (v30/*: any*/),
+        "article.seriesArticle.thumbnailTitle": (v29/*: any*/),
+        "article.slug": (v29/*: any*/),
+        "article.title": (v29/*: any*/),
+        "article.vertical": (v29/*: any*/)
       }
     },
     "name": "ArticleBody_test_Query",
     "operationKind": "query",
-    "text": "query ArticleBody_test_Query {\n  article(id: \"example\") {\n    ...ArticleBody_article\n    id\n  }\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHero_article\n  ...ArticleByline_article\n  ...ArticleSectionAd_article\n  ...ArticleNewsSource_article\n  hero {\n    __typename\n  }\n  seriesArticle {\n    thumbnailTitle\n    href\n    id\n  }\n  vertical\n  byline\n  internalID\n  slug\n  layout\n  leadParagraph\n  title\n  href\n  publishedAt\n  sections {\n    __typename\n    ...ArticleSection_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    internalID\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHero_article on Article {\n  title\n  href\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      media\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleNewsSource_article on Article {\n  newsSource {\n    title\n    url\n  }\n}\n\nfragment ArticleSectionAd_article on Article {\n  layout\n  sections {\n    __typename\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n  _layout: layout\n}\n\nfragment ArticleSectionImageCollectionCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ...Metadata_artwork\n  ... on ArticleImageSection {\n    caption\n  }\n}\n\nfragment ArticleSectionImageCollectionImage_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  ... on ArticleImageSection {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on Artwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ...ArticleSectionImageCollectionImage_figure\n    ...ArticleSectionImageCollectionCaption_figure\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ArticleImageSection {\n      id\n    }\n    ... on ArticleUnpublishedArtwork {\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  fallbackEmbed: embed(autoPlay: false)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSection_section on ArticleSections {\n  __isArticleSections: __typename\n  __typename\n  ...ArticleSectionText_section\n  ...ArticleSectionImageCollection_section\n  ...ArticleSectionImageSet_section\n  ...ArticleSectionVideo_section\n  ...ArticleSectionSocialEmbed_section\n  ...ArticleSectionEmbed_section\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query ArticleBody_test_Query {\n  article(id: \"example\") {\n    ...ArticleBody_article\n    id\n  }\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHero_article\n  ...ArticleByline_article\n  ...ArticleSectionAd_article\n  ...ArticleNewsSource_article\n  hero {\n    __typename\n  }\n  seriesArticle {\n    thumbnailTitle\n    href\n    id\n  }\n  vertical\n  byline\n  internalID\n  slug\n  layout\n  leadParagraph\n  title\n  href\n  publishedAt\n  sections {\n    __typename\n    ...ArticleSection_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    internalID\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHero_article on Article {\n  title\n  href\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      media\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleNewsSource_article on Article {\n  newsSource {\n    title\n    url\n  }\n}\n\nfragment ArticleSectionAd_article on Article {\n  layout\n  sections {\n    __typename\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n  _layout: layout\n}\n\nfragment ArticleSectionImageCollectionCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ...Metadata_artwork\n  ... on ArticleImageSection {\n    caption\n  }\n  ... on ArticleUnpublishedArtwork {\n    title\n    date\n    artist {\n      name\n    }\n    partner {\n      name\n    }\n  }\n}\n\nfragment ArticleSectionImageCollectionImage_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  ... on ArticleImageSection {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on Artwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on ArticleUnpublishedArtwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ...ArticleSectionImageCollectionImage_figure\n    ...ArticleSectionImageCollectionCaption_figure\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ArticleImageSection {\n      id\n    }\n    ... on ArticleUnpublishedArtwork {\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  fallbackEmbed: embed(autoPlay: false)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSection_section on ArticleSections {\n  __isArticleSections: __typename\n  __typename\n  ...ArticleSectionText_section\n  ...ArticleSectionImageCollection_section\n  ...ArticleSectionImageSet_section\n  ...ArticleSectionVideo_section\n  ...ArticleSectionSocialEmbed_section\n  ...ArticleSectionEmbed_section\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArticleInfiniteScrollQuery.graphql.ts
+++ b/src/__generated__/ArticleInfiniteScrollQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d5aa9292a49d4c30bdcc21f1eca52f3b>>
+ * @generated SignedSource<<27273b65b28bea87eb1a4f7106e2c713>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -213,21 +213,28 @@ v21 = {
   ],
   "storageKey": null
 },
-v22 = [
+v22 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "date",
+  "storageKey": null
+},
+v23 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v24 = [
+v25 = [
   {
     "alias": null,
     "args": null,
@@ -236,33 +243,35 @@ v24 = [
     "storageKey": null
   }
 ],
-v25 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v26 = [
+v27 = [
   (v16/*: any*/),
   (v17/*: any*/)
 ],
-v27 = [
-  (v17/*: any*/)
+v28 = [
+  (v16/*: any*/)
 ],
-v28 = {
+v29 = {
   "kind": "InlineFragment",
-  "selections": (v27/*: any*/),
+  "selections": [
+    (v17/*: any*/)
+  ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v29 = [
+v30 = [
   (v12/*: any*/),
   (v13/*: any*/),
   (v20/*: any*/),
   (v19/*: any*/)
 ],
-v30 = [
+v31 = [
   (v17/*: any*/),
   {
     "alias": null,
@@ -291,7 +300,7 @@ v30 = [
         "kind": "LinkedField",
         "name": "cropped",
         "plural": false,
-        "selections": (v29/*: any*/),
+        "selections": (v30/*: any*/),
         "storageKey": "cropped(height:80,version:[\"normalized\",\"larger\",\"large\"],width:80)"
       },
       {
@@ -308,7 +317,7 @@ v30 = [
         "kind": "LinkedField",
         "name": "resized",
         "plural": false,
-        "selections": (v29/*: any*/),
+        "selections": (v30/*: any*/),
         "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:1220)"
       }
     ],
@@ -615,13 +624,7 @@ return {
                                       (v21/*: any*/),
                                       (v6/*: any*/),
                                       (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "date",
-                                        "storageKey": null
-                                      },
+                                      (v22/*: any*/),
                                       {
                                         "alias": "sale_message",
                                         "args": null,
@@ -638,7 +641,7 @@ return {
                                       },
                                       {
                                         "alias": null,
-                                        "args": (v22/*: any*/),
+                                        "args": (v23/*: any*/),
                                         "concreteType": "Artist",
                                         "kind": "LinkedField",
                                         "name": "artists",
@@ -659,7 +662,7 @@ return {
                                       },
                                       {
                                         "alias": null,
-                                        "args": (v22/*: any*/),
+                                        "args": (v23/*: any*/),
                                         "concreteType": "Partner",
                                         "kind": "LinkedField",
                                         "name": "partner",
@@ -679,7 +682,7 @@ return {
                                         "name": "sale",
                                         "plural": false,
                                         "selections": [
-                                          (v23/*: any*/),
+                                          (v24/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -741,7 +744,7 @@ return {
                                             "name": "lotLabel",
                                             "storageKey": null
                                           },
-                                          (v23/*: any*/),
+                                          (v24/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -781,7 +784,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "highestBid",
                                             "plural": false,
-                                            "selections": (v24/*: any*/),
+                                            "selections": (v25/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -791,7 +794,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "openingBid",
                                             "plural": false,
-                                            "selections": (v24/*: any*/),
+                                            "selections": (v25/*: any*/),
                                             "storageKey": null
                                           },
                                           (v17/*: any*/)
@@ -799,7 +802,7 @@ return {
                                         "storageKey": null
                                       },
                                       (v15/*: any*/),
-                                      (v25/*: any*/),
+                                      (v26/*: any*/),
                                       {
                                         "alias": "is_saved",
                                         "args": null,
@@ -814,7 +817,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "attributionClass",
                                         "plural": false,
-                                        "selections": (v26/*: any*/),
+                                        "selections": (v27/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -832,7 +835,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "filterGene",
                                             "plural": false,
-                                            "selections": (v26/*: any*/),
+                                            "selections": (v27/*: any*/),
                                             "storageKey": null
                                           }
                                         ],
@@ -842,13 +845,38 @@ return {
                                     "type": "Artwork",
                                     "abstractKey": null
                                   },
-                                  (v28/*: any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v27/*: any*/),
+                                    "selections": [
+                                      (v17/*: any*/),
+                                      (v21/*: any*/),
+                                      (v5/*: any*/),
+                                      (v22/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "ArticleUnpublishedArtworkArtist",
+                                        "kind": "LinkedField",
+                                        "name": "artist",
+                                        "plural": false,
+                                        "selections": (v28/*: any*/),
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "ArticleUnpublishedArtworkPartner",
+                                        "kind": "LinkedField",
+                                        "name": "partner",
+                                        "plural": false,
+                                        "selections": (v28/*: any*/),
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "type": "ArticleUnpublishedArtwork",
                                     "abstractKey": null
-                                  }
+                                  },
+                                  (v29/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -896,17 +924,17 @@ return {
                                   (v8/*: any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v30/*: any*/),
+                                    "selections": (v31/*: any*/),
                                     "type": "ArticleImageSection",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v30/*: any*/),
+                                    "selections": (v31/*: any*/),
                                     "type": "Artwork",
                                     "abstractKey": null
                                   },
-                                  (v28/*: any*/)
+                                  (v29/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -1048,7 +1076,7 @@ return {
                         "storageKey": null
                       },
                       (v15/*: any*/),
-                      (v25/*: any*/),
+                      (v26/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1188,12 +1216,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b57ca4ea9d8d90c3f977b1e5b2c9077c",
+    "cacheID": "58a4c2d0d7ed38f7c9220befc00f8cb5",
     "id": null,
     "metadata": {},
     "name": "ArticleInfiniteScrollQuery",
     "operationKind": "query",
-    "text": "query ArticleInfiniteScrollQuery(\n  $after: String\n  $channelID: String!\n  $articleID: String!\n) {\n  viewer {\n    ...ArticleInfiniteScroll_viewer_1LMuZg\n  }\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHero_article\n  ...ArticleByline_article\n  ...ArticleSectionAd_article\n  ...ArticleNewsSource_article\n  hero {\n    __typename\n  }\n  seriesArticle {\n    thumbnailTitle\n    href\n    id\n  }\n  vertical\n  byline\n  internalID\n  slug\n  layout\n  leadParagraph\n  title\n  href\n  publishedAt\n  sections {\n    __typename\n    ...ArticleSection_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    internalID\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHero_article on Article {\n  title\n  href\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      media\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleInfiniteScroll_viewer_1LMuZg on Viewer {\n  articlesConnection(first: 1, after: $after, channelId: $channelID, omit: [$articleID], sort: PUBLISHED_AT_DESC, layout: STANDARD) {\n    edges {\n      node {\n        ...ArticleBody_article\n        ...ArticleVisibilityMetadata_article\n        internalID\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment ArticleNewsSource_article on Article {\n  newsSource {\n    title\n    url\n  }\n}\n\nfragment ArticleSectionAd_article on Article {\n  layout\n  sections {\n    __typename\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n  _layout: layout\n}\n\nfragment ArticleSectionImageCollectionCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ...Metadata_artwork\n  ... on ArticleImageSection {\n    caption\n  }\n}\n\nfragment ArticleSectionImageCollectionImage_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  ... on ArticleImageSection {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on Artwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ...ArticleSectionImageCollectionImage_figure\n    ...ArticleSectionImageCollectionCaption_figure\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ArticleImageSection {\n      id\n    }\n    ... on ArticleUnpublishedArtwork {\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  fallbackEmbed: embed(autoPlay: false)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSection_section on ArticleSections {\n  __isArticleSections: __typename\n  __typename\n  ...ArticleSectionText_section\n  ...ArticleSectionImageCollection_section\n  ...ArticleSectionImageSet_section\n  ...ArticleSectionVideo_section\n  ...ArticleSectionSocialEmbed_section\n  ...ArticleSectionEmbed_section\n}\n\nfragment ArticleVisibilityMetadata_article on Article {\n  title\n  searchTitle\n  href\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query ArticleInfiniteScrollQuery(\n  $after: String\n  $channelID: String!\n  $articleID: String!\n) {\n  viewer {\n    ...ArticleInfiniteScroll_viewer_1LMuZg\n  }\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHero_article\n  ...ArticleByline_article\n  ...ArticleSectionAd_article\n  ...ArticleNewsSource_article\n  hero {\n    __typename\n  }\n  seriesArticle {\n    thumbnailTitle\n    href\n    id\n  }\n  vertical\n  byline\n  internalID\n  slug\n  layout\n  leadParagraph\n  title\n  href\n  publishedAt\n  sections {\n    __typename\n    ...ArticleSection_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    internalID\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHero_article on Article {\n  title\n  href\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      media\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleInfiniteScroll_viewer_1LMuZg on Viewer {\n  articlesConnection(first: 1, after: $after, channelId: $channelID, omit: [$articleID], sort: PUBLISHED_AT_DESC, layout: STANDARD) {\n    edges {\n      node {\n        ...ArticleBody_article\n        ...ArticleVisibilityMetadata_article\n        internalID\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment ArticleNewsSource_article on Article {\n  newsSource {\n    title\n    url\n  }\n}\n\nfragment ArticleSectionAd_article on Article {\n  layout\n  sections {\n    __typename\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n  _layout: layout\n}\n\nfragment ArticleSectionImageCollectionCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ...Metadata_artwork\n  ... on ArticleImageSection {\n    caption\n  }\n  ... on ArticleUnpublishedArtwork {\n    title\n    date\n    artist {\n      name\n    }\n    partner {\n      name\n    }\n  }\n}\n\nfragment ArticleSectionImageCollectionImage_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  ... on ArticleImageSection {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on Artwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on ArticleUnpublishedArtwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ...ArticleSectionImageCollectionImage_figure\n    ...ArticleSectionImageCollectionCaption_figure\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ArticleImageSection {\n      id\n    }\n    ... on ArticleUnpublishedArtwork {\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  fallbackEmbed: embed(autoPlay: false)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSection_section on ArticleSections {\n  __isArticleSections: __typename\n  __typename\n  ...ArticleSectionText_section\n  ...ArticleSectionImageCollection_section\n  ...ArticleSectionImageSet_section\n  ...ArticleSectionVideo_section\n  ...ArticleSectionSocialEmbed_section\n  ...ArticleSectionEmbed_section\n}\n\nfragment ArticleVisibilityMetadata_article on Article {\n  title\n  searchTitle\n  href\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArticleSectionImageCollectionCaption_figure.graphql.ts
+++ b/src/__generated__/ArticleSectionImageCollectionCaption_figure.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3dfbbdbb3c2b11c9aec82320da4cd272>>
+ * @generated SignedSource<<bdef699ea354df94e7453e09a8ef174d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,7 +12,15 @@ import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArticleSectionImageCollectionCaption_figure$data = {
   readonly __typename: string;
+  readonly artist?: {
+    readonly name: string | null;
+  } | null;
   readonly caption?: string | null;
+  readonly date?: string | null;
+  readonly partner?: {
+    readonly name: string | null;
+  } | null;
+  readonly title?: string | null;
   readonly " $fragmentSpreads": FragmentRefs<"Metadata_artwork">;
   readonly " $fragmentType": "ArticleSectionImageCollectionCaption_figure";
 };
@@ -21,7 +29,17 @@ export type ArticleSectionImageCollectionCaption_figure$key = {
   readonly " $fragmentSpreads": FragmentRefs<"ArticleSectionImageCollectionCaption_figure">;
 };
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  }
+];
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -52,12 +70,54 @@ const node: ReaderFragment = {
       ],
       "type": "ArticleImageSection",
       "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "title",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "date",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArticleUnpublishedArtworkArtist",
+          "kind": "LinkedField",
+          "name": "artist",
+          "plural": false,
+          "selections": (v0/*: any*/),
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArticleUnpublishedArtworkPartner",
+          "kind": "LinkedField",
+          "name": "partner",
+          "plural": false,
+          "selections": (v0/*: any*/),
+          "storageKey": null
+        }
+      ],
+      "type": "ArticleUnpublishedArtwork",
+      "abstractKey": null
     }
   ],
   "type": "ArticleSectionImageCollectionFigure",
   "abstractKey": "__isArticleSectionImageCollectionFigure"
 };
+})();
 
-(node as any).hash = "446271f2fd3efad0800c1e6260f3fd5b";
+(node as any).hash = "69dca86fbddcfacf903b09514bf640fc";
 
 export default node;

--- a/src/__generated__/ArticleSectionImageCollectionImage_figure.graphql.ts
+++ b/src/__generated__/ArticleSectionImageCollectionImage_figure.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<dd3cfe99b2d392a9682e05577e196f39>>
+ * @generated SignedSource<<8683b202fcfb5e064a4629e447c868d5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -93,6 +93,12 @@ return {
       "selections": (v0/*: any*/),
       "type": "Artwork",
       "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": (v0/*: any*/),
+      "type": "ArticleUnpublishedArtwork",
+      "abstractKey": null
     }
   ],
   "type": "ArticleSectionImageCollectionFigure",
@@ -100,6 +106,6 @@ return {
 };
 })();
 
-(node as any).hash = "ef16ef43b057a46f4cc81474730a3b79";
+(node as any).hash = "236232a2e8b3677ee5e6260ed908e106";
 
 export default node;

--- a/src/__generated__/ArticleZoomGalleryCaption_figure.graphql.ts
+++ b/src/__generated__/ArticleZoomGalleryCaption_figure.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<de05f0f8b2939c474661fa6a8f1655e7>>
+ * @generated SignedSource<<c65a8f0a010a818001ae94071ae086f7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,17 @@ import { FragmentRefs } from "relay-runtime";
 export type ArticleZoomGalleryCaption_figure$data = {
   readonly __typename: "ArticleImageSection";
   readonly caption: string | null;
+  readonly " $fragmentType": "ArticleZoomGalleryCaption_figure";
+} | {
+  readonly __typename: "ArticleUnpublishedArtwork";
+  readonly artist: {
+    readonly name: string | null;
+  } | null;
+  readonly date: string | null;
+  readonly partner: {
+    readonly name: string | null;
+  } | null;
+  readonly title: string | null;
   readonly " $fragmentType": "ArticleZoomGalleryCaption_figure";
 } | {
   readonly __typename: "Artwork";
@@ -30,7 +41,17 @@ export type ArticleZoomGalleryCaption_figure$key = {
   readonly " $fragmentSpreads": FragmentRefs<"ArticleZoomGalleryCaption_figure">;
 };
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  }
+];
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -75,12 +96,54 @@ const node: ReaderFragment = {
       ],
       "type": "ArticleImageSection",
       "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "title",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "date",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArticleUnpublishedArtworkArtist",
+          "kind": "LinkedField",
+          "name": "artist",
+          "plural": false,
+          "selections": (v0/*: any*/),
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArticleUnpublishedArtworkPartner",
+          "kind": "LinkedField",
+          "name": "partner",
+          "plural": false,
+          "selections": (v0/*: any*/),
+          "storageKey": null
+        }
+      ],
+      "type": "ArticleUnpublishedArtwork",
+      "abstractKey": null
     }
   ],
   "type": "ArticleSectionImageCollectionFigure",
   "abstractKey": "__isArticleSectionImageCollectionFigure"
 };
+})();
 
-(node as any).hash = "9542cbe3378e46fa0ff671166b18b18d";
+(node as any).hash = "48db763f1f8a0b2f28d82482cd659864";
 
 export default node;

--- a/src/__generated__/ArticleZoomGalleryFigure_figure.graphql.ts
+++ b/src/__generated__/ArticleZoomGalleryFigure_figure.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0521b546f116daf77e6e723df1189376>>
+ * @generated SignedSource<<aa8f14b85781b8b547e4b3b4472dafa9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,14 @@ import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArticleZoomGalleryFigure_figure$data = {
   readonly __typename: "ArticleImageSection";
+  readonly image: {
+    readonly height: number | null;
+    readonly url: string | null;
+    readonly width: number | null;
+  } | null;
+  readonly " $fragmentType": "ArticleZoomGalleryFigure_figure";
+} | {
+  readonly __typename: "ArticleUnpublishedArtwork";
   readonly image: {
     readonly height: number | null;
     readonly url: string | null;
@@ -106,6 +114,12 @@ return {
       "selections": (v0/*: any*/),
       "type": "ArticleImageSection",
       "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": (v0/*: any*/),
+      "type": "ArticleUnpublishedArtwork",
+      "abstractKey": null
     }
   ],
   "type": "ArticleSectionImageCollectionFigure",
@@ -113,6 +127,6 @@ return {
 };
 })();
 
-(node as any).hash = "be0d702024ad600e40a808c3e62f6d4e";
+(node as any).hash = "3e038525be1ac1edbe524df55537cd86";
 
 export default node;

--- a/src/__generated__/ArticleZoomGalleryQuery.graphql.ts
+++ b/src/__generated__/ArticleZoomGalleryQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0843c99a19b04857e728c73a605c6f10>>
+ * @generated SignedSource<<d3c332e966648d0e9a7d548029e7796e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -101,35 +101,42 @@ v5 = {
   "name": "title",
   "storageKey": null
 },
-v6 = [
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "date",
+  "storageKey": null
+},
+v7 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v10 = [
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -138,23 +145,17 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = [
-  (v8/*: any*/),
-  (v7/*: any*/)
+v12 = [
+  (v9/*: any*/),
+  (v8/*: any*/)
 ],
-v12 = {
+v13 = {
   "kind": "InlineFragment",
   "selections": [
     (v3/*: any*/),
     (v4/*: any*/),
     (v5/*: any*/),
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "date",
-      "storageKey": null
-    },
+    (v6/*: any*/),
     {
       "alias": "sale_message",
       "args": null,
@@ -171,15 +172,15 @@ v12 = {
     },
     {
       "alias": null,
-      "args": (v6/*: any*/),
+      "args": (v7/*: any*/),
       "concreteType": "Artist",
       "kind": "LinkedField",
       "name": "artists",
       "plural": true,
       "selections": [
-        (v7/*: any*/),
+        (v8/*: any*/),
         (v4/*: any*/),
-        (v8/*: any*/)
+        (v9/*: any*/)
       ],
       "storageKey": "artists(shallow:true)"
     },
@@ -192,15 +193,15 @@ v12 = {
     },
     {
       "alias": null,
-      "args": (v6/*: any*/),
+      "args": (v7/*: any*/),
       "concreteType": "Partner",
       "kind": "LinkedField",
       "name": "partner",
       "plural": false,
       "selections": [
-        (v8/*: any*/),
+        (v9/*: any*/),
         (v4/*: any*/),
-        (v7/*: any*/)
+        (v8/*: any*/)
       ],
       "storageKey": "partner(shallow:true)"
     },
@@ -212,7 +213,7 @@ v12 = {
       "name": "sale",
       "plural": false,
       "selections": [
-        (v9/*: any*/),
+        (v10/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -248,7 +249,7 @@ v12 = {
           "name": "isClosed",
           "storageKey": null
         },
-        (v7/*: any*/)
+        (v8/*: any*/)
       ],
       "storageKey": null
     },
@@ -274,7 +275,7 @@ v12 = {
           "name": "lotLabel",
           "storageKey": null
         },
-        (v9/*: any*/),
+        (v10/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -314,7 +315,7 @@ v12 = {
           "kind": "LinkedField",
           "name": "highestBid",
           "plural": false,
-          "selections": (v10/*: any*/),
+          "selections": (v11/*: any*/),
           "storageKey": null
         },
         {
@@ -324,14 +325,14 @@ v12 = {
           "kind": "LinkedField",
           "name": "openingBid",
           "plural": false,
-          "selections": (v10/*: any*/),
+          "selections": (v11/*: any*/),
           "storageKey": null
         },
-        (v7/*: any*/)
+        (v8/*: any*/)
       ],
       "storageKey": null
     },
-    (v7/*: any*/),
+    (v8/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -360,7 +361,7 @@ v12 = {
       "kind": "LinkedField",
       "name": "attributionClass",
       "plural": false,
-      "selections": (v11/*: any*/),
+      "selections": (v12/*: any*/),
       "storageKey": null
     },
     {
@@ -378,7 +379,7 @@ v12 = {
           "kind": "LinkedField",
           "name": "filterGene",
           "plural": false,
-          "selections": (v11/*: any*/),
+          "selections": (v12/*: any*/),
           "storageKey": null
         }
       ],
@@ -388,19 +389,42 @@ v12 = {
   "type": "Artwork",
   "abstractKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "caption",
   "storageKey": null
 },
-v14 = [
-  (v7/*: any*/)
+v15 = [
+  (v9/*: any*/)
 ],
-v15 = {
+v16 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArticleUnpublishedArtworkArtist",
+  "kind": "LinkedField",
+  "name": "artist",
+  "plural": false,
+  "selections": (v15/*: any*/),
+  "storageKey": null
+},
+v17 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArticleUnpublishedArtworkPartner",
+  "kind": "LinkedField",
+  "name": "partner",
+  "plural": false,
+  "selections": (v15/*: any*/),
+  "storageKey": null
+},
+v18 = [
+  (v8/*: any*/)
+],
+v19 = {
   "kind": "InlineFragment",
-  "selections": (v14/*: any*/),
+  "selections": (v18/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 };
@@ -470,24 +494,31 @@ return {
                         "abstractKey": "__isArticleSectionImageCollectionFigure"
                       },
                       (v2/*: any*/),
-                      (v12/*: any*/),
+                      (v13/*: any*/),
                       {
                         "kind": "InlineFragment",
                         "selections": [
                           (v3/*: any*/),
-                          (v13/*: any*/),
-                          (v7/*: any*/)
+                          (v14/*: any*/),
+                          (v8/*: any*/)
                         ],
                         "type": "ArticleImageSection",
                         "abstractKey": null
                       },
-                      (v15/*: any*/),
                       {
                         "kind": "InlineFragment",
-                        "selections": (v14/*: any*/),
+                        "selections": [
+                          (v3/*: any*/),
+                          (v5/*: any*/),
+                          (v6/*: any*/),
+                          (v16/*: any*/),
+                          (v17/*: any*/),
+                          (v8/*: any*/)
+                        ],
                         "type": "ArticleUnpublishedArtwork",
                         "abstractKey": null
-                      }
+                      },
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -511,14 +542,26 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v12/*: any*/),
+                          (v13/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
                               (v3/*: any*/),
-                              (v13/*: any*/)
+                              (v14/*: any*/)
                             ],
                             "type": "ArticleImageSection",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v3/*: any*/),
+                              (v5/*: any*/),
+                              (v6/*: any*/),
+                              (v16/*: any*/),
+                              (v17/*: any*/)
+                            ],
+                            "type": "ArticleUnpublishedArtwork",
                             "abstractKey": null
                           }
                         ],
@@ -527,17 +570,17 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v14/*: any*/),
+                        "selections": (v18/*: any*/),
                         "type": "Artwork",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v14/*: any*/),
+                        "selections": (v18/*: any*/),
                         "type": "ArticleImageSection",
                         "abstractKey": null
                       },
-                      (v15/*: any*/)
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -548,19 +591,19 @@ return {
             ],
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "aca3c1d00a94a868a43deca2d1c93c6d",
+    "cacheID": "1beed79b27d5f976d4b3595443d82423",
     "id": null,
     "metadata": {},
     "name": "ArticleZoomGalleryQuery",
     "operationKind": "query",
-    "text": "query ArticleZoomGalleryQuery(\n  $id: String!\n) {\n  article(id: $id) {\n    ...ArticleZoomGallery_article\n    id\n  }\n}\n\nfragment ArticleZoomGalleryCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ... on Artwork {\n    ...Metadata_artwork\n    href\n  }\n  ... on ArticleImageSection {\n    caption\n  }\n}\n\nfragment ArticleZoomGalleryFigure_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ... on Artwork {\n    image {\n      width\n      height\n      url(version: [\"normalized\", \"larger\", \"large\"])\n    }\n  }\n  ... on ArticleImageSection {\n    image {\n      width\n      height\n      url(version: [\"normalized\", \"larger\", \"large\"])\n    }\n  }\n}\n\nfragment ArticleZoomGallery_article on Article {\n  sections {\n    __typename\n    ... on ArticleSectionImageCollection {\n      figures {\n        ...ArticleZoomGalleryFigure_figure\n        ...ArticleZoomGalleryCaption_figure\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on ArticleImageSection {\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on ArticleUnpublishedArtwork {\n          id\n        }\n      }\n    }\n    ... on ArticleSectionImageSet {\n      title\n      figures {\n        ...ArticleZoomGalleryFigure_figure\n        ...ArticleZoomGalleryCaption_figure\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on ArticleImageSection {\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query ArticleZoomGalleryQuery(\n  $id: String!\n) {\n  article(id: $id) {\n    ...ArticleZoomGallery_article\n    id\n  }\n}\n\nfragment ArticleZoomGalleryCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ... on Artwork {\n    ...Metadata_artwork\n    href\n  }\n  ... on ArticleImageSection {\n    caption\n  }\n  ... on ArticleUnpublishedArtwork {\n    title\n    date\n    artist {\n      name\n    }\n    partner {\n      name\n    }\n  }\n}\n\nfragment ArticleZoomGalleryFigure_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ... on Artwork {\n    image {\n      width\n      height\n      url(version: [\"normalized\", \"larger\", \"large\"])\n    }\n  }\n  ... on ArticleImageSection {\n    image {\n      width\n      height\n      url(version: [\"normalized\", \"larger\", \"large\"])\n    }\n  }\n  ... on ArticleUnpublishedArtwork {\n    image {\n      width\n      height\n      url(version: [\"normalized\", \"larger\", \"large\"])\n    }\n  }\n}\n\nfragment ArticleZoomGallery_article on Article {\n  sections {\n    __typename\n    ... on ArticleSectionImageCollection {\n      figures {\n        ...ArticleZoomGalleryFigure_figure\n        ...ArticleZoomGalleryCaption_figure\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on ArticleImageSection {\n          id\n        }\n        ... on ArticleUnpublishedArtwork {\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    ... on ArticleSectionImageSet {\n      title\n      figures {\n        ...ArticleZoomGalleryFigure_figure\n        ...ArticleZoomGalleryCaption_figure\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on ArticleImageSection {\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArticleZoomGallery_article.graphql.ts
+++ b/src/__generated__/ArticleZoomGallery_article.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d10bccda51b6c3bb4de63c171fd116f9>>
+ * @generated SignedSource<<dc56d4ed9abb11f0acd9599d60ec6346>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -46,7 +46,17 @@ var v0 = {
   "name": "__typename",
   "storageKey": null
 },
-v1 = [
+v1 = {
+  "args": null,
+  "kind": "FragmentSpread",
+  "name": "ArticleZoomGalleryFigure_figure"
+},
+v2 = {
+  "args": null,
+  "kind": "FragmentSpread",
+  "name": "ArticleZoomGalleryCaption_figure"
+},
+v3 = [
   {
     "alias": null,
     "args": null,
@@ -55,39 +65,17 @@ v1 = [
     "storageKey": null
   }
 ],
-v2 = {
-  "alias": null,
-  "args": null,
-  "concreteType": null,
-  "kind": "LinkedField",
-  "name": "figures",
-  "plural": true,
-  "selections": [
-    {
-      "args": null,
-      "kind": "FragmentSpread",
-      "name": "ArticleZoomGalleryFigure_figure"
-    },
-    {
-      "args": null,
-      "kind": "FragmentSpread",
-      "name": "ArticleZoomGalleryCaption_figure"
-    },
-    (v0/*: any*/),
-    {
-      "kind": "InlineFragment",
-      "selections": (v1/*: any*/),
-      "type": "Artwork",
-      "abstractKey": null
-    },
-    {
-      "kind": "InlineFragment",
-      "selections": (v1/*: any*/),
-      "type": "ArticleImageSection",
-      "abstractKey": null
-    }
-  ],
-  "storageKey": null
+v4 = {
+  "kind": "InlineFragment",
+  "selections": (v3/*: any*/),
+  "type": "Artwork",
+  "abstractKey": null
+},
+v5 = {
+  "kind": "InlineFragment",
+  "selections": (v3/*: any*/),
+  "type": "ArticleImageSection",
+  "abstractKey": null
 };
 return {
   "argumentDefinitions": [],
@@ -107,7 +95,28 @@ return {
         {
           "kind": "InlineFragment",
           "selections": [
-            (v2/*: any*/)
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "figures",
+              "plural": true,
+              "selections": [
+                (v1/*: any*/),
+                (v2/*: any*/),
+                (v0/*: any*/),
+                (v4/*: any*/),
+                (v5/*: any*/),
+                {
+                  "kind": "InlineFragment",
+                  "selections": (v3/*: any*/),
+                  "type": "ArticleUnpublishedArtwork",
+                  "abstractKey": null
+                }
+              ],
+              "storageKey": null
+            }
           ],
           "type": "ArticleSectionImageCollection",
           "abstractKey": null
@@ -122,7 +131,22 @@ return {
               "name": "title",
               "storageKey": null
             },
-            (v2/*: any*/)
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "figures",
+              "plural": true,
+              "selections": [
+                (v1/*: any*/),
+                (v2/*: any*/),
+                (v0/*: any*/),
+                (v4/*: any*/),
+                (v5/*: any*/)
+              ],
+              "storageKey": null
+            }
           ],
           "type": "ArticleSectionImageSet",
           "abstractKey": null
@@ -136,6 +160,6 @@ return {
 };
 })();
 
-(node as any).hash = "718ade481e06a3457816550a1f14c849";
+(node as any).hash = "10f3e86aee0c73695b2beac505b64ddb";
 
 export default node;

--- a/src/__generated__/ArticleZoomGallery_test_Query.graphql.ts
+++ b/src/__generated__/ArticleZoomGallery_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<18be0b2b1d4e88aeb71fb524d7800fb2>>
+ * @generated SignedSource<<65aa575439b93564efbcf474880fd508>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -92,35 +92,42 @@ v4 = {
   "name": "title",
   "storageKey": null
 },
-v5 = [
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "date",
+  "storageKey": null
+},
+v6 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v9 = [
+v10 = [
   {
     "alias": null,
     "args": null,
@@ -129,23 +136,17 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = [
-  (v7/*: any*/),
-  (v6/*: any*/)
+v11 = [
+  (v8/*: any*/),
+  (v7/*: any*/)
 ],
-v11 = {
+v12 = {
   "kind": "InlineFragment",
   "selections": [
     (v2/*: any*/),
     (v3/*: any*/),
     (v4/*: any*/),
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "date",
-      "storageKey": null
-    },
+    (v5/*: any*/),
     {
       "alias": "sale_message",
       "args": null,
@@ -162,15 +163,15 @@ v11 = {
     },
     {
       "alias": null,
-      "args": (v5/*: any*/),
+      "args": (v6/*: any*/),
       "concreteType": "Artist",
       "kind": "LinkedField",
       "name": "artists",
       "plural": true,
       "selections": [
-        (v6/*: any*/),
+        (v7/*: any*/),
         (v3/*: any*/),
-        (v7/*: any*/)
+        (v8/*: any*/)
       ],
       "storageKey": "artists(shallow:true)"
     },
@@ -183,15 +184,15 @@ v11 = {
     },
     {
       "alias": null,
-      "args": (v5/*: any*/),
+      "args": (v6/*: any*/),
       "concreteType": "Partner",
       "kind": "LinkedField",
       "name": "partner",
       "plural": false,
       "selections": [
-        (v7/*: any*/),
+        (v8/*: any*/),
         (v3/*: any*/),
-        (v6/*: any*/)
+        (v7/*: any*/)
       ],
       "storageKey": "partner(shallow:true)"
     },
@@ -203,7 +204,7 @@ v11 = {
       "name": "sale",
       "plural": false,
       "selections": [
-        (v8/*: any*/),
+        (v9/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -239,7 +240,7 @@ v11 = {
           "name": "isClosed",
           "storageKey": null
         },
-        (v6/*: any*/)
+        (v7/*: any*/)
       ],
       "storageKey": null
     },
@@ -265,7 +266,7 @@ v11 = {
           "name": "lotLabel",
           "storageKey": null
         },
-        (v8/*: any*/),
+        (v9/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -305,7 +306,7 @@ v11 = {
           "kind": "LinkedField",
           "name": "highestBid",
           "plural": false,
-          "selections": (v9/*: any*/),
+          "selections": (v10/*: any*/),
           "storageKey": null
         },
         {
@@ -315,14 +316,14 @@ v11 = {
           "kind": "LinkedField",
           "name": "openingBid",
           "plural": false,
-          "selections": (v9/*: any*/),
+          "selections": (v10/*: any*/),
           "storageKey": null
         },
-        (v6/*: any*/)
+        (v7/*: any*/)
       ],
       "storageKey": null
     },
-    (v6/*: any*/),
+    (v7/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -351,7 +352,7 @@ v11 = {
       "kind": "LinkedField",
       "name": "attributionClass",
       "plural": false,
-      "selections": (v10/*: any*/),
+      "selections": (v11/*: any*/),
       "storageKey": null
     },
     {
@@ -369,7 +370,7 @@ v11 = {
           "kind": "LinkedField",
           "name": "filterGene",
           "plural": false,
-          "selections": (v10/*: any*/),
+          "selections": (v11/*: any*/),
           "storageKey": null
         }
       ],
@@ -379,47 +380,70 @@ v11 = {
   "type": "Artwork",
   "abstractKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "caption",
   "storageKey": null
 },
-v13 = [
-  (v6/*: any*/)
+v14 = [
+  (v8/*: any*/)
 ],
-v14 = {
+v15 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArticleUnpublishedArtworkArtist",
+  "kind": "LinkedField",
+  "name": "artist",
+  "plural": false,
+  "selections": (v14/*: any*/),
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArticleUnpublishedArtworkPartner",
+  "kind": "LinkedField",
+  "name": "partner",
+  "plural": false,
+  "selections": (v14/*: any*/),
+  "storageKey": null
+},
+v17 = [
+  (v7/*: any*/)
+],
+v18 = {
   "kind": "InlineFragment",
-  "selections": (v13/*: any*/),
+  "selections": (v17/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v15 = {
+v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v16 = {
+v20 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v17 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v18 = {
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v19 = {
+v23 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -491,24 +515,31 @@ return {
                         "abstractKey": "__isArticleSectionImageCollectionFigure"
                       },
                       (v1/*: any*/),
-                      (v11/*: any*/),
+                      (v12/*: any*/),
                       {
                         "kind": "InlineFragment",
                         "selections": [
                           (v2/*: any*/),
-                          (v12/*: any*/),
-                          (v6/*: any*/)
+                          (v13/*: any*/),
+                          (v7/*: any*/)
                         ],
                         "type": "ArticleImageSection",
                         "abstractKey": null
                       },
-                      (v14/*: any*/),
                       {
                         "kind": "InlineFragment",
-                        "selections": (v13/*: any*/),
+                        "selections": [
+                          (v2/*: any*/),
+                          (v4/*: any*/),
+                          (v5/*: any*/),
+                          (v15/*: any*/),
+                          (v16/*: any*/),
+                          (v7/*: any*/)
+                        ],
                         "type": "ArticleUnpublishedArtwork",
                         "abstractKey": null
-                      }
+                      },
+                      (v18/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -532,14 +563,26 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v11/*: any*/),
+                          (v12/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
                               (v2/*: any*/),
-                              (v12/*: any*/)
+                              (v13/*: any*/)
                             ],
                             "type": "ArticleImageSection",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v2/*: any*/),
+                              (v4/*: any*/),
+                              (v5/*: any*/),
+                              (v15/*: any*/),
+                              (v16/*: any*/)
+                            ],
+                            "type": "ArticleUnpublishedArtwork",
                             "abstractKey": null
                           }
                         ],
@@ -548,17 +591,17 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v13/*: any*/),
+                        "selections": (v17/*: any*/),
                         "type": "Artwork",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v13/*: any*/),
+                        "selections": (v17/*: any*/),
                         "type": "ArticleImageSection",
                         "abstractKey": null
                       },
-                      (v14/*: any*/)
+                      (v18/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -569,14 +612,14 @@ return {
             ],
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": "article(id:\"example\")"
       }
     ]
   },
   "params": {
-    "cacheID": "bce696ed199b078c0f60f844979195c8",
+    "cacheID": "4567b7209eda6a397d1ac4fa574ee8a0",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -586,57 +629,64 @@ return {
           "plural": false,
           "type": "Article"
         },
-        "article.id": (v15/*: any*/),
+        "article.id": (v19/*: any*/),
         "article.sections": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "ArticleSections"
         },
-        "article.sections.__typename": (v16/*: any*/),
+        "article.sections.__typename": (v20/*: any*/),
         "article.sections.figures": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "ArticleSectionImageCollectionFigure"
         },
-        "article.sections.figures.__isArticleSectionImageCollectionFigure": (v16/*: any*/),
-        "article.sections.figures.__isNode": (v16/*: any*/),
-        "article.sections.figures.__typename": (v16/*: any*/),
+        "article.sections.figures.__isArticleSectionImageCollectionFigure": (v20/*: any*/),
+        "article.sections.figures.__isNode": (v20/*: any*/),
+        "article.sections.figures.__typename": (v20/*: any*/),
+        "article.sections.figures.artist": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArticleUnpublishedArtworkArtist"
+        },
+        "article.sections.figures.artist.name": (v21/*: any*/),
         "article.sections.figures.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "article.sections.figures.artists.href": (v17/*: any*/),
-        "article.sections.figures.artists.id": (v15/*: any*/),
-        "article.sections.figures.artists.name": (v17/*: any*/),
+        "article.sections.figures.artists.href": (v21/*: any*/),
+        "article.sections.figures.artists.id": (v19/*: any*/),
+        "article.sections.figures.artists.name": (v21/*: any*/),
         "article.sections.figures.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "article.sections.figures.attributionClass.id": (v15/*: any*/),
-        "article.sections.figures.attributionClass.name": (v17/*: any*/),
-        "article.sections.figures.caption": (v17/*: any*/),
-        "article.sections.figures.collecting_institution": (v17/*: any*/),
-        "article.sections.figures.cultural_maker": (v17/*: any*/),
-        "article.sections.figures.date": (v17/*: any*/),
-        "article.sections.figures.href": (v17/*: any*/),
-        "article.sections.figures.id": (v15/*: any*/),
+        "article.sections.figures.attributionClass.id": (v19/*: any*/),
+        "article.sections.figures.attributionClass.name": (v21/*: any*/),
+        "article.sections.figures.caption": (v21/*: any*/),
+        "article.sections.figures.collecting_institution": (v21/*: any*/),
+        "article.sections.figures.cultural_maker": (v21/*: any*/),
+        "article.sections.figures.date": (v21/*: any*/),
+        "article.sections.figures.href": (v21/*: any*/),
+        "article.sections.figures.id": (v19/*: any*/),
         "article.sections.figures.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "article.sections.figures.image.height": (v18/*: any*/),
-        "article.sections.figures.image.url": (v17/*: any*/),
-        "article.sections.figures.image.width": (v18/*: any*/),
-        "article.sections.figures.internalID": (v15/*: any*/),
-        "article.sections.figures.is_saved": (v19/*: any*/),
+        "article.sections.figures.image.height": (v22/*: any*/),
+        "article.sections.figures.image.url": (v21/*: any*/),
+        "article.sections.figures.image.width": (v22/*: any*/),
+        "article.sections.figures.internalID": (v19/*: any*/),
+        "article.sections.figures.is_saved": (v23/*: any*/),
         "article.sections.figures.mediumType": {
           "enumValues": null,
           "nullable": true,
@@ -649,30 +699,30 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "article.sections.figures.mediumType.filterGene.id": (v15/*: any*/),
-        "article.sections.figures.mediumType.filterGene.name": (v17/*: any*/),
+        "article.sections.figures.mediumType.filterGene.id": (v19/*: any*/),
+        "article.sections.figures.mediumType.filterGene.name": (v21/*: any*/),
         "article.sections.figures.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "article.sections.figures.partner.href": (v17/*: any*/),
-        "article.sections.figures.partner.id": (v15/*: any*/),
-        "article.sections.figures.partner.name": (v17/*: any*/),
+        "article.sections.figures.partner.href": (v21/*: any*/),
+        "article.sections.figures.partner.id": (v19/*: any*/),
+        "article.sections.figures.partner.name": (v21/*: any*/),
         "article.sections.figures.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "article.sections.figures.sale.cascadingEndTimeIntervalMinutes": (v18/*: any*/),
-        "article.sections.figures.sale.endAt": (v17/*: any*/),
-        "article.sections.figures.sale.extendedBiddingIntervalMinutes": (v18/*: any*/),
-        "article.sections.figures.sale.id": (v15/*: any*/),
-        "article.sections.figures.sale.is_auction": (v19/*: any*/),
-        "article.sections.figures.sale.is_closed": (v19/*: any*/),
-        "article.sections.figures.sale.startAt": (v17/*: any*/),
+        "article.sections.figures.sale.cascadingEndTimeIntervalMinutes": (v22/*: any*/),
+        "article.sections.figures.sale.endAt": (v21/*: any*/),
+        "article.sections.figures.sale.extendedBiddingIntervalMinutes": (v22/*: any*/),
+        "article.sections.figures.sale.id": (v19/*: any*/),
+        "article.sections.figures.sale.is_auction": (v23/*: any*/),
+        "article.sections.figures.sale.is_closed": (v23/*: any*/),
+        "article.sections.figures.sale.startAt": (v21/*: any*/),
         "article.sections.figures.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -691,35 +741,35 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "article.sections.figures.sale_artwork.endAt": (v17/*: any*/),
-        "article.sections.figures.sale_artwork.extendedBiddingEndAt": (v17/*: any*/),
-        "article.sections.figures.sale_artwork.formattedEndDateTime": (v17/*: any*/),
+        "article.sections.figures.sale_artwork.endAt": (v21/*: any*/),
+        "article.sections.figures.sale_artwork.extendedBiddingEndAt": (v21/*: any*/),
+        "article.sections.figures.sale_artwork.formattedEndDateTime": (v21/*: any*/),
         "article.sections.figures.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "article.sections.figures.sale_artwork.highest_bid.display": (v17/*: any*/),
-        "article.sections.figures.sale_artwork.id": (v15/*: any*/),
-        "article.sections.figures.sale_artwork.lotID": (v17/*: any*/),
-        "article.sections.figures.sale_artwork.lotLabel": (v17/*: any*/),
+        "article.sections.figures.sale_artwork.highest_bid.display": (v21/*: any*/),
+        "article.sections.figures.sale_artwork.id": (v19/*: any*/),
+        "article.sections.figures.sale_artwork.lotID": (v21/*: any*/),
+        "article.sections.figures.sale_artwork.lotLabel": (v21/*: any*/),
         "article.sections.figures.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "article.sections.figures.sale_artwork.opening_bid.display": (v17/*: any*/),
-        "article.sections.figures.sale_message": (v17/*: any*/),
-        "article.sections.figures.slug": (v15/*: any*/),
-        "article.sections.figures.title": (v17/*: any*/),
-        "article.sections.title": (v17/*: any*/)
+        "article.sections.figures.sale_artwork.opening_bid.display": (v21/*: any*/),
+        "article.sections.figures.sale_message": (v21/*: any*/),
+        "article.sections.figures.slug": (v19/*: any*/),
+        "article.sections.figures.title": (v21/*: any*/),
+        "article.sections.title": (v21/*: any*/)
       }
     },
     "name": "ArticleZoomGallery_test_Query",
     "operationKind": "query",
-    "text": "query ArticleZoomGallery_test_Query {\n  article(id: \"example\") {\n    ...ArticleZoomGallery_article\n    id\n  }\n}\n\nfragment ArticleZoomGalleryCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ... on Artwork {\n    ...Metadata_artwork\n    href\n  }\n  ... on ArticleImageSection {\n    caption\n  }\n}\n\nfragment ArticleZoomGalleryFigure_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ... on Artwork {\n    image {\n      width\n      height\n      url(version: [\"normalized\", \"larger\", \"large\"])\n    }\n  }\n  ... on ArticleImageSection {\n    image {\n      width\n      height\n      url(version: [\"normalized\", \"larger\", \"large\"])\n    }\n  }\n}\n\nfragment ArticleZoomGallery_article on Article {\n  sections {\n    __typename\n    ... on ArticleSectionImageCollection {\n      figures {\n        ...ArticleZoomGalleryFigure_figure\n        ...ArticleZoomGalleryCaption_figure\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on ArticleImageSection {\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on ArticleUnpublishedArtwork {\n          id\n        }\n      }\n    }\n    ... on ArticleSectionImageSet {\n      title\n      figures {\n        ...ArticleZoomGalleryFigure_figure\n        ...ArticleZoomGalleryCaption_figure\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on ArticleImageSection {\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query ArticleZoomGallery_test_Query {\n  article(id: \"example\") {\n    ...ArticleZoomGallery_article\n    id\n  }\n}\n\nfragment ArticleZoomGalleryCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ... on Artwork {\n    ...Metadata_artwork\n    href\n  }\n  ... on ArticleImageSection {\n    caption\n  }\n  ... on ArticleUnpublishedArtwork {\n    title\n    date\n    artist {\n      name\n    }\n    partner {\n      name\n    }\n  }\n}\n\nfragment ArticleZoomGalleryFigure_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ... on Artwork {\n    image {\n      width\n      height\n      url(version: [\"normalized\", \"larger\", \"large\"])\n    }\n  }\n  ... on ArticleImageSection {\n    image {\n      width\n      height\n      url(version: [\"normalized\", \"larger\", \"large\"])\n    }\n  }\n  ... on ArticleUnpublishedArtwork {\n    image {\n      width\n      height\n      url(version: [\"normalized\", \"larger\", \"large\"])\n    }\n  }\n}\n\nfragment ArticleZoomGallery_article on Article {\n  sections {\n    __typename\n    ... on ArticleSectionImageCollection {\n      figures {\n        ...ArticleZoomGalleryFigure_figure\n        ...ArticleZoomGalleryCaption_figure\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on ArticleImageSection {\n          id\n        }\n        ... on ArticleUnpublishedArtwork {\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    ... on ArticleSectionImageSet {\n      title\n      figures {\n        ...ArticleZoomGalleryFigure_figure\n        ...ArticleZoomGalleryCaption_figure\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on ArticleImageSection {\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/NewsIndexArticlesQuery.graphql.ts
+++ b/src/__generated__/NewsIndexArticlesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4f88b0cdaa194661ebdd41326581b69a>>
+ * @generated SignedSource<<17cc62382b3167f7e25e58e11701a090>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -187,21 +187,28 @@ v19 = {
   ],
   "storageKey": null
 },
-v20 = [
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "date",
+  "storageKey": null
+},
+v21 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v22 = [
+v23 = [
   {
     "alias": null,
     "args": null,
@@ -210,33 +217,35 @@ v22 = [
     "storageKey": null
   }
 ],
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v24 = [
+v25 = [
   (v14/*: any*/),
   (v15/*: any*/)
 ],
-v25 = [
-  (v15/*: any*/)
+v26 = [
+  (v14/*: any*/)
 ],
-v26 = {
+v27 = {
   "kind": "InlineFragment",
-  "selections": (v25/*: any*/),
+  "selections": [
+    (v15/*: any*/)
+  ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v27 = [
+v28 = [
   (v11/*: any*/),
   (v12/*: any*/),
   (v18/*: any*/),
   (v17/*: any*/)
 ],
-v28 = [
+v29 = [
   (v15/*: any*/),
   {
     "alias": null,
@@ -265,7 +274,7 @@ v28 = [
         "kind": "LinkedField",
         "name": "cropped",
         "plural": false,
-        "selections": (v27/*: any*/),
+        "selections": (v28/*: any*/),
         "storageKey": "cropped(height:80,version:[\"normalized\",\"larger\",\"large\"],width:80)"
       },
       {
@@ -282,7 +291,7 @@ v28 = [
         "kind": "LinkedField",
         "name": "resized",
         "plural": false,
-        "selections": (v27/*: any*/),
+        "selections": (v28/*: any*/),
         "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:1220)"
       }
     ],
@@ -572,13 +581,7 @@ return {
                                       (v19/*: any*/),
                                       (v5/*: any*/),
                                       (v4/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "date",
-                                        "storageKey": null
-                                      },
+                                      (v20/*: any*/),
                                       {
                                         "alias": "sale_message",
                                         "args": null,
@@ -595,7 +598,7 @@ return {
                                       },
                                       {
                                         "alias": null,
-                                        "args": (v20/*: any*/),
+                                        "args": (v21/*: any*/),
                                         "concreteType": "Artist",
                                         "kind": "LinkedField",
                                         "name": "artists",
@@ -616,7 +619,7 @@ return {
                                       },
                                       {
                                         "alias": null,
-                                        "args": (v20/*: any*/),
+                                        "args": (v21/*: any*/),
                                         "concreteType": "Partner",
                                         "kind": "LinkedField",
                                         "name": "partner",
@@ -636,7 +639,7 @@ return {
                                         "name": "sale",
                                         "plural": false,
                                         "selections": [
-                                          (v21/*: any*/),
+                                          (v22/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -698,7 +701,7 @@ return {
                                             "name": "lotLabel",
                                             "storageKey": null
                                           },
-                                          (v21/*: any*/),
+                                          (v22/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -738,7 +741,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "highestBid",
                                             "plural": false,
-                                            "selections": (v22/*: any*/),
+                                            "selections": (v23/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -748,7 +751,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "openingBid",
                                             "plural": false,
-                                            "selections": (v22/*: any*/),
+                                            "selections": (v23/*: any*/),
                                             "storageKey": null
                                           },
                                           (v15/*: any*/)
@@ -756,7 +759,7 @@ return {
                                         "storageKey": null
                                       },
                                       (v3/*: any*/),
-                                      (v23/*: any*/),
+                                      (v24/*: any*/),
                                       {
                                         "alias": "is_saved",
                                         "args": null,
@@ -771,7 +774,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "attributionClass",
                                         "plural": false,
-                                        "selections": (v24/*: any*/),
+                                        "selections": (v25/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -789,7 +792,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "filterGene",
                                             "plural": false,
-                                            "selections": (v24/*: any*/),
+                                            "selections": (v25/*: any*/),
                                             "storageKey": null
                                           }
                                         ],
@@ -799,13 +802,38 @@ return {
                                     "type": "Artwork",
                                     "abstractKey": null
                                   },
-                                  (v26/*: any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v25/*: any*/),
+                                    "selections": [
+                                      (v15/*: any*/),
+                                      (v19/*: any*/),
+                                      (v4/*: any*/),
+                                      (v20/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "ArticleUnpublishedArtworkArtist",
+                                        "kind": "LinkedField",
+                                        "name": "artist",
+                                        "plural": false,
+                                        "selections": (v26/*: any*/),
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "ArticleUnpublishedArtworkPartner",
+                                        "kind": "LinkedField",
+                                        "name": "partner",
+                                        "plural": false,
+                                        "selections": (v26/*: any*/),
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "type": "ArticleUnpublishedArtwork",
                                     "abstractKey": null
-                                  }
+                                  },
+                                  (v27/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -853,17 +881,17 @@ return {
                                   (v7/*: any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v28/*: any*/),
+                                    "selections": (v29/*: any*/),
                                     "type": "ArticleImageSection",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v28/*: any*/),
+                                    "selections": (v29/*: any*/),
                                     "type": "Artwork",
                                     "abstractKey": null
                                   },
-                                  (v26/*: any*/)
+                                  (v27/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -1004,7 +1032,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v23/*: any*/),
+                      (v24/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1135,12 +1163,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4283b86d622055d099ac6aa0fb31c7b5",
+    "cacheID": "e2c260eeecaf2832b17c3b536deb9247",
     "id": null,
     "metadata": {},
     "name": "NewsIndexArticlesQuery",
     "operationKind": "query",
-    "text": "query NewsIndexArticlesQuery(\n  $after: String\n) {\n  viewer {\n    ...NewsIndexArticles_viewer_WGPvJ\n  }\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHero_article\n  ...ArticleByline_article\n  ...ArticleSectionAd_article\n  ...ArticleNewsSource_article\n  hero {\n    __typename\n  }\n  seriesArticle {\n    thumbnailTitle\n    href\n    id\n  }\n  vertical\n  byline\n  internalID\n  slug\n  layout\n  leadParagraph\n  title\n  href\n  publishedAt\n  sections {\n    __typename\n    ...ArticleSection_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    internalID\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHero_article on Article {\n  title\n  href\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      media\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleNewsSource_article on Article {\n  newsSource {\n    title\n    url\n  }\n}\n\nfragment ArticleSectionAd_article on Article {\n  layout\n  sections {\n    __typename\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n  _layout: layout\n}\n\nfragment ArticleSectionImageCollectionCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ...Metadata_artwork\n  ... on ArticleImageSection {\n    caption\n  }\n}\n\nfragment ArticleSectionImageCollectionImage_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  ... on ArticleImageSection {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on Artwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ...ArticleSectionImageCollectionImage_figure\n    ...ArticleSectionImageCollectionCaption_figure\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ArticleImageSection {\n      id\n    }\n    ... on ArticleUnpublishedArtwork {\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  fallbackEmbed: embed(autoPlay: false)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSection_section on ArticleSections {\n  __isArticleSections: __typename\n  __typename\n  ...ArticleSectionText_section\n  ...ArticleSectionImageCollection_section\n  ...ArticleSectionImageSet_section\n  ...ArticleSectionVideo_section\n  ...ArticleSectionSocialEmbed_section\n  ...ArticleSectionEmbed_section\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment NewsIndexArticles_viewer_WGPvJ on Viewer {\n  articlesConnection(first: 15, after: $after, layout: NEWS, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...ArticleBody_article\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NewsIndexArticlesQuery(\n  $after: String\n) {\n  viewer {\n    ...NewsIndexArticles_viewer_WGPvJ\n  }\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHero_article\n  ...ArticleByline_article\n  ...ArticleSectionAd_article\n  ...ArticleNewsSource_article\n  hero {\n    __typename\n  }\n  seriesArticle {\n    thumbnailTitle\n    href\n    id\n  }\n  vertical\n  byline\n  internalID\n  slug\n  layout\n  leadParagraph\n  title\n  href\n  publishedAt\n  sections {\n    __typename\n    ...ArticleSection_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    internalID\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHero_article on Article {\n  title\n  href\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      media\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleNewsSource_article on Article {\n  newsSource {\n    title\n    url\n  }\n}\n\nfragment ArticleSectionAd_article on Article {\n  layout\n  sections {\n    __typename\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n  _layout: layout\n}\n\nfragment ArticleSectionImageCollectionCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ...Metadata_artwork\n  ... on ArticleImageSection {\n    caption\n  }\n  ... on ArticleUnpublishedArtwork {\n    title\n    date\n    artist {\n      name\n    }\n    partner {\n      name\n    }\n  }\n}\n\nfragment ArticleSectionImageCollectionImage_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  ... on ArticleImageSection {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on Artwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on ArticleUnpublishedArtwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ...ArticleSectionImageCollectionImage_figure\n    ...ArticleSectionImageCollectionCaption_figure\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ArticleImageSection {\n      id\n    }\n    ... on ArticleUnpublishedArtwork {\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  fallbackEmbed: embed(autoPlay: false)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSection_section on ArticleSections {\n  __isArticleSections: __typename\n  __typename\n  ...ArticleSectionText_section\n  ...ArticleSectionImageCollection_section\n  ...ArticleSectionImageSet_section\n  ...ArticleSectionVideo_section\n  ...ArticleSectionSocialEmbed_section\n  ...ArticleSectionEmbed_section\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment NewsIndexArticles_viewer_WGPvJ on Viewer {\n  articlesConnection(first: 15, after: $after, layout: NEWS, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...ArticleBody_article\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/articleRoutes_ArticleQuery.graphql.ts
+++ b/src/__generated__/articleRoutes_ArticleQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a547950c9ab81de93f1331a593c59b30>>
+ * @generated SignedSource<<9f66be8e7b578143095317e955fbb2d4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -178,21 +178,28 @@ v19 = {
   ],
   "storageKey": null
 },
-v20 = [
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "date",
+  "storageKey": null
+},
+v21 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v22 = [
+v23 = [
   {
     "alias": null,
     "args": null,
@@ -201,33 +208,35 @@ v22 = [
     "storageKey": null
   }
 ],
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v24 = [
+v25 = [
   (v14/*: any*/),
   (v15/*: any*/)
 ],
-v25 = [
-  (v15/*: any*/)
+v26 = [
+  (v14/*: any*/)
 ],
-v26 = {
+v27 = {
   "kind": "InlineFragment",
-  "selections": (v25/*: any*/),
+  "selections": [
+    (v15/*: any*/)
+  ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v27 = [
+v28 = [
   (v10/*: any*/),
   (v11/*: any*/),
   (v18/*: any*/),
   (v17/*: any*/)
 ],
-v28 = [
+v29 = [
   (v15/*: any*/),
   {
     "alias": null,
@@ -256,7 +265,7 @@ v28 = [
         "kind": "LinkedField",
         "name": "cropped",
         "plural": false,
-        "selections": (v27/*: any*/),
+        "selections": (v28/*: any*/),
         "storageKey": "cropped(height:80,version:[\"normalized\",\"larger\",\"large\"],width:80)"
       },
       {
@@ -273,28 +282,28 @@ v28 = [
         "kind": "LinkedField",
         "name": "resized",
         "plural": false,
-        "selections": (v27/*: any*/),
+        "selections": (v28/*: any*/),
         "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:1220)"
       }
     ],
     "storageKey": null
   }
 ],
-v29 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "thumbnailTitle",
   "storageKey": null
 },
-v30 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "description",
   "storageKey": null
 },
-v31 = {
+v32 = {
   "alias": null,
   "args": null,
   "concreteType": "ArticleSponsor",
@@ -326,7 +335,7 @@ v31 = {
   ],
   "storageKey": null
 },
-v32 = {
+v33 = {
   "alias": "display",
   "args": [
     {
@@ -347,7 +356,7 @@ v32 = {
   "selections": (v12/*: any*/),
   "storageKey": "cropped(height:580,width:869)"
 },
-v33 = {
+v34 = {
   "alias": null,
   "args": [
     {
@@ -360,14 +369,14 @@ v33 = {
   "name": "publishedAt",
   "storageKey": "publishedAt(format:\"MMM DD, YYYY\")"
 },
-v34 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "duration",
   "storageKey": null
 },
-v35 = {
+v36 = {
   "alias": null,
   "args": null,
   "concreteType": "ArticleMedia",
@@ -375,11 +384,11 @@ v35 = {
   "name": "media",
   "plural": false,
   "selections": [
-    (v34/*: any*/)
+    (v35/*: any*/)
   ],
   "storageKey": null
 },
-v36 = {
+v37 = {
   "alias": null,
   "args": null,
   "concreteType": "Article",
@@ -392,7 +401,7 @@ v36 = {
   ],
   "storageKey": null
 },
-v37 = [
+v38 = [
   (v9/*: any*/)
 ];
 return {
@@ -645,13 +654,7 @@ return {
                           (v19/*: any*/),
                           (v3/*: any*/),
                           (v2/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "date",
-                            "storageKey": null
-                          },
+                          (v20/*: any*/),
                           {
                             "alias": "sale_message",
                             "args": null,
@@ -668,7 +671,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
@@ -689,7 +692,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
@@ -709,7 +712,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
+                              (v22/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -771,7 +774,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v21/*: any*/),
+                              (v22/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -811,7 +814,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v22/*: any*/),
+                                "selections": (v23/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -821,7 +824,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v22/*: any*/),
+                                "selections": (v23/*: any*/),
                                 "storageKey": null
                               },
                               (v15/*: any*/)
@@ -829,7 +832,7 @@ return {
                             "storageKey": null
                           },
                           (v13/*: any*/),
-                          (v23/*: any*/),
+                          (v24/*: any*/),
                           {
                             "alias": "is_saved",
                             "args": null,
@@ -844,7 +847,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v24/*: any*/),
+                            "selections": (v25/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -862,7 +865,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v24/*: any*/),
+                                "selections": (v25/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -872,13 +875,38 @@ return {
                         "type": "Artwork",
                         "abstractKey": null
                       },
-                      (v26/*: any*/),
                       {
                         "kind": "InlineFragment",
-                        "selections": (v25/*: any*/),
+                        "selections": [
+                          (v15/*: any*/),
+                          (v19/*: any*/),
+                          (v2/*: any*/),
+                          (v20/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArticleUnpublishedArtworkArtist",
+                            "kind": "LinkedField",
+                            "name": "artist",
+                            "plural": false,
+                            "selections": (v26/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArticleUnpublishedArtworkPartner",
+                            "kind": "LinkedField",
+                            "name": "partner",
+                            "plural": false,
+                            "selections": (v26/*: any*/),
+                            "storageKey": null
+                          }
+                        ],
                         "type": "ArticleUnpublishedArtwork",
                         "abstractKey": null
-                      }
+                      },
+                      (v27/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -926,17 +954,17 @@ return {
                       (v6/*: any*/),
                       {
                         "kind": "InlineFragment",
-                        "selections": (v28/*: any*/),
+                        "selections": (v29/*: any*/),
                         "type": "ArticleImageSection",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v28/*: any*/),
+                        "selections": (v29/*: any*/),
                         "type": "Artwork",
                         "abstractKey": null
                       },
-                      (v26/*: any*/)
+                      (v27/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1065,17 +1093,17 @@ return {
             "name": "seriesArticle",
             "plural": false,
             "selections": [
-              (v29/*: any*/),
+              (v30/*: any*/),
               (v3/*: any*/),
               (v15/*: any*/),
               (v2/*: any*/),
-              (v30/*: any*/),
-              (v31/*: any*/)
+              (v31/*: any*/),
+              (v32/*: any*/)
             ],
             "storageKey": null
           },
           (v13/*: any*/),
-          (v23/*: any*/),
+          (v24/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1138,17 +1166,17 @@ return {
                     "selections": (v12/*: any*/),
                     "storageKey": "cropped(height:100,width:100)"
                   },
-                  (v32/*: any*/)
+                  (v33/*: any*/)
                 ],
                 "storageKey": null
               },
               (v15/*: any*/),
               (v4/*: any*/),
-              (v29/*: any*/),
               (v30/*: any*/),
-              (v33/*: any*/),
-              (v35/*: any*/),
-              (v36/*: any*/)
+              (v31/*: any*/),
+              (v34/*: any*/),
+              (v36/*: any*/),
+              (v37/*: any*/)
             ],
             "storageKey": null
           },
@@ -1160,12 +1188,12 @@ return {
             "name": "series",
             "plural": false,
             "selections": [
-              (v30/*: any*/)
+              (v31/*: any*/)
             ],
             "storageKey": null
           },
+          (v32/*: any*/),
           (v31/*: any*/),
-          (v30/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1181,7 +1209,7 @@ return {
                 "kind": "LinkedField",
                 "name": "coverImage",
                 "plural": false,
-                "selections": (v37/*: any*/),
+                "selections": (v38/*: any*/),
                 "storageKey": null
               },
               {
@@ -1191,8 +1219,8 @@ return {
                 "name": "credits",
                 "storageKey": null
               },
-              (v30/*: any*/),
-              (v34/*: any*/),
+              (v31/*: any*/),
+              (v35/*: any*/),
               {
                 "alias": null,
                 "args": [
@@ -1227,10 +1255,10 @@ return {
               (v3/*: any*/),
               (v4/*: any*/),
               (v2/*: any*/),
-              (v29/*: any*/),
-              (v5/*: any*/),
               (v30/*: any*/),
-              (v33/*: any*/),
+              (v5/*: any*/),
+              (v31/*: any*/),
+              (v34/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1239,12 +1267,12 @@ return {
                 "name": "thumbnailImage",
                 "plural": false,
                 "selections": [
-                  (v32/*: any*/)
+                  (v33/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v35/*: any*/),
               (v36/*: any*/),
+              (v37/*: any*/),
               (v13/*: any*/),
               (v15/*: any*/)
             ],
@@ -1285,7 +1313,7 @@ return {
             "kind": "LinkedField",
             "name": "thumbnailImage",
             "plural": false,
-            "selections": (v37/*: any*/),
+            "selections": (v38/*: any*/),
             "storageKey": null
           },
           {
@@ -1302,12 +1330,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "62ba245c448f2f1a41f12965123c58b7",
+    "cacheID": "7f761f1c953f59739c60b3709b16fc1c",
     "id": null,
     "metadata": {},
     "name": "articleRoutes_ArticleQuery",
     "operationKind": "query",
-    "text": "query articleRoutes_ArticleQuery(\n  $id: String!\n) {\n  article(id: $id) @principalField {\n    ...ArticleApp_article\n    id\n  }\n}\n\nfragment ArticleApp_article on Article {\n  ...ArticleBody_article\n  ...ArticleSeries_article\n  ...ArticleVideo_article\n  ...ArticleVisibilityMetadata_article\n  ...ArticleMetaTags_article\n  internalID\n  layout\n  channelID\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHero_article\n  ...ArticleByline_article\n  ...ArticleSectionAd_article\n  ...ArticleNewsSource_article\n  hero {\n    __typename\n  }\n  seriesArticle {\n    thumbnailTitle\n    href\n    id\n  }\n  vertical\n  byline\n  internalID\n  slug\n  layout\n  leadParagraph\n  title\n  href\n  publishedAt\n  sections {\n    __typename\n    ...ArticleSection_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    internalID\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHero_article on Article {\n  title\n  href\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      media\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleMetaTags_article on Article {\n  byline\n  href\n  keywords\n  metaPublishedAt: publishedAt\n  title\n  searchTitle\n  description\n  searchDescription\n  thumbnailImage {\n    url\n  }\n}\n\nfragment ArticleNewsSource_article on Article {\n  newsSource {\n    title\n    url\n  }\n}\n\nfragment ArticleSectionAd_article on Article {\n  layout\n  sections {\n    __typename\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n  _layout: layout\n}\n\nfragment ArticleSectionImageCollectionCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ...Metadata_artwork\n  ... on ArticleImageSection {\n    caption\n  }\n}\n\nfragment ArticleSectionImageCollectionImage_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  ... on ArticleImageSection {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on Artwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ...ArticleSectionImageCollectionImage_figure\n    ...ArticleSectionImageCollectionCaption_figure\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ArticleImageSection {\n      id\n    }\n    ... on ArticleUnpublishedArtwork {\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  fallbackEmbed: embed(autoPlay: false)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSection_section on ArticleSections {\n  __isArticleSections: __typename\n  __typename\n  ...ArticleSectionText_section\n  ...ArticleSectionImageCollection_section\n  ...ArticleSectionImageSet_section\n  ...ArticleSectionVideo_section\n  ...ArticleSectionSocialEmbed_section\n  ...ArticleSectionEmbed_section\n}\n\nfragment ArticleSeriesItem_article on Article {\n  href\n  vertical\n  title\n  thumbnailTitle\n  byline\n  description\n  publishedAt(format: \"MMM DD, YYYY\")\n  thumbnailImage {\n    display: cropped(width: 869, height: 580) {\n      src\n      srcSet\n    }\n  }\n  media {\n    duration\n  }\n  seriesArticle {\n    title\n    id\n  }\n}\n\nfragment ArticleSeries_article on Article {\n  title\n  byline\n  href\n  series {\n    description\n  }\n  sponsor {\n    ...ArticleSponsor_sponsor\n  }\n  relatedArticles {\n    ...ArticleSeriesItem_article\n    internalID\n    id\n  }\n}\n\nfragment ArticleSponsor_sponsor on ArticleSponsor {\n  partnerLightLogo\n  partnerDarkLogo\n  partnerLogoLink\n}\n\nfragment ArticleVideo_article on Article {\n  vertical\n  title\n  href\n  description\n  media {\n    coverImage {\n      url\n    }\n    credits\n    description\n    duration\n    releaseDate(format: \"MMM DD, YYYY h:mma\")\n    url\n  }\n  seriesArticle {\n    title\n    href\n    description\n    sponsor {\n      ...ArticleSponsor_sponsor\n    }\n    id\n  }\n  moreRelatedArticles: relatedArticles(size: 4) {\n    ...ArticleSeriesItem_article\n    internalID\n    id\n  }\n}\n\nfragment ArticleVisibilityMetadata_article on Article {\n  title\n  searchTitle\n  href\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query articleRoutes_ArticleQuery(\n  $id: String!\n) {\n  article(id: $id) @principalField {\n    ...ArticleApp_article\n    id\n  }\n}\n\nfragment ArticleApp_article on Article {\n  ...ArticleBody_article\n  ...ArticleSeries_article\n  ...ArticleVideo_article\n  ...ArticleVisibilityMetadata_article\n  ...ArticleMetaTags_article\n  internalID\n  layout\n  channelID\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHero_article\n  ...ArticleByline_article\n  ...ArticleSectionAd_article\n  ...ArticleNewsSource_article\n  hero {\n    __typename\n  }\n  seriesArticle {\n    thumbnailTitle\n    href\n    id\n  }\n  vertical\n  byline\n  internalID\n  slug\n  layout\n  leadParagraph\n  title\n  href\n  publishedAt\n  sections {\n    __typename\n    ...ArticleSection_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    internalID\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHero_article on Article {\n  title\n  href\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      media\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleMetaTags_article on Article {\n  byline\n  href\n  keywords\n  metaPublishedAt: publishedAt\n  title\n  searchTitle\n  description\n  searchDescription\n  thumbnailImage {\n    url\n  }\n}\n\nfragment ArticleNewsSource_article on Article {\n  newsSource {\n    title\n    url\n  }\n}\n\nfragment ArticleSectionAd_article on Article {\n  layout\n  sections {\n    __typename\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n  _layout: layout\n}\n\nfragment ArticleSectionImageCollectionCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ...Metadata_artwork\n  ... on ArticleImageSection {\n    caption\n  }\n  ... on ArticleUnpublishedArtwork {\n    title\n    date\n    artist {\n      name\n    }\n    partner {\n      name\n    }\n  }\n}\n\nfragment ArticleSectionImageCollectionImage_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  ... on ArticleImageSection {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on Artwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on ArticleUnpublishedArtwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ...ArticleSectionImageCollectionImage_figure\n    ...ArticleSectionImageCollectionCaption_figure\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ArticleImageSection {\n      id\n    }\n    ... on ArticleUnpublishedArtwork {\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  fallbackEmbed: embed(autoPlay: false)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSection_section on ArticleSections {\n  __isArticleSections: __typename\n  __typename\n  ...ArticleSectionText_section\n  ...ArticleSectionImageCollection_section\n  ...ArticleSectionImageSet_section\n  ...ArticleSectionVideo_section\n  ...ArticleSectionSocialEmbed_section\n  ...ArticleSectionEmbed_section\n}\n\nfragment ArticleSeriesItem_article on Article {\n  href\n  vertical\n  title\n  thumbnailTitle\n  byline\n  description\n  publishedAt(format: \"MMM DD, YYYY\")\n  thumbnailImage {\n    display: cropped(width: 869, height: 580) {\n      src\n      srcSet\n    }\n  }\n  media {\n    duration\n  }\n  seriesArticle {\n    title\n    id\n  }\n}\n\nfragment ArticleSeries_article on Article {\n  title\n  byline\n  href\n  series {\n    description\n  }\n  sponsor {\n    ...ArticleSponsor_sponsor\n  }\n  relatedArticles {\n    ...ArticleSeriesItem_article\n    internalID\n    id\n  }\n}\n\nfragment ArticleSponsor_sponsor on ArticleSponsor {\n  partnerLightLogo\n  partnerDarkLogo\n  partnerLogoLink\n}\n\nfragment ArticleVideo_article on Article {\n  vertical\n  title\n  href\n  description\n  media {\n    coverImage {\n      url\n    }\n    credits\n    description\n    duration\n    releaseDate(format: \"MMM DD, YYYY h:mma\")\n    url\n  }\n  seriesArticle {\n    title\n    href\n    description\n    sponsor {\n      ...ArticleSponsor_sponsor\n    }\n    id\n  }\n  moreRelatedArticles: relatedArticles(size: 4) {\n    ...ArticleSeriesItem_article\n    internalID\n    id\n  }\n}\n\nfragment ArticleVisibilityMetadata_article on Article {\n  title\n  searchTitle\n  href\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/articlesRoutes_NewsQuery.graphql.ts
+++ b/src/__generated__/articlesRoutes_NewsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1fa86ebdb6941422a07c7acdf8c041eb>>
+ * @generated SignedSource<<4dadb8bcc8c7a926f2fb3a2eaa556f4c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -172,21 +172,28 @@ v17 = {
   ],
   "storageKey": null
 },
-v18 = [
+v18 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "date",
+  "storageKey": null
+},
+v19 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v20 = [
+v21 = [
   {
     "alias": null,
     "args": null,
@@ -195,33 +202,35 @@ v20 = [
     "storageKey": null
   }
 ],
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v22 = [
+v23 = [
   (v12/*: any*/),
   (v13/*: any*/)
 ],
-v23 = [
-  (v13/*: any*/)
+v24 = [
+  (v12/*: any*/)
 ],
-v24 = {
+v25 = {
   "kind": "InlineFragment",
-  "selections": (v23/*: any*/),
+  "selections": [
+    (v13/*: any*/)
+  ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v25 = [
+v26 = [
   (v9/*: any*/),
   (v10/*: any*/),
   (v16/*: any*/),
   (v15/*: any*/)
 ],
-v26 = [
+v27 = [
   (v13/*: any*/),
   {
     "alias": null,
@@ -250,7 +259,7 @@ v26 = [
         "kind": "LinkedField",
         "name": "cropped",
         "plural": false,
-        "selections": (v25/*: any*/),
+        "selections": (v26/*: any*/),
         "storageKey": "cropped(height:80,version:[\"normalized\",\"larger\",\"large\"],width:80)"
       },
       {
@@ -267,7 +276,7 @@ v26 = [
         "kind": "LinkedField",
         "name": "resized",
         "plural": false,
-        "selections": (v25/*: any*/),
+        "selections": (v26/*: any*/),
         "storageKey": "resized(version:[\"normalized\",\"larger\",\"large\"],width:1220)"
       }
     ],
@@ -555,13 +564,7 @@ return {
                                       (v17/*: any*/),
                                       (v3/*: any*/),
                                       (v2/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "date",
-                                        "storageKey": null
-                                      },
+                                      (v18/*: any*/),
                                       {
                                         "alias": "sale_message",
                                         "args": null,
@@ -578,7 +581,7 @@ return {
                                       },
                                       {
                                         "alias": null,
-                                        "args": (v18/*: any*/),
+                                        "args": (v19/*: any*/),
                                         "concreteType": "Artist",
                                         "kind": "LinkedField",
                                         "name": "artists",
@@ -599,7 +602,7 @@ return {
                                       },
                                       {
                                         "alias": null,
-                                        "args": (v18/*: any*/),
+                                        "args": (v19/*: any*/),
                                         "concreteType": "Partner",
                                         "kind": "LinkedField",
                                         "name": "partner",
@@ -619,7 +622,7 @@ return {
                                         "name": "sale",
                                         "plural": false,
                                         "selections": [
-                                          (v19/*: any*/),
+                                          (v20/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -681,7 +684,7 @@ return {
                                             "name": "lotLabel",
                                             "storageKey": null
                                           },
-                                          (v19/*: any*/),
+                                          (v20/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -721,7 +724,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "highestBid",
                                             "plural": false,
-                                            "selections": (v20/*: any*/),
+                                            "selections": (v21/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -731,7 +734,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "openingBid",
                                             "plural": false,
-                                            "selections": (v20/*: any*/),
+                                            "selections": (v21/*: any*/),
                                             "storageKey": null
                                           },
                                           (v13/*: any*/)
@@ -739,7 +742,7 @@ return {
                                         "storageKey": null
                                       },
                                       (v1/*: any*/),
-                                      (v21/*: any*/),
+                                      (v22/*: any*/),
                                       {
                                         "alias": "is_saved",
                                         "args": null,
@@ -754,7 +757,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "attributionClass",
                                         "plural": false,
-                                        "selections": (v22/*: any*/),
+                                        "selections": (v23/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -772,7 +775,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "filterGene",
                                             "plural": false,
-                                            "selections": (v22/*: any*/),
+                                            "selections": (v23/*: any*/),
                                             "storageKey": null
                                           }
                                         ],
@@ -782,13 +785,38 @@ return {
                                     "type": "Artwork",
                                     "abstractKey": null
                                   },
-                                  (v24/*: any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v23/*: any*/),
+                                    "selections": [
+                                      (v13/*: any*/),
+                                      (v17/*: any*/),
+                                      (v2/*: any*/),
+                                      (v18/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "ArticleUnpublishedArtworkArtist",
+                                        "kind": "LinkedField",
+                                        "name": "artist",
+                                        "plural": false,
+                                        "selections": (v24/*: any*/),
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "ArticleUnpublishedArtworkPartner",
+                                        "kind": "LinkedField",
+                                        "name": "partner",
+                                        "plural": false,
+                                        "selections": (v24/*: any*/),
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "type": "ArticleUnpublishedArtwork",
                                     "abstractKey": null
-                                  }
+                                  },
+                                  (v25/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -836,17 +864,17 @@ return {
                                   (v5/*: any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v26/*: any*/),
+                                    "selections": (v27/*: any*/),
                                     "type": "ArticleImageSection",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v26/*: any*/),
+                                    "selections": (v27/*: any*/),
                                     "type": "Artwork",
                                     "abstractKey": null
                                   },
-                                  (v24/*: any*/)
+                                  (v25/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -987,7 +1015,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v21/*: any*/),
+                      (v22/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1118,12 +1146,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "57812b0e810583771f6067c25d611278",
+    "cacheID": "a4909d7c74e28df2f870df338e42430a",
     "id": null,
     "metadata": {},
     "name": "articlesRoutes_NewsQuery",
     "operationKind": "query",
-    "text": "query articlesRoutes_NewsQuery {\n  viewer {\n    ...NewsApp_viewer\n  }\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHero_article\n  ...ArticleByline_article\n  ...ArticleSectionAd_article\n  ...ArticleNewsSource_article\n  hero {\n    __typename\n  }\n  seriesArticle {\n    thumbnailTitle\n    href\n    id\n  }\n  vertical\n  byline\n  internalID\n  slug\n  layout\n  leadParagraph\n  title\n  href\n  publishedAt\n  sections {\n    __typename\n    ...ArticleSection_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    internalID\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHero_article on Article {\n  title\n  href\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      media\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleNewsSource_article on Article {\n  newsSource {\n    title\n    url\n  }\n}\n\nfragment ArticleSectionAd_article on Article {\n  layout\n  sections {\n    __typename\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n  _layout: layout\n}\n\nfragment ArticleSectionImageCollectionCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ...Metadata_artwork\n  ... on ArticleImageSection {\n    caption\n  }\n}\n\nfragment ArticleSectionImageCollectionImage_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  ... on ArticleImageSection {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on Artwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ...ArticleSectionImageCollectionImage_figure\n    ...ArticleSectionImageCollectionCaption_figure\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ArticleImageSection {\n      id\n    }\n    ... on ArticleUnpublishedArtwork {\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  fallbackEmbed: embed(autoPlay: false)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSection_section on ArticleSections {\n  __isArticleSections: __typename\n  __typename\n  ...ArticleSectionText_section\n  ...ArticleSectionImageCollection_section\n  ...ArticleSectionImageSet_section\n  ...ArticleSectionVideo_section\n  ...ArticleSectionSocialEmbed_section\n  ...ArticleSectionEmbed_section\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment NewsApp_viewer on Viewer {\n  ...NewsIndexArticles_viewer\n}\n\nfragment NewsIndexArticles_viewer on Viewer {\n  articlesConnection(first: 15, layout: NEWS, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...ArticleBody_article\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query articlesRoutes_NewsQuery {\n  viewer {\n    ...NewsApp_viewer\n  }\n}\n\nfragment ArticleBody_article on Article {\n  ...ArticleHero_article\n  ...ArticleByline_article\n  ...ArticleSectionAd_article\n  ...ArticleNewsSource_article\n  hero {\n    __typename\n  }\n  seriesArticle {\n    thumbnailTitle\n    href\n    id\n  }\n  vertical\n  byline\n  internalID\n  slug\n  layout\n  leadParagraph\n  title\n  href\n  publishedAt\n  sections {\n    __typename\n    ...ArticleSection_section\n  }\n  postscript\n  relatedArticles {\n    internalID\n    title\n    href\n    byline\n    thumbnailImage {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleByline_article on Article {\n  byline\n  authors {\n    internalID\n    name\n    initials\n    bio\n    image {\n      cropped(width: 60, height: 60) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArticleHero_article on Article {\n  title\n  href\n  vertical\n  byline\n  hero {\n    __typename\n    ... on ArticleFeatureSection {\n      layout\n      embed\n      media\n      image {\n        url\n        split: resized(width: 900) {\n          src\n          srcSet\n        }\n        text: cropped(width: 1600, height: 900) {\n          src\n          srcSet\n        }\n      }\n    }\n  }\n}\n\nfragment ArticleNewsSource_article on Article {\n  newsSource {\n    title\n    url\n  }\n}\n\nfragment ArticleSectionAd_article on Article {\n  layout\n  sections {\n    __typename\n  }\n}\n\nfragment ArticleSectionEmbed_section on ArticleSectionEmbed {\n  url\n  height\n  mobileHeight\n  _layout: layout\n}\n\nfragment ArticleSectionImageCollectionCaption_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  __typename\n  ...Metadata_artwork\n  ... on ArticleImageSection {\n    caption\n  }\n  ... on ArticleUnpublishedArtwork {\n    title\n    date\n    artist {\n      name\n    }\n    partner {\n      name\n    }\n  }\n}\n\nfragment ArticleSectionImageCollectionImage_figure on ArticleSectionImageCollectionFigure {\n  __isArticleSectionImageCollectionFigure: __typename\n  ... on ArticleImageSection {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on Artwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n  ... on ArticleUnpublishedArtwork {\n    id\n    image {\n      url(version: [\"normalized\", \"larger\", \"large\"])\n      width\n      height\n    }\n  }\n}\n\nfragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {\n  layout\n  figures {\n    __typename\n    ...ArticleSectionImageCollectionImage_figure\n    ...ArticleSectionImageCollectionCaption_figure\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ArticleImageSection {\n      id\n    }\n    ... on ArticleUnpublishedArtwork {\n      id\n    }\n  }\n}\n\nfragment ArticleSectionImageSet_section on ArticleSectionImageSet {\n  setLayout: layout\n  title\n  counts {\n    figures\n  }\n  cover {\n    __typename\n    ... on ArticleImageSection {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Artwork {\n      id\n      image {\n        small: cropped(width: 80, height: 80, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n        large: resized(width: 1220, version: [\"normalized\", \"larger\", \"large\"]) {\n          src\n          srcSet\n          height\n          width\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {\n  url\n  embed\n}\n\nfragment ArticleSectionText_section on ArticleSectionText {\n  body\n}\n\nfragment ArticleSectionVideo_section on ArticleSectionVideo {\n  embed(autoPlay: true)\n  fallbackEmbed: embed(autoPlay: false)\n  image {\n    cropped(width: 910, height: 512) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArticleSection_section on ArticleSections {\n  __isArticleSections: __typename\n  __typename\n  ...ArticleSectionText_section\n  ...ArticleSectionImageCollection_section\n  ...ArticleSectionImageSet_section\n  ...ArticleSectionVideo_section\n  ...ArticleSectionSocialEmbed_section\n  ...ArticleSectionEmbed_section\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment NewsApp_viewer on Viewer {\n  ...NewsIndexArticles_viewer\n}\n\nfragment NewsIndexArticles_viewer on Viewer {\n  articlesConnection(first: 15, layout: NEWS, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...ArticleBody_article\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Closes: [GRO-1299](https://artsyproduct.atlassian.net/browse/GRO-1299)

<del>Will draft until I open and merge the Metaphysics PR wherein I add a new `ArticleUnpublishedArtwork` type.</del>

https://github.com/artsy/metaphysics/pull/4431 adds an `ArticleUnpublishedArtwork` type.

This uses that type to display the missing works. Basically looks the same but there's no link to the artwork, just a normal zoom.