### PR TITLE
chore(FX-4367): Empty state version should have 40px padding between tabs and copy

### DIFF
--- a/src/Components/Notifications/NotificationsEmptyStateByType.tsx
+++ b/src/Components/Notifications/NotificationsEmptyStateByType.tsx
@@ -30,7 +30,7 @@ export const NotificationsEmptyStateByType: React.FC<NotificationsEmptyStateByTy
   const state = emptyStateByType[type]
 
   return (
-    <Box p={2} aria-label="There is nothing to show">
+    <Box px={2} py={4} aria-label="There is nothing to show">
       <Text variant="sm-display" textAlign="center">
         {state.title}
       </Text>


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

This PR solves [FX-4367]

### Demo
| Before | After |
| ------------- | ------------- |
| <img width="451" alt="before" src="https://user-images.githubusercontent.com/3513494/196239083-6ab65180-4732-4e6f-99d6-5ef5c1450945.png"> | <img width="451" alt="after" src="https://user-images.githubusercontent.com/3513494/196239123-6b6ac2e1-58bc-4a73-874b-1486f604ddee.png"> |

<!-- Implementation description -->


[FX-4367]: https://artsyproduct.atlassian.net/browse/FX-4367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ