### PR TITLE
fix: follow buttons’ tracking payloads

### DIFF
--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -1,4 +1,9 @@
-import { AuthContextModule, Intent, ContextModule } from "@artsy/cohesion"
+import {
+  AuthContextModule,
+  Intent,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
 import { ButtonProps, Popover } from "@artsy/palette"
 import { FollowArtistButtonMutation } from "__generated__/FollowArtistButtonMutation.graphql"
 import { FollowArtistPopoverQueryRenderer } from "Components/FollowArtistPopover"
@@ -30,6 +35,7 @@ const FollowArtistButton: React.FC<FollowArtistButtonProps> = ({
   const { isLoggedIn, mediator } = useSystemContext()
 
   const { trackFollow } = useFollowButtonTracking({
+    ownerType: OwnerType.artist,
     ownerId: artist.internalID,
     ownerSlug: artist.slug,
     contextModule,

--- a/src/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/Components/FollowButton/FollowGeneButton.tsx
@@ -5,7 +5,12 @@ import { FollowButton } from "./Button"
 import { FollowGeneButton_gene$data } from "__generated__/FollowGeneButton_gene.graphql"
 import { ButtonProps } from "@artsy/palette"
 import { openAuthToSatisfyIntent } from "Utils/openAuthModal"
-import { Intent, ContextModule, AuthContextModule } from "@artsy/cohesion"
+import {
+  Intent,
+  ContextModule,
+  AuthContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
 import { useMutation } from "Utils/Hooks/useMutation"
 import { useFollowButtonTracking } from "./useFollowButtonTracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
@@ -26,6 +31,7 @@ const FollowGeneButton: React.FC<FollowGeneButtonProps> = ({
   const { isLoggedIn, mediator } = useSystemContext()
 
   const { trackFollow } = useFollowButtonTracking({
+    ownerType: OwnerType.gene,
     ownerId: gene.internalID,
     ownerSlug: gene.slug,
     contextModule,

--- a/src/Components/FollowButton/FollowProfileButton.tsx
+++ b/src/Components/FollowButton/FollowProfileButton.tsx
@@ -5,7 +5,12 @@ import { FollowButton } from "./Button"
 import { FollowProfileButton_profile$data } from "__generated__/FollowProfileButton_profile.graphql"
 import { ButtonProps } from "@artsy/palette"
 import { openAuthToSatisfyIntent } from "Utils/openAuthModal"
-import { Intent, AuthContextModule, ContextModule } from "@artsy/cohesion"
+import {
+  Intent,
+  AuthContextModule,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
 import { useMutation } from "Utils/Hooks/useMutation"
 import { useFollowButtonTracking } from "./useFollowButtonTracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
@@ -26,6 +31,7 @@ const FollowProfileButton: React.FC<FollowProfileButtonProps> = ({
   const { isLoggedIn, mediator } = useSystemContext()
 
   const { trackFollow } = useFollowButtonTracking({
+    ownerType: OwnerType.profile,
     ownerId: profile.internalID,
     ownerSlug: profile.slug,
     contextModule,

--- a/src/Components/FollowButton/__tests__/useFollowButtonTracking.jest.ts
+++ b/src/Components/FollowButton/__tests__/useFollowButtonTracking.jest.ts
@@ -1,0 +1,131 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { act, renderHook } from "@testing-library/react-hooks"
+import { useTracking } from "react-tracking"
+import { useFollowButtonTracking } from "Components/FollowButton/useFollowButtonTracking"
+
+jest.mock("react-tracking")
+
+const mockuseTracking = useTracking as jest.Mock
+const trackingSpy = jest.fn()
+
+beforeAll(() => {
+  mockuseTracking.mockImplementation(() => ({
+    trackEvent: trackingSpy,
+  }))
+})
+
+const OWNER_IS_ALREADY_FOLLOWED = true
+const OWNER_IS_NOT_ALREADY_FOLLOWED = false
+
+describe("trackEvent", () => {
+  it("sends correct FollowArtist payloads", () => {
+    const { result } = renderHook(() =>
+      useFollowButtonTracking({
+        ownerType: OwnerType.artist,
+        ownerId: "artistId",
+        ownerSlug: "artistSlug",
+        contextModule: ContextModule.artistHeader,
+      })
+    )
+
+    act(() => {
+      result.current.trackFollow(OWNER_IS_NOT_ALREADY_FOLLOWED)
+    })
+
+    expect(trackingSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "followedArtist",
+        owner_id: "artistId",
+        owner_slug: "artistSlug",
+        owner_type: "artist",
+      })
+    )
+
+    act(() => {
+      result.current.trackFollow(OWNER_IS_ALREADY_FOLLOWED)
+    })
+
+    expect(trackingSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "unfollowedArtist",
+        owner_id: "artistId",
+        owner_slug: "artistSlug",
+        owner_type: "artist",
+      })
+    )
+  })
+
+  it("sends correct FollowGene payloads", () => {
+    const { result } = renderHook(() =>
+      useFollowButtonTracking({
+        ownerType: OwnerType.gene,
+        ownerId: "geneId",
+        ownerSlug: "geneSlug",
+        contextModule: ContextModule.geneHeader,
+      })
+    )
+
+    act(() => {
+      result.current.trackFollow(OWNER_IS_NOT_ALREADY_FOLLOWED)
+    })
+
+    expect(trackingSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "followedGene",
+        owner_id: "geneId",
+        owner_slug: "geneSlug",
+        owner_type: "gene",
+      })
+    )
+
+    act(() => {
+      result.current.trackFollow(OWNER_IS_ALREADY_FOLLOWED)
+    })
+
+    expect(trackingSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "unfollowedGene",
+        owner_id: "geneId",
+        owner_slug: "geneSlug",
+        owner_type: "gene",
+      })
+    )
+  })
+
+  it("sends correct FollowProfile payloads", () => {
+    const { result } = renderHook(() =>
+      useFollowButtonTracking({
+        ownerType: OwnerType.profile,
+        ownerId: "profileId",
+        ownerSlug: "profileSlug",
+        contextModule: ContextModule.partnerHeader,
+      })
+    )
+
+    act(() => {
+      result.current.trackFollow(OWNER_IS_NOT_ALREADY_FOLLOWED)
+    })
+
+    expect(trackingSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "followedPartner",
+        owner_id: "profileId",
+        owner_slug: "profileSlug",
+        owner_type: "partner",
+      })
+    )
+
+    act(() => {
+      result.current.trackFollow(OWNER_IS_ALREADY_FOLLOWED)
+    })
+
+    expect(trackingSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "unfollowedPartner",
+        owner_id: "profileId",
+        owner_slug: "profileSlug",
+        owner_type: "partner",
+      })
+    )
+  })
+})

--- a/src/Components/FollowButton/useFollowButtonTracking.ts
+++ b/src/Components/FollowButton/useFollowButtonTracking.ts
@@ -1,7 +1,18 @@
 import {
   AuthContextModule,
   FollowedArgs,
+  FollowedArtist,
+  followedArtist,
+  FollowedGene,
+  followedGene,
+  FollowedPartner,
   followedPartner,
+  OwnerType,
+  UnfollowedArtist,
+  unfollowedArtist,
+  UnfollowedGene,
+  unfollowedGene,
+  UnfollowedPartner,
   unfollowedPartner,
 } from "@artsy/cohesion"
 import { useCallback } from "react"
@@ -9,12 +20,14 @@ import { useTracking } from "react-tracking"
 import { useAnalyticsContext } from "System"
 
 interface UseFollowButtonTracking {
+  ownerType: OwnerType
   ownerId: string
   ownerSlug: string
   contextModule: AuthContextModule
 }
 
 export const useFollowButtonTracking = ({
+  ownerType,
   ownerId,
   ownerSlug,
   contextModule,
@@ -38,13 +51,35 @@ export const useFollowButtonTracking = ({
         contextOwnerType: contextPageOwnerType!,
       }
 
-      trackEvent(isFollowed ? unfollowedPartner(args) : followedPartner(args))
+      let followPayload: FollowedPartner | FollowedArtist | FollowedGene
+
+      let unfollowPayload: UnfollowedPartner | UnfollowedArtist | UnfollowedGene
+
+      switch (ownerType) {
+        case OwnerType.profile:
+          followPayload = followedPartner(args)
+          unfollowPayload = unfollowedPartner(args)
+          break
+        case OwnerType.artist:
+          followPayload = followedArtist(args)
+          unfollowPayload = unfollowedArtist(args)
+          break
+        case OwnerType.gene:
+          followPayload = followedGene(args)
+          unfollowPayload = unfollowedGene(args)
+          break
+        default:
+          throw new Error("Unrecognized owner type")
+      }
+
+      trackEvent(isFollowed ? unfollowPayload : followPayload)
     },
     [
       contextModule,
       contextPageOwnerId,
       contextPageOwnerSlug,
       contextPageOwnerType,
+      ownerType,
       ownerId,
       ownerSlug,
       trackEvent,


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [FX-4390]

### Description

It appears that ever since the refactor in https://github.com/artsy/force/pull/10434 the follow buttons for artist/gene/profile have been _always_ sending `followedPartner` / `unfollowedPartner` payloads instead of the ones appropriate to their owner type.

This PR 
- introduces a new `ownerType` arg for `useFollowButtonTracking` to solve that
- updates follow button call sites accordingly
- adds test coverage 

### Before and after

Selected examples for…

#### Following an artist

|Before|After|
|---|---|
|<img width="100%" alt="follow before" src="https://user-images.githubusercontent.com/140521/197247043-e28b9c65-d284-4efd-b72d-59533e5de537.png">|<img width="100%" alt="follow after" src="https://user-images.githubusercontent.com/140521/197247045-83644232-c6cf-4a0a-b106-d3a780078b4e.png">|

#### Un-following a gene

|Before|After|
|---|---|
|<img width="100%" alt="unfollow before" src="https://user-images.githubusercontent.com/140521/197247038-0fb7f15e-e45c-4d60-b49f-fa22f07d4c10.png">|<img width="100%" alt="unfollow after" src="https://user-images.githubusercontent.com/140521/197247044-29470d8a-c8f4-4d47-9904-38960a8dfb68.png">|







[FX-4390]: https://artsyproduct.atlassian.net/browse/FX-4390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ