### PR TITLE
fix(FX-4319): commercial buttons section overflow

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2CommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2CommercialButtons.tsx
@@ -6,6 +6,7 @@ import {
 import {
   Button,
   Flex,
+  Join,
   Separator,
   Spacer,
   Text,
@@ -27,6 +28,7 @@ import { ContextModule, Intent } from "@artsy/cohesion"
 import { openAuthModal } from "Utils/openAuthModal"
 import currency from "currency.js"
 import { useTranslation } from "react-i18next"
+import { Media } from "Utils/Responsive"
 
 interface SaleMessageProps {
   saleMessage: string | null
@@ -288,10 +290,7 @@ const ArtworkSidebar2CommerialButtons: React.FC<ArtworkSidebar2CommercialButtons
     }
 
     return (
-      <>
-        <Spacer mt={2} />
-        <ArtworkSidebarCreateAlertButtonFragmentContainer artwork={artwork} />
-      </>
+      <ArtworkSidebarCreateAlertButtonFragmentContainer artwork={artwork} />
     )
   }
 
@@ -326,21 +325,32 @@ const ArtworkSidebar2CommerialButtons: React.FC<ArtworkSidebar2CommercialButtons
         </>
       )}
 
-      <Flex>
-        {artwork.isSold && renderCreateAlertButton()}
-        {artwork.isAcquireable && (
-          <Button
-            width="100%"
-            size="large"
-            loading={isCommitingCreateOrderMutation}
-            onClick={handleCreateOrder}
-          >
-            {t("artworkPage.sidebar.commercialButtons.buyNow")}
-          </Button>
-        )}
-        {artwork.isOfferable && (
-          <>
-            <Spacer ml={artwork.isAcquireable ? 1 : 0} />
+      <Flex flexDirection={["column", "column", "column", "column", "row"]}>
+        <Join
+          separator={
+            <>
+              <Media at="xl">
+                <Spacer ml={1} />
+              </Media>
+
+              <Media lessThan="xl">
+                <Spacer mt={1} />
+              </Media>
+            </>
+          }
+        >
+          {artwork.isSold && renderCreateAlertButton()}
+          {artwork.isAcquireable && (
+            <Button
+              width="100%"
+              size="large"
+              loading={isCommitingCreateOrderMutation}
+              onClick={handleCreateOrder}
+            >
+              {t("artworkPage.sidebar.commercialButtons.buyNow")}
+            </Button>
+          )}
+          {artwork.isOfferable && (
             <Button
               variant={
                 artwork.isAcquireable ? "secondaryBlack" : "primaryBlack"
@@ -352,11 +362,8 @@ const ArtworkSidebar2CommerialButtons: React.FC<ArtworkSidebar2CommercialButtons
             >
               {t("artworkPage.sidebar.commercialButtons.makeOffer")}
             </Button>
-          </>
-        )}
-        {artwork.isInquireable && (
-          <>
-            <Spacer ml={isSecondaryContactGalleryButton ? 1 : 0} />
+          )}
+          {artwork.isInquireable && (
             <Button
               width="100%"
               size="large"
@@ -369,8 +376,8 @@ const ArtworkSidebar2CommerialButtons: React.FC<ArtworkSidebar2CommercialButtons
             >
               {t("artworkPage.sidebar.commercialButtons.contactGallery")}
             </Button>
-          </>
-        )}
+          )}
+        </Join>
       </Flex>
 
       <Spacer mt={4} />

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2CommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2CommercialButtons.tsx
@@ -28,7 +28,6 @@ import { ContextModule, Intent } from "@artsy/cohesion"
 import { openAuthModal } from "Utils/openAuthModal"
 import currency from "currency.js"
 import { useTranslation } from "react-i18next"
-import { Media } from "Utils/Responsive"
 
 interface SaleMessageProps {
   saleMessage: string | null
@@ -326,19 +325,7 @@ const ArtworkSidebar2CommerialButtons: React.FC<ArtworkSidebar2CommercialButtons
       )}
 
       <Flex flexDirection={["column", "column", "column", "column", "row"]}>
-        <Join
-          separator={
-            <>
-              <Media at="xl">
-                <Spacer ml={1} />
-              </Media>
-
-              <Media lessThan="xl">
-                <Spacer mt={1} />
-              </Media>
-            </>
-          }
-        >
+        <Join separator={<Spacer ml={1} mt={1} />}>
           {artwork.isSold && renderCreateAlertButton()}
           {artwork.isAcquireable && (
             <Button


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4319]

Review app: [commercial-buttons](http://commercial-buttons.artsy.net/)
Quick artwork example: [Link](https://commercial-buttons.artsy.net/artwork/damon-zucconi-editioned-cg-price-range-arta-us-2)

### Problems
* Commercial buttons starts overflowing the sidebar when screen width < 1075
* iPhone SE (first generation) does the same when contact gallery is secondary

### Solution
We discussed with Kseniya and decided that the buttons will be placed under each other by default (column view). When the screen width is `1192px` or more (`xl` breakpoint according to the list of [supported breakpoints](https://palette.artsy.net/guides/responsive/#all-breakpoints)), then place the buttons in a row

### Demo
#### Problem №1 - when screen width < 1075
| Before | After |
| ------------- | ------------- |
| <img width="981" alt="before-1" src="https://user-images.githubusercontent.com/3513494/194873078-da908823-650d-42a2-97d1-3da438f352eb.png"> | <img width="981" alt="after-1" src="https://user-images.githubusercontent.com/3513494/194873116-bb2fe07f-152d-4ada-8ab1-83ecc8018545.png"> | 

#### Problem №2 - when the device has a small screen (e.g. iPhone SE first generation)
| Before | After |
| ------------- | ------------- |
| <img width="679" alt="before-2" src="https://user-images.githubusercontent.com/3513494/194873282-eb2a4541-a783-490c-9367-3c1301f42dd8.png"> | <img width="679" alt="after-2" src="https://user-images.githubusercontent.com/3513494/194873418-339a661e-6916-4948-8237-234caa5d48bb.png"> | 

<!-- Implementation description -->


[FX-4319]: https://artsyproduct.atlassian.net/browse/FX-4319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ