### PR TITLE
feat: Initialize SWA form images when submitting an artwork from My Collection

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/UploadPhotosForm.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/UploadPhotosForm.tsx
@@ -65,7 +65,7 @@ export const UploadPhotosForm: React.FC<UploadPhotosFormProps> = ({
 
   useEffect(() => {
     const imagesToUpload = values.photos.filter(
-      c => !(c.geminiToken || c.url) && !c.loading
+      c => !(c.geminiToken || c.url) && !c.loading && !c.errorMessage
     )
 
     if (imagesToUpload.length) {

--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -12,7 +12,7 @@ import { BackLink } from "Components/Links/BackLink"
 import { PhotoThumbnail } from "Components/PhotoUpload/Components/PhotoThumbnail"
 import { normalizePhoto, Photo } from "Components/PhotoUpload/Utils/fileUtils"
 import { Form, Formik } from "formik"
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import {
   createFragmentContainer,
   Environment,
@@ -161,6 +161,16 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
         initialErrors={initialErrors}
       >
         {({ values, setFieldValue, isValid, isSubmitting }) => {
+          useEffect(() => {
+            console.log({
+              photos: values.photos,
+            })
+            console.log(
+              "photos",
+              values.photos.map(p => p.removed)
+            )
+          }, [values.photos])
+
           const handlePhotoDelete = (photo: Photo) => {
             photo.removed = true
             photo.abortUploading?.()

--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -1,8 +1,16 @@
 import { Box, Button, Text } from "@artsy/palette"
 import { SubmissionStepper } from "Apps/Consign/Components/SubmissionStepper"
+import {
+  useAddAssetToConsignmentSubmission,
+  useRemoveAssetFromConsignmentSubmission,
+} from "Apps/Consign/Routes/SubmissionFlow/Mutations"
+import {
+  uploadPhotosValidationSchema,
+  validate,
+} from "Apps/Consign/Routes/SubmissionFlow/Utils/validation"
 import { BackLink } from "Components/Links/BackLink"
 import { PhotoThumbnail } from "Components/PhotoUpload/Components/PhotoThumbnail"
-import { Photo } from "Components/PhotoUpload/Utils/fileUtils"
+import { normalizePhoto, Photo } from "Components/PhotoUpload/Utils/fileUtils"
 import { Form, Formik } from "formik"
 import { useRef, useState } from "react"
 import {
@@ -16,22 +24,14 @@ import { useSystemContext } from "System"
 import { useRouter } from "System/Router/useRouter"
 import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
+import { redirects_submission$data } from "__generated__/redirects_submission.graphql"
 import { UploadPhotos_ImageRefetch_Query } from "__generated__/UploadPhotos_ImageRefetch_Query.graphql"
-import { UploadPhotos_submission$data } from "__generated__/UploadPhotos_submission.graphql"
 import { UploadPhotos_myCollectionArtwork$data } from "__generated__/UploadPhotos_myCollectionArtwork.graphql"
-import {
-  useAddAssetToConsignmentSubmission,
-  useRemoveAssetFromConsignmentSubmission,
-} from "Apps/Consign/Routes/SubmissionFlow/Mutations"
-import {
-  uploadPhotosValidationSchema,
-  validate,
-} from "Apps/Consign/Routes/SubmissionFlow/Utils/validation"
+import { UploadPhotos_submission$data } from "__generated__/UploadPhotos_submission.graphql"
 import {
   UploadPhotosForm,
   UploadPhotosFormModel,
 } from "./Components/UploadPhotosForm"
-import { redirects_submission$data } from "__generated__/redirects_submission.graphql"
 
 const logger = createLogger("SubmissionFlow/UploadPhotos.tsx")
 
@@ -53,10 +53,29 @@ const getPhotoUrlFromAsset = (asset: SubmissionAsset) => {
 }
 
 export const getUploadPhotosFormInitialValues = (
-  submission?: UploadPhotos_submission$data | redirects_submission$data
+  submission?: UploadPhotos_submission$data | redirects_submission$data,
+  myCollectionArtwork?: UploadPhotos_myCollectionArtwork$data
 ): UploadPhotosFormModel => {
-  return {
-    photos:
+  let submissionPhotos: Photo[] = []
+  let artworkPhotos: any[] = []
+
+  // Only add photos from artwork if they haven't been added already
+  // if (myCollectionArtwork && !submission?.assets?.length) {
+  if (myCollectionArtwork) {
+    artworkPhotos =
+      myCollectionArtwork?.images?.map(image => ({
+        name: "Automatically added",
+        externalUrl: image?.url!,
+      })) || []
+
+    // Needs to be adjusted
+    artworkPhotos = artworkPhotos.map(file =>
+      normalizePhoto(file, undefined, file.externalUrl)
+    )
+  }
+
+  if (submission) {
+    submissionPhotos =
       submission?.assets
         ?.filter(asset => !!asset)
         .map(asset => ({
@@ -68,8 +87,10 @@ export const getUploadPhotosFormInitialValues = (
           url: getPhotoUrlFromAsset(asset),
           removed: false,
           loading: false,
-        })) || [],
+        })) || []
   }
+
+  return { photos: [...artworkPhotos, ...submissionPhotos] }
 }
 
 export const UploadPhotos: React.FC<UploadPhotosProps> = ({
@@ -85,7 +106,11 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
   } = useRemoveAssetFromConsignmentSubmission()
   const { submitMutation: addAsset } = useAddAssetToConsignmentSubmission()
 
-  const initialValue = getUploadPhotosFormInitialValues(submission)
+  const initialValue = getUploadPhotosFormInitialValues(
+    submission,
+    myCollectionArtwork
+  )
+  console.log("Upload Flow", { initialValue })
   const initialErrors = validate(initialValue, uploadPhotosValidationSchema)
   const artworkId = myCollectionArtwork?.internalID
 
@@ -314,6 +339,9 @@ export const UploadPhotosFragmentContainer = createFragmentContainer(
     myCollectionArtwork: graphql`
       fragment UploadPhotos_myCollectionArtwork on Artwork {
         internalID
+        images {
+          url(version: "large")
+        }
       }
     `,
   }

--- a/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
@@ -11,10 +11,10 @@ import {
   Spinner,
   Text,
 } from "@artsy/palette"
+import { formatFileSize, Photo } from "Components/PhotoUpload/Utils/fileUtils"
 import { ComponentProps, useEffect, useState } from "react"
 import styled from "styled-components"
 import { Media } from "Utils/Responsive"
-import { formatFileSize, Photo } from "Components/PhotoUpload/Utils/fileUtils"
 
 export interface PhotoThumbnailProps {
   photo: Photo
@@ -46,16 +46,15 @@ export const PhotoThumbnail: React.FC<
   const [photoSrc, setPhotoSrc] = useState<string>()
 
   useEffect(() => {
-    if (photo.file) {
+    if (photo.externalUrl) {
+      setPhotoSrc(photo.externalUrl)
+    } else if (photo.file) {
       const reader = new FileReader()
-      try {
-        reader.readAsDataURL(photo.file as File)
 
-        reader.onloadend = () => {
-          setPhotoSrc(reader.result as string)
-        }
-      } catch (e) {
-        setPhotoSrc(photo.externalUrl)
+      reader.readAsDataURL(photo.file as File)
+
+      reader.onloadend = () => {
+        setPhotoSrc(reader.result as string)
       }
     } else {
       setPhotoSrc(photo.url)

--- a/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
@@ -14,7 +14,7 @@ import {
 import { ComponentProps, useEffect, useState } from "react"
 import styled from "styled-components"
 import { Media } from "Utils/Responsive"
-import { formatFileSize, Photo } from "../Utils/fileUtils"
+import { formatFileSize, Photo } from "Components/PhotoUpload/Utils/fileUtils"
 
 export interface PhotoThumbnailProps {
   photo: Photo
@@ -49,7 +49,7 @@ export const PhotoThumbnail: React.FC<
     if (photo.file) {
       const reader = new FileReader()
       try {
-        reader.readAsDataURL(photo.file)
+        reader.readAsDataURL(photo.file as File)
 
         reader.onloadend = () => {
           setPhotoSrc(reader.result as string)

--- a/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
@@ -48,10 +48,14 @@ export const PhotoThumbnail: React.FC<
   useEffect(() => {
     if (photo.file) {
       const reader = new FileReader()
-      reader.readAsDataURL(photo.file)
+      try {
+        reader.readAsDataURL(photo.file)
 
-      reader.onloadend = () => {
-        setPhotoSrc(reader.result as string)
+        reader.onloadend = () => {
+          setPhotoSrc(reader.result as string)
+        }
+      } catch (e) {
+        setPhotoSrc(photo.externalUrl)
       }
     } else {
       setPhotoSrc(photo.url)

--- a/src/Components/PhotoUpload/Utils/fileUtils.ts
+++ b/src/Components/PhotoUpload/Utils/fileUtils.ts
@@ -2,9 +2,9 @@ import { ErrorCode, FileRejection } from "react-dropzone"
 import { Environment } from "relay-runtime"
 import createLogger from "Utils/logger"
 import uuid from "uuid"
-import { createGeminiAssetWithS3Credentials } from "../Mutations/createGeminiAssetWithS3Credentials"
-import { getConvectionGeminiKey } from "../Mutations/getConvectionGeminiKey"
-import { getGeminiCredentialsForEnvironment } from "../Mutations/getGeminiCredentialsForEnvironment"
+import { createGeminiAssetWithS3Credentials } from "Components/PhotoUpload/Mutations/createGeminiAssetWithS3Credentials"
+import { getConvectionGeminiKey } from "Components/PhotoUpload/Mutations/getConvectionGeminiKey"
+import { getGeminiCredentialsForEnvironment } from "Components/PhotoUpload/Mutations/getGeminiCredentialsForEnvironment"
 import { uploadFileToS3 } from "./uploadFileToS3"
 
 const logger = createLogger("PhotoUpload/fileUtils.ts")
@@ -26,7 +26,7 @@ export function formatFileSize(size?: number): string {
 export interface Photo {
   id: string
   assetId?: string
-  file?: File
+  file?: File | ExternalFile
   name: string
   size?: number
   url?: string
@@ -40,8 +40,15 @@ export interface Photo {
   errorMessage?: string
 }
 
+interface ExternalFile {
+  name: string
+  externalUrl: string
+  size?: number
+  type?: string
+}
+
 export function normalizePhoto(
-  file: File,
+  file: File | ExternalFile,
   errorMessage?: string,
   externalUrl?: string
 ): Photo {

--- a/src/Components/PhotoUpload/Utils/fileUtils.ts
+++ b/src/Components/PhotoUpload/Utils/fileUtils.ts
@@ -30,6 +30,7 @@ export interface Photo {
   name: string
   size?: number
   url?: string
+  externalUrl?: string
   geminiToken?: string
   abortUploading?: () => void
   progress?: number
@@ -39,10 +40,15 @@ export interface Photo {
   errorMessage?: string
 }
 
-export function normalizePhoto(file: File, errorMessage?: string): Photo {
+export function normalizePhoto(
+  file: File,
+  errorMessage?: string,
+  externalUrl?: string
+): Photo {
   return {
     id: uuid(),
     assetId: undefined,
+    externalUrl,
     file,
     name: file.name,
     size: file.size,

--- a/src/Components/PhotoUpload/Utils/uploadFileToS3.tsx
+++ b/src/Components/PhotoUpload/Utils/uploadFileToS3.tsx
@@ -1,4 +1,4 @@
-import { AssetCredentials } from "../Mutations/getGeminiCredentialsForEnvironment"
+import { AssetCredentials } from "Components/PhotoUpload/Mutations/getGeminiCredentialsForEnvironment"
 import { Photo } from "./fileUtils"
 
 const externalPhotoToFile = async (photo: Photo) => {
@@ -32,7 +32,14 @@ export const uploadFileToS3 = (
 
     const isExternalPhoto = photo.externalUrl
 
-    const file = isExternalPhoto ? await externalPhotoToFile(photo) : photo.file
+    let file
+
+    try {
+      file = isExternalPhoto ? await externalPhotoToFile(photo) : photo.file
+    } catch (error) {
+      reject(new Error("Initializing artwork photo failed."))
+      return
+    }
 
     const data = {
       acl,

--- a/src/Components/PhotoUpload/Utils/uploadFileToS3.tsx
+++ b/src/Components/PhotoUpload/Utils/uploadFileToS3.tsx
@@ -1,7 +1,8 @@
 import { AssetCredentials } from "Components/PhotoUpload/Mutations/getGeminiCredentialsForEnvironment"
 import { Photo } from "./fileUtils"
 
-const externalPhotoToFile = async (photo: Photo) => {
+// Fetches the artwork image and returns a file that can then be used to upload the image to S3.
+const fetchExternalFile = async (photo: Photo) => {
   const response = await fetch(photo.externalUrl!)
   const blob = await response.blob()
 
@@ -35,7 +36,7 @@ export const uploadFileToS3 = (
     let file
 
     try {
-      file = isExternalPhoto ? await externalPhotoToFile(photo) : photo.file
+      file = isExternalPhoto ? await fetchExternalFile(photo) : photo.file
     } catch (error) {
       reject(new Error("Initializing artwork photo failed."))
       return
@@ -43,7 +44,7 @@ export const uploadFileToS3 = (
 
     const data = {
       acl,
-      "Content-Type": photo.file.type || "image/jpg",
+      "Content-Type": photo.file.type,
       key: geminiKey + "/${filename}", // NOTE: This form (which _looks_ like ES6 interpolation) is required by AWS
       AWSAccessKeyId: asset.credentials,
       success_action_status:

--- a/src/__generated__/UploadPhotos_SubmissionMyCollectionFlowTest_Query.graphql.ts
+++ b/src/__generated__/UploadPhotos_SubmissionMyCollectionFlowTest_Query.graphql.ts
@@ -1,0 +1,288 @@
+/**
+ * @generated SignedSource<<7e8e11bb3e2617b361e08f422ea8935b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type UploadPhotos_SubmissionMyCollectionFlowTest_Query$variables = {
+  artworkId: string;
+  externalId?: string | null;
+};
+export type UploadPhotos_SubmissionMyCollectionFlowTest_Query$data = {
+  readonly myCollectionArtwork: {
+    readonly " $fragmentSpreads": FragmentRefs<"UploadPhotos_myCollectionArtwork">;
+  } | null;
+  readonly submission: {
+    readonly " $fragmentSpreads": FragmentRefs<"UploadPhotos_submission">;
+  } | null;
+};
+export type UploadPhotos_SubmissionMyCollectionFlowTest_Query = {
+  response: UploadPhotos_SubmissionMyCollectionFlowTest_Query$data;
+  variables: UploadPhotos_SubmissionMyCollectionFlowTest_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "artworkId"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "externalId"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "externalId",
+    "variableName": "externalId"
+  }
+],
+v3 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artworkId"
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v6 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "UploadPhotos_SubmissionMyCollectionFlowTest_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "ConsignmentSubmission",
+        "kind": "LinkedField",
+        "name": "submission",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "UploadPhotos_submission"
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "myCollectionArtwork",
+        "args": (v3/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "UploadPhotos_myCollectionArtwork"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "UploadPhotos_SubmissionMyCollectionFlowTest_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "ConsignmentSubmission",
+        "kind": "LinkedField",
+        "name": "submission",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "externalId",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ConsignmentSubmissionCategoryAsset",
+            "kind": "LinkedField",
+            "name": "assets",
+            "plural": true,
+            "selections": [
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "imageUrls",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "geminiToken",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "size",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "filename",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "myCollectionArtwork",
+        "args": (v3/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "images",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:\"large\")"
+              }
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ac7aaae8fd7970833dcfe7a1744bc99b",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "myCollectionArtwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "myCollectionArtwork.id": (v5/*: any*/),
+        "myCollectionArtwork.images": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Image"
+        },
+        "myCollectionArtwork.images.url": (v6/*: any*/),
+        "myCollectionArtwork.internalID": (v5/*: any*/),
+        "submission": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ConsignmentSubmission"
+        },
+        "submission.assets": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ConsignmentSubmissionCategoryAsset"
+        },
+        "submission.assets.filename": (v6/*: any*/),
+        "submission.assets.geminiToken": (v6/*: any*/),
+        "submission.assets.id": (v5/*: any*/),
+        "submission.assets.imageUrls": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "JSON"
+        },
+        "submission.assets.size": (v6/*: any*/),
+        "submission.externalId": (v5/*: any*/),
+        "submission.id": (v5/*: any*/)
+      }
+    },
+    "name": "UploadPhotos_SubmissionMyCollectionFlowTest_Query",
+    "operationKind": "query",
+    "text": "query UploadPhotos_SubmissionMyCollectionFlowTest_Query(\n  $externalId: ID\n  $artworkId: String!\n) {\n  submission(externalId: $externalId) {\n    ...UploadPhotos_submission\n    id\n  }\n  myCollectionArtwork: artwork(id: $artworkId) {\n    ...UploadPhotos_myCollectionArtwork\n    id\n  }\n}\n\nfragment UploadPhotos_myCollectionArtwork on Artwork {\n  internalID\n  images {\n    url(version: \"large\")\n  }\n}\n\nfragment UploadPhotos_submission on ConsignmentSubmission {\n  externalId\n  assets {\n    id\n    imageUrls\n    geminiToken\n    size\n    filename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "0d3770683651cdd8479126c52f825d90";
+
+export default node;

--- a/src/__generated__/UploadPhotos_myCollectionArtwork.graphql.ts
+++ b/src/__generated__/UploadPhotos_myCollectionArtwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<968bacab6e7c4f5fc78304493bb9ffec>>
+ * @generated SignedSource<<6a5b42ebc7808ed76c6d6158e687c28d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,9 @@
 import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type UploadPhotos_myCollectionArtwork$data = {
+  readonly images: ReadonlyArray<{
+    readonly url: string | null;
+  } | null> | null;
   readonly internalID: string;
   readonly " $fragmentType": "UploadPhotos_myCollectionArtwork";
 };
@@ -31,12 +34,36 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "internalID",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "images",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": "large"
+            }
+          ],
+          "kind": "ScalarField",
+          "name": "url",
+          "storageKey": "url(version:\"large\")"
+        }
+      ],
+      "storageKey": null
     }
   ],
   "type": "Artwork",
   "abstractKey": null
 };
 
-(node as any).hash = "d4227ffb5b0258195c56775669b19c6b";
+(node as any).hash = "cd5ae6aabb31d6b51ab9aa88ea2b680b";
 
 export default node;

--- a/src/__generated__/consignFromMyCollectionRoutes_uploadArtworkPhotosQuery.graphql.ts
+++ b/src/__generated__/consignFromMyCollectionRoutes_uploadArtworkPhotosQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3700134dfec0c632d67afc9fe8a53183>>
+ * @generated SignedSource<<0bab45a71ab56a9b77c98dcfb732160e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -426,6 +426,30 @@ return {
         "plural": false,
         "selections": [
           (v6/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "images",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:\"large\")"
+              }
+            ],
+            "storageKey": null
+          },
           (v24/*: any*/)
         ],
         "storageKey": null
@@ -433,12 +457,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b1e3eb0b41c2236ab4f30742d2d6ba42",
+    "cacheID": "2fbf16eee60c1768a8b6158de5af4ac1",
     "id": null,
     "metadata": {},
     "name": "consignFromMyCollectionRoutes_uploadArtworkPhotosQuery",
     "operationKind": "query",
-    "text": "query consignFromMyCollectionRoutes_uploadArtworkPhotosQuery(\n  $id: ID\n  $externalId: ID\n  $sessionID: String\n  $artworkId: String!\n) {\n  submission(id: $id, externalId: $externalId, sessionID: $sessionID) {\n    ...UploadPhotos_submission\n    externalId\n    artist {\n      internalID\n      name\n      id\n    }\n    locationCity\n    locationCountry\n    locationState\n    locationPostalCode\n    locationCountryCode\n    year\n    title\n    medium\n    attributionClass\n    editionNumber\n    editionSize\n    height\n    width\n    depth\n    dimensionsMetric\n    provenance\n    assets {\n      id\n      imageUrls\n      geminiToken\n      size\n      filename\n    }\n    id\n  }\n  myCollectionArtwork: artwork(id: $artworkId) {\n    ...UploadPhotos_myCollectionArtwork\n    id\n  }\n}\n\nfragment UploadPhotos_myCollectionArtwork on Artwork {\n  internalID\n}\n\nfragment UploadPhotos_submission on ConsignmentSubmission {\n  externalId\n  assets {\n    id\n    imageUrls\n    geminiToken\n    size\n    filename\n  }\n}\n"
+    "text": "query consignFromMyCollectionRoutes_uploadArtworkPhotosQuery(\n  $id: ID\n  $externalId: ID\n  $sessionID: String\n  $artworkId: String!\n) {\n  submission(id: $id, externalId: $externalId, sessionID: $sessionID) {\n    ...UploadPhotos_submission\n    externalId\n    artist {\n      internalID\n      name\n      id\n    }\n    locationCity\n    locationCountry\n    locationState\n    locationPostalCode\n    locationCountryCode\n    year\n    title\n    medium\n    attributionClass\n    editionNumber\n    editionSize\n    height\n    width\n    depth\n    dimensionsMetric\n    provenance\n    assets {\n      id\n      imageUrls\n      geminiToken\n      size\n      filename\n    }\n    id\n  }\n  myCollectionArtwork: artwork(id: $artworkId) {\n    ...UploadPhotos_myCollectionArtwork\n    id\n  }\n}\n\nfragment UploadPhotos_myCollectionArtwork on Artwork {\n  internalID\n  images {\n    url(version: \"large\")\n  }\n}\n\nfragment UploadPhotos_submission on ConsignmentSubmission {\n  externalId\n  assets {\n    id\n    imageUrls\n    geminiToken\n    size\n    filename\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2952](https://artsyproduct.atlassian.net/browse/CX-2952)

### Description

This PR implements the initialization of images in the Sell With Artsy form when submitting an artwork from My Collection.
All images from the My Collection artwork will be automatically reuploaded and processed and added as assets to the submission.


<img width="1016" alt="Screenshot 2022-10-10 at 11 03 52" src="https://user-images.githubusercontent.com/4691889/194834042-35c27a40-a646-4a43-b692-2d7ceb8632b9.png">


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ