### PR TITLE
fix(FX-4320): make artworksidebar2classification more defensive

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2Classification.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2Classification.tsx
@@ -3,7 +3,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { ArtworkSidebar2Classification_artwork$data } from "__generated__/ArtworkSidebar2Classification_artwork.graphql"
 import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
-import { ArtworkSidebarClassificationsModalQueryRenderer } from "../ArtworkSidebarClassificationsModal"
+import { ArtworkSidebarClassificationsModalQueryRenderer } from "Apps/Artwork/Components/ArtworkSidebarClassificationsModal"
 import { ArtworkIcon, Clickable, Flex, Text } from "@artsy/palette"
 
 interface ArtworkSidebar2ClassificationProps {
@@ -28,11 +28,11 @@ const ArtworkSidebar2Classification: React.FC<ArtworkSidebar2ClassificationProps
 
   const closeModal = () => setIsModalOpen(false)
 
-  if (!artwork.attributionClass) {
+  if (!artwork.attributionClass?.shortArrayDescription?.length) {
     return null
   }
 
-  const { shortArrayDescription } = artwork.attributionClass
+  const shortArrayDescription = artwork.attributionClass?.shortArrayDescription
 
   return (
     <>


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4320]

### Description

Made artworksidebar2classification more defensive, there were some cases where the `shortArrayDescription` was in a weird state and it resulted in a 500 error, after debugging it the stacktrace led us to [this line](https://github.com/artsy/force/compare/gkartalis/FX-4320?expand=1#diff-939cb6b50bc43cdd9bad7d07f9b299588080dea5bf44017432b427d87ec2bf87L46)

> (also updated an import path)

How to test:

Spawn an online auction, go to a lot that doesn't have an attribution class to gravity staging, add an attributionClass and reload, the page in force should not break (make sure that you wait some seconds after adding the attributionClass)

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4320]: https://artsyproduct.atlassian.net/browse/FX-4320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ