### PR TITLE
chore(artwork): update secure payment copy in artsy guarantee section

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2ArtsyGuarantee.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2ArtsyGuarantee.tsx
@@ -23,7 +23,7 @@ export const ArtworkSidebar2ArtsyGuarantee: React.FC<{}> = () => {
       <Text variant="sm" color="black60">
         <Flex flexDirection="row" alignItems="center">
           <SecureLockIcon {...iconProps} />
-          <Text>{t("artworkPage.sidebar.artsyGuarantee.securePayment")}</Text>
+          <Text>{t("artworkPage.sidebar.artsyGuarantee.secureCheckout")}</Text>
         </Flex>
         <Spacer mt={1} />
         <Flex flexDirection="row" alignItems="center">

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/__tests__/ArtworkSidebar2.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/__tests__/ArtworkSidebar2.jest.tsx
@@ -127,7 +127,9 @@ describe("ArtworkSidebar2Artists", () => {
       })
 
       expect(
-        screen.queryByText("Be covered by the Artsy Guarantee")
+        screen.queryByText(
+          "Be covered by the Artsy Guarantee when you checkout with Artsy"
+        )
       ).toBeInTheDocument()
     })
 
@@ -139,7 +141,9 @@ describe("ArtworkSidebar2Artists", () => {
       })
 
       expect(
-        screen.queryByText("Be covered by the Artsy Guarantee")
+        screen.queryByText(
+          "Be covered by the Artsy Guarantee when you checkout with Artsy"
+        )
       ).not.toBeInTheDocument()
     })
 
@@ -150,7 +154,9 @@ describe("ArtworkSidebar2Artists", () => {
         }),
       })
 
-      const button = screen.getByText("Be covered by the Artsy Guarantee")
+      const button = screen.getByText(
+        "Be covered by the Artsy Guarantee when you checkout with Artsy"
+      )
 
       fireEvent.click(button)
 
@@ -162,7 +168,7 @@ describe("ArtworkSidebar2Artists", () => {
             "context_module": "artworkSidebar",
             "context_owner_type": "artwork",
             "expand": true,
-            "subject": "Be covered by the Artsy Guarantee",
+            "subject": "Be covered by the Artsy Guarantee when you checkout with Artsy",
           },
         ]
       `)
@@ -177,7 +183,7 @@ describe("ArtworkSidebar2Artists", () => {
             "context_module": "artworkSidebar",
             "context_owner_type": "artwork",
             "expand": false,
-            "subject": "Be covered by the Artsy Guarantee",
+            "subject": "Be covered by the Artsy Guarantee when you checkout with Artsy",
           },
         ]
       `)

--- a/src/Apps/Artwork/Components/ArtworkSidebar2/__tests__/ArtworkSidebar2ArtsyGuarantee.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/__tests__/ArtworkSidebar2ArtsyGuarantee.jest.tsx
@@ -5,7 +5,7 @@ describe("ArtworkSidebar2ArtsyGuarantee", () => {
   it("renders the Artsy Guarantee section", async () => {
     render(<ArtworkSidebar2ArtsyGuarantee />)
 
-    expect(screen.queryByText("Secure Payment")).toBeInTheDocument()
+    expect(screen.queryByText("Secure Checkout")).toBeInTheDocument()
     expect(screen.queryByText("Money-Back Guarantee")).toBeInTheDocument()
     expect(screen.queryByText("Authenticity Guarantee")).toBeInTheDocument()
 

--- a/src/Apps/Artwork/Components/TrustSignals/SecurePayment.tsx
+++ b/src/Apps/Artwork/Components/TrustSignals/SecurePayment.tsx
@@ -19,7 +19,7 @@ export const SecurePayment: React.FC<SecurePaymentProps> = ({
     return (
       <TrustSignal
         Icon={<LockIcon />}
-        label="Secure payment"
+        label="Secure Checkout"
         description={
           <>
             {"Secure transactions by credit card through Stripe."}

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -63,8 +63,8 @@
         "shipsFrom": "Ships from"
       },
       "artsyGuarantee": {
-        "expandableLabel": "Be covered by the Artsy Guarantee",
-        "securePayment": "Secure Payment",
+        "expandableLabel": "Be covered by the Artsy Guarantee when you checkout with Artsy",
+        "secureCheckout": "Secure Checkout",
         "moneyBack": "Money-Back Guarantee",
         "authenticity": "Authenticity Guarantee",
         "learnMore": "Learn more"


### PR DESCRIPTION
Old copy: Be covered by the Artsy Guarantee
New copy: Be covered by the Artsy Guarantee when you checkout with Artsy

Old copy: Secure Payment
New copy: Secure Checkout

Jira: [FX-4455](https://artsyproduct.atlassian.net/browse/FX-4455)

### Screenshots

**Before**

<img width="381" alt="Screenshot 2022-11-16 at 13 43 00" src="https://user-images.githubusercontent.com/123595/202211138-0f52913d-5a6c-44f7-a905-9bb18a39300d.png">

**After**

<img width="682" alt="Screenshot 2022-11-25 at 12 46 00" src="https://user-images.githubusercontent.com/123595/203979178-d57f64cc-009e-4cbf-b1fe-8bbf178364bc.png">


