### PR TITLE
WIP:bug:ensure image in partner artist rail is scoped to partner

### DIFF
--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarouselItem.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarouselItem.tsx
@@ -1,0 +1,86 @@
+import * as React from "react"
+import { Image, EntityHeader, Flex } from "@artsy/palette"
+import { ContextModule } from "@artsy/cohesion"
+import { createFragmentContainer, graphql } from "react-relay"
+import { RouterLink } from "System/Router/RouterLink"
+import { FollowArtistButtonFragmentContainer } from "Components/FollowButton/FollowArtistButton"
+import { PartnerArtistsCarouselItem_artist$data } from "__generated__/PartnerArtistsCarouselItem_artist.graphql"
+import { extractNodes } from "Utils/extractNodes"
+
+export interface PartnerArtistsCarouselItemProps {
+  artist: PartnerArtistsCarouselItem_artist$data
+  partnerArtistHref: string
+}
+
+export const PartnerArtistsCarouselItem: React.FC<PartnerArtistsCarouselItemProps> = ({
+  artist,
+  partnerArtistHref,
+}) => {
+  const artwork = extractNodes(artist.artworksConnection)
+
+  if (!artist || !artist.node || artwork.length === 0) return null
+
+  return (
+    <>
+      <RouterLink to={partnerArtistHref}>
+        <Image
+          lazyLoad
+          width={artwork[0].image?.cropped?.width ?? 320}
+          height={artwork[0].image?.cropped?.height ?? 240}
+          src={artwork[0].image?.cropped?.src}
+          srcSet={artwork[0].image?.cropped?.srcSet}
+        />
+      </RouterLink>
+
+      <Flex mt={1} justifyContent="space-between">
+        <EntityHeader
+          imageUrl={artist.node.image?.cropped?.url || ""}
+          name={artist.node.name || ""}
+          meta={artist.node.formattedNationalityAndBirthday || undefined}
+          href={partnerArtistHref}
+        />
+        <FollowArtistButtonFragmentContainer
+          // @ts-ignore RELAY UPGRADE 13
+          artist={artist.node!}
+          contextModule={ContextModule.recommendedArtistsRail}
+          size="small"
+        />
+      </Flex>
+    </>
+  )
+}
+
+export const PartnerArtistsCarouselItemFragmentContainer = createFragmentContainer(
+  PartnerArtistsCarouselItem,
+  {
+    artist: graphql`
+      fragment PartnerArtistsCarouselItem_artist on ArtistPartnerEdge {
+        artworksConnection(first: 1) {
+          edges {
+            node {
+              image {
+                cropped(width: 320, height: 240) {
+                  src
+                  srcSet
+                  height
+                  width
+                }
+              }
+            }
+          }
+        }
+        node {
+          id
+          name
+          formattedNationalityAndBirthday
+          ...FollowArtistButton_artist
+          image {
+            cropped(width: 100, height: 100) {
+              url
+            }
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/index.ts
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/index.ts
@@ -1,2 +1,3 @@
 export * from "./PartnerArtistsCarousel"
+export * from "./PartnerArtistsCarouselItem"
 export * from "./PartnerArtistsCarouselPlaceholder"

--- a/src/__generated__/PartnerArtistsCarouselItem_artist.graphql.ts
+++ b/src/__generated__/PartnerArtistsCarouselItem_artist.graphql.ts
@@ -1,0 +1,236 @@
+/**
+ * @generated SignedSource<<c5bd15d5b26673b9d55b3d2ce205ebda>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type PartnerArtistsCarouselItem_artist$data = {
+  readonly artworksConnection: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly image: {
+          readonly cropped: {
+            readonly height: number;
+            readonly src: string;
+            readonly srcSet: string;
+            readonly width: number;
+          } | null;
+        } | null;
+      } | null;
+    } | null> | null;
+  } | null;
+  readonly node: {
+    readonly formattedNationalityAndBirthday: string | null;
+    readonly id: string;
+    readonly image: {
+      readonly cropped: {
+        readonly url: string;
+      } | null;
+    } | null;
+    readonly name: string | null;
+    readonly " $fragmentSpreads": FragmentRefs<"FollowArtistButton_artist">;
+  } | null;
+  readonly " $fragmentType": "PartnerArtistsCarouselItem_artist";
+};
+export type PartnerArtistsCarouselItem_artist$key = {
+  readonly " $data"?: PartnerArtistsCarouselItem_artist$data;
+  readonly " $fragmentSpreads": FragmentRefs<"PartnerArtistsCarouselItem_artist">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "PartnerArtistsCarouselItem_artist",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "kind": "LinkedField",
+      "name": "artworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworkEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Image",
+                  "kind": "LinkedField",
+                  "name": "image",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": [
+                        {
+                          "kind": "Literal",
+                          "name": "height",
+                          "value": 240
+                        },
+                        {
+                          "kind": "Literal",
+                          "name": "width",
+                          "value": 320
+                        }
+                      ],
+                      "concreteType": "CroppedImageUrl",
+                      "kind": "LinkedField",
+                      "name": "cropped",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "src",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "srcSet",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "height",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "width",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": "cropped(height:240,width:320)"
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artworksConnection(first:1)"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Artist",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "formattedNationalityAndBirthday",
+          "storageKey": null
+        },
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "FollowArtistButton_artist"
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Image",
+          "kind": "LinkedField",
+          "name": "image",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "height",
+                  "value": 100
+                },
+                {
+                  "kind": "Literal",
+                  "name": "width",
+                  "value": 100
+                }
+              ],
+              "concreteType": "CroppedImageUrl",
+              "kind": "LinkedField",
+              "name": "cropped",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "url",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": "cropped(height:100,width:100)"
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "ArtistPartnerEdge",
+  "abstractKey": null
+};
+
+(node as any).hash = "5c477a5d45c3bb4dcd4b18bc5ffe3af4";
+
+export default node;

--- a/src/__generated__/PartnerArtistsCarouselRendererQuery.graphql.ts
+++ b/src/__generated__/PartnerArtistsCarouselRendererQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e885066017662c98ec6aedeb3c62a840>>
+ * @generated SignedSource<<d8327ef30d4336711eb25b71e36ad4d4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -45,23 +45,7 @@ v2 = {
   "name": "slug",
   "storageKey": null
 },
-v3 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "src",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
-  }
-],
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -145,23 +129,35 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "Artist",
+                    "concreteType": "PartnerArtistCounts",
                     "kind": "LinkedField",
-                    "name": "node",
+                    "name": "counts",
                     "plural": false,
                     "selections": [
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "internalID",
+                        "name": "artworks",
                         "storageKey": null
-                      },
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "href",
+                        "name": "internalID",
                         "storageKey": null
                       },
                       (v2/*: any*/),
@@ -176,14 +172,14 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "initials",
+                        "name": "formattedNationalityAndBirthday",
                         "storageKey": null
                       },
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "formattedNationalityAndBirthday",
+                        "name": "isFollowed",
                         "storageKey": null
                       },
                       {
@@ -198,47 +194,8 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "artworks",
+                            "name": "follows",
                             "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "forSaleArtworks",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "avatar",
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "height",
-                                "value": 45
-                              },
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 45
-                              }
-                            ],
-                            "concreteType": "CroppedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "cropped",
-                            "plural": false,
-                            "selections": (v3/*: any*/),
-                            "storageKey": "cropped(height:45,width:45)"
                           }
                         ],
                         "storageKey": null
@@ -257,56 +214,156 @@ return {
                               {
                                 "kind": "Literal",
                                 "name": "height",
-                                "value": 334
-                              },
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": [
-                                  "larger",
-                                  "large"
-                                ]
+                                "value": 100
                               },
                               {
                                 "kind": "Literal",
                                 "name": "width",
-                                "value": 445
+                                "value": 100
                               }
                             ],
                             "concreteType": "CroppedImageUrl",
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v3/*: any*/),
-                            "storageKey": "cropped(height:334,version:[\"larger\",\"large\"],width:445)"
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "url",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "cropped(height:100,width:100)"
                           }
                         ],
                         "storageKey": null
-                      },
-                      (v4/*: any*/)
+                      }
                     ],
                     "storageKey": null
                   },
-                  (v4/*: any*/)
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 1
+                      }
+                    ],
+                    "concreteType": "ArtworkConnection",
+                    "kind": "LinkedField",
+                    "name": "artworksConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "height",
+                                        "value": 240
+                                      },
+                                      {
+                                        "kind": "Literal",
+                                        "name": "width",
+                                        "value": 320
+                                      }
+                                    ],
+                                    "concreteType": "CroppedImageUrl",
+                                    "kind": "LinkedField",
+                                    "name": "cropped",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "src",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "srcSet",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "cropped(height:240,width:320)"
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              (v3/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "artworksConnection(first:1)"
+                  },
+                  (v3/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,first:20,hasPublishedArtworks:true)"
           },
-          (v4/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "1f0031a1815908cedc67afc72226f607",
+    "cacheID": "74653bb62bd69fa49e72e85138720ec0",
     "id": null,
     "metadata": {},
     "name": "PartnerArtistsCarouselRendererQuery",
     "operationKind": "query",
-    "text": "query PartnerArtistsCarouselRendererQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistsCarousel_partner\n    id\n  }\n}\n\nfragment CellArtist_artist on Artist {\n  ...EntityHeaderArtist_artist\n  internalID\n  slug\n  name\n  href\n  initials\n  image {\n    cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment PartnerArtistsCarousel_partner on Partner {\n  slug\n  artistsConnection(first: 20, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      node {\n        ...CellArtist_artist\n        internalID\n        slug\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query PartnerArtistsCarouselRendererQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistsCarousel_partner\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  slug\n  name\n  internalID\n  isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment PartnerArtistsCarouselItem_artist on ArtistPartnerEdge {\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          cropped(width: 320, height: 240) {\n            src\n            srcSet\n            height\n            width\n          }\n        }\n        id\n      }\n    }\n  }\n  node {\n    id\n    name\n    formattedNationalityAndBirthday\n    ...FollowArtistButton_artist\n    image {\n      cropped(width: 100, height: 100) {\n        url\n      }\n    }\n  }\n}\n\nfragment PartnerArtistsCarousel_partner on Partner {\n  slug\n  artistsConnection(first: 20, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      counts {\n        artworks\n      }\n      node {\n        id\n        internalID\n        slug\n      }\n      ...PartnerArtistsCarouselItem_artist\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerArtistsCarousel_partner.graphql.ts
+++ b/src/__generated__/PartnerArtistsCarousel_partner.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<736e947799c840b8ef0d535bd4854ba2>>
+ * @generated SignedSource<<8a3bbe9d8d4f39aaa0779f1c051e3743>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,11 +13,15 @@ import { FragmentRefs } from "relay-runtime";
 export type PartnerArtistsCarousel_partner$data = {
   readonly artistsConnection: {
     readonly edges: ReadonlyArray<{
+      readonly counts: {
+        readonly artworks: any | null;
+      } | null;
       readonly node: {
+        readonly id: string;
         readonly internalID: string;
         readonly slug: string;
-        readonly " $fragmentSpreads": FragmentRefs<"CellArtist_artist">;
       } | null;
+      readonly " $fragmentSpreads": FragmentRefs<"PartnerArtistsCarouselItem_artist">;
     } | null> | null;
   } | null;
   readonly slug: string;
@@ -78,15 +82,35 @@ return {
             {
               "alias": null,
               "args": null,
+              "concreteType": "PartnerArtistCounts",
+              "kind": "LinkedField",
+              "name": "counts",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "artworks",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
               "concreteType": "Artist",
               "kind": "LinkedField",
               "name": "node",
               "plural": false,
               "selections": [
                 {
+                  "alias": null,
                   "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "CellArtist_artist"
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
                 },
                 {
                   "alias": null,
@@ -98,6 +122,11 @@ return {
                 (v0/*: any*/)
               ],
               "storageKey": null
+            },
+            {
+              "args": null,
+              "kind": "FragmentSpread",
+              "name": "PartnerArtistsCarouselItem_artist"
             }
           ],
           "storageKey": null
@@ -111,6 +140,6 @@ return {
 };
 })();
 
-(node as any).hash = "29d1837af9e22e88c9fd85a64a7317f2";
+(node as any).hash = "27a14086019c5e53cdce39dd4f0729b0";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: Fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [:px-5309]
### Description

This PR reverts back to the old way we had the artist rail because the recent change was no longer scoping to specific Partner. 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ