### PR TITLE
fix: Correct demand Icon spacing

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -139,8 +139,8 @@ const HighDemandInfo = () => {
   return (
     <Flex flexDirection="row" alignItems="center">
       <HighDemandIcon width={16} height={16} />
-      <Text variant="xs" color="blue100" ml="3px">
-        High Demand
+      <Text variant="xs" color="blue100">
+        &nbsp;High Demand
       </Text>
     </Flex>
   )

--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -139,7 +139,7 @@ const HighDemandInfo = () => {
   return (
     <Flex flexDirection="row" alignItems="center">
       <HighDemandIcon width={16} height={16} />
-      <Text variant="xs" color="blue100" ml={0.3}>
+      <Text variant="xs" color="blue100" ml="3px">
         High Demand
       </Text>
     </Flex>


### PR DESCRIPTION
Addresses an issue in [CX-3077](https://artsyproduct.atlassian.net/browse/CX-3077)

## Description

Correct demand Icon spacing ([more context](https://github.com/artsy/force/pull/11344#discussion_r1021939091)).