### PR TITLE
fix: shelf placeholders

### DIFF
--- a/src/Apps/About/AboutArtworksRail.tsx
+++ b/src/Apps/About/AboutArtworksRail.tsx
@@ -4,14 +4,11 @@ import { AboutArtworksRailQuery } from "__generated__/AboutArtworksRailQuery.gra
 import { AboutArtworksRail_viewer$data } from "__generated__/AboutArtworksRail_viewer.graphql"
 import { Rail } from "Components/Rail"
 import { extractNodes } from "Utils/extractNodes"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
 import {
-  Box,
-  Skeleton,
-  SkeletonBox,
-  SkeletonText,
-  Spacer,
-} from "@artsy/palette"
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
+import { Skeleton } from "@artsy/palette"
 
 interface AboutArtworksRailProps {
   viewer: AboutArtworksRail_viewer$data
@@ -77,7 +74,6 @@ export const AboutArtworksRailQueryRenderer: React.FC = () => {
           return PLACEHOLDER
         }
 
-        // @ts-ignore RELAY UPGRDE 13
         return <AboutArtworksRailFragmentContainer viewer={props.viewer} />
       }}
     />
@@ -92,16 +88,7 @@ const PLACEHOLDER = (
       viewAllHref="/gene/trending-this-week"
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
-          return (
-            <Box width={200} key={i}>
-              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-              <Spacer mt={1} />
-              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-              <SkeletonText variant="xs">Partner</SkeletonText>
-              <SkeletonText variant="xs">Price</SkeletonText>
-            </Box>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
@@ -3,20 +3,17 @@ import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { useAnalyticsContext, useSystemContext } from "System"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import { extractNodes } from "Utils/extractNodes"
 import { ArtistNotableWorksRail_artist$data } from "__generated__/ArtistNotableWorksRail_artist.graphql"
 import { ArtistNotableWorksRailQuery } from "__generated__/ArtistNotableWorksRailQuery.graphql"
 import { scrollToTop } from "Apps/Artist/Routes/Overview/Utils/scrollToTop"
 import { Rail } from "Components/Rail"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import {
-  Box,
-  Skeleton,
-  SkeletonBox,
-  SkeletonText,
-  Spacer,
-} from "@artsy/palette"
+import { Box, Skeleton } from "@artsy/palette"
 
 interface ArtistNotableWorksRailProps {
   artist: ArtistNotableWorksRail_artist$data
@@ -66,7 +63,6 @@ const ArtistNotableWorksRail: React.FC<ArtistNotableWorksRailProps> = ({
               artwork={node}
               contextModule={ContextModule.topWorksRail}
               key={index}
-              showMetadata
               lazyLoad
               onClick={() => {
                 tracking.trackEvent(
@@ -119,16 +115,7 @@ const PLACEHOLDER = (
       viewAllLabel="View All Works"
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
-          return (
-            <Box width={200} key={i}>
-              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-              <Spacer mt={1} />
-              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-              <SkeletonText variant="xs">Partner</SkeletonText>
-              <SkeletonText variant="xs">Price</SkeletonText>
-            </Box>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
@@ -3,13 +3,16 @@ import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { useAnalyticsContext, useSystemContext } from "System"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import { extractNodes } from "Utils/extractNodes"
 import { ArtistWorksForSaleRail_artist$data } from "__generated__/ArtistWorksForSaleRail_artist.graphql"
 import { ArtistWorksForSaleRailQuery } from "__generated__/ArtistWorksForSaleRailQuery.graphql"
 import { scrollToTop } from "Apps/Artist/Routes/Overview/Utils/scrollToTop"
 import { Rail } from "Components/Rail"
-import { Box, Skeleton, SkeletonBox, SkeletonText } from "@artsy/palette"
+import { Box, Skeleton } from "@artsy/palette"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 
 interface ArtistWorksForSaleRailProps {
@@ -61,7 +64,6 @@ const ArtistWorksForSaleRail: React.FC<ArtistWorksForSaleRailProps> = ({
                 artwork={node}
                 contextModule={ContextModule.worksForSaleRail}
                 key={index}
-                showMetadata
                 lazyLoad
                 onClick={() => {
                   tracking.trackEvent(
@@ -115,13 +117,7 @@ const PLACEHOLDER = (
       viewAllLabel="View All Works"
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
-          return (
-            <React.Fragment key={i}>
-              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-              <SkeletonText variant="lg-display">Some Artist</SkeletonText>
-              <SkeletonText variant="sm-display">Location</SkeletonText>
-            </React.Fragment>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />

--- a/src/Apps/Artwork/Components/OtherWorks/Header.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/Header.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Text } from "@artsy/palette"
+import { Flex, SkeletonText, Text } from "@artsy/palette"
 import { RouterLink } from "System/Router/RouterLink"
 import * as React from "react"
 
@@ -8,21 +8,37 @@ interface HeaderProps {
   title: string
 }
 
-export const Header: React.FC<HeaderProps> = props => {
-  const { buttonHref, children, title } = props
-
+export const Header: React.FC<HeaderProps> = ({
+  buttonHref,
+  children,
+  title,
+}) => {
   return (
     <Flex flexDirection="row" justifyContent="space-between">
-      <Text variant="lg-display" color="black100">
-        {title}
-      </Text>
+      <Text variant="lg-display">{title}</Text>
 
       {buttonHref && (
-        <Box ml={2} flexShrink={0}>
-          <RouterLink to={buttonHref}>
-            <Text variant="sm-display">View All</Text>
-          </RouterLink>
-        </Box>
+        <RouterLink to={buttonHref} ml={2} flexShrink={0}>
+          <Text variant="sm-display">View All</Text>
+        </RouterLink>
+      )}
+
+      {children}
+    </Flex>
+  )
+}
+
+export const HeaderPlaceholder: React.FC<
+  Omit<HeaderProps, "buttonHref"> & { buttonHref?: boolean }
+> = ({ buttonHref, children, title }) => {
+  return (
+    <Flex flexDirection="row" justifyContent="space-between">
+      <SkeletonText variant="lg-display">{title}</SkeletonText>
+
+      {buttonHref && (
+        <SkeletonText ml={2} flexShrink={0} variant="sm-display">
+          View All
+        </SkeletonText>
       )}
 
       {children}

--- a/src/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
@@ -12,7 +12,6 @@ import createLogger from "Utils/logger"
 import { ContextModule } from "@artsy/cohesion"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { get } from "Utils/get"
-import { Mediator } from "Server/mediator"
 import track from "react-tracking"
 
 const logger = createLogger("RelatedWorksArtworkGrid.tsx")
@@ -22,7 +21,6 @@ const MAX_TAB_ITEMS = 3
 interface RelatedWorksArtworkGridProps {
   relay: RelayRefetchProp
   artwork: RelatedWorksArtworkGrid_artwork$data
-  mediator?: Mediator
 }
 
 interface RelatedWorksArtworkGridState {
@@ -71,7 +69,6 @@ class RelatedWorksArtworkGrid extends Component<
   render() {
     const {
       artwork: { layers, layer },
-      mediator,
     } = this.props
 
     // The layer might have failed to fetch, so we use the `get` helper
@@ -110,13 +107,14 @@ class RelatedWorksArtworkGrid extends Component<
                   {this.state.isLoading ? (
                     <Spinner /> // Should be a placeholder
                   ) : (
-                    <ArtworkGrid
-                      contextModule={ContextModule.relatedWorksRail}
-                      artworks={artworksConnection}
-                      columnCount={[2, 3, 4, 4]}
-                      mediator={mediator}
-                      onBrickClick={this.trackBrickClick.bind(this)}
-                    />
+                    artworksConnection && (
+                      <ArtworkGrid
+                        contextModule={ContextModule.relatedWorksRail}
+                        artworks={artworksConnection}
+                        columnCount={[2, 3, 4, 4]}
+                        onBrickClick={this.trackBrickClick.bind(this)}
+                      />
+                    )
                   )}
                 </ArtworksContainer>
               </Tab>

--- a/src/Apps/Artwork/Components/__tests__/OtherWorks.jest.tsx
+++ b/src/Apps/Artwork/Components/__tests__/OtherWorks.jest.tsx
@@ -1,6 +1,6 @@
 import { mount, shallow } from "enzyme"
-import { Header } from "../OtherWorks/Header"
-import { OtherWorksFragmentContainer as OtherWorks } from "../OtherWorks/index"
+import { Header } from "Apps/Artwork/Components/OtherWorks/Header"
+import { OtherWorksFragmentContainer as OtherWorks } from "Apps/Artwork/Components/OtherWorks/index"
 import { useTracking } from "react-tracking"
 
 jest.mock("react-tracking")

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/SoldRecentlyOnArtsy.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/SoldRecentlyOnArtsy.tsx
@@ -1,17 +1,11 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import {
-  Box,
-  Flex,
-  Skeleton,
-  SkeletonBox,
-  SkeletonText,
-  Spacer,
-  Text,
-} from "@artsy/palette"
+import { Flex, Skeleton, SkeletonText, Spacer, Text } from "@artsy/palette"
 import { shuffle } from "lodash"
-import { Fragment } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import { Rail } from "Components/Rail"
 import { useTracking } from "react-tracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
@@ -58,29 +52,30 @@ export const SoldRecentlyOnArtsy: React.FC<SoldRecentlyOnArtsyProps> = ({
             if (!artwork) return <></>
 
             return (
-              <Fragment key={artwork.internalID}>
-                <ShelfArtworkFragmentContainer
-                  artwork={artwork}
-                  hideSaleInfo
-                  lazyLoad
-                  width={[325]}
-                  data-testid="soldRecentlyItem"
-                  onClick={trackArtworkItemClick(artwork, i)}
-                  // FIXME:
-                  contextModule={ContextModule.artworkRecentlySoldGrid as any}
-                />
+              <ShelfArtworkFragmentContainer
+                key={artwork.internalID}
+                artwork={artwork}
+                hideSaleInfo
+                lazyLoad
+                data-testid="soldRecentlyItem"
+                onClick={trackArtworkItemClick(artwork, i)}
+                // FIXME:
+                contextModule={ContextModule.artworkRecentlySoldGrid as any}
+              >
+                <Spacer mt={4} />
 
                 <Flex
-                  mt={4}
                   flexDirection="row"
                   alignItems="center"
                   justifyContent="space-between"
                   color="black60"
                 >
-                  <Text variant="xs">Estimate</Text>
+                  <Text variant="xs" overflowEllipsis>
+                    Estimate
+                  </Text>
 
-                  <Text variant="xs">
-                    {lowEstimate?.display}—{highEstimate?.display}
+                  <Text variant="xs" overflowEllipsis>
+                    {lowEstimate?.display}–{highEstimate?.display}
                   </Text>
                 </Flex>
 
@@ -90,11 +85,15 @@ export const SoldRecentlyOnArtsy: React.FC<SoldRecentlyOnArtsyProps> = ({
                   justifyContent="space-between"
                   color="blue100"
                 >
-                  <Text variant="xs">Sold for (incl. premium)</Text>
+                  <Text variant="xs" overflowEllipsis>
+                    Sold for (incl. premium)
+                  </Text>
 
-                  <Text variant="xs">{priceRealized?.display}</Text>
+                  <Text variant="xs" overflowEllipsis>
+                    {priceRealized?.display}
+                  </Text>
                 </Flex>
-              </Fragment>
+              </ShelfArtworkFragmentContainer>
             )
           }
         )
@@ -139,11 +138,7 @@ const PLACEHOLDER = (
       getItems={() => {
         return [...new Array(20)].map((_, i) => {
           return (
-            <Box width={325} key={i}>
-              <SkeletonBox width={325} height={[200, 300, 250, 275][i % 4]} />
-              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-
+            <ShelfArtworkPlaceholder index={i} hideSaleInfo>
               <Spacer mt={4} />
 
               <Flex
@@ -151,9 +146,13 @@ const PLACEHOLDER = (
                 alignItems="center"
                 justifyContent="space-between"
               >
-                <SkeletonText variant="xs">Estimate</SkeletonText>
+                <SkeletonText variant="xs" overflowEllipsis>
+                  Estimate
+                </SkeletonText>
 
-                <SkeletonText variant="xs">USD 100,000 - 100,000</SkeletonText>
+                <SkeletonText variant="xs" overflowEllipsis>
+                  USD 100,000–100,000
+                </SkeletonText>
               </Flex>
 
               <Flex
@@ -161,13 +160,15 @@ const PLACEHOLDER = (
                 alignItems="center"
                 justifyContent="space-between"
               >
-                <SkeletonText variant="xs">
+                <SkeletonText variant="xs" overflowEllipsis>
                   Sold for (incl. premium)
                 </SkeletonText>
 
-                <SkeletonText variant="xs">USD 100,000</SkeletonText>
+                <SkeletonText variant="xs" overflowEllipsis>
+                  USD 100,000
+                </SkeletonText>
               </Flex>
-            </Box>
+            </ShelfArtworkPlaceholder>
           )
         })
       }}

--- a/src/Apps/Home/Components/HomeAuctionLotsRail.tsx
+++ b/src/Apps/Home/Components/HomeAuctionLotsRail.tsx
@@ -1,10 +1,4 @@
-import {
-  Box,
-  Spacer,
-  Skeleton,
-  SkeletonText,
-  SkeletonBox,
-} from "@artsy/palette"
+import { Skeleton } from "@artsy/palette"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "System"
@@ -12,7 +6,10 @@ import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { HomeAuctionLotsRail_viewer$data } from "__generated__/HomeAuctionLotsRail_viewer.graphql"
 import { HomeAuctionLotsRailQuery } from "__generated__/HomeAuctionLotsRailQuery.graphql"
 import { extractNodes } from "Utils/extractNodes"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import {
   ActionType,
   ClickedArtworkGroup,
@@ -89,16 +86,7 @@ const PLACEHOLDER = (
       viewAllHref="/auctions"
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
-          return (
-            <Box width={200} key={i}>
-              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-              <Spacer mt={1} />
-              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-              <SkeletonText variant="xs">Partner</SkeletonText>
-              <SkeletonText variant="xs">Price</SkeletonText>
-            </Box>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />

--- a/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
+++ b/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Shelf,
-  Skeleton,
-  SkeletonText,
-  SkeletonBox,
-  Spacer,
-} from "@artsy/palette"
+import { Shelf, Skeleton } from "@artsy/palette"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "System"
@@ -13,7 +6,10 @@ import { useTracking } from "react-tracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { HomeNewWorksForYouRail_artworksForUser$data } from "__generated__/HomeNewWorksForYouRail_artworksForUser.graphql"
 import { HomeNewWorksForYouRailQuery } from "__generated__/HomeNewWorksForYouRailQuery.graphql"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import { extractNodes } from "Utils/extractNodes"
 import {
   ActionType,
@@ -73,18 +69,7 @@ const PLACEHOLDER = (
   <Skeleton>
     <Shelf>
       {[...new Array(8)].map((_, i) => {
-        return (
-          <Box width={200} key={i}>
-            <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-
-            <Spacer mt={1} />
-
-            <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-            <SkeletonText variant="xs">Partner</SkeletonText>
-            <SkeletonText variant="xs">Price</SkeletonText>
-          </Box>
-        )
+        return <ShelfArtworkPlaceholder key={i} index={i} />
       })}
     </Shelf>
   </Skeleton>

--- a/src/Apps/Home/Components/HomeRecentlyViewedRail.tsx
+++ b/src/Apps/Home/Components/HomeRecentlyViewedRail.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Shelf,
-  Skeleton,
-  SkeletonText,
-  SkeletonBox,
-  Spacer,
-} from "@artsy/palette"
+import { Shelf, Skeleton } from "@artsy/palette"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "System"
@@ -13,7 +6,10 @@ import { useTracking } from "react-tracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { HomeRecentlyViewedRail_homePage$data } from "__generated__/HomeRecentlyViewedRail_homePage.graphql"
 import { HomeRecentlyViewedRailQuery } from "__generated__/HomeRecentlyViewedRailQuery.graphql"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import {
   ActionType,
   ClickedArtworkGroup,
@@ -72,18 +68,7 @@ const PLACEHOLDER = (
   <Skeleton>
     <Shelf>
       {[...new Array(8)].map((_, i) => {
-        return (
-          <Box width={200} key={i}>
-            <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-
-            <Spacer mt={1} />
-
-            <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-            <SkeletonText variant="xs">Partner</SkeletonText>
-            <SkeletonText variant="xs">Price</SkeletonText>
-          </Box>
-        )
+        return <ShelfArtworkPlaceholder key={i} index={i} />
       })}
     </Shelf>
   </Skeleton>

--- a/src/Apps/Home/Components/HomeTroveArtworksRail.tsx
+++ b/src/Apps/Home/Components/HomeTroveArtworksRail.tsx
@@ -4,15 +4,12 @@ import {
   ContextModule,
   OwnerType,
 } from "@artsy/cohesion"
-import {
-  Box,
-  Skeleton,
-  SkeletonBox,
-  SkeletonText,
-  Spacer,
-} from "@artsy/palette"
+import { Skeleton } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import { Rail } from "Components/Rail/Rail"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { extractNodes } from "Utils/extractNodes"
@@ -136,16 +133,7 @@ const PLACEHOLDER = (
       subTitle="A weekly curated selection of the best works on Artsy by emerging and sought after artists."
       getItems={() => {
         return [...new Array(8)].map((_, i) => {
-          return (
-            <Box width={200} key={i}>
-              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-              <Spacer mt={1} />
-              <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-              <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-              <SkeletonText variant="xs">Partner</SkeletonText>
-              <SkeletonText variant="xs">Price</SkeletonText>
-            </Box>
-          )
+          return <ShelfArtworkPlaceholder key={i} index={i} />
         })
       }}
     />

--- a/src/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
+++ b/src/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Shelf,
-  Skeleton,
-  SkeletonText,
-  SkeletonBox,
-  Spacer,
-} from "@artsy/palette"
+import { Shelf, Skeleton } from "@artsy/palette"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "System"
@@ -13,7 +6,10 @@ import { useTracking } from "react-tracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { HomeWorksByArtistsYouFollowRail_homePage$data } from "__generated__/HomeWorksByArtistsYouFollowRail_homePage.graphql"
 import { HomeWorksByArtistsYouFollowRailQuery } from "__generated__/HomeWorksByArtistsYouFollowRailQuery.graphql"
-import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
 import {
   ActionType,
   ClickedArtworkGroup,
@@ -72,18 +68,7 @@ const PLACEHOLDER = (
   <Skeleton>
     <Shelf>
       {[...new Array(8)].map((_, i) => {
-        return (
-          <Box width={200} key={i}>
-            <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-
-            <Spacer mt={1} />
-
-            <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-            <SkeletonText variant="xs">Partner</SkeletonText>
-            <SkeletonText variant="xs">Price</SkeletonText>
-          </Box>
-        )
+        return <ShelfArtworkPlaceholder key={i} index={i} />
       })}
     </Shelf>
   </Skeleton>

--- a/src/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
+++ b/src/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
@@ -13,7 +13,8 @@ export const NewForYouArtworksGrid: FC<NewForYouArtworksGridProps> = ({
 }) => {
   return (
     <>
-      {viewer.artworksForUser?.totalCount! > 0 ? (
+      {viewer.artworksForUser &&
+      (viewer.artworksForUser.totalCount ?? 0) > 0 ? (
         <ArtworkGrid artworks={viewer.artworksForUser} />
       ) : (
         <Text variant="lg" mt={4} color="black60">

--- a/src/Apps/Settings/Routes/Saves/Components/SettingsSavesArtworks.tsx
+++ b/src/Apps/Settings/Routes/Saves/Components/SettingsSavesArtworks.tsx
@@ -1,13 +1,6 @@
-import {
-  ResponsiveBox,
-  Skeleton,
-  SkeletonBox,
-  SkeletonText,
-  Spacer,
-  Sup,
-  Text,
-} from "@artsy/palette"
+import { Skeleton, SkeletonText, Spacer, Sup, Text } from "@artsy/palette"
 import { ArtworkGridItemFragmentContainer } from "Components/Artwork/GridItem"
+import { ArtworkGridPlaceholder } from "Components/ArtworkGrid"
 import { Masonry } from "Components/Masonry"
 import { PaginationFragmentContainer } from "Components/Pagination"
 import { FC, Fragment, useState } from "react"
@@ -147,30 +140,7 @@ const SETTINGS_SAVES_ARTWORKS_PLACEHOLDER = (
       Saved Artworks
     </SkeletonText>
 
-    <Masonry columnCount={[2, 3, 4]}>
-      {[...new Array(10)].map((_, i) => {
-        return (
-          <div key={i}>
-            <ResponsiveBox
-              aspectWidth={[4, 3, 5, 6][i % 4]}
-              aspectHeight={[3, 4, 5][i % 3]}
-              maxWidth="100%"
-            >
-              <SkeletonBox width="100%" height="100%" />
-            </ResponsiveBox>
-
-            <SkeletonText variant="sm-display" mt={1}>
-              Artist Name
-            </SkeletonText>
-            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-            <SkeletonText variant="xs">Partner Name</SkeletonText>
-            <SkeletonText variant="xs">US$0,000</SkeletonText>
-
-            <Spacer mt={4} />
-          </div>
-        )
-      })}
-    </Masonry>
+    <ArtworkGridPlaceholder columnCount={[2, 3, 4]} amount={10} />
   </Skeleton>
 )
 

--- a/src/Components/ArtistRail.tsx
+++ b/src/Components/ArtistRail.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment } from "react"
+import { FC } from "react"
 import {
   Box,
   Flex,
@@ -13,7 +13,10 @@ import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { extractNodes } from "Utils/extractNodes"
 import { ArtistRailQuery } from "__generated__/ArtistRailQuery.graphql"
 import { ArtistRail_artist$data } from "__generated__/ArtistRail_artist.graphql"
-import { ShelfArtworkFragmentContainer } from "./Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "./Artwork/ShelfArtwork"
 import { EntityHeaderArtistFragmentContainer } from "./EntityHeaders/EntityHeaderArtist"
 
 interface ArtistRailProps {
@@ -63,23 +66,7 @@ export const ARTIST_RAIL_PLACEHOLDER = (
 
     <Shelf>
       {[...new Array(10)].map((_, i) => {
-        return (
-          <Fragment key={i}>
-            <SkeletonBox
-              width={200}
-              height={[
-                [100, 150, 200, 250][i % 4],
-                [100, 320, 200, 250][i % 4],
-              ]}
-              mb={1}
-            />
-
-            <SkeletonText variant="sm-display">Artist Name</SkeletonText>
-            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-            <SkeletonText variant="xs">Partner</SkeletonText>
-            <SkeletonText variant="xs">US$0,000</SkeletonText>
-          </Fragment>
-        )
+        return <ShelfArtworkPlaceholder key={i} index={i} />
       })}
     </Shelf>
   </Skeleton>

--- a/src/Components/Artwork/ShelfArtwork.tsx
+++ b/src/Components/Artwork/ShelfArtwork.tsx
@@ -11,10 +11,10 @@ import { resized } from "Utils/resized"
 export interface ShelfArtworkProps
   extends Omit<RouterLinkProps, "to" | "width"> {
   artwork: ShelfArtwork_artwork$data
+  children?: React.ReactNode
   contextModule?: AuthContextModule
   hideSaleInfo?: boolean
   lazyLoad?: boolean
-  showMetadata?: boolean
   onClick?: () => void
   width?: number[]
 }
@@ -25,8 +25,8 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
   hideSaleInfo,
   lazyLoad,
   onClick,
-  showMetadata = true,
   width = [150, 175, 200],
+  children,
   ...rest
 }) => {
   const { isHovered, onMouseEnter, onMouseLeave } = useHoverMetadata()
@@ -77,17 +77,17 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
         <Box style={{ aspectRatio: "1 / 1" }} maxWidth="100%" bg="black10" />
       )}
 
-      {showMetadata && (
-        <Metadata
-          artwork={artwork}
-          hideSaleInfo={hideSaleInfo}
-          isHovered={isHovered}
-          contextModule={contextModule}
-          showSaveButton
-          disableRouterLinking
-          maxWidth="100%"
-        />
-      )}
+      <Metadata
+        artwork={artwork}
+        hideSaleInfo={hideSaleInfo}
+        isHovered={isHovered}
+        contextModule={contextModule}
+        showSaveButton
+        disableRouterLinking
+        maxWidth="100%"
+      />
+
+      {children}
     </RouterLink>
   )
 }
@@ -111,7 +111,8 @@ export const ShelfArtworkFragmentContainer = createFragmentContainer(
   }
 )
 
-interface ShelfArtworkPlaceholderProps {
+interface ShelfArtworkPlaceholderProps
+  extends Pick<ShelfArtworkProps, "hideSaleInfo" | "children"> {
   // Used to cycle through a set of placeholder heights
   index: number
   width?: number[]
@@ -120,6 +121,7 @@ interface ShelfArtworkPlaceholderProps {
 export const ShelfArtworkPlaceholder: React.FC<ShelfArtworkPlaceholderProps> = ({
   index,
   width = [150, 175, 200],
+  children,
 }) => {
   return (
     <Box
@@ -131,6 +133,8 @@ export const ShelfArtworkPlaceholder: React.FC<ShelfArtworkPlaceholderProps> = (
       <SkeletonBox width="100W%" height={[200, 300, 250, 275][index % 4]} />
 
       <MetadataPlaceholder />
+
+      {children}
     </Box>
   )
 }

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -1,5 +1,12 @@
 import { AuthContextModule, ContextModule } from "@artsy/cohesion"
-import { Column, Flex, GridColumns } from "@artsy/palette"
+import {
+  Column,
+  Flex,
+  GridColumns,
+  ResponsiveBox,
+  SkeletonBox,
+  Spacer,
+} from "@artsy/palette"
 import { ArtworkGrid_artworks$data } from "__generated__/ArtworkGrid_artworks.graphql"
 import { ArtworkGridEmptyState } from "Components/ArtworkGrid/ArtworkGridEmptyState"
 import { isEmpty, isEqual } from "lodash"
@@ -7,22 +14,22 @@ import memoizeOnce from "memoize-one"
 import { ReactNode } from "react"
 import * as React from "react"
 import ReactDOM from "react-dom"
-// @ts-ignore
-import { ComponentRef, createFragmentContainer, graphql } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { Media, valuesWithBreakpointProps } from "Utils/Responsive"
 import GridItem from "Components/Artwork/GridItem"
 import { withArtworkGridContext } from "./ArtworkGridContext"
 import { extractNodes } from "Utils/extractNodes"
 import { FlatGridItemFragmentContainer } from "Components/Artwork/FlatGridItem"
+import { Masonry, MasonryProps } from "Components/Masonry"
+import { MetadataPlaceholder } from "Components/Artwork/Metadata"
 
 // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
 type Artwork = ArtworkGrid_artworks$data["edges"][0]["node"]
 
 type SectionedArtworks = Array<Array<Artwork>>
 
-export interface ArtworkGridProps
-  extends React.HTMLProps<ArtworkGridContainer> {
+export interface ArtworkGridProps extends React.HTMLProps<HTMLDivElement> {
   artworks: ArtworkGrid_artworks$data
   contextModule?: AuthContextModule
   columnCount?: number | number[]
@@ -350,4 +357,50 @@ export function createSectionedArtworks(
   })
 
   return sectionedArtworks
+}
+
+const PLACEHOLDER_DIMENSIONS = [
+  [300, 400],
+  [300, 375],
+  [300, 200],
+  [300, 450],
+  [300, 300],
+  [300, 400],
+  [300, 380],
+  [300, 300],
+]
+
+interface ArtworkGridPlaceholderProps extends MasonryProps {
+  amount?: number
+}
+
+export const ArtworkGridPlaceholder: React.FC<ArtworkGridPlaceholderProps> = ({
+  amount = 8,
+  ...rest
+}) => {
+  return (
+    <Masonry {...rest}>
+      {[...new Array(amount)].map((_, i) => {
+        const [width, height] = PLACEHOLDER_DIMENSIONS[
+          i % PLACEHOLDER_DIMENSIONS.length
+        ]
+
+        return (
+          <div key={i}>
+            <ResponsiveBox
+              aspectWidth={width}
+              aspectHeight={height}
+              maxWidth="100%"
+            >
+              <SkeletonBox width="100%" height="100%" />
+            </ResponsiveBox>
+
+            <MetadataPlaceholder />
+
+            <Spacer mt={4} />
+          </div>
+        )
+      })}
+    </Masonry>
+  )
 }

--- a/src/Components/ArtworkGrid/ArtworkGridContext.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGridContext.tsx
@@ -34,8 +34,10 @@ export const useArtworkGridContext = () => {
   return artworkGridContext
 }
 
-export const withArtworkGridContext = Component => {
-  return props => {
+export const withArtworkGridContext = <T,>(
+  Component: React.ComponentType<T>
+) => {
+  return (props: T) => {
     return (
       <ArtworkGridContext.Consumer>
         {contextValues => {

--- a/src/Components/CategoryRail.tsx
+++ b/src/Components/CategoryRail.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment } from "react"
+import { FC } from "react"
 import {
   Box,
   Flex,
@@ -13,7 +13,10 @@ import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { extractNodes } from "Utils/extractNodes"
 import { CategoryRailQuery } from "__generated__/CategoryRailQuery.graphql"
 import { CategoryRail_category$data } from "__generated__/CategoryRail_category.graphql"
-import { ShelfArtworkFragmentContainer } from "./Artwork/ShelfArtwork"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "./Artwork/ShelfArtwork"
 import { EntityHeaderGeneFragmentContainer } from "./EntityHeaders/EntityHeaderGene"
 
 interface CategoryRailProps {
@@ -62,23 +65,7 @@ export const CATEGORY_RAIL_PLACEHOLDER = (
 
     <Shelf>
       {[...new Array(10)].map((_, i) => {
-        return (
-          <Fragment key={i}>
-            <SkeletonBox
-              width={200}
-              height={[
-                [100, 150, 200, 250][i % 4],
-                [100, 320, 200, 250][i % 4],
-              ]}
-              mb={1}
-            />
-
-            <SkeletonText variant="sm-display">Category Name</SkeletonText>
-            <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
-            <SkeletonText variant="xs">Partner</SkeletonText>
-            <SkeletonText variant="xs">US$0,000</SkeletonText>
-          </Fragment>
-        )
+        return <ShelfArtworkPlaceholder key={i} index={i} />
       })}
     </Shelf>
   </Skeleton>

--- a/src/Components/Masonry.tsx
+++ b/src/Components/Masonry.tsx
@@ -12,9 +12,11 @@ const columnCount = style({
   cssProperty: "columnCount",
 })
 
-export const Masonry = styled(Box)<
-  { columnCount?: number[] | number } & GridColumnGapProps
->`
+export interface MasonryProps extends GridColumnGapProps {
+  columnCount?: number[] | number
+}
+
+export const Masonry = styled(Box)<MasonryProps>`
   ${compose(columnCount, gridColumnGap)};
 
   * {


### PR DESCRIPTION
Closes [GRO-1351](https://artsyproduct.atlassian.net/browse/GRO-1351)

This ensures we're using consistent placeholders for the artwork rails; adds a placeholder for the grids and uses it.

Ultimately this doesn't have a huge effect on layout shift for two reasons:

* We need to set a specific height for rails (which I do in the area based scaling PR)
* In a few places we don't know what modules we're actually loading, notably the artwork page might have up to 4 grids on it.

That said, this does get us closer, reduces the amount of duplicate work when building new rails and grids, looks better.