### PR TITLE
Fix(CX-3149): Update Career Highlights modal copy

### DIFF
--- a/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/CareerHighlightsModal/Components/CareerHighlightModalPromoStep.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/CareerHighlightsModal/Components/CareerHighlightModalPromoStep.tsx
@@ -51,7 +51,7 @@ const CareerHighlightModalPromoStepDesktop = () => {
 
         <Flex minWidth="45%" flexDirection="column">
           <Text variant="lg-display">
-            Discover Career Highlights for Your Artists
+            Discover career highlights for artists you collect.
           </Text>
 
           <Spacer mt={2} />
@@ -83,16 +83,10 @@ const CareerHighlightModalPromoStepMobile = () => {
   return (
     <Flex flex={1} flexDirection="column">
       <Text variant="lg-display">
-        Discover Career Highlights for Your Artists
+        Discover career highlights for artists you collect.
       </Text>
 
-      <Spacer mt={2} />
-
-      <Text variant="sm" color="black60">
-        Add artworks to reveal career highlights for your artists.
-      </Text>
-
-      <Spacer mt={4} />
+      <Spacer mt={6} />
 
       <Button
         // @ts-ignore
@@ -102,7 +96,6 @@ const CareerHighlightModalPromoStepMobile = () => {
         size="large"
         to="/my-collection/artworks/new"
         py={1}
-        mx={2}
       >
         Upload Artwork
       </Button>

--- a/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/CareerHighlightsModal/Components/CareerHighlightsModal.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/CareerHighlightsModal/Components/CareerHighlightsModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "@artsy/palette"
 import { useCareerHighlightsStoriesContext } from "Apps/Settings/Routes/Insights/Components/CareerHighlights/CareerHighlightsModal/Hooks/useCareerHighlightsStoriesContext"
 import { omit } from "lodash"
+import { useNextPrevious } from "Utils/Hooks/useNextPrevious"
 
 type CareerHighlightModalProps = ModalBaseProps
 
@@ -24,6 +25,7 @@ export const CareerHighlightModal: React.FC<CareerHighlightModalProps> = ({
   const isMounted = useDidMount()
   const [boxProps, modalProps] = splitBoxProps(rest)
   const { dotPosition, total, back, next } = useCareerHighlightsStoriesContext()
+  const { containerRef } = useNextPrevious({ onNext: next, onPrevious: back })
 
   return (
     <ModalBase
@@ -43,6 +45,7 @@ export const CareerHighlightModal: React.FC<CareerHighlightModalProps> = ({
       {...omit(modalProps, "dialogProps")}
     >
       <Flex
+        ref={containerRef as any}
         flexDirection="column"
         width="100%"
         height={["100vh", "90%"]}

--- a/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/InsightsCareerHighlightCard.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/InsightsCareerHighlightCard.tsx
@@ -2,7 +2,7 @@ import {
   Clickable,
   ClickableProps,
   Flex,
-  FlexProps,
+  splitBoxProps,
   Text,
 } from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
@@ -58,7 +58,6 @@ export const InsightsCareerHighlightCard: React.FC<InsightsCareerHighlightCardPr
   )
 }
 
-// extending ClickableProps since the type already has FlexProps (BoxProps)
 interface CardWrapperProps extends ClickableProps {
   onClick?: () => void
 }
@@ -68,6 +67,7 @@ const CardWrapper: React.FC<CardWrapperProps> = ({
   children,
   ...rest
 }) => {
+  const [boxProps] = splitBoxProps(rest)
   const isCareerHighlightModalEnabled = useFeatureFlag(
     "my-collection-web-phase-7-career-highlights-modal"
   )
@@ -79,7 +79,8 @@ const CardWrapper: React.FC<CardWrapperProps> = ({
       </ClickableCard>
     )
   }
-  return <Card {...(rest as FlexProps)}>{children}</Card>
+
+  return <Card {...boxProps}>{children}</Card>
 }
 
 const Card = styled(Flex)`

--- a/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/InsightsCareerHighlightPromoCard.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/InsightsCareerHighlightPromoCard.tsx
@@ -3,9 +3,9 @@ import {
   Clickable,
   ClickableProps,
   Flex,
-  FlexProps,
   Image,
   ResponsiveBox,
+  splitBoxProps,
   Text,
 } from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
@@ -105,7 +105,6 @@ export const InsightsCareerHighlightPromoCard: React.FC<{
   )
 }
 
-// extending ClickableProps since the type already has FlexProps (BoxProps)
 interface CardWrapperProps extends ClickableProps {
   onClick?: () => void
 }
@@ -115,6 +114,7 @@ const CardWrapper: React.FC<CardWrapperProps> = ({
   children,
   ...rest
 }) => {
+  const [boxProps] = splitBoxProps(rest)
   const isCareerHighlightModalEnabled = useFeatureFlag(
     "my-collection-web-phase-7-career-highlights-modal"
   )
@@ -126,7 +126,8 @@ const CardWrapper: React.FC<CardWrapperProps> = ({
       </ClickableCard>
     )
   }
-  return <Card {...(rest as FlexProps)}>{children}</Card>
+
+  return <Card {...boxProps}>{children}</Card>
 }
 
 const Card = styled(Flex)`

--- a/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/InsightsCareerHighlightPromoCard.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/InsightsCareerHighlightPromoCard.tsx
@@ -45,7 +45,7 @@ export const InsightsCareerHighlightPromoCard: React.FC<{
         flexDirection="column"
       >
         <Text variant={["xs", "sm-display"]} mb={[1, 2]}>
-          Discover career highlights for your artists.
+          Discover career highlights for artists you collect.
         </Text>
 
         <Button

--- a/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/__tests__/InsightsCareerHighlightRail.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/__tests__/InsightsCareerHighlightRail.jest.tsx
@@ -44,7 +44,7 @@ describe("InsightsCareerHighlightRail", () => {
 
       // promo card
       expect(
-        screen.getByText("Discover career highlights for your artists.")
+        screen.getByText("Discover career highlights for artists you collect.")
       ).toBeInTheDocument()
 
       expect(
@@ -62,7 +62,9 @@ describe("InsightsCareerHighlightRail", () => {
       ).not.toBeInTheDocument()
 
       expect(
-        screen.queryByText("Discover career highlights for your artists.")
+        screen.queryByText(
+          "Discover career highlights for artists you collect."
+        )
       ).not.toBeInTheDocument()
     })
   })


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3149]

### Description
This PR updates the copy of the last step in the Career Highlights Modal, and adds keyboard accessibility

### Screenshots

| mWeb | Desktop |
|--|--|
| ![image](https://user-images.githubusercontent.com/20655703/201944115-46552180-eb4e-4a58-b087-a06274851aef.png) | ![image](https://user-images.githubusercontent.com/20655703/201943988-828a164b-56c4-49a9-9af0-c9d873d916df.png) |

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3149]: https://artsyproduct.atlassian.net/browse/CX-3149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ