### PR TITLE
fix(TX-824): Type guard for credit card picker in new payment

### DIFF
--- a/src/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/Apps/Order/Routes/NewPayment/index.tsx
@@ -74,7 +74,7 @@ export const NewPaymentRoute: FC<NewPaymentProps & StripeProps> = props => {
 
       if (result?.type === "error") {
         dialog.showErrorDialog({
-          title: result.error,
+          title: result?.error,
           message:
             "Please enter another payment method or contact your bank for more information.",
         })
@@ -85,7 +85,7 @@ export const NewPaymentRoute: FC<NewPaymentProps & StripeProps> = props => {
         dialog.showErrorDialog({
           title: "An internal error occurred",
         })
-        logger.error(result.error)
+        logger.error(result?.error)
         return
       }
 
@@ -97,18 +97,18 @@ export const NewPaymentRoute: FC<NewPaymentProps & StripeProps> = props => {
             orderId: order.internalID,
           },
         })
-      ).commerceFixFailedPayment?.orderOrError
+      ).commerceFixFailedPayment?.orderOrError!
 
-      if (orderOrError?.error) {
+      if (orderOrError.error) {
         handleFixFailedPaymentError(orderOrError.error.code)
         return
       }
 
-      if (orderOrError?.actionData && orderOrError?.actionData.clientSecret) {
+      if (orderOrError.actionData && orderOrError.actionData.clientSecret) {
         const scaResult = await stripe.handleCardAction(
           orderOrError.actionData.clientSecret
         )
-        if (scaResult?.error) {
+        if (scaResult.error) {
           dialog.showErrorDialog({
             title: "An error occurred",
             message: scaResult.error.message,

--- a/src/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/Apps/Order/Routes/NewPayment/index.tsx
@@ -67,12 +67,12 @@ export const NewPaymentRoute: FC<NewPaymentProps & StripeProps> = props => {
   const onContinue = async () => {
     try {
       setIsGettingCreditCardId(true)
-      const result = await CreditCardPicker?.current?.getCreditCardId()!
+      const result = await CreditCardPicker?.current?.getCreditCardId()
       setIsGettingCreditCardId(false)
 
-      if (result.type === "invalid_form") return
+      if (result?.type === "invalid_form") return
 
-      if (result.type === "error") {
+      if (result?.type === "error") {
         dialog.showErrorDialog({
           title: result.error,
           message:
@@ -81,7 +81,7 @@ export const NewPaymentRoute: FC<NewPaymentProps & StripeProps> = props => {
         return
       }
 
-      if (result.type === "internal_error") {
+      if (result?.type === "internal_error") {
         dialog.showErrorDialog({
           title: "An internal error occurred",
         })
@@ -92,23 +92,23 @@ export const NewPaymentRoute: FC<NewPaymentProps & StripeProps> = props => {
       const orderOrError = (
         await fixFailedPayment({
           input: {
-            creditCardId: result.creditCardId,
+            creditCardId: result?.creditCardId!,
             offerId: order.lastOffer?.internalID,
             orderId: order.internalID,
           },
         })
-      ).commerceFixFailedPayment?.orderOrError!
+      ).commerceFixFailedPayment?.orderOrError
 
-      if (orderOrError.error) {
+      if (orderOrError?.error) {
         handleFixFailedPaymentError(orderOrError.error.code)
         return
       }
 
-      if (orderOrError.actionData && orderOrError.actionData.clientSecret) {
+      if (orderOrError?.actionData && orderOrError?.actionData.clientSecret) {
         const scaResult = await stripe.handleCardAction(
           orderOrError.actionData.clientSecret
         )
-        if (scaResult.error) {
+        if (scaResult?.error) {
           dialog.showErrorDialog({
             title: "An error occurred",
             message: scaResult.error.message,

--- a/src/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/Apps/Order/Routes/NewPayment/index.tsx
@@ -47,10 +47,21 @@ export interface NewPaymentProps {
   isCommittingMutation: boolean
 }
 
+type CreditCardPickerResultType =
+  | { type: "error"; error: string | undefined }
+  | { type: "internal_error"; error: string | undefined }
+  | { type: "invalid_form" }
+  | { type: "success"; creditCardId: string }
+
 const logger = createLogger("Order/Routes/NewPayment/index.tsx")
 
 export const NewPaymentRoute: FC<NewPaymentProps & StripeProps> = props => {
   const [isGettingCreditCardId, setIsGettingCreditCardId] = useState(false)
+  const [
+    creditCardPickerResult,
+    setCreditCardPickerResult,
+  ] = useState<CreditCardPickerResultType | null>(null)
+
   const {
     order,
     me,
@@ -64,62 +75,80 @@ export const NewPaymentRoute: FC<NewPaymentProps & StripeProps> = props => {
   const isLoading = isCommittingMutation || isGettingCreditCardId
   const CreditCardPicker = createRef<CreditCardPicker>()
 
+  const getCreditCardId = async (): Promise<string | null> => {
+    setIsGettingCreditCardId(true)
+
+    const result = await CreditCardPicker?.current?.getCreditCardId()
+
+    setIsGettingCreditCardId(false)
+
+    if (result?.type === "invalid_form") return null
+
+    if (result?.type === "error") {
+      dialog.showErrorDialog({
+        title: result?.error,
+        message:
+          "Please enter another payment method or contact your bank for more information.",
+      })
+      return null
+    }
+
+    if (result?.type === "internal_error") {
+      dialog.showErrorDialog({
+        title: "An internal error occurred",
+      })
+      logger.error(result?.error)
+      return null
+    }
+
+    if (result?.type === "success" && result?.creditCardId) {
+      setCreditCardPickerResult(result)
+      return result.creditCardId
+    }
+
+    return null
+  }
+
   const onContinue = async () => {
     try {
-      setIsGettingCreditCardId(true)
-      const result = await CreditCardPicker?.current?.getCreditCardId()
-      setIsGettingCreditCardId(false)
+      const creditCardId =
+        creditCardPickerResult?.type === "success"
+          ? creditCardPickerResult.creditCardId
+          : await getCreditCardId()
 
-      if (result?.type === "invalid_form") return
-
-      if (result?.type === "error") {
-        dialog.showErrorDialog({
-          title: result?.error,
-          message:
-            "Please enter another payment method or contact your bank for more information.",
-        })
-        return
-      }
-
-      if (result?.type === "internal_error") {
-        dialog.showErrorDialog({
-          title: "An internal error occurred",
-        })
-        logger.error(result?.error)
-        return
-      }
-
-      const orderOrError = (
-        await fixFailedPayment({
-          input: {
-            creditCardId: result?.creditCardId!,
-            offerId: order.lastOffer?.internalID,
-            orderId: order.internalID,
-          },
-        })
-      ).commerceFixFailedPayment?.orderOrError!
-
-      if (orderOrError.error) {
-        handleFixFailedPaymentError(orderOrError.error.code)
-        return
-      }
-
-      if (orderOrError.actionData && orderOrError.actionData.clientSecret) {
-        const scaResult = await stripe.handleCardAction(
-          orderOrError.actionData.clientSecret
-        )
-        if (scaResult.error) {
-          dialog.showErrorDialog({
-            title: "An error occurred",
-            message: scaResult.error.message,
+      if (creditCardId) {
+        const orderOrError = (
+          await fixFailedPayment({
+            input: {
+              creditCardId,
+              offerId: order.lastOffer?.internalID,
+              orderId: order.internalID,
+            },
           })
-          return
-        } else {
-          onContinue()
-        }
-      }
+        ).commerceFixFailedPayment?.orderOrError!
 
-      router.push(`/orders/${order.internalID}/status`)
+        if (orderOrError.error) {
+          handleFixFailedPaymentError(orderOrError.error.code)
+          return
+        }
+
+        if (orderOrError.actionData && orderOrError.actionData.clientSecret) {
+          const scaResult = await stripe.handleCardAction(
+            orderOrError.actionData.clientSecret
+          )
+          if (scaResult.error) {
+            dialog.showErrorDialog({
+              title: "An error occurred",
+              message: scaResult.error.message,
+            })
+            return
+          } else {
+            onContinue()
+          }
+        }
+
+        router.push(`/orders/${order.internalID}/status`)
+      }
     } catch (error) {
       logger.error(error)
       dialog.showErrorDialog()


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [TX-824]

### Description
This PR attempts to fix the problem that buyers cannot fix a failed payment with credit card initially and have to try a second time to succeed. 

The detected problem was that by the time the buyer is prompted to authenticate their purchase through 3D Security, our credit card picker has already presented the creditCardId. When the buyer re-lands on the page after authorising the purchase through the Stripe modal, we lose the creditCardId initially acquired and make an API call to MP's newPayment mutation with creditCardId missing in the payload. 

This PR makes sure that we have the creditCardId after the 3D security modal has been closed. 

#### Video -> Make offer, accept offer, payment fails, user sets new payment with 3D
https://user-images.githubusercontent.com/42584148/199185863-f74c74f0-c93c-4e89-b45c-fa395a4a11a1.mov

[TX-824]: https://artsyproduct.atlassian.net/browse/TX-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ