### PR TITLE
fix(GRO-1372): Update logged out copy

### DIFF
--- a/src/Apps/NewForYou/NewForYouApp.tsx
+++ b/src/Apps/NewForYou/NewForYouApp.tsx
@@ -27,7 +27,6 @@ export const NewForYouApp: FC<NewForYouAppProps> = ({ viewer }) => {
       {!isLoggedIn && (
         <>
           <Message variant="warning">
-            Already have an account?{" "}
             <RouterLink to={`/login?redirectTo=${route.path}`}>
               Log in
             </RouterLink>{" "}

--- a/src/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
+++ b/src/Apps/NewForYou/__tests__/NewForYouApp.jest.tsx
@@ -45,9 +45,6 @@ describe("NewForYouApp", () => {
     ;(useSystemContext as jest.Mock).mockReturnValue({ isLoggedIn: false })
     renderWithRelay()
 
-    expect(
-      screen.getByText(/(^Already have an account\?)/g)
-    ).toBeInTheDocument()
     expect(screen.getByText(/(^Log in)/g)).toBeInTheDocument()
     expect(
       screen.getByText(/(to see your personalized recommendations\.$)/g)


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1372]

### Description

<!-- Implementation description -->
When a user lands on `/new-for-you` from email, we know the user has an account, but we’re unable to display their recommendations without being logged in. This PR updates the copy to reflect the fact that we know the user already has an Artsy account.

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1372]: https://artsyproduct.atlassian.net/browse/GRO-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ