### PR TITLE
fix(home): tightens up homepage placeholders

### DIFF
--- a/src/Apps/Auctions/Components/MyBids/MyBids.tsx
+++ b/src/Apps/Auctions/Components/MyBids/MyBids.tsx
@@ -5,7 +5,6 @@ import { MyBidsBidHeaderFragmentContainer } from "./MyBidsBidHeader"
 import { MyBidsBidItemFragmentContainer } from "./MyBidsBidItem"
 import {
   Box,
-  Flex,
   Button,
   Join,
   Separator,
@@ -13,9 +12,6 @@ import {
   Spacer,
   StackableBorderBox,
   Text,
-  Skeleton,
-  SkeletonText,
-  SkeletonBox,
 } from "@artsy/palette"
 import { RouterLink } from "System/Router/RouterLink"
 import { useTracking } from "react-tracking"
@@ -133,77 +129,6 @@ export const MyBidsFragmentContainer = createFragmentContainer(MyBids, {
   `,
 })
 
-const MyBidsPlaceholder: React.FC = () => {
-  return (
-    <>
-      <Text variant="lg-display">Your Auctions and Bids</Text>
-
-      <Spacer mt={4} />
-
-      <Skeleton>
-        <Shelf alignItems="flex-start">
-          {[...new Array(3)].map((_, i) => {
-            return (
-              <React.Fragment key={i}>
-                <StackableBorderBox
-                  width={330}
-                  flexDirection="column"
-                  p={0}
-                  pb={1}
-                >
-                  <SkeletonBox width="100%" height={100} />
-
-                  <Spacer mt={1} />
-
-                  <Box px={2}>
-                    <SkeletonText variant="xs">Partner Name</SkeletonText>
-
-                    <Spacer mt={1} />
-
-                    <SkeletonText variant="lg-display">Sale Name</SkeletonText>
-
-                    <SkeletonText variant="lg-display">
-                      Starts at Mon 0
-                    </SkeletonText>
-                  </Box>
-                </StackableBorderBox>
-
-                <StackableBorderBox p={0} flexDirection="column">
-                  <Join separator={<Separator />}>
-                    <Flex py={1} px={2}>
-                      <SkeletonBox size={55} mr={1} />
-
-                      <Flex flex={1}>
-                        <Box>
-                          <SkeletonText variant="xs">Artist Name</SkeletonText>
-
-                          <SkeletonText variant="xs">Lot 0</SkeletonText>
-                        </Box>
-
-                        <Flex
-                          flex={1}
-                          flexDirection="column"
-                          alignItems="flex-end"
-                        >
-                          <SkeletonText variant="xs">
-                            $0,000 (0 bids)
-                          </SkeletonText>
-
-                          <SkeletonText variant="xs">Highest Bid</SkeletonText>
-                        </Flex>
-                      </Flex>
-                    </Flex>
-                  </Join>
-                </StackableBorderBox>
-              </React.Fragment>
-            )
-          })}
-        </Shelf>
-      </Skeleton>
-    </>
-  )
-}
-
 export const MyBidsQueryRenderer: React.FC = () => {
   const { relayEnvironment, user } = useSystemContext()
 
@@ -222,7 +147,6 @@ export const MyBidsQueryRenderer: React.FC = () => {
           }
         }
       `}
-      placeholder={<MyBidsPlaceholder />}
       render={({ error, props }) => {
         if (error) {
           console.error(error)
@@ -230,7 +154,7 @@ export const MyBidsQueryRenderer: React.FC = () => {
         }
 
         if (!props) {
-          return <MyBidsPlaceholder />
+          return null
         }
 
         if (props.me) {

--- a/src/Apps/Home/Components/HomeFeaturedMarketNews.tsx
+++ b/src/Apps/Home/Components/HomeFeaturedMarketNews.tsx
@@ -186,28 +186,34 @@ const PLACEHOLDER = (
   <Skeleton>
     <HomeFeaturedMarketNewsContainer>
       <GridColumns>
-        <Column span={6}>
+        <Column span={[12, 6]} mb={[4, 0]}>
           <Media greaterThan="xs">
-            <SkeletonBox bg="black30" width="670" height={720} mb={2} />
+            <ResponsiveBox aspectWidth={670} aspectHeight={720} maxWidth="100%">
+              <SkeletonBox width="100%" height="100%" />
+            </ResponsiveBox>
 
-            <SkeletonText variant="xs" my={1}>
+            <SkeletonText variant="xs" fontWeight="bold" mt={1}>
               Art Fairs
             </SkeletonText>
 
-            <SkeletonText variant="xl">
+            <SkeletonText variant="xl" mt={0.5}>
               Essential Tips for Collecting Work by Anni and Josef Albers
             </SkeletonText>
 
             <SkeletonText variant="lg-display" mt={1}>
               By Artsy Editorial
             </SkeletonText>
+
+            <SkeletonText variant="lg-display" mt={0.5}>
+              Jan 1, 2000
+            </SkeletonText>
           </Media>
         </Column>
 
         <Column span={[12, 6]}>
           <Masonry columnCount={2}>
-            {[...new Array(8)].map((_, i) => {
-              return <CellArticlePlaceholder key={i} />
+            {[...new Array(ARTICLE_COUNT)].map((_, i) => {
+              return <CellArticlePlaceholder key={i} mode="GRID" mb={4} />
             })}
           </Masonry>
         </Column>

--- a/src/Components/Cells/CellArticle.tsx
+++ b/src/Components/Cells/CellArticle.tsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { CellArticle_article$data } from "__generated__/CellArticle_article.graphql"
 import {
   Box,
+  BoxProps,
   Image,
   ResponsiveBox,
   SkeletonBox,
@@ -99,15 +100,16 @@ export const CellArticleFragmentContainer = createFragmentContainer(
   }
 )
 
-type CellArticlePlaceholderProps = Pick<CellArticleProps, "mode">
+type CellArticlePlaceholderProps = Pick<CellArticleProps, "mode"> & BoxProps
 
 export const CellArticlePlaceholder: FC<CellArticlePlaceholderProps> = ({
   mode = "RAIL",
+  ...rest
 }) => {
   const width = mode === "GRID" ? "100%" : DEFAULT_CELL_WIDTH
 
   return (
-    <Box width={width}>
+    <Box width={width} {...rest}>
       <ResponsiveBox aspectWidth={4} aspectHeight={3} maxWidth="100%">
         <SkeletonBox width="100%" height="100%" />
       </ResponsiveBox>


### PR DESCRIPTION
Minor thing; going around trying to improve some of the placeholders to reduce layout shift.

In a separate PR I'm going to extract some work from https://github.com/artsy/force/pull/11126 which included a bunch of placeholder improvements (— not sure when we'll get to a point where we can start breaking the image caches).