### PR TITLE
fix: Remove callback to avoid removed photos to appear again in the SWA form

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/UploadPhotosForm.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/UploadPhotosForm.tsx
@@ -9,7 +9,7 @@ import {
 } from "Components/PhotoUpload/Utils/fileUtils"
 import { useFormikContext } from "formik"
 import * as React from "react"
-import { useCallback, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { FileRejection } from "react-dropzone"
 import { useSystemContext } from "System"
 
@@ -74,7 +74,7 @@ export const UploadPhotosForm: React.FC<UploadPhotosFormProps> = ({
     }
   }, [values.photos])
 
-  const onDrop = useCallback((acceptedFiles: File[]) => {
+  const onDrop = (acceptedFiles: File[]) => {
     const photos = acceptedFiles.map(file => normalizePhoto(file))
 
     setErrors([])
@@ -82,7 +82,7 @@ export const UploadPhotosForm: React.FC<UploadPhotosFormProps> = ({
       ...values.photos.filter(p => !p.errorMessage),
       ...photos,
     ])
-  }, [])
+  }
 
   const onReject = (rejections: FileRejection[]) => {
     setErrors(rejections)


### PR DESCRIPTION

## Description

Removes `callback` to avoid removed photos to appear again in the SWA form when adding a new photo.

### Steps to reproduce the bug / QA steps

1. Submit an artwork
2. Add artwork details
3. Add some photos
4. Remove some photos
5. Add a new photo
6. **Removed photos shouldn't appear again**