### PR TITLE
fix: Remove bogus canonical tag from auction results GRO-1357

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -1,4 +1,5 @@
 import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
+import { Title } from "react-head"
 import { ContextModule, Intent } from "@artsy/cohesion"
 import {
   Box,
@@ -47,7 +48,6 @@ import { KeywordFilter } from "./Components/KeywordFilter"
 import { MarketStatsQueryRenderer } from "./Components/MarketStats"
 import { SortSelect } from "./Components/SortSelect"
 import { TableSidebar } from "./Components/TableSidebar"
-import { MetaTags } from "Components/MetaTags"
 import { extractNodes } from "Utils/extractNodes"
 
 const logger = createLogger("ArtistAuctionResults.tsx")
@@ -214,7 +214,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
   return (
     <>
-      <MetaTags title={titleString} />
+      <Title>{titleString}</Title>
 
       <Box id="scrollTo--marketSignalsTop" />
 


### PR DESCRIPTION
I can't be sure but I believe the intention here was to set the page title but rather than using the react-head approach we were using the MetaTags approach. This didn't work well because it caused us to render _all_ the meta tags again (incorrectly) so this PR just gets us back on track.

https://artsyproduct.atlassian.net/browse/GRO-1357

/cc @artsy/grow-devs