### PR TITLE
fix: Adjust error message when initial artwork image loading fails in SWA flow

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/UploadPhotosForm.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/Components/UploadPhotosForm.tsx
@@ -52,7 +52,9 @@ export const UploadPhotosForm: React.FC<UploadPhotosFormProps> = ({
       photo.loading = false
 
       if (!geminiToken) {
-        photo.errorMessage = `Photo could not be added: ${photo.name}`
+        photo.errorMessage = photo.externalUrl
+          ? "Artwork image could not be automatically added. Please add a photo."
+          : `Photo could not be added: ${photo.name}`
         setFieldValue("photos", values.photos)
         return
       }

--- a/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
@@ -89,22 +89,24 @@ export const PhotoThumbnail: React.FC<
 
   return (
     <>
-      <Flex
-        p={photo.errorMessage ? [15] : [15, 2]}
-        border="1px solid"
-        borderRadius={4}
-        borderColor={photo.errorMessage ? "red100" : "black15"}
-        {...rest}
-      >
-        <CSSGrid
-          gridTemplateColumns="minmax(50px, 75%) minmax(120px, 25%)"
-          gridGap={2}
-          width="100%"
+      {!photo.errorMessage && (
+        <Flex
+          p={photo.errorMessage ? [15] : [15, 2]}
+          border="1px solid"
+          borderRadius={4}
+          borderColor={photo.errorMessage ? "red100" : "black15"}
+          {...rest}
         >
-          {renderThumbnail(photoSrc)}
-        </CSSGrid>
-      </Flex>
-      {photo.errorMessage && (
+          <CSSGrid
+            gridTemplateColumns="minmax(50px, 75%) minmax(120px, 25%)"
+            gridGap={2}
+            width="100%"
+          >
+            {renderThumbnail(photoSrc)}
+          </CSSGrid>
+        </Flex>
+      )}
+      {!!photo.errorMessage && (
         <Text
           data-testid="photo-thumbnail-error"
           mt={[0.5, 2]}

--- a/src/Components/PhotoUpload/Utils/uploadFileToS3.tsx
+++ b/src/Components/PhotoUpload/Utils/uploadFileToS3.tsx
@@ -38,7 +38,7 @@ export const uploadFileToS3 = (
     try {
       file = isExternalPhoto ? await fetchExternalFile(photo) : photo.file
     } catch (error) {
-      reject(new Error("Initializing artwork photo failed."))
+      reject(new Error("Artwork image could not be automatically added."))
       return
     }
 

--- a/src/Components/PhotoUpload/__tests__/PhotoThumbnail.jest.tsx
+++ b/src/Components/PhotoUpload/__tests__/PhotoThumbnail.jest.tsx
@@ -3,7 +3,7 @@ import { mount, ReactWrapper } from "enzyme"
 import {
   PhotoThumbnail,
   PhotoThumbnailProps,
-} from "../Components/PhotoThumbnail"
+} from "Components/PhotoUpload/Components/PhotoThumbnail"
 
 const deleteFn = jest.fn()
 const file = new File([new Array(10000).join(" ")], "foo.png", {
@@ -83,27 +83,8 @@ describe("PhotoThumbnail", () => {
       wrapper = getWrapper(props)
     })
 
-    it("renders name", () => {
-      expect(wrapper.text()).toContain("foo.png")
-    })
-
-    it("renders size", () => {
-      expect(wrapper.text()).toContain("0.01 MB")
-    })
-
     it("doesn't render image", () => {
       expect(wrapper.find(Image)).toHaveLength(0)
-    })
-
-    it("renders delete button", () => {
-      const deletePhotoThumbnail = wrapper.find("RemoveButton")
-
-      expect(deletePhotoThumbnail).toHaveLength(1)
-
-      deletePhotoThumbnail.simulate("click")
-
-      expect(deleteFn).toHaveBeenCalled()
-      expect(deleteFn).toHaveBeenCalledWith(props.photo)
     })
 
     it("renders error message", () => {


### PR DESCRIPTION
Addresses [CX-2952]

## Description

Adjust error message when initial artwork image loading (from My Collection) fails in SWA flow.
<img width="903" alt="Screenshot 2022-10-11 at 15 21 44" src="https://user-images.githubusercontent.com/4691889/195104529-8d6650f8-f457-4b14-ac3c-ed763d85c0c0.png">



[Slack Thread with more context](https://artsy.slack.com/archives/C01B2P6LJUU/p1665492951106379)

[CX-2952]: https://artsyproduct.atlassian.net/browse/CX-2952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ