### PR TITLE
perf(TX-689): Extend error logging in payment route

### DIFF
--- a/src/Apps/Order/Components/BankAccountPicker.tsx
+++ b/src/Apps/Order/Components/BankAccountPicker.tsx
@@ -1,5 +1,6 @@
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { StripeError } from "@stripe/stripe-js"
 
 import { BankDebitProvider } from "Components/BankDebitForm/BankDebitProvider"
 import { BankAccountPicker_me$data } from "__generated__/BankAccountPicker_me.graphql"
@@ -10,7 +11,7 @@ import { BankDebitDetails } from "./BankDebitDetails"
 import { InsufficientFundsError } from "./InsufficientFundsError"
 import { BankAccountPicker_order$data } from "__generated__/BankAccountPicker_order.graphql"
 import { extractNodes } from "Utils/extractNodes"
-import { useSetPayment } from "../Mutations/useSetPayment"
+import { useSetPayment } from "Apps/Order/Mutations/useSetPayment"
 import { camelCase, upperFirst } from "lodash"
 import { useOrderPaymentContext } from "Apps/Order/Routes/Payment/PaymentContext/OrderPaymentContext"
 
@@ -22,6 +23,7 @@ interface BankAccountRecord {
 interface Props {
   order: BankAccountPicker_order$data
   me: BankAccountPicker_me$data
+  onError: (error: Error | StripeError) => void
 }
 
 export const BankAccountPicker: FC<Props> = props => {
@@ -83,7 +85,7 @@ export const BankAccountPicker: FC<Props> = props => {
 
       setSelectedBankAccountId(bankAccountSelection?.id!)
     } catch (error) {
-      console.error(error)
+      props.onError(error)
     } finally {
       setIsSavingPayment(false)
     }
@@ -137,7 +139,7 @@ export const BankAccountPicker: FC<Props> = props => {
 
       <Collapse open={bankAccountSelection?.type === "new"}>
         {bankAccountSelection?.type === "new" && (
-          <BankDebitProvider order={order} />
+          <BankDebitProvider order={order} onError={props.onError} />
         )}
       </Collapse>
 

--- a/src/Apps/Order/Components/PollAccountBalance.tsx
+++ b/src/Apps/Order/Components/PollAccountBalance.tsx
@@ -105,6 +105,7 @@ export const PollAccountBalanceRefetchContainer = createRefetchContainer(
 interface PollAccountBalanceQueryRendererProps {
   setupIntentId: string
   bankAccountId: string
+  onError: (error: Error) => void
   onBalanceCheckComplete: (
     displayInsufficientFundsError: boolean,
     checkResult: BalanceCheckResult
@@ -116,6 +117,7 @@ interface PollAccountBalanceQueryRendererProps {
 export const PollAccountBalanceQueryRenderer: FC<PollAccountBalanceQueryRendererProps> = ({
   setupIntentId,
   bankAccountId,
+  onError,
   ...rest
 }) => {
   const { relayEnvironment } = useSystemContext()
@@ -129,9 +131,13 @@ export const PollAccountBalanceQueryRenderer: FC<PollAccountBalanceQueryRenderer
         bankAccountId ? { bankAccountId } : { setupIntentId, bankAccountId: "" }
       }
       query={BALANCE_QUERY}
-      render={({ props }) => {
+      render={({ props, error }) => {
         if (!props?.commerceBankAccountBalance) {
           return <SavingPaymentSpinner />
+        }
+
+        if (error) {
+          onError(error)
         }
 
         return (

--- a/src/Apps/Order/Components/__tests__/BankAccountPicker.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/BankAccountPicker.jest.tsx
@@ -6,13 +6,13 @@ import {
 } from "Apps/__tests__/Fixtures/Order"
 import { expectOne, RootTestPage } from "DevTools/RootTestPage"
 import { graphql } from "react-relay"
-import { BankAccountPickerFragmentContainer } from "../BankAccountPicker"
+import { BankAccountPickerFragmentContainer } from "Apps/Order/Components/BankAccountPicker"
 import { MockBoot } from "DevTools"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { BankAccountPicker_me$data } from "__generated__/BankAccountPicker_me.graphql"
 import { BankDebitProvider } from "Components/BankDebitForm/BankDebitProvider"
-import { useSetPayment } from "../../Mutations/useSetPayment"
-import { BankAccountSelection } from "../../Routes/Payment/index"
+import { useSetPayment } from "Apps/Order/Mutations/useSetPayment"
+import { BankAccountSelection } from "Apps/Order/Routes/Payment/index"
 import { useOrderPaymentContext } from "Apps/Order/Routes/Payment/PaymentContext/OrderPaymentContext"
 
 jest.mock("Apps/Order/Routes/Payment/PaymentContext/OrderPaymentContext")
@@ -114,6 +114,7 @@ describe("BankAccountFragmentContainer", () => {
           <BankAccountPickerFragmentContainer
             order={props.order}
             me={props.me}
+            onError={jest.fn()}
           />
         </MockBoot>
       ),
@@ -149,6 +150,7 @@ describe("BankAccountFragmentContainer", () => {
           <BankAccountPickerFragmentContainer
             order={props.order}
             me={props.me}
+            onError={jest.fn()}
           />
         </MockBoot>
       ),

--- a/src/Apps/Order/Components/__tests__/BankAccountPicker.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/BankAccountPicker.jest.tsx
@@ -91,6 +91,8 @@ let mockBankAccountSelection: BankAccountSelection = {
   type: "new",
 }
 
+const mockOnError = jest.fn()
+
 describe("BankAccountFragmentContainer", () => {
   beforeAll(() => {
     ;(useOrderPaymentContext as jest.Mock).mockImplementation(() => {
@@ -114,7 +116,7 @@ describe("BankAccountFragmentContainer", () => {
           <BankAccountPickerFragmentContainer
             order={props.order}
             me={props.me}
-            onError={jest.fn()}
+            onError={mockOnError}
           />
         </MockBoot>
       ),
@@ -316,6 +318,46 @@ describe("BankAccountFragmentContainer", () => {
           },
         },
       })
+    })
+
+    it("calls payment route error logger when setPayment mutation fails", async () => {
+      ;(useOrderPaymentContext as jest.Mock).mockImplementation(() => {
+        return {
+          selectedPaymentMethod: "US_BANK_ACCOUNT",
+          setBalanceCheckComplete: jest.fn(),
+          setSelectedBankAccountId: jest.fn(),
+          setBankAccountSelection: jest.fn(),
+          setIsSavingPayment: jest.fn(),
+          bankAccountSelection: mockBankAccountSelection,
+        }
+      })
+
+      const submitMutationMock = jest.fn().mockResolvedValue({
+        commerceSetPayment: {
+          orderOrError: {
+            error: {
+              message: "a problem occured",
+            },
+          },
+        },
+      })
+      ;(useSetPayment as jest.Mock).mockImplementation(() => ({
+        submitMutation: submitMutationMock,
+      }))
+
+      const wrapper = getWrapper({
+        CommerceOrder: () => BuyOrderPickup,
+        Me: () => ({
+          bankAccounts: {
+            edges: [{ node: bankAccounts[0] }, { node: bankAccounts[1] }],
+          },
+        }),
+      })
+      const page = new BankAccountPickerTestPage(wrapper)
+      page.clickRadio(1)
+      page.submitButton.simulate("click")
+      page.update()
+      expect(mockOnError).toHaveBeenCalled()
     })
   })
 })

--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -38,6 +38,7 @@ export interface Props {
   me: Payment_me$data
   commitMutation: CommitMutation
   onSetPayment: () => void
+  onError: (error: Error) => void
   CreditCardPicker: RefObject<CreditCardPicker>
 }
 
@@ -132,7 +133,11 @@ export const PaymentContent: FC<Props> = props => {
         <Spacer mb={2} />
         {selectedPaymentMethod === "US_BANK_ACCOUNT" && (
           // @ts-ignore RELAY_UPGRADE 13
-          <BankAccountPickerFragmentContainer me={me} order={order} />
+          <BankAccountPickerFragmentContainer
+            me={me}
+            order={order}
+            onError={props.onError}
+          />
         )}
       </Collapse>
 
@@ -142,7 +147,11 @@ export const PaymentContent: FC<Props> = props => {
         <Spacer mb={2} />
         {selectedPaymentMethod === "SEPA_DEBIT" && (
           // @ts-ignore RELAY_UPGRADE 13
-          <BankAccountPickerFragmentContainer me={me} order={order} />
+          <BankAccountPickerFragmentContainer
+            me={me}
+            order={order}
+            onError={props.onError}
+          />
         )}
       </Collapse>
 

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -133,7 +133,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     isSavingPayment ||
     (!!match?.location?.query?.setup_intent && !bankAccountHasInsufficientFunds)
 
-  // fired when an error is encountered during selecting bank account or setting payment
+  // fired when an error is encountered during selecting bank account, polling balance, or setting payment
   const handlePaymentError = (error: Error | StripeError) => {
     const errorContent = {
       ...error,

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -1,7 +1,7 @@
 // libs
 import { createRef, FC, useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import type { Stripe, StripeElements } from "@stripe/stripe-js"
+import { Stripe, StripeElements, StripeError } from "@stripe/stripe-js"
 import { Router } from "found"
 import { Box, Flex, Spacer } from "@artsy/palette"
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
@@ -133,6 +133,19 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     isSavingPayment ||
     (!!match?.location?.query?.setup_intent && !bankAccountHasInsufficientFunds)
 
+  // fired when an error is encountered during selecting bank account or setting payment
+  const handlePaymentError = (error: Error | StripeError) => {
+    const errorContent = {
+      ...error,
+      orderId: props.order.internalID!,
+      selectedPaymentMethod,
+      bankAccountHasInsufficientFunds,
+      shouldLogErrorToSentry: true,
+    }
+
+    logger.error(errorContent)
+  }
+
   // fired when balance check is done: either sets error state or moves to /review
   const handleBalanceCheckComplete = (
     displayInsufficientFundsError: boolean,
@@ -226,7 +239,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
       handlePaymentStepComplete()
     } catch (error) {
       setIsSavingPayment(false)
-      logger.error(error)
+      handlePaymentError(error)
       props.dialog.showErrorDialog()
     }
   }
@@ -250,8 +263,8 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
 
       handlePaymentStepComplete()
     } catch (error) {
+      handlePaymentError(error)
       setIsSavingPayment(false)
-      logger.error(error)
       props.dialog.showErrorDialog()
     }
   }
@@ -331,6 +344,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
               onBalanceCheckComplete={handleBalanceCheckComplete}
               buyerTotalCents={order.buyerTotalCents!}
               orderCurrencyCode={order.currencyCode}
+              onError={handlePaymentError}
             />
           ) : (
             <>
@@ -347,6 +361,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
                   order={props.order}
                   CreditCardPicker={CreditCardPicker}
                   onSetPayment={handleSetPayment}
+                  onError={handlePaymentError}
                 />
               </Flex>
             </>

--- a/src/Components/BankDebitForm/BankDebitForm.tsx
+++ b/src/Components/BankDebitForm/BankDebitForm.tsx
@@ -1,4 +1,5 @@
 import { FC, useState } from "react"
+import { StripeError } from "@stripe/stripe-js"
 import { PaymentElement, useStripe, useElements } from "@stripe/react-stripe-js"
 import { ActionType, OwnerType } from "@artsy/cohesion"
 import {
@@ -21,9 +22,10 @@ import { useOrderPaymentContext } from "Apps/Order/Routes/Payment/PaymentContext
 
 interface Props {
   order: { mode: string | null; internalID: string }
+  onError: (error: Error | StripeError) => void
 }
 
-export const BankDebitForm: FC<Props> = ({ order }) => {
+export const BankDebitForm: FC<Props> = ({ order, onError }) => {
   const {
     selectedPaymentMethod,
     bankAccountHasInsufficientFunds,
@@ -85,6 +87,7 @@ export const BankDebitForm: FC<Props> = ({ order }) => {
 
     if (error) {
       setIsSavingPayment(false)
+      onError(error)
       throw error
     }
   }

--- a/src/Components/BankDebitForm/__tests__/BankDebitForm.jest.tsx
+++ b/src/Components/BankDebitForm/__tests__/BankDebitForm.jest.tsx
@@ -3,7 +3,7 @@ import { BuyOrderWithShippingDetails } from "Apps/__tests__/Fixtures/Order"
 import { useSystemContext } from "System"
 import { useTracking } from "react-tracking"
 import { PaymentTestQuery$rawResponse } from "__generated__/PaymentTestQuery.graphql"
-import { BankDebitForm } from "../BankDebitForm"
+import { BankDebitForm } from "Components/BankDebitForm/BankDebitForm"
 import { useOrderPaymentContext } from "Apps/Order/Routes/Payment/PaymentContext/OrderPaymentContext"
 
 // In our stripe PaymentElement mock
@@ -68,7 +68,7 @@ describe("BankDebitForm", () => {
     it("tracks a `complete` event from the onChange handler", () => {
       mockEvent = { complete: true, empty: true }
 
-      render(<BankDebitForm order={testOrder} />)
+      render(<BankDebitForm order={testOrder} onError={jest.fn()} />)
 
       expect(trackEvent).toHaveBeenCalledWith({
         flow: "BUY",
@@ -80,7 +80,9 @@ describe("BankDebitForm", () => {
     })
 
     it("renders correct not enough funds message", () => {
-      const screen = render(<BankDebitForm order={testOrder} />)
+      const screen = render(
+        <BankDebitForm order={testOrder} onError={jest.fn()} />
+      )
 
       expect(
         screen.queryByText("This bank account doesn’t have enough funds.")
@@ -102,7 +104,9 @@ describe("BankDebitForm", () => {
     })
 
     it("does not render a checkbox to save bank account", () => {
-      const screen = render(<BankDebitForm order={testOrder} />)
+      const screen = render(
+        <BankDebitForm order={testOrder} onError={jest.fn()} />
+      )
 
       expect(
         screen.queryByTestId("SaveBankAccountCheckbox")

--- a/src/Components/BankDebitForm/__tests__/BankDebitProvider.jest.tsx
+++ b/src/Components/BankDebitForm/__tests__/BankDebitProvider.jest.tsx
@@ -33,6 +33,7 @@ describe("BankDebitProvider", () => {
           paymentMethodDetails: null,
           " $fragmentType": "BankAccountPicker_order",
         }}
+        onError={jest.fn()}
       />
     )
 

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -1,7 +1,8 @@
 import { sendErrorToService } from "Utils/errors"
 
-export const shouldCaptureError = (environment: string = "development") =>
-  environment === "staging" || environment === "production"
+export const shouldCaptureError = (
+  environment: string = "development"
+): boolean => environment === "staging" || environment === "production"
 
 export default function createLogger(namespace = "") {
   const formattedNamespace = namespace ? `${namespace} |` : ""
@@ -15,7 +16,9 @@ export default function createLogger(namespace = "") {
       console.warn(formattedNamespace, ...warnings, "\n")
     },
     error: (...errors) => {
-      const error = errors.find(e => e instanceof Error)
+      const error = errors.find(
+        e => e instanceof Error || e.shouldLogErrorToSentry
+      )
 
       if (error && shouldCaptureError(process.env.NODE_ENV)) {
         sendErrorToService(error)


### PR DESCRIPTION
The type of this PR is: **Perf**

This PR solves [TX-689]

### Description
This PR extends error logging to Sentry in the payment route of the checkout flow. With these changes, we will be able to spot error by orderId and payment method in Sentry. 

Note that I could not find a way to log mock errors that I threw locally to Sentry in order to test the shape of the logged objects. I am intending to do the QA after this work is on staging. If anyone has a way to accomplish this locally, please let me know 🙏 


[TX-689]: https://artsyproduct.atlassian.net/browse/TX-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ