### PR TITLE
feat(GRO-1437): rebuilds auth dialog

### DIFF
--- a/src/Apps/Debug/DebugAuth.tsx
+++ b/src/Apps/Debug/DebugAuth.tsx
@@ -1,0 +1,140 @@
+import { AuthIntent, Intent } from "@artsy/cohesion"
+import {
+  Button,
+  Checkbox,
+  Input,
+  Join,
+  Select,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import {
+  AuthDialogMode,
+  AUTH_DIALOG_MODES,
+} from "Components/AuthDialog/AuthDialogContext"
+import { useAuthDialog } from "Components/AuthDialog"
+import { FC, useState } from "react"
+import { Title } from "react-head"
+
+export const DebugAuth: FC = () => {
+  const { showAuthDialog } = useAuthDialog()
+
+  const [state, setState] = useState<
+    Required<Parameters<typeof showAuthDialog>[0]>
+  >({
+    mode: "Login",
+    options: {},
+  })
+
+  return (
+    <>
+      <Title>AuthDialog</Title>
+
+      <Spacer y={4} />
+
+      <Join separator={<Spacer y={4} />}>
+        <Button
+          variant="primaryBlue"
+          onClick={() => {
+            showAuthDialog(state)
+          }}
+        >
+          Open AuthDialog with options
+        </Button>
+
+        <Text as="pre" variant="xs" bg="black5" py={0.5} px={1}>
+          {JSON.stringify(state, null, 2)}
+        </Text>
+
+        <Select
+          title="View"
+          selected={state.mode}
+          options={AUTH_DIALOG_MODES.map(mode => ({
+            value: mode,
+            text: mode,
+          }))}
+          onSelect={(mode: AuthDialogMode) => {
+            setState(prevState => ({ ...prevState, mode }))
+          }}
+        />
+
+        <Input
+          title="Title"
+          value={state.options.title}
+          placeholder="Copy to display as title"
+          onChange={({ target: { value: title } }) => {
+            setState(prevState => ({
+              ...prevState,
+              options: { ...prevState.options, title },
+            }))
+          }}
+        />
+
+        <Input
+          title="Redirect to"
+          value={state.options.redirectTo}
+          placeholder="Pathname to redirect to after authentication"
+          onChange={({ target: { value: redirectTo } }) => {
+            setState(prevState => ({
+              ...prevState,
+              options: { ...prevState.options, redirectTo },
+            }))
+          }}
+        />
+
+        <Select
+          title="Intent"
+          value={state.options.intent}
+          options={AUTH_INTENTS.map(intent => ({
+            value: intent,
+            text: intent,
+          }))}
+          onSelect={(intent: AuthIntent) => {
+            setState(prevState => ({
+              ...prevState,
+              options: { ...prevState.options, intent },
+            }))
+          }}
+        />
+
+        <Checkbox
+          selected={state.options.image}
+          onSelect={image =>
+            setState(prevState => ({
+              ...prevState,
+              options: { ...prevState.options, image },
+            }))
+          }
+        >
+          Display image panel?
+        </Checkbox>
+      </Join>
+    </>
+  )
+}
+
+const AUTH_INTENTS: AuthIntent[] = [
+  Intent.bid,
+  Intent.buyNow,
+  Intent.consign,
+  Intent.createAlert,
+  Intent.followArtist,
+  Intent.followGene,
+  Intent.followPartner,
+  Intent.forgot,
+  Intent.inquire,
+  Intent.login,
+  Intent.seeEstimateAuctionRecords,
+  Intent.seePriceAuctionRecords,
+  Intent.seeRealizedPriceAuctionRecords,
+  Intent.makeOffer,
+  Intent.registerToBid,
+  Intent.requestConditionReport,
+  Intent.saveArtwork,
+  Intent.signup,
+  Intent.viewAuctionResults,
+  Intent.viewArtist,
+  Intent.viewEditorial,
+  Intent.viewFair,
+  Intent.viewViewingRoom,
+]

--- a/src/Apps/Debug/debugRoutes.tsx
+++ b/src/Apps/Debug/debugRoutes.tsx
@@ -1,5 +1,6 @@
 import { Text } from "@artsy/palette"
 import loadable from "@loadable/component"
+import { AuthDialogProvider } from "Components/AuthDialog/AuthDialogContext"
 import { HttpError } from "found"
 import { AppRouteConfig } from "System/Router/Route"
 import { RouterLink } from "System/Router/RouterLink"
@@ -7,6 +8,11 @@ import { RouterLink } from "System/Router/RouterLink"
 const DebugApp = loadable(
   () => import(/* webpackChunkName: "debugBundle" */ "./DebugApp"),
   { resolveComponent: component => component.DebugApp }
+)
+
+const DebugAuth = loadable(
+  () => import(/* webpackChunkName: "debugBundle" */ "./DebugAuth"),
+  { resolveComponent: component => component.DebugAuth }
 )
 
 /**
@@ -17,11 +23,19 @@ const DebugApp = loadable(
 export const debugRoutes: AppRouteConfig[] = [
   {
     path: "/debug",
-    Component: ({ children }) => children,
+    Component: ({ children }) => (
+      // TODO: Move AuthDialogProvider to Boot
+      <AuthDialogProvider>{children}</AuthDialogProvider>
+    ),
     children: [
       {
         path: "baseline",
         Component: DebugApp,
+      },
+      // TODO: Remove this route once new AuthDialog is deployed
+      {
+        path: "auth",
+        Component: DebugAuth,
       },
       {
         path: "error-404",

--- a/src/Components/AuthDialog/AuthDialog.tsx
+++ b/src/Components/AuthDialog/AuthDialog.tsx
@@ -1,0 +1,80 @@
+import { ModalDialog, Image } from "@artsy/palette"
+import {
+  AuthDialogMode,
+  useAuthDialogContext,
+} from "Components/AuthDialog/AuthDialogContext"
+import { AuthDialogLogin } from "Components/AuthDialog/Views/AuthDialogLogin"
+import { AuthDialogForgotPassword } from "Components/AuthDialog/Views/AuthDialogForgotPassword"
+import { AuthDialogSignUpQueryRenderer } from "Components/AuthDialog/Views/AuthDialogSignUp"
+import { FC } from "react"
+import { useRecaptcha } from "Utils/EnableRecaptcha"
+import { resized } from "Utils/resized"
+
+export interface AuthDialogProps {
+  onClose: () => void
+}
+
+export const AuthDialog: FC<AuthDialogProps> = ({ onClose }) => {
+  useRecaptcha()
+
+  const {
+    state: { mode, options },
+  } = useAuthDialogContext()
+
+  return (
+    <ModalDialog
+      onClose={onClose}
+      title={options.title || DEFAULT_TITLES[mode]}
+      hasLogo
+      {...(options.image
+        ? {
+            width: 900,
+            leftPanel: <AuthDialogLeftPanel />,
+          }
+        : { width: 450 })}
+    >
+      <AuthDialogView />
+    </ModalDialog>
+  )
+}
+
+const AuthDialogView: FC = () => {
+  const { state } = useAuthDialogContext()
+
+  switch (state.mode) {
+    case "Login":
+      return <AuthDialogLogin />
+    case "SignUp":
+      return <AuthDialogSignUpQueryRenderer />
+    case "ForgotPassword":
+      return <AuthDialogForgotPassword />
+  }
+}
+
+const DEFAULT_TITLES: Record<AuthDialogMode, string> = {
+  Login: "Log in to collect art by the world’s leading artists",
+  SignUp: "Sign up to collect art by the world’s leading artists",
+  ForgotPassword: "Reset your password", // pragma: allowlist secret
+}
+
+const IMAGE = {
+  width: 900,
+  height: 2030,
+  src:
+    "https://files.artsy.net/images/2x_Evergreen-Artist-Page-Sign-Up-Modal.jpg",
+}
+
+const IMG = resized(IMAGE.src, { width: 450 })
+
+const AuthDialogLeftPanel: FC = () => {
+  return (
+    <Image
+      {...IMG}
+      width="100%"
+      height="100%"
+      lazyLoad
+      alt=""
+      style={{ objectFit: "cover" }}
+    />
+  )
+}

--- a/src/Components/AuthDialog/AuthDialogContext.tsx
+++ b/src/Components/AuthDialog/AuthDialogContext.tsx
@@ -1,0 +1,119 @@
+import { AuthContextModule, AuthIntent } from "@artsy/cohesion"
+import { useToasts } from "@artsy/palette"
+import { AuthDialog, AuthDialogProps } from "Components/AuthDialog/AuthDialog"
+import { createContext, FC, useContext, useReducer } from "react"
+import { useSystemContext } from "System"
+import { AfterAuthAction } from "Utils/Hooks/useAuthIntent"
+
+export const AUTH_DIALOG_MODES = ["Login", "SignUp", "ForgotPassword"] as const
+
+export type AuthDialogMode = typeof AUTH_DIALOG_MODES[number]
+
+export type AuthDialogOptions = {
+  contextModule?: AuthContextModule
+  /** Whether or not to display an evergreen side panel for visual interest */
+  image?: boolean
+  intent?: AuthIntent
+  /** Applies to SignUp or Login, not ForgotPassword */
+  afterAuthAction?: AfterAuthAction
+  /** Applies to SignUp or Login, not ForgotPassword */
+  redirectTo?: string
+  title?: string
+}
+
+type State = {
+  isVisible: boolean
+  mode: AuthDialogMode
+  options: AuthDialogOptions
+}
+
+const INITIAL_STATE: State = { mode: "SignUp", isVisible: false, options: {} }
+
+const AuthDialogContext = createContext<{
+  dispatch: React.Dispatch<Action>
+  hideAuthDialog(): void
+  showAuthDialog(options: {
+    mode: AuthDialogMode
+    options?: AuthDialogOptions
+  }): void
+  state: State
+}>({
+  dispatch: () => null,
+  hideAuthDialog: () => null,
+  showAuthDialog: () => null,
+  state: INITIAL_STATE,
+})
+
+type Action =
+  | { type: "MODE"; payload: { mode: AuthDialogMode } }
+  | { type: "SHOW" }
+  | { type: "HIDE" }
+  | { type: "OPTIONS"; payload: AuthDialogOptions }
+
+const reducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case "MODE":
+      return { ...state, mode: action.payload.mode }
+    case "SHOW":
+      return { ...state, isVisible: true }
+    case "HIDE": // Resets state on close
+      return INITIAL_STATE
+    case "OPTIONS":
+      return { ...state, options: action.payload }
+    default:
+      return state
+  }
+}
+
+export const AuthDialogProvider: FC<Omit<AuthDialogProps, "onClose">> = ({
+  children,
+}) => {
+  const { isLoggedIn } = useSystemContext()
+  const { sendToast } = useToasts()
+
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  const hideAuthDialog = () => {
+    dispatch({ type: "HIDE" })
+  }
+
+  const showAuthDialog = ({
+    mode,
+    options,
+  }: {
+    mode: AuthDialogMode
+    options?: AuthDialogOptions
+  }) => {
+    if (isLoggedIn) {
+      sendToast({
+        variant: "message",
+        message: "You are already logged in.",
+      })
+
+      return
+    }
+
+    // Move dialog into the appropriate view
+    dispatch({ type: "MODE", payload: { mode } })
+
+    // Set any options
+    if (options) dispatch({ type: "OPTIONS", payload: options })
+
+    // Display the dialog
+    dispatch({ type: "SHOW" })
+  }
+
+  return (
+    <AuthDialogContext.Provider
+      value={{ state, dispatch, showAuthDialog, hideAuthDialog }}
+    >
+      {children}
+
+      {state.isVisible && <AuthDialog onClose={hideAuthDialog} />}
+    </AuthDialogContext.Provider>
+  )
+}
+
+export const useAuthDialogContext = () => {
+  return useContext(AuthDialogContext)
+}

--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -1,0 +1,73 @@
+import {
+  Button,
+  Join,
+  Spacer,
+  AppleIcon,
+  GoogleIcon,
+  FacebookIcon,
+} from "@artsy/palette"
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+import { stringify } from "qs"
+import { FC } from "react"
+import { getENV } from "Utils/getENV"
+import { sanitizeRedirect } from "Utils/sanitizeRedirect"
+
+export const AuthDialogSocial: FC = () => {
+  const { applePath, facebookPath, googlePath } = getENV("AP")
+
+  const {
+    state: { options },
+  } = useAuthDialogContext()
+
+  // These params are handled by the routes in the Passport app,
+  // they get pushed onto the session and then handled when the social
+  // service redirects back to Force.
+  const query = stringify(
+    {
+      afterSignUpAction: options.afterAuthAction,
+      "redirect-to": sanitizeRedirect(options.redirectTo),
+      "signup-intent": options.intent,
+      "signup-referer": null, // TODO: Add referer
+      accepted_terms_of_service: true,
+      agreed_to_receive_emails: true,
+    },
+    { skipNulls: true }
+  )
+
+  return (
+    <Join separator={<Spacer y={1} />}>
+      <Button
+        variant="secondaryBlack"
+        width="100%"
+        Icon={AppleIcon}
+        // @ts-ignore
+        as="a"
+        href={`${applePath}?${query}`}
+      >
+        Continue with Apple
+      </Button>
+
+      <Button
+        variant="secondaryBlack"
+        width="100%"
+        Icon={GoogleIcon}
+        // @ts-ignore
+        as="a"
+        href={`${googlePath}?${query}`}
+      >
+        Continue with Google
+      </Button>
+
+      <Button
+        variant="secondaryBlack"
+        width="100%"
+        Icon={FacebookIcon}
+        // @ts-ignore
+        as="a"
+        href={`${facebookPath}?${query}`}
+      >
+        Continue with Facebook
+      </Button>
+    </Join>
+  )
+}

--- a/src/Components/AuthDialog/Components/AuthTermsCheckboxes.tsx
+++ b/src/Components/AuthDialog/Components/AuthTermsCheckboxes.tsx
@@ -1,0 +1,100 @@
+import { Text, Checkbox, Join, Spacer } from "@artsy/palette"
+import { INITIAL_VALUES } from "Components/AuthDialog/Views/AuthDialogSignUp"
+import { useFormikContext } from "formik"
+import { FC } from "react"
+
+interface AuthTermsCheckboxesProps {
+  isAutomaticallySubscribed: boolean
+}
+
+export const AuthTermsCheckboxes: FC<AuthTermsCheckboxesProps> = ({
+  isAutomaticallySubscribed,
+}) => {
+  const { values, setFieldValue, touched, errors } = useFormikContext<
+    typeof INITIAL_VALUES
+  >()
+
+  if (!isAutomaticallySubscribed) {
+    return (
+      <Checkbox
+        selected={values.accepted_terms_of_service}
+        onSelect={selected => {
+          setFieldValue("agreed_to_receive_emails", selected)
+          setFieldValue("accepted_terms_of_service", selected)
+        }}
+        data-test="agreeToTerms"
+        data-testid="agreeToTerms"
+        error={
+          !!(
+            touched.accepted_terms_of_service &&
+            errors.accepted_terms_of_service
+          )
+        }
+      >
+        <Text variant="xs">
+          I agree to the{" "}
+          <a href="https://www.artsy.net/terms" target="_blank">
+            Terms of Use
+          </a>
+          {", "}
+          <a href="https://www.artsy.net/privacy" target="_blank">
+            Privacy Policy
+          </a>
+          , and{" "}
+          <a href="https://www.artsy.net/conditions-of-sale" target="_blank">
+            Conditions of Sale
+          </a>{" "}
+          and to receiving emails from Artsy.
+        </Text>
+      </Checkbox>
+    )
+  }
+
+  return (
+    <Join separator={<Spacer y={1} />}>
+      <Checkbox
+        selected={values.accepted_terms_of_service}
+        onSelect={selected => {
+          setFieldValue("accepted_terms_of_service", selected)
+        }}
+        data-test="agreeToTerms"
+        data-testid="agreeToTerms"
+        error={
+          !!(
+            touched.accepted_terms_of_service &&
+            errors.accepted_terms_of_service
+          )
+        }
+      >
+        <Text variant="xs">
+          By checking this box, you consent to our{" "}
+          <a href="https://www.artsy.net/terms" target="_blank">
+            Terms of Use
+          </a>
+          {", "}
+          <a href="https://www.artsy.net/privacy" target="_blank">
+            Privacy Policy
+          </a>
+          , and{" "}
+          <a href="https://www.artsy.net/conditions-of-sale" target="_blank">
+            Conditions of Sale
+          </a>
+          .
+        </Text>
+      </Checkbox>
+
+      <Checkbox
+        selected={values.agreed_to_receive_emails}
+        onSelect={selected => {
+          setFieldValue("agreed_to_receive_emails", selected)
+        }}
+      >
+        <Text variant="xs">
+          Dive deeper into the art market with Artsy emails. Subscribe to hear
+          about our products, services, editorials, and other promotional
+          content. Unsubscribe at any time.
+        </Text>
+      </Checkbox>
+    </Join>
+  )
+}

--- a/src/Components/AuthDialog/Hooks/__tests__/useAfterAuthenticationRedirect.jest.ts
+++ b/src/Components/AuthDialog/Hooks/__tests__/useAfterAuthenticationRedirect.jest.ts
@@ -1,0 +1,92 @@
+import { renderHook } from "@testing-library/react-hooks"
+import { useAfterAuthenticationRedirect } from "Components/AuthDialog/Hooks/useAfterAuthenticationRedirect"
+import { useElligibleForOnboarding } from "Components/AuthDialog/Hooks/useElligibleForOnboarding"
+
+jest.mock("Utils/getENV", () => ({
+  getENV: jest.fn().mockImplementation(key => {
+    return {
+      APP_URL: "https://www.artsy.net",
+      API_URL: "https://api.artsy.net",
+      AP: {
+        loginPagePath: "/login",
+        signupPagePath: "/signup",
+      },
+    }[key]
+  }),
+}))
+
+jest.mock("Components/AuthDialog/Hooks/useElligibleForOnboarding", () => ({
+  useElligibleForOnboarding: jest.fn().mockImplementation(() => ({
+    isElligibleForOnboarding: true,
+  })),
+}))
+
+describe("useAfterAuthenticationRedirect", () => {
+  const locationAssignMock = jest.fn()
+
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { assign: locationAssignMock },
+    })
+  })
+
+  afterEach(() => {
+    locationAssignMock.mockReset()
+  })
+
+  it("should redirect back to the current URL", () => {
+    window.location.pathname = "/some/path"
+    window.location.href = "https://www.artsy.net/some/path"
+
+    const { result } = renderHook(() => useAfterAuthenticationRedirect())
+
+    result.current.runRedirect()
+
+    expect(locationAssignMock).toBeCalledWith(
+      "https://www.artsy.net/some/path?onboarding=true"
+    )
+  })
+
+  it("should redirect back to the default path if we are on the signup path", () => {
+    window.location.pathname = "/signup"
+    window.location.href = "https://www.artsy.net/signup"
+
+    const { result } = renderHook(() => useAfterAuthenticationRedirect())
+
+    result.current.runRedirect()
+
+    expect(locationAssignMock).toBeCalledWith(
+      "https://www.artsy.net/?onboarding=true"
+    )
+  })
+
+  it("should redirect to gravity when there is a trust token", () => {
+    window.location.pathname = "/some/path"
+    window.location.href = "https://www.artsy.net/some/path"
+
+    const { result } = renderHook(() => useAfterAuthenticationRedirect())
+
+    result.current.runRedirect("some-token")
+
+    // TODO: Validate that afterAuthActions still execute correctly when they are serialized in the query params like this
+    expect(locationAssignMock).toBeCalledWith(
+      "https://api.artsy.net/users/sign_in?trust_token=some-token&redirect_uri=https%3A%2F%2Fwww.artsy.net%2Fsome%2Fpath%3Fonboarding%3Dtrue"
+    )
+  })
+
+  it("does not pass the onboarding flag if the user is not elligible", () => {
+    ;(useElligibleForOnboarding as jest.Mock).mockImplementation(() => ({
+      isElligibleForOnboarding: false,
+    }))
+
+    window.location.pathname = "/some/path"
+    window.location.href = "https://www.artsy.net/some/path"
+
+    const { result } = renderHook(() => useAfterAuthenticationRedirect())
+
+    result.current.runRedirect()
+
+    expect(locationAssignMock).toBeCalledWith("https://www.artsy.net/some/path")
+  })
+})

--- a/src/Components/AuthDialog/Hooks/useAfterAuthentication.ts
+++ b/src/Components/AuthDialog/Hooks/useAfterAuthentication.ts
@@ -1,0 +1,40 @@
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+import { useAfterAuthenticationRedirect } from "Components/AuthDialog/Hooks/useAfterAuthenticationRedirect"
+import { getTrustToken } from "Utils/auth"
+import { setAfterAuthAction } from "Utils/Hooks/useAuthIntent"
+
+/**
+ * Runs anything that needs to happen after Login or SignUp
+ */
+export const useAfterAuthentication = () => {
+  const {
+    state: { mode, options },
+  } = useAuthDialogContext()
+
+  const { runRedirect } = useAfterAuthenticationRedirect()
+
+  const runAfterAuthentication = async ({
+    accessToken,
+  }: {
+    accessToken?: string
+  } = {}) => {
+    if (mode === "ForgotPassword") return // Do nothing
+
+    if (options.afterAuthAction) {
+      setAfterAuthAction(options.afterAuthAction)
+    }
+
+    // trustToken is used to login to Gravity
+    let trustToken: string | null = null
+
+    try {
+      trustToken = accessToken ? await getTrustToken(accessToken) : null
+    } catch (err) {
+      console.error(err)
+    }
+
+    runRedirect(trustToken)
+  }
+
+  return { runAfterAuthentication }
+}

--- a/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirect.ts
+++ b/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirect.ts
@@ -1,0 +1,55 @@
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+import { useElligibleForOnboarding } from "Components/AuthDialog/Hooks/useElligibleForOnboarding"
+import { getENV } from "Utils/getENV"
+
+const DEFAULT_AFTER_AUTH_REDIRECT_PATH = "/"
+
+const GRAVITY_AUTHENTICATION_ENDPOINT = `${getENV("API_URL")}/users/sign_in`
+
+/**
+ * Returns a function that will redirect the user to the correct page
+ */
+export const useAfterAuthenticationRedirect = () => {
+  const {
+    state: { options },
+  } = useAuthDialogContext()
+
+  const { isElligibleForOnboarding } = useElligibleForOnboarding()
+
+  const runRedirect = (trustToken?: string | null) => {
+    const redirect = options.redirectTo || getDefaultRedirect()
+    const redirectUrl = new URL(redirect, getENV("APP_URL"))
+
+    if (isElligibleForOnboarding) {
+      redirectUrl.searchParams.append("onboarding", "true")
+    }
+
+    // If we have a trust token; use that to log into Gravity instead.
+    // Gravity will then handle the redirect after authentication.
+    if (trustToken) {
+      const gravityUrl = new URL(GRAVITY_AUTHENTICATION_ENDPOINT)
+
+      gravityUrl.searchParams.append("trust_token", trustToken)
+      gravityUrl.searchParams.append("redirect_uri", redirectUrl.toString())
+
+      window.location.assign(gravityUrl.toString())
+
+      return
+    }
+
+    // Otherwise; just redirect to the URL.
+    return window.location.assign(redirectUrl.toString())
+  }
+
+  return { runRedirect }
+}
+
+const getDefaultRedirect = () => {
+  const { loginPagePath, signupPagePath } = getENV("AP")
+
+  // If we're on the login or sign up path; we should redirect to the default (index).
+  // Otherwise stay on the same page.
+  return [loginPagePath, signupPagePath].includes(window.location.pathname)
+    ? DEFAULT_AFTER_AUTH_REDIRECT_PATH
+    : window.location.href
+}

--- a/src/Components/AuthDialog/Hooks/useElligibleForOnboarding.ts
+++ b/src/Components/AuthDialog/Hooks/useElligibleForOnboarding.ts
@@ -1,0 +1,25 @@
+import { Intent } from "@artsy/cohesion"
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+
+export const COMMERCIAL_AUTH_INTENTS = [
+  Intent.bid,
+  Intent.buyNow,
+  Intent.createAlert,
+  Intent.inquire,
+  Intent.makeOffer,
+  Intent.registerToBid,
+]
+
+export const useElligibleForOnboarding = () => {
+  const {
+    state: { mode, options },
+  } = useAuthDialogContext()
+
+  const isElligibleForOnboarding =
+    // Only trigger onboarding for sign ups...
+    mode === "SignUp" &&
+    // ...without a commercial intent
+    !(options.intent && COMMERCIAL_AUTH_INTENTS.includes(options.intent))
+
+  return { isElligibleForOnboarding }
+}

--- a/src/Components/AuthDialog/README.md
+++ b/src/Components/AuthDialog/README.md
@@ -1,0 +1,38 @@
+# AuthDialog
+
+## Usage
+
+Import the `useAuthDialog` hook and call the returned `showAuthDialog` function with any options.
+
+```tsx
+import { useAuthDialog } from "Components/AuthDialog"
+
+const YourComponent = () => {
+  const { showAuthDialog } = useAuthDialog()
+
+  return (
+    <Button
+      onClick={() => {
+        showAuthDialog({
+          mode: "Login",
+          options: {
+            title: "Login to save artworks",
+          },
+        })
+      }}
+    >
+      Login
+    </Button>
+  )
+}
+```
+
+## Authentication Flow
+
+- Authentication happens via a login or sign up.
+- Those functions return a user with an `accessToken`
+- We take that `accessToken` and pass it to the `runAfterAuthentication` function which does a few things:
+  - It sets a cookie for `afterAuthAction` if there is one (which will then get run on the next full page load)
+  - We construct a final `redirectTo` based on the intent. If there's no commerical action we append the onboarding param.
+  - We take the `accessToken` and use it to get a `trustToken` which we pass along with `redirectTo` to construct a URL that logs into Gravity.
+  - We redirect to that Gravity URL which logs in and then redirects back to the ultimate destination in Force.

--- a/src/Components/AuthDialog/Views/AuthDialogForgotPassword.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogForgotPassword.tsx
@@ -1,0 +1,117 @@
+import * as Yup from "yup"
+import { FC } from "react"
+import {
+  Button,
+  Clickable,
+  Input,
+  Join,
+  Message,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+import { Form, Formik } from "formik"
+import { forgotPassword } from "Utils/auth"
+
+export const AuthDialogForgotPassword: FC = () => {
+  const { dispatch } = useAuthDialogContext()
+
+  return (
+    <Formik
+      validateOnBlur={false}
+      validationSchema={VALIDATION_SCHEMA}
+      initialValues={{ email: "", mode: "Pending" }}
+      onSubmit={async ({ email }, { setStatus, setFieldValue }) => {
+        setStatus({ error: null })
+        setFieldValue("mode", "Loading")
+
+        try {
+          await forgotPassword({ email })
+          setFieldValue("mode", "Success")
+        } catch (err) {
+          console.error(err)
+
+          setFieldValue("mode", "Error")
+          setStatus({ error: err.message })
+        }
+      }}
+    >
+      {({
+        dirty,
+        errors,
+        handleBlur,
+        handleChange,
+        isSubmitting,
+        isValid,
+        status,
+        touched,
+        values,
+      }) => {
+        return (
+          <Form data-test="ForgotPasswordForm">
+            <Join separator={<Spacer y={2} />}>
+              <Input
+                name="email"
+                title="Email"
+                type="email"
+                placeholder="Enter your email address"
+                value={values.email}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                autoFocus
+                autoComplete="email"
+                error={touched.email && errors.email}
+              />
+
+              {status?.error && (
+                <Message variant="error">{status.error}</Message>
+              )}
+
+              {values.mode === "Success" && (
+                <Message variant="success">
+                  We’ve sent you an email with a link to reset your password.
+                </Message>
+              )}
+
+              <Button
+                width="100%"
+                type="submit"
+                loading={isSubmitting}
+                disabled={!isValid || !dirty}
+              >
+                Send me reset instructions
+              </Button>
+
+              <Text variant="xs" textAlign="center" color="black60">
+                Don’t need to reset?{" "}
+                <Clickable
+                  textDecoration="underline"
+                  onClick={() => {
+                    dispatch({ type: "MODE", payload: { mode: "Login" } })
+                  }}
+                >
+                  Log in
+                </Clickable>{" "}
+                or{" "}
+                <Clickable
+                  textDecoration="underline"
+                  onClick={() => {
+                    dispatch({ type: "MODE", payload: { mode: "SignUp" } })
+                  }}
+                >
+                  sign up.
+                </Clickable>
+              </Text>
+            </Join>
+          </Form>
+        )
+      }}
+    </Formik>
+  )
+}
+
+const VALIDATION_SCHEMA = Yup.object().shape({
+  email: Yup.string()
+    .email("Please enter a valid email.")
+    .required("Email required."),
+})

--- a/src/Components/AuthDialog/Views/AuthDialogLogin.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogLogin.tsx
@@ -1,0 +1,203 @@
+import * as Yup from "yup"
+import { FC } from "react"
+import {
+  Box,
+  Button,
+  Clickable,
+  Input,
+  Join,
+  Message,
+  PasswordInput,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+import { AuthDialogSocial } from "Components/AuthDialog/Components/AuthDialogSocial"
+import { Form, Formik } from "formik"
+import { login } from "Utils/auth"
+import { useAfterAuthentication } from "Components/AuthDialog/Hooks/useAfterAuthentication"
+
+export const AuthDialogLogin: FC = () => {
+  const { dispatch } = useAuthDialogContext()
+
+  const { runAfterAuthentication } = useAfterAuthentication()
+
+  return (
+    <Formik
+      validateOnBlur={false}
+      validationSchema={VALIDATION_SCHEMA}
+      initialValues={{
+        email: "",
+        password: "",
+        authenticationCode: "",
+        mode: "Pending",
+      }}
+      onSubmit={async (
+        { email, password, authenticationCode },
+        { setStatus, setFieldValue }
+      ) => {
+        setStatus({ error: null })
+        setFieldValue("mode", "Loading")
+
+        try {
+          const { user } = await login({ email, password, authenticationCode })
+
+          runAfterAuthentication({ accessToken: user.accessToken })
+
+          setFieldValue("mode", "Success")
+        } catch (err) {
+          console.error(err)
+
+          if (err.message === "missing on-demand authentication code") {
+            setFieldValue("mode", "OnDemand")
+            return
+          }
+
+          if (err.message === "missing two-factor authentication code") {
+            setFieldValue("mode", "TwoFactor")
+            return
+          }
+
+          if (err.message === "invalid two-factor authentication code") {
+            setFieldValue("mode", "TwoFactor")
+            setStatus({ error: err.message })
+            return
+          }
+
+          setFieldValue("mode", "Error")
+          setStatus({ error: err.message })
+        }
+      }}
+    >
+      {({
+        dirty,
+        errors,
+        handleBlur,
+        handleChange,
+        isValid,
+        status,
+        touched,
+        values,
+      }) => {
+        return (
+          <Form data-test="LoginForm">
+            <Join separator={<Spacer y={2} />}>
+              <Input
+                name="email"
+                title="Email"
+                placeholder="Enter your email address"
+                type="email"
+                value={values.email}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                autoFocus
+                autoComplete="email"
+                error={touched.email && errors.email}
+              />
+
+              <Box>
+                <PasswordInput
+                  name="password"
+                  title="Password"
+                  placeholder="Enter your password"
+                  value={values.password}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  autoComplete="current-password"
+                  error={touched.password && errors.password}
+                />
+
+                <Spacer y={0.5} />
+
+                <Text variant="xs" textAlign="right" color="black60">
+                  <Clickable
+                    textDecoration="underline"
+                    onClick={() => {
+                      dispatch({
+                        type: "MODE",
+                        payload: { mode: "ForgotPassword" },
+                      })
+                    }}
+                  >
+                    Forgot Password?
+                  </Clickable>
+                </Text>
+              </Box>
+
+              {values.mode === "OnDemand" && (
+                <Message variant="info">
+                  Your safety and security are important to us. Please check
+                  your email for a one-time authentication code to complete your
+                  login.
+                </Message>
+              )}
+
+              {(values.mode === "TwoFactor" || values.mode === "OnDemand") && (
+                <Input
+                  name="authenticationCode"
+                  title="Authentication Code"
+                  placeholder="Enter an authentication code"
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  autoFocus
+                  error={
+                    touched.authenticationCode && errors.authenticationCode
+                  }
+                />
+              )}
+
+              {status?.error && (
+                <Message variant="error">{status.error}</Message>
+              )}
+
+              <Button
+                type="submit"
+                width="100%"
+                loading={values.mode === "Loading" || values.mode === "Success"}
+                disabled={!isValid || !dirty}
+              >
+                Log in
+              </Button>
+
+              <Text variant="xs" textAlign="center" color="black60" my={-1}>
+                or
+              </Text>
+
+              <AuthDialogSocial />
+
+              <Text variant="xs" textAlign="center" color="black60">
+                Don’t have an account?{" "}
+                <Clickable
+                  textDecoration="underline"
+                  onClick={() => {
+                    dispatch({ type: "MODE", payload: { mode: "SignUp" } })
+                  }}
+                >
+                  Sign up.
+                </Clickable>
+              </Text>
+            </Join>
+          </Form>
+        )
+      }}
+    </Formik>
+  )
+}
+
+const VALIDATION_SCHEMA = Yup.object().shape({
+  email: Yup.string()
+    .email("Please enter a valid email.")
+    .required("Email required."),
+  // We allow any input for password since requirements have changed over the years.
+  password: Yup.string().required("Password required"),
+  // If auth code then require it
+  authenticationCode: Yup.string()
+    .when("mode", {
+      is: "OnDemand",
+      then: Yup.string().required("Authentication code required."),
+    })
+    .when("mode", {
+      is: "TwoFactor",
+      then: Yup.string().required("Authentication code required."),
+    }),
+})

--- a/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
@@ -1,0 +1,277 @@
+import * as Yup from "yup"
+import {
+  Box,
+  Button,
+  Clickable,
+  Input,
+  Join,
+  Message,
+  PasswordInput,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+import { AuthDialogSocial } from "Components/AuthDialog/Components/AuthDialogSocial"
+import { Form, Formik } from "formik"
+import { FC } from "react"
+import { signUp } from "Utils/auth"
+import { createFragmentContainer, graphql } from "react-relay"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import { getENV } from "Utils/getENV"
+import { AuthDialogSignUpQuery } from "__generated__/AuthDialogSignUpQuery.graphql"
+import { AuthDialogSignUp_requestLocation$data } from "__generated__/AuthDialogSignUp_requestLocation.graphql"
+import { AuthTermsCheckboxes } from "Components/AuthDialog/Components/AuthTermsCheckboxes"
+import { useAfterAuthentication } from "Components/AuthDialog/Hooks/useAfterAuthentication"
+
+interface AuthDialogSignUpProps {
+  requestLocation?: AuthDialogSignUp_requestLocation$data | null
+}
+
+export const AuthDialogSignUp: FC<AuthDialogSignUpProps> = ({
+  requestLocation,
+}) => {
+  const { dispatch } = useAuthDialogContext()
+
+  const { runAfterAuthentication } = useAfterAuthentication()
+
+  const countryCode = requestLocation?.countryCode ?? ""
+  const isAutomaticallySubscribed = !GDPR_COUNTRY_CODES.includes(countryCode)
+
+  return (
+    <Formik
+      validateOnBlur={false}
+      initialValues={INITIAL_VALUES}
+      validationSchema={VALIDATION_SCHEMA}
+      onSubmit={async ({ mode, ...values }, { setFieldValue, setStatus }) => {
+        setStatus({ error: null })
+        setFieldValue("mode", "Loading")
+
+        try {
+          const { user } = await signUp(values)
+
+          runAfterAuthentication({ accessToken: user.accessToken })
+
+          setFieldValue("mode", "Success")
+        } catch (err) {
+          console.error(err)
+
+          setFieldValue("mode", "Error")
+          setStatus({ error: err.message })
+        }
+      }}
+    >
+      {({
+        dirty,
+        errors,
+        handleBlur,
+        handleChange,
+        isValid,
+        status,
+        touched,
+        values,
+      }) => {
+        return (
+          <Form data-test="SignUpForm">
+            <Join separator={<Spacer y={2} />}>
+              <Input
+                name="name"
+                title="Name"
+                placeholder="Enter your full name"
+                value={values.name}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                autoComplete="name"
+                autoFocus
+                error={touched.name && errors.name}
+              />
+
+              <Input
+                name="email"
+                title="Email"
+                type="email"
+                placeholder="Enter your email address"
+                value={values.email}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                autoComplete="email"
+                error={touched.email && errors.email}
+              />
+
+              <Box>
+                <PasswordInput
+                  name="password"
+                  title="Password"
+                  placeholder="Enter your password"
+                  value={values.password}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  autoComplete="new-password"
+                  error={touched.password && errors.password}
+                />
+
+                <Spacer y={0.5} />
+
+                <Text variant="xs" color="black60">
+                  Password must be at least 8 characters and include a lowercase
+                  letter, uppercase letter, and digit.
+                </Text>
+              </Box>
+
+              <AuthTermsCheckboxes
+                isAutomaticallySubscribed={isAutomaticallySubscribed}
+              />
+
+              {status?.error && (
+                <Message variant="error">{status.error}</Message>
+              )}
+
+              <Button
+                width="100%"
+                type="submit"
+                loading={values.mode === "Loading" || values.mode === "Success"}
+                disabled={!isValid || !dirty}
+              >
+                Sign up
+              </Button>
+
+              <Text variant="xs" textAlign="center" color="black60" my={-1}>
+                or
+              </Text>
+
+              <AuthDialogSocial />
+
+              <Text variant="xs" color="black60" textAlign="center">
+                Already have an account?{" "}
+                <Clickable
+                  textDecoration="underline"
+                  onClick={() => {
+                    dispatch({ type: "MODE", payload: { mode: "Login" } })
+                  }}
+                >
+                  Log in.
+                </Clickable>
+              </Text>
+
+              <Text variant="xs" color="black60" textAlign="center">
+                This site is protected by reCAPTCHA and the{" "}
+                <a
+                  href="https://policies.google.com/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Google Privacy Policy
+                </a>{" "}
+                and{" "}
+                <a
+                  href="https://policies.google.com/terms"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Terms of Service
+                </a>{" "}
+                apply.
+              </Text>
+            </Join>
+          </Form>
+        )
+      }}
+    </Formik>
+  )
+}
+
+const AuthDialogSignUpFragmentContainer = createFragmentContainer(
+  AuthDialogSignUp,
+  {
+    requestLocation: graphql`
+      fragment AuthDialogSignUp_requestLocation on RequestLocation {
+        countryCode
+      }
+    `,
+  }
+)
+
+export const AuthDialogSignUpQueryRenderer: FC = () => {
+  return (
+    <SystemQueryRenderer<AuthDialogSignUpQuery>
+      variables={{ ip: getENV("IP_ADDRESS") || "0.0.0.0" }}
+      query={graphql`
+        query AuthDialogSignUpQuery($ip: String!) {
+          requestLocation(ip: $ip) {
+            ...AuthDialogSignUp_requestLocation
+          }
+        }
+      `}
+      placeholder={<AuthDialogSignUp />}
+      render={({ error, props }) => {
+        if (error || !props || !props.requestLocation) {
+          return <AuthDialogSignUpFragmentContainer />
+        }
+
+        return (
+          <AuthDialogSignUpFragmentContainer
+            requestLocation={props.requestLocation}
+          />
+        )
+      }}
+    />
+  )
+}
+
+export const INITIAL_VALUES = {
+  name: "",
+  email: "",
+  password: "",
+  accepted_terms_of_service: false,
+  agreed_to_receive_emails: false,
+  mode: "Pending",
+}
+
+const VALIDATION_SCHEMA = Yup.object().shape({
+  name: Yup.string().required("Name is required."),
+  email: Yup.string()
+    .email("Please enter a valid email.")
+    .required("Please enter a valid email."),
+  password: Yup.string()
+    .required("Password required")
+    .min(8, "Your password must be at least 8 characters.")
+    .matches(/\d{1}/, "Your password must have at least 1 digit.")
+    .matches(/[a-z]{1}/, "Your password must have at least 1 lowercase letter.")
+    .matches(
+      /[A-Z]{1}/,
+      "Your password must have at least 1 uppercase letter."
+    ),
+  accepted_terms_of_service: Yup.boolean()
+    .required("You must agree to our terms to continue.")
+    .oneOf([true]),
+})
+
+const GDPR_COUNTRY_CODES = [
+  "AT",
+  "BE",
+  "BG",
+  "CY",
+  "CZ",
+  "DE",
+  "DK",
+  "EE",
+  "ES",
+  "FI",
+  "FR",
+  "GB",
+  "GR",
+  "HR",
+  "HU",
+  "IE",
+  "IT",
+  "LT",
+  "LU",
+  "LV",
+  "MT",
+  "NL",
+  "PL",
+  "PT",
+  "RO",
+  "SE",
+  "SI",
+  "SK",
+]

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogForgotPassword.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogForgotPassword.jest.tsx
@@ -1,0 +1,85 @@
+import { screen, render, fireEvent, waitFor } from "@testing-library/react"
+import { AuthDialogForgotPassword } from "Components/AuthDialog/Views/AuthDialogForgotPassword"
+import { forgotPassword } from "Utils/auth"
+
+jest.mock("Utils/auth", () => ({
+  forgotPassword: jest.fn(),
+}))
+
+describe("AuthDialogForgotPassword", () => {
+  it("renders correctly", () => {
+    render(<AuthDialogForgotPassword />)
+
+    expect(screen.getByText("Send me reset instructions")).toBeInTheDocument()
+  })
+
+  it("submits the email and displays a success message", async () => {
+    render(<AuthDialogForgotPassword />)
+
+    const forgotPasswordMock = jest.fn().mockReturnValue(Promise.resolve())
+
+    ;(forgotPassword as jest.Mock).mockImplementationOnce(forgotPasswordMock)
+
+    const input = screen.getByPlaceholderText("Enter your email address")
+
+    const submit = screen.getByText("Send me reset instructions")
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const button = submit.parentElement!
+
+    expect(button).toBeDisabled()
+
+    fireEvent.change(input, { target: { value: "example@example.com" } })
+
+    expect(button).toBeEnabled()
+
+    expect(
+      screen.queryByText(
+        "We’ve sent you an email with a link to reset your password."
+      )
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(forgotPasswordMock).toBeCalledWith({
+        email: "example@example.com",
+      })
+
+      expect(
+        screen.getByText(
+          "We’ve sent you an email with a link to reset your password."
+        )
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('displays an error message when the "forgotPassword" function throws an error', async () => {
+    render(<AuthDialogForgotPassword />)
+
+    const forgotPasswordMock = jest
+      .fn()
+      .mockReturnValue(Promise.reject(new Error("An error occurred")))
+
+    ;(forgotPassword as jest.Mock).mockImplementationOnce(forgotPasswordMock)
+
+    const input = screen.getByPlaceholderText("Enter your email address")
+
+    const submit = screen.getByText("Send me reset instructions")
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const button = submit.parentElement!
+
+    fireEvent.change(input, { target: { value: "example@example.com" } })
+
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(forgotPasswordMock).toBeCalledWith({
+        email: "example@example.com",
+      })
+
+      expect(screen.getByText("An error occurred")).toBeInTheDocument()
+    })
+  })
+})

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogLogin.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogLogin.jest.tsx
@@ -1,0 +1,160 @@
+import { AuthDialogLogin } from "Components/AuthDialog/Views/AuthDialogLogin"
+import { screen, render, fireEvent, waitFor } from "@testing-library/react"
+import { login } from "Utils/auth"
+
+jest.mock("Utils/getENV", () => ({
+  getENV: jest.fn().mockImplementation(key => {
+    return {
+      AP: {
+        applePath: "/users/auth/apple",
+        facebookPath: "/users/auth/facebook",
+        googlePath: "/users/auth/google",
+      },
+    }[key]
+  }),
+}))
+
+jest.mock("Utils/auth", () => ({
+  login: jest.fn(),
+}))
+
+describe("AuthDialogLogin", () => {
+  it("renders correctly", () => {
+    render(<AuthDialogLogin />)
+
+    expect(screen.getByText("Log in")).toBeInTheDocument()
+  })
+
+  it("renders the social auth buttons", () => {
+    render(<AuthDialogLogin />)
+
+    expect(screen.getByText("Continue with Facebook")).toBeInTheDocument()
+    expect(screen.getByText("Continue with Google")).toBeInTheDocument()
+    expect(screen.getByText("Continue with Apple")).toBeInTheDocument()
+  })
+
+  it("submits the email and password", async () => {
+    render(<AuthDialogLogin />)
+
+    const loginMock = jest.fn().mockReturnValue(Promise.resolve())
+    ;(login as jest.Mock).mockImplementationOnce(loginMock)
+
+    const email = screen.getByPlaceholderText("Enter your email address")
+    const password = screen.getByPlaceholderText("Enter your password")
+    const submit = screen.getByText("Log in")
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const button = submit.parentNode!
+
+    expect(button).toBeDisabled()
+
+    fireEvent.change(email, { target: { value: "example@example.com" } })
+    fireEvent.change(password, { target: { value: "secret" } })
+
+    expect(button).toBeEnabled()
+
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(loginMock).toBeCalledWith({
+        authenticationCode: "",
+        email: "example@example.com",
+        password: "secret",
+      })
+    })
+  })
+
+  it('displays the auth code field when "missing on-demand authentication code" error is thrown', async () => {
+    render(<AuthDialogLogin />)
+
+    const loginMock = jest
+      .fn()
+      .mockReturnValue(
+        Promise.reject(new Error("missing on-demand authentication code"))
+      )
+    ;(login as jest.Mock).mockImplementationOnce(loginMock)
+
+    const email = screen.getByPlaceholderText("Enter your email address")
+    const password = screen.getByPlaceholderText("Enter your password")
+    const submit = screen.getByText("Log in")
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const button = submit.parentNode!
+
+    expect(button).toBeDisabled()
+
+    fireEvent.change(email, { target: { value: "example@example.com" } })
+    fireEvent.change(password, { target: { value: "secret" } })
+
+    fireEvent.click(button)
+
+    expect(button).toBeEnabled()
+
+    await waitFor(() => {
+      expect(loginMock).toBeCalledWith({
+        authenticationCode: "",
+        email: "example@example.com",
+        password: "secret",
+      })
+    })
+
+    expect(
+      screen.getByText(
+        "Your safety and security are important to us. Please check your email for a one-time authentication code to complete your login."
+      )
+    ).toBeInTheDocument()
+
+    // TODO: Should be disabled
+    // expect(button).toBeDisabled()
+
+    const authCode = screen.getByPlaceholderText("Enter an authentication code")
+
+    fireEvent.change(authCode, { target: { value: "123456" } })
+
+    // TODO: Button is stale, unable to re-submit
+  })
+
+  it('displays the auth code field when "missing two-factor authentication code" error is thrown', async () => {
+    render(<AuthDialogLogin />)
+
+    const loginMock = jest
+      .fn()
+      .mockReturnValue(
+        Promise.reject(new Error("missing two-factor authentication code"))
+      )
+    ;(login as jest.Mock).mockImplementationOnce(loginMock)
+
+    const email = screen.getByPlaceholderText("Enter your email address")
+    const password = screen.getByPlaceholderText("Enter your password")
+    const submit = screen.getByText("Log in")
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const button = submit.parentNode!
+
+    expect(button).toBeDisabled()
+
+    fireEvent.change(email, { target: { value: "example@example.com" } })
+    fireEvent.change(password, { target: { value: "secret" } })
+
+    fireEvent.click(button)
+
+    expect(button).toBeEnabled()
+
+    await waitFor(() => {
+      expect(loginMock).toBeCalledWith({
+        authenticationCode: "",
+        email: "example@example.com",
+        password: "secret",
+      })
+    })
+
+    // TODO: Should be disabled
+    // expect(button).toBeDisabled()
+
+    const authCode = screen.getByPlaceholderText("Enter an authentication code")
+
+    fireEvent.change(authCode, { target: { value: "123456" } })
+
+    // TODO: Button is stale, unable to re-submit
+  })
+})

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { AuthDialogSignUp } from "Components/AuthDialog/Views/AuthDialogSignUp"
+import { signUp } from "Utils/auth"
+
+jest.mock("Utils/getENV", () => ({
+  getENV: jest.fn().mockImplementation(key => {
+    return {
+      AP: {
+        applePath: "/users/auth/apple",
+        facebookPath: "/users/auth/facebook",
+        googlePath: "/users/auth/google",
+      },
+    }[key]
+  }),
+}))
+
+jest.mock("Utils/auth", () => ({
+  signUp: jest.fn(),
+}))
+
+describe("AuthDialogSignUp", () => {
+  it("renders correctly", () => {
+    render(<AuthDialogSignUp />)
+
+    expect(screen.getByText("Sign up")).toBeInTheDocument()
+  })
+
+  it("renders the social auth buttons", () => {
+    render(<AuthDialogSignUp />)
+
+    expect(screen.getByText("Continue with Facebook")).toBeInTheDocument()
+    expect(screen.getByText("Continue with Google")).toBeInTheDocument()
+    expect(screen.getByText("Continue with Apple")).toBeInTheDocument()
+  })
+
+  it("submits the user details", async () => {
+    render(<AuthDialogSignUp />)
+
+    const signUpMock = jest.fn().mockReturnValue(Promise.resolve())
+    ;(signUp as jest.Mock).mockImplementationOnce(signUpMock)
+
+    const name = screen.getByPlaceholderText("Enter your full name")
+    const email = screen.getByPlaceholderText("Enter your email address")
+    const password = screen.getByPlaceholderText("Enter your password")
+    const terms = screen.getByTestId("agreeToTerms")
+    const submit = screen.getByText("Sign up")
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const button = submit.parentNode!
+
+    expect(button).toBeDisabled()
+
+    fireEvent.change(name, { target: { value: "Test User" } })
+    fireEvent.change(email, { target: { value: "example@example.com" } })
+    fireEvent.change(password, { target: { value: "Secret000" } }) // pragma: allowlist secret
+    fireEvent.click(terms)
+
+    expect(button).toBeEnabled()
+
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(signUpMock).toBeCalledWith({
+        name: "Test User",
+        email: "example@example.com",
+        password: "Secret000", // pragma: allowlist secret
+        accepted_terms_of_service: true,
+        agreed_to_receive_emails: false,
+      })
+    })
+  })
+})

--- a/src/Components/AuthDialog/index.ts
+++ b/src/Components/AuthDialog/index.ts
@@ -1,0 +1,1 @@
+export * from "./useAuthDialog"

--- a/src/Components/AuthDialog/useAuthDialog.tsx
+++ b/src/Components/AuthDialog/useAuthDialog.tsx
@@ -1,0 +1,10 @@
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+
+/**
+ * Exposes specific dialog functions and hides internal context.
+ */
+export const useAuthDialog = () => {
+  const { showAuthDialog, hideAuthDialog } = useAuthDialogContext()
+
+  return { showAuthDialog, hideAuthDialog }
+}

--- a/src/Utils/EnableRecaptcha.tsx
+++ b/src/Utils/EnableRecaptcha.tsx
@@ -1,9 +1,15 @@
 import * as React from "react"
-import { data as sd } from "sharify"
+import { getENV } from "Utils/getENV"
 import { useAppendStylesheet } from "./Hooks/useAppendStylesheet"
 import { useLoadScript } from "./Hooks/useLoadScript"
 
 export const EnableRecaptcha: React.FC = () => {
+  useRecaptcha()
+
+  return null
+}
+
+export const useRecaptcha = () => {
   useAppendStylesheet({
     id: "google-recaptcha-css",
     body: ".grecaptcha-badge { visibility: hidden; }",
@@ -11,8 +17,8 @@ export const EnableRecaptcha: React.FC = () => {
 
   useLoadScript({
     id: "google-recaptcha-js",
-    src: `https://www.google.com/recaptcha/api.js?render=${sd.RECAPTCHA_KEY}`,
+    src: `https://www.google.com/recaptcha/api.js?render=${getENV(
+      "RECAPTCHA_KEY"
+    )}`,
   })
-
-  return null
 }

--- a/src/Utils/Hooks/useAuthIntent/index.tsx
+++ b/src/Utils/Hooks/useAuthIntent/index.tsx
@@ -138,3 +138,7 @@ export const useAuthIntent = () => {
 
   return { value, setValue, clearValue: () => setValue(null) }
 }
+
+export const setAfterAuthAction = (afterAuthAction: AfterAuthAction) => {
+  Cookies.set(AFTER_AUTH_ACTION_KEY, JSON.stringify(afterAuthAction))
+}

--- a/src/Utils/__tests__/auth.jest.ts
+++ b/src/Utils/__tests__/auth.jest.ts
@@ -1,4 +1,10 @@
-import { login, forgotPassword, signUp, resetPassword, logout } from "../auth"
+import {
+  login,
+  forgotPassword,
+  signUp,
+  resetPassword,
+  logout,
+} from "Utils/auth"
 
 jest.mock("sharify", () => ({
   data: {
@@ -78,6 +84,22 @@ describe("forgotPassword", () => {
     )
 
     expect(res).toEqual({ success: true })
+  })
+
+  it("parses the error JSON and rejects with the message", () => {
+    const mockFetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        text: () => Promise.resolve(JSON.stringify({ error: "error message" })),
+      })
+    )
+
+    // @ts-ignore
+    global.fetch = mockFetch
+
+    return expect(forgotPassword({ email: "example@example" })).rejects.toEqual(
+      new Error("error message")
+    )
   })
 })
 

--- a/src/Utils/__tests__/sanitizeRedirect.jest.ts
+++ b/src/Utils/__tests__/sanitizeRedirect.jest.ts
@@ -1,0 +1,89 @@
+import { sanitizeRedirect } from "Utils/sanitizeRedirect"
+
+describe("sanitizeRedirect", () => {
+  it("lets artsy.net through", () => {
+    expect(sanitizeRedirect("http://artsy.net")).toEqual("http://artsy.net")
+  })
+
+  it("lets artsy.net without a protocol through", () => {
+    expect(sanitizeRedirect("//artsy.net")).toEqual("//artsy.net")
+  })
+
+  it("lets artsy.net subdomains through", () => {
+    expect(sanitizeRedirect("http://2013.artsy.net")).toEqual(
+      "http://2013.artsy.net"
+    )
+  })
+
+  it("lets artsy.net subdomains without a protocol through", () => {
+    expect(sanitizeRedirect("//2013.artsy.net")).toEqual("//2013.artsy.net")
+  })
+
+  it("lets relative paths through", () => {
+    expect(sanitizeRedirect("/path")).toEqual("/path")
+  })
+
+  it("lets deeply nested artsy.net subdomains through", () => {
+    expect(sanitizeRedirect("https://foo.2013.artsy.net")).toEqual(
+      "https://foo.2013.artsy.net"
+    )
+  })
+
+  it("lets artsy.net links through", () => {
+    expect(sanitizeRedirect("https://artsy.net/about")).toEqual(
+      "https://artsy.net/about"
+    )
+  })
+
+  it("lets localhost through", () => {
+    expect(
+      sanitizeRedirect("http://localhost:3003/artwork/joe-piccillo-a-riposo")
+    ).toEqual("http://localhost:3003/artwork/joe-piccillo-a-riposo")
+  })
+
+  it("lets internal paths through", () => {
+    expect(sanitizeRedirect("/log_in?redirect-to=/foo/bar")).toEqual(
+      "/log_in?redirect-to=/foo/bar"
+    )
+  })
+
+  it("blocks data urls", () => {
+    expect(
+      sanitizeRedirect(
+        "data:text/html;base64,PHNjcmlwdD5hbGVydChsb2NhdGlvbi5oYXNoKTs8L3NjcmlwdD4="
+      )[0]
+    ).toEqual("/")
+  })
+
+  it("blocks external links not whitelisted; redirects to root", () => {
+    expect(sanitizeRedirect("http://google.com")).toEqual("/")
+  })
+
+  it("blocks external links that lack protocol; redirects to root", () => {
+    expect(sanitizeRedirect("//google.com")).toEqual("/")
+  })
+
+  it("blocks other protocols; redirects to root", () => {
+    expect(sanitizeRedirect("ftp://google.com")).toEqual("/")
+    expect(sanitizeRedirect("javascript:alert(1);")).toEqual("/")
+  })
+
+  it("blocks malformed URLs (1)", () => {
+    expect(sanitizeRedirect("http:/google.com")).toEqual("/")
+  })
+
+  it("blocks malformed URLs (2)", () => {
+    expect(sanitizeRedirect("https:/google.com")).toEqual("/")
+  })
+
+  it("blocks malformed URLs (3)", () => {
+    expect(sanitizeRedirect("http:///google.com")).toEqual("/")
+  })
+
+  it("strips out whitespace", () => {
+    expect(
+      sanitizeRedirect(`http://artsy.net
+attacker.com/`)
+    ).toEqual("/")
+  })
+})

--- a/src/Utils/auth.ts
+++ b/src/Utils/auth.ts
@@ -1,10 +1,10 @@
 // Modernized version of src/desktop/apps/authentication/helpers.ts
 // - Wraps auth related functions in consistent Promise interface
-// - Automatically handles CSRF token, session ID, ReCaptcha token
+// - Automatically handles CSRF token, session ID, reCAPTCHA token
 
 import Cookies from "cookies-js"
 import { getENV } from "Utils/getENV"
-import { recaptcha as _recaptcha } from "Utils/recaptcha"
+import { recaptcha as _recaptcha, RecaptchaAction } from "Utils/recaptcha"
 
 const headers = {
   Accept: "application/json",
@@ -17,6 +17,8 @@ export const login = async (args: {
   password: string
   authenticationCode: string
 }) => {
+  recaptcha("login_submit")
+
   const loginUrl = `${getENV("APP_URL")}${getENV("AP").loginPagePath}`
 
   const response = await fetch(loginUrl, {
@@ -51,6 +53,8 @@ export const login = async (args: {
  * Triggers a password reset (sends an email with password reset instructions)
  */
 export const forgotPassword = async (args: { email: string }) => {
+  recaptcha("forgot_submit")
+
   const forgotPasswordUrl = `${getENV(
     "API_URL"
   )}/api/v1/users/send_reset_password_instructions`
@@ -70,7 +74,12 @@ export const forgotPassword = async (args: { email: string }) => {
   }
 
   const err = await response.text()
-  return await Promise.reject(new Error(err))
+
+  try {
+    return Promise.reject(new Error(JSON.parse(err).error))
+  } catch {
+    return Promise.reject(new Error(err))
+  }
 }
 
 /**
@@ -111,9 +120,8 @@ export const resetPassword = async (args: {
   return await Promise.reject(new Error(JSON.stringify(err)))
 }
 
-// TODO: Handle recaptcha impressions
-const recaptcha = () => {
-  return new Promise(resolve => _recaptcha("signup_submit", resolve))
+const recaptcha = (action: RecaptchaAction) => {
+  return new Promise(resolve => _recaptcha(action, resolve))
 }
 
 /**
@@ -126,7 +134,7 @@ export const signUp = async (args: {
 }) => {
   const signUpUrl = `${getENV("APP_URL")}${getENV("AP").signupPagePath}`
 
-  const recaptchaToken = await recaptcha()
+  const recaptchaToken = await recaptcha("signup_submit")
 
   return await fetch(signUpUrl, {
     headers: {
@@ -170,6 +178,24 @@ export const logout = async () => {
 
   if (response.ok) {
     return await response.json()
+  }
+
+  const err = await response.json()
+  return Promise.reject(new Error(err.error))
+}
+
+/**
+ * Returns a token used to authenticate with Gravity
+ */
+export const getTrustToken = async (accessToken: string): Promise<string> => {
+  const response = await fetch(`${getENV("APP_URL")}/api/v1/me/trust_token`, {
+    method: "POST",
+    headers: { "X-Access-Token": accessToken },
+  })
+
+  if (response.ok) {
+    const body = await response.json()
+    return body.trust_token
   }
 
   const err = await response.json()

--- a/src/Utils/auth.ts
+++ b/src/Utils/auth.ts
@@ -2,8 +2,8 @@
 // - Wraps auth related functions in consistent Promise interface
 // - Automatically handles CSRF token, session ID, ReCaptcha token
 
-import { data as sd } from "sharify"
 import Cookies from "cookies-js"
+import { getENV } from "Utils/getENV"
 import { recaptcha as _recaptcha } from "Utils/recaptcha"
 
 const headers = {
@@ -17,7 +17,7 @@ export const login = async (args: {
   password: string
   authenticationCode: string
 }) => {
-  const loginUrl = `${sd.APP_URL}${sd.AP.loginPagePath}`
+  const loginUrl = `${getENV("APP_URL")}${getENV("AP").loginPagePath}`
 
   const response = await fetch(loginUrl, {
     headers,
@@ -28,7 +28,7 @@ export const login = async (args: {
       password: args.password,
       otp_attempt: args.authenticationCode.replace(/ /g, ""),
       otpRequired: !!args.authenticationCode,
-      session_id: sd.SESSION_ID,
+      session_id: getENV("SESSION_ID"),
       _csrf: Cookies.get("CSRF_TOKEN"),
     }),
   })
@@ -51,13 +51,18 @@ export const login = async (args: {
  * Triggers a password reset (sends an email with password reset instructions)
  */
 export const forgotPassword = async (args: { email: string }) => {
-  const forgotPasswordUrl = `${sd.API_URL}/api/v1/users/send_reset_password_instructions`
+  const forgotPasswordUrl = `${getENV(
+    "API_URL"
+  )}/api/v1/users/send_reset_password_instructions`
 
   const response = await fetch(forgotPasswordUrl, {
-    headers: { ...headers, "X-XAPP-TOKEN": sd.ARTSY_XAPP_TOKEN },
+    headers: { ...headers, "X-XAPP-TOKEN": getENV("ARTSY_XAPP_TOKEN") },
     method: "POST",
     credentials: "same-origin",
-    body: JSON.stringify({ email: args.email, session_id: sd.SESSION_ID }),
+    body: JSON.stringify({
+      email: args.email,
+      session_id: getENV("SESSION_ID"),
+    }),
   })
 
   if (response.ok) {
@@ -76,10 +81,10 @@ export const resetPassword = async (args: {
   password: string
   passwordConfirmation: string
 }) => {
-  const resetPasswordUrl = `${sd.API_URL}/api/v1/users/reset_password`
+  const resetPasswordUrl = `${getENV("API_URL")}/api/v1/users/reset_password`
 
   const response = await fetch(resetPasswordUrl, {
-    headers: { ...headers, "X-XAPP-TOKEN": sd.ARTSY_XAPP_TOKEN },
+    headers: { ...headers, "X-XAPP-TOKEN": getENV("ARTSY_XAPP_TOKEN") },
     method: "PUT",
     credentials: "same-origin",
     body: JSON.stringify({
@@ -119,7 +124,7 @@ export const signUp = async (args: {
   email: string
   password: string
 }) => {
-  const signUpUrl = `${sd.APP_URL}${sd.AP.signupPagePath}`
+  const signUpUrl = `${getENV("APP_URL")}${getENV("AP").signupPagePath}`
 
   const recaptchaToken = await recaptcha()
 
@@ -135,7 +140,7 @@ export const signUp = async (args: {
       name: args.name,
       email: args.email,
       password: args.password,
-      session_id: sd.SESSION_ID,
+      session_id: getENV("SESSION_ID"),
       _csrf: Cookies.get("CSRF_TOKEN"),
       accepted_terms_of_service: true,
       recaptcha_token: recaptchaToken,
@@ -151,7 +156,7 @@ export const signUp = async (args: {
 }
 
 export const logout = async () => {
-  const logoutUrl = `${sd.APP_URL}${sd.AP.logoutPath}`
+  const logoutUrl = `${getENV("APP_URL")}${getENV("AP").logoutPath}`
 
   const response = await fetch(logoutUrl, {
     headers: {

--- a/src/Utils/sanitizeRedirect.ts
+++ b/src/Utils/sanitizeRedirect.ts
@@ -1,0 +1,44 @@
+import { parse } from "url"
+
+const REDIRECT_FALLBACK = "/"
+
+const ALLOWLIST_HOSTS = ["internal", "localhost", "artsy.net"]
+
+const ALLOWLIST_PROTOCOLS = ["http:", "https:", null]
+
+const bareHost = (hostname: string | null) => {
+  if (hostname == null) return "internal"
+
+  const hostParts = hostname.split(".")
+
+  return hostParts.slice(hostParts.length - 2).join(".")
+}
+
+const normalizeAddress = (address: string) => {
+  return (
+    address
+      // Corrects number of slashes
+      .replace(/^http:\/+/, "http://")
+      .replace(/^https:\/+/, "https://")
+      // Strip whitespace
+      .replace(/\s/g, "")
+  )
+}
+
+const safeAddress = (address: string) => {
+  const parsed = parse(normalizeAddress(address), false, true)
+
+  return (
+    ALLOWLIST_PROTOCOLS.includes(parsed.protocol) &&
+    ALLOWLIST_HOSTS.includes(bareHost(parsed.hostname))
+  )
+}
+
+/**
+ * Extracted from unmaintained passport directory
+ */
+export const sanitizeRedirect = (address?: string) => {
+  if (!address) return REDIRECT_FALLBACK
+
+  return safeAddress(address) ? address : REDIRECT_FALLBACK
+}

--- a/src/__generated__/AuthDialogSignUpQuery.graphql.ts
+++ b/src/__generated__/AuthDialogSignUpQuery.graphql.ts
@@ -1,0 +1,114 @@
+/**
+ * @generated SignedSource<<285366d938b12302e86fd4c151f736ee>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type AuthDialogSignUpQuery$variables = {
+  ip: string;
+};
+export type AuthDialogSignUpQuery$data = {
+  readonly requestLocation: {
+    readonly " $fragmentSpreads": FragmentRefs<"AuthDialogSignUp_requestLocation">;
+  } | null;
+};
+export type AuthDialogSignUpQuery = {
+  response: AuthDialogSignUpQuery$data;
+  variables: AuthDialogSignUpQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "ip"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "ip",
+    "variableName": "ip"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuthDialogSignUpQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "RequestLocation",
+        "kind": "LinkedField",
+        "name": "requestLocation",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "AuthDialogSignUp_requestLocation"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuthDialogSignUpQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "RequestLocation",
+        "kind": "LinkedField",
+        "name": "requestLocation",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "countryCode",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "406f55c4ab1ab8594a749b4314d9b84e",
+    "id": null,
+    "metadata": {},
+    "name": "AuthDialogSignUpQuery",
+    "operationKind": "query",
+    "text": "query AuthDialogSignUpQuery(\n  $ip: String!\n) {\n  requestLocation(ip: $ip) {\n    ...AuthDialogSignUp_requestLocation\n    id\n  }\n}\n\nfragment AuthDialogSignUp_requestLocation on RequestLocation {\n  countryCode\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "5ef35817675f8dfa44892337b25dca4c";
+
+export default node;

--- a/src/__generated__/AuthDialogSignUp_requestLocation.graphql.ts
+++ b/src/__generated__/AuthDialogSignUp_requestLocation.graphql.ts
@@ -1,0 +1,42 @@
+/**
+ * @generated SignedSource<<f2e4ad798e224bc2838cc4f92ab03e39>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type AuthDialogSignUp_requestLocation$data = {
+  readonly countryCode: string | null;
+  readonly " $fragmentType": "AuthDialogSignUp_requestLocation";
+};
+export type AuthDialogSignUp_requestLocation$key = {
+  readonly " $data"?: AuthDialogSignUp_requestLocation$data;
+  readonly " $fragmentSpreads": FragmentRefs<"AuthDialogSignUp_requestLocation">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "AuthDialogSignUp_requestLocation",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "countryCode",
+      "storageKey": null
+    }
+  ],
+  "type": "RequestLocation",
+  "abstractKey": null
+};
+
+(node as any).hash = "f8cf9971da121431b0c3fc5856281941";
+
+export default node;


### PR DESCRIPTION
I'm just going to open a draft here to update progress.

This is what's left on my TODO:

- [x] Support passing title
- [x] Support redirectTo
- [x] Support [images](https://drive.google.com/drive/u/2/search?q=2x_Evergreen)
- [x] Support intent
- [x] Handle redirects
- [x] Wire up social auth
- [x] showRecaptchaDisclaimer
- [x] Set post login/signup cookies (afterSignUpAction)
- [x] Ensure state reset on close?
- [x] Pop up a toast that you're already authenticated if attempting to open while logged in
- [ ] Support usage within SSR auth routes
- [ ] Investigate `autoFocus` behavior within Modals
- [ ] Double check for any existing data-test attrs
- [ ] Add specs
- [ ] Support contextModule
- [ ] Wire up analytics tracking
- [ ] Extract copy to en file
- [ ] Ensure terms needs to be checked when using social authentication
- [ ] Pass Integrity checks
- [ ] Clean up error messages
- [ ] Validate that afterAuthActions still execute correctly when they are serialized in the query params during Gravity auth

-------


https://user-images.githubusercontent.com/112297/202306804-2693b7a0-acf1-4c3b-bef2-19ce4ae4650d.mov

