### PR TITLE
fix: Guard against undefined images in RSS feed GRO-1358

### DIFF
--- a/src/Apps/RSS/templates/article.ejs
+++ b/src/Apps/RSS/templates/article.ejs
@@ -46,7 +46,7 @@
                   <%= figure.partner.name %>
                 <% } %>
               </p>
-            <% } else { %>
+            <% } else if (figure.image) { %>
               <img
                 src="<%= figure.image.resized.src %>"
                 srcSet="<%= figure.image.resized.srcSet %>"


### PR DESCRIPTION
I'm having a hard time seeing _why_ this is happening so I'll do some more poking around but I wanted to fix this so that RSS clients aren't stuck.

https://artsyproduct.atlassian.net/browse/GRO-1358

/cc @artsy/grow-devs