### PR TITLE
feat(FX-4361): Hide activity panel notifications without artworks

### DIFF
--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -17,6 +17,7 @@ import { SystemContext } from "System"
 import { NotificationsListScrollSentinel } from "./NotificationsListScrollSentinel"
 import { NotificationPaginationType, NotificationType } from "./types"
 import { NotificationsEmptyStateByType } from "./NotificationsEmptyStateByType"
+import { shouldDisplayNotification } from "./util"
 
 interface NotificationsListQueryRendererProps {
   type: NotificationType
@@ -38,7 +39,9 @@ const NotificationsList: React.FC<NotificationsListProps> = ({
   const [currentPaginationType, setCurrentPaginationType] = useState(
     paginationType
   )
-  const nodes = extractNodes(viewer.notifications)
+  const nodes = extractNodes(viewer.notifications).filter(node =>
+    shouldDisplayNotification(node)
+  )
 
   const handleLoadNext = () => {
     if (!relay.hasMore() || relay.isLoading()) {
@@ -133,6 +136,14 @@ export const NotificationsListFragmentContainer = createPaginationContainer(
           edges {
             node {
               internalID
+              notificationType
+              artworksConnection(first: 4) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
               ...NotificationItem_item
             }
           }

--- a/src/Components/Notifications/__tests__/util.jest.ts
+++ b/src/Components/Notifications/__tests__/util.jest.ts
@@ -1,5 +1,8 @@
 import { DateTime, Settings } from "luxon"
-import { getDateLabel } from "../util"
+import {
+  getDateLabel,
+  shouldDisplayNotification,
+} from "Components/Notifications/util"
 
 describe("getDateLabel", () => {
   it("returns 'Today' label", () => {
@@ -36,5 +39,36 @@ describe("getDateLabel", () => {
     const endOfPrevDay = DateTime.now().endOf("day").minus({ days: 1 })
     const result2 = getDateLabel(endOfPrevDay.toString())
     expect(result2).toEqual("Yesterday")
+  })
+})
+
+describe("shouldDisplayNotification", () => {
+  it("returns true when notification is not artworks based", () => {
+    const result = shouldDisplayNotification({
+      notificationType: "VIEWING_ROOM_PUBLISHED",
+    })
+    expect(result).toEqual(true)
+  })
+
+  it("returns true when notification is artworks based, but has artworks", () => {
+    const result = shouldDisplayNotification({
+      notificationType: "ARTWORK_ALERT",
+      artworksConnection: { edges: [{ node: { id: "artwork_id" } }] },
+    })
+    expect(result).toEqual(true)
+
+    const result2 = shouldDisplayNotification({
+      notificationType: "ARTWORK_PUBLISHED",
+      artworksConnection: { edges: [{ node: { id: "artwork_id" } }] },
+    })
+    expect(result2).toEqual(true)
+  })
+
+  it("returns false when notification is artworks based, and has no artworks", () => {
+    const result = shouldDisplayNotification({
+      notificationType: "ARTWORK_ALERT",
+      artworksConnection: [],
+    })
+    expect(result).toEqual(false)
   })
 })

--- a/src/Components/Notifications/util.ts
+++ b/src/Components/Notifications/util.ts
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon"
+import { extractNodes } from "Utils/extractNodes"
 
 export const getDateLabel = (timestamp: string) => {
   const date = DateTime.fromISO(timestamp)
@@ -23,4 +24,18 @@ const isToday = (date: DateTime) => {
 
 const daysAgo = (date: DateTime) => {
   return Math.floor(DateTime.now().diff(date, "days").days)
+}
+
+export const shouldDisplayNotification = notification => {
+  if (!isArtworksBasedNotification(notification)) {
+    return true
+  }
+
+  return extractNodes(notification.artworksConnection).length > 0
+}
+
+const isArtworksBasedNotification = notification => {
+  return ["ARTWORK_ALERT", "ARTWORK_PUBLISHED"].includes(
+    notification.notificationType
+  )
 }

--- a/src/__generated__/NotificationsListNextQuery.graphql.ts
+++ b/src/__generated__/NotificationsListNextQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f557d89dd58a1027881a472864a6cc2b>>
+ * @generated SignedSource<<484f188362ed5cecc48c5a6f361ff9c9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -72,14 +72,14 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "title",
+  "name": "id",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "title",
   "storageKey": null
 };
 return {
@@ -164,35 +164,6 @@ return {
                     "plural": false,
                     "selections": [
                       (v2/*: any*/),
-                      (v3/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "message",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "createdAt",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "targetHref",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isUnread",
-                        "storageKey": null
-                      },
                       {
                         "alias": null,
                         "args": null,
@@ -230,8 +201,9 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v2/*: any*/),
                                   (v3/*: any*/),
+                                  (v2/*: any*/),
+                                  (v4/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -278,8 +250,7 @@ return {
                                       }
                                     ],
                                     "storageKey": null
-                                  },
-                                  (v4/*: any*/)
+                                  }
                                 ],
                                 "storageKey": null
                               }
@@ -290,6 +261,35 @@ return {
                         "storageKey": "artworksConnection(first:4)"
                       },
                       (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "message",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "createdAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "targetHref",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isUnread",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -353,12 +353,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a465a7e6d2d548603529ad5c0bb6db94",
+    "cacheID": "1969c14ac2d757f9c8d4a2f1a000bc2c",
     "id": null,
     "metadata": {},
     "name": "NotificationsListNextQuery",
     "operationKind": "query",
-    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworksConnection(first: 4) {\n          edges {\n            node {\n              id\n            }\n          }\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListQuery.graphql.ts
+++ b/src/__generated__/NotificationsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b856388cec79d79b5238ced62d151e3a>>
+ * @generated SignedSource<<a1da80abfa9f17ad91a2dc6467920df9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -55,14 +55,14 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "title",
+  "name": "id",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "title",
   "storageKey": null
 };
 return {
@@ -137,35 +137,6 @@ return {
                     "plural": false,
                     "selections": [
                       (v2/*: any*/),
-                      (v3/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "message",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "createdAt",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "targetHref",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isUnread",
-                        "storageKey": null
-                      },
                       {
                         "alias": null,
                         "args": null,
@@ -203,8 +174,9 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v2/*: any*/),
                                   (v3/*: any*/),
+                                  (v2/*: any*/),
+                                  (v4/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -251,8 +223,7 @@ return {
                                       }
                                     ],
                                     "storageKey": null
-                                  },
-                                  (v4/*: any*/)
+                                  }
                                 ],
                                 "storageKey": null
                               }
@@ -263,6 +234,35 @@ return {
                         "storageKey": "artworksConnection(first:4)"
                       },
                       (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "message",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "createdAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "targetHref",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isUnread",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -326,12 +326,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f5eb5fe936e2e07254483530c676277f",
+    "cacheID": "9b57b22c734f3d339ef8c8daf4b508f2",
     "id": null,
     "metadata": {},
     "name": "NotificationsListQuery",
     "operationKind": "query",
-    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworksConnection(first: 4) {\n          edges {\n            node {\n              id\n            }\n          }\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsList_test_Query.graphql.ts
+++ b/src/__generated__/NotificationsList_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<61557680b410e354290c4de2e4e2367b>>
+ * @generated SignedSource<<ca63203e7757f521a15a4150a01cfb84>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -40,14 +40,14 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "title",
+  "name": "id",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "title",
   "storageKey": null
 },
 v4 = {
@@ -140,35 +140,6 @@ return {
                     "plural": false,
                     "selections": [
                       (v1/*: any*/),
-                      (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "message",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "createdAt",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "targetHref",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isUnread",
-                        "storageKey": null
-                      },
                       {
                         "alias": null,
                         "args": null,
@@ -206,8 +177,9 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v1/*: any*/),
                                   (v2/*: any*/),
+                                  (v1/*: any*/),
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -254,8 +226,7 @@ return {
                                       }
                                     ],
                                     "storageKey": null
-                                  },
-                                  (v3/*: any*/)
+                                  }
                                 ],
                                 "storageKey": null
                               }
@@ -266,6 +237,35 @@ return {
                         "storageKey": "artworksConnection(first:4)"
                       },
                       (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "message",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "createdAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "targetHref",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isUnread",
+                        "storageKey": null
+                      },
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -329,7 +329,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "26b2d88c3b941f8069136333aa887c06",
+    "cacheID": "06550027c89aa26f3d9e53184a560efd",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -423,7 +423,7 @@ return {
     },
     "name": "NotificationsList_test_Query",
     "operationKind": "query",
-    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  createdAt\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworksConnection(first: 4) {\n          edges {\n            node {\n              id\n            }\n          }\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsList_viewer.graphql.ts
+++ b/src/__generated__/NotificationsList_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<33384683602355681f1db529cd816ae8>>
+ * @generated SignedSource<<5dbd6386ea7d88e282d64494d5536ad8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,12 +9,21 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
+export type NotificationTypesEnum = "ARTWORK_ALERT" | "ARTWORK_PUBLISHED" | "VIEWING_ROOM_PUBLISHED" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type NotificationsList_viewer$data = {
   readonly notifications: {
     readonly edges: ReadonlyArray<{
       readonly node: {
+        readonly artworksConnection: {
+          readonly edges: ReadonlyArray<{
+            readonly node: {
+              readonly id: string;
+            } | null;
+          } | null> | null;
+        } | null;
         readonly internalID: string;
+        readonly notificationType: NotificationTypesEnum;
         readonly " $fragmentSpreads": FragmentRefs<"NotificationItem_item">;
       } | null;
     } | null> | null;
@@ -91,6 +100,59 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "notificationType",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "first",
+                      "value": 4
+                    }
+                  ],
+                  "concreteType": "ArtworkConnection",
+                  "kind": "LinkedField",
+                  "name": "artworksConnection",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "ArtworkEdge",
+                      "kind": "LinkedField",
+                      "name": "edges",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "Artwork",
+                          "kind": "LinkedField",
+                          "name": "node",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "id",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": "artworksConnection(first:4)"
+                },
+                {
                   "args": null,
                   "kind": "FragmentSpread",
                   "name": "NotificationItem_item"
@@ -148,6 +210,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "24853e1171ff783f11859741da1be54e";
+(node as any).hash = "878c4dca42287a5c87e972a842456733";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [FX-4361]

### Description

Currently notifications remain in feed even if all their artworks are unpublished. This PR introduce a quick fix of this problem. It is only a temporary solution, until the issue is solved on backend side.

Note that this fix breaks unread notifications counter.

Before:

![Screenshot 2022-10-13 at 11 56 07](https://user-images.githubusercontent.com/3934579/195566335-d08f5583-d016-4aa4-bbd4-bb19f75e5073.png)

After:

![Screenshot 2022-10-13 at 11 56 21](https://user-images.githubusercontent.com/3934579/195566361-48843a21-3377-4071-9a56-667e692f2adf.png)

