### PR TITLE
fix(artwork): prevents re-render

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowserSmall.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowserSmall.tsx
@@ -15,7 +15,9 @@ import { ArtworkVideoPlayerFragmentContainer } from "Apps/Artwork/Components/Art
 
 interface ArtworkImageBrowserSmallProps {
   artwork: ArtworkImageBrowserSmall_artwork$data
+  /** Index of the currently active artwork */
   index: number
+  /** Update the currently active artwork (on swipe change) */
   setIndex(index: number): void
   maxHeight: number
 }
@@ -54,7 +56,7 @@ const ArtworkImageBrowserSmall: React.FC<ArtworkImageBrowserSmallProps> = ({
                   maxHeight={maxHeight}
                   my={2}
                   artwork={artwork}
-                  activeIndex={artwork.isSetVideoAsCover ? index - 1 : index}
+                  activeIndex={artwork.isSetVideoAsCover ? i - 1 : i}
                   lazyLoad={i !== 0}
                   onClick={
                     activeFigure.type === "Image" && activeFigure.isZoomable


### PR DESCRIPTION
Closes: [GRO-1411](https://artsyproduct.atlassian.net/browse/GRO-1411)

So turns out this problem was a little weird than I had initially thought. I ticketed this thinking updating the index was causing re-renders — what was actually happening was a bit more subtle. This change: https://github.com/artsy/force/commit/f3dc33a53cafd1b4172f2f4067ab1111135e82f3#diff-9f79588cb81cf2099b264bdfb20a943d6b5eb82b78d6ccfbbfad94b0fbe0e528 mixed up the variables `index` and `i`. 

What we _want_ to be doing is render the swiper with all of the images in them. As you swipe through them it updates the index that you're viewing which in turn updates the progress indicator dots on the bottom. What this change did was render a swiper with N copies of the active image. So as you swiped through it would update that index which would then update the swiper to re-render the entire thing with N copies of the new image.

Thank you to @MrSltun for the bug report in #practice-web.