### PR TITLE
feat(FX-4072): add Keyword filter for other grids

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
@@ -1,4 +1,5 @@
-import * as React from "react";
+import { Join, Spacer } from "@artsy/palette"
+import * as React from "react"
 import { AuctionHouseFilter } from "./AuctionHouseFilter"
 import { MediumFilter } from "./MediumFilter"
 import { SizeFilter } from "./SizeFilter"
@@ -6,11 +7,11 @@ import { YearCreated } from "./YearCreated"
 
 export const AuctionFilters: React.FC = () => {
   return (
-    <>
+    <Join separator={<Spacer mt={4} />}>
       <MediumFilter />
       <SizeFilter />
       <YearCreated />
       <AuctionHouseFilter />
-    </>
+    </Join>
   )
 }

--- a/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -14,6 +14,7 @@ import { AuctionArtworkFilter_viewer$data } from "__generated__/AuctionArtworkFi
 import { ActiveFilterPills } from "Components/SavedSearchAlert/Components/ActiveFilterPills"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { Join, Spacer } from "@artsy/palette"
 
 interface AuctionArtworkFilterProps {
   relay: RelayRefetchProp
@@ -51,12 +52,12 @@ const AuctionArtworkFilter: React.FC<AuctionArtworkFilterProps> = ({
         ]}
         viewer={viewer}
         Filters={
-          <>
+          <Join separator={<Spacer mt={4} />}>
             {showKeywordFilter && <KeywordFilter />}
             <ArtistsFilter expanded />
             <PriceRangeFilter expanded />
             <MediumFilter expanded />
-          </>
+          </Join>
         }
         FilterPillsSection={<ActiveFilterPills />}
       />

--- a/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -12,6 +12,8 @@ import { ArtworkGridContextProvider } from "Components/ArtworkGrid/ArtworkGridCo
 import { useSystemContext } from "System"
 import { AuctionArtworkFilter_viewer$data } from "__generated__/AuctionArtworkFilter_viewer.graphql"
 import { ActiveFilterPills } from "Components/SavedSearchAlert/Components/ActiveFilterPills"
+import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface AuctionArtworkFilterProps {
   relay: RelayRefetchProp
@@ -23,6 +25,7 @@ const AuctionArtworkFilter: React.FC<AuctionArtworkFilterProps> = ({
 }) => {
   const { user } = useSystemContext()
   const { match } = useRouter()
+  const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
 
   if (!viewer.sidebarAggregations) return null
 
@@ -49,6 +52,7 @@ const AuctionArtworkFilter: React.FC<AuctionArtworkFilterProps> = ({
         viewer={viewer}
         Filters={
           <>
+            {showKeywordFilter && <KeywordFilter />}
             <ArtistsFilter expanded />
             <PriceRangeFilter expanded />
             <MediumFilter expanded />

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
@@ -25,6 +25,8 @@ import { ArtistsFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistsFi
 import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 import { ActiveFilterPills } from "Components/SavedSearchAlert/Components/ActiveFilterPills"
 import { useSystemContext } from "System"
+import { useFeatureFlag } from "System/useFeatureFlag"
+import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
 
 interface CollectionArtworksFilterProps {
   relay: RelayRefetchProp
@@ -41,9 +43,11 @@ export const CollectionArtworksFilter: React.FC<CollectionArtworksFilterProps> =
   const { match } = useRouter()
   const { pathname } = usePathnameComplete()
   const { userPreferences } = useSystemContext()
+  const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
 
   const Filters = (
     <>
+      {showKeywordFilter && <KeywordFilter />}
       {!isArtistCollection && <ArtistsFilter expanded />}
       <AttributionClassFilter expanded />
       <MediumFilter expanded />

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
@@ -27,6 +27,7 @@ import { ActiveFilterPills } from "Components/SavedSearchAlert/Components/Active
 import { useSystemContext } from "System"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
+import { Join, Spacer } from "@artsy/palette"
 
 interface CollectionArtworksFilterProps {
   relay: RelayRefetchProp
@@ -46,7 +47,7 @@ export const CollectionArtworksFilter: React.FC<CollectionArtworksFilterProps> =
   const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
 
   const Filters = (
-    <>
+    <Join separator={<Spacer mt={4} />}>
       {showKeywordFilter && <KeywordFilter />}
       {!isArtistCollection && <ArtistsFilter expanded />}
       <AttributionClassFilter expanded />
@@ -60,7 +61,7 @@ export const CollectionArtworksFilter: React.FC<CollectionArtworksFilterProps> =
       <TimePeriodFilter expanded />
       <ColorFilter expanded />
       <PartnersFilter expanded />
-    </>
+    </Join>
   )
 
   return (

--- a/src/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/Apps/Fair/Routes/FairArtworks.tsx
@@ -25,6 +25,7 @@ import { ActiveFilterPills } from "Components/SavedSearchAlert/Components/Active
 import { useSystemContext } from "System"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
+import { Join, Spacer } from "@artsy/palette"
 
 interface FairArtworksFilterProps {
   fair: FairArtworks_fair$data
@@ -51,7 +52,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   // For some reason, they are undefined when `useSystemContext()` is referenced
   // in <ArtistsFilter />. So, pass as props for now.
   const Filters = (
-    <>
+    <Join separator={<Spacer mt={4} />}>
       {showKeywordFilter && <KeywordFilter />}
       <PartnersFilter label="Exhibitors" expanded />
       <ArtistsFilter fairID={fair.internalID} expanded />
@@ -65,7 +66,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
       <ArtworkLocationFilter expanded />
       <TimePeriodFilter expanded />
       <ColorFilter expanded />
-    </>
+    </Join>
   )
 
   return (

--- a/src/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/Apps/Fair/Routes/FairArtworks.tsx
@@ -23,6 +23,8 @@ import { ArtworkLocationFilter } from "Components/ArtworkFilter/ArtworkFilters/A
 import { SizeFilter } from "Components/ArtworkFilter/ArtworkFilters/SizeFilter"
 import { ActiveFilterPills } from "Components/SavedSearchAlert/Components/ActiveFilterPills"
 import { useSystemContext } from "System"
+import { useFeatureFlag } from "System/useFeatureFlag"
+import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
 
 interface FairArtworksFilterProps {
   fair: FairArtworks_fair$data
@@ -33,6 +35,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   const { relay, fair } = props
   const { match } = useRouter()
   const { userPreferences } = useSystemContext()
+  const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
   const { filtered_artworks, sidebarAggregations } = fair
 
   const hasFilter = filtered_artworks && filtered_artworks.id
@@ -49,6 +52,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   // in <ArtistsFilter />. So, pass as props for now.
   const Filters = (
     <>
+      {showKeywordFilter && <KeywordFilter />}
       <PartnersFilter label="Exhibitors" expanded />
       <ArtistsFilter fairID={fair.internalID} expanded />
       <AttributionClassFilter expanded />

--- a/src/Apps/Search/Components/SearchResultsArtworksFilters.tsx
+++ b/src/Apps/Search/Components/SearchResultsArtworksFilters.tsx
@@ -1,0 +1,32 @@
+import { Join, Spacer } from "@artsy/palette"
+import { ArtistNationalityFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter"
+import { ArtistsFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistsFilter"
+import { ArtworkLocationFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter"
+import { AttributionClassFilter } from "Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
+import { ColorFilter } from "Components/ArtworkFilter/ArtworkFilters/ColorFilter"
+import { MaterialsFilter } from "Components/ArtworkFilter/ArtworkFilters/MaterialsFilter"
+import { MediumFilter } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
+import { PartnersFilter } from "Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
+import { PriceRangeFilter } from "Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter"
+import { SizeFilter } from "Components/ArtworkFilter/ArtworkFilters/SizeFilter"
+import { TimePeriodFilter } from "Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter"
+import { WaysToBuyFilter } from "Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter"
+
+export const SearchResultsArtworksFilters = () => {
+  return (
+    <Join separator={<Spacer mt={4} />}>
+      <ArtistsFilter expanded />
+      <AttributionClassFilter expanded />
+      <MediumFilter expanded />
+      <PriceRangeFilter expanded />
+      <SizeFilter expanded />
+      <WaysToBuyFilter expanded />
+      <MaterialsFilter expanded />
+      <ArtistNationalityFilter expanded />
+      <ArtworkLocationFilter expanded />
+      <TimePeriodFilter expanded />
+      <ColorFilter expanded />
+      <PartnersFilter expanded />
+    </Join>
+  )
+}

--- a/src/Apps/Search/Routes/SearchResultsArtworks.tsx
+++ b/src/Apps/Search/Routes/SearchResultsArtworks.tsx
@@ -11,6 +11,7 @@ import {
 } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { ActiveFilterPills } from "Components/SavedSearchAlert/Components/ActiveFilterPills"
 import { useSystemContext } from "System"
+import { SearchResultsArtworksFilters } from "Apps/Search/Components/SearchResultsArtworksFilters"
 
 interface SearchResultsRouteProps {
   viewer: SearchResultsArtworks_viewer$data
@@ -42,6 +43,7 @@ export const SearchResultsArtworksRoute: React.FC<SearchResultsRouteProps> = pro
         { value: "-year", text: "Artwork year (desc.)" },
         { value: "year", text: "Artwork year (asc.)" },
       ]}
+      Filters={<SearchResultsArtworksFilters />}
       FilterPillsSection={<ActiveFilterPills />}
       userPreferredMetric={userPreferences?.metric}
     />

--- a/src/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -13,6 +13,8 @@ import { PartnersFilter } from "./PartnersFilter"
 import { ArtistsFilter } from "./ArtistsFilter"
 import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { Join, Spacer } from "@artsy/palette"
+import { useFeatureFlag } from "System/useFeatureFlag"
+import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
 
 interface ArtworkFiltersProps {
   user?: User
@@ -22,9 +24,11 @@ interface ArtworkFiltersProps {
 // Some filters will be rendered only if there is the necessary data in aggregations (for example, ArtistsFilter)
 export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
   const { user, relayEnvironment } = props
+  const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
 
   return (
     <Join separator={<Spacer mt={4} />}>
+      {showKeywordFilter && <KeywordFilter />}
       <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
       <AttributionClassFilter expanded />
       <MediumFilter expanded />


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4072]

### Description
#### Keyword filter is displayed on grids
* [Artist](https://keyword-filter.artsy.net/artist/jean-michel-basquiat/works-for-sale)
* [Artist Series](https://keyword-filter.artsy.net/artist-series/zao-wou-ki-zhao-wu-ji-abstractions)
* [Collect](https://keyword-filter.artsy.net/collect)
* [Collection](https://keyword-filter.artsy.net/collection/takashi-murakami-pillows)
* [Fair](https://keyword-filter.artsy.net/fair/1-54-paris-2021/artworks)
* [Gene](https://keyword-filter.artsy.net/gene/color-field-painting)
* [Show](https://keyword-filter.artsy.net/show/dab-art-art-in-the-time-of-corona)
* [Tag](https://keyword-filter.artsy.net/tag/horse)
* [Auctions](https://keyword-filter.artsy.net/auction/artsy-x-seoul-auction-contemporary-icons)

#### Keyword filter is NOT displayed on grids
* [Auction Results](https://keyword-filter.artsy.net/artist/andy-warhol/auction-results)
* [Search Results](https://keyword-filter.artsy.net/search?term=puppet)

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4072]: https://artsyproduct.atlassian.net/browse/FX-4072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ