### PR TITLE
chore: add box around artwork details query renderer for cypress targeting

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
@@ -166,30 +166,32 @@ export const ArtworkDetailsQueryRenderer: React.FC<{
   const { relayEnvironment } = useSystemContext()
 
   return (
-    <SystemQueryRenderer<ArtworkDetailsQuery>
-      lazyLoad
-      environment={relayEnvironment}
-      variables={{ slug }}
-      placeholder={PLACEHOLDER}
-      query={graphql`
-        query ArtworkDetailsQuery($slug: String!) {
-          artwork(id: $slug) {
-            ...ArtworkDetails_artwork
+    <Box data-test="ArtworkDetailsQueryRenderer">
+      <SystemQueryRenderer<ArtworkDetailsQuery>
+        lazyLoad
+        environment={relayEnvironment}
+        variables={{ slug }}
+        placeholder={PLACEHOLDER}
+        query={graphql`
+          query ArtworkDetailsQuery($slug: String!) {
+            artwork(id: $slug) {
+              ...ArtworkDetails_artwork
+            }
           }
-        }
-      `}
-      render={({ error, props }) => {
-        if (error) {
-          console.error(error)
-          return null
-        }
-        if (!props) {
-          return PLACEHOLDER
-        }
-        if (props.artwork) {
-          return <ArtworkDetailsFragmentContainer artwork={props.artwork} />
-        }
-      }}
-    />
+        `}
+        render={({ error, props }) => {
+          if (error) {
+            console.error(error)
+            return null
+          }
+          if (!props) {
+            return PLACEHOLDER
+          }
+          if (props.artwork) {
+            return <ArtworkDetailsFragmentContainer artwork={props.artwork} />
+          }
+        }}
+      />
+    </Box>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

This is a lazily-loaded component, which when properly fetched renders some data (which we'd like to target via Integrity). I _think_ (based on looking at a couple of analogous examples), that this may aid in that, it's a proper div which can be scrolled to (kicking off the query instead of more arbitrary scrolling), and then data found as normal.