### PR TITLE
fix(CX-3130): Remove "share followed artists..." from Inquiry Flow

### DIFF
--- a/src/Components/Inquiry/Views/InquiryBasicInfo.tsx
+++ b/src/Components/Inquiry/Views/InquiryBasicInfo.tsx
@@ -2,7 +2,6 @@ import {
   Banner,
   Box,
   Button,
-  Checkbox,
   Input,
   Skeleton,
   SkeletonBox,
@@ -57,10 +56,6 @@ const InquiryBasicInfo: React.FC<InquiryBasicInfoProps> = ({ artwork, me }) => {
 
   const handleLocation = (place: Place) => {
     setState(prevState => ({ ...prevState, location: normalizePlace(place) }))
-  }
-
-  const handleSelect = (value: boolean) => {
-    setState(prevState => ({ ...prevState, shareFollows: value }))
   }
 
   const handleInputChange = (name: "profession" | "phone") => (
@@ -128,10 +123,6 @@ const InquiryBasicInfo: React.FC<InquiryBasicInfoProps> = ({ artwork, me }) => {
         mb={2}
       />
 
-      <Checkbox onSelect={handleSelect} selected={state.shareFollows} mb={2}>
-        Share followed artists, categories, and galleries
-      </Checkbox>
-
       <Button
         type="submit"
         width="100%"
@@ -168,10 +159,6 @@ const InquiryBasicInfoPlaceholder: React.FC = () => {
       </SkeletonText>
 
       <SkeletonBox height={50} mb={2} />
-
-      <SkeletonText variant="sm" mb={2}>
-        Share followed artists, categories, and galleries
-      </SkeletonText>
 
       <SkeletonBox height={50} />
     </Skeleton>

--- a/src/Components/Inquiry/__tests__/Views/InquiryBasicInfo.jest.tsx
+++ b/src/Components/Inquiry/__tests__/Views/InquiryBasicInfo.jest.tsx
@@ -89,8 +89,6 @@ describe("InquiryBasicInfo", () => {
     fill(wrapper, "profession", "Carpenter")
     fill(wrapper, "phone", "555-555-5555")
 
-    wrapper.find('[role="checkbox"]').first().simulate("click")
-
     wrapper.find("form").simulate("submit")
 
     await flushPromiseQueue()
@@ -98,7 +96,7 @@ describe("InquiryBasicInfo", () => {
     expect(mockSubmitUpdateMyUserProfile).toBeCalledWith({
       profession: "Carpenter",
       phone: "555-555-5555",
-      shareFollows: false,
+      shareFollows: true,
     })
 
     expect(mockNext).toBeCalled()


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3130]

### Description
This PR removes the "Share followed artists, categories, and galleries" from the inquiry flow

### Screenshots

| mWeb | Desktop |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/20655703/203355248-709cb446-90e9-467a-9b0f-9af75e17dfa9.png) | ![image](https://user-images.githubusercontent.com/20655703/203355088-be106142-f3ef-4554-b988-d5ef64192051.png) |


<!-- Implementation description -->


[CX-3130]: https://artsyproduct.atlassian.net/browse/CX-3130