### PR TITLE
fix: Only show last error message in SWA photo upload form

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -12,6 +12,7 @@ import { BackLink } from "Components/Links/BackLink"
 import { PhotoThumbnail } from "Components/PhotoUpload/Components/PhotoThumbnail"
 import { normalizePhoto, Photo } from "Components/PhotoUpload/Utils/fileUtils"
 import { Form, Formik } from "formik"
+import { findLast } from "lodash"
 import { useRef, useState } from "react"
 import {
   createFragmentContainer,
@@ -254,6 +255,12 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
             refetchPhotos()
           }
 
+          const errorMessageForAutomaticallyUploadedPhotos = findLast(
+            values.photos,
+            photo => photo.errorMessage && photo.externalUrl
+            // @ts-ignore
+          )?.errorMessage
+
           return (
             <Form>
               <UploadPhotosForm
@@ -273,6 +280,16 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
                     onDelete={handlePhotoDelete}
                   />
                 ))}
+                {!!errorMessageForAutomaticallyUploadedPhotos && (
+                  <Text
+                    data-testid="photo-thumbnail-error"
+                    mt={[0.5, 2]}
+                    variant="xs"
+                    color="red100"
+                  >
+                    {errorMessageForAutomaticallyUploadedPhotos}
+                  </Text>
+                )}
               </Box>
 
               <Button

--- a/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
@@ -87,6 +87,9 @@ export const PhotoThumbnail: React.FC<
     }
   }
 
+  // Only show error messages for photos that have been uploaded by the user
+  const showErrorMessage = photo.errorMessage && !photo.externalUrl
+
   return (
     <>
       {!photo.errorMessage && (
@@ -106,7 +109,7 @@ export const PhotoThumbnail: React.FC<
           </CSSGrid>
         </Flex>
       )}
-      {!!photo.errorMessage && (
+      {!!showErrorMessage && (
         <Text
           data-testid="photo-thumbnail-error"
           mt={[0.5, 2]}

--- a/src/Components/PhotoUpload/__tests__/PhotoThumbnail.jest.tsx
+++ b/src/Components/PhotoUpload/__tests__/PhotoThumbnail.jest.tsx
@@ -88,6 +88,10 @@ describe("PhotoThumbnail", () => {
     })
   })
 
+  it("renders error message", () => {
+    expect(wrapper.text()).toContain("error")
+  })
+
   describe("loading state", () => {
     let props
 

--- a/src/Components/PhotoUpload/__tests__/PhotoThumbnail.jest.tsx
+++ b/src/Components/PhotoUpload/__tests__/PhotoThumbnail.jest.tsx
@@ -1,9 +1,9 @@
 import { Image, ProgressBar } from "@artsy/palette"
-import { mount, ReactWrapper } from "enzyme"
 import {
   PhotoThumbnail,
   PhotoThumbnailProps,
 } from "Components/PhotoUpload/Components/PhotoThumbnail"
+import { mount, ReactWrapper } from "enzyme"
 
 const deleteFn = jest.fn()
 const file = new File([new Array(10000).join(" ")], "foo.png", {
@@ -85,10 +85,6 @@ describe("PhotoThumbnail", () => {
 
     it("doesn't render image", () => {
       expect(wrapper.find(Image)).toHaveLength(0)
-    })
-
-    it("renders error message", () => {
-      expect(wrapper.text()).toContain("error")
     })
   })
 


### PR DESCRIPTION
Addresses [CX-2952]

## Description

Only show last error message in SWA photo upload form.

| Before | After |
| --- | --- |
|<img width="1767" alt="Screenshot 2022-10-13 at 15 43 09" src="https://user-images.githubusercontent.com/4691889/195613590-7c0de1f6-5c65-4ef5-8023-0ed2875a5536.png"> |<img width="1770" alt="Screenshot 2022-10-13 at 15 37 37" src="https://user-images.githubusercontent.com/4691889/195613612-6c65c4f0-ab89-4b15-aff6-4ae698cfac7b.png"> |





[CX-2952]: https://artsyproduct.atlassian.net/browse/CX-2952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ