### PR TITLE
fix: Adjust Price estimate page header

### DIFF
--- a/src/Apps/MyCollection/Routes/PriceEstimate/PriceEstimateConfirmation.tsx
+++ b/src/Apps/MyCollection/Routes/PriceEstimate/PriceEstimateConfirmation.tsx
@@ -1,9 +1,9 @@
-import { MetaTags } from "Components/MetaTags"
-import { ConfirmationScreenComponent } from "Components/ConfirmationScreenComponent"
-import { ArtsyLogoBlackIcon, Flex, FullBleed } from "@artsy/palette"
-import { RouterLink } from "System/Router/RouterLink"
+import { ArtsyLogoBlackIcon, Flex } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
+import { ConfirmationScreenComponent } from "Components/ConfirmationScreenComponent"
 import { BackLink } from "Components/Links/BackLink"
+import { MetaTags } from "Components/MetaTags"
+import { RouterLink } from "System/Router/RouterLink"
 import { useRouter } from "System/Router/useRouter"
 
 export const PriceEstimateConfirmation = () => {
@@ -13,18 +13,17 @@ export const PriceEstimateConfirmation = () => {
   return (
     <>
       <MetaTags title="Request a Price Estimate | Artsy" />
-      <Flex my={4}>
+
+      <Flex mt={4}>
         <RouterLink to="/my-collection" display="block">
           <ArtsyLogoBlackIcon display="block" />
         </RouterLink>
       </Flex>
 
-      <FullBleed border="1px solid" borderColor="black10" />
-
       <AppContainer>
         <BackLink
           py={2}
-          mb={4}
+          mb={6}
           width="min-content"
           to={`/my-collection/artwork/${artworkId}`}
         >

--- a/src/Apps/MyCollection/Routes/PriceEstimate/PriceEstimateContactInformation.tsx
+++ b/src/Apps/MyCollection/Routes/PriceEstimate/PriceEstimateContactInformation.tsx
@@ -3,7 +3,6 @@ import {
   ArtsyLogoBlackIcon,
   Button,
   Flex,
-  FullBleed,
   Spacer,
   Text,
   useToasts,
@@ -105,18 +104,16 @@ export const PriceEstimateContactInformation: React.FC<PriceEstimateContactInfor
     <>
       <MetaTags title="Request a Price Estimate | Artsy" />
 
-      <Flex my={4}>
+      <Flex mt={4}>
         <RouterLink to="/my-collection" display="block">
           <ArtsyLogoBlackIcon display="block" />
         </RouterLink>
       </Flex>
 
-      <FullBleed border="1px solid" borderColor="black10" />
-
       <AppContainer>
         <BackLink
           py={2}
-          mb={4}
+          mb={6}
           width="min-content"
           to={`/my-collection/artwork/${artwork.internalID}`}
         >


### PR DESCRIPTION

## Description

Adjust Price estimate page header.

| Before | After |
| --- | --- |
| <img width="1157" alt="Screenshot 2022-10-17 at 11 14 02" src="https://user-images.githubusercontent.com/4691889/196138823-cf0adf3c-e240-4511-86ef-ce259eb33b1a.png">| <img width="1246" alt="Screenshot 2022-10-17 at 11 13 31" src="https://user-images.githubusercontent.com/4691889/196138741-9f3c4077-8386-4e4f-ba72-687d6ae28ea2.png">|



