### PR TITLE
fix: my collection UI updates

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx",
         "hashed_secret": "dc312ec7ed341804d6911ecdcf18eea1858f6091",
         "is_verified": false,
-        "line_number": 523
+        "line_number": 544
       }
     ],
     "src/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx": [
@@ -1338,5 +1338,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-06T20:29:46Z"
+  "generated_at": "2022-10-18T14:27:31Z"
 }

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionArtworkForm.tsx
@@ -313,7 +313,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                                       photo => photo.loading
                                     ).length > 0
                                   }
-                                  disabled={!isValid}
+                                  disabled={!isValid || !dirty}
                                 >
                                   {isEditing
                                     ? "Save Changes"
@@ -387,7 +387,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
                         values.newPhotos.filter(photo => photo.loading).length >
                           0
                       }
-                      disabled={!isValid}
+                      disabled={!isValid || !dirty}
                     >
                       {isEditing ? "Save Changes" : "Upload Artwork"}
                     </Button>

--- a/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionArtworkForm.jest.tsx
@@ -95,7 +95,7 @@ describe("Edit artwork", () => {
       getWrapper().renderWithRelay({ Artwork: () => mockArtwork })
 
       expect(screen.getByText("Save Changes")).toBeInTheDocument()
-      expect(screen.getByTestId("save-button")).toBeEnabled()
+      expect(screen.getByTestId("save-button")).toBeDisabled()
 
       expect(screen.getByText("Edit Artwork Details")).toBeInTheDocument()
 
@@ -187,10 +187,24 @@ describe("Edit artwork", () => {
   })
 
   describe("With valid values", () => {
-    it("enables save button", () => {
+    it("keeps save button disabled if form is not dirty", () => {
       getWrapper().renderWithRelay({
         Artwork: () => mockArtwork,
       })
+
+      expect(screen.getByTestId("save-button")).toBeDisabled()
+    })
+
+    it("enables save button if form is dirty", () => {
+      getWrapper().renderWithRelay({
+        Artwork: () => mockArtwork,
+      })
+      fireEvent.change(
+        screen.getByTestId("my-collection-artwork-details-title"),
+        {
+          target: { value: "Some new value" },
+        }
+      )
       expect(screen.getByTestId("save-button")).toBeEnabled()
     })
   })
@@ -208,10 +222,17 @@ describe("Edit artwork", () => {
   })
 
   describe("Form submit", () => {
-    it("saves the artwork and navigates to artwork detail page", async () => {
+    it("saves the artwork and navigates to artwork detail page if changes have been made", async () => {
       getWrapper().renderWithRelay({
         Artwork: () => mockArtwork,
       })
+
+      fireEvent.change(
+        screen.getByTestId("my-collection-artwork-details-title"),
+        {
+          target: { value: "Some new value" },
+        }
+      )
 
       fireEvent.click(screen.getByText("Save Changes"))
 
@@ -238,7 +259,7 @@ describe("Edit artwork", () => {
               pricePaidCents: 400000,
               pricePaidCurrency: "EUR",
               provenance: "Fooo",
-              title: "Untitled",
+              title: "Some new value",
               width: "11",
             },
           },

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
@@ -112,8 +112,8 @@ const InsightColumn = ({ name, value }: { name: string; value: string }) => {
   return (
     <Column span={[6, 4, 2]}>
       <Flex flexDirection={"column"} justifyContent="flex-start">
-        <Text variant={["xs", "sm-display", "sm-display"]}>{name}</Text>
-        <Text variant={["lg", "xl", "xl"]}>{value}</Text>
+        <Text variant={["xs", "sm-display"]}>{name}</Text>
+        <Text variant={["lg", "xl"]}>{value}</Text>
       </Flex>
     </Column>
   )

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
@@ -112,7 +112,7 @@ const InsightColumn = ({ name, value }: { name: string; value: string }) => {
   return (
     <Column span={[6, 4, 2]}>
       <Flex flexDirection={"column"} justifyContent="flex-start">
-        <Text variant={["xs", "md", "md"]}>{name}</Text>
+        <Text variant={["xs", "sm-display", "sm-display"]}>{name}</Text>
         <Text variant={["lg", "xl", "xl"]}>{value}</Text>
       </Flex>
     </Column>

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkArtistMarket.tsx
@@ -35,9 +35,9 @@ export const MyCollectionArtworkArtistMarket = ({
   return (
     <>
       <Media greaterThanOrEqual="sm">
-        <Text variant="lg">Artist Market</Text>
+        <Text variant="md">Artist Market</Text>
 
-        <Text variant="md" color="black60">
+        <Text variant="sm-display" color="black60">
           Based on the last 36 months of auction sale data from top commercial
           auction houses.
         </Text>

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkAuctionResults.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkAuctionResults.tsx
@@ -31,7 +31,7 @@ const MyCollectionAuctionResultsContainer: React.FC<MyCollectionArtworkAuctionRe
         alignItems="center"
         mb={2}
       >
-        <Text variant={["sm-display", "lg"]} textAlign="left">
+        <Text variant={["sm-display", "md"]} textAlign="left">
           Auction Results
         </Text>
         <RouterLink

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkComparables.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkComparables.tsx
@@ -27,7 +27,7 @@ const MyCollectionArtworkComparables: React.FC<MyCollectionArtworkComparablesPro
     <>
       <MetaTags title={titleString} />
 
-      <Text variant={["sm-display", "lg"]} textAlign="left">
+      <Text variant={["sm-display", "md"]} textAlign="left">
         Comparable Works
       </Text>
 

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkDemandIndex/index.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkDemandIndex/index.tsx
@@ -66,7 +66,7 @@ const MyCollectionArtworkDemandIndex: React.FC<MyCollectionArtworkDemandIndexPro
 
       <Spacer m={2} />
 
-      <Text variant={["xl", "xxl"]} color={demandRankColor}>
+      <Text variant={"xl"} color={demandRankColor}>
         {adjustedDemandRank}
       </Text>
       <Flex flexDirection="row" alignItems="center">
@@ -76,7 +76,7 @@ const MyCollectionArtworkDemandIndex: React.FC<MyCollectionArtworkDemandIndexPro
           </Flex>
         )}
 
-        <Text variant={["md", "lg"]} color={demandRankColor}>
+        <Text variant={"md"} color={demandRankColor}>
           {marketPriceInsights.demandRankDisplayText}
         </Text>
       </Flex>

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkDemandIndex/index.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkDemandIndex/index.tsx
@@ -39,9 +39,11 @@ const MyCollectionArtworkDemandIndex: React.FC<MyCollectionArtworkDemandIndexPro
   return (
     <>
       <Media greaterThanOrEqual="sm">
-        <Text variant="lg">Demand Index</Text>
+        <Text variant="md" mt={4}>
+          Demand Index
+        </Text>
 
-        <Text variant="md" color="black60">
+        <Text variant="sm-display" color="black60">
           {DemandIndexExplanation}
         </Text>
       </Media>

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarMetadata.tsx
@@ -76,7 +76,9 @@ const MetadataField = ({ label, value }) => {
       </Text>
 
       <Box display="flex" flex={1} flexDirection="column">
-        <WrappedText variant="sm">{value || emptyValue}</WrappedText>
+        <WrappedText variant="sm" color={value ? "black100" : "black60"}>
+          {value || emptyValue}
+        </WrappedText>
       </Box>
     </Box>
   )


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3065]

### Description
Checklist: 

1. Save changes - disable the button if no changes are made on the form
2. Demand Index - make padding 40
3. Titles in Insights - make title 20, subtitle (if exists) 13 (sm-display)
4. Demand Index - make number 40 (xl) and text 20 (medium)
5. Market insights - make the titles small-display
6. My collection Artwork - make “---” black60

| fix | before | after |
| --- | --- | --- |
| 1. Save changes button, disable when form is dirty | <img width="1214" alt="image" src="https://user-images.githubusercontent.com/36167539/196445737-57ce8829-0a36-4e63-94d6-69eca2774692.png"> | <img width="1218" alt="image" src="https://user-images.githubusercontent.com/36167539/196445635-6f45e995-b0d7-4b3b-a667-141d6f6d95d1.png"> |
| 2. Demand Index top padding | <img width="1217" alt="image" src="https://user-images.githubusercontent.com/36167539/196446115-01c72451-aa2e-44d9-8ecc-f26996bf54f1.png"> | <img width="1215" alt="image" src="https://user-images.githubusercontent.com/36167539/196445969-c252ace5-41ba-41d6-b563-688ee5da457f.png"> |
| 3. Titles and subtitles in Insights | <img width="592" alt="image" src="https://user-images.githubusercontent.com/36167539/196447260-9760d3a2-7436-4db0-b684-f5b183503b31.png"> | <img width="613" alt="image" src="https://user-images.githubusercontent.com/36167539/196446415-bc7aeee8-4bb5-4637-814e-3e1b2771f11d.png"> |
| 4. Demand Index Section | <img width="270" alt="image" src="https://user-images.githubusercontent.com/36167539/196447043-84633bd1-8e3f-4c6e-a158-119d56aabfeb.png">| <img width="223" alt="image" src="https://user-images.githubusercontent.com/36167539/196446610-eceaa424-5c17-406d-b50a-ac38f72f4233.png"> |
| 5. Market insights Section | <img width="529" alt="image" src="https://user-images.githubusercontent.com/36167539/196447099-7dce24fb-988a-42eb-85dc-bfdfdfde346c.png"> | <img width="499" alt="image" src="https://user-images.githubusercontent.com/36167539/196446741-6f1ead63-eb61-44bd-9151-be573a2e96b2.png"> |
| 6. My collection Artwork details, empty value | <img width="145" alt="image" src="https://user-images.githubusercontent.com/36167539/196447155-61e6f848-f9eb-456b-9672-8d54994231d8.png"> | <img width="170" alt="image" src="https://user-images.githubusercontent.com/36167539/196446915-b6e49426-9e09-49b0-b3aa-e0d4f582b640.png"> |


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3065]: https://artsyproduct.atlassian.net/browse/CX-3065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ