### PR TITLE
fix: Hide Career Highlights carousel behind feature flag

### DIFF
--- a/src/Apps/Settings/Routes/Insights/InsightsRoute.tsx
+++ b/src/Apps/Settings/Routes/Insights/InsightsRoute.tsx
@@ -15,6 +15,9 @@ interface InsightsRouteProps {
 
 const InsightsRoute: React.FC<InsightsRouteProps> = ({ me }) => {
   const isInsightsEnabled = useFeatureFlag("my-collection-web-phase-7-insights")
+  const isCareerHighlightEnabled = useFeatureFlag(
+    "my-collection-web-phase-7-career-highlights"
+  )
 
   if (!me.myCollectionInfo?.artworksCount) {
     return <InsightsLandingPage />
@@ -22,25 +25,29 @@ const InsightsRoute: React.FC<InsightsRouteProps> = ({ me }) => {
 
   return (
     <>
-      {isInsightsEnabled && (
+      {!!isInsightsEnabled && (
         <>
           <InsightsHeader />
 
           <Join separator={<Spacer my={[4, 6]} />}>
             <InsightsOverviewFragmentContainer info={me?.myCollectionInfo!} />
 
-            <Media greaterThanOrEqual="sm">
-              <InsightsCareerHighlightRailFragmentContainer
-                me={me}
-                showProgress={true}
-              />
-            </Media>
-            <Media lessThan="sm">
-              <InsightsCareerHighlightRailFragmentContainer
-                me={me}
-                showProgress={false}
-              />
-            </Media>
+            {!!isCareerHighlightEnabled && (
+              <>
+                <Media greaterThanOrEqual="sm">
+                  <InsightsCareerHighlightRailFragmentContainer
+                    me={me}
+                    showProgress={true}
+                  />
+                </Media>
+                <Media lessThan="sm">
+                  <InsightsCareerHighlightRailFragmentContainer
+                    me={me}
+                    showProgress={false}
+                  />
+                </Media>
+              </>
+            )}
 
             <InsightsAuctionResultsFragmentContainer me={me} />
           </Join>


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves []

### Description
This PR hides the Career Highlights carousel behind the `my-collection-web-phase-7-career-highlights` feature flag

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ