### PR TITLE
fix: add spacer when artwork is Sold

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2CommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2CommercialButtons.tsx
@@ -298,7 +298,10 @@ const ArtworkSidebar2CommerialButtons: React.FC<ArtworkSidebar2CommercialButtons
       {inquiryComponent}
 
       {(artwork?.editionSets?.length ?? 0) < 2 ? (
-        <SaleMessage saleMessage={artwork.saleMessage} />
+        <>
+          <SaleMessage saleMessage={artwork.saleMessage} />
+          {createAlertAvailable && <Spacer mt={1} />}
+        </>
       ) : (
         <>
           <Separator />


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4382]

### Description

Add separator with margin when artwork is sold

screenshots
<img width="392" alt="Screenshot 2022-10-20 at 10 37 40" src="https://user-images.githubusercontent.com/21178754/196899606-3b576eed-44aa-4e47-bc56-d1c352c68d2b.png">
<img width="1512" alt="Screenshot 2022-10-20 at 10 37 31" src="https://user-images.githubusercontent.com/21178754/196899609-a83258b6-b0e4-4602-b76d-68d160c27e8f.png">



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4382]: https://artsyproduct.atlassian.net/browse/FX-4382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ