### PR TITLE
feat(FX-4363): Activity panel: Remove artworks counter

### DIFF
--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -15,7 +15,6 @@ const UNREAD_INDICATOR_SIZE = 8
 
 const NotificationItem: React.FC<NotificationItemProps> = ({ item }) => {
   const artworks = extractNodes(item.artworksConnection)
-  const remainingArtworksCount = (item.artworksConnection?.totalCount ?? 0) - 4
 
   const getNotificationType = () => {
     if (item.notificationType === "ARTWORK_ALERT") {
@@ -66,17 +65,6 @@ const NotificationItem: React.FC<NotificationItemProps> = ({ item }) => {
               )
             })}
           </Join>
-
-          {remainingArtworksCount > 0 && (
-            <Text
-              variant="xs"
-              color="black60"
-              aria-label="Remaining artworks count"
-              ml={1}
-            >
-              + {remainingArtworksCount}
-            </Text>
-          )}
         </Flex>
       </Flex>
 

--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -94,7 +94,6 @@ export const NotificationItemFragmentContainer = createFragmentContainer(
         isUnread
         notificationType
         artworksConnection(first: 4) {
-          totalCount
           edges {
             node {
               internalID

--- a/src/Components/Notifications/__tests__/NotificationItem.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationItem.jest.tsx
@@ -179,7 +179,6 @@ const notification = {
   isUnread: false,
   notificationType: "ARTWORK_PUBLISHED",
   artworksConnection: {
-    totalCount: 4,
     edges: artworks,
   },
 }

--- a/src/Components/Notifications/__tests__/NotificationItem.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationItem.jest.tsx
@@ -74,31 +74,6 @@ describe("NotificationItem", () => {
     expect(screen.getAllByRole("img")).toHaveLength(4)
   })
 
-  describe("the remaining artworks count", () => {
-    it("should NOT be rendered if there are less or equal to 4", () => {
-      renderWithRelay({
-        Notification: () => notification,
-      })
-
-      const label = screen.queryByLabelText("Remaining artworks count")
-      expect(label).not.toBeInTheDocument()
-    })
-
-    it("should be rendered if there are more than 4", () => {
-      renderWithRelay({
-        Notification: () => ({
-          ...notification,
-          artworksConnection: {
-            ...notification.artworksConnection,
-            totalCount: 10,
-          },
-        }),
-      })
-
-      expect(screen.getByText("+ 6")).toBeInTheDocument()
-    })
-  })
-
   describe("Unread notification indicator", () => {
     it("should NOT be rendered by default", () => {
       renderWithRelay({

--- a/src/__generated__/NotificationItem_item.graphql.ts
+++ b/src/__generated__/NotificationItem_item.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<deb44d6f363c4392d9b0c36ac3f8920f>>
+ * @generated SignedSource<<4e283abf747db086eeb229aef1e76842>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,7 +25,6 @@ export type NotificationItem_item$data = {
         readonly title: string | null;
       } | null;
     } | null> | null;
-    readonly totalCount: number | null;
   } | null;
   readonly createdAt: string | null;
   readonly isUnread: boolean;
@@ -104,13 +103,6 @@ return {
       "name": "artworksConnection",
       "plural": false,
       "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "totalCount",
-          "storageKey": null
-        },
         {
           "alias": null,
           "args": null,
@@ -197,6 +189,6 @@ return {
 };
 })();
 
-(node as any).hash = "00ea44f628b676260e68860b4294e07a";
+(node as any).hash = "ecfa0b0d4f8520c26166fbe59835ae1f";
 
 export default node;

--- a/src/__generated__/NotificationItem_test_Query.graphql.ts
+++ b/src/__generated__/NotificationItem_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<592eee5d3ce5ba7843091e628ac25e12>>
+ * @generated SignedSource<<bcb259313c4387768f0fb917b8cee6f9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -197,13 +197,6 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "totalCount",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
                         "concreteType": "ArtworkEdge",
                         "kind": "LinkedField",
                         "name": "edges",
@@ -295,7 +288,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fa535ac7881c171045fcce6622a0a693",
+    "cacheID": "e7ab529d8573736662b76b4bfd3d33e4",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -352,12 +345,6 @@ return {
         "notificationsConnection.edges.node.artworksConnection.edges.node.image.thumb.srcSet": (v4/*: any*/),
         "notificationsConnection.edges.node.artworksConnection.edges.node.internalID": (v3/*: any*/),
         "notificationsConnection.edges.node.artworksConnection.edges.node.title": (v5/*: any*/),
-        "notificationsConnection.edges.node.artworksConnection.totalCount": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Int"
-        },
         "notificationsConnection.edges.node.createdAt": (v5/*: any*/),
         "notificationsConnection.edges.node.id": (v3/*: any*/),
         "notificationsConnection.edges.node.isUnread": {
@@ -383,7 +370,7 @@ return {
     },
     "name": "NotificationItem_test_Query",
     "operationKind": "query",
-    "text": "query NotificationItem_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...NotificationItem_item\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    totalCount\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query NotificationItem_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...NotificationItem_item\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListNextQuery.graphql.ts
+++ b/src/__generated__/NotificationsListNextQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<25f30ddc5a6c0dd1b9dfde3b6e5de2b6>>
+ * @generated SignedSource<<f557d89dd58a1027881a472864a6cc2b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -217,13 +217,6 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "kind": "ScalarField",
-                            "name": "totalCount",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
                             "concreteType": "ArtworkEdge",
                             "kind": "LinkedField",
                             "name": "edges",
@@ -360,12 +353,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e26bb00cd9ad953ebc3c9a2c14b6cd7a",
+    "cacheID": "a465a7e6d2d548603529ad5c0bb6db94",
     "id": null,
     "metadata": {},
     "name": "NotificationsListNextQuery",
     "operationKind": "query",
-    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    totalCount\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListQuery.graphql.ts
+++ b/src/__generated__/NotificationsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<88fe41ad01c3b2ee4edc07b14c351706>>
+ * @generated SignedSource<<b856388cec79d79b5238ced62d151e3a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -190,13 +190,6 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "kind": "ScalarField",
-                            "name": "totalCount",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
                             "concreteType": "ArtworkEdge",
                             "kind": "LinkedField",
                             "name": "edges",
@@ -333,12 +326,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "95162cf0a33077a27d7dad7545cbc98f",
+    "cacheID": "f5eb5fe936e2e07254483530c676277f",
     "id": null,
     "metadata": {},
     "name": "NotificationsListQuery",
     "operationKind": "query",
-    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    totalCount\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsList_test_Query.graphql.ts
+++ b/src/__generated__/NotificationsList_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<909186df0d6486bc6817dc87c5e42fd4>>
+ * @generated SignedSource<<61557680b410e354290c4de2e4e2367b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -193,13 +193,6 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "kind": "ScalarField",
-                            "name": "totalCount",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
                             "concreteType": "ArtworkEdge",
                             "kind": "LinkedField",
                             "name": "edges",
@@ -336,7 +329,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cb3e0703e461bb2d2463041fdfb74298",
+    "cacheID": "26b2d88c3b941f8069136333aa887c06",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -401,12 +394,6 @@ return {
         "viewer.notifications.edges.node.artworksConnection.edges.node.image.thumb.srcSet": (v4/*: any*/),
         "viewer.notifications.edges.node.artworksConnection.edges.node.internalID": (v5/*: any*/),
         "viewer.notifications.edges.node.artworksConnection.edges.node.title": (v6/*: any*/),
-        "viewer.notifications.edges.node.artworksConnection.totalCount": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Int"
-        },
         "viewer.notifications.edges.node.createdAt": (v6/*: any*/),
         "viewer.notifications.edges.node.id": (v5/*: any*/),
         "viewer.notifications.edges.node.internalID": (v5/*: any*/),
@@ -436,7 +423,7 @@ return {
     },
     "name": "NotificationsList_test_Query",
     "operationKind": "query",
-    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    totalCount\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [FX-4363]

### Description

Removes counters from individual notifications since backend returns not complete data which makes it impossible to display a correct number. This is a temporary solution until the issue is resolved on BE side.

![Screenshot 2022-10-11 at 11 53 57](https://user-images.githubusercontent.com/3934579/195058875-1d0764e3-414b-45e6-b51e-561ec07a8417.png)


[FX-4363]: https://artsyproduct.atlassian.net/browse/FX-4363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ