### PR TITLE
chore(FX-4449): change navigation link copy

### DIFF
--- a/src/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
+++ b/src/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
@@ -32,7 +32,7 @@ describe("NavBarSubMenu", () => {
     const wrapper = getWrapper()
     const linkMenuItems = wrapper.find("a")
 
-    expect(linkMenuItems.at(0).text()).toContain("Trove: Editor's Picks")
+    expect(linkMenuItems.at(0).text()).toContain("Trove: Editors' Picks")
     expect(linkMenuItems.at(0).prop("href")).toEqual(
       "/collection/trove-editors-picks"
     )

--- a/src/Components/NavBar/menuData.ts
+++ b/src/Components/NavBar/menuData.ts
@@ -151,7 +151,7 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
     title: "Artworks",
     links: [
       {
-        text: "Trove: Editor's Picks",
+        text: "Trove: Editors' Picks",
         href: "/collection/trove-editors-picks",
       },
       {


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4449]

### Demo
| Before | After |
| ------------- | ------------- |
| <img width="1000" alt="before" src="https://user-images.githubusercontent.com/3513494/202426496-7725e5fc-2a04-4f59-8f25-998d5e3260ec.png"> | <img width="1000" alt="after" src="https://user-images.githubusercontent.com/3513494/202426532-2fc01ff5-036f-48bf-bda1-8e4d77226398.png"> | 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4449]: https://artsyproduct.atlassian.net/browse/FX-4449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ