### PR TITLE
fix(theme): uses a single theme provider

### DIFF
--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Theme } from "@artsy/palette"
+import { Box, Flex } from "@artsy/palette"
 import { useNetworkOfflineMonitor } from "Utils/Hooks/useNetworkOfflineMonitor"
 import { findCurrentRoute } from "System/Router/Utils/findCurrentRoute"
 import { NavBar } from "Components/NavBar"
@@ -86,30 +86,28 @@ export const AppShell: React.FC<AppShellProps> = props => {
         </Box>
       )}
 
-      <Theme theme="v3">
-        <AppToasts accomodateNav={showNav} />
+      <AppToasts accomodateNav={showNav} />
 
-        <Flex
-          as="main"
-          id="main"
-          // Occupies available vertical space
-          flex={1}
-        >
-          <AppContainer maxWidth={appContainerMaxWidth}>
-            <HorizontalPadding>{children}</HorizontalPadding>
+      <Flex
+        as="main"
+        id="main"
+        // Occupies available vertical space
+        flex={1}
+      >
+        <AppContainer maxWidth={appContainerMaxWidth}>
+          <HorizontalPadding>{children}</HorizontalPadding>
+        </AppContainer>
+      </Flex>
+
+      {showFooter && (
+        <Flex bg="white100" zIndex={Z.footer}>
+          <AppContainer>
+            <HorizontalPadding>
+              <Footer />
+            </HorizontalPadding>
           </AppContainer>
         </Flex>
-
-        {showFooter && (
-          <Flex bg="white100" zIndex={Z.footer}>
-            <AppContainer>
-              <HorizontalPadding>
-                <Footer />
-              </HorizontalPadding>
-            </AppContainer>
-          </Flex>
-        )}
-      </Theme>
+      )}
 
       {onboardingComponent}
 

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -1,14 +1,6 @@
 import { useEffect, useState } from "react"
 import * as React from "react"
-import {
-  Button,
-  Flex,
-  themeProps,
-  Text,
-  Dropdown,
-  ThemeProviderV3,
-  Box,
-} from "@artsy/palette"
+import { Button, Flex, themeProps, Text, Dropdown, Box } from "@artsy/palette"
 import { useSystemContext } from "System/SystemContext"
 import { SearchBarQueryRenderer } from "Components/Search/SearchBar"
 import { NavBarSubMenu } from "./Menus"
@@ -138,7 +130,7 @@ export const NavBar: React.FC = track(
   }
 
   return (
-    <ThemeProviderV3>
+    <>
       <NavBarSkipLink />
 
       <Box
@@ -474,6 +466,6 @@ export const NavBar: React.FC = track(
           />
         </>
       )}
-    </ThemeProviderV3>
+    </>
   )
 })

--- a/src/Components/Onboarding/Components/OnboardingFollows.tsx
+++ b/src/Components/Onboarding/Components/OnboardingFollows.tsx
@@ -7,13 +7,13 @@ import {
   Flex,
 } from "@artsy/palette"
 import { FC, useState } from "react"
-import { OnboardingOrderedSetQueryRenderer } from "../Components/OnboardingOrderedSet"
-import { useOnboardingContext } from "../Hooks/useOnboardingContext"
-import { OnboardingSearchResultsQueryRenderer } from "../Components/OnboardingSearchResults"
+import { OnboardingOrderedSetQueryRenderer } from "Components/Onboarding/Components/OnboardingOrderedSet"
+import { useOnboardingContext } from "Components/Onboarding/Hooks/useOnboardingContext"
+import { OnboardingSearchResultsQueryRenderer } from "Components/Onboarding/Components/OnboardingSearchResults"
 import { useDebouncedValue } from "Utils/Hooks/useDebounce"
-import { useOnboardingFadeTransition } from "../Hooks/useOnboardingFadeTransition"
-import { OnboardingFigure } from "../Components/OnboardingFigure"
-import { useOnboardingTracking } from "../Hooks/useOnboardingTracking"
+import { useOnboardingFadeTransition } from "Components/Onboarding/Hooks/useOnboardingFadeTransition"
+import { OnboardingFigure } from "Components/Onboarding/Components/OnboardingFigure"
+import { useOnboardingTracking } from "Components/Onboarding/Hooks/useOnboardingTracking"
 import { SplitLayout } from "Components/SplitLayout"
 
 interface OnboardingFollowsProps {

--- a/src/Components/Onboarding/Components/OnboardingProgress.tsx
+++ b/src/Components/Onboarding/Components/OnboardingProgress.tsx
@@ -2,7 +2,7 @@ import { Box, ProgressBar } from "@artsy/palette"
 import { BackLink } from "Components/Links/BackLink"
 import { FC } from "react"
 import { useDebouncedValue } from "Utils/Hooks/useDebounce"
-import { useOnboardingContext } from "../Hooks/useOnboardingContext"
+import { useOnboardingContext } from "Components/Onboarding/Hooks/useOnboardingContext"
 
 interface OnboardingProgressProps {
   preview?: boolean
@@ -24,6 +24,7 @@ export const OnboardingProgress: FC<OnboardingProgressProps> = ({
     <Box position="relative">
       <BackLink
         to="/"
+        // FIXME: Brittle magic number positioning *will* break
         top={-19}
         left={-17}
         position="absolute"

--- a/src/Components/Onboarding/Views/OnboardingFollowArtists.tsx
+++ b/src/Components/Onboarding/Views/OnboardingFollowArtists.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react"
-import { OnboardingFollows } from "../Components/OnboardingFollows"
+import { OnboardingFollows } from "Components/Onboarding/Components/OnboardingFollows"
 
 export const OnboardingFollowArtists: FC = () => {
   return <OnboardingFollows kind="artists" />

--- a/src/System/Router/Boot.tsx
+++ b/src/System/Router/Boot.tsx
@@ -23,7 +23,7 @@ import {
   MediaContextProvider,
   ResponsiveProvider,
 } from "Utils/Responsive"
-import { AnalyticsContext } from "../Analytics/AnalyticsContext"
+import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { ClientContext } from "System/Router/buildClientAppContext"
 import { SiftContainer } from "Utils/SiftContainer"
 import { setupSentryClient } from "Server/setupSentryClient"
@@ -71,7 +71,7 @@ export const Boot = track(undefined, {
   }
 
   return (
-    <Theme>
+    <Theme theme="v3">
       <GlobalStyles />
 
       <HeadProvider headTags={headTags}>


### PR DESCRIPTION
Noticed that components weren't adhering to the design system in onboarding. Turns out it was sitting inside of the v2 theme context. This PR removes that possibility from happening in the future.