### PR TITLE
feat(CX-2943): add select artist modal to median sale price

### DIFF
--- a/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/Components/MyCollectionInsightsSelectArtistModal.tsx
+++ b/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/Components/MyCollectionInsightsSelectArtistModal.tsx
@@ -1,0 +1,33 @@
+import { Box, Spacer, Text } from "@artsy/palette"
+import { SearchInputContainer } from "Components/Search/SearchInputContainer"
+import { useState, useCallback } from "react"
+
+export const MyCollectionInsightsSelectArtistModal: React.FC = () => {
+  const [query, setQuery] = useState("")
+
+  const handleChange = useCallback(event => {
+    setQuery(event.target.value)
+  }, [])
+
+  return (
+    <Box>
+      <Text variant={["lg-display", "lg"]}>Select Artist</Text>
+
+      <Spacer mb={[2, 4]} />
+
+      <SearchInputContainer
+        value={query}
+        onChange={handleChange}
+        placeholder="Search for artists in your collection"
+      />
+
+      <Spacer mb={[2, 4]} />
+
+      <Box>
+        <Text variant={["sm-display", "md"]}>
+          Insights currently unavailable
+        </Text>
+      </Box>
+    </Box>
+  )
+}

--- a/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
+++ b/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
@@ -1,8 +1,9 @@
-import { Box, Clickable, Flex, Spacer, Text } from "@artsy/palette"
+import { Box, Clickable, Flex, ModalDialog, Spacer, Text } from "@artsy/palette"
 import { graphql, useFragment } from "react-relay"
 import { EntityHeaderArtistFragmentContainer } from "Components/EntityHeaders/EntityHeaderArtist"
 import { MyCollectionInsightsMedianSalePriceAtAuction_artist$key } from "__generated__/MyCollectionInsightsMedianSalePriceAtAuction_artist.graphql"
-import { Fragment } from "react"
+import { Fragment, useState } from "react"
+import { MyCollectionInsightsSelectArtistModal } from "./Components/MyCollectionInsightsSelectArtistModal"
 
 interface MyCollectionInsightsMedianSalePriceAtAuctionProps {
   artist: MyCollectionInsightsMedianSalePriceAtAuction_artist$key
@@ -12,6 +13,7 @@ export const MyCollectionInsightsMedianSalePriceAtAuction: React.FC<MyCollection
   artist,
 }) => {
   const artistData = useFragment(medianSalePriceAtAuctionFragment, artist)
+  const [showSelectArtistModal, setShowSelectArtistModal] = useState(false)
 
   return (
     <Box>
@@ -36,10 +38,23 @@ export const MyCollectionInsightsMedianSalePriceAtAuction: React.FC<MyCollection
 
         <Spacer ml={4} />
 
-        <Clickable color="black60" textDecoration="underline">
+        <Clickable
+          color="black60"
+          textDecoration="underline"
+          onClick={() => setShowSelectArtistModal(!showSelectArtistModal)}
+        >
           Change Artist
         </Clickable>
       </Flex>
+
+      {showSelectArtistModal && (
+        <ModalDialog
+          onClose={() => setShowSelectArtistModal(false)}
+          width={"100%"}
+        >
+          <MyCollectionInsightsSelectArtistModal />
+        </ModalDialog>
+      )}
     </Box>
   )
 }

--- a/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
+++ b/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
@@ -1,6 +1,18 @@
-import { Box, Text } from "@artsy/palette"
+import { Box, Clickable, Flex, Spacer, Text } from "@artsy/palette"
+import { graphql, useFragment } from "react-relay"
+import { EntityHeaderArtistFragmentContainer } from "Components/EntityHeaders/EntityHeaderArtist"
+import { MyCollectionInsightsMedianSalePriceAtAuction_artist$key } from "__generated__/MyCollectionInsightsMedianSalePriceAtAuction_artist.graphql"
+import { Fragment } from "react"
 
-export const MyCollectionInsightsMedianSalePriceAtAuction = () => {
+interface MyCollectionInsightsMedianSalePriceAtAuctionProps {
+  artist: MyCollectionInsightsMedianSalePriceAtAuction_artist$key
+}
+
+export const MyCollectionInsightsMedianSalePriceAtAuction: React.FC<MyCollectionInsightsMedianSalePriceAtAuctionProps> = ({
+  artist,
+}) => {
+  const artistData = useFragment(medianSalePriceAtAuctionFragment, artist)
+
   return (
     <Box>
       <Text mt={2} variant={["lg-display", "lg"]}>
@@ -9,6 +21,31 @@ export const MyCollectionInsightsMedianSalePriceAtAuction = () => {
       <Text variant={["xs", "sm-display"]} color="black60">
         Track price stability or growth of your artists
       </Text>
+
+      <Spacer mb={[2, 4]} />
+
+      <Flex
+        flexDirection={"row"}
+        justifyContent={["space-between", "flex-start"]}
+      >
+        <EntityHeaderArtistFragmentContainer
+          artist={artistData}
+          FollowButton={<Fragment></Fragment>}
+          displayLink={false}
+        />
+
+        <Spacer ml={4} />
+
+        <Clickable color="black60" textDecoration="underline">
+          Change Artist
+        </Clickable>
+      </Flex>
     </Box>
   )
 }
+
+const medianSalePriceAtAuctionFragment = graphql`
+  fragment MyCollectionInsightsMedianSalePriceAtAuction_artist on Artist {
+    ...EntityHeaderArtist_artist
+  }
+`

--- a/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
+++ b/src/Apps/MyCollectionInsights/Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction.tsx
@@ -50,7 +50,7 @@ export const MyCollectionInsightsMedianSalePriceAtAuction: React.FC<MyCollection
       {showSelectArtistModal && (
         <ModalDialog
           onClose={() => setShowSelectArtistModal(false)}
-          width={"100%"}
+          width={["100%", 800]}
         >
           <MyCollectionInsightsSelectArtistModal />
         </ModalDialog>

--- a/src/Apps/MyCollectionInsights/myCollectionInsightsRoutes.tsx
+++ b/src/Apps/MyCollectionInsights/myCollectionInsightsRoutes.tsx
@@ -1,4 +1,5 @@
 import loadable from "@loadable/component"
+import { graphql } from "react-relay"
 import { AppRouteConfig } from "System/Router/Route"
 
 const MyCollectionInsightsMedianSalePriceAtAuction = loadable(
@@ -16,6 +17,19 @@ export const myCollectionInsightsRoutes: AppRouteConfig[] = [
   {
     path: "/my-collection/median-sale-price-at-auction/:artistID",
     getComponent: () => MyCollectionInsightsMedianSalePriceAtAuction,
+    onClientSideRender: () => {
+      MyCollectionInsightsMedianSalePriceAtAuction.preload()
+    },
+    query: graphql`
+      query myCollectionInsightsRoutesQuery($artistID: String!) {
+        artist(id: $artistID) @principalField {
+          ...MyCollectionInsightsMedianSalePriceAtAuction_artist
+        }
+      }
+    `,
+    cacheConfig: {
+      force: true,
+    },
     // hideNav: true, // TODO: Hide/Unhide depending on the conversation with the #design team
     // hideFooter: true, // TODO: Hide/Unhide depending on the conversation with the #design team
   },

--- a/src/__generated__/MyCollectionInsightsMedianSalePriceAtAuction_artist.graphql.ts
+++ b/src/__generated__/MyCollectionInsightsMedianSalePriceAtAuction_artist.graphql.ts
@@ -1,0 +1,40 @@
+/**
+ * @generated SignedSource<<bab99f5c72de60fdd722d756dd3fd1ee>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type MyCollectionInsightsMedianSalePriceAtAuction_artist$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"EntityHeaderArtist_artist">;
+  readonly " $fragmentType": "MyCollectionInsightsMedianSalePriceAtAuction_artist";
+};
+export type MyCollectionInsightsMedianSalePriceAtAuction_artist$key = {
+  readonly " $data"?: MyCollectionInsightsMedianSalePriceAtAuction_artist$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyCollectionInsightsMedianSalePriceAtAuction_artist">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "MyCollectionInsightsMedianSalePriceAtAuction_artist",
+  "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "EntityHeaderArtist_artist"
+    }
+  ],
+  "type": "Artist",
+  "abstractKey": null
+};
+
+(node as any).hash = "aa687bac3a5d11a40155542462fdf17b";
+
+export default node;

--- a/src/__generated__/myCollectionInsightsRoutesQuery.graphql.ts
+++ b/src/__generated__/myCollectionInsightsRoutesQuery.graphql.ts
@@ -1,0 +1,221 @@
+/**
+ * @generated SignedSource<<01318da1edc16725dc1eb786e4e7db8b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type myCollectionInsightsRoutesQuery$variables = {
+  artistID: string;
+};
+export type myCollectionInsightsRoutesQuery$data = {
+  readonly artist: {
+    readonly " $fragmentSpreads": FragmentRefs<"MyCollectionInsightsMedianSalePriceAtAuction_artist">;
+  } | null;
+};
+export type myCollectionInsightsRoutesQuery = {
+  response: myCollectionInsightsRoutesQuery$data;
+  variables: myCollectionInsightsRoutesQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "artistID"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "myCollectionInsightsRoutesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "MyCollectionInsightsMedianSalePriceAtAuction_artist"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "myCollectionInsightsRoutesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "initials",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "formattedNationalityAndBirthday",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "artworks",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "forSaleArtworks",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": "avatar",
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 45
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 45
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "src",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "srcSet",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:45,width:45)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "487050601670ad71eb0d41baf8f479ae",
+    "id": null,
+    "metadata": {},
+    "name": "myCollectionInsightsRoutesQuery",
+    "operationKind": "query",
+    "text": "query myCollectionInsightsRoutesQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...MyCollectionInsightsMedianSalePriceAtAuction_artist\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment MyCollectionInsightsMedianSalePriceAtAuction_artist on Artist {\n  ...EntityHeaderArtist_artist\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "7d070e2f9e7efa7c0f0aca548d53c860";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-2943]

### Description

This PR adds the select artist screen as a **modal**. The reason behind that is as discussed with Pierluca and Dascha the ease of the implementation and to use the existing `ModalDialog`.


https://user-images.githubusercontent.com/11945712/197208057-c47fb121-db30-4c83-8cfa-f8942eddca35.mov


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-2943]: https://artsyproduct.atlassian.net/browse/CX-2943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ