### PR TITLE
fix(FX-4326): artworksidebar > partner link should not be underlined

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2PartnerInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2PartnerInfo.tsx
@@ -9,6 +9,7 @@ import { RouterLink } from "System/Router/RouterLink"
 import { ArtworkSidebar2PartnerInfo_artwork$data } from "__generated__/ArtworkSidebar2PartnerInfo_artwork.graphql"
 import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { themeGet } from "@styled-system/theme-get"
 
 interface ArtworkSidebar2PartnerInfoProps {
   artwork: ArtworkSidebar2PartnerInfo_artwork$data
@@ -21,6 +22,15 @@ interface PartnerNameProps {
 
 const PartnerContainer = styled(Box)`
   word-break: break-word;
+`
+
+const StyledPartnerLink = styled(RouterLink)`
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  color: ${themeGet("colors.black100")};
+
+  &:hover {
+    text-decoration: underline;
+  }
 `
 
 const ArtworkSidebar2PartnerInfo: React.FC<ArtworkSidebar2PartnerInfoProps> = ({
@@ -88,7 +98,9 @@ const PartnerName: React.FC<PartnerNameProps> = ({ partner, sale }) => {
   if (sale) {
     return (
       <Text variant="sm-display">
-        <RouterLink to={sale.href ?? ""}>{sale.name}</RouterLink>
+        <StyledPartnerLink textDecoration="none" to={sale.href ?? ""}>
+          {sale.name}
+        </StyledPartnerLink>
       </Text>
     )
   }
@@ -99,7 +111,9 @@ const PartnerName: React.FC<PartnerNameProps> = ({ partner, sale }) => {
 
   return partner.href ? (
     <Text variant="sm-display">
-      <RouterLink to={partner.href}>{partner.name}</RouterLink>
+      <StyledPartnerLink textDecoration="none" to={partner.href}>
+        {partner.name}
+      </StyledPartnerLink>
     </Text>
   ) : (
     <Text variant="sm-display">{partner.name}</Text>


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4326]

### Description

Removes underline from partner link in sidebar

#### Screenshots

|Before|After|
|---|---|
|<img width="1911" alt="Screenshot 2022-10-21 at 11 53 23" src="https://user-images.githubusercontent.com/21178754/197168995-9488c014-85d7-4a1f-8735-7240eee6818f.png">|<img width="2560" alt="Screenshot 2022-10-21 at 11 52 44" src="https://user-images.githubusercontent.com/21178754/197169039-f3c01536-41ca-42e0-a0a3-0d3f80c4014e.png">|
|<img width="417" alt="Screenshot 2022-10-21 at 11 53 11" src="https://user-images.githubusercontent.com/21178754/197169031-0615c359-ce42-42d8-8946-36a9964d179d.png">|<img width="387" alt="Screenshot 2022-10-21 at 11 52 55" src="https://user-images.githubusercontent.com/21178754/197169036-73383703-9028-46a3-bd95-aab632ee69b7.png">|

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4326]: https://artsyproduct.atlassian.net/browse/FX-4326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ