### PR TITLE
fix: Restore artist follow count to all breakpoints GRO-1382

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -100,7 +100,7 @@ const ArtistHeader: React.FC<ArtistHeaderProps> = ({ artist }) => {
               {!!artist.counts?.follows && (
                 <Column
                   span={6}
-                  display={["block", "none", "none", "flex"]}
+                  display={["block", "flex"]}
                   alignItems="center"
                 >
                   <Text


### PR DESCRIPTION
Those `none` values were causing the follow count to be suppressed so this just restores them. Looks like this:

<img width="2672" alt="Screen Shot 2022-10-27 at 9 17 04 AM" src="https://user-images.githubusercontent.com/79799/198310672-9b99f78e-b588-48b8-8e72-4088b1ba7e53.png">
<img width="1343" alt="Screen Shot 2022-10-27 at 9 17 10 AM" src="https://user-images.githubusercontent.com/79799/198310678-0bd6859f-b5b6-4dbc-9c7d-6168d3fb99d6.png">
<img width="901" alt="Screen Shot 2022-10-27 at 9 17 14 AM" src="https://user-images.githubusercontent.com/79799/198310681-57ce49fb-8387-495a-bf4f-97d1405f37b3.png">
<img width="612" alt="Screen Shot 2022-10-27 at 9 17 20 AM" src="https://user-images.githubusercontent.com/79799/198310686-c8e0dde9-e121-4a81-b5de-576c990e6057.png">


https://artsyproduct.atlassian.net/browse/GRO-1382

/cc @artsy/grow-devs