### PR TITLE
fix: Type guard in logger

### DIFF
--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -17,7 +17,7 @@ export default function createLogger(namespace = "") {
     },
     error: (...errors) => {
       const error = errors.find(
-        e => e instanceof Error || e.shouldLogErrorToSentry
+        e => e instanceof Error || e?.shouldLogErrorToSentry
       )
 
       if (error && shouldCaptureError(process.env.NODE_ENV)) {


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description
Adding a type guard for `shouldLogErrorToSentry` property in error logger. 
