### PR TITLE
fix(partner): removes carousels on artist rails

### DIFF
--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistArtworksRail.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistArtworksRail.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useState } from "react"
 import * as React from "react"
-import { Carousel } from "Components/Carousel"
 import {
   createPaginationContainer,
   graphql,
@@ -8,8 +6,8 @@ import {
 } from "react-relay"
 import { PartnerArtistArtworksRail_partnerArtist$data } from "__generated__/PartnerArtistArtworksRail_partnerArtist.graphql"
 import { extractNodes } from "Utils/extractNodes"
-import FillwidthItem from "Components/Artwork/FillwidthItem"
-import { PartnerArtistArtworkCarouselItemPlaceholder } from "./PartnerArtistDetailsPlaceholder"
+import { Shelf } from "@artsy/palette"
+import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
 
 export interface PartnerArtistArtworksRailProps {
   partnerArtist: PartnerArtistArtworksRail_partnerArtist$data
@@ -18,63 +16,25 @@ export interface PartnerArtistArtworksRailProps {
   relay: RelayPaginationProp
 }
 
-const PAGE_SIZE = 12
-
 export const PartnerArtistArtworksRail: React.FC<PartnerArtistArtworksRailProps> = ({
   partnerArtist,
   relay,
 }) => {
+  if (!partnerArtist.artworksConnection) return null
+
   const artworks = extractNodes(partnerArtist.artworksConnection)
 
-  const [isLoading, setIsLoading] = useState(false)
-  const [page, setPage] = useState(0)
-  const [pageCount, setPageCount] = useState(0)
-
-  useEffect(() => {
-    // check that the current page is close to the end of the carousel
-    if (relay.hasMore() && pageCount > 0 && pageCount - (page + 1) <= 1) {
-      loadMore()
-    }
-  }, [page, pageCount])
-
-  const loadMore = () => {
-    if (!relay.hasMore() || relay.isLoading()) return
-
-    setIsLoading(true)
-    relay.loadMore(PAGE_SIZE, error => {
-      if (error) console.error(error)
-
-      setIsLoading(false)
-    })
-  }
-
   return (
-    <Carousel
-      onChange={setPage}
-      onPageCountChange={setPageCount}
-      arrowHeight={160}
-    >
-      {artworks
-        .map(artwork => {
-          return (
-            <FillwidthItem
-              key={artwork.id}
-              artwork={artwork}
-              imageHeight={160}
-              lazyLoad
-              // @ts-ignore TODO: Add relevant contextModule
-              contextModule={null}
-            />
-          )
-        })
-        .concat(
-          isLoading
-            ? [
-                <PartnerArtistArtworkCarouselItemPlaceholder key="artwork-placeholder" />,
-              ]
-            : []
-        )}
-    </Carousel>
+    <Shelf>
+      {artworks.map(artwork => {
+        return (
+          <ShelfArtworkFragmentContainer
+            key={artwork.internalID}
+            artwork={artwork}
+          />
+        )
+      })}
+    </Shelf>
   )
 }
 
@@ -107,10 +67,11 @@ export const PartnerArtistArtworksRailPaginationContainer = createPaginationCont
         ) {
         artworksConnection(first: $first, after: $after)
           @connection(key: "PartnerArtistArtworksRail_artworksConnection") {
+          totalCount
           edges {
             node {
-              id
-              ...FillwidthItem_artwork
+              ...ShelfArtwork_artwork
+              internalID
             }
           }
         }

--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
@@ -35,7 +35,7 @@ export const PartnerArtistDetails: React.FC<PartnerArtistDetailsProps> = ({
   } = partnerArtist
 
   return (
-    <GridColumns gridRowGap={[2, 4]} my={4}>
+    <GridColumns gridRowGap={[2, 4]}>
       <Column span={6}>
         <GridColumns gridRowGap={2}>
           <Column span={12}>
@@ -59,22 +59,27 @@ export const PartnerArtistDetails: React.FC<PartnerArtistDetailsProps> = ({
       </Column>
 
       <Column span={6}>
-        <Join separator={<Spacer mt={2} />}>
-          {biographyBlurb?.text && (
-            <HTML variant="sm">
-              <ReadMore maxChars={320} content={biographyBlurb.text} />
-            </HTML>
-          )}
+        {biographyBlurb && (
+          <Join separator={<Spacer mt={2} />}>
+            {biographyBlurb.text && (
+              <HTML variant="sm">
+                <ReadMore maxChars={320} content={biographyBlurb.text} />
+              </HTML>
+            )}
 
-          {biographyBlurb?.credit && (
-            <HTML color="black60" variant="sm">
-              <ReadMore maxChars={320} content={`— ${biographyBlurb.credit}`} />
-            </HTML>
-          )}
-        </Join>
+            {biographyBlurb.credit && (
+              <HTML color="black60" variant="sm">
+                <ReadMore
+                  maxChars={320}
+                  content={`— ${biographyBlurb.credit}`}
+                />
+              </HTML>
+            )}
+          </Join>
+        )}
       </Column>
 
-      <Column span={12} maxWidth="100%">
+      <Column span={12}>
         <PartnerArtistArtworksRailPaginationContainer
           partnerId={partnerId}
           artistId={partnerArtist.node.slug}

--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetailsPlaceholder.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetailsPlaceholder.tsx
@@ -1,15 +1,15 @@
 import {
-  Box,
+  Button,
   Column,
   GridColumns,
-  SkeletonBox,
+  Shelf,
   SkeletonText,
 } from "@artsy/palette"
-import { Carousel } from "Components/Carousel"
+import { ShelfArtworkPlaceholder } from "Components/Artwork/ShelfArtwork"
 
 export const PartnerArtistDetailsPlaceholder: React.FC = () => {
   return (
-    <GridColumns gridRowGap={[2, 4]} my={4}>
+    <GridColumns gridRowGap={[2, 4]}>
       <Column span={6}>
         <GridColumns gridRowGap={2}>
           <Column span={12}>
@@ -19,13 +19,15 @@ export const PartnerArtistDetailsPlaceholder: React.FC = () => {
           </Column>
 
           <Column span={[12, 6]}>
-            <SkeletonBox width="100%" height={40} />
+            <Button variant="secondaryBlack" width="100%" disabled>
+              —
+            </Button>
           </Column>
         </GridColumns>
       </Column>
 
       <Column span={6}>
-        <SkeletonText>
+        <SkeletonText variant="sm">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum
           lacinia varius neque ac rhoncus. Phasellus cursus finibus aliquam. Nam
           congue eget erat faucibus scelerisque. Nulla elementum aliquet
@@ -35,27 +37,13 @@ export const PartnerArtistDetailsPlaceholder: React.FC = () => {
         </SkeletonText>
       </Column>
 
-      <Column span={12} maxWidth="100%">
-        <Carousel arrowHeight={160}>
+      <Column span={12}>
+        <Shelf>
           {[...new Array(10)].map((_, i) => {
-            return <PartnerArtistArtworkCarouselItemPlaceholder key={i} />
+            return <ShelfArtworkPlaceholder key={i} index={i} />
           })}
-        </Carousel>
+        </Shelf>
       </Column>
     </GridColumns>
   )
 }
-
-export const PartnerArtistArtworkCarouselItemPlaceholder: React.FC = () => (
-  <Box>
-    <SkeletonBox width={220} height={160} mb={1} />
-
-    <SkeletonText variant="sm-display">Artist name</SkeletonText>
-
-    <SkeletonText variant="sm">Artwork name</SkeletonText>
-
-    <SkeletonText variant="sm">Partner name</SkeletonText>
-
-    <SkeletonText variant="sm">Contact for price</SkeletonText>
-  </Box>
-)

--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsList.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsList.tsx
@@ -1,7 +1,6 @@
-import { Box, Join, Separator } from "@artsy/palette"
+import { Box, Join, Spacer } from "@artsy/palette"
 import { useEffect, useRef, useState } from "react"
 import * as React from "react"
-import { useSystemContext } from "System"
 import {
   createPaginationContainer,
   graphql,
@@ -64,11 +63,9 @@ export const PartnerArtistDetailsList: React.FC<PartnerArtistDetailsListProps> =
 
   return (
     <Box ref={containerRef as any}>
-      <Join separator={<Separator />}>
+      <Join separator={<Spacer mt={4} />}>
         {partner.artists?.edges?.map(edge => {
-          if (!edge) {
-            return null
-          }
+          if (!edge) return null
 
           return (
             <PartnerArtistDetailsFragmentContainer
@@ -82,7 +79,7 @@ export const PartnerArtistDetailsList: React.FC<PartnerArtistDetailsListProps> =
 
       {isLoading && (
         <>
-          <Separator />
+          <Spacer mt={4} />
 
           <PartnerArtistDetailsListPlaceholder count={PAGE_SIZE} />
         </>
@@ -148,12 +145,10 @@ export const PartnerArtistDetailsListPaginationContainer = createPaginationConta
 export const PartnerArtistDetailsListRenderer: React.FC<{
   partnerId: string
 }> = ({ partnerId, ...rest }) => {
-  const { relayEnvironment } = useSystemContext()
-
   return (
     <SystemQueryRenderer<PartnerArtistDetailsListQuery>
       lazyLoad
-      environment={relayEnvironment}
+      // debugPlaceholder
       query={graphql`
         query PartnerArtistDetailsListRendererQuery($partnerId: String!) {
           partner(id: $partnerId) @principalField {

--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsListPlaceholder.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsListPlaceholder.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { PartnerArtistDetailsPlaceholder } from "Apps/Partner/Components/PartnerArtists/PartnerArtistDetails"
-import { Join, Separator } from "@artsy/palette"
+import { Join, Skeleton, Spacer } from "@artsy/palette"
 
 export interface PartnerArtistDetailsListPlaceholderProps {
   count: number
@@ -10,10 +10,12 @@ export const PartnerArtistDetailsListPlaceholder: React.FC<PartnerArtistDetailsL
   count,
 }) => {
   return (
-    <Join separator={<Separator />}>
-      {[...Array(count)].map((_, i) => (
-        <PartnerArtistDetailsPlaceholder key={i} />
-      ))}
-    </Join>
+    <Skeleton>
+      <Join separator={<Spacer mt={4} />}>
+        {[...Array(count)].map((_, i) => (
+          <PartnerArtistDetailsPlaceholder key={i} />
+        ))}
+      </Join>
+    </Skeleton>
   )
 }

--- a/src/__generated__/PartnerArtistArtworksRailQuery.graphql.ts
+++ b/src/__generated__/PartnerArtistArtworksRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<04b5cebd5b0a4daf7c375d5d26abaaad>>
+ * @generated SignedSource<<23ffc54b7108dae3463c7fe092146a4c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -92,14 +92,14 @@ v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "href",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
+  "name": "id",
   "storageKey": null
 },
 v9 = [
@@ -134,7 +134,7 @@ v12 = [
 ],
 v13 = [
   (v10/*: any*/),
-  (v7/*: any*/)
+  (v8/*: any*/)
 ];
 return {
   "fragment": {
@@ -236,6 +236,13 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "kind": "ScalarField",
+                        "name": "totalCount",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "concreteType": "ArtworkEdge",
                         "kind": "LinkedField",
                         "name": "edges",
@@ -253,54 +260,8 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
-                                "concreteType": "Image",
-                                "kind": "LinkedField",
-                                "name": "image",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "version",
-                                        "value": "larger"
-                                      }
-                                    ],
-                                    "kind": "ScalarField",
-                                    "name": "url",
-                                    "storageKey": "url(version:\"larger\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "aspectRatio",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "imageTitle",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
                                 "kind": "ScalarField",
                                 "name": "title",
-                                "storageKey": null
-                              },
-                              (v8/*: any*/),
-                              {
-                                "alias": "is_saved",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isSaved",
                                 "storageKey": null
                               },
                               {
@@ -350,7 +311,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/)
+                                  (v8/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -380,8 +341,8 @@ return {
                                 "name": "artists",
                                 "plural": true,
                                 "selections": [
-                                  (v7/*: any*/),
                                   (v8/*: any*/),
+                                  (v7/*: any*/),
                                   (v10/*: any*/)
                                 ],
                                 "storageKey": "artists(shallow:true)"
@@ -402,8 +363,8 @@ return {
                                 "plural": false,
                                 "selections": [
                                   (v10/*: any*/),
-                                  (v8/*: any*/),
-                                  (v7/*: any*/)
+                                  (v7/*: any*/),
+                                  (v8/*: any*/)
                                 ],
                                 "storageKey": "partner(shallow:true)"
                               },
@@ -451,21 +412,7 @@ return {
                                     "name": "isClosed",
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/),
-                                  {
-                                    "alias": "is_preview",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isPreview",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "display_timely_at",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "displayTimelyAt",
-                                    "storageKey": null
-                                  }
+                                  (v8/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -544,10 +491,11 @@ return {
                                     "selections": (v12/*: any*/),
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/)
+                                  (v8/*: any*/)
                                 ],
                                 "storageKey": null
                               },
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -560,6 +508,13 @@ return {
                                 "args": null,
                                 "kind": "ScalarField",
                                 "name": "slug",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_saved",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isSaved",
                                 "storageKey": null
                               },
                               {
@@ -594,10 +549,52 @@ return {
                                 "storageKey": null
                               },
                               {
-                                "alias": "is_biddable",
+                                "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
-                                "name": "isBiddable",
+                                "name": "artistNames",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "src",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": [
+                                          "normalized",
+                                          "larger",
+                                          "large"
+                                        ]
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "width",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "height",
+                                    "storageKey": null
+                                  }
+                                ],
                                 "storageKey": null
                               },
                               {
@@ -657,26 +654,26 @@ return {
                     "kind": "LinkedHandle",
                     "name": "artworksConnection"
                   },
-                  (v7/*: any*/)
+                  (v8/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "d61d2b57722dececcbd5d5a780be6273",
+    "cacheID": "9ca476c6804bd996b8730567559d587d",
     "id": null,
     "metadata": {},
     "name": "PartnerArtistArtworksRailQuery",
     "operationKind": "query",
-    "text": "query PartnerArtistArtworksRailQuery(\n  $partnerId: String!\n  $artistId: String!\n  $first: Int\n  $after: String\n) {\n  partner(id: $partnerId) {\n    artistsConnection(artistIDs: [$artistId], first: 1) {\n      edges {\n        ...PartnerArtistArtworksRail_partnerArtist_2HEEH6\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PartnerArtistArtworksRail_partnerArtist_2HEEH6 on ArtistPartnerEdge {\n  artworksConnection(first: $first, after: $after) {\n    edges {\n      node {\n        id\n        ...FillwidthItem_artwork\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query PartnerArtistArtworksRailQuery(\n  $partnerId: String!\n  $artistId: String!\n  $first: Int\n  $after: String\n) {\n  partner(id: $partnerId) {\n    artistsConnection(artistIDs: [$artistId], first: 1) {\n      edges {\n        ...PartnerArtistArtworksRail_partnerArtist_2HEEH6\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PartnerArtistArtworksRail_partnerArtist_2HEEH6 on ArtistPartnerEdge {\n  artworksConnection(first: $first, after: $after) {\n    totalCount\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerArtistArtworksRail_partnerArtist.graphql.ts
+++ b/src/__generated__/PartnerArtistArtworksRail_partnerArtist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<274db5dbb442bb255afec491951007ab>>
+ * @generated SignedSource<<e211312e7c0edd756b30abb669545d2b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,10 +14,11 @@ export type PartnerArtistArtworksRail_partnerArtist$data = {
   readonly artworksConnection: {
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly id: string;
-        readonly " $fragmentSpreads": FragmentRefs<"FillwidthItem_artwork">;
+        readonly internalID: string;
+        readonly " $fragmentSpreads": FragmentRefs<"ShelfArtwork_artwork">;
       } | null;
     } | null> | null;
+    readonly totalCount: number | null;
   } | null;
   readonly " $fragmentType": "PartnerArtistArtworksRail_partnerArtist";
 };
@@ -65,6 +66,13 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
           "concreteType": "ArtworkEdge",
           "kind": "LinkedField",
           "name": "edges",
@@ -79,16 +87,16 @@ const node: ReaderFragment = {
               "plural": false,
               "selections": [
                 {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "ShelfArtwork_artwork"
+                },
+                {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "id",
+                  "name": "internalID",
                   "storageKey": null
-                },
-                {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "FillwidthItem_artwork"
                 },
                 {
                   "alias": null,
@@ -143,6 +151,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "292a7fb2cf8a823f690116e4c56469b5";
+(node as any).hash = "60f6d7b38c7470b4b0618dc407c149e1";
 
 export default node;

--- a/src/__generated__/PartnerArtistDetailsListQuery.graphql.ts
+++ b/src/__generated__/PartnerArtistDetailsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<93730305d17c8b53d6414f974f1dbec7>>
+ * @generated SignedSource<<886a28ce782a69e15925ab6d1f512db1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -317,6 +317,13 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "kind": "ScalarField",
+                        "name": "totalCount",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "concreteType": "ArtworkEdge",
                         "kind": "LinkedField",
                         "name": "edges",
@@ -330,58 +337,12 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v8/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Image",
-                                "kind": "LinkedField",
-                                "name": "image",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "version",
-                                        "value": "larger"
-                                      }
-                                    ],
-                                    "kind": "ScalarField",
-                                    "name": "url",
-                                    "storageKey": "url(version:\"larger\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "aspectRatio",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "imageTitle",
-                                "storageKey": null
-                              },
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
                                 "name": "title",
-                                "storageKey": null
-                              },
-                              (v10/*: any*/),
-                              {
-                                "alias": "is_saved",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isSaved",
                                 "storageKey": null
                               },
                               {
@@ -532,21 +493,7 @@ return {
                                     "name": "isClosed",
                                     "storageKey": null
                                   },
-                                  (v8/*: any*/),
-                                  {
-                                    "alias": "is_preview",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isPreview",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "display_timely_at",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "displayTimelyAt",
-                                    "storageKey": null
-                                  }
+                                  (v8/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -629,8 +576,16 @@ return {
                                 ],
                                 "storageKey": null
                               },
+                              (v8/*: any*/),
                               (v15/*: any*/),
                               (v6/*: any*/),
+                              {
+                                "alias": "is_saved",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isSaved",
+                                "storageKey": null
+                              },
                               {
                                 "alias": null,
                                 "args": null,
@@ -663,10 +618,52 @@ return {
                                 "storageKey": null
                               },
                               {
-                                "alias": "is_biddable",
+                                "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
-                                "name": "isBiddable",
+                                "name": "artistNames",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "src",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": [
+                                          "normalized",
+                                          "larger",
+                                          "large"
+                                        ]
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "width",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "height",
+                                    "storageKey": null
+                                  }
+                                ],
                                 "storageKey": null
                               },
                               (v17/*: any*/)
@@ -741,12 +738,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "86c5d9e1029947d7ec82329055581d7c",
+    "cacheID": "1d143614123837575fbd3b312c674214",
     "id": null,
     "metadata": {},
     "name": "PartnerArtistDetailsListQuery",
     "operationKind": "query",
-    "text": "query PartnerArtistDetailsListQuery(\n  $partnerId: String!\n  $first: Int!\n  $after: String\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistDetailsList_partner_2HEEH6\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PartnerArtistArtworksRail_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 12) {\n    edges {\n      node {\n        id\n        ...FillwidthItem_artwork\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetailsList_partner_2HEEH6 on Partner {\n  slug\n  artists: artistsConnection(first: $first, after: $after, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      id\n      representedBy\n      counts {\n        artworks\n      }\n      ...PartnerArtistDetails_partnerArtist\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  ...PartnerArtistArtworksRail_partnerArtist\n  node {\n    internalID\n    slug\n    name\n    href\n    formattedNationalityAndBirthday\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query PartnerArtistDetailsListQuery(\n  $partnerId: String!\n  $first: Int!\n  $after: String\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistDetailsList_partner_2HEEH6\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PartnerArtistArtworksRail_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 12) {\n    totalCount\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetailsList_partner_2HEEH6 on Partner {\n  slug\n  artists: artistsConnection(first: $first, after: $after, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      id\n      representedBy\n      counts {\n        artworks\n      }\n      ...PartnerArtistDetails_partnerArtist\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  ...PartnerArtistArtworksRail_partnerArtist\n  node {\n    internalID\n    slug\n    name\n    href\n    formattedNationalityAndBirthday\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerArtistDetailsListRendererQuery.graphql.ts
+++ b/src/__generated__/PartnerArtistDetailsListRendererQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4e301ec74f01ae801dc042698eb8e0a0>>
+ * @generated SignedSource<<bbe50862a77d0d954cd76a0d63a3b7b4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -289,6 +289,13 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "kind": "ScalarField",
+                        "name": "totalCount",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "concreteType": "ArtworkEdge",
                         "kind": "LinkedField",
                         "name": "edges",
@@ -302,58 +309,12 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v4/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Image",
-                                "kind": "LinkedField",
-                                "name": "image",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "version",
-                                        "value": "larger"
-                                      }
-                                    ],
-                                    "kind": "ScalarField",
-                                    "name": "url",
-                                    "storageKey": "url(version:\"larger\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "aspectRatio",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "imageTitle",
-                                "storageKey": null
-                              },
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
                                 "name": "title",
-                                "storageKey": null
-                              },
-                              (v6/*: any*/),
-                              {
-                                "alias": "is_saved",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isSaved",
                                 "storageKey": null
                               },
                               {
@@ -504,21 +465,7 @@ return {
                                     "name": "isClosed",
                                     "storageKey": null
                                   },
-                                  (v4/*: any*/),
-                                  {
-                                    "alias": "is_preview",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isPreview",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "display_timely_at",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "displayTimelyAt",
-                                    "storageKey": null
-                                  }
+                                  (v4/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -601,8 +548,16 @@ return {
                                 ],
                                 "storageKey": null
                               },
+                              (v4/*: any*/),
                               (v11/*: any*/),
                               (v2/*: any*/),
+                              {
+                                "alias": "is_saved",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isSaved",
+                                "storageKey": null
+                              },
                               {
                                 "alias": null,
                                 "args": null,
@@ -635,10 +590,52 @@ return {
                                 "storageKey": null
                               },
                               {
-                                "alias": "is_biddable",
+                                "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
-                                "name": "isBiddable",
+                                "name": "artistNames",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "src",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": [
+                                          "normalized",
+                                          "larger",
+                                          "large"
+                                        ]
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "width",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "height",
+                                    "storageKey": null
+                                  }
+                                ],
                                 "storageKey": null
                               },
                               (v13/*: any*/)
@@ -713,12 +710,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ba5ea0d244fffc28b092407a3614bc4a",
+    "cacheID": "d755537ce8a2f39d0516796956fe0d59",
     "id": null,
     "metadata": {},
     "name": "PartnerArtistDetailsListRendererQuery",
     "operationKind": "query",
-    "text": "query PartnerArtistDetailsListRendererQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistDetailsList_partner\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PartnerArtistArtworksRail_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 12) {\n    edges {\n      node {\n        id\n        ...FillwidthItem_artwork\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetailsList_partner on Partner {\n  slug\n  artists: artistsConnection(first: 3, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      id\n      representedBy\n      counts {\n        artworks\n      }\n      ...PartnerArtistDetails_partnerArtist\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  ...PartnerArtistArtworksRail_partnerArtist\n  node {\n    internalID\n    slug\n    name\n    href\n    formattedNationalityAndBirthday\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query PartnerArtistDetailsListRendererQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistDetailsList_partner\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PartnerArtistArtworksRail_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 12) {\n    totalCount\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetailsList_partner on Partner {\n  slug\n  artists: artistsConnection(first: 3, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      id\n      representedBy\n      counts {\n        artworks\n      }\n      ...PartnerArtistDetails_partnerArtist\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  ...PartnerArtistArtworksRail_partnerArtist\n  node {\n    internalID\n    slug\n    name\n    href\n    formattedNationalityAndBirthday\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerArtistDetailsQuery.graphql.ts
+++ b/src/__generated__/PartnerArtistDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a8dcbd089e7a36b09cf1110b16bf8a4b>>
+ * @generated SignedSource<<61a1816f526a82c0fb2b8048d627b335>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -75,14 +75,14 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "href",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
+  "name": "id",
   "storageKey": null
 },
 v7 = [
@@ -131,7 +131,7 @@ v12 = {
 },
 v13 = [
   (v8/*: any*/),
-  (v5/*: any*/)
+  (v6/*: any*/)
 ];
 return {
   "fragment": {
@@ -260,6 +260,13 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "kind": "ScalarField",
+                        "name": "totalCount",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "concreteType": "ArtworkEdge",
                         "kind": "LinkedField",
                         "name": "edges",
@@ -277,54 +284,8 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
-                                "concreteType": "Image",
-                                "kind": "LinkedField",
-                                "name": "image",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "version",
-                                        "value": "larger"
-                                      }
-                                    ],
-                                    "kind": "ScalarField",
-                                    "name": "url",
-                                    "storageKey": "url(version:\"larger\")"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "aspectRatio",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "imageTitle",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
                                 "kind": "ScalarField",
                                 "name": "title",
-                                "storageKey": null
-                              },
-                              (v6/*: any*/),
-                              {
-                                "alias": "is_saved",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isSaved",
                                 "storageKey": null
                               },
                               {
@@ -374,7 +335,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -404,8 +365,8 @@ return {
                                 "name": "artists",
                                 "plural": true,
                                 "selections": [
-                                  (v5/*: any*/),
                                   (v6/*: any*/),
+                                  (v5/*: any*/),
                                   (v8/*: any*/)
                                 ],
                                 "storageKey": "artists(shallow:true)"
@@ -426,8 +387,8 @@ return {
                                 "plural": false,
                                 "selections": [
                                   (v8/*: any*/),
-                                  (v6/*: any*/),
-                                  (v5/*: any*/)
+                                  (v5/*: any*/),
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": "partner(shallow:true)"
                               },
@@ -475,21 +436,7 @@ return {
                                     "name": "isClosed",
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/),
-                                  {
-                                    "alias": "is_preview",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isPreview",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "display_timely_at",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "displayTimelyAt",
-                                    "storageKey": null
-                                  }
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -568,12 +515,20 @@ return {
                                     "selections": (v10/*: any*/),
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": null
                               },
+                              (v6/*: any*/),
                               (v11/*: any*/),
                               (v12/*: any*/),
+                              {
+                                "alias": "is_saved",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isSaved",
+                                "storageKey": null
+                              },
                               {
                                 "alias": null,
                                 "args": null,
@@ -606,10 +561,52 @@ return {
                                 "storageKey": null
                               },
                               {
-                                "alias": "is_biddable",
+                                "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
-                                "name": "isBiddable",
+                                "name": "artistNames",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "src",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": [
+                                          "normalized",
+                                          "larger",
+                                          "large"
+                                        ]
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:[\"normalized\",\"larger\",\"large\"])"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "width",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "height",
+                                    "storageKey": null
+                                  }
+                                ],
                                 "storageKey": null
                               },
                               {
@@ -680,7 +677,7 @@ return {
                       (v11/*: any*/),
                       (v12/*: any*/),
                       (v8/*: any*/),
-                      (v6/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -688,30 +685,30 @@ return {
                         "name": "formattedNationalityAndBirthday",
                         "storageKey": null
                       },
-                      (v5/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v5/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "98b0d03e470dc985549a08708a668041",
+    "cacheID": "2169027a351be6fab825f588f947d0b8",
     "id": null,
     "metadata": {},
     "name": "PartnerArtistDetailsQuery",
     "operationKind": "query",
-    "text": "query PartnerArtistDetailsQuery(\n  $partnerId: String!\n  $artistId: String!\n) {\n  partner(id: $partnerId) {\n    artistsConnection(artistIDs: [$artistId], first: 1) {\n      edges {\n        ...PartnerArtistDetails_partnerArtist\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PartnerArtistArtworksRail_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 12) {\n    edges {\n      node {\n        id\n        ...FillwidthItem_artwork\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  ...PartnerArtistArtworksRail_partnerArtist\n  node {\n    internalID\n    slug\n    name\n    href\n    formattedNationalityAndBirthday\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query PartnerArtistDetailsQuery(\n  $partnerId: String!\n  $artistId: String!\n) {\n  partner(id: $partnerId) {\n    artistsConnection(artistIDs: [$artistId], first: 1) {\n      edges {\n        ...PartnerArtistDetails_partnerArtist\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment PartnerArtistArtworksRail_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 12) {\n    totalCount\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  ...PartnerArtistArtworksRail_partnerArtist\n  node {\n    internalID\n    slug\n    name\n    href\n    formattedNationalityAndBirthday\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"normalized\", \"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Still working towards [GRO-1383](https://artsyproduct.atlassian.net/browse/GRO-1383)

This PR removes the usage of `Carousel` and `FillWidthItem` on the `/partner/:id/artists` tab. Replacing those with `Shelf` components.