### PR TITLE
chore: errors on exhaustive-deps

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,7 +66,7 @@ module.exports = {
     "react/react-in-jsx-scope": "off",
     "react/prop-types": 0,
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
+    "react-hooks/exhaustive-deps": "error",
 
     // FIXME: Investigate / reenable these rules. Disabled to introduce eslint
     // into codebase.


### PR DESCRIPTION
Simply ignoring the warnings leads to very difficult to refactor components and hooks. There's very little effort involved with actually addressing the errors. Ignoring them tends to paper over actual bugs that will when the component is extended or altered. If we're to ignore errors then you should be forced to include a comment explaining why you are doing so (there's valid reasons but they tend to be rare in practice.)