### PR TITLE
feat(CX-2879): Add Median Sale Price to MyC Insights

### DIFF
--- a/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
@@ -1,0 +1,92 @@
+import { Box, Flex, Text } from "@artsy/palette"
+
+export const InsightsMedianSalePrice = () => {
+  return (
+    <Box>
+      <Text variant="md">Median Auction Price in the Last 3 Years</Text>
+
+      <Flex mt={2}>
+        <Flex flex={1} flexDirection="column">
+          <Flex alignItems="center">
+            <Box
+              backgroundColor="red"
+              width={40}
+              height={40}
+              borderRadius="50%"
+            />
+
+            <Box ml={1}>
+              <Text variant="sm-display">Name</Text>
+              <Text variant="xs" color="black60">
+                other stuff
+              </Text>
+            </Box>
+          </Flex>
+        </Flex>
+
+        <Flex flex={1} flexDirection="column">
+          <Flex
+            minHeight={40}
+            alignItems="center"
+            justifyContent="space-evenly"
+          >
+            <Text variant="sm" color="black60">
+              Type
+            </Text>
+            <Text variant="sm" fontWeight="semibold">
+              Price
+            </Text>
+          </Flex>
+
+          <Flex
+            minHeight={40}
+            alignItems="center"
+            justifyContent="space-evenly"
+          >
+            <Text variant="sm" color="black60">
+              Type
+            </Text>
+            <Text variant="sm" fontWeight="semibold">
+              Price
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+
+      <Flex mt={2}>
+        <Flex flex={1} flexDirection="column">
+          <Flex alignItems="center">
+            <Box
+              backgroundColor="blue"
+              width={40}
+              height={40}
+              borderRadius="50%"
+            />
+
+            <Box ml={1}>
+              <Text variant="sm-display">Name</Text>
+              <Text variant="xs" color="black60">
+                other stuff
+              </Text>
+            </Box>
+          </Flex>
+        </Flex>
+
+        <Flex flex={1} flexDirection="column">
+          <Flex
+            minHeight={40}
+            alignItems="center"
+            justifyContent="space-evenly"
+          >
+            <Text variant="sm" color="black60">
+              Type
+            </Text>
+            <Text variant="sm" fontWeight="semibold">
+              Price
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
@@ -24,12 +24,15 @@ const InsightsMedianSalePrice: React.FC<InsightsMedianSalePriceProps> = ({
 
   return (
     <Box>
-      <Text variant="md">Median Auction Price in the Last 3 Years</Text>
+      <Text variant={["sm-display", "md"]}>
+        Median Auction Price in the Last 3 Years
+      </Text>
+
       {groupedMedianSalePrices.map(msps => {
         const [artistData] = msps
 
         return (
-          <Flex mt={2}>
+          <Flex mt={2} mb={[4, 0]} flexDirection={["column", "row"]}>
             <EntityHeaderArtistFragmentContainer
               flex={1}
               alignItems="flex-start"
@@ -42,11 +45,21 @@ const InsightsMedianSalePrice: React.FC<InsightsMedianSalePriceProps> = ({
             <Flex flex={1} flexDirection="column">
               {msps.map(msp => {
                 return (
-                  <Flex minHeight={45} alignItems="center">
-                    <Text variant="sm" color="black60" minWidth={200} mr={2}>
+                  <Flex
+                    mt={[2, 0]}
+                    minHeight={[0, 45]}
+                    alignItems="center"
+                    justifyContent={["space-between", null]}
+                  >
+                    <Text
+                      variant={["xs", "sm"]}
+                      color="black60"
+                      minWidth={[0, 200]}
+                      mr={2}
+                    >
                       {msp.mediumType?.name}
                     </Text>
-                    <Text variant="sm" fontWeight="bold">
+                    <Text variant={["xs", "sm"]} fontWeight="bold">
                       {msp.marketPriceInsights?.medianSalePriceDisplayText}
                     </Text>
                   </Flex>

--- a/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
@@ -18,8 +18,9 @@ const InsightsMedianSalePrice: React.FC<InsightsMedianSalePriceProps> = ({
     return null
   }
 
+  // Grouping median sale prices by artist id to array of arrays
   const groupedMedianSalePrices = Object.values(
-    groupBy(medianSalePrices, msp => msp?.artist?.internalID)
+    groupBy(medianSalePrices, medianSalePrice => medianSalePrice?.artist?.internalID)
   )
 
   return (
@@ -28,22 +29,22 @@ const InsightsMedianSalePrice: React.FC<InsightsMedianSalePriceProps> = ({
         Median Auction Price in the Last 3 Years
       </Text>
 
-      {groupedMedianSalePrices.map(msps => {
-        const [artistData] = msps
+      {groupedMedianSalePrices.map(artistMedianSalePrices => {
+        const [firstElement] = artistMedianSalePrices
 
         return (
           <Flex mt={2} mb={[4, 0]} flexDirection={["column", "row"]}>
             <EntityHeaderArtistFragmentContainer
               flex={1}
               alignItems="flex-start"
-              artist={artistData.artist!}
+              artist={firstElement.artist!}
               displayLink={false}
               // added this to hide the follow button
               FollowButton={<></>}
             />
 
             <Flex flex={1} flexDirection="column">
-              {msps.map(msp => {
+              {artistMedianSalePrices.map(medianSalePrice => {
                 return (
                   <Flex
                     mt={[2, 0]}
@@ -57,10 +58,10 @@ const InsightsMedianSalePrice: React.FC<InsightsMedianSalePriceProps> = ({
                       minWidth={[0, 200]}
                       mr={2}
                     >
-                      {msp.mediumType?.name}
+                      {medianSalePrice.mediumType?.name}
                     </Text>
                     <Text variant={["xs", "sm"]} fontWeight="bold">
-                      {msp.marketPriceInsights?.medianSalePriceDisplayText}
+                      {medianSalePrice.marketPriceInsights?.medianSalePriceDisplayText}
                     </Text>
                   </Flex>
                 )

--- a/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
@@ -38,7 +38,7 @@ const InsightsMedianSalePrice: React.FC<InsightsMedianSalePriceProps> = ({
               alignItems="flex-start"
               artist={artistData.artist!}
               displayLink={false}
-              // to hide the follow button
+              // added this to hide the follow button
               FollowButton={<></>}
             />
 

--- a/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
@@ -1,92 +1,93 @@
 import { Box, Flex, Text } from "@artsy/palette"
+import { EntityHeaderArtistFragmentContainer } from "Components/EntityHeaders/EntityHeaderArtist"
+import { groupBy } from "lodash"
+import { createFragmentContainer, graphql } from "react-relay"
+import { extractNodes } from "Utils/extractNodes"
+import { InsightsMedianSalePrice_me$data } from "__generated__/InsightsMedianSalePrice_me.graphql"
 
-export const InsightsMedianSalePrice = () => {
+interface InsightsMedianSalePriceProps {
+  me: InsightsMedianSalePrice_me$data
+}
+
+const InsightsMedianSalePrice: React.FC<InsightsMedianSalePriceProps> = ({
+  me,
+}) => {
+  const medianSalePrices = extractNodes(me.medianSalePrices)
+
+  if (!medianSalePrices.length) {
+    return null
+  }
+
+  const groupedMedianSalePrices = Object.values(
+    groupBy(medianSalePrices, msp => msp?.artist?.internalID)
+  )
+
   return (
     <Box>
       <Text variant="md">Median Auction Price in the Last 3 Years</Text>
+      {groupedMedianSalePrices.map(msps => {
+        const [artistData] = msps
 
-      <Flex mt={2}>
-        <Flex flex={1} flexDirection="column">
-          <Flex alignItems="center">
-            <Box
-              backgroundColor="red"
-              width={40}
-              height={40}
-              borderRadius="50%"
+        return (
+          <Flex mt={2}>
+            <EntityHeaderArtistFragmentContainer
+              flex={1}
+              alignItems="flex-start"
+              artist={artistData.artist!}
+              displayLink={false}
+              // to hide the follow button
+              FollowButton={<></>}
             />
 
-            <Box ml={1}>
-              <Text variant="sm-display">Name</Text>
-              <Text variant="xs" color="black60">
-                other stuff
-              </Text>
-            </Box>
+            <Flex flex={1} flexDirection="column">
+              {msps.map(msp => {
+                return (
+                  <Flex minHeight={45} alignItems="center">
+                    <Text variant="sm" color="black60" minWidth={200} mr={2}>
+                      {msp.mediumType?.name}
+                    </Text>
+                    <Text variant="sm" fontWeight="bold">
+                      {msp.marketPriceInsights?.medianSalePriceDisplayText}
+                    </Text>
+                  </Flex>
+                )
+              })}
+            </Flex>
           </Flex>
-        </Flex>
-
-        <Flex flex={1} flexDirection="column">
-          <Flex
-            minHeight={40}
-            alignItems="center"
-            justifyContent="space-evenly"
-          >
-            <Text variant="sm" color="black60">
-              Type
-            </Text>
-            <Text variant="sm" fontWeight="semibold">
-              Price
-            </Text>
-          </Flex>
-
-          <Flex
-            minHeight={40}
-            alignItems="center"
-            justifyContent="space-evenly"
-          >
-            <Text variant="sm" color="black60">
-              Type
-            </Text>
-            <Text variant="sm" fontWeight="semibold">
-              Price
-            </Text>
-          </Flex>
-        </Flex>
-      </Flex>
-
-      <Flex mt={2}>
-        <Flex flex={1} flexDirection="column">
-          <Flex alignItems="center">
-            <Box
-              backgroundColor="blue"
-              width={40}
-              height={40}
-              borderRadius="50%"
-            />
-
-            <Box ml={1}>
-              <Text variant="sm-display">Name</Text>
-              <Text variant="xs" color="black60">
-                other stuff
-              </Text>
-            </Box>
-          </Flex>
-        </Flex>
-
-        <Flex flex={1} flexDirection="column">
-          <Flex
-            minHeight={40}
-            alignItems="center"
-            justifyContent="space-evenly"
-          >
-            <Text variant="sm" color="black60">
-              Type
-            </Text>
-            <Text variant="sm" fontWeight="semibold">
-              Price
-            </Text>
-          </Flex>
-        </Flex>
-      </Flex>
+        )
+      })}
     </Box>
   )
 }
+
+export const InsightsMedianSalePriceFragmentContainer = createFragmentContainer(
+  InsightsMedianSalePrice,
+  {
+    me: graphql`
+      fragment InsightsMedianSalePrice_me on Me {
+        medianSalePrices: myCollectionConnection(
+          first: 3
+          sortByLastAuctionResultDate: true
+        ) {
+          edges {
+            node {
+              internalID
+              medium
+              mediumType {
+                name
+              }
+              title
+              artist {
+                internalID
+                ...EntityHeaderArtist_artist
+              }
+              marketPriceInsights {
+                medianSalePriceDisplayText
+              }
+            }
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
@@ -1,0 +1,94 @@
+// test rending
+// test returning null
+
+import { screen } from "@testing-library/react"
+import { InsightsMedianSalePriceFragmentContainer } from "Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { graphql } from "react-relay"
+import { InsightsMedianSalePriceTestQuery } from "__generated__/InsightsMedianSalePriceTestQuery.graphql"
+
+jest.unmock("react-relay")
+
+describe("InsightsMedianSalePrice", () => {
+  const { renderWithRelay } = setupTestWrapperTL<
+    InsightsMedianSalePriceTestQuery
+  >({
+    Component: InsightsMedianSalePriceFragmentContainer,
+    query: graphql`
+      query InsightsMedianSalePriceTestQuery @relay_test_operation {
+        me {
+          ...InsightsMedianSalePrice_me
+        }
+      }
+    `,
+  })
+
+  describe("when there are market price insights data", () => {
+    it("renders correctly", () => {
+      renderWithRelay(mockResolver, false)
+
+      expect(
+        screen.getByText("Median Auction Price in the Last 3 Years")
+      ).toBeInTheDocument()
+
+      expect(screen.getByText("Takashi Murakami")).toBeInTheDocument()
+      expect(screen.getByText("Japanese, b. 1962")).toBeInTheDocument()
+      expect(screen.getByText("Photography")).toBeInTheDocument()
+      expect(screen.getByText("US$3,750")).toBeInTheDocument()
+
+      expect(screen.getByText("Andy Warhol")).toBeInTheDocument()
+      expect(screen.getByText("American, 1928–1987")).toBeInTheDocument()
+      expect(screen.getByText("Print")).toBeInTheDocument()
+      expect(screen.getByText("US$39,930")).toBeInTheDocument()
+    })
+  })
+
+  describe("when there are no market price insights data", () => {
+    it("renders nothing", () => {
+      renderWithRelay(mockEmptyResolver, false)
+
+      expect(
+        screen.queryByText("Median Auction Price in the Last 3 Years")
+      ).not.toBeInTheDocument()
+    })
+  })
+})
+
+const mockEmptyResolver = {
+  Me: () => ({
+    medianSalePrices: {
+      edges: [],
+    },
+  }),
+}
+
+const mockResolver = {
+  Me: () => ({
+    medianSalePrices: {
+      edges: [
+        {
+          node: {
+            mediumType: { name: "Print" },
+            artist: {
+              internalID: "takashi-murakami",
+              name: "Takashi Murakami",
+              formattedNationalityAndBirthday: "Japanese, b. 1962",
+            },
+            marketPriceInsights: { medianSalePriceDisplayText: "US$3,750" },
+          },
+        },
+        {
+          node: {
+            mediumType: { name: "Photography" },
+            artist: {
+              internalID: "andy-warhol",
+              name: "Andy Warhol",
+              formattedNationalityAndBirthday: "American, 1928–1987",
+            },
+            marketPriceInsights: { medianSalePriceDisplayText: "US$39,930" },
+          },
+        },
+      ],
+    },
+  }),
+}

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
@@ -1,6 +1,3 @@
-// test rending
-// test returning null
-
 import { screen } from "@testing-library/react"
 import { InsightsMedianSalePriceFragmentContainer } from "Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"

--- a/src/Apps/Settings/Routes/Insights/InsightsRoute.tsx
+++ b/src/Apps/Settings/Routes/Insights/InsightsRoute.tsx
@@ -1,6 +1,6 @@
 import { Join, Spacer } from "@artsy/palette"
 import { InsightsCareerHighlightRailFragmentContainer } from "Apps/Settings/Routes/Insights/Components/CareerHighlights/InsightsCareerHighlightRail"
-import { InsightsMedianSalePrice } from "Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice"
+import { InsightsMedianSalePriceFragmentContainer } from "Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { Media } from "Utils/Responsive"
@@ -55,7 +55,9 @@ const InsightsRoute: React.FC<InsightsRouteProps> = ({ me }) => {
               </>
             )}
 
-            {!!isMedianSalePriceEnabled && <InsightsMedianSalePrice />}
+            {!!isMedianSalePriceEnabled && (
+              <InsightsMedianSalePriceFragmentContainer me={me} />
+            )}
           </Join>
         </>
       )}
@@ -75,6 +77,7 @@ export const InsightsRouteFragmentContainer = createFragmentContainer(
         }
         ...InsightsAuctionResults_me
         ...InsightsCareerHighlightRail_me
+        ...InsightsMedianSalePrice_me
       }
     `,
   }

--- a/src/Apps/Settings/Routes/Insights/InsightsRoute.tsx
+++ b/src/Apps/Settings/Routes/Insights/InsightsRoute.tsx
@@ -1,5 +1,6 @@
 import { Join, Spacer } from "@artsy/palette"
 import { InsightsCareerHighlightRailFragmentContainer } from "Apps/Settings/Routes/Insights/Components/CareerHighlights/InsightsCareerHighlightRail"
+import { InsightsMedianSalePrice } from "Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { Media } from "Utils/Responsive"
@@ -17,6 +18,9 @@ const InsightsRoute: React.FC<InsightsRouteProps> = ({ me }) => {
   const isInsightsEnabled = useFeatureFlag("my-collection-web-phase-7-insights")
   const isCareerHighlightEnabled = useFeatureFlag(
     "my-collection-web-phase-7-career-highlights"
+  )
+  const isMedianSalePriceEnabled = useFeatureFlag(
+    "my-collection-web-phase-7-median-sale-price"
   )
 
   if (!me.myCollectionInfo?.artworksCount) {
@@ -46,10 +50,12 @@ const InsightsRoute: React.FC<InsightsRouteProps> = ({ me }) => {
                     showProgress={false}
                   />
                 </Media>
+
+                <InsightsAuctionResultsFragmentContainer me={me} />
               </>
             )}
 
-            <InsightsAuctionResultsFragmentContainer me={me} />
+            {!!isMedianSalePriceEnabled && <InsightsMedianSalePrice />}
           </Join>
         </>
       )}

--- a/src/__generated__/InsightsMedianSalePriceTestQuery.graphql.ts
+++ b/src/__generated__/InsightsMedianSalePriceTestQuery.graphql.ts
@@ -1,0 +1,415 @@
+/**
+ * @generated SignedSource<<08198f107e84dbbe973ae98caa1725b2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type InsightsMedianSalePriceTestQuery$variables = {};
+export type InsightsMedianSalePriceTestQuery$data = {
+  readonly me: {
+    readonly " $fragmentSpreads": FragmentRefs<"InsightsMedianSalePrice_me">;
+  } | null;
+};
+export type InsightsMedianSalePriceTestQuery = {
+  response: InsightsMedianSalePriceTestQuery$data;
+  variables: InsightsMedianSalePriceTestQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v5 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FormattedNumber"
+},
+v6 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "InsightsMedianSalePriceTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "InsightsMedianSalePrice_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "InsightsMedianSalePriceTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": "medianSalePrices",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 3
+              },
+              {
+                "kind": "Literal",
+                "name": "sortByLastAuctionResultDate",
+                "value": true
+              }
+            ],
+            "concreteType": "MyCollectionConnection",
+            "kind": "LinkedField",
+            "name": "myCollectionConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "MyCollectionEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v0/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "medium",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkMedium",
+                        "kind": "LinkedField",
+                        "name": "mediumType",
+                        "plural": false,
+                        "selections": [
+                          (v1/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artist",
+                        "plural": false,
+                        "selections": [
+                          (v0/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "href",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "slug",
+                            "storageKey": null
+                          },
+                          (v1/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "initials",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "formattedNationalityAndBirthday",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtistCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "artworks",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "forSaleArtworks",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "avatar",
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "height",
+                                    "value": 45
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 45
+                                  }
+                                ],
+                                "concreteType": "CroppedImageUrl",
+                                "kind": "LinkedField",
+                                "name": "cropped",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "src",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "srcSet",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": "cropped(height:45,width:45)"
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkPriceInsights",
+                        "kind": "LinkedField",
+                        "name": "marketPriceInsights",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "medianSalePriceDisplayText",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "myCollectionConnection(first:3,sortByLastAuctionResultDate:true)"
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "7f52549e0c3161b7e7f8df2aff9cfa18",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.id": (v3/*: any*/),
+        "me.medianSalePrices": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "MyCollectionConnection"
+        },
+        "me.medianSalePrices.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "MyCollectionEdge"
+        },
+        "me.medianSalePrices.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "me.medianSalePrices.edges.node.artist": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artist"
+        },
+        "me.medianSalePrices.edges.node.artist.avatar": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "me.medianSalePrices.edges.node.artist.avatar.cropped": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CroppedImageUrl"
+        },
+        "me.medianSalePrices.edges.node.artist.avatar.cropped.src": (v4/*: any*/),
+        "me.medianSalePrices.edges.node.artist.avatar.cropped.srcSet": (v4/*: any*/),
+        "me.medianSalePrices.edges.node.artist.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtistCounts"
+        },
+        "me.medianSalePrices.edges.node.artist.counts.artworks": (v5/*: any*/),
+        "me.medianSalePrices.edges.node.artist.counts.forSaleArtworks": (v5/*: any*/),
+        "me.medianSalePrices.edges.node.artist.formattedNationalityAndBirthday": (v6/*: any*/),
+        "me.medianSalePrices.edges.node.artist.href": (v6/*: any*/),
+        "me.medianSalePrices.edges.node.artist.id": (v3/*: any*/),
+        "me.medianSalePrices.edges.node.artist.initials": (v6/*: any*/),
+        "me.medianSalePrices.edges.node.artist.internalID": (v3/*: any*/),
+        "me.medianSalePrices.edges.node.artist.name": (v6/*: any*/),
+        "me.medianSalePrices.edges.node.artist.slug": (v3/*: any*/),
+        "me.medianSalePrices.edges.node.id": (v3/*: any*/),
+        "me.medianSalePrices.edges.node.internalID": (v3/*: any*/),
+        "me.medianSalePrices.edges.node.marketPriceInsights": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkPriceInsights"
+        },
+        "me.medianSalePrices.edges.node.marketPriceInsights.medianSalePriceDisplayText": (v6/*: any*/),
+        "me.medianSalePrices.edges.node.medium": (v6/*: any*/),
+        "me.medianSalePrices.edges.node.mediumType": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkMedium"
+        },
+        "me.medianSalePrices.edges.node.mediumType.name": (v6/*: any*/),
+        "me.medianSalePrices.edges.node.title": (v6/*: any*/)
+      }
+    },
+    "name": "InsightsMedianSalePriceTestQuery",
+    "operationKind": "query",
+    "text": "query InsightsMedianSalePriceTestQuery {\n  me {\n    ...InsightsMedianSalePrice_me\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment InsightsMedianSalePrice_me on Me {\n  medianSalePrices: myCollectionConnection(first: 3, sortByLastAuctionResultDate: true) {\n    edges {\n      node {\n        internalID\n        medium\n        mediumType {\n          name\n        }\n        title\n        artist {\n          internalID\n          ...EntityHeaderArtist_artist\n          id\n        }\n        marketPriceInsights {\n          medianSalePriceDisplayText\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "6769944a893edcab7958bf42803f3d36";
+
+export default node;

--- a/src/__generated__/InsightsMedianSalePrice_me.graphql.ts
+++ b/src/__generated__/InsightsMedianSalePrice_me.graphql.ts
@@ -1,0 +1,174 @@
+/**
+ * @generated SignedSource<<a54751d27235392666bec4596efcf6c1>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type InsightsMedianSalePrice_me$data = {
+  readonly medianSalePrices: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly artist: {
+          readonly internalID: string;
+          readonly " $fragmentSpreads": FragmentRefs<"EntityHeaderArtist_artist">;
+        } | null;
+        readonly internalID: string;
+        readonly marketPriceInsights: {
+          readonly medianSalePriceDisplayText: string | null;
+        } | null;
+        readonly medium: string | null;
+        readonly mediumType: {
+          readonly name: string | null;
+        } | null;
+        readonly title: string | null;
+      } | null;
+    } | null> | null;
+  } | null;
+  readonly " $fragmentType": "InsightsMedianSalePrice_me";
+};
+export type InsightsMedianSalePrice_me$key = {
+  readonly " $data"?: InsightsMedianSalePrice_me$data;
+  readonly " $fragmentSpreads": FragmentRefs<"InsightsMedianSalePrice_me">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "InsightsMedianSalePrice_me",
+  "selections": [
+    {
+      "alias": "medianSalePrices",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 3
+        },
+        {
+          "kind": "Literal",
+          "name": "sortByLastAuctionResultDate",
+          "value": true
+        }
+      ],
+      "concreteType": "MyCollectionConnection",
+      "kind": "LinkedField",
+      "name": "myCollectionConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "MyCollectionEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "medium",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "ArtworkMedium",
+                  "kind": "LinkedField",
+                  "name": "mediumType",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "name",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "title",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Artist",
+                  "kind": "LinkedField",
+                  "name": "artist",
+                  "plural": false,
+                  "selections": [
+                    (v0/*: any*/),
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "EntityHeaderArtist_artist"
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "ArtworkPriceInsights",
+                  "kind": "LinkedField",
+                  "name": "marketPriceInsights",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "medianSalePriceDisplayText",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "myCollectionConnection(first:3,sortByLastAuctionResultDate:true)"
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "2fe34f95002e3673d8bfb4bddeb3ba75";
+
+export default node;

--- a/src/__generated__/InsightsRoute_me.graphql.ts
+++ b/src/__generated__/InsightsRoute_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a81966588b419866f8cd1e88e27b3fab>>
+ * @generated SignedSource<<36801c51b4ed18e4f93ff13b0637b30a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,7 +16,7 @@ export type InsightsRoute_me$data = {
     readonly artworksCount: number;
     readonly " $fragmentSpreads": FragmentRefs<"InsightsOverview_info">;
   } | null;
-  readonly " $fragmentSpreads": FragmentRefs<"InsightsAuctionResults_me" | "InsightsCareerHighlightRail_me">;
+  readonly " $fragmentSpreads": FragmentRefs<"InsightsAuctionResults_me" | "InsightsCareerHighlightRail_me" | "InsightsMedianSalePrice_me">;
   readonly " $fragmentType": "InsightsRoute_me";
 };
 export type InsightsRoute_me$key = {
@@ -69,12 +69,17 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "FragmentSpread",
       "name": "InsightsCareerHighlightRail_me"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "InsightsMedianSalePrice_me"
     }
   ],
   "type": "Me",
   "abstractKey": null
 };
 
-(node as any).hash = "4d476e9988812fa11e4233426cc970b0";
+(node as any).hash = "ebd1af3514143e581cce38d10da1f709";
 
 export default node;

--- a/src/__generated__/settingsRoutes_InsightsRouteQuery.graphql.ts
+++ b/src/__generated__/settingsRoutes_InsightsRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b48279d4577913ff5a0812c914b590b7>>
+ * @generated SignedSource<<9ee7cfda009f63e5026956901cbbd52b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,10 +26,45 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "internalID",
   "storageKey": null
 },
 v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "src",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "srcSet",
+  "storageKey": null
+},
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -77,13 +112,7 @@ return {
         "name": "me",
         "plural": false,
         "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "internalID",
-            "storageKey": null
-          },
+          (v0/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -185,13 +214,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "title",
-                        "storageKey": null
-                      },
+                      (v1/*: any*/),
                       {
                         "alias": "dimension_text",
                         "args": null,
@@ -214,14 +237,8 @@ return {
                         "name": "artist",
                         "plural": false,
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "name",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
+                          (v2/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -260,20 +277,8 @@ return {
                                 "name": "cropped",
                                 "plural": false,
                                 "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "src",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "srcSet",
-                                    "storageKey": null
-                                  },
+                                  (v4/*: any*/),
+                                  (v5/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -347,7 +352,7 @@ return {
                         "name": "priceRealized",
                         "plural": false,
                         "selections": [
-                          (v1/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": "display_usd",
                             "args": null,
@@ -391,11 +396,11 @@ return {
                         "name": "estimate",
                         "plural": false,
                         "selections": [
-                          (v1/*: any*/)
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v0/*: any*/)
+                      (v3/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -405,19 +410,205 @@ return {
             ],
             "storageKey": "myCollectionAuctionResults(first:6)"
           },
-          (v0/*: any*/)
+          {
+            "alias": "medianSalePrices",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 3
+              },
+              {
+                "kind": "Literal",
+                "name": "sortByLastAuctionResultDate",
+                "value": true
+              }
+            ],
+            "concreteType": "MyCollectionConnection",
+            "kind": "LinkedField",
+            "name": "myCollectionConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "MyCollectionEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v0/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "medium",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkMedium",
+                        "kind": "LinkedField",
+                        "name": "mediumType",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artist",
+                        "plural": false,
+                        "selections": [
+                          (v0/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "href",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "slug",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "initials",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "formattedNationalityAndBirthday",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtistCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "artworks",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "forSaleArtworks",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "avatar",
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "height",
+                                    "value": 45
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 45
+                                  }
+                                ],
+                                "concreteType": "CroppedImageUrl",
+                                "kind": "LinkedField",
+                                "name": "cropped",
+                                "plural": false,
+                                "selections": [
+                                  (v4/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": "cropped(height:45,width:45)"
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkPriceInsights",
+                        "kind": "LinkedField",
+                        "name": "marketPriceInsights",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "medianSalePriceDisplayText",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "myCollectionConnection(first:3,sortByLastAuctionResultDate:true)"
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "f97b286c44a0f8e09b18fbb719b4d05f",
+    "cacheID": "667e70920aebedcde8a8c892c870ab62",
     "id": null,
     "metadata": {},
     "name": "settingsRoutes_InsightsRouteQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_InsightsRouteQuery {\n  me {\n    ...InsightsRoute_me\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    larger {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n}\n\nfragment InsightsAuctionResults_me on Me {\n  myCollectionAuctionResults(first: 6) {\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment InsightsCareerHighlightRail_me on Me {\n  myCollectionInfo {\n    artistInsightsCount {\n      BIENNIAL: biennialCount\n      COLLECTED: collectedCount\n      GROUP_SHOW: groupShowCount\n      SOLO_SHOW: soloShowCount\n      REVIEWED: reviewedCount\n    }\n  }\n}\n\nfragment InsightsOverview_info on MyCollectionInfo {\n  artworksCount\n  artistsCount\n}\n\nfragment InsightsRoute_me on Me {\n  internalID\n  myCollectionInfo {\n    artworksCount\n    ...InsightsOverview_info\n  }\n  ...InsightsAuctionResults_me\n  ...InsightsCareerHighlightRail_me\n}\n"
+    "text": "query settingsRoutes_InsightsRouteQuery {\n  me {\n    ...InsightsRoute_me\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    larger {\n      cropped(width: 100, height: 100) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment InsightsAuctionResults_me on Me {\n  myCollectionAuctionResults(first: 6) {\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment InsightsCareerHighlightRail_me on Me {\n  myCollectionInfo {\n    artistInsightsCount {\n      BIENNIAL: biennialCount\n      COLLECTED: collectedCount\n      GROUP_SHOW: groupShowCount\n      SOLO_SHOW: soloShowCount\n      REVIEWED: reviewedCount\n    }\n  }\n}\n\nfragment InsightsMedianSalePrice_me on Me {\n  medianSalePrices: myCollectionConnection(first: 3, sortByLastAuctionResultDate: true) {\n    edges {\n      node {\n        internalID\n        medium\n        mediumType {\n          name\n        }\n        title\n        artist {\n          internalID\n          ...EntityHeaderArtist_artist\n          id\n        }\n        marketPriceInsights {\n          medianSalePriceDisplayText\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment InsightsOverview_info on MyCollectionInfo {\n  artworksCount\n  artistsCount\n}\n\nfragment InsightsRoute_me on Me {\n  internalID\n  myCollectionInfo {\n    artworksCount\n    ...InsightsOverview_info\n  }\n  ...InsightsAuctionResults_me\n  ...InsightsCareerHighlightRail_me\n  ...InsightsMedianSalePrice_me\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2879]

### Description

This PR adds the Median Sale Price to My Collection insights tab. this work is hidden behind a feature flag:
`my-collection-web-phase-7-median-sale-price`

### Screenshots

| Desktop | Mobile | 
| -- | -- |
| ![image](https://user-images.githubusercontent.com/20655703/195318087-561ed9ed-4df4-4316-8770-e287df32397f.png) | ![image](https://user-images.githubusercontent.com/20655703/195318043-82d5100c-064d-4b11-87b8-25a8c91f52b6.png) |

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2879]: https://artsyproduct.atlassian.net/browse/CX-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ