### PR TITLE
fix(video): Temporarily remove bg color for now

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkVideoPlayer/ArtworkVideoPlayer.tsx
+++ b/src/Apps/Artwork/Components/ArtworkVideoPlayer/ArtworkVideoPlayer.tsx
@@ -42,7 +42,8 @@ const ArtworkVideoPlayer: FC<ArtworkVideoPlayerProps> = ({
         maxHeight={MAX_DIMENSION}
         aspectWidth={activeVideo.videoWidth}
         aspectHeight={activeVideo.videoHeight}
-        bg="black10"
+        // TODO: Uncomment this when dimensions issue is investigated a bit more
+        // bg="black10"
       >
         <iframe
           src={activeVideo.url}


### PR DESCRIPTION
This temporarily removes the background frame color on the video while we investigate other issues with vimeo possibly returning wrong dimensions. For now this fixes the issue seen:

before: 
<img width="1029" alt="Screen Shot 2022-11-03 at 10 34 59 AM" src="https://user-images.githubusercontent.com/236943/199803212-f9686d8b-e1d9-46d8-9401-e62c8cd58749.png">

after: 
<img width="1486" alt="Screen Shot 2022-11-03 at 11 05 23 AM" src="https://user-images.githubusercontent.com/236943/199803349-89e16e69-26e1-42c9-bde2-1ee2ea4f2640.png">


