### PR TITLE
chore(volley): updates image metrics

### DIFF
--- a/src/Utils/Hooks/__tests__/useImagePerformanceObserver.jest.ts
+++ b/src/Utils/Hooks/__tests__/useImagePerformanceObserver.jest.ts
@@ -45,25 +45,34 @@ describe("useImagePerformanceObserver", () => {
 
     result.current.current = [
       {
-        initiatorType: "img",
-        transferSize: 10000,
-        name:
-          "https://d7hftxdivxxvm.cloudfront.net?resize_to=width&width=100&quality=80",
-        duration: 100,
+        rootPath: "article",
+        entry: {
+          initiatorType: "img",
+          transferSize: 10000,
+          name:
+            "https://d7hftxdivxxvm.cloudfront.net?resize_to=width&width=100&quality=80",
+          duration: 100,
+        },
       },
       {
-        initiatorType: "img",
-        transferSize: 3333333,
-        name:
-          "https://d7hftxdivxxvm.cloudfront.net?resize_to=width&width=100&quality=80",
-        duration: 333,
+        rootPath: "article",
+        entry: {
+          initiatorType: "img",
+          transferSize: 3333333,
+          name:
+            "https://d7hftxdivxxvm.cloudfront.net?resize_to=width&width=100&quality=80",
+          duration: 333,
+        },
       },
       {
-        initiatorType: "img",
-        transferSize: 100000,
-        name:
-          "https://d7hftxdivxxvm.cloudfront.net?resize_to=width&width=100&quality=80",
-        duration: 150,
+        rootPath: "article",
+        entry: {
+          initiatorType: "img",
+          transferSize: 100000,
+          name:
+            "https://d7hftxdivxxvm.cloudfront.net?resize_to=width&width=100&quality=80",
+          duration: 150,
+        },
       },
     ]
 
@@ -73,19 +82,34 @@ describe("useImagePerformanceObserver", () => {
     expect(spy).toBeCalledWith([
       {
         name: "image.load-time",
-        tags: ["transfer-size:sm", "device-type:desktop"],
+        tags: [
+          "transfer-size:0-100kb",
+          "device-type:desktop",
+          "pixel-ratio:1",
+          "root-path:article",
+        ],
         timing: 100,
         type: "timing",
       },
       {
         name: "image.load-time",
-        tags: ["transfer-size:xl", "device-type:desktop"],
+        tags: [
+          "transfer-size:3300-3400kb",
+          "device-type:desktop",
+          "pixel-ratio:1",
+          "root-path:article",
+        ],
         timing: 333,
         type: "timing",
       },
       {
         name: "image.load-time",
-        tags: ["transfer-size:md", "device-type:desktop"],
+        tags: [
+          "transfer-size:100-200kb",
+          "device-type:desktop",
+          "pixel-ratio:1",
+          "root-path:article",
+        ],
         timing: 150,
         type: "timing",
       },


### PR DESCRIPTION
Closes [GRO-1406](https://artsyproduct.atlassian.net/browse/GRO-1406)

* I can't use the `pageType` tagging that the page load metrics use. Those rely on something server-side and aren't updated as the client-side route changes. Instead I went with just pulling off the first path dir, tagged with `root-path`. Now that we no longer have top-level vanity routes, this should be sufficent: `artwork`, `article`, `collect`... etc.
* I added a tag for device pixel ratio. Not sure if this is necessary but would be nice to have to better determine where large images are coming from.
* I didn't add a cap to the transfer size because I just don't know where that top is. It'd be good to get some insight here.