### PR TITLE
chore: Add placeholder content cards GRO-1324

### DIFF
--- a/src/Apps/Home/Components/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards.tsx
@@ -5,6 +5,70 @@ import {
   StaticHeroUnit,
 } from "Apps/Home/Components/HomeHeroUnits/HomeHeroUnit"
 import { CaptionedImage as BrazeContentCard } from "@braze/web-sdk"
+import {
+  Box,
+  ResponsiveBox,
+  GridColumns,
+  Column,
+  SkeletonBox,
+  SkeletonText,
+  Spacer,
+} from "@artsy/palette"
+import { Media } from "Utils/Responsive"
+
+const HomeContentCardPlaceholder = () => {
+  return (
+    <GridColumns bg="black5" width="100%">
+      <Column span={6} bg="black30">
+        <>
+          <Media at="xs">
+            <ResponsiveBox aspectWidth={3} aspectHeight={2} maxWidth="100%" />
+          </Media>
+          <Media greaterThan="xs">
+            <Box height={[300, 400, 500]} />
+          </Media>
+        </>
+      </Column>
+      <Column span={6}>
+        <GridColumns height="100%">
+          <Column
+            start={[2, 3]}
+            span={[10, 8]}
+            display="flex"
+            justifyContent="center"
+            flexDirection="column"
+            py={4}
+          >
+            <Media greaterThan="xs">
+              <SkeletonText variant="xs">Artsy Auction</SkeletonText>
+              <Spacer mt={2} />
+            </Media>
+            <SkeletonText variant={["lg-display", "xl", "xl"]}>
+              Post-War and Contemporary
+            </SkeletonText>
+            <Spacer mt={[1, 2]} />
+            <SkeletonText variant={["xs", "sm-display", "lg-display"]}>
+              Bid on works by Alice Neel, Ugo Rondinone, Robert Nava, and
+              more—and benefit the Immediate Abortion Access Fund to support
+              reproductive justice for all.
+            </SkeletonText>
+            <Media greaterThan="xs">
+              <Spacer
+                // Unconventional value here to keep visual rhythm
+                mt="30px"
+              />
+              <SkeletonBox mt={2} width={200} height={50} />
+            </Media>
+            <Media at="xs">
+              <Spacer mt={1} />
+              <SkeletonBox mt={2} width={200} height={50} />
+            </Media>
+          </Column>
+        </GridColumns>
+      </Column>
+    </GridColumns>
+  )
+}
 
 interface ContentCardProps {
   card: BrazeContentCard
@@ -51,15 +115,16 @@ export const HomeContentCards: React.FC = () => {
     })
   }, [])
 
-  if (cards.length < 1) {
-    return <h1>placeholder</h1>
-  }
+  const placeholderCards = [
+    <HomeContentCardPlaceholder />,
+    <HomeContentCardPlaceholder />,
+  ]
 
-  return (
-    <HeroCarousel>
-      {cards.map((card, index) => (
-        <ContentCard card={card} key={card.id} index={index} />
-      ))}
-    </HeroCarousel>
-  )
+  const realCards = cards.map((card, index) => (
+    <ContentCard card={card} key={card.id} index={index} />
+  ))
+
+  const heroCards = cards.length < 1 ? placeholderCards : realCards
+
+  return <HeroCarousel>{heroCards}</HeroCarousel>
 }


### PR DESCRIPTION
This PR uses our Skeleton components to draw a placeholder for the content cards so that we avoid layout shifting. For the text I used an example of content from a card that's running today. I'll play with this on production to see if it's jarring and we can adjust that content as needed.

<details>
<summary>Here's some screenshots</summary>
<img width="612" alt="Screen Shot 2022-11-15 at 1 49 01 PM" src="https://user-images.githubusercontent.com/79799/202012168-2985617a-45eb-4189-9f2d-9f743001d1ac.png">
<img width="869" alt="Screen Shot 2022-11-15 at 1 49 08 PM" src="https://user-images.githubusercontent.com/79799/202012172-4dd23efb-8ecd-41fa-b855-58999c37f981.png">

<img width="952" alt="Screen Shot 2022-11-15 at 1 47 01 PM" src="https://user-images.githubusercontent.com/79799/202012202-dd6943b2-485c-4e7d-b207-cc30924ae0b3.png">
<img width="1505" alt="Screen Shot 2022-11-15 at 1 47 18 PM" src="https://user-images.githubusercontent.com/79799/202012206-e50e01a8-398d-4ecc-b084-d4683551d2ba.png">
<img width="2439" alt="Screen Shot 2022-11-15 at 1 47 23 PM" src="https://user-images.githubusercontent.com/79799/202012208-ab93aec9-85e6-4d81-a501-3601a74edcfa.png">

 
</details>

https://artsyproduct.atlassian.net/browse/GRO-1324

/cc @artsy/grow-devs