### PR TITLE
fix: remove is sold from artsy guarantee check

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
@@ -81,9 +81,6 @@ export const ArtworkSidebar2: React.FC<ArtworkSidebarProps> = ({
 
   const lotLabel = artwork.isBiddable ? artwork.saleArtwork?.lotLabel : null
 
-  const shouldDisplayArtsyGuarantee =
-    isSold !== true && isEligibleForArtsyGuarantee
-
   return (
     <Flex flexDirection="column" data-test={ContextModule.artworkSidebar}>
       {lotLabel && (
@@ -137,7 +134,7 @@ export const ArtworkSidebar2: React.FC<ArtworkSidebarProps> = ({
         </>
       )}
 
-      {shouldDisplayArtsyGuarantee && (
+      {!!isEligibleForArtsyGuarantee && (
         <>
           <Separator />
           <SidebarExpandable

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/__tests__/ArtworkSidebar2.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/__tests__/ArtworkSidebar2.jest.tsx
@@ -119,10 +119,9 @@ describe("ArtworkSidebar2Artists", () => {
   })
 
   describe("Artsy Guarantee section", () => {
-    it("should be displayed when not sold and eligible", () => {
+    it("should be displayed when eligible for artsy guarantee", () => {
       renderWithRelay({
         Artwork: () => ({
-          isSold: false,
           isEligibleForArtsyGuarantee: true,
         }),
       })
@@ -132,23 +131,9 @@ describe("ArtworkSidebar2Artists", () => {
       ).toBeInTheDocument()
     })
 
-    it("should not be displayed when sold", () => {
+    it("should not be displayed when ineligible for artsy guarantee", () => {
       renderWithRelay({
         Artwork: () => ({
-          isSold: true,
-          isEligibleForArtsyGuarantee: true,
-        }),
-      })
-
-      expect(
-        screen.queryByText("Be covered by the Artsy Guarantee")
-      ).not.toBeInTheDocument()
-    })
-
-    it("should not be displayed when inelgible", () => {
-      renderWithRelay({
-        Artwork: () => ({
-          isSold: false,
           isEligibleForArtsyGuarantee: false,
         }),
       })
@@ -161,7 +146,6 @@ describe("ArtworkSidebar2Artists", () => {
     it("should track click to expand/collapse the Artsy Guarantee section", () => {
       renderWithRelay({
         Artwork: () => ({
-          isSold: false,
           isEligibleForArtsyGuarantee: true,
         }),
       })


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Realized on https://github.com/artsy/eigen/pull/7526#discussion_r1001632469 that we don't need to check for isSold in order to display the Artsy Guarantee section since `isEligibleForArtsyGuarantee` field will return `false` if the artwork `isSold = true`

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ