### PR TITLE
Fix: make Zendesk z-index lower than OneTrust's cookie banner

### DIFF
--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -17,7 +17,6 @@ import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
 import { useProductionEnvironmentWarning } from "Utils/Hooks/useProductionEnvironmentWarning"
 import { useAuthValidation } from "Utils/Hooks/useAuthValidation"
 import { Z } from "./constants"
-import { createGlobalStyle } from "styled-components"
 import { useDidMount } from "Utils/Hooks/useDidMount"
 import { useOnboardingModal } from "Utils/Hooks/useOnboardingModal"
 import { useImagePerformanceObserver } from "Utils/Hooks/useImagePerformanceObserver"
@@ -111,17 +110,7 @@ export const AppShell: React.FC<AppShellProps> = props => {
 
       {onboardingComponent}
 
-      {isMounted && <OneTrustModalOverlayHotfixStyles />}
+      {isMounted}
     </Flex>
   )
 }
-
-/**
- * This is a workaround for the cookie consent banner overlay appearing on top
- * of our modals. This positions it below so that modal buttons are clickable.
- */
-export const OneTrustModalOverlayHotfixStyles = createGlobalStyle`
-  #onetrust-banner-sdk {
-    z-index: 1 !important;
-  }
-`

--- a/src/Components/OneTrustConsentStyles.ts
+++ b/src/Components/OneTrustConsentStyles.ts
@@ -412,6 +412,7 @@ export const OneTrustConsentStyles = createGlobalStyle`
       ${toStyle({
         boxShadow: DROP_SHADOW,
         borderTop: `1px solid ${THEME.colors.black15}`,
+        zIndex: "1 !important",
       })}
 
       .ot-sdk-container {

--- a/src/Components/OneTrustConsentStyles.ts
+++ b/src/Components/OneTrustConsentStyles.ts
@@ -412,6 +412,7 @@ export const OneTrustConsentStyles = createGlobalStyle`
       ${toStyle({
         boxShadow: DROP_SHADOW,
         borderTop: `1px solid ${THEME.colors.black15}`,
+        // keeping the banner below the onboarding modal
         zIndex: "999 !important",
       })}
 

--- a/src/Components/OneTrustConsentStyles.ts
+++ b/src/Components/OneTrustConsentStyles.ts
@@ -412,7 +412,7 @@ export const OneTrustConsentStyles = createGlobalStyle`
       ${toStyle({
         boxShadow: DROP_SHADOW,
         borderTop: `1px solid ${THEME.colors.black15}`,
-        zIndex: "1 !important",
+        zIndex: "999 !important",
       })}
 
       .ot-sdk-container {

--- a/src/Components/ZendeskWrapper.tsx
+++ b/src/Components/ZendeskWrapper.tsx
@@ -21,6 +21,11 @@ export const ZendeskWrapper: FC<ZendeskWrapperProps> = ({
     src: `https://static.zdassets.com/ekr/snippet.js?key=${key}`,
     removeOnUnmount: true,
     onReady: () => {
+      window.zESettings = {
+        webWidget: {
+          zIndex: 99,
+        },
+      }
       window.zEmbed?.show?.()
     },
   })

--- a/src/Components/ZendeskWrapper.tsx
+++ b/src/Components/ZendeskWrapper.tsx
@@ -23,6 +23,7 @@ export const ZendeskWrapper: FC<ZendeskWrapperProps> = ({
     onReady: () => {
       window.zESettings = {
         webWidget: {
+          // keeping the widget below the cookie banner
           zIndex: 99,
         },
       }

--- a/src/Typings/global.d.ts
+++ b/src/Typings/global.d.ts
@@ -43,6 +43,7 @@ declare global {
     OptanonWrapper: () => void
     ReactNativeWebView?: { postMessage: (message: string) => void }
     sd: any
+    // Zendesk properties
     zEmbed: { show: () => void; hide: () => void }
     zESettings: object
   }

--- a/src/Typings/global.d.ts
+++ b/src/Typings/global.d.ts
@@ -44,6 +44,7 @@ declare global {
     ReactNativeWebView?: { postMessage: (message: string) => void }
     sd: any
     zEmbed: { show: () => void; hide: () => void }
+    zESettings: object
   }
 }
 


### PR DESCRIPTION
The type of this PR is: **FIX**

This PR solves [GRO-1377]

### Description

This PR does the following things:
* Moves the onboarding styling z-index 🔥 hotfix 🔥 to the `OneTrustConsentStyles` component and sets it to 999 to keep it below the onboarding modal's (9999)
* Sets the Zendesk widget's z-index to 99
  * This was tested locally by mimicking the cookie banner, i.e. making a div with a z-index > 99 and confirming that the widget stays below.

### Next steps:
* Merge upon 👍 ✅ 
* QA on staging 
* Deploy if all looks good