### PR TITLE
feat: web deployment to prefer spot tier

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -92,6 +92,14 @@ spec:
                 values:
                 - foreground
                 - foreground-spot
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground-spot
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -99,6 +99,14 @@ spec:
                 values:
                 - foreground
                 - foreground-spot
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground-spot
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [PLATFORM-4614]

### Description

Follows https://github.com/artsy/force/pull/10995

Make web  deployment prefer Spot tier, to maximize Spot usage. [Dashboard](https://app.datadoghq.com/dashboard/2n5-6tr-ypp/kubernetes-deployments?tpl_var_deployment%5B0%5D=force-web&tpl_var_hpa%5B0%5D=force-web&from_ts=1665066560349&to_ts=1665671360349&live=true) shows spot/on-demand distribution.

[PLATFORM-4614]: https://artsyproduct.atlassian.net/browse/PLATFORM-4614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ