### PR TITLE
fix(navbar): uses consistent notifications style

### DIFF
--- a/src/Components/NavBar/NavBarLoggedInActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedInActions.tsx
@@ -2,13 +2,7 @@ import { useContext } from "react"
 import * as React from "react"
 import { NavBarNotificationsQueryRenderer, NavBarUserMenu } from "./Menus"
 import { SystemContext } from "System"
-import {
-  BellIcon,
-  Dropdown,
-  EnvelopeIcon,
-  Flex,
-  SoloIcon,
-} from "@artsy/palette"
+import { BellIcon, Dropdown, EnvelopeIcon, SoloIcon } from "@artsy/palette"
 import { graphql } from "react-relay"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import {
@@ -17,8 +11,6 @@ import {
 } from "__generated__/NavBarLoggedInActionsQuery.graphql"
 import { isServer } from "Server/isServer"
 import { checkAndSyncIndicatorsCount } from "./helpers"
-import styled from "styled-components"
-import { themeGet } from "@styled-system/theme-get"
 import { NavBarItemButton, NavBarItemLink } from "./NavBarItem"
 import { Z } from "Apps/Components/constants"
 import { useFeatureFlag } from "System/useFeatureFlag"
@@ -60,6 +52,11 @@ export const NavBarLoggedInActions: React.FC<Partial<
             ref={anchorRef as any}
             active={visible}
             {...anchorProps}
+            aria-label={
+              hasNotifications
+                ? `${me?.unreadNotificationsCount} unread notifications`
+                : "Notifications"
+            }
             onClick={event => {
               anchorProps.onClick?.(event)
 
@@ -70,34 +67,36 @@ export const NavBarLoggedInActions: React.FC<Partial<
               }
             }}
           >
-            <BellIcon
-              title="Notifications"
-              // @ts-ignore
-              fill="currentColor"
-            />
+            <BellIcon title="Notifications" fill="currentColor" />
 
-            {hasNotifications &&
-              (enableActivityPanel ? (
-                <NavBarNotificationIndicator
-                  position="absolute"
-                  top="15px"
-                  right="9px"
-                />
-              ) : (
-                <NavBarLoggedInActionsNotificationIndicator />
-              ))}
+            {hasNotifications && (
+              <NavBarNotificationIndicator
+                position="absolute"
+                top="15px"
+                right="9px"
+              />
+            )}
           </NavBarItemButton>
         )}
       </Dropdown>
 
-      <NavBarItemLink href="/user/conversations">
-        <EnvelopeIcon
-          title="Inbox"
-          // @ts-ignore
-          fill="currentColor"
-        />
+      <NavBarItemLink
+        href="/user/conversations"
+        aria-label={
+          hasConversations
+            ? `${me?.unreadConversationCount} unread conversations`
+            : "Conversations"
+        }
+      >
+        <EnvelopeIcon title="Inbox" fill="currentColor" />
 
-        {hasConversations && <NavBarLoggedInActionsNotificationIndicator />}
+        {hasConversations && (
+          <NavBarNotificationIndicator
+            position="absolute"
+            top="15px"
+            right="5px"
+          />
+        )}
       </NavBarItemLink>
 
       <Dropdown
@@ -115,11 +114,7 @@ export const NavBarLoggedInActions: React.FC<Partial<
             active={visible}
             {...anchorProps}
           >
-            <SoloIcon
-              title="Your account"
-              // @ts-ignore
-              fill="currentColor"
-            />
+            <SoloIcon title="Your account" fill="currentColor" />
           </NavBarItemButton>
         )}
       </Dropdown>
@@ -169,16 +164,3 @@ export const NavBarLoggedInActionsQueryRenderer: React.FC<{}> = () => {
     />
   )
 }
-
-export const NavBarLoggedInActionsNotificationIndicator = styled(Flex).attrs({
-  bg: "red100",
-})`
-  border-radius: 50%;
-  width: 6px;
-  height: 6px;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  top: ${themeGet("space.2")};
-  right: 5px;
-`

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
@@ -28,7 +28,12 @@ export const NavBarMobileMenuNotificationsIndicator: React.FC<NavBarMobileMenuNo
   }
 
   return (
-    <NavBarNotificationIndicator position="absolute" top="5px" right="5px" />
+    <NavBarNotificationIndicator
+      position="absolute"
+      top="5px"
+      right="5px"
+      data-testid="notifications-indicator"
+    />
   )
 }
 

--- a/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenuNotificationsIndicator.jest.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenuNotificationsIndicator.jest.tsx
@@ -26,7 +26,7 @@ describe("NavBarMobileMenuNotificationsIndicator", () => {
       }),
     })
 
-    const indicator = screen.queryByLabelText("Unread notifications indicator")
+    const indicator = screen.queryByTestId("notifications-indicator")
     expect(indicator).not.toBeInTheDocument()
   })
 
@@ -38,7 +38,7 @@ describe("NavBarMobileMenuNotificationsIndicator", () => {
       }),
     })
 
-    const indicator = screen.getByLabelText("Unread notifications indicator")
+    const indicator = screen.getByTestId("notifications-indicator")
     expect(indicator).toBeInTheDocument()
   })
 
@@ -50,7 +50,7 @@ describe("NavBarMobileMenuNotificationsIndicator", () => {
       }),
     })
 
-    const indicator = screen.getByLabelText("Unread notifications indicator")
+    const indicator = screen.getByTestId("notifications-indicator")
     expect(indicator).toBeInTheDocument()
   })
 })

--- a/src/Components/NavBar/NavBarNotificationIndicator.tsx
+++ b/src/Components/NavBar/NavBarNotificationIndicator.tsx
@@ -8,7 +8,3 @@ export const NavBarNotificationIndicator = styled(Box)`
   background-color: ${themeGet("colors.brand")};
   border-radius: 50%;
 `
-
-NavBarNotificationIndicator.defaultProps = {
-  "aria-label": "Unread notifications indicator",
-}


### PR DESCRIPTION
This just ensures we use a consistent notification indicator style on both notifications and conversations.

I don't *think* there should be any merge conflicts with https://github.com/artsy/force/pull/11375 but we should get that merged too!

![](https://static.damonzucconi.com/_capture/eGWBetSp.png)