### PR TITLE
fix(TX-828): Postal code validation in shipping step address form

### DIFF
--- a/src/Apps/Order/Components/__tests__/CreditCardPicker.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/CreditCardPicker.jest.tsx
@@ -19,7 +19,7 @@ import { graphql } from "react-relay"
 import {
   CreditCardPicker,
   CreditCardPickerFragmentContainer,
-} from "../CreditCardPicker"
+} from "Apps/Order/Components/CreditCardPicker"
 import type { Token, StripeError } from "@stripe/stripe-js"
 import { mockStripe } from "DevTools/mockStripe"
 import { MockBoot } from "DevTools"
@@ -276,13 +276,13 @@ describe("CreditCardPickerFragmentContainer", () => {
     await page.getCreditCardId()
 
     expect(_mockStripe().createToken).toHaveBeenLastCalledWith(null, {
-      name: "Artsy UK Ltd",
-      address_line1: "14 Gower's Walk",
-      address_line2: "Suite 2.5, The Loom",
-      address_city: "Whitechapel",
-      address_state: "London",
-      address_zip: "E1 8PY",
-      address_country: "UK",
+      name: "Erik David",
+      address_line1: "401 Broadway",
+      address_line2: "",
+      address_city: "New York",
+      address_state: "NY",
+      address_zip: "15601",
+      address_country: "US",
     })
   })
 
@@ -317,13 +317,13 @@ describe("CreditCardPickerFragmentContainer", () => {
     await page.getCreditCardId()
 
     expect(_mockStripe().createToken).toHaveBeenLastCalledWith(null, {
-      name: "Artsy UK Ltd",
-      address_line1: "14 Gower's Walk",
-      address_line2: "Suite 2.5, The Loom",
-      address_city: "Whitechapel",
-      address_state: "London",
-      address_zip: "E1 8PY",
-      address_country: "UK",
+      name: "Erik David",
+      address_line1: "401 Broadway",
+      address_line2: "",
+      address_city: "New York",
+      address_state: "NY",
+      address_zip: "15601",
+      address_country: "US",
     })
   })
 

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -1456,8 +1456,14 @@ describe("Shipping", () => {
               .simulate("click")
             const inputs = page.find("AddressModal").find("input")
             inputs.forEach(input => {
-              // @ts-ignore
-              input.instance().value = `Test input '${input.props().name}'`
+              if (input.props().name === "postalCode") {
+                // @ts-ignore
+                input.instance().value = `15601`
+              } else {
+                // @ts-ignore
+                input.instance().value = `Test input '${input.props().name}'`
+              }
+
               input.simulate("change")
             })
             const countrySelect = page
@@ -1475,7 +1481,7 @@ describe("Shipping", () => {
               city: "Test input 'city'",
               country: "US",
               name: "Test input 'name'",
-              postalCode: "Test input 'postalCode'",
+              postalCode: "15601",
               region: "Test input 'region'",
             }
 
@@ -1557,8 +1563,13 @@ describe("Shipping", () => {
               .simulate("click")
             const inputs = page.find("AddressModal").find("input")
             inputs.forEach(input => {
-              // @ts-ignore
-              input.instance().value = `Test input '${input.props().name}'`
+              if (input.props().name === "postalCode") {
+                // @ts-ignore
+                input.instance().value = `15601`
+              } else {
+                // @ts-ignore
+                input.instance().value = `Test input '${input.props().name}'`
+              }
               input.simulate("change")
             })
             const countrySelect = page
@@ -1587,7 +1598,7 @@ describe("Shipping", () => {
                 country: "US",
                 name: "Test input 'name'",
                 phoneNumber: "555-555-5555",
-                postalCode: "Test input 'postalCode'",
+                postalCode: "15601",
                 region: "Test input 'region'",
               },
               expect.anything(),
@@ -1660,8 +1671,13 @@ describe("Shipping", () => {
           .simulate("click")
         const inputs = page.find("AddressModal").find("input")
         inputs.forEach(input => {
-          // @ts-ignore
-          input.instance().value = `Test input '${input.props().name}'`
+          if (input.props().name === "postalCode") {
+            // @ts-ignore
+            input.instance().value = `15601`
+          } else {
+            // @ts-ignore
+            input.instance().value = `Test input '${input.props().name}'`
+          }
           input.simulate("change")
         })
         const countrySelect = page.find("AddressModal").find("select").first()
@@ -1685,7 +1701,7 @@ describe("Shipping", () => {
             country: "US",
             name: "Test input 'name'",
             phoneNumber: "555-555-5555",
-            postalCode: "Test input 'postalCode'",
+            postalCode: "15601",
             region: "Test input 'region'",
           },
           expect.anything(),

--- a/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
+++ b/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
@@ -12,6 +12,9 @@ describe("formValidators/validatePostalCode", () => {
   it("returns no error when postal code is valid for US", () => {
     expect(validatePostalCode("15601", "US")).toBe(null)
   })
+  it("returns no error when a 9-digit postal code is valid for US", () => {
+    expect(validatePostalCode("88310-7241", "US")).toBe(null)
+  })
   it("returns no error when postal code is valid for CA", () => {
     expect(validatePostalCode("M3J3N3", "CA")).toBe(null)
   })

--- a/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
+++ b/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
@@ -7,7 +7,7 @@ import {
 
 describe("formValidators/validatePostalCode", () => {
   it("returns error when postal code is invalid for US", () => {
-    expect(validatePostalCode("XX", "US")).toBe("This field is required")
+    expect(validatePostalCode("XX", "US")).toBe("Postal code is invalid")
   })
   it("returns no error when postal code is valid for US", () => {
     expect(validatePostalCode("15601", "US")).toBe(null)
@@ -19,7 +19,7 @@ describe("formValidators/validatePostalCode", () => {
     expect(validatePostalCode("M3J3N3", "CA")).toBe(null)
   })
   it("returns error when postal code is invalid for CA", () => {
-    expect(validatePostalCode("YY", "CA")).toBe("This field is required")
+    expect(validatePostalCode("YY", "CA")).toBe("Postal code is invalid")
   })
 })
 
@@ -206,7 +206,7 @@ describe("formValidators/validateAddress", () => {
       const result = validateAddress(address)
 
       expect(result.hasErrors).toEqual(true)
-      expect(result.errors.postalCode).toEqual("This field is required")
+      expect(result.errors.postalCode).toEqual("Postal code is invalid")
     })
 
     it("returns no error for a valid postalCode for US", () => {
@@ -240,7 +240,7 @@ describe("formValidators/validateAddress", () => {
       const result = validateAddress(address)
 
       expect(result.hasErrors).toEqual(true)
-      expect(result.errors.postalCode).toEqual("This field is required")
+      expect(result.errors.postalCode).toEqual("Postal code is invalid")
     })
 
     it("returns no error for a valid postalCode for Canada", () => {

--- a/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
+++ b/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
@@ -1,5 +1,27 @@
 import { Address } from "Components/AddressForm"
-import { validateAddress, validatePresence } from "../formValidators"
+import {
+  validateAddress,
+  validatePresence,
+  validatePostalCode,
+} from "Apps/Order/Utils/formValidators"
+
+describe("formValidators/validatePostalCode", () => {
+  it("returns error when postal code is invalid for US", () => {
+    expect(validatePostalCode("XX", "US")).toBe("This field is required")
+  })
+  it("returns no error when postal code is valid for US", () => {
+    expect(validatePostalCode("15601", "US")).toBe(null)
+  })
+  it("returns error when postal code is invalid for CA", () => {
+    expect(validatePostalCode("M3J3N3", "CA")).toBe(null)
+  })
+  it("returns no error when postal code is valid for CA", () => {
+    expect(validatePostalCode("YY", "CA")).toBe("This field is required")
+  })
+  it("returns no error when postal code is outside of US and CA", () => {
+    expect(validatePostalCode("ZZ", "UK")).toBe(null)
+  })
+})
 
 describe("formValidators/validatePresence", () => {
   it("returns error when field is null", () => {
@@ -165,20 +187,20 @@ describe("formValidators/validateAddress", () => {
   })
 
   describe("postalCode", () => {
-    it("returns no error for an undefined postalCode if it's not US/CA", () => {
+    it("returns no error for a postalCode outside of US and CA", () => {
       const address: Address = buildAddress()
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      address.postalCode = undefined
+      address.postalCode = "zz"
+      address.country = "DE"
 
       const result = validateAddress(address)
 
       expect(result.hasErrors).toEqual(false)
     })
 
-    it("returns an error for an undefined postalCode if it's US", () => {
+    it("returns an error for an invalid postalCode for US", () => {
       const address: Address = buildAddress()
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      address.postalCode = undefined
+
+      address.postalCode = "xx"
       address.country = "US"
 
       const result = validateAddress(address)
@@ -187,7 +209,41 @@ describe("formValidators/validateAddress", () => {
       expect(result.errors.postalCode).toEqual("This field is required")
     })
 
-    it("returns an error for a whitespace postalCode if it's US", () => {
+    it("returns no error for a valid postalCode for US", () => {
+      const address: Address = buildAddress()
+
+      address.postalCode = "15601"
+      address.country = "US"
+
+      const result = validateAddress(address)
+
+      expect(result.hasErrors).toEqual(false)
+    })
+
+    it("returns an error for an invalid postalCode for Canada", () => {
+      const address: Address = buildAddress()
+
+      address.postalCode = "yy"
+      address.country = "CA"
+
+      const result = validateAddress(address)
+
+      expect(result.hasErrors).toEqual(true)
+      expect(result.errors.postalCode).toEqual("This field is required")
+    })
+
+    it("returns no error for a valid postalCode for Canada", () => {
+      const address: Address = buildAddress()
+
+      address.postalCode = "M3J3N3"
+      address.country = "CA"
+
+      const result = validateAddress(address)
+
+      expect(result.hasErrors).toEqual(false)
+    })
+
+    it("returns an error for a whitespace postalCode", () => {
       const address: Address = buildAddress()
       address.postalCode = "   \t"
       address.country = "US"

--- a/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
+++ b/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
@@ -12,10 +12,10 @@ describe("formValidators/validatePostalCode", () => {
   it("returns no error when postal code is valid for US", () => {
     expect(validatePostalCode("15601", "US")).toBe(null)
   })
-  it("returns error when postal code is invalid for CA", () => {
+  it("returns no error when postal code is valid for CA", () => {
     expect(validatePostalCode("M3J3N3", "CA")).toBe(null)
   })
-  it("returns no error when postal code is valid for CA", () => {
+  it("returns error when postal code is invalid for CA", () => {
     expect(validatePostalCode("YY", "CA")).toBe("This field is required")
   })
 })
@@ -210,6 +210,17 @@ describe("formValidators/validateAddress", () => {
       const address: Address = buildAddress()
 
       address.postalCode = "15601"
+      address.country = "US"
+
+      const result = validateAddress(address)
+
+      expect(result.hasErrors).toEqual(false)
+    })
+
+    it("returns no error for a valid 9-digit postalCode for US", () => {
+      const address: Address = buildAddress()
+
+      address.postalCode = "88310-7241"
       address.country = "US"
 
       const result = validateAddress(address)

--- a/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
+++ b/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
@@ -18,9 +18,6 @@ describe("formValidators/validatePostalCode", () => {
   it("returns no error when postal code is valid for CA", () => {
     expect(validatePostalCode("YY", "CA")).toBe("This field is required")
   })
-  it("returns no error when postal code is outside of US and CA", () => {
-    expect(validatePostalCode("ZZ", "UK")).toBe(null)
-  })
 })
 
 describe("formValidators/validatePresence", () => {

--- a/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
+++ b/src/Apps/Order/Utils/__tests__/formValidators.jest.tsx
@@ -7,7 +7,9 @@ import {
 
 describe("formValidators/validatePostalCode", () => {
   it("returns error when postal code is invalid for US", () => {
-    expect(validatePostalCode("XX", "US")).toBe("Postal code is invalid")
+    expect(validatePostalCode("XX", "US")).toBe(
+      "Please enter a valid zip/postal code for your region"
+    )
   })
   it("returns no error when postal code is valid for US", () => {
     expect(validatePostalCode("15601", "US")).toBe(null)
@@ -19,7 +21,9 @@ describe("formValidators/validatePostalCode", () => {
     expect(validatePostalCode("M3J3N3", "CA")).toBe(null)
   })
   it("returns error when postal code is invalid for CA", () => {
-    expect(validatePostalCode("YY", "CA")).toBe("Postal code is invalid")
+    expect(validatePostalCode("YY", "CA")).toBe(
+      "Please enter a valid zip/postal code for your region"
+    )
   })
 })
 
@@ -206,7 +210,9 @@ describe("formValidators/validateAddress", () => {
       const result = validateAddress(address)
 
       expect(result.hasErrors).toEqual(true)
-      expect(result.errors.postalCode).toEqual("Postal code is invalid")
+      expect(result.errors.postalCode).toEqual(
+        "Please enter a valid zip/postal code for your region"
+      )
     })
 
     it("returns no error for a valid postalCode for US", () => {
@@ -240,7 +246,9 @@ describe("formValidators/validateAddress", () => {
       const result = validateAddress(address)
 
       expect(result.hasErrors).toEqual(true)
-      expect(result.errors.postalCode).toEqual("Postal code is invalid")
+      expect(result.errors.postalCode).toEqual(
+        "Please enter a valid zip/postal code for your region"
+      )
     })
 
     it("returns no error for a valid postalCode for Canada", () => {

--- a/src/Apps/Order/Utils/formValidators.tsx
+++ b/src/Apps/Order/Utils/formValidators.tsx
@@ -14,7 +14,9 @@ export const validatePostalCode = (postalCode: string, countryCode: string) => {
       ? /^([0-9]{5})(?:[-\s]*([0-9]{4}))?$/
       : /^([A-Z][0-9][A-Z])\s*([0-9][A-Z][0-9])$/
 
-  return postalCodeRegex.test(postalCode) ? null : "Postal code is invalid"
+  return postalCodeRegex.test(postalCode)
+    ? null
+    : "Please enter a valid zip/postal code for your region"
 }
 
 export const validateAddress = (address: Address) => {

--- a/src/Apps/Order/Utils/formValidators.tsx
+++ b/src/Apps/Order/Utils/formValidators.tsx
@@ -9,18 +9,10 @@ export const validatePresence = (value: string): string | null => {
 }
 
 export const validatePostalCode = (postalCode: string, countryCode: string) => {
-  let postalCodeRegex: RegExp
-
-  switch (countryCode) {
-    case "US":
-      postalCodeRegex = /^([0-9]{5})(?:[-\s]*([0-9]{4}))?$/
-      break
-    case "CA":
-      postalCodeRegex = /^([A-Z][0-9][A-Z])\s*([0-9][A-Z][0-9])$/
-      break
-    default:
-      postalCodeRegex = /[^\n]+/
-  }
+  let postalCodeRegex: RegExp =
+    countryCode === "US"
+      ? /^([0-9]{5})(?:[-\s]*([0-9]{4}))?$/
+      : /^([A-Z][0-9][A-Z])\s*([0-9][A-Z][0-9])$/
 
   return postalCodeRegex.test(postalCode) ? null : "This field is required"
 }
@@ -34,7 +26,7 @@ export const validateAddress = (address: Address) => {
     city: validatePresence(city),
     region: usOrCanada && validatePresence(region),
     country: validatePresence(country),
-    postalCode: validatePostalCode(postalCode, country),
+    postalCode: usOrCanada && validatePostalCode(postalCode, country),
   }
   const hasErrors = Object.keys(errors).filter(key => errors[key]).length > 0
 

--- a/src/Apps/Order/Utils/formValidators.tsx
+++ b/src/Apps/Order/Utils/formValidators.tsx
@@ -22,7 +22,7 @@ export const validateAddress = (address: Address) => {
   const usOrCanada = country === "US" || country === "CA"
 
   let postalCodeValidationResult: string | null = null
-  // check presence and check corretness if present
+  // check presence and check correctness if present
   if (usOrCanada) {
     postalCodeValidationResult = validatePresence(postalCode)
 

--- a/src/Apps/Order/Utils/formValidators.tsx
+++ b/src/Apps/Order/Utils/formValidators.tsx
@@ -8,6 +8,23 @@ export const validatePresence = (value: string): string | null => {
   return null
 }
 
+export const validatePostalCode = (postalCode: string, countryCode: string) => {
+  let postalCodeRegex: RegExp
+
+  switch (countryCode) {
+    case "US":
+      postalCodeRegex = /^([0-9]{5})(?:[-\s]*([0-9]{4}))?$/
+      break
+    case "CA":
+      postalCodeRegex = /^([A-Z][0-9][A-Z])\s*([0-9][A-Z][0-9])$/
+      break
+    default:
+      postalCodeRegex = /[^\n]+/
+  }
+
+  return postalCodeRegex.test(postalCode) ? null : "This field is required"
+}
+
 export const validateAddress = (address: Address) => {
   const { name, addressLine1, city, region, country, postalCode } = address
   const usOrCanada = country === "US" || country === "CA"
@@ -17,7 +34,7 @@ export const validateAddress = (address: Address) => {
     city: validatePresence(city),
     region: usOrCanada && validatePresence(region),
     country: validatePresence(country),
-    postalCode: usOrCanada && validatePresence(postalCode),
+    postalCode: validatePostalCode(postalCode, country),
   }
   const hasErrors = Object.keys(errors).filter(key => errors[key]).length > 0
 

--- a/src/Apps/Order/Utils/formValidators.tsx
+++ b/src/Apps/Order/Utils/formValidators.tsx
@@ -14,19 +14,30 @@ export const validatePostalCode = (postalCode: string, countryCode: string) => {
       ? /^([0-9]{5})(?:[-\s]*([0-9]{4}))?$/
       : /^([A-Z][0-9][A-Z])\s*([0-9][A-Z][0-9])$/
 
-  return postalCodeRegex.test(postalCode) ? null : "This field is required"
+  return postalCodeRegex.test(postalCode) ? null : "Postal code is invalid"
 }
 
 export const validateAddress = (address: Address) => {
   const { name, addressLine1, city, region, country, postalCode } = address
   const usOrCanada = country === "US" || country === "CA"
+
+  let postalCodeValidationResult: string | null = null
+  // check presence and check corretness if present
+  if (usOrCanada) {
+    postalCodeValidationResult = validatePresence(postalCode)
+
+    if (postalCodeValidationResult === null) {
+      postalCodeValidationResult = validatePostalCode(postalCode, country)
+    }
+  }
+
   const errors = {
     name: validatePresence(name),
     addressLine1: validatePresence(addressLine1),
     city: validatePresence(city),
     region: usOrCanada && validatePresence(region),
     country: validatePresence(country),
-    postalCode: usOrCanada && validatePostalCode(postalCode, country),
+    postalCode: postalCodeValidationResult,
   }
   const hasErrors = Object.keys(errors).filter(key => errors[key]).length > 0
 

--- a/src/Components/__tests__/Utils/addressForm.ts
+++ b/src/Components/__tests__/Utils/addressForm.ts
@@ -3,14 +3,14 @@ import { CountrySelect } from "Components/CountrySelect"
 import { Input } from "@artsy/palette"
 
 export const validAddress: Address = {
-  name: "Artsy UK Ltd",
-  addressLine1: "14 Gower's Walk",
-  addressLine2: "Suite 2.5, The Loom",
-  city: "Whitechapel",
-  region: "London",
-  postalCode: "E1 8PY",
-  country: "UK",
-  phoneNumber: "8475937743",
+  name: "Erik David",
+  addressLine1: "401 Broadway",
+  addressLine2: "",
+  city: "New York",
+  region: "NY",
+  postalCode: "15601",
+  phoneNumber: "5555937743",
+  country: "US",
 }
 
 export const fillIn = (


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [TX-828]

### Description
Currently the address validation util used for the address form in the shipping step of the checkout flow does not capture wrong postal code submissions by the user. As a result of that, we go ahead and make a request to our API to set the (invalid) address on the order, which results in an error as illustrated below: 

<img width="1771" alt="Screenshot 2022-10-18 at 14 37 01" src="https://user-images.githubusercontent.com/42584148/196442993-d5f0fcf0-b067-4210-87b2-fe063da45e84.png">

This PR adds a validator function for postal code for addresses in the US and CA, so that: 
- user is informed about the wrong information they submitted 
- we avoid trying to set an invalid address on the order


[TX-828]: https://artsyproduct.atlassian.net/browse/TX-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ