### PR TITLE
feat(FX-4386): add analytics to expandable sidebar sections

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/__tests__/ArtworkSidebar2.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/__tests__/ArtworkSidebar2.jest.tsx
@@ -1,9 +1,12 @@
+import { useTracking } from "react-tracking"
 import { graphql } from "react-relay"
-import { screen } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { ArtworkSidebar2FragmentContainer } from "Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2"
 
 jest.unmock("react-relay")
+
+jest.mock("react-tracking")
 
 const ARTWORKSIDEBAR2_TEST_QUERY = graphql`
   query ArtworkSidebar2_Test_Query @relay_test_operation {
@@ -19,6 +22,21 @@ const { renderWithRelay } = setupTestWrapperTL({
 })
 
 describe("ArtworkSidebar2Artists", () => {
+  const trackEvent = jest.fn()
+  const mockTracking = useTracking as jest.Mock
+
+  beforeAll(() => {
+    mockTracking.mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe("should display the create alert section", () => {
     it("renders the create alert section", () => {
       renderWithRelay()
@@ -138,6 +156,90 @@ describe("ArtworkSidebar2Artists", () => {
       expect(
         screen.queryByText("Be covered by the Artsy Guarantee")
       ).not.toBeInTheDocument()
+    })
+
+    it("should track click to expand/collapse the Artsy Guarantee section", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          isSold: false,
+          isEligibleForArtsyGuarantee: true,
+        }),
+      })
+
+      const button = screen.getByText("Be covered by the Artsy Guarantee")
+
+      fireEvent.click(button)
+
+      expect(trackEvent).toHaveBeenCalledTimes(1)
+      expect(trackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action": "toggledAccordion",
+            "context_module": "artworkSidebar",
+            "context_owner_type": "artwork",
+            "expand": true,
+            "subject": "Be covered by the Artsy Guarantee",
+          },
+        ]
+      `)
+
+      fireEvent.click(button)
+
+      expect(trackEvent).toHaveBeenCalledTimes(2)
+      expect(trackEvent.mock.calls[1]).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action": "toggledAccordion",
+            "context_module": "artworkSidebar",
+            "context_owner_type": "artwork",
+            "expand": false,
+            "subject": "Be covered by the Artsy Guarantee",
+          },
+        ]
+      `)
+    })
+  })
+
+  describe("Shipping and Taxes section", () => {
+    it("should track click to expand/collapse the Shipping and Taxes section", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          isSold: false,
+          isAcquireable: true,
+        }),
+      })
+
+      const button = screen.getByText("Shipping and Taxes")
+
+      fireEvent.click(button)
+
+      expect(trackEvent).toHaveBeenCalledTimes(1)
+      expect(trackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action": "toggledAccordion",
+            "context_module": "artworkSidebar",
+            "context_owner_type": "artwork",
+            "expand": true,
+            "subject": "Shipping and Taxes",
+          },
+        ]
+      `)
+
+      fireEvent.click(button)
+
+      expect(trackEvent).toHaveBeenCalledTimes(2)
+      expect(trackEvent.mock.calls[1]).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action": "toggledAccordion",
+            "context_module": "artworkSidebar",
+            "context_owner_type": "artwork",
+            "expand": false,
+            "subject": "Shipping and Taxes",
+          },
+        ]
+      `)
     })
   })
 })

--- a/src/Components/Artwork/SidebarExpandable.tsx
+++ b/src/Components/Artwork/SidebarExpandable.tsx
@@ -8,9 +8,10 @@ import {
   Spacer,
 } from "@artsy/palette"
 import { useState } from "react"
-
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import { useTracking } from "react-tracking"
 interface ExpandableProps extends ClickableProps {
-  label?: string | JSX.Element
+  label: string
   expanded?: boolean
   children: React.ReactNode
 }
@@ -28,11 +29,19 @@ export const SidebarExpandable: React.FC<ExpandableProps> = ({
   onClick,
 }) => {
   const [expanded, setExpanded] = useState(defaultExpanded)
+  const { trackEvent } = useTracking()
 
   const handleClick = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
     setExpanded(prevExpanded => !prevExpanded)
+    trackEvent({
+      action: ActionType.toggledAccordion,
+      context_module: ContextModule.artworkSidebar,
+      context_owner_type: OwnerType.artwork,
+      subject: label,
+      expand: !expanded,
+    })
     onClick && onClick(event)
   }
 


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4386]

### Description

Adds analytics to sidebarExpandable component for `shipping and taxes` & `Artsy Guarantee` sections

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4386]: https://artsyproduct.atlassian.net/browse/FX-4386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ