### PR TITLE
fix(CX-3151): fix duplication of MyCollection after submission

### DIFF
--- a/src/Apps/Consign/Components/SubmissionStepper.tsx
+++ b/src/Apps/Consign/Components/SubmissionStepper.tsx
@@ -1,27 +1,11 @@
-import { Box, Step, Stepper, themeProps } from "@artsy/palette"
+import { Box, Step, Stepper } from "@artsy/palette"
+import { useSubmissionFlowSteps } from "Apps/Consign/Hooks/useSubmissionFlowSteps"
 import { FC } from "react"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 
 interface SubmissionStepperProps {
   currentStep: ReturnType<typeof useSubmissionFlowSteps>["0"]
 }
-
-function typedArray<T extends string>(...elems: T[]): T[] {
-  return elems
-}
-
-export const submissionFlowSteps = typedArray(
-  "Artwork Details",
-  "Upload Photos",
-  "Contact Information"
-)
-
-export const submissionFlowStepsMobile = typedArray(
-  "Artwork",
-  "Photos",
-  "Contact"
-)
 
 enum ALIAS {
   "Artwork Details" = "Artwork",
@@ -30,22 +14,6 @@ enum ALIAS {
   Contact = "Contact Information",
   "Upload Photos" = "Photos",
   Photos = "Upload Photos",
-}
-
-export const useSubmissionFlowSteps = () => {
-  const enableFlowReorder = useFeatureFlag(
-    "reorder-swa-artwork-submission-flow"
-  )
-  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
-  if (enableFlowReorder && isMobile) {
-    return typedArray("Contact", "Artwork", "Photos")
-  } else if (enableFlowReorder) {
-    return typedArray("Contact Information", "Artwork Details", "Upload Photos")
-  }
-  if (isMobile) {
-    return submissionFlowStepsMobile
-  }
-  return submissionFlowSteps
 }
 
 export const SubmissionStepper: FC<SubmissionStepperProps> = ({

--- a/src/Apps/Consign/Hooks/useSubmissionFlowSteps.ts
+++ b/src/Apps/Consign/Hooks/useSubmissionFlowSteps.ts
@@ -1,0 +1,35 @@
+import { themeProps } from "@artsy/palette"
+import { useFeatureFlag } from "System/useFeatureFlag"
+import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
+
+function typedArray<T extends string>(...elems: T[]): T[] {
+  return elems
+}
+
+export const submissionFlowSteps = typedArray(
+  "Artwork Details",
+  "Upload Photos",
+  "Contact Information"
+)
+
+export const submissionFlowStepsMobile = typedArray(
+  "Artwork",
+  "Photos",
+  "Contact"
+)
+
+export const useSubmissionFlowSteps = () => {
+  const enableFlowReorder = useFeatureFlag(
+    "reorder-swa-artwork-submission-flow"
+  )
+  const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
+  if (enableFlowReorder && isMobile) {
+    return typedArray("Contact", "Artwork", "Photos")
+  } else if (enableFlowReorder) {
+    return typedArray("Contact Information", "Artwork Details", "Upload Photos")
+  }
+  if (isMobile) {
+    return submissionFlowStepsMobile
+  }
+  return submissionFlowSteps
+}

--- a/src/Apps/Consign/Hooks/useSubmissionFlowSteps.ts
+++ b/src/Apps/Consign/Hooks/useSubmissionFlowSteps.ts
@@ -2,31 +2,32 @@ import { themeProps } from "@artsy/palette"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 
-function typedArray<T extends string>(...elems: T[]): T[] {
-  return elems
-}
+type MobileSteps = "Artwork" | "Photos" | "Contact"
 
-export const submissionFlowSteps = typedArray(
+type DesktopSteps = "Artwork Details" | "Upload Photos" | "Contact Information"
+
+export const submissionFlowSteps: DesktopSteps[] = [
   "Artwork Details",
   "Upload Photos",
-  "Contact Information"
-)
+  "Contact Information",
+]
 
-export const submissionFlowStepsMobile = typedArray(
+export const submissionFlowStepsMobile: MobileSteps[] = [
   "Artwork",
   "Photos",
-  "Contact"
-)
+  "Contact",
+]
 
-export const useSubmissionFlowSteps = () => {
+export const useSubmissionFlowSteps = (): DesktopSteps[] | MobileSteps[] => {
   const enableFlowReorder = useFeatureFlag(
     "reorder-swa-artwork-submission-flow"
   )
   const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
   if (enableFlowReorder && isMobile) {
-    return typedArray("Contact", "Artwork", "Photos")
-  } else if (enableFlowReorder) {
-    return typedArray("Contact Information", "Artwork Details", "Upload Photos")
+    return ["Contact", "Artwork", "Photos"]
+  }
+  if (enableFlowReorder) {
+    return ["Contact Information", "Artwork Details", "Upload Photos"]
   }
   if (isMobile) {
     return submissionFlowStepsMobile

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -129,6 +129,7 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
         utmSource: utmParams?.utmSource,
         utmTerm: utmParams?.utmTerm,
         sessionID: !isLoggedIn ? getENV("SESSION_ID") : undefined,
+        // myCollectionArtworkID is necessary in order to prevent duplication or mycollection artwork
         myCollectionArtworkID: artworkId && isFirstStep ? artworkId : undefined,
       }
       if (artworkId && !match?.params?.id) {

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -73,7 +73,6 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
   const initialErrors = validate(initialValue, artworkDetailsValidationSchema)
 
   const artworkId = myCollectionArtwork?.internalID
-  console.log("artworkId", artworkId, "isFirstStep", isFirstStep)
 
   const handleSubmit = async (values: ArtworkDetailsFormModel) => {
     const isLimitedEditionRarity = values.rarity === "limited edition"

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -57,6 +57,7 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
     [...steps].indexOf("Artwork")
   )
   const isLastStep = stepIndex === steps.length - 1
+  const isFirstStep = stepIndex === 0
 
   let data: getArtworkDetailsFormInitialValuesProps = {
     type: SubmissionType.default,
@@ -128,11 +129,11 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
         utmSource: utmParams?.utmSource,
         utmTerm: utmParams?.utmTerm,
         sessionID: !isLoggedIn ? getENV("SESSION_ID") : undefined,
+        myCollectionArtworkID: artworkId && isFirstStep ? artworkId : undefined,
       }
       if (artworkId && !match?.params?.id) {
         ;(submissionData as CreateSubmissionMutationInput).source =
           "MY_COLLECTION"
-        ;(submissionData as CreateSubmissionMutationInput).myCollectionArtworkID = artworkId
       }
       try {
         submissionId = await createOrUpdateConsignSubmission(

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -1,8 +1,5 @@
 import { Button, Text, useToasts } from "@artsy/palette"
-import {
-  SubmissionStepper,
-  useSubmissionFlowSteps,
-} from "Apps/Consign/Components/SubmissionStepper"
+import { SubmissionStepper } from "Apps/Consign/Components/SubmissionStepper"
 import { Form, Formik } from "formik"
 import {
   ArtworkDetailsForm,
@@ -35,6 +32,7 @@ import { ArtworkDetails_myCollectionArtwork$data } from "__generated__/ArtworkDe
 import { LocationDescriptor } from "found"
 import { trackEvent } from "Server/analytics/helpers"
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import { useSubmissionFlowSteps } from "Apps/Consign/Hooks/useSubmissionFlowSteps"
 
 const logger = createLogger("SubmissionFlow/ArtworkDetails.tsx")
 
@@ -75,6 +73,7 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
   const initialErrors = validate(initialValue, artworkDetailsValidationSchema)
 
   const artworkId = myCollectionArtwork?.internalID
+  console.log("artworkId", artworkId, "isFirstStep", isFirstStep)
 
   const handleSubmit = async (values: ArtworkDetailsFormModel) => {
     const isLimitedEditionRarity = values.rarity === "limited edition"

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
@@ -6,11 +6,11 @@ import { graphql } from "react-relay"
 import { fireEvent, screen } from "@testing-library/react"
 import { ArtworkDetailsFragmentContainer } from "Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails"
 import { ArtworkDetails_submission$data } from "__generated__/ArtworkDetails_submission.graphql"
+import { createOrUpdateConsignSubmission } from "Apps/Consign/Routes/SubmissionFlow/Utils/createOrUpdateConsignSubmission"
 import {
   submissionFlowSteps,
   submissionFlowStepsMobile,
-} from "Apps/Consign/Components/SubmissionStepper"
-import { createOrUpdateConsignSubmission } from "Apps/Consign/Routes/SubmissionFlow/Utils/createOrUpdateConsignSubmission"
+} from "Apps/Consign/Hooks/useSubmissionFlowSteps"
 
 const validForm = {
   externalId: "b2449fe2-e828-4a32-ace7-ff0753cd01ef",

--- a/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
@@ -93,8 +93,10 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
             userPhone: phone.international,
             state: isLastStep ? "SUBMITTED" : "DRAFT",
             sessionID: !isLoggedIn ? getENV("SESSION_ID") : undefined,
+            // myCollectionArtworkID is necessary in order to prevent duplication or mycollection artwork
             myCollectionArtworkID:
               artworkId && isFirstStep ? artworkId : undefined,
+            // Source is necessary in order to link this to a mycollection artwork
             source: isFirstStep && artworkId ? "MY_COLLECTION" : undefined,
           }
         )

--- a/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
@@ -1,9 +1,7 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { Button, Text, useToasts } from "@artsy/palette"
-import {
-  SubmissionStepper,
-  useSubmissionFlowSteps,
-} from "Apps/Consign/Components/SubmissionStepper"
+import { SubmissionStepper } from "Apps/Consign/Components/SubmissionStepper"
+import { useSubmissionFlowSteps } from "Apps/Consign/Hooks/useSubmissionFlowSteps"
 import { createOrUpdateConsignSubmission } from "Apps/Consign/Routes/SubmissionFlow/Utils/createOrUpdateConsignSubmission"
 import {
   contactInformationValidationSchema,

--- a/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
@@ -67,6 +67,7 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
     [...steps].indexOf("Contact")
   )
   const isLastStep = stepIndex === steps.length - 1
+  const isFirstStep = stepIndex === 0
 
   const handleRecaptcha = (action: RecaptchaAction) =>
     new Promise(resolve => recaptcha(action, resolve))
@@ -92,6 +93,9 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
             userPhone: phone.international,
             state: isLastStep ? "SUBMITTED" : "DRAFT",
             sessionID: !isLoggedIn ? getENV("SESSION_ID") : undefined,
+            myCollectionArtworkID:
+              artworkId && isFirstStep ? artworkId : undefined,
+            source: isFirstStep && artworkId ? "MY_COLLECTION" : undefined,
           }
         )
 

--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -131,8 +131,10 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
             externalId: submission.externalId,
             state: isLastStep ? "SUBMITTED" : "DRAFT",
             sessionID: !isLoggedIn ? getENV("SESSION_ID") : undefined,
+            // myCollectionArtworkID is necessary in order to prevent duplication or mycollection artwork
             myCollectionArtworkID:
               artworkId && isFirstStep ? artworkId : undefined,
+            // Source is necessary in order to link this to a mycollection artwork
             source: isFirstStep && artworkId ? "MY_COLLECTION" : undefined,
           }
         )

--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -1,9 +1,7 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { Box, Button, Text } from "@artsy/palette"
-import {
-  SubmissionStepper,
-  useSubmissionFlowSteps,
-} from "Apps/Consign/Components/SubmissionStepper"
+import { SubmissionStepper } from "Apps/Consign/Components/SubmissionStepper"
+import { useSubmissionFlowSteps } from "Apps/Consign/Hooks/useSubmissionFlowSteps"
 import {
   useAddAssetToConsignmentSubmission,
   useRemoveAssetFromConsignmentSubmission,

--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -113,6 +113,7 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
     [...steps].indexOf("Photos")
   )
   const isLastStep = stepIndex === steps.length - 1
+  const isFirstStep = stepIndex === 0
 
   const initialValue = getUploadPhotosFormInitialValues(
     submission,
@@ -128,8 +129,11 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
           relayEnvironment,
           {
             externalId: submission.externalId,
-            state: "SUBMITTED",
+            state: isLastStep ? "SUBMITTED" : "DRAFT",
             sessionID: !isLoggedIn ? getENV("SESSION_ID") : undefined,
+            myCollectionArtworkID:
+              artworkId && isFirstStep ? artworkId : undefined,
+            source: isFirstStep && artworkId ? "MY_COLLECTION" : undefined,
           }
         )
         trackEvent({


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3151]

### Description

<!-- Implementation description -->
- Fixes the duplication of MyCollection Artwork after submission. 
- Fixes submission_id not being updated on MyCollection Artwork submission because the source is forced to `web_inbound` instead of `my_collection`


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3151]: https://artsyproduct.atlassian.net/browse/CX-3151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ