### PR TITLE
fix: remove timely formatting

### DIFF
--- a/src/Apps/Auction/Components/AuctionAssociatedSale.tsx
+++ b/src/Apps/Auction/Components/AuctionAssociatedSale.tsx
@@ -1,5 +1,4 @@
 import { Column, GridColumns, Image, ResponsiveBox, Text } from "@artsy/palette"
-import { startCase } from "lodash"
 import { createFragmentContainer, graphql } from "react-relay"
 import { RouterLink } from "System/Router/RouterLink"
 import { AuctionAssociatedSale_sale$data } from "__generated__/AuctionAssociatedSale_sale.graphql"
@@ -45,9 +44,8 @@ const AuctionAssociatedSale: React.FC<AuctionAssociatedSaleProps> = ({
           </ResponsiveBox>
 
           <Text variant="sm" mt={1}>
-            {sale.associatedSale.name}
+            {sale.associatedSale.name}{" "}
           </Text>
-
           <Text variant="sm" color="black60">
             {sale.associatedSale.displayTimelyAt!}
           </Text>

--- a/src/Apps/Auction/Components/AuctionAssociatedSale.tsx
+++ b/src/Apps/Auction/Components/AuctionAssociatedSale.tsx
@@ -49,11 +49,7 @@ const AuctionAssociatedSale: React.FC<AuctionAssociatedSaleProps> = ({
           </Text>
 
           <Text variant="sm" color="black60">
-            {startCase(sale.associatedSale.displayTimelyAt!)
-              .replace("By", "by")
-              .replace(" In", " in")
-              .replace(" Am", "am")
-              .replace(" Pm", "pm")}
+            {sale.associatedSale.displayTimelyAt!}
           </Text>
         </RouterLink>
       </Column>

--- a/src/Apps/Auction/Components/__tests__/AuctionAssociatedSale.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionAssociatedSale.jest.tsx
@@ -1,6 +1,6 @@
 import { graphql } from "react-relay"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
-import { AuctionAssociatedSaleFragmentContainer } from "../AuctionAssociatedSale"
+import { AuctionAssociatedSaleFragmentContainer } from "Apps/Auction/Components/AuctionAssociatedSale"
 import { AuctionAssociatedSaleTestQuery } from "__generated__/AuctionAssociatedSaleTestQuery.graphql"
 
 jest.unmock("react-relay")
@@ -29,6 +29,6 @@ describe("AuctionAssociatedSale", () => {
 
     expect(wrapper.find("Image")).toHaveLength(1)
     expect(wrapper.text()).toContain("Sale Name")
-    expect(wrapper.text()).toContain("Starts Tomorrow")
+    expect(wrapper.text()).toContain("Starts tomorrow")
   })
 })


### PR DESCRIPTION
The type of this PR is: Fix

This PR solves [GRO-1354]

### Description

Force should not be doing its own formatting for `sale. displayTimelyAt`, as Metaphysics already does it for clients.

Related Metaphysics [deploy](https://github.com/artsy/metaphysics/pull/4444). 

[GRO-1354]: https://artsyproduct.atlassian.net/browse/GRO-1354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ