### PR TITLE
feat(TX-875): Implement new 'us accounts only' design

### DIFF
--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -15,9 +15,6 @@ import {
   Tooltip,
   Flex,
 } from "@artsy/palette"
-import styled from "styled-components"
-import { themeGet } from "@styled-system/theme-get"
-
 import { Payment_me$data } from "__generated__/Payment_me.graphql"
 import {
   Payment_order$data,
@@ -112,7 +109,6 @@ export const PaymentContent: FC<Props> = props => {
 
       {/* Credit card */}
       <Collapse open={selectedPaymentMethod === "CREDIT_CARD"}>
-        {/* @ts-ignore RELAY_UPGRADE 13  */}
         <CreditCardPickerFragmentContainer
           commitMutation={commitMutation}
           me={me}
@@ -132,7 +128,6 @@ export const PaymentContent: FC<Props> = props => {
         {getPaymentMethodInfo(selectedPaymentMethod)}
         <Spacer mb={2} />
         {selectedPaymentMethod === "US_BANK_ACCOUNT" && (
-          // @ts-ignore RELAY_UPGRADE 13
           <BankAccountPickerFragmentContainer
             me={me}
             order={order}
@@ -146,7 +141,6 @@ export const PaymentContent: FC<Props> = props => {
         {getPaymentMethodInfo(selectedPaymentMethod)}
         <Spacer mb={2} />
         {selectedPaymentMethod === "SEPA_DEBIT" && (
-          // @ts-ignore RELAY_UPGRADE 13
           <BankAccountPickerFragmentContainer
             me={me}
             order={order}
@@ -168,23 +162,6 @@ export const PaymentContent: FC<Props> = props => {
     </>
   )
 }
-
-const USBankOnlyLabel = styled(Text)`
-  background-color: ${themeGet("colors.orange10")};
-  color: ${themeGet("colors.orange150")};
-  padding: 1px 5px;
-  border-radius: 2px;
-  align-self: center;
-`
-
-const RadioWithLabel = styled(BorderedRadio)`
-  padding-right: 0px !important;
-  div {
-    flex-direction: row;
-    flex-grow: 0;
-    white-space: nowrap;
-  }
-`
 
 /*
  * returns all available payment methods in the form of BorderRadio
@@ -232,7 +209,7 @@ const getAvailablePaymentMethods = (
   // when available, unshift ACH since it's the first option we want to offer for US artworks
   if (availablePaymentMethods.includes("US_BANK_ACCOUNT")) {
     paymentMethods.unshift(
-      <RadioWithLabel
+      <BorderedRadio
         data-test-id="us-bank-account"
         key="US_BANK_ACCOUNT"
         value={(paymentMethod = "US_BANK_ACCOUNT")}
@@ -245,10 +222,10 @@ const getAvailablePaymentMethods = (
           </>
         }
       >
-        <USBankOnlyLabel ml={0.5} variant="xs">
+        <Text ml="24px" variant="xs" color="black60">
           US bank account only
-        </USBankOnlyLabel>
-      </RadioWithLabel>
+        </Text>
+      </BorderedRadio>
     )
   }
 

--- a/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -7,18 +7,18 @@ import {
 } from "Apps/__tests__/Fixtures/Order"
 import { AddressForm } from "Components/AddressForm"
 import { graphql } from "react-relay"
-import { settingOrderPaymentFailed } from "../__fixtures__/MutationResults"
-import { PaymentFragmentContainer } from "../Payment"
+import { settingOrderPaymentFailed } from "Apps/Order/Routes/__fixtures__/MutationResults"
+import { PaymentFragmentContainer } from "Apps/Order/Routes/Payment"
 import { OrderAppTestPage } from "./Utils/OrderAppTestPage"
 import { useSystemContext } from "System"
 import { useTracking } from "react-tracking"
-import { CreditCardPickerFragmentContainer } from "../../Components/CreditCardPicker"
-import { useSetPayment } from "../../Mutations/useSetPayment"
+import { CreditCardPickerFragmentContainer } from "Apps/Order/Components/CreditCardPicker"
+import { useSetPayment } from "Apps/Order/Mutations/useSetPayment"
 import { CommercePaymentMethodEnum } from "__generated__/Payment_order.graphql"
 import { flushPromiseQueue, MockBoot } from "DevTools"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { BankAccountPickerFragmentContainer } from "Apps/Order/Components/BankAccountPicker"
-import { useOrderPaymentContext } from "../Payment/PaymentContext/OrderPaymentContext"
+import { useOrderPaymentContext } from "Apps/Order/Routes/Payment/PaymentContext/OrderPaymentContext"
 
 jest.unmock("react-tracking")
 jest.unmock("react-relay")
@@ -339,6 +339,10 @@ describe("Payment", () => {
     it("renders selection of payment methods", () => {
       expect(page.text()).toContain("Credit card")
       expect(page.text()).toContain("Bank transfer")
+    })
+
+    it("renders correct copy for ACH radio button description", () => {
+      expect(page.text()).toContain("US bank account only")
     })
 
     it("tracks the initially-selected payment method on load like any other selection", () => {


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [TX-875]

### Description

This PR implements the new design for how we display "Us bank accounts only" copy for ACH payment method. 

<img width="1189" alt="Screenshot 2022-11-10 at 09 55 09" src="https://user-images.githubusercontent.com/42584148/201045341-85dc30f3-4b86-42f2-9ed4-b26335630ca2.png">


[TX-875]: https://artsyproduct.atlassian.net/browse/TX-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ