### PR TITLE
(fix)[GRO-1409] move NFTs from home nav to artwork medium

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -422,15 +422,6 @@ export const NavBar: React.FC = track(
                 >
                   {t`navbar.museums`}
                 </NavBarItemLink>
-
-                <NavBarItemLink
-                  href="/collect?additional_gene_ids[0]=nft"
-                  onClick={handleClick}
-                  data-label="NFTs"
-                  display={["none", "none", "flex"]}
-                >
-                  {t`navbar.nfts`}
-                </NavBarItemLink>
               </Flex>
 
               <Flex alignItems="stretch" display={["none", "none", "flex"]}>

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
@@ -111,10 +111,6 @@ export const NavBarMobileMenu: React.FC<NavBarMobileMenuProps> = ({
               Museums
             </NavBarMobileMenuItemLink>
 
-            <NavBarMobileMenuItemLink to="/nft" onClick={handleClick}>
-              NFTs
-            </NavBarMobileMenuItemLink>
-
             <Separator my={1} />
 
             <NavBarMobileMenuItemLink

--- a/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
@@ -1,10 +1,10 @@
 import { SystemContextProvider } from "System"
 import { useTracking } from "react-tracking"
 import { mount } from "enzyme"
-import { NavBarMobileMenu } from "../NavBarMobileMenu"
+import { NavBarMobileMenu } from "Components/NavBar/NavBarMobileMenu/NavBarMobileMenu"
 import { mediator } from "Server/mediator"
-import { NavBarMobileMenuTransition } from "../NavBarMobileMenuTransition"
-import { NavBarMobileSubMenuBack } from "../NavBarMobileSubMenu"
+import { NavBarMobileMenuTransition } from "Components/NavBar/NavBarMobileMenu/NavBarMobileMenuTransition"
+import { NavBarMobileSubMenuBack } from "Components/NavBar/NavBarMobileMenu/NavBarMobileSubMenu"
 import { FeatureFlags } from "System/useFeatureFlag"
 
 jest.mock("react-tracking")
@@ -69,7 +69,6 @@ describe("NavBarMobileMenu", () => {
         ["/art-fairs", "Fairs"],
         ["/shows", "Shows"],
         ["/institutions", "Museums"],
-        ["/nft", "NFTs"],
         ["/sell", "Sell"],
         ["/price-database", "Price Database"],
         ["/articles", "Editorial"],

--- a/src/Components/NavBar/menuData.ts
+++ b/src/Components/NavBar/menuData.ts
@@ -263,6 +263,10 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
               text: "Design",
               href: "/collection/design",
             },
+            {
+              text: "NFTs",
+              href: "/collect?additional_gene_ids[0]=nft",
+            },
           ],
         },
         dividerBelow: true,


### PR DESCRIPTION
The type of this PR is: fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1409]

### Description

The goal of this PR is to clean up the nav bar a bit as part of the fix it sprint. NFTs now live under artwork mediums where they belong :)

<!-- Implementation description -->
Desktop

https://user-images.githubusercontent.com/23108927/203132713-f8d7cae2-4cc5-4ff6-af5b-cae4bb7bb376.mp4


MWEB

https://user-images.githubusercontent.com/23108927/203132974-ad27c625-f9cd-489f-a2f9-e77fbf4b525e.mp4


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1409]: https://artsyproduct.atlassian.net/browse/GRO-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ