### PR TITLE
feat(FX-4388): display register to bid popover after auth flow

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
@@ -7,7 +7,7 @@ import {
   Popover,
   Text,
 } from "@artsy/palette"
-import * as React from "react"
+import { useEffect, useCallback, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSaveArtwork } from "Components/Artwork/SaveButton/useSaveArtwork"
 import { ArtworkActionsSaveButton_artwork$data } from "__generated__/ArtworkActionsSaveButton_artwork.graphql"
@@ -15,6 +15,7 @@ import { UtilButton } from "./UtilButton"
 import { ArtworkAuctionRegistrationPanelFragmentContainer } from "Apps/Artwork/Components/ArtworkImageBrowser/ArtworkAuctionRegistrationPanel"
 import { useSystemContext } from "System"
 import { useTranslation } from "react-i18next"
+import { mediator } from "Server/mediator"
 
 interface ArtworkActionsSaveButtonProps {
   artwork: ArtworkActionsSaveButton_artwork$data
@@ -29,6 +30,7 @@ const ArtworkActionsSaveButton: React.FC<ArtworkActionsSaveButtonProps> = ({
     artwork,
     contextModule: ContextModule.artworkImage,
   })
+  const [popoverVisible, setPopoverVisible] = useState(false)
 
   const {
     isAuction,
@@ -50,12 +52,32 @@ const ArtworkActionsSaveButton: React.FC<ArtworkActionsSaveButtonProps> = ({
     isLiveOpen ||
     registrationAttempted
 
+  const openAuctionRegistrationPopover = useCallback(() => {
+    if (!ignoreAuctionRegistrationPopover) {
+      setPopoverVisible(true)
+    }
+  }, [ignoreAuctionRegistrationPopover])
+
+  const onPopoverClosed = useCallback(() => {
+    setPopoverVisible(false)
+  }, [])
+
+  useEffect(() => {
+    mediator.on("artwork:save", openAuctionRegistrationPopover)
+
+    return () => {
+      mediator.off("artwork:save")
+    }
+  }, [openAuctionRegistrationPopover])
+
   // If an Auction, use Bell (for notifications); if a standard artwork use Heart
   if (isOpenSale) {
     const FilledIcon = () => <BellFillIcon fill="blue100" />
 
     return (
       <Popover
+        visible={popoverVisible}
+        onClose={onPopoverClosed}
         title={
           <Text variant="sm-display">
             {t(
@@ -72,7 +94,7 @@ const ArtworkActionsSaveButton: React.FC<ArtworkActionsSaveButtonProps> = ({
         maxWidth={[335, 410]}
         width="100%"
       >
-        {({ anchorRef, onVisible }) => {
+        {({ anchorRef }) => {
           return (
             <UtilButton
               ref={anchorRef}
@@ -83,7 +105,7 @@ const ArtworkActionsSaveButton: React.FC<ArtworkActionsSaveButtonProps> = ({
                 handleSave()
 
                 if (!ignoreAuctionRegistrationPopover) {
-                  onVisible()
+                  setPopoverVisible(true)
                 }
               }}
             />

--- a/src/Utils/Hooks/useAuthIntent/index.ts
+++ b/src/Utils/Hooks/useAuthIntent/index.ts
@@ -67,6 +67,7 @@ export const runAuthIntent = async (
           }
           break
         case "save":
+          triggerEvent(mediator, "artwork:save", value)
           return saveArtworkMutation(relayEnvironment, value.objectId)
       }
     })()


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

Related Force PR: artsy/force#11171

This PR solves [FX-4388]

Review app: [show-register-to-bid-popup-after-auth](https://show-register-to-bid-popup-after-auth.artsy.net/)

Artwork example: https://show-register-to-bid-popup-after-auth.artsy.net/artwork/henri-van-noordenburg-untitled-1

### Demo
https://user-images.githubusercontent.com/3513494/197199913-824e6591-d82e-413f-8255-d5a92cc2d18b.mp4


<!-- Implementation description -->


[FX-4388]: https://artsyproduct.atlassian.net/browse/FX-4388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ