### PR TITLE
fix(artist): temporarily removes sticky zero state while investigating infinite loop render bug

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
@@ -2,7 +2,6 @@ import { Box, BoxProps, Message } from "@artsy/palette"
 import { isEmpty } from "lodash"
 import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { ArtworkGridEmptyState } from "Components/ArtworkGrid/ArtworkGridEmptyState"
-import { Sticky } from "Components/Sticky"
 
 export const ZeroState: React.FC<BoxProps> = props => {
   const { selectedFiltersCounts, resetFilters } = useArtworkFilterContext()
@@ -14,18 +13,9 @@ export const ZeroState: React.FC<BoxProps> = props => {
 
   return (
     <Box width="100%" {...props}>
-      <Sticky>
-        {({ stuck }) => {
-          return (
-            <Box pt={stuck ? 1 : 0}>
-              <Message title="No works available by the artist at this time">
-                Create an Alert to receive notifications when new works are
-                added
-              </Message>
-            </Box>
-          )
-        }}
-      </Sticky>
+      <Message title="No works available by the artist at this time">
+        Create an Alert to receive notifications when new works are added
+      </Message>
     </Box>
   )
 }

--- a/src/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
@@ -1,4 +1,3 @@
-import { Sticky } from "../Sticky"
 import { Box, BoxProps, Clickable, Message } from "@artsy/palette"
 import * as React from "react"
 import styled from "styled-components"
@@ -12,30 +11,19 @@ export const ArtworkGridEmptyState: React.FC<ArtworkGridEmptyStateProps> = ({
   ...rest
 }) => (
   <Box width="100%" {...rest}>
-    <Sticky>
-      {({ stuck }) => {
-        return (
-          <Box pt={stuck ? 1 : 0}>
-            <Message width="100%">
-              There aren't any works available that meet the following criteria
-              at this time.{" "}
-              {onClearFilters && (
-                <>
-                  Change your filter criteria to view more works.{" "}
-                  <ResetFilterLink
-                    textDecoration="underline"
-                    onClick={onClearFilters}
-                  >
-                    Clear all filters
-                  </ResetFilterLink>
-                  .
-                </>
-              )}
-            </Message>
-          </Box>
-        )
-      }}
-    </Sticky>
+    <Message width="100%">
+      There aren't any works available that meet the following criteria at this
+      time.{" "}
+      {onClearFilters && (
+        <>
+          Change your filter criteria to view more works.{" "}
+          <ResetFilterLink textDecoration="underline" onClick={onClearFilters}>
+            Clear all filters
+          </ResetFilterLink>
+          .
+        </>
+      )}
+    </Message>
   </Box>
 )
 


### PR DESCRIPTION
Re: [GRO-1424](https://artsyproduct.atlassian.net/browse/GRO-1424)

Temporarily removing the `Sticky` surrounding the empty states here while investigating. This bug is almost certainly caused by my work with the `Jump` component but it's hard to pinpoint because the filter has such a convoluted component architecture.

Disabling sticky here while I try to set up a clean room repro of the problem in Storybook.