### PR TITLE
feat: Send content card events to braze GRO-1324

### DIFF
--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -17,7 +17,6 @@ import { HomeHeroUnitCredit } from "./HomeHeroUnits/HomeHeroUnitCredit"
 
 interface ContentCard {
   creditLine?: string
-  heading?: string | JSX.Element
 }
 
 interface HomeContentCardProps {
@@ -33,7 +32,6 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
 
   const contentCard: ContentCard = {
     creditLine: extras.credit,
-    heading: extras.label,
   }
 
   const image = cropped(card.imageUrl!, {
@@ -129,10 +127,10 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
               style={{ display: "block", textDecoration: "none" }}
             >
               <Media greaterThan="xs">
-                {contentCard.heading && (
+                {extras.label && (
                   <>
                     <Text variant="xs" color="black100">
-                      {contentCard.heading}
+                      {extras.label}
                     </Text>
 
                     <Spacer mt={2} />

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -44,7 +44,6 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
   heroUnit,
   index,
 }) => {
-  const layout = "a"
   const { trackEvent } = useTracking()
 
   const handleTrackEvent = useCallback(() => {
@@ -124,7 +123,7 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
                         width="100%"
                         bottom={0}
                         background="linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.1) 100%);"
-                        {...(layout === "a" ? { left: 0 } : { right: 0 })}
+                        left={0}
                       >
                         <HomeHeroUnitCredit>
                           {heroUnit.creditLine}
@@ -139,7 +138,7 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
         </RouterLink>
       </Column>
     ),
-    [handleTrackEvent, heroUnit.creditLine, heroUnit.href, image, index, layout]
+    [handleTrackEvent, heroUnit.creditLine, heroUnit.href, image, index]
   )
 
   const description = useMemo(
@@ -261,17 +260,10 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
       )}
 
       <GridColumns bg="black5" width="100%">
-        {layout === "a" ? (
-          <>
-            {figure}
-            {description}
-          </>
-        ) : (
-          <>
-            {description}
-            {figure}
-          </>
-        )}
+        <>
+          {figure}
+          {description}
+        </>
       </GridColumns>
     </>
   )

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -18,8 +18,6 @@ import { HomeHeroUnitCredit } from "./HomeHeroUnits/HomeHeroUnitCredit"
 interface ContentCard {
   creditLine?: string
   heading?: string | JSX.Element
-  subtitle: string
-  title: string
 }
 
 interface HomeContentCardProps {
@@ -36,8 +34,6 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
   const contentCard: ContentCard = {
     creditLine: extras.credit,
     heading: extras.label,
-    subtitle: card.description,
-    title: card.title,
   }
 
   const image = cropped(card.imageUrl!, {
@@ -150,10 +146,10 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
                 color="black100"
                 lineClamp={3}
               >
-                {contentCard.title}
+                {card.title}
               </Text>
 
-              {contentCard.subtitle && (
+              {card.description && (
                 <>
                   <Spacer mt={[1, 2]} />
 
@@ -162,7 +158,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
                     color="black60"
                     lineClamp={4}
                   >
-                    {contentCard.subtitle}
+                    {card.description}
                   </Text>
                 </>
               )}

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -45,60 +45,56 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
           }}
           tabIndex={-1}
         >
-          {image && (
-            <>
-              <Media at="xs">
-                <ResponsiveBox
-                  aspectWidth={3}
-                  aspectHeight={2}
-                  maxWidth="100%"
-                  bg="black10"
-                >
-                  <Image
-                    src={image.src}
-                    srcSet={image.srcSet}
-                    width="100%"
-                    height="100%"
-                    lazyLoad={index > 0}
-                  />
-                </ResponsiveBox>
-              </Media>
+          <Media at="xs">
+            <ResponsiveBox
+              aspectWidth={3}
+              aspectHeight={2}
+              maxWidth="100%"
+              bg="black10"
+            >
+              <Image
+                src={image.src}
+                srcSet={image.srcSet}
+                width="100%"
+                height="100%"
+                lazyLoad={index > 0}
+              />
+            </ResponsiveBox>
+          </Media>
 
-              <Media greaterThan="xs">
-                {className => (
+          <Media greaterThan="xs">
+            {className => (
+              <Box
+                className={className}
+                height={[300, 400, 500]}
+                position="relative"
+              >
+                <Image
+                  src={image.src}
+                  srcSet={image.srcSet}
+                  width="100%"
+                  height="100%"
+                  style={{ objectFit: "cover" }}
+                  lazyLoad={index > 0}
+                />
+
+                {extras.credit && (
                   <Box
-                    className={className}
-                    height={[300, 400, 500]}
-                    position="relative"
+                    position="absolute"
+                    px={2}
+                    pb={1}
+                    pt={6}
+                    width="100%"
+                    bottom={0}
+                    background="linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.1) 100%);"
+                    left={0}
                   >
-                    <Image
-                      src={image.src}
-                      srcSet={image.srcSet}
-                      width="100%"
-                      height="100%"
-                      style={{ objectFit: "cover" }}
-                      lazyLoad={index > 0}
-                    />
-
-                    {extras.credit && (
-                      <Box
-                        position="absolute"
-                        px={2}
-                        pb={1}
-                        pt={6}
-                        width="100%"
-                        bottom={0}
-                        background="linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.1) 100%);"
-                        left={0}
-                      >
-                        <HomeHeroUnitCredit>{extras.credit}</HomeHeroUnitCredit>
-                      </Box>
-                    )}
+                    <HomeHeroUnitCredit>{extras.credit}</HomeHeroUnitCredit>
                   </Box>
                 )}
-              </Media>
-            </>
-          )}
+              </Box>
+            )}
+          </Media>
         </RouterLink>
       </Column>
       <Column span={6}>

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -14,7 +14,6 @@ import { cropped } from "Utils/resized"
 import { RouterLink } from "System/Router/RouterLink"
 import { Media } from "Utils/Responsive"
 import { HomeHeroUnitCredit } from "./HomeHeroUnits/HomeHeroUnitCredit"
-import { useMemo } from "react"
 
 export interface ContentCard {
   backgroundImageURL: string
@@ -44,8 +43,8 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
       })
     : null
 
-  const figure = useMemo(
-    () => (
+  return (
+    <GridColumns bg="black5" width="100%">
       <Column span={6} bg="white100">
         <RouterLink
           to={contentCard.href ?? ""}
@@ -114,12 +113,6 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
           )}
         </RouterLink>
       </Column>
-    ),
-    [contentCard.creditLine, contentCard.href, image, index]
-  )
-
-  const description = useMemo(
-    () => (
       <Column span={6}>
         <GridColumns height="100%">
           <Column
@@ -208,21 +201,6 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
           </Column>
         </GridColumns>
       </Column>
-    ),
-    [
-      contentCard.heading,
-      contentCard.href,
-      contentCard.linkText,
-      contentCard.subtitle,
-      contentCard.title,
-      index,
-    ]
-  )
-
-  return (
-    <GridColumns bg="black5" width="100%">
-      {figure}
-      {description}
     </GridColumns>
   )
 }

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -37,15 +37,14 @@ export interface StaticHeroUnit {
 
 export interface HomeHeroUnitProps {
   heroUnit: HomeHeroUnit_heroUnit$data | StaticHeroUnit
-  layout: "a" | "b"
   index: number
 }
 
 export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
   heroUnit,
-  layout = "a",
   index,
 }) => {
+  const layout = "a"
   const { trackEvent } = useTracking()
 
   const handleTrackEvent = useCallback(() => {
@@ -299,5 +298,5 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
     title: card.title,
   }
 
-  return <HomeHeroUnit heroUnit={heroUnit} index={index} layout="a" />
+  return <HomeHeroUnit heroUnit={heroUnit} index={index} />
 }

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -15,7 +15,7 @@ import { RouterLink } from "System/Router/RouterLink"
 import { Media } from "Utils/Responsive"
 import { HomeHeroUnitCredit } from "./HomeHeroUnits/HomeHeroUnitCredit"
 
-export interface ContentCard {
+interface ContentCard {
   backgroundImageURL: string
   creditLine?: string
   heading?: string | JSX.Element
@@ -25,15 +25,27 @@ export interface ContentCard {
   title: string
 }
 
-export interface HomeHeroUnitProps {
-  contentCard: ContentCard
+interface HomeContentCardProps {
+  card: BrazeContentCard
   index: number
 }
 
-export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
-  contentCard,
+export const HomeContentCard: React.FC<HomeContentCardProps> = ({
+  card,
   index,
 }) => {
+  const extras = card.extras || {}
+
+  const contentCard: ContentCard = {
+    backgroundImageURL: card.imageUrl!,
+    creditLine: extras.credit,
+    heading: extras.label,
+    href: card.url!,
+    linkText: card.linkText,
+    subtitle: card.description,
+    title: card.title,
+  }
+
   const image = contentCard.backgroundImageURL
     ? cropped(contentCard.backgroundImageURL, {
         // 3:2
@@ -203,28 +215,4 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
       </Column>
     </GridColumns>
   )
-}
-
-interface HomeContentCardProps {
-  card: BrazeContentCard
-  index: number
-}
-
-export const HomeContentCard: React.FC<HomeContentCardProps> = ({
-  card,
-  index,
-}) => {
-  const extras = card.extras || {}
-
-  const contentCard: ContentCard = {
-    backgroundImageURL: card.imageUrl!,
-    creditLine: extras.credit,
-    heading: extras.label,
-    href: card.url!,
-    linkText: card.linkText,
-    subtitle: card.description,
-    title: card.title,
-  }
-
-  return <HomeHeroUnit contentCard={contentCard} index={index} />
 }

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -16,7 +16,6 @@ import { Media } from "Utils/Responsive"
 import { HomeHeroUnitCredit } from "./HomeHeroUnits/HomeHeroUnitCredit"
 
 interface ContentCard {
-  backgroundImageURL: string
   creditLine?: string
   heading?: string | JSX.Element
   href: string
@@ -37,7 +36,6 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
   const extras = card.extras || {}
 
   const contentCard: ContentCard = {
-    backgroundImageURL: card.imageUrl!,
     creditLine: extras.credit,
     heading: extras.label,
     href: card.url!,
@@ -46,7 +44,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
     title: card.title,
   }
 
-  const image = cropped(contentCard.backgroundImageURL, {
+  const image = cropped(card.imageUrl!, {
     // 3:2
     width: 910,
     height: 607,

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -27,10 +27,8 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
   const extras = card.extras || {}
 
   const image = cropped(card.imageUrl!, {
-    // 3:2
-    width: 910,
-    height: 607,
-    quality: 75,
+    width: 1270,
+    height: 500,
   })
 
   const cardLink = card.url ?? ""

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -10,7 +10,6 @@ import {
   GridColumns,
   Column,
 } from "@artsy/palette"
-import { HomeHeroUnit_heroUnit$data } from "__generated__/HomeHeroUnit_heroUnit.graphql"
 import { cropped } from "Utils/resized"
 import { RouterLink } from "System/Router/RouterLink"
 import { Media } from "Utils/Responsive"
@@ -35,7 +34,7 @@ export interface StaticHeroUnit {
 }
 
 export interface HomeHeroUnitProps {
-  heroUnit: HomeHeroUnit_heroUnit$data | StaticHeroUnit
+  heroUnit: StaticHeroUnit
   index: number
 }
 

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -35,17 +35,19 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
 
   const cardLink = card.url ?? ""
 
+  const handleClick = () => {
+    const appboy = (window as any).appboy
+    appboy.logCardClick(card)
+  }
+
   return (
     <GridColumns bg="black5" width="100%">
       <Column span={6} bg="white100">
         <RouterLink
-          to={cardLink}
-          style={{
-            display: "block",
-            width: "100%",
-            height: "100%",
-          }}
+          onClick={handleClick}
+          style={{ display: "block", height: "100%", width: "100%" }}
           tabIndex={-1}
+          to={cardLink}
         >
           <Media at="xs">
             <ResponsiveBox
@@ -55,11 +57,11 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
               bg="black10"
             >
               <Image
+                height="100%"
+                lazyLoad={index > 0}
                 src={image.src}
                 srcSet={image.srcSet}
                 width="100%"
-                height="100%"
-                lazyLoad={index > 0}
               />
             </ResponsiveBox>
           </Media>
@@ -110,9 +112,10 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
             py={4}
           >
             <RouterLink
-              to={cardLink}
-              tabIndex={-1}
+              onClick={handleClick}
               style={{ display: "block", textDecoration: "none" }}
+              tabIndex={-1}
+              to={cardLink}
             >
               <Media greaterThan="xs">
                 {extras.label && (
@@ -155,10 +158,11 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
               <GridColumns>
                 <Column span={[12, 12, 6]}>
                   <Button
-                    variant="secondaryBlack"
                     // @ts-ignore
                     as={RouterLink}
+                    onClick={handleClick}
                     to={cardLink}
+                    variant="secondaryBlack"
                     width="100%"
                   >
                     {card.linkText}
@@ -170,7 +174,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
             <Media at="xs">
               <Spacer mt={1} />
 
-              <RouterLink to={cardLink} noUnderline>
+              <RouterLink noUnderline onClick={handleClick} to={cardLink}>
                 <Text variant="xs" color="black100">
                   {card.linkText}
                 </Text>

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -46,14 +46,12 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
     title: card.title,
   }
 
-  const image = contentCard.backgroundImageURL
-    ? cropped(contentCard.backgroundImageURL, {
-        // 3:2
-        width: 910,
-        height: 607,
-        quality: 75,
-      })
-    : null
+  const image = cropped(contentCard.backgroundImageURL, {
+    // 3:2
+    width: 910,
+    height: 607,
+    quality: 75,
+  })
 
   return (
     <GridColumns bg="black5" width="100%">

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -11,7 +11,6 @@ import {
   Column,
 } from "@artsy/palette"
 import { Link } from "react-head"
-import { createFragmentContainer, graphql } from "react-relay"
 import { HomeHeroUnit_heroUnit$data } from "__generated__/HomeHeroUnit_heroUnit.graphql"
 import { cropped } from "Utils/resized"
 import { RouterLink } from "System/Router/RouterLink"
@@ -278,23 +277,6 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
     </>
   )
 }
-
-export const HomeHeroUnitFragmentContainer = createFragmentContainer(
-  HomeHeroUnit,
-  {
-    heroUnit: graphql`
-      fragment HomeHeroUnit_heroUnit on HomePageHeroUnit {
-        backgroundImageURL
-        heading
-        title
-        subtitle
-        linkText
-        href
-        creditLine
-      }
-    `,
-  }
-)
 
 export const LOGGED_OUT_HERO_UNIT: StaticHeroUnit = {
   title: "Collect art by the world’s leading artists",

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -35,7 +35,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
 
   const handleClick = () => {
     const appboy = (window as any).appboy
-    appboy.logCardClick(card)
+    appboy?.logCardClick(card)
   }
 
   return (

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -33,11 +33,13 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
     quality: 75,
   })
 
+  const cardLink = card.url ?? ""
+
   return (
     <GridColumns bg="black5" width="100%">
       <Column span={6} bg="white100">
         <RouterLink
-          to={card.url ?? ""}
+          to={cardLink}
           style={{
             display: "block",
             width: "100%",
@@ -108,7 +110,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
             py={4}
           >
             <RouterLink
-              to={card.url ?? ""}
+              to={cardLink}
               tabIndex={-1}
               style={{ display: "block", textDecoration: "none" }}
             >
@@ -156,7 +158,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
                     variant="secondaryBlack"
                     // @ts-ignore
                     as={RouterLink}
-                    to={card.url}
+                    to={cardLink}
                     width="100%"
                   >
                     {card.linkText}
@@ -168,7 +170,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
             <Media at="xs">
               <Spacer mt={1} />
 
-              <RouterLink to={card.url ?? ""} noUnderline>
+              <RouterLink to={cardLink} noUnderline>
                 <Text variant="xs" color="black100">
                   {card.linkText}
                 </Text>

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -10,7 +10,6 @@ import {
   GridColumns,
   Column,
 } from "@artsy/palette"
-import { Link } from "react-head"
 import { HomeHeroUnit_heroUnit$data } from "__generated__/HomeHeroUnit_heroUnit.graphql"
 import { cropped } from "Utils/resized"
 import { RouterLink } from "System/Router/RouterLink"
@@ -250,15 +249,6 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
 
   return (
     <>
-      {image && index === 0 && (
-        <Link
-          rel="preload"
-          as="image"
-          href={image.src}
-          imagesrcset={image.srcSet}
-        />
-      )}
-
       <GridColumns bg="black5" width="100%">
         <>
           {figure}

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -278,14 +278,6 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
   )
 }
 
-export const LOGGED_OUT_HERO_UNIT: StaticHeroUnit = {
-  title: "Collect art by the world’s leading artists",
-  subtitle: "Register for updates on available works, market news, and more.",
-  href: "/signup",
-  linkText: "Sign Up",
-  backgroundImageURL: "https://files.artsy.net/homepage/signup-banner.png",
-}
-
 interface HomeContentCardProps {
   card: BrazeContentCard
   index: number

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -133,55 +133,47 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
                 {card.title}
               </Text>
 
-              {card.description && (
-                <>
-                  <Spacer mt={[1, 2]} />
+              <Spacer mt={[1, 2]} />
 
-                  <Text
-                    variant={["xs", "sm-display", "lg-display"]}
-                    color="black60"
-                    lineClamp={4}
-                  >
-                    {card.description}
-                  </Text>
-                </>
-              )}
+              <Text
+                variant={["xs", "sm-display", "lg-display"]}
+                color="black60"
+                lineClamp={4}
+              >
+                {card.description}
+              </Text>
             </RouterLink>
 
-            {card.linkText && card.url && (
-              <>
-                <Media greaterThan="xs">
-                  <Spacer
-                    // Unconventional value here to keep visual rhythm
-                    mt="30px"
-                  />
+            <Media greaterThan="xs">
+              <Spacer
+                // Unconventional value here to keep visual rhythm
+                mt="30px"
+              />
 
-                  <GridColumns>
-                    <Column span={[12, 12, 6]}>
-                      <Button
-                        variant="secondaryBlack"
-                        // @ts-ignore
-                        as={RouterLink}
-                        to={card.url}
-                        width="100%"
-                      >
-                        {card.linkText}
-                      </Button>
-                    </Column>
-                  </GridColumns>
-                </Media>
+              <GridColumns>
+                <Column span={[12, 12, 6]}>
+                  <Button
+                    variant="secondaryBlack"
+                    // @ts-ignore
+                    as={RouterLink}
+                    to={card.url}
+                    width="100%"
+                  >
+                    {card.linkText}
+                  </Button>
+                </Column>
+              </GridColumns>
+            </Media>
 
-                <Media at="xs">
-                  <Spacer mt={1} />
+            <Media at="xs">
+              <Spacer mt={1} />
 
-                  <RouterLink to={card.url} noUnderline>
-                    <Text variant="xs" color="black100">
-                      {card.linkText}
-                    </Text>
-                  </RouterLink>
-                </Media>
-              </>
-            )}
+              <RouterLink to={card.url ?? ""} noUnderline>
+                <Text variant="xs" color="black100">
+                  {card.linkText}
+                </Text>
+              </RouterLink>
+            </Media>
           </Column>
         </GridColumns>
       </Column>

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -1,0 +1,29 @@
+import { CaptionedImage as BrazeContentCard } from "@braze/web-sdk"
+import {
+  HomeHeroUnit,
+  StaticHeroUnit,
+} from "Apps/Home/Components/HomeHeroUnits/HomeHeroUnit"
+
+interface HomeContentCardProps {
+  card: BrazeContentCard
+  index: number
+}
+
+export const HomeContentCard: React.FC<HomeContentCardProps> = ({
+  card,
+  index,
+}) => {
+  const extras = card.extras || {}
+
+  const heroUnit: StaticHeroUnit = {
+    backgroundImageURL: card.imageUrl!,
+    creditLine: extras.credit,
+    heading: extras.label,
+    href: card.url!,
+    linkText: card.linkText,
+    subtitle: card.description,
+    title: card.title,
+  }
+
+  return <HomeHeroUnit heroUnit={heroUnit} index={index} layout="a" />
+}

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -15,10 +15,6 @@ import { RouterLink } from "System/Router/RouterLink"
 import { Media } from "Utils/Responsive"
 import { HomeHeroUnitCredit } from "./HomeHeroUnits/HomeHeroUnitCredit"
 
-interface ContentCard {
-  creditLine?: string
-}
-
 interface HomeContentCardProps {
   card: BrazeContentCard
   index: number
@@ -29,10 +25,6 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
   index,
 }) => {
   const extras = card.extras || {}
-
-  const contentCard: ContentCard = {
-    creditLine: extras.credit,
-  }
 
   const image = cropped(card.imageUrl!, {
     // 3:2
@@ -88,7 +80,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
                       lazyLoad={index > 0}
                     />
 
-                    {contentCard.creditLine && (
+                    {extras.credit && (
                       <Box
                         position="absolute"
                         px={2}
@@ -99,9 +91,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
                         background="linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.1) 100%);"
                         left={0}
                       >
-                        <HomeHeroUnitCredit>
-                          {contentCard.creditLine}
-                        </HomeHeroUnitCredit>
+                        <HomeHeroUnitCredit>{extras.credit}</HomeHeroUnitCredit>
                       </Box>
                     )}
                   </Box>

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -18,7 +18,6 @@ import { HomeHeroUnitCredit } from "./HomeHeroUnits/HomeHeroUnitCredit"
 interface ContentCard {
   creditLine?: string
   heading?: string | JSX.Element
-  linkText?: string
   subtitle: string
   title: string
 }
@@ -37,7 +36,6 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
   const contentCard: ContentCard = {
     creditLine: extras.credit,
     heading: extras.label,
-    linkText: card.linkText,
     subtitle: card.description,
     title: card.title,
   }
@@ -170,7 +168,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
               )}
             </RouterLink>
 
-            {contentCard.linkText && card.url && (
+            {card.linkText && card.url && (
               <>
                 <Media greaterThan="xs">
                   <Spacer
@@ -187,7 +185,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
                         to={card.url}
                         width="100%"
                       >
-                        {contentCard.linkText}
+                        {card.linkText}
                       </Button>
                     </Column>
                   </GridColumns>
@@ -198,7 +196,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
 
                   <RouterLink to={card.url} noUnderline>
                     <Text variant="xs" color="black100">
-                      {contentCard.linkText}
+                      {card.linkText}
                     </Text>
                   </RouterLink>
                 </Media>

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -220,14 +220,10 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
   )
 
   return (
-    <>
-      <GridColumns bg="black5" width="100%">
-        <>
-          {figure}
-          {description}
-        </>
-      </GridColumns>
-    </>
+    <GridColumns bg="black5" width="100%">
+      {figure}
+      {description}
+    </GridColumns>
   )
 }
 

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -1,8 +1,308 @@
 import { CaptionedImage as BrazeContentCard } from "@braze/web-sdk"
+import * as React from "react"
 import {
+  Box,
+  Image,
+  ResponsiveBox,
+  Spacer,
+  Text,
+  Button,
+  GridColumns,
+  Column,
+} from "@artsy/palette"
+import { Link } from "react-head"
+import { createFragmentContainer, graphql } from "react-relay"
+import { HomeHeroUnit_heroUnit$data } from "__generated__/HomeHeroUnit_heroUnit.graphql"
+import { cropped } from "Utils/resized"
+import { RouterLink } from "System/Router/RouterLink"
+import { Media } from "Utils/Responsive"
+import { HomeHeroUnitCredit } from "./HomeHeroUnits/HomeHeroUnitCredit"
+import { useTracking } from "react-tracking"
+import {
+  ActionType,
+  ClickedPromoSpace,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
+import { useCallback, useMemo } from "react"
+
+export interface StaticHeroUnit {
+  backgroundImageURL: string
+  href: string
+  heading?: string | JSX.Element
+  title: string
+  subtitle: string
+  linkText?: string
+  creditLine?: string
+}
+
+export interface HomeHeroUnitProps {
+  heroUnit: HomeHeroUnit_heroUnit$data | StaticHeroUnit
+  layout: "a" | "b"
+  index: number
+}
+
+export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
+  heroUnit,
+  layout = "a",
+  index,
+}) => {
+  const { trackEvent } = useTracking()
+
+  const handleTrackEvent = useCallback(() => {
+    const event: ClickedPromoSpace = {
+      action: ActionType.clickedPromoSpace,
+      context_module: ContextModule.banner,
+      context_screen_owner_type: OwnerType.home,
+      destination_path: heroUnit.href ?? "",
+      subject: "clicking on the promo banner",
+    }
+    trackEvent(event)
+  }, [heroUnit.href, trackEvent])
+
+  const image = heroUnit.backgroundImageURL
+    ? cropped(heroUnit.backgroundImageURL, {
+        // 3:2
+        width: 910,
+        height: 607,
+        quality: 75,
+      })
+    : null
+
+  const figure = useMemo(
+    () => (
+      <Column span={6} bg="white100">
+        <RouterLink
+          to={heroUnit.href ?? ""}
+          style={{
+            display: "block",
+            width: "100%",
+            height: "100%",
+          }}
+          tabIndex={-1}
+          onClick={handleTrackEvent}
+        >
+          {image && (
+            <>
+              <Media at="xs">
+                <ResponsiveBox
+                  aspectWidth={3}
+                  aspectHeight={2}
+                  maxWidth="100%"
+                  bg="black10"
+                >
+                  <Image
+                    src={image.src}
+                    srcSet={image.srcSet}
+                    width="100%"
+                    height="100%"
+                    lazyLoad={index > 0}
+                  />
+                </ResponsiveBox>
+              </Media>
+
+              <Media greaterThan="xs">
+                {className => (
+                  <Box
+                    className={className}
+                    height={[300, 400, 500]}
+                    position="relative"
+                  >
+                    <Image
+                      src={image.src}
+                      srcSet={image.srcSet}
+                      width="100%"
+                      height="100%"
+                      style={{ objectFit: "cover" }}
+                      lazyLoad={index > 0}
+                    />
+
+                    {heroUnit.creditLine && (
+                      <Box
+                        position="absolute"
+                        px={2}
+                        pb={1}
+                        pt={6}
+                        width="100%"
+                        bottom={0}
+                        background="linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.1) 100%);"
+                        {...(layout === "a" ? { left: 0 } : { right: 0 })}
+                      >
+                        <HomeHeroUnitCredit>
+                          {heroUnit.creditLine}
+                        </HomeHeroUnitCredit>
+                      </Box>
+                    )}
+                  </Box>
+                )}
+              </Media>
+            </>
+          )}
+        </RouterLink>
+      </Column>
+    ),
+    [handleTrackEvent, heroUnit.creditLine, heroUnit.href, image, index, layout]
+  )
+
+  const description = useMemo(
+    () => (
+      <Column span={6}>
+        <GridColumns height="100%">
+          <Column
+            start={[2, 3]}
+            span={[10, 8]}
+            display="flex"
+            justifyContent="center"
+            flexDirection="column"
+            py={4}
+          >
+            <RouterLink
+              to={heroUnit.href ?? ""}
+              tabIndex={-1}
+              style={{ display: "block", textDecoration: "none" }}
+              onClick={handleTrackEvent}
+            >
+              <Media greaterThan="xs">
+                {heroUnit.heading && (
+                  <>
+                    <Text variant="xs" color="black100">
+                      {heroUnit.heading}
+                    </Text>
+
+                    <Spacer mt={2} />
+                  </>
+                )}
+              </Media>
+
+              <Text
+                as={index === 0 ? "h1" : "h2"}
+                variant={["lg-display", "xl", "xl"]}
+                color="black100"
+                lineClamp={3}
+              >
+                {heroUnit.title}
+              </Text>
+
+              {heroUnit.subtitle && (
+                <>
+                  <Spacer mt={[1, 2]} />
+
+                  <Text
+                    variant={["xs", "sm-display", "lg-display"]}
+                    color="black60"
+                    lineClamp={4}
+                  >
+                    {heroUnit.subtitle}
+                  </Text>
+                </>
+              )}
+            </RouterLink>
+
+            {heroUnit.linkText && heroUnit.href && (
+              <>
+                <Media greaterThan="xs">
+                  <Spacer
+                    // Unconventional value here to keep visual rhythm
+                    mt="30px"
+                  />
+
+                  <GridColumns>
+                    <Column span={[12, 12, 6]}>
+                      <Button
+                        variant="secondaryBlack"
+                        // @ts-ignore
+                        as={RouterLink}
+                        to={heroUnit.href}
+                        width="100%"
+                      >
+                        {heroUnit.linkText}
+                      </Button>
+                    </Column>
+                  </GridColumns>
+                </Media>
+
+                <Media at="xs">
+                  <Spacer mt={1} />
+
+                  <RouterLink
+                    to={heroUnit.href}
+                    noUnderline
+                    onClick={handleTrackEvent}
+                  >
+                    <Text variant="xs" color="black100">
+                      {heroUnit.linkText}
+                    </Text>
+                  </RouterLink>
+                </Media>
+              </>
+            )}
+          </Column>
+        </GridColumns>
+      </Column>
+    ),
+    [
+      handleTrackEvent,
+      heroUnit.heading,
+      heroUnit.href,
+      heroUnit.linkText,
+      heroUnit.subtitle,
+      heroUnit.title,
+      index,
+    ]
+  )
+
+  return (
+    <>
+      {image && index === 0 && (
+        <Link
+          rel="preload"
+          as="image"
+          href={image.src}
+          imagesrcset={image.srcSet}
+        />
+      )}
+
+      <GridColumns bg="black5" width="100%">
+        {layout === "a" ? (
+          <>
+            {figure}
+            {description}
+          </>
+        ) : (
+          <>
+            {description}
+            {figure}
+          </>
+        )}
+      </GridColumns>
+    </>
+  )
+}
+
+export const HomeHeroUnitFragmentContainer = createFragmentContainer(
   HomeHeroUnit,
-  StaticHeroUnit,
-} from "Apps/Home/Components/HomeHeroUnits/HomeHeroUnit"
+  {
+    heroUnit: graphql`
+      fragment HomeHeroUnit_heroUnit on HomePageHeroUnit {
+        backgroundImageURL
+        heading
+        title
+        subtitle
+        linkText
+        href
+        creditLine
+      }
+    `,
+  }
+)
+
+export const LOGGED_OUT_HERO_UNIT: StaticHeroUnit = {
+  title: "Collect art by the world’s leading artists",
+  subtitle: "Register for updates on available works, market news, and more.",
+  href: "/signup",
+  linkText: "Sign Up",
+  backgroundImageURL: "https://files.artsy.net/homepage/signup-banner.png",
+}
 
 interface HomeContentCardProps {
   card: BrazeContentCard

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -14,14 +14,7 @@ import { cropped } from "Utils/resized"
 import { RouterLink } from "System/Router/RouterLink"
 import { Media } from "Utils/Responsive"
 import { HomeHeroUnitCredit } from "./HomeHeroUnits/HomeHeroUnitCredit"
-import { useTracking } from "react-tracking"
-import {
-  ActionType,
-  ClickedPromoSpace,
-  ContextModule,
-  OwnerType,
-} from "@artsy/cohesion"
-import { useCallback, useMemo } from "react"
+import { useMemo } from "react"
 
 export interface ContentCard {
   backgroundImageURL: string
@@ -42,19 +35,6 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
   contentCard,
   index,
 }) => {
-  const { trackEvent } = useTracking()
-
-  const handleTrackEvent = useCallback(() => {
-    const event: ClickedPromoSpace = {
-      action: ActionType.clickedPromoSpace,
-      context_module: ContextModule.banner,
-      context_screen_owner_type: OwnerType.home,
-      destination_path: contentCard.href ?? "",
-      subject: "clicking on the promo banner",
-    }
-    trackEvent(event)
-  }, [contentCard.href, trackEvent])
-
   const image = contentCard.backgroundImageURL
     ? cropped(contentCard.backgroundImageURL, {
         // 3:2
@@ -75,7 +55,6 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
             height: "100%",
           }}
           tabIndex={-1}
-          onClick={handleTrackEvent}
         >
           {image && (
             <>
@@ -136,7 +115,7 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
         </RouterLink>
       </Column>
     ),
-    [handleTrackEvent, contentCard.creditLine, contentCard.href, image, index]
+    [contentCard.creditLine, contentCard.href, image, index]
   )
 
   const description = useMemo(
@@ -155,7 +134,6 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
               to={contentCard.href ?? ""}
               tabIndex={-1}
               style={{ display: "block", textDecoration: "none" }}
-              onClick={handleTrackEvent}
             >
               <Media greaterThan="xs">
                 {contentCard.heading && (
@@ -219,11 +197,7 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
                 <Media at="xs">
                   <Spacer mt={1} />
 
-                  <RouterLink
-                    to={contentCard.href}
-                    noUnderline
-                    onClick={handleTrackEvent}
-                  >
+                  <RouterLink to={contentCard.href} noUnderline>
                     <Text variant="xs" color="black100">
                       {contentCard.linkText}
                     </Text>
@@ -236,7 +210,6 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
       </Column>
     ),
     [
-      handleTrackEvent,
       contentCard.heading,
       contentCard.href,
       contentCard.linkText,

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -18,7 +18,6 @@ import { HomeHeroUnitCredit } from "./HomeHeroUnits/HomeHeroUnitCredit"
 interface ContentCard {
   creditLine?: string
   heading?: string | JSX.Element
-  href: string
   linkText?: string
   subtitle: string
   title: string
@@ -38,7 +37,6 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
   const contentCard: ContentCard = {
     creditLine: extras.credit,
     heading: extras.label,
-    href: card.url!,
     linkText: card.linkText,
     subtitle: card.description,
     title: card.title,
@@ -55,7 +53,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
     <GridColumns bg="black5" width="100%">
       <Column span={6} bg="white100">
         <RouterLink
-          to={contentCard.href ?? ""}
+          to={card.url ?? ""}
           style={{
             display: "block",
             width: "100%",
@@ -132,7 +130,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
             py={4}
           >
             <RouterLink
-              to={contentCard.href ?? ""}
+              to={card.url ?? ""}
               tabIndex={-1}
               style={{ display: "block", textDecoration: "none" }}
             >
@@ -172,7 +170,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
               )}
             </RouterLink>
 
-            {contentCard.linkText && contentCard.href && (
+            {contentCard.linkText && card.url && (
               <>
                 <Media greaterThan="xs">
                   <Spacer
@@ -186,7 +184,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
                         variant="secondaryBlack"
                         // @ts-ignore
                         as={RouterLink}
-                        to={contentCard.href}
+                        to={card.url}
                         width="100%"
                       >
                         {contentCard.linkText}
@@ -198,7 +196,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
                 <Media at="xs">
                   <Spacer mt={1} />
 
-                  <RouterLink to={contentCard.href} noUnderline>
+                  <RouterLink to={card.url} noUnderline>
                     <Text variant="xs" color="black100">
                       {contentCard.linkText}
                     </Text>

--- a/src/Apps/Home/Components/HomeContentCard.tsx
+++ b/src/Apps/Home/Components/HomeContentCard.tsx
@@ -23,23 +23,23 @@ import {
 } from "@artsy/cohesion"
 import { useCallback, useMemo } from "react"
 
-export interface StaticHeroUnit {
+export interface ContentCard {
   backgroundImageURL: string
-  href: string
-  heading?: string | JSX.Element
-  title: string
-  subtitle: string
-  linkText?: string
   creditLine?: string
+  heading?: string | JSX.Element
+  href: string
+  linkText?: string
+  subtitle: string
+  title: string
 }
 
 export interface HomeHeroUnitProps {
-  heroUnit: StaticHeroUnit
+  contentCard: ContentCard
   index: number
 }
 
 export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
-  heroUnit,
+  contentCard,
   index,
 }) => {
   const { trackEvent } = useTracking()
@@ -49,14 +49,14 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
       action: ActionType.clickedPromoSpace,
       context_module: ContextModule.banner,
       context_screen_owner_type: OwnerType.home,
-      destination_path: heroUnit.href ?? "",
+      destination_path: contentCard.href ?? "",
       subject: "clicking on the promo banner",
     }
     trackEvent(event)
-  }, [heroUnit.href, trackEvent])
+  }, [contentCard.href, trackEvent])
 
-  const image = heroUnit.backgroundImageURL
-    ? cropped(heroUnit.backgroundImageURL, {
+  const image = contentCard.backgroundImageURL
+    ? cropped(contentCard.backgroundImageURL, {
         // 3:2
         width: 910,
         height: 607,
@@ -68,7 +68,7 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
     () => (
       <Column span={6} bg="white100">
         <RouterLink
-          to={heroUnit.href ?? ""}
+          to={contentCard.href ?? ""}
           style={{
             display: "block",
             width: "100%",
@@ -112,7 +112,7 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
                       lazyLoad={index > 0}
                     />
 
-                    {heroUnit.creditLine && (
+                    {contentCard.creditLine && (
                       <Box
                         position="absolute"
                         px={2}
@@ -124,7 +124,7 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
                         left={0}
                       >
                         <HomeHeroUnitCredit>
-                          {heroUnit.creditLine}
+                          {contentCard.creditLine}
                         </HomeHeroUnitCredit>
                       </Box>
                     )}
@@ -136,7 +136,7 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
         </RouterLink>
       </Column>
     ),
-    [handleTrackEvent, heroUnit.creditLine, heroUnit.href, image, index]
+    [handleTrackEvent, contentCard.creditLine, contentCard.href, image, index]
   )
 
   const description = useMemo(
@@ -152,16 +152,16 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
             py={4}
           >
             <RouterLink
-              to={heroUnit.href ?? ""}
+              to={contentCard.href ?? ""}
               tabIndex={-1}
               style={{ display: "block", textDecoration: "none" }}
               onClick={handleTrackEvent}
             >
               <Media greaterThan="xs">
-                {heroUnit.heading && (
+                {contentCard.heading && (
                   <>
                     <Text variant="xs" color="black100">
-                      {heroUnit.heading}
+                      {contentCard.heading}
                     </Text>
 
                     <Spacer mt={2} />
@@ -175,10 +175,10 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
                 color="black100"
                 lineClamp={3}
               >
-                {heroUnit.title}
+                {contentCard.title}
               </Text>
 
-              {heroUnit.subtitle && (
+              {contentCard.subtitle && (
                 <>
                   <Spacer mt={[1, 2]} />
 
@@ -187,13 +187,13 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
                     color="black60"
                     lineClamp={4}
                   >
-                    {heroUnit.subtitle}
+                    {contentCard.subtitle}
                   </Text>
                 </>
               )}
             </RouterLink>
 
-            {heroUnit.linkText && heroUnit.href && (
+            {contentCard.linkText && contentCard.href && (
               <>
                 <Media greaterThan="xs">
                   <Spacer
@@ -207,10 +207,10 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
                         variant="secondaryBlack"
                         // @ts-ignore
                         as={RouterLink}
-                        to={heroUnit.href}
+                        to={contentCard.href}
                         width="100%"
                       >
-                        {heroUnit.linkText}
+                        {contentCard.linkText}
                       </Button>
                     </Column>
                   </GridColumns>
@@ -220,12 +220,12 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
                   <Spacer mt={1} />
 
                   <RouterLink
-                    to={heroUnit.href}
+                    to={contentCard.href}
                     noUnderline
                     onClick={handleTrackEvent}
                   >
                     <Text variant="xs" color="black100">
-                      {heroUnit.linkText}
+                      {contentCard.linkText}
                     </Text>
                   </RouterLink>
                 </Media>
@@ -237,11 +237,11 @@ export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
     ),
     [
       handleTrackEvent,
-      heroUnit.heading,
-      heroUnit.href,
-      heroUnit.linkText,
-      heroUnit.subtitle,
-      heroUnit.title,
+      contentCard.heading,
+      contentCard.href,
+      contentCard.linkText,
+      contentCard.subtitle,
+      contentCard.title,
       index,
     ]
   )
@@ -269,7 +269,7 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
 }) => {
   const extras = card.extras || {}
 
-  const heroUnit: StaticHeroUnit = {
+  const contentCard: ContentCard = {
     backgroundImageURL: card.imageUrl!,
     creditLine: extras.credit,
     heading: extras.label,
@@ -279,5 +279,5 @@ export const HomeContentCard: React.FC<HomeContentCardProps> = ({
     title: card.title,
   }
 
-  return <HomeHeroUnit heroUnit={heroUnit} index={index} />
+  return <HomeHeroUnit contentCard={contentCard} index={index} />
 }

--- a/src/Apps/Home/Components/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards.tsx
@@ -102,5 +102,11 @@ export const HomeContentCards: React.FC = () => {
 
   const heroCards = cards.length < 1 ? placeholderCards : realCards
 
-  return <HeroCarousel>{heroCards}</HeroCarousel>
+  const handleChange = newIndex => {
+    const appboy = (window as any).appboy
+    const card = cards[newIndex]
+    appboy.logCardImpressions([card])
+  }
+
+  return <HeroCarousel onChange={handleChange}>{heroCards}</HeroCarousel>
 }

--- a/src/Apps/Home/Components/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards.tsx
@@ -104,6 +104,8 @@ export const HomeContentCards: React.FC = () => {
 
   const handleChange = newIndex => {
     const appboy = (window as any).appboy
+    if (!appboy) return
+
     const card = cards[newIndex]
     appboy.logCardImpressions([card])
   }

--- a/src/Apps/Home/Components/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards.tsx
@@ -1,9 +1,5 @@
 import React, { useEffect, useState } from "react"
 import { HeroCarousel } from "Components/HeroCarousel/HeroCarousel"
-import {
-  HomeHeroUnit,
-  StaticHeroUnit,
-} from "Apps/Home/Components/HomeHeroUnits/HomeHeroUnit"
 import { CaptionedImage as BrazeContentCard } from "@braze/web-sdk"
 import {
   Box,
@@ -15,6 +11,7 @@ import {
   Spacer,
 } from "@artsy/palette"
 import { Media } from "Utils/Responsive"
+import { HomeContentCard } from "./HomeContentCard"
 
 const HomeContentCardPlaceholder = () => {
   return (
@@ -70,27 +67,6 @@ const HomeContentCardPlaceholder = () => {
   )
 }
 
-interface ContentCardProps {
-  card: BrazeContentCard
-  index: number
-}
-
-const ContentCard: React.FC<ContentCardProps> = ({ card, index }) => {
-  const extras = card.extras || {}
-
-  const heroUnit: StaticHeroUnit = {
-    backgroundImageURL: card.imageUrl!,
-    creditLine: extras.credit,
-    heading: extras.label,
-    href: card.url!,
-    linkText: card.linkText,
-    subtitle: card.description,
-    title: card.title,
-  }
-
-  return <HomeHeroUnit heroUnit={heroUnit} index={index} layout="a" />
-}
-
 export const HomeContentCards: React.FC = () => {
   const [cards, setCards] = useState<BrazeContentCard[]>([])
 
@@ -121,7 +97,7 @@ export const HomeContentCards: React.FC = () => {
   ]
 
   const realCards = cards.map((card, index) => (
-    <ContentCard card={card} key={card.id} index={index} />
+    <HomeContentCard card={card} key={card.id} index={index} />
   ))
 
   const heroCards = cards.length < 1 ? placeholderCards : realCards

--- a/src/Apps/Home/Components/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards.tsx
@@ -102,11 +102,11 @@ export const HomeContentCards: React.FC = () => {
 
   const heroCards = cards.length < 1 ? placeholderCards : realCards
 
-  const handleChange = newIndex => {
+  const handleChange = index => {
     const appboy = (window as any).appboy
     if (!appboy) return
 
-    const card = cards[newIndex]
+    const card = cards[index]
     appboy.logCardImpressions([card])
   }
 

--- a/src/Components/HeroCarousel/HeroCarousel.tsx
+++ b/src/Components/HeroCarousel/HeroCarousel.tsx
@@ -7,20 +7,24 @@ export interface HeroCarouselProps {
   children: ReactNode
   /** Only utilizes full-bleed at desktop sizes */
   fullBleed?: boolean
+  onChange?: (newIndex) => void
 }
 
 export const HeroCarousel: FC<HeroCarouselProps> = ({
   children,
   fullBleed = true,
+  onChange,
 }) => {
   return (
     <>
       <Media at="xs">
-        <HeroCarouselSmall>{children}</HeroCarouselSmall>
+        <HeroCarouselSmall onChange={onChange}>{children}</HeroCarouselSmall>
       </Media>
 
       <Media greaterThan="xs">
-        <HeroCarouselLarge fullBleed={fullBleed}>{children}</HeroCarouselLarge>
+        <HeroCarouselLarge onChange={onChange} fullBleed={fullBleed}>
+          {children}
+        </HeroCarouselLarge>
       </Media>
     </>
   )

--- a/src/Components/HeroCarousel/HeroCarousel.tsx
+++ b/src/Components/HeroCarousel/HeroCarousel.tsx
@@ -7,7 +7,7 @@ export interface HeroCarouselProps {
   children: ReactNode
   /** Only utilizes full-bleed at desktop sizes */
   fullBleed?: boolean
-  onChange?: (newIndex) => void
+  onChange?: (index) => void
 }
 
 export const HeroCarousel: FC<HeroCarouselProps> = ({

--- a/src/Components/HeroCarousel/HeroCarouselLarge.tsx
+++ b/src/Components/HeroCarousel/HeroCarouselLarge.tsx
@@ -27,7 +27,7 @@ import { useNextPrevious } from "Utils/Hooks/useNextPrevious"
 interface HeroCarouselLargeProps {
   children: React.ReactNode
   fullBleed?: boolean
-  onChange?: (newIndex) => void
+  onChange?: (index) => void
 }
 
 export const HeroCarouselLarge: React.FC<HeroCarouselLargeProps> = ({

--- a/src/Components/HeroCarousel/HeroCarouselLarge.tsx
+++ b/src/Components/HeroCarousel/HeroCarouselLarge.tsx
@@ -27,11 +27,13 @@ import { useNextPrevious } from "Utils/Hooks/useNextPrevious"
 interface HeroCarouselLargeProps {
   children: React.ReactNode
   fullBleed?: boolean
+  onChange?: (newIndex) => void
 }
 
 export const HeroCarouselLarge: React.FC<HeroCarouselLargeProps> = ({
   children,
   fullBleed = true,
+  onChange,
 }) => {
   const length = Children.count(children)
 

--- a/src/Components/HeroCarousel/HeroCarouselSmall.tsx
+++ b/src/Components/HeroCarousel/HeroCarouselSmall.tsx
@@ -15,10 +15,25 @@ import {
   SwiperRailProps,
 } from "@artsy/palette"
 
-export const HeroCarouselSmall: FC = ({ children }) => {
+interface HeroCarouselSmallProps {
+  onChange?: (index) => void
+}
+
+export const HeroCarouselSmall: FC<HeroCarouselSmallProps> = ({
+  children,
+  onChange,
+}) => {
   const length = Children.count(children)
 
   const [index, setIndex] = useState(0)
+
+  const handleChange = newIndex => {
+    if (onChange) {
+      onChange(newIndex)
+    }
+
+    setIndex(newIndex)
+  }
 
   return (
     <>
@@ -27,7 +42,7 @@ export const HeroCarouselSmall: FC = ({ children }) => {
         snap="center"
         Cell={Cell}
         Rail={Rail}
-        onChange={setIndex}
+        onChange={handleChange}
       >
         {children}
       </Swiper>

--- a/src/Components/HeroCarousel/HeroCarouselSmall.tsx
+++ b/src/Components/HeroCarousel/HeroCarouselSmall.tsx
@@ -27,12 +27,12 @@ export const HeroCarouselSmall: FC<HeroCarouselSmallProps> = ({
 
   const [index, setIndex] = useState(0)
 
-  const handleChange = newIndex => {
+  const handleChange = index => {
     if (onChange) {
-      onChange(newIndex)
+      onChange(index)
     }
 
-    setIndex(newIndex)
+    setIndex(index)
   }
 
   return (


### PR DESCRIPTION
This PR updates the Braze content card code to use their SDK to send events. Because we're loading these things ourselves, we are responsible for sending clicks and impressions so that's what this PR does.

Note that I started by duplicating the `HomeHeroUnit` and then spent about a dozen commits pruning it down to just what I needed in this case. Ultimately we'll end up removing that component once we fully ship Braze content cards but not yet. We still use a query param to load the Braze ones so this acts as a feature flag for now. Hopefully we can remove all that stuff next week!

While this project was meant to focus only on replicating how the existing cards behave we had an opportunity to chat about the images and improve things there - more here:

https://artsy.slack.com/archives/C01ADJNCS5D/p1668700831526749?thread_ts=1668624990.972969&cid=C01ADJNCS5D

https://artsyproduct.atlassian.net/browse/GRO-1324

/cc @artsy/grow-devs