### PR TITLE
feat(CX-2942): create median sale price screen wrapper

### DIFF
--- a/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
+++ b/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
@@ -1,5 +1,11 @@
-import { Text } from "@artsy/palette"
+import { Box, Text } from "@artsy/palette"
 
 export const MyCollectionInsightsMedianSalePriceAtAuction = () => {
-  return <Text>My Collection Insights Median Sale Price At Auction</Text>
+  return (
+    <Box>
+      <Text mt={2} variant={"lg-display"}>
+        Median Auction Price
+      </Text>
+    </Box>
+  )
 }

--- a/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
+++ b/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
@@ -6,7 +6,7 @@ export const MyCollectionInsightsMedianSalePriceAtAuction = () => {
       <Text mt={2} variant={"lg-display"}>
         Median Auction Price
       </Text>
-      <Text variant={["sm-display", "xs"]} color="black60">
+      <Text variant={["xs", "sm-display"]} color="black60">
         Track price stability or growth of your artists
       </Text>
     </Box>

--- a/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
+++ b/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "@artsy/palette"
 export const MyCollectionInsightsMedianSalePriceAtAuction = () => {
   return (
     <Box>
-      <Text mt={2} variant={"lg-display"}>
+      <Text mt={2} variant={["lg-display", "lg"]}>
         Median Auction Price
       </Text>
       <Text variant={["xs", "sm-display"]} color="black60">

--- a/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
+++ b/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
@@ -6,6 +6,9 @@ export const MyCollectionInsightsMedianSalePriceAtAuction = () => {
       <Text mt={2} variant={"lg-display"}>
         Median Auction Price
       </Text>
+      <Text variant={["sm-display", "xs"]} color="black60">
+        Track price stability or growth of your artists
+      </Text>
     </Box>
   )
 }

--- a/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
+++ b/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
@@ -1,0 +1,5 @@
+import { Text } from "@artsy/palette"
+
+export const MyCollectionInsightsMedianSalePriceAtAuction = () => {
+  return <Text>My Collection Insights Median Sale Price At Auction</Text>
+}

--- a/src/Apps/MyCollectionInsights/myCollectionInsightsRoutes.tsx
+++ b/src/Apps/MyCollectionInsights/myCollectionInsightsRoutes.tsx
@@ -16,5 +16,7 @@ export const myCollectionInsightsRoutes: AppRouteConfig[] = [
   {
     path: "/my-collection/median-sale-price-at-auction/:artistID",
     getComponent: () => MyCollectionInsightsMedianSalePriceAtAuction,
+    // hideNav: true, // TODO: Hide/Unhide depending on the conversation with the #design team
+    // hideFooter: true, // TODO: Hide/Unhide depending on the conversation with the #design team
   },
 ]

--- a/src/Apps/MyCollectionInsights/myCollectionInsightsRoutes.tsx
+++ b/src/Apps/MyCollectionInsights/myCollectionInsightsRoutes.tsx
@@ -1,0 +1,20 @@
+import loadable from "@loadable/component"
+import { AppRouteConfig } from "System/Router/Route"
+
+const MyCollectionInsightsMedianSalePriceAtAuction = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "myCollectionInsightsBundle" */ "./Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction"
+    ),
+  {
+    resolveComponent: component =>
+      component.MyCollectionInsightsMedianSalePriceAtAuction,
+  }
+)
+
+export const myCollectionInsightsRoutes: AppRouteConfig[] = [
+  {
+    path: "/my-collection/median-sale-price-at-auction/:artistID",
+    getComponent: () => MyCollectionInsightsMedianSalePriceAtAuction,
+  },
+]

--- a/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
@@ -44,7 +44,10 @@ const InsightsMedianSalePrice: React.FC<InsightsMedianSalePriceProps> = ({
           const [firstElement] = artistMedianSalePrices
 
           return (
-            <ArtistRowWrapper artistID={firstElement.artist?.internalID!}>
+            <ArtistRowWrapper
+              artistID={firstElement.artist?.internalID!}
+              medium={firstElement.mediumType?.name!}
+            >
               <Flex py={1} mb={[4, 0]} flexDirection={["column", "row"]}>
                 <EntityHeaderArtistFragmentContainer
                   flex={1}
@@ -94,7 +97,8 @@ const InsightsMedianSalePrice: React.FC<InsightsMedianSalePriceProps> = ({
 const ArtistRowWrapper: React.FC<{
   artistID: string
   children: JSX.Element
-}> = ({ artistID, children }) => {
+  medium: string
+}> = ({ artistID, children, medium }) => {
   const { router } = useRouter()
 
   const enableMedianSalePriceGraphScreen = useFeatureFlag(
@@ -104,7 +108,9 @@ const ArtistRowWrapper: React.FC<{
     return (
       <ClickableArtistRow
         onClick={() =>
-          router.push(`/my-collection/median-sale-price-at-auction/${artistID}`)
+          router.push(
+            `/my-collection/median-sale-price-at-auction/${artistID}?medium=${medium}`
+          )
         }
       >
         {children}

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
@@ -1,10 +1,22 @@
-import { screen } from "@testing-library/react"
+import { screen, fireEvent } from "@testing-library/react"
 import { InsightsMedianSalePriceFragmentContainer } from "Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
+import { useSystemContext } from "System/SystemContext"
 import { InsightsMedianSalePriceTestQuery } from "__generated__/InsightsMedianSalePriceTestQuery.graphql"
 
 jest.unmock("react-relay")
+
+const mockPush = jest.fn()
+
+jest.mock("System/useSystemContext")
+jest.mock("System/Router/useRouter", () => ({
+  useRouter: () => ({
+    router: {
+      push: mockPush,
+    },
+  }),
+}))
 
 describe("InsightsMedianSalePrice", () => {
   const { renderWithRelay } = setupTestWrapperTL<
@@ -20,23 +32,55 @@ describe("InsightsMedianSalePrice", () => {
     `,
   })
 
+  beforeAll(() => {
+    ;(useSystemContext as jest.Mock).mockImplementation(() => ({
+      featureFlags: {
+        "my-collection-web-phase-7-median-sale-price-graph": {
+          flagEnabled: false,
+        },
+      },
+    }))
+  })
+
   describe("when there are market price insights data", () => {
-    it("renders correctly", () => {
+    describe("Median auction price in the last 3 years", () => {
+      it("renders the median auction price in the last 3 years", () => {
+        renderWithRelay(mockResolver, false)
+
+        expect(
+          screen.getByText("Median Auction Price in the Last 3 Years")
+        ).toBeInTheDocument()
+
+        expect(screen.getByText("Takashi Murakami")).toBeInTheDocument()
+        expect(screen.getByText("Japanese, b. 1962")).toBeInTheDocument()
+        expect(screen.getByText("Photography")).toBeInTheDocument()
+        expect(screen.getByText("US$3,750")).toBeInTheDocument()
+
+        expect(screen.getByText("Andy Warhol")).toBeInTheDocument()
+        expect(screen.getByText("American, 1928–1987")).toBeInTheDocument()
+        expect(screen.getByText("Print")).toBeInTheDocument()
+        expect(screen.getByText("US$39,930")).toBeInTheDocument()
+      })
+    })
+
+    it("navigates to the median auction price screen when the feature flag is enabled", () => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => ({
+        featureFlags: {
+          "my-collection-web-phase-7-median-sale-price-graph": {
+            flagEnabled: true,
+          },
+        },
+      }))
+
       renderWithRelay(mockResolver, false)
 
-      expect(
-        screen.getByText("Median Auction Price in the Last 3 Years")
-      ).toBeInTheDocument()
+      const artistRow = screen.getByText("Takashi Murakami")
 
-      expect(screen.getByText("Takashi Murakami")).toBeInTheDocument()
-      expect(screen.getByText("Japanese, b. 1962")).toBeInTheDocument()
-      expect(screen.getByText("Photography")).toBeInTheDocument()
-      expect(screen.getByText("US$3,750")).toBeInTheDocument()
+      fireEvent.click(artistRow)
 
-      expect(screen.getByText("Andy Warhol")).toBeInTheDocument()
-      expect(screen.getByText("American, 1928–1987")).toBeInTheDocument()
-      expect(screen.getByText("Print")).toBeInTheDocument()
-      expect(screen.getByText("US$39,930")).toBeInTheDocument()
+      expect(mockPush).toHaveBeenCalledWith(
+        "/my-collection/median-sale-price-at-auction/takashi-murakami-id"
+      )
     })
   })
 
@@ -67,7 +111,7 @@ const mockResolver = {
           node: {
             mediumType: { name: "Print" },
             artist: {
-              internalID: "takashi-murakami",
+              internalID: "takashi-murakami-id",
               name: "Takashi Murakami",
               formattedNationalityAndBirthday: "Japanese, b. 1962",
             },

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
@@ -79,7 +79,7 @@ describe("InsightsMedianSalePrice", () => {
       fireEvent.click(artistRow)
 
       expect(mockPush).toHaveBeenCalledWith(
-        "/my-collection/median-sale-price-at-auction/takashi-murakami-id"
+        "/my-collection/median-sale-price-at-auction/takashi-murakami-id?medium=Print"
       )
     })
   })

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -51,6 +51,7 @@ import { pressRoutes } from "./Apps/Press/pressRoutes"
 import { priceDatabaseRoutes } from "./Apps/PriceDatabase/priceDatabaseRoutes"
 import { tagRoutes } from "./Apps/Tag/tagRoutes"
 import { worksForYouRoutes } from "./Apps/WorksForYou/worksForYouRoutes"
+import { myCollectionInsightsRoutes } from "Apps/MyCollectionInsights/myCollectionInsightsRoutes"
 
 export const getAppRoutes = (): AppRouteConfig[] => {
   return buildAppRoutes([
@@ -86,6 +87,7 @@ export const getAppRoutes = (): AppRouteConfig[] => {
     { routes: jobsRoutes },
     { routes: meetTheSpecialistsRoutes },
     { routes: myCollectionRoutes },
+    { routes: myCollectionInsightsRoutes },
     { routes: newForYouRoutes },
     { routes: notificationsRoutes },
     { routes: onboardingRoutes },


### PR DESCRIPTION
The type of this PR is: **feature**

This PR solves [CX-2942]

### Description

- This PR adds the median sale price at auction screen wrapper.

**Note:**
- It's still not yet clear if we will hide or show the navigation and footer.
- The medium type will be sent as a query param, this is in order to support deep linking to the same page if needed later in App. When none is specified or a wrong one is specified, the fallback should be ideally `All`, as we do in App.

https://user-images.githubusercontent.com/11945712/196888467-a6e0c66e-9ffe-4bed-88f9-d958a12fab72.mov



<!-- Implementation description -->


[CX-2942]: https://artsyproduct.atlassian.net/browse/CX-2942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ