### PR TITLE
feat(FX-4365): Change copy of Alert's tab empty state

### DIFF
--- a/src/Components/Notifications/NotificationsEmptyStateByType.tsx
+++ b/src/Components/Notifications/NotificationsEmptyStateByType.tsx
@@ -18,9 +18,9 @@ const emptyStateByType: Record<
       "Follow artists to keep track of their latest work and career highlights. Following artists helps Artsy to recommend works you might like.",
   },
   alerts: {
-    title: "You haven't created any Alerts yet.",
+    title: "Set alerts for artworks you're hunting for.",
     message:
-      "Filter for the artworks you love on an Artist Page and tap 'Create Alert' to be notified when new works are added to Artsy.",
+      'Filter for the artworks you love on an artist page and tap "Create Alert". Get notifications here when there\'s a match.',
   },
 }
 

--- a/src/Components/Notifications/__tests__/NotificationsEmptyStateByType.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationsEmptyStateByType.jest.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react"
-import { NotificationsEmptyStateByType } from "../NotificationsEmptyStateByType"
+import { NotificationsEmptyStateByType } from "Components/Notifications/NotificationsEmptyStateByType"
 
 describe("NotificationsEmptyStateByType", () => {
   it("should render correct state when type is 'All'", () => {
@@ -16,9 +16,9 @@ describe("NotificationsEmptyStateByType", () => {
   it("should render correct state when type is 'Alerts'", () => {
     render(<NotificationsEmptyStateByType type="alerts" />)
 
-    const title = "You haven't created any Alerts yet."
+    const title = "Set alerts for artworks you're hunting for."
     const message =
-      "Filter for the artworks you love on an Artist Page and tap 'Create Alert' to be notified when new works are added to Artsy."
+      'Filter for the artworks you love on an artist page and tap "Create Alert". Get notifications here when there\'s a match.'
 
     expect(screen.getByText(title)).toBeInTheDocument()
     expect(screen.getByText(message)).toBeInTheDocument()


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [FX-4365]

### Description

![Screenshot 2022-10-13 at 17 40 02](https://user-images.githubusercontent.com/3934579/195643088-9336b3d9-3e5e-467c-ad3c-4ae282c83881.png)


[FX-4365]: https://artsyproduct.atlassian.net/browse/FX-4365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ