### PR TITLE
feat: Secretly support Braze content cards GRO-1385

### DIFF
--- a/src/Apps/Home/Components/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards.tsx
@@ -1,0 +1,3 @@
+export const HomeContentCards = () => {
+  return <h1>Content Cards Go Here</h1>
+}

--- a/src/Apps/Home/Components/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards.tsx
@@ -1,3 +1,64 @@
-export const HomeContentCards = () => {
-  return <h1>Content Cards Go Here</h1>
+import React, { useEffect, useState } from "react"
+import { HeroCarousel } from "Components/HeroCarousel/HeroCarousel"
+import {
+  HomeHeroUnit,
+  StaticHeroUnit,
+} from "Apps/Home/Components/HomeHeroUnits/HomeHeroUnit"
+
+interface ContentCardProps {
+  card: any
+  index: any
+}
+
+const ContentCard: React.FC<ContentCardProps> = ({ card, index }) => {
+  const extras = card.extras || {}
+
+  const heroUnit = {
+    backgroundImageURL: card.imageUrl,
+    creditLine: extras.credit,
+    heading: extras.label,
+    href: card.url,
+    linkText: card.linkText,
+    subtitle: card.description,
+    title: card.title,
+  } as StaticHeroUnit
+
+  return <HomeHeroUnit heroUnit={heroUnit} index={index} layout="a" />
+}
+
+export const HomeContentCards: React.FC = () => {
+  const [cards, setCards] = useState([] as any)
+
+  useEffect(() => {
+    window.analytics?.ready(() => {
+      const appboy = (window as any).appboy
+
+      if (!appboy) return
+
+      appboy.subscribeToContentCardsUpdates(async () => {
+        const response = await appboy.getCachedContentCards()
+        const { cards: updatedCards } = response
+        const sortedCards = updatedCards.sort((lhs, rhs) => {
+          const lhsPosition = (lhs.extras || {}).position || lhs.id
+          const rhsPosition = (rhs.extras || {}).position || rhs.id
+          return lhsPosition > rhsPosition ? 1 : -1
+        })
+        setCards(sortedCards)
+      })
+
+      appboy.requestContentCardsRefresh()
+    })
+  }, [])
+
+  if (cards.length < 1) {
+    return <h1>placeholder</h1>
+  }
+
+  return (
+    <HeroCarousel>
+      {cards.map((card, index) => (
+        <ContentCard card={card} key={card.id} index={index} />
+      ))}
+    </HeroCarousel>
+  )
 }

--- a/src/Apps/Home/HomeApp.tsx
+++ b/src/Apps/Home/HomeApp.tsx
@@ -26,6 +26,8 @@ export const HomeApp: React.FC<HomeAppProps> = ({
   homePage,
   featuredEventsOrderedSet,
 }) => {
+  const showHomeHeroUnits = !!homePage
+
   return (
     <>
       <HomeMeta />
@@ -34,7 +36,9 @@ export const HomeApp: React.FC<HomeAppProps> = ({
 
       <Spacer mt={[2, 0]} />
 
-      {homePage && <HomeHeroUnitsFragmentContainer homePage={homePage} />}
+      {showHomeHeroUnits && (
+        <HomeHeroUnitsFragmentContainer homePage={homePage} />
+      )}
 
       <Spacer mt={[4, 6]} />
 

--- a/src/Apps/Home/HomeApp.tsx
+++ b/src/Apps/Home/HomeApp.tsx
@@ -16,6 +16,9 @@ import { HomeAuctionLotsRailQueryRenderer } from "./Components/HomeAuctionLotsRa
 import { HomeWorksForYouTabBar } from "./Components/HomeWorksForYouTabBar"
 import { MyBidsQueryRenderer } from "Apps/Auctions/Components/MyBids/MyBids"
 import { HomeTroveArtworksRailQueryRenderer } from "./Components/HomeTroveArtworksRail"
+import { useRouter } from "System/Router/useRouter"
+import { paramsToCamelCase } from "Components/ArtworkFilter/Utils/urlBuilder"
+import { HomeContentCards } from "./Components/HomeContentCards"
 
 interface HomeAppProps {
   homePage: HomeApp_homePage$data | null
@@ -26,7 +29,12 @@ export const HomeApp: React.FC<HomeAppProps> = ({
   homePage,
   featuredEventsOrderedSet,
 }) => {
-  const showHomeHeroUnits = !!homePage
+  const { match } = useRouter()
+  const { brazeContentCards } = paramsToCamelCase(match?.location.query) as {
+    brazeContentCards?: boolean
+  }
+  const showBrazeContentCards = !!brazeContentCards
+  const showHomeHeroUnits = !showBrazeContentCards && !!homePage
 
   return (
     <>
@@ -35,6 +43,8 @@ export const HomeApp: React.FC<HomeAppProps> = ({
       <FlashBannerQueryRenderer />
 
       <Spacer mt={[2, 0]} />
+
+      {showBrazeContentCards && <HomeContentCards />}
 
       {showHomeHeroUnits && (
         <HomeHeroUnitsFragmentContainer homePage={homePage} />


### PR DESCRIPTION
This PR adds support on the homepage for a query param that will show us Braze content cards. This is useful as we build towards completely migrating to Braze for this content. An intermediary step like this let's us tinker in the Braze dashboard with the cards before users actually see them.

A follow up PR should include:

* proper placeholder
* log impressions to Braze
* log clicks to Braze
* suppress segment tracking
* (optionally) set a standard height to avoid ragged bottoms

And so I can work through that while other folks work on getting the stuff done in Braze.

https://artsyproduct.atlassian.net/browse/GRO-1385

/cc @artsy/grow-devs