### PR TITLE
feat(artwork): hide next/prev nav when idle

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -102,6 +102,7 @@ export const ArtworkImageBrowser: React.FC<ArtworkImageBrowserProps> = ({
           activeIndex={activeIndex}
           onNext={handleNext}
           onPrev={handlePrev}
+          onChange={setCursor}
           maxHeight={maxHeight}
         />
       </Media>

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowserLarge.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowserLarge.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  ChevronIcon,
   Clickable,
   ProgressDots,
   Spacer,
@@ -15,12 +14,17 @@ import { ArtworkImageBrowserLarge_artwork$data } from "__generated__/ArtworkImag
 import { useNextPrevious } from "Utils/Hooks/useNextPrevious"
 import { DeepZoomFragmentContainer, useDeepZoom } from "Components/DeepZoom"
 import { ArtworkVideoPlayerFragmentContainer } from "Apps/Artwork/Components/ArtworkVideoPlayer"
+import { useDetectActivity } from "Utils/Hooks/useDetectActivity"
+import ChevronRightIcon from "@artsy/icons/ChevronRightIcon"
+import ChevronLeftIcon from "@artsy/icons/ChevronLeftIcon"
+import { isTouch } from "Utils/device"
 
 interface ArtworkImageBrowserLargeProps {
   artwork: ArtworkImageBrowserLarge_artwork$data
   activeIndex: number
   onNext(): void
   onPrev(): void
+  onChange(index: number): void
   maxHeight: number
 }
 
@@ -29,6 +33,7 @@ const ArtworkImageBrowserLarge: React.FC<ArtworkImageBrowserLargeProps> = ({
   activeIndex,
   onNext,
   onPrev,
+  onChange,
   maxHeight,
 }) => {
   const { figures } = artwork
@@ -38,6 +43,10 @@ const ArtworkImageBrowserLarge: React.FC<ArtworkImageBrowserLargeProps> = ({
   const { showDeepZoom, hideDeepZoom, isDeepZoomVisible } = useDeepZoom()
 
   const { containerRef } = useNextPrevious({ onNext, onPrevious: onPrev })
+
+  const { detectActivityProps, isActive } = useDetectActivity()
+
+  const isNavVisible = isActive || isTouch
 
   if (figures.length === 0) {
     return null
@@ -52,7 +61,12 @@ const ArtworkImageBrowserLarge: React.FC<ArtworkImageBrowserLargeProps> = ({
         />
       )}
 
-      <Box ref={containerRef as any} position="relative">
+      <Box
+        ref={containerRef as any}
+        position="relative"
+        bg="white100"
+        {...detectActivityProps}
+      >
         {figures.length > 1 && (
           <nav>
             <NextPrevious
@@ -60,10 +74,9 @@ const ArtworkImageBrowserLarge: React.FC<ArtworkImageBrowserLargeProps> = ({
               aria-label="Previous image"
               left={0}
               p={2}
+              style={{ opacity: isNavVisible ? 1 : 0 }}
             >
-              <ChevronIcon
-                direction="left"
-                // @ts-ignore
+              <ChevronLeftIcon
                 fill="currentColor"
                 width={30}
                 height={30}
@@ -76,10 +89,9 @@ const ArtworkImageBrowserLarge: React.FC<ArtworkImageBrowserLargeProps> = ({
               aria-label="Next image"
               right={0}
               p={2}
+              style={{ opacity: isNavVisible ? 1 : 0 }}
             >
-              <ChevronIcon
-                direction="right"
-                // @ts-ignore
+              <ChevronRightIcon
                 fill="currentColor"
                 width={30}
                 height={30}
@@ -122,6 +134,7 @@ const ArtworkImageBrowserLarge: React.FC<ArtworkImageBrowserLargeProps> = ({
               activeIndex={activeIndex}
               amount={figures.length}
               variant="dash"
+              onClick={onChange}
             />
           </>
         )}
@@ -156,16 +169,20 @@ export const ArtworkImageBrowserLargeFragmentContainer = createFragmentContainer
 
 const NextPrevious = styled(Clickable)`
   position: absolute;
-  top: 20%;
-  height: 60%;
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: ${themeGet("colors.black30")};
-  transition: color 250ms;
+  color: ${themeGet("colors.black60")};
+  mix-blend-mode: difference;
+  transition: color 250ms, opacity 250ms;
   z-index: 1;
 
-  &:hover {
-    color: ${themeGet("colors.black100")};
+  &:hover,
+  &:focus,
+  &.focus-visible {
+    outline: none;
+    color: ${themeGet("colors.black10")};
   }
 `

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowserSmall.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowserSmall.tsx
@@ -46,7 +46,13 @@ const ArtworkImageBrowserSmall: React.FC<ArtworkImageBrowserSmallProps> = ({
         />
       )}
 
-      <Swiper snap="center" onChange={setActiveIndex} Cell={Cell} Rail={Rail}>
+      <Swiper
+        snap="center"
+        onChange={setActiveIndex}
+        Cell={Cell}
+        Rail={Rail}
+        initialIndex={activeIndex}
+      >
         {figures.map((figure, i) => {
           switch (figure.type) {
             case "Image":
@@ -86,6 +92,7 @@ const ArtworkImageBrowserSmall: React.FC<ArtworkImageBrowserSmallProps> = ({
           variant="dash"
           amount={figures.length}
           activeIndex={activeIndex}
+          onClick={setActiveIndex}
         />
       )}
     </>

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowserLarge.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowserLarge.jest.tsx
@@ -21,6 +21,7 @@ const { getWrapper } = setupTestWrapper<ArtworkImageBrowserLarge_Test_Query>({
           activeIndex={0}
           onNext={jest.fn()}
           onPrev={jest.fn()}
+          onChange={jest.fn()}
         />
       </MockBoot>
     )

--- a/src/Apps/Artwork/Components/ArtworkVideoPlayer/ArtworkVideoPlayer.tsx
+++ b/src/Apps/Artwork/Components/ArtworkVideoPlayer/ArtworkVideoPlayer.tsx
@@ -79,12 +79,6 @@ const ArtworkVideoPlayer: FC<ArtworkVideoPlayerProps> = ({
       justifyContent="center"
       height={[null, null, maxHeight]}
       width="100%"
-      px={[
-        0,
-        // FIXME: Pad to avoid overlapping with the next/prev buttons
-        // We can just show/hide the UI when hovering over the video instead
-        70,
-      ]}
       {...rest}
     >
       <ResponsiveBox

--- a/src/Components/DeepZoom/DeepZoom.tsx
+++ b/src/Components/DeepZoom/DeepZoom.tsx
@@ -1,6 +1,6 @@
 import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { Box, Flex, ModalBase } from "@artsy/palette"
-import { once, throttle } from "lodash"
+import { once } from "lodash"
 import * as React from "react"
 import { DeepZoomCloseButton } from "./DeepZoomCloseButton"
 import { DeepZoomSlider } from "./DeepZoomSlider"
@@ -11,6 +11,7 @@ import { useRef } from "react"
 import { useEffect } from "react"
 import { useDidMount } from "Utils/Hooks/useDidMount"
 import { useTracking } from "react-tracking"
+import { useDetectActivity } from "Utils/Hooks/useDetectActivity"
 
 const ZOOM_PER_CLICK = 1.4
 
@@ -186,41 +187,6 @@ export const DeepZoomFragmentContainer = createFragmentContainer(DeepZoom, {
     }
   `,
 })
-
-const useDetectActivity = (
-  { waitTime }: { waitTime: number } = { waitTime: 2500 }
-) => {
-  const [isActive, setIsActive] = useState(true)
-
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const detectActivity = throttle(() => {
-    setIsActive(true)
-
-    timeoutRef.current && clearTimeout(timeoutRef.current)
-    timeoutRef.current = setTimeout(() => setIsActive(false), waitTime)
-  }, 500)
-
-  useEffect(() => {
-    timeoutRef.current = setTimeout(() => setIsActive(false), waitTime)
-
-    return () => {
-      timeoutRef.current && clearTimeout(timeoutRef.current)
-    }
-  }, [waitTime])
-
-  return {
-    detectActivity,
-    isActive,
-    detectActivityProps: {
-      onMouseMove: detectActivity,
-      onWheel: detectActivity,
-      onTouchStart: detectActivity,
-      onTouchMove: detectActivity,
-      onClick: detectActivity,
-    },
-  }
-}
 
 export const useDeepZoom = () => {
   const [isDeepZoomVisible, setIsDeepZoomVisible] = useState(false)

--- a/src/Utils/Hooks/useDetectActivity.ts
+++ b/src/Utils/Hooks/useDetectActivity.ts
@@ -1,0 +1,49 @@
+import { throttle } from "lodash"
+import { useEffect, useMemo, useRef, useState } from "react"
+
+interface UseDetectActivity {
+  waitTime: number
+}
+
+/**
+ * Detect when user is idle within a component
+ */
+export const useDetectActivity = (
+  { waitTime }: UseDetectActivity = { waitTime: 2500 }
+) => {
+  const [isActive, setIsActive] = useState(true)
+
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const detectActivity = useMemo(
+    () =>
+      throttle(() => {
+        setIsActive(true)
+
+        timeoutRef.current && clearTimeout(timeoutRef.current)
+        timeoutRef.current = setTimeout(() => setIsActive(false), waitTime)
+      }, 500),
+    [waitTime]
+  )
+
+  useEffect(() => {
+    timeoutRef.current = setTimeout(() => setIsActive(false), waitTime)
+
+    return () => {
+      timeoutRef.current && clearTimeout(timeoutRef.current)
+    }
+  }, [waitTime])
+
+  return {
+    detectActivity: detectActivity,
+    isActive,
+    // Spread on target element
+    detectActivityProps: {
+      onMouseMove: detectActivity,
+      onWheel: detectActivity,
+      onTouchStart: detectActivity,
+      onTouchMove: detectActivity,
+      onClick: detectActivity,
+    },
+  }
+}


### PR DESCRIPTION
OK — there's no ticket here; so we can take or leave this. Just wanting to make it so that videos fill the space more optimally, as if they were sized like the images.

Previously we had `70px` of horizontal padding on either side to accommodate the next/previous arrows. This PR does a few things:

* Removes that padding so that the arrows overlay the video directly, just like they currently do on images.
* Changes the blend mode to difference so that they are always visible.
* Extracts the idle detection hook that I used in the deep zoom viewer to hide the nav after a few seconds of inactivity and to redisplay it when you move the cursor.
* Reduced the click area of the arrows so as to not interfere with the video UI.
* Added index support to the progress dashes at the bottom so those go to the figure when clicked.

https://user-images.githubusercontent.com/112297/200911655-b82c95d7-15aa-447e-8094-2806627ed876.mov
