### PR TITLE
fix(filter): fixes infinite render bug

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -76,7 +76,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
         { value: "-year", text: "Artwork year (desc.)" },
         { value: "year", text: "Artwork year (asc.)" },
       ]}
-      ZeroState={() => <ZeroState my={1} />}
+      ZeroState={ZeroState}
       userPreferredMetric={userPreferences?.metric}
     >
       <BaseArtworkFilter

--- a/src/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ZeroState.tsx
@@ -2,6 +2,7 @@ import { Box, BoxProps, Message } from "@artsy/palette"
 import { isEmpty } from "lodash"
 import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { ArtworkGridEmptyState } from "Components/ArtworkGrid/ArtworkGridEmptyState"
+import { Sticky } from "Components/Sticky"
 
 export const ZeroState: React.FC<BoxProps> = props => {
   const { selectedFiltersCounts, resetFilters } = useArtworkFilterContext()
@@ -13,9 +14,18 @@ export const ZeroState: React.FC<BoxProps> = props => {
 
   return (
     <Box width="100%" {...props}>
-      <Message title="No works available by the artist at this time">
-        Create an Alert to receive notifications when new works are added
-      </Message>
+      <Sticky>
+        {({ stuck }) => {
+          return (
+            <Box pt={stuck ? 1 : 0}>
+              <Message title="No works available by the artist at this time">
+                Create an Alert to receive notifications when new works are
+                added
+              </Message>
+            </Box>
+          )
+        }}
+      </Sticky>
     </Box>
   )
 }

--- a/src/Apps/Example/Routes/ArtworkFilter/ExampleArtworkFilterRoute.tsx
+++ b/src/Apps/Example/Routes/ArtworkFilter/ExampleArtworkFilterRoute.tsx
@@ -30,9 +30,13 @@ const ExampleArtworkFilterRoute: React.FC<ExampleArtworkFilterProps> = ({
         { text: "Artwork year (desc.)", value: "-year" },
         { text: "Artwork year (asc.)", value: "year" },
       ]}
-      ZeroState={() => <Text variant="sm-display">No Results.</Text>}
+      ZeroState={CustomZeroState}
     />
   )
+}
+
+const CustomZeroState = () => {
+  return <Text variant="sm-display">No Results.</Text>
 }
 
 export const ExampleArtworkFilterFragmentContainer = createFragmentContainer(

--- a/src/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGridEmptyState.tsx
@@ -1,4 +1,5 @@
 import { Box, BoxProps, Clickable, Message } from "@artsy/palette"
+import { Sticky } from "Components/Sticky"
 import * as React from "react"
 import styled from "styled-components"
 
@@ -11,19 +12,30 @@ export const ArtworkGridEmptyState: React.FC<ArtworkGridEmptyStateProps> = ({
   ...rest
 }) => (
   <Box width="100%" {...rest}>
-    <Message width="100%">
-      There aren't any works available that meet the following criteria at this
-      time.{" "}
-      {onClearFilters && (
-        <>
-          Change your filter criteria to view more works.{" "}
-          <ResetFilterLink textDecoration="underline" onClick={onClearFilters}>
-            Clear all filters
-          </ResetFilterLink>
-          .
-        </>
-      )}
-    </Message>
+    <Sticky>
+      {({ stuck }) => {
+        return (
+          <Box pt={stuck ? 1 : 0}>
+            <Message width="100%">
+              There aren't any works available that meet the following criteria
+              at this time.{" "}
+              {onClearFilters && (
+                <>
+                  Change your filter criteria to view more works.{" "}
+                  <ResetFilterLink
+                    textDecoration="underline"
+                    onClick={onClearFilters}
+                  >
+                    Clear all filters
+                  </ResetFilterLink>
+                  .
+                </>
+              )}
+            </Message>
+          </Box>
+        )
+      }}
+    </Sticky>
   </Box>
 )
 


### PR DESCRIPTION
Closes: [GRO-1424](https://artsyproduct.atlassian.net/browse/GRO-1424)

I wasn't actually able to recreate this bug in Storybook, but my thinking is that it has to do with the Sticky being declared in one component render body, then passed through context down which is then nested inside of another Sticky. Very confusing and hopefully a rare happening.

But: please, *please*, if you see components declared in a render body: please call it out in review. This is a very common problem and always leads to bugs. There is *never* a good reason to do it.