### PR TITLE
feat(TX-861): improve accessibility tabbing on order app 

### DIFF
--- a/src/Apps/Order/Components/SavedAddressItem.tsx
+++ b/src/Apps/Order/Components/SavedAddressItem.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, RadioProps } from "@artsy/palette"
+import { Flex, Text, RadioProps, Clickable } from "@artsy/palette"
 import * as React from "react"
 import styled from "styled-components"
 import { SavedAddresses_me$data } from "__generated__/SavedAddresses_me.graphql"
@@ -68,7 +68,7 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
           {phoneNumber}
         </Text>
       </Flex>
-      <EditButton
+      <Clickable
         position="absolute"
         top={2}
         right={2}
@@ -78,12 +78,12 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
 
           handleClickEdit(index)
         }}
-        textColor="blue100"
-        variant="sm"
         data-test="editAddressInShipping"
       >
-        Edit
-      </EditButton>
+        <EditButton textColor="blue100" variant="sm">
+          Edit
+        </EditButton>
+      </Clickable>
     </Flex>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-861]

### Description

This PR improves the accessibility of the order app by making sure all buttons / radios / inputs are able to be tab navigated and keypress clickable. 

So far I've only discovered one failing button --> the edit button. 

I've also noticed that the modal close buttons are also failing, but I will complete this in a separate Palette PR. Please let me know if you see anything else!

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-861]: https://artsyproduct.atlassian.net/browse/TX-861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ