### PR TITLE
chore: instrument client-side image loading

### DIFF
--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -20,6 +20,7 @@ import { Z } from "./constants"
 import { createGlobalStyle } from "styled-components"
 import { useDidMount } from "Utils/Hooks/useDidMount"
 import { useOnboardingModal } from "Utils/Hooks/useOnboardingModal"
+import { useImagePerformanceObserver } from "Utils/Hooks/useImagePerformanceObserver"
 
 const logger = createLogger("Apps/Components/AppShell")
 interface AppShellProps {
@@ -28,6 +29,8 @@ interface AppShellProps {
 }
 
 export const AppShell: React.FC<AppShellProps> = props => {
+  useImagePerformanceObserver()
+
   const isMounted = useDidMount()
   const { onboardingComponent } = useOnboardingModal()
 

--- a/src/Server/__tests__/volley.jest.ts
+++ b/src/Server/__tests__/volley.jest.ts
@@ -1,146 +1,193 @@
-const mockSend = jest.fn()
-jest.mock("superagent", () => ({
-  post() {
-    return {
-      send: mockSend,
-    }
-  },
+import { OwnerType } from "@artsy/cohesion"
+import { reportLoadTimeToVolley } from "Server/volley"
+
+jest.mock("Utils/getENV", () => ({
+  getENV: () => "https://volley.endpoint",
 }))
-jest.mock("sharify", () => ({
-  data: {
-    VOLLEY_ENDPOINT: "http://volley",
-  },
-}))
-
-import { metricPayload, reportLoadTimeToVolley } from "../volley"
-
-describe("metricsPayload", () => {
-  it("should return null if the duration is null", () => {
-    expect(metricPayload("", "", "", null)).toBe(null)
-  })
-
-  it("should output in the expected format", () => {
-    expect(metricPayload("article", "desktop", "dom-interactive", 1000))
-      .toMatchInlineSnapshot(`
-Object {
-  "name": "load-time",
-  "tags": Array [
-    "page-type:article",
-    "device-type:desktop",
-    "mark:dom-interactive",
-  ],
-  "timing": 1000,
-  "type": "timing",
-}
-`)
-  })
-})
 
 describe("Reporting metrics to Volley", () => {
-  beforeEach(() => {
+  const mockFetch = jest.fn()
+
+  // @ts-ignore
+  global.fetch = mockFetch
+
+  afterEach(() => {
     jest.resetAllMocks()
   })
 
   it("reports valid metrics", async () => {
-    await reportLoadTimeToVolley("", "desktop", {
-      "dom-complete": () => 10,
-      "load-event-end": () => 5,
+    await reportLoadTimeToVolley({
+      pageType: OwnerType.article,
+      deviceType: "desktop",
+      metricsMap: {
+        "dom-complete": () => 10,
+        "load-event-end": () => 5,
+      },
     })
-    expect(mockSend.mock.calls[0][0]).toEqual(
-      expect.objectContaining({
-        serviceName: "force",
-        metrics: [
-          {
-            type: "timing",
-            name: "load-time",
-            timing: 10,
-            tags: [`page-type:`, `device-type:desktop`, `mark:dom-complete`],
-          },
-          {
-            type: "timing",
-            name: "load-time",
-            timing: 5,
-            tags: [`page-type:`, `device-type:desktop`, `mark:load-event-end`],
-          },
-        ],
-      })
-    )
+
+    expect(mockFetch.mock.calls[0]).toEqual([
+      "https://volley.endpoint",
+      {
+        body: JSON.stringify({
+          serviceName: "force",
+          metrics: [
+            {
+              type: "timing",
+              name: "load-time",
+              timing: 10,
+              tags: [
+                "page-type:article",
+                "device-type:desktop",
+                "mark:dom-complete",
+              ],
+            },
+            {
+              type: "timing",
+              name: "load-time",
+              timing: 5,
+              tags: [
+                "page-type:article",
+                "device-type:desktop",
+                "mark:load-event-end",
+              ],
+            },
+          ],
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      },
+    ])
   })
 
   it("reports valid metrics with 'mobile' as the device type when on mobile", async () => {
-    await reportLoadTimeToVolley("", "mobile", {
-      "dom-complete": () => 10,
-      "load-event-end": () => 5,
+    await reportLoadTimeToVolley({
+      pageType: OwnerType.article,
+      deviceType: "mobile",
+      metricsMap: {
+        "dom-complete": () => 10,
+        "load-event-end": () => 5,
+      },
     })
-    expect(mockSend.mock.calls[0][0]).toEqual(
-      expect.objectContaining({
-        serviceName: "force",
-        metrics: [
-          {
-            type: "timing",
-            name: "load-time",
-            timing: 10,
-            tags: [`page-type:`, `device-type:mobile`, `mark:dom-complete`],
-          },
-          {
-            type: "timing",
-            name: "load-time",
-            timing: 5,
-            tags: [`page-type:`, `device-type:mobile`, `mark:load-event-end`],
-          },
-        ],
-      })
-    )
+
+    expect(mockFetch.mock.calls[0]).toEqual([
+      "https://volley.endpoint",
+      {
+        body: JSON.stringify({
+          serviceName: "force",
+          metrics: [
+            {
+              type: "timing",
+              name: "load-time",
+              timing: 10,
+              tags: [
+                "page-type:article",
+                "device-type:mobile",
+                "mark:dom-complete",
+              ],
+            },
+            {
+              type: "timing",
+              name: "load-time",
+              timing: 5,
+              tags: [
+                "page-type:article",
+                "device-type:mobile",
+                "mark:load-event-end",
+              ],
+            },
+          ],
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      },
+    ])
   })
 
   it("reports valid metrics with 'desktop' as the device type when not on mobile", async () => {
-    await reportLoadTimeToVolley("", "desktop", {
-      "dom-complete": () => 10,
-      "load-event-end": () => 5,
+    await reportLoadTimeToVolley({
+      pageType: OwnerType.article,
+      deviceType: "desktop",
+      metricsMap: {
+        "dom-complete": () => 10,
+        "load-event-end": () => 5,
+      },
     })
-    expect(mockSend.mock.calls[0][0]).toEqual(
-      expect.objectContaining({
-        serviceName: "force",
-        metrics: [
-          {
-            type: "timing",
-            name: "load-time",
-            timing: 10,
-            tags: [`page-type:`, `device-type:desktop`, `mark:dom-complete`],
-          },
-          {
-            type: "timing",
-            name: "load-time",
-            timing: 5,
-            tags: [`page-type:`, `device-type:desktop`, `mark:load-event-end`],
-          },
-        ],
-      })
-    )
+
+    expect(mockFetch.mock.calls[0]).toEqual([
+      "https://volley.endpoint",
+      {
+        body: JSON.stringify({
+          serviceName: "force",
+          metrics: [
+            {
+              type: "timing",
+              name: "load-time",
+              timing: 10,
+              tags: [
+                "page-type:article",
+                "device-type:desktop",
+                "mark:dom-complete",
+              ],
+            },
+            {
+              type: "timing",
+              name: "load-time",
+              timing: 5,
+              tags: [
+                "page-type:article",
+                "device-type:desktop",
+                "mark:load-event-end",
+              ],
+            },
+          ],
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      },
+    ])
   })
 
   it("omits an invalid metric", async () => {
-    await reportLoadTimeToVolley("", "desktop", {
-      "dom-complete": () => 10,
-      "load-event-end": () => null,
+    await reportLoadTimeToVolley({
+      pageType: OwnerType.article,
+      deviceType: "desktop",
+      metricsMap: {
+        "dom-complete": () => 10,
+        "load-event-end": () => null,
+      },
     })
-    expect(mockSend.mock.calls[0][0]).toEqual(
-      expect.objectContaining({
-        serviceName: "force",
-        metrics: [
-          {
-            type: "timing",
-            name: "load-time",
-            timing: 10,
-            tags: [`page-type:`, `device-type:desktop`, `mark:dom-complete`],
-          },
-        ],
-      })
-    )
+
+    expect(mockFetch.mock.calls[0]).toEqual([
+      "https://volley.endpoint",
+      {
+        body: JSON.stringify({
+          serviceName: "force",
+          metrics: [
+            {
+              type: "timing",
+              name: "load-time",
+              timing: 10,
+              tags: [
+                "page-type:article",
+                "device-type:desktop",
+                "mark:dom-complete",
+              ],
+            },
+          ],
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      },
+    ])
   })
 
   it("doesn't send anything if called with no valid data", async () => {
-    await reportLoadTimeToVolley("", "desktop", {})
-    expect(mockSend.mock.calls.length).toBe(0)
+    await reportLoadTimeToVolley({
+      pageType: OwnerType.article,
+      deviceType: "desktop",
+      metricsMap: {},
+    })
+
+    expect(mockFetch.mock.calls.length).toBe(0)
   })
 })

--- a/src/Server/analytics/helpers.ts
+++ b/src/Server/analytics/helpers.ts
@@ -138,7 +138,7 @@ const trackPageLoadSpeed = () => {
         if (sd.TRACK_PAGELOAD_PATHS.split("|").includes(pageType)) {
           window.setTimeout(function () {
             let deviceType = sd.IS_MOBILE ? "mobile" : "desktop"
-            reportLoadTimeToVolley(pageType, deviceType)
+            reportLoadTimeToVolley({ pageType, deviceType })
           }, 0)
         }
       })

--- a/src/Server/volley.ts
+++ b/src/Server/volley.ts
@@ -1,5 +1,6 @@
-import { data as sd } from "sharify"
-import request from "superagent"
+import { PageOwnerType } from "@artsy/cohesion"
+import { compact } from "lodash"
+import { getENV } from "Utils/getENV"
 import {
   getDomComplete,
   getDomContentLoadedEnd,
@@ -11,58 +12,118 @@ import {
 } from "./userPerformanceMetrics"
 
 interface MetricMap {
-  [metricName: string]: () => Promise<number> | number | null
+  [metricName: string]: () => Promise<number | null> | number | null
 }
 
-const defaultMetrics: MetricMap = {
+const DEFAULT_METRICS: MetricMap = {
   "dom-complete": getDomComplete,
   "dom-content-loaded-start": getDomContentLoadedStart,
   "dom-content-loaded-end": getDomContentLoadedEnd,
   "load-event-end": getLoadEventEnd,
   "first-paint": getFirstPaint,
   "first-contentful-paint": getFirstContentfulPaint,
-  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   "time-to-interactive": getTTI,
 }
 
-export const metricPayload = (pageType, deviceType, name, duration) => {
-  return !duration
-    ? null
-    : {
-        type: "timing",
-        name: "load-time",
-        timing: duration,
-        tags: [
-          `page-type:${pageType}`,
-          `device-type:${deviceType}`,
-          `mark:${name}`,
-        ],
-      }
-}
-
-export async function reportLoadTimeToVolley(
+export async function reportLoadTimeToVolley({
   pageType,
   deviceType,
-  metricsMap: MetricMap = defaultMetrics
-) {
-  if (sd.VOLLEY_ENDPOINT) {
-    const metrics = (
-      await Promise.all(
-        Object.keys(metricsMap).map(async metricName =>
-          metricPayload(
-            pageType,
-            deviceType,
-            metricName,
-            await metricsMap[metricName]()
-          )
-        )
-      )
-    ).filter(metric => metric != null)
-    if (metrics.length > 0) {
-      return request.post(sd.VOLLEY_ENDPOINT).send({
-        serviceName: "force",
-        metrics,
+  metricsMap = DEFAULT_METRICS,
+}: {
+  pageType: PageOwnerType
+  deviceType: string
+  metricsMap?: MetricMap
+}) {
+  const metrics = compact(
+    await Promise.all(
+      Object.keys(metricsMap).map(async name => {
+        const duration = await metricsMap[name]()
+
+        if (!duration) {
+          return null
+        }
+
+        const metric: VolleyMetric = {
+          type: "timing",
+          name: "load-time",
+          timing: duration,
+          tags: [
+            `page-type:${pageType}`,
+            `device-type:${deviceType}`,
+            `mark:${name}`,
+          ],
+        }
+
+        return metric
       })
+    )
+  )
+
+  sendToVolley(metrics)
+}
+
+export type VolleyMetric =
+  | {
+      type: "timing"
+      name: string
+      timing: number
+      sampleRate?: number
+      tags?: string[]
     }
+  | {
+      type: "increment"
+      name: string
+      sampleRate?: number
+      tags?: string[]
+    }
+  | {
+      type: "incrementBy"
+      name: string
+      value: number
+      tags?: string[]
+    }
+  | {
+      type: "decrement"
+      name: string
+      sampleRate?: number
+      tags?: string[]
+    }
+  | {
+      type: "decrementBy"
+      name: string
+      value: number
+      tags?: string[]
+    }
+  | {
+      type: "gauge"
+      name: string
+      sampleRate?: number
+      value: number
+      tags?: string[]
+    }
+  | {
+      type: "histogram"
+      name: string
+      sampleRate?: number
+      value: number
+      tags?: string[]
+    }
+  | {
+      type: "set"
+      name: string
+      sampleRate?: number
+      value: number
+      tags?: string[]
+    }
+
+export const sendToVolley = (metrics: VolleyMetric[]) => {
+  if (!getENV("VOLLEY_ENDPOINT") || metrics.length === 0) {
+    return
   }
+
+  return fetch(getENV("VOLLEY_ENDPOINT"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ serviceName: "force", metrics }),
+  })
 }

--- a/src/Utils/Hooks/__tests__/useImagePerformanceObserver.jest.ts
+++ b/src/Utils/Hooks/__tests__/useImagePerformanceObserver.jest.ts
@@ -1,0 +1,107 @@
+import { renderHook } from "@testing-library/react-hooks"
+import { useImagePerformanceObserver } from "Utils/Hooks/useImagePerformanceObserver"
+import { sendToVolley } from "Server/volley"
+
+jest.mock("Server/volley", () => {
+  return {
+    sendToVolley: jest.fn(),
+  }
+})
+
+describe("useImagePerformanceObserver", () => {
+  const mockSendToVolley = sendToVolley as jest.Mock
+
+  class MockPerformanceObserver {
+    observe = jest.fn()
+    disconnect = jest.fn()
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+
+    // @ts-ignore
+    global.PerformanceObserver = MockPerformanceObserver
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+
+    // @ts-ignore
+    delete global.PerformanceObserver
+
+    mockSendToVolley.mockReset()
+  })
+
+  it("returns the queue", () => {
+    const { result } = renderHook(useImagePerformanceObserver)
+    expect(result.current).toEqual({ current: [] })
+  })
+
+  it("sends and clears the queue", () => {
+    const spy = jest.fn()
+    mockSendToVolley.mockImplementation(spy)
+
+    const { result } = renderHook(useImagePerformanceObserver)
+
+    result.current.current = [
+      {
+        initiatorType: "img",
+        transferSize: 10000,
+        name:
+          "https://d7hftxdivxxvm.cloudfront.net?resize_to=width&width=100&quality=80",
+        duration: 100,
+      },
+      {
+        initiatorType: "img",
+        transferSize: 3333333,
+        name:
+          "https://d7hftxdivxxvm.cloudfront.net?resize_to=width&width=100&quality=80",
+        duration: 333,
+      },
+      {
+        initiatorType: "img",
+        transferSize: 100000,
+        name:
+          "https://d7hftxdivxxvm.cloudfront.net?resize_to=width&width=100&quality=80",
+        duration: 150,
+      },
+    ]
+
+    jest.advanceTimersByTime(5000)
+
+    expect(spy).toBeCalledTimes(1)
+    expect(spy).toBeCalledWith([
+      {
+        name: "image.load-time",
+        tags: ["transfer-size:sm", "device-type:desktop"],
+        timing: 100,
+        type: "timing",
+      },
+      {
+        name: "image.load-time",
+        tags: ["transfer-size:xl", "device-type:desktop"],
+        timing: 333,
+        type: "timing",
+      },
+      {
+        name: "image.load-time",
+        tags: ["transfer-size:md", "device-type:desktop"],
+        timing: 150,
+        type: "timing",
+      },
+    ])
+
+    jest.advanceTimersByTime(5000)
+
+    expect(spy).toBeCalledTimes(1)
+    expect(result.current.current).toEqual([])
+  })
+
+  it('does not error if "PerformanceObserver" is not available', () => {
+    // @ts-ignore
+    delete global.PerformanceObserver
+
+    const { result } = renderHook(useImagePerformanceObserver)
+    expect(result.current).toEqual({ current: [] })
+  })
+})

--- a/src/Utils/Hooks/useImagePerformanceObserver.ts
+++ b/src/Utils/Hooks/useImagePerformanceObserver.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from "react"
+import { sendToVolley, VolleyMetric } from "Server/volley"
+import { getENV } from "Utils/getENV"
+import { GEMINI_CLOUDFRONT_URL } from "Utils/resizer"
+
+const DEVICE_TYPE = getENV("IS_MOBILE") ? "mobile" : "desktop"
+
+export const useImagePerformanceObserver = () => {
+  const queue = useRef<
+    Pick<
+      PerformanceResourceTiming,
+      "initiatorType" | "transferSize" | "name" | "duration"
+    >[]
+  >([])
+
+  useEffect(() => {
+    if (typeof PerformanceObserver === "undefined") return
+
+    const performanceObserver = new PerformanceObserver(observedEntries => {
+      const entries = observedEntries.getEntries()
+
+      entries.forEach((entry: PerformanceResourceTiming) => {
+        if (
+          // Only log images
+          entry.initiatorType !== "img" ||
+          // Ensure they are uncached
+          entry.transferSize === 0 ||
+          // Ensure they are Gemini images
+          !entry.name.includes(GEMINI_CLOUDFRONT_URL)
+        ) {
+          return
+        }
+
+        queue.current.push(entry)
+      })
+    })
+
+    performanceObserver.observe({
+      type: "resource",
+      buffered: true,
+    })
+
+    return () => {
+      performanceObserver.disconnect()
+    }
+  }, [])
+
+  // Every 5 seconds, send the queue to the server
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const entries = queue.current
+
+      if (entries.length === 0) return
+
+      const data = entries.map(entry => {
+        const payload: VolleyMetric = {
+          type: "timing",
+          name: "image.load-time",
+          timing: entry.duration,
+          tags: [
+            `transfer-size:${bucket(entry.transferSize)}`,
+            `device-type:${DEVICE_TYPE}`,
+          ],
+        }
+
+        return payload
+      })
+
+      sendToVolley(data)
+
+      queue.current = []
+    }, 5000)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [])
+
+  return queue
+}
+
+type Bucket = "sm" | "md" | "lg" | "xl"
+
+const bucket = (size: number): Bucket => {
+  // 0 - 100kb
+  if (size < 100000) return "sm"
+  // 100kb - 200kb
+  if (size < 200000) return "md"
+  // 200kb - 300kb
+  if (size < 300000) return "lg"
+  // 300kb+
+  return "xl"
+}

--- a/src/Utils/resizer.ts
+++ b/src/Utils/resizer.ts
@@ -1,7 +1,7 @@
 import qs from "qs"
 import { getENV } from "./getENV"
 
-const GEMINI_CLOUDFRONT_URL =
+export const GEMINI_CLOUDFRONT_URL =
   getENV("GEMINI_CLOUDFRONT_URL") ?? "https://d7hftxdivxxvm.cloudfront.net"
 
 const warn = (message: string) => {


### PR DESCRIPTION
Sets up a `PerformanceObserver` in the `AppShell` and listens for image loads.

The Volley payload looks like:

```json
{
  "serviceName": "force",
  "metrics": [
    {
      "type": "timing",
      "name": "image.load-time",
      "timing": 21.799999952316284,
      "tags": [
        "transfer-size:sm",
        "device-type:desktop"
      ]
    },
    {
      "type": "timing",
      "name": "image.load-time",
      "timing": 27.30000001192093,
      "tags": [
        "transfer-size:md",
        "device-type:desktop"
      ]
    },
    {
      "type": "timing",
      "name": "image.load-time",
      "timing": 42.69999998807907,
      "tags": [
        "transfer-size:sm",
        "device-type:desktop"
      ]
    },
    {
      "type": "timing",
      "name": "image.load-time",
      "timing": 61.5,
      "tags": [
        "transfer-size:sm",
        "device-type:desktop"
      ]
    },
    {
      "type": "timing",
      "name": "image.load-time",
      "timing": 69.5,
      "tags": [
        "transfer-size:sm",
        "device-type:desktop"
      ]
    },
    {
      "type": "timing",
      "name": "image.load-time",
      "timing": 87.10000002384186,
      "tags": [
        "transfer-size:sm",
        "device-type:desktop"
      ]
    },
    {
      "type": "timing",
      "name": "image.load-time",
      "timing": 104.89999997615814,
      "tags": [
        "transfer-size:sm",
        "device-type:desktop"
      ]
    }
  ]
}
```