### PR TITLE
Fix(CX-3146): Add session_id property in UploadPhotos step

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -129,6 +129,7 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
           {
             externalId: submission.externalId,
             state: "SUBMITTED",
+            sessionID: !isLoggedIn ? getENV("SESSION_ID") : undefined,
           }
         )
         trackEvent({


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3146]

### Description

<!-- Implementation description -->
- Without this, updating a submission as a logged out user will fail with `Submission Not Found`

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3146]: https://artsyproduct.atlassian.net/browse/CX-3146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ