### PR TITLE
refactor(auth): removes destination

### DIFF
--- a/src/Apps/Article/ArticleApp.tsx
+++ b/src/Apps/Article/ArticleApp.tsx
@@ -30,7 +30,6 @@ const ArticleApp: FC<ArticleAppProps> = ({ article }) => {
       intent: Intent.viewEditorial,
       contextModule: ContextModule.popUpModal,
       copy: "Sign up for the latest in art market news",
-      destination: location.pathname,
       // TODO: Onboarding is triggered based on contents of redirectTo
       // prop. Move this to `afterSignupAction.action`
       redirectTo: location.pathname,

--- a/src/Apps/Articles/ArticlesApp.tsx
+++ b/src/Apps/Articles/ArticlesApp.tsx
@@ -8,24 +8,18 @@ import { getENV } from "Utils/getENV"
 import { ArticlesApp_viewer$data } from "__generated__/ArticlesApp_viewer.graphql"
 import { useScrollToOpenAuthModal } from "Utils/Hooks/useScrollToOpenAuthModal"
 import { ContextModule, Intent } from "@artsy/cohesion"
-import { useRouter } from "System/Router/useRouter"
 
 interface ArticlesAppProps {
   viewer: ArticlesApp_viewer$data
 }
 
 const ArticlesApp: FC<ArticlesAppProps> = ({ viewer }) => {
-  const {
-    match: { location },
-  } = useRouter()
-
   useScrollToOpenAuthModal({
     key: "editorial-signup-dismissed",
     modalOptions: {
       intent: Intent.viewEditorial,
       contextModule: ContextModule.popUpModal,
       copy: "Sign up for the latest in art market news",
-      destination: location.pathname,
     },
   })
 

--- a/src/Apps/Articles/NewsApp.tsx
+++ b/src/Apps/Articles/NewsApp.tsx
@@ -9,24 +9,17 @@ import { NewsIndexArticlesPaginationContainer } from "./Components/NewsIndexArti
 import { ArticleAdProvider } from "Apps/Article/Components/ArticleAd"
 import { useScrollToOpenAuthModal } from "Utils/Hooks/useScrollToOpenAuthModal"
 import { ContextModule, Intent } from "@artsy/cohesion"
-import { useRouter } from "System/Router/useRouter"
-
 interface NewsAppProps {
   viewer: NewsApp_viewer$data
 }
 
 const NewsApp: FC<NewsAppProps> = ({ viewer }) => {
-  const {
-    match: { location },
-  } = useRouter()
-
   useScrollToOpenAuthModal({
     key: "editorial-signup-dismissed",
     modalOptions: {
       intent: Intent.viewEditorial,
       contextModule: ContextModule.popUpModal,
       copy: "Sign up for the latest in art market news",
-      destination: location.pathname,
     },
   })
 

--- a/src/Apps/Authentication/Components/ModalContainer.tsx
+++ b/src/Apps/Authentication/Components/ModalContainer.tsx
@@ -21,7 +21,6 @@ export class ModalContainer extends Component<any> {
   }
 
   onOpenAuth = (options: ModalOptions) => {
-    options.destination = options.destination || location.href
     if (options && (options.mode as any) === "register") {
       options.mode = ModalType.signup
     }
@@ -46,7 +45,6 @@ export class ModalContainer extends Component<any> {
   onSocialAuthEvent = ({
     contextModule,
     copy,
-    destination,
     intent,
     mode,
     redirectTo,
@@ -54,7 +52,7 @@ export class ModalContainer extends Component<any> {
     triggerSeconds,
   }: SocialAuthArgs) => {
     const options = {
-      auth_redirect: redirectTo || destination,
+      auth_redirect: redirectTo,
       context_module: contextModule,
       modal_copy: copy,
       intent,

--- a/src/Apps/Authentication/Components/__tests__/ModalContainer.jest.tsx
+++ b/src/Apps/Authentication/Components/__tests__/ModalContainer.jest.tsx
@@ -2,7 +2,7 @@ import { mount } from "enzyme"
 // eslint-disable-next-line no-restricted-imports
 import { data as sd } from "sharify"
 import { ModalManager } from "Components/Authentication/ModalManager"
-import { ModalContainer } from "../ModalContainer"
+import { ModalContainer } from "Apps/Authentication/Components/ModalContainer"
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { ModalOptions, ModalType } from "Components/Authentication/Types"
 import { mediator } from "Server/mediator"
@@ -54,16 +54,6 @@ describe("ModalContainer", () => {
     // FIXME: reaction migration
     // @ts-ignore
     expect(form.currentType).toBe("reset_password")
-  })
-
-  it("Sets a cookie when opening the modal", () => {
-    mount(<ModalContainer />)
-    mediator.trigger("open:auth", {
-      mode: ModalType.login,
-      destination: "foo",
-    } as ModalOptions)
-
-    expect(cookieSet).toBeCalledWith("destination", "foo", { expires: 86400 })
   })
 
   it("onSocialAuthEvent sets cookie on signup with expected args", () => {

--- a/src/Apps/Authentication/Utils/__tests__/helpers.jest.ts
+++ b/src/Apps/Authentication/Utils/__tests__/helpers.jest.ts
@@ -5,7 +5,7 @@ import {
   maybeUpdateRedirectTo,
   setCookies,
   updateURLWithOnboardingParam,
-} from "../helpers"
+} from "Apps/Authentication/Utils/helpers"
 import {
   COMMERCIAL_AUTH_INTENTS,
   ModalType,
@@ -84,17 +84,6 @@ describe("Authentication Helpers", () => {
       expect(cookie[0]).toBe("afterSignUpAction")
       expect(cookie[1]).toMatch("an action")
     })
-
-    it("Sets a cookie with expiration for destination", () => {
-      setCookies({
-        destination: "/foo",
-      })
-      const cookie = CookiesSet.mock.calls[0]
-
-      expect(cookie[0]).toBe("destination")
-      expect(cookie[1]).toMatch("/foo")
-      expect(cookie[2].expires).toBe(86400)
-    })
   })
 
   describe("#handleSubmit", () => {
@@ -124,7 +113,6 @@ describe("Authentication Helpers", () => {
         {
           contextModule: ContextModule.popUpModal,
           intent: Intent.viewEditorial,
-          destination: "/articles",
           triggerSeconds: 2,
         },
         {
@@ -187,7 +175,6 @@ describe("Authentication Helpers", () => {
         {
           contextModule: ContextModule.popUpModal,
           intent: Intent.viewEditorial,
-          destination: "/articles",
           triggerSeconds: 2,
         },
         {
@@ -256,7 +243,6 @@ describe("Authentication Helpers", () => {
         {
           contextModule: ContextModule.popUpModal,
           intent: Intent.viewEditorial,
-          destination: "/articles",
           triggerSeconds: 2,
         },
         {
@@ -318,7 +304,6 @@ describe("Authentication Helpers", () => {
         {
           contextModule: ContextModule.popUpModal,
           intent: Intent.viewEditorial,
-          destination: "/articles",
           triggerSeconds: 2,
         },
         {

--- a/src/Apps/Authentication/Utils/__tests__/helpers.jest.ts
+++ b/src/Apps/Authentication/Utils/__tests__/helpers.jest.ts
@@ -114,6 +114,7 @@ describe("Authentication Helpers", () => {
           contextModule: ContextModule.popUpModal,
           intent: Intent.viewEditorial,
           triggerSeconds: 2,
+          redirectTo: "/articles",
         },
         {
           email: "foo@foo.com",
@@ -176,6 +177,7 @@ describe("Authentication Helpers", () => {
           contextModule: ContextModule.popUpModal,
           intent: Intent.viewEditorial,
           triggerSeconds: 2,
+          redirectTo: "/articles",
         },
         {
           name: "foo",
@@ -221,7 +223,7 @@ describe("Authentication Helpers", () => {
             ]
           `)
         expect(window.location.assign).toBeCalledWith(
-          "https://artsy.net/?onboarding=true"
+          "https://artsy.net/articles?onboarding=true"
         )
       })
     })
@@ -244,6 +246,7 @@ describe("Authentication Helpers", () => {
           contextModule: ContextModule.popUpModal,
           intent: Intent.viewEditorial,
           triggerSeconds: 2,
+          redirectTo: "/articles",
         },
         {
           email: "foo@foo.com",

--- a/src/Apps/Authentication/Utils/__tests__/useAuthForm.jest.ts
+++ b/src/Apps/Authentication/Utils/__tests__/useAuthForm.jest.ts
@@ -19,7 +19,6 @@ describe("useAuthForm", () => {
     afterSignUpAction: "afterSignUpAction",
     contextModule: "contextModule",
     copy: null,
-    destination: "destination",
     intent: "intent",
   }
 
@@ -60,7 +59,6 @@ describe("useAuthForm", () => {
       options: {
         contextModule: "contextModule",
         copy: null,
-        destination: "destination",
         intent: "intent",
         redirectTo: "/redirect-to",
         signupReferer: "/someReferer",

--- a/src/Apps/Authentication/Utils/helpers.ts
+++ b/src/Apps/Authentication/Utils/helpers.ts
@@ -91,7 +91,7 @@ export const handleSubmit = async (
             analyticsOptions = tracks.createdAccount(
               options,
               res?.user?.id,
-              !redirectTo
+              isAbleToTriggerOnboarding({ type, intent })
             )
             break
           case ModalType.forgot:
@@ -158,21 +158,31 @@ export const updateURLWithOnboardingParam = (url: string) => {
   return updatedRedirectTo
 }
 
+const isAbleToTriggerOnboarding = ({
+  type,
+  intent,
+}: {
+  type: ModalType
+  intent?: AuthIntent
+}) => {
+  // Only trigger onboarding for sign ups without a commercial intent
+  return !!(
+    type === ModalType.signup &&
+    intent &&
+    !COMMERCIAL_AUTH_INTENTS.includes(intent)
+  )
+}
+
 export const maybeUpdateRedirectTo = (
   type: ModalType,
   redirectTo: string = "/",
   intent: AuthIntent
 ): string | URL => {
-  if (type !== ModalType.signup) {
-    return redirectTo
+  if (isAbleToTriggerOnboarding({ type, intent })) {
+    return updateURLWithOnboardingParam(redirectTo)
   }
 
-  if (COMMERCIAL_AUTH_INTENTS.includes(intent)) {
-    return redirectTo
-  } else {
-    const url = updateURLWithOnboardingParam(redirectTo)
-    return url
-  }
+  return redirectTo
 }
 
 export const setCookies = options => {

--- a/src/Apps/Authentication/Utils/helpers.ts
+++ b/src/Apps/Authentication/Utils/helpers.ts
@@ -45,7 +45,6 @@ export const handleSubmit = async (
   const {
     contextModule,
     copy,
-    destination,
     redirectTo,
     intent,
     signupReferer,
@@ -71,7 +70,7 @@ export const handleSubmit = async (
 
       if (analytics) {
         const options: AnalyticsOptions = {
-          auth_redirect: redirectTo || destination!,
+          auth_redirect: redirectTo!,
           context_module: contextModule!,
           modal_copy: copy,
           intent,
@@ -177,16 +176,10 @@ export const maybeUpdateRedirectTo = (
 }
 
 export const setCookies = options => {
-  const { afterSignUpAction, destination } = options
+  const { afterSignUpAction } = options
 
   if (afterSignUpAction) {
     Cookies.set(AFTER_AUTH_ACTION_KEY, JSON.stringify(afterSignUpAction))
-  }
-
-  if (destination) {
-    Cookies.set("destination", destination, {
-      expires: 60 * 60 * 24,
-    })
   }
 }
 

--- a/src/Apps/Authentication/Utils/useAuthForm.ts
+++ b/src/Apps/Authentication/Utils/useAuthForm.ts
@@ -29,7 +29,6 @@ export const useAuthForm = ({
     afterSignUpAction,
     contextModule,
     copy: copyQueryParam,
-    destination,
     intent,
     oauthLogin,
     // FIXME: Convection should link using the `afterSignUpAction` param, not `submissionId`
@@ -70,7 +69,6 @@ export const useAuthForm = ({
   const options: ModalOptions = {
     contextModule,
     copy: copyQueryParam,
-    destination,
     intent,
     oauthLogin,
     redirectTo,

--- a/src/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
+++ b/src/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
@@ -4,10 +4,10 @@ import { MockBoot, MockRouter } from "DevTools"
 import { NextFunction } from "express"
 import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
 import qs from "qs"
-import { authenticationRoutes } from "../authenticationRoutes"
-import { checkForRedirect } from "../Server/checkForRedirect"
-import { setReferer } from "../Server/setReferer"
-import { redirectIfLoggedIn } from "../Server/redirectIfLoggedIn"
+import { authenticationRoutes } from "Apps/Authentication/authenticationRoutes"
+import { checkForRedirect } from "Apps/Authentication/Server/checkForRedirect"
+import { setReferer } from "Apps/Authentication/Server/setReferer"
+import { redirectIfLoggedIn } from "Apps/Authentication/Server/redirectIfLoggedIn"
 import { getENV } from "Utils/getENV"
 
 jest.mock("../Server/checkForRedirect", () => ({
@@ -133,7 +133,6 @@ describe("authenticationRoutes", () => {
       it("sets cookie with passed login params on mount", async () => {
         const queryParams = {
           action: "follow",
-          destination: "/foo",
           kind: "artist",
           objectId: 123,
           redirectTo: "/bar",
@@ -219,7 +218,6 @@ describe("authenticationRoutes", () => {
       it("sets cookie with passed login params on mount", async () => {
         const queryParams = {
           action: "follow",
-          destination: "/foo",
           kind: "artist",
           objectId: 123,
           redirectTo: "/bar",

--- a/src/Components/Authentication/Types.ts
+++ b/src/Components/Authentication/Types.ts
@@ -70,11 +70,6 @@ export interface ModalOptions {
    */
   copy?: string
   /**
-   * the page path the user is redirected to after successfully
-   * login or account creation after onboarding.
-   */
-  destination?: string
-  /**
    * The image rendered with the modal
    */
   image?: string

--- a/src/Components/Authentication/__tests__/FormSwitcher.jest.tsx
+++ b/src/Components/Authentication/__tests__/FormSwitcher.jest.tsx
@@ -1,11 +1,11 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { Clickable, Button } from "@artsy/palette"
 import { mount } from "enzyme"
-import { ForgotPasswordForm } from "../Views/ForgotPasswordForm"
-import { LoginForm } from "../Views/LoginForm"
-import { SignUpFormQueryRenderer } from "../Views/SignUpForm"
-import { FormSwitcher } from "../FormSwitcher"
-import { ModalType } from "../Types"
+import { ForgotPasswordForm } from "Components/Authentication/Views/ForgotPasswordForm"
+import { LoginForm } from "Components/Authentication/Views/LoginForm"
+import { SignUpFormQueryRenderer } from "Components/Authentication/Views/SignUpForm"
+import { FormSwitcher } from "Components/Authentication/FormSwitcher"
+import { ModalType } from "Components/Authentication/Types"
 import { mockLocation } from "DevTools/mockLocation"
 
 describe("FormSwitcher", () => {
@@ -18,7 +18,6 @@ describe("FormSwitcher", () => {
         options={{
           contextModule: ContextModule.header,
           copy: "Foo Bar",
-          destination: "/collect",
           intent: Intent.followArtist,
           redirectTo: "/foo",
           triggerSeconds: 1,
@@ -76,7 +75,7 @@ describe("FormSwitcher", () => {
         .simulate("click")
 
       expect(window.location.assign).toHaveBeenCalledWith(
-        "/signup?contextModule=header&copy=Foo%20Bar&destination=%2Fcollect&intent=followArtist&redirectTo=%2Ffoo&triggerSeconds=1"
+        "/signup?contextModule=header&copy=Foo%20Bar&intent=followArtist&redirectTo=%2Ffoo&triggerSeconds=1"
       )
     })
 
@@ -126,7 +125,7 @@ describe("FormSwitcher", () => {
       )
 
       expect((window.location.assign as any).mock.calls[0][0]).toEqual(
-        "/users/auth/apple?contextModule=header&copy=Foo%20Bar&destination=%2Fcollect&intent=followArtist&redirectTo=%2Ffoo&triggerSeconds=1&accepted_terms_of_service=true&afterSignUpAction=&agreed_to_receive_emails=true&signup-referer=&redirect-to=%2Ffoo&signup-intent=followArtist&service=apple"
+        "/users/auth/apple?contextModule=header&copy=Foo%20Bar&intent=followArtist&redirectTo=%2Ffoo&triggerSeconds=1&accepted_terms_of_service=true&afterSignUpAction=&agreed_to_receive_emails=true&signup-referer=&redirect-to=%2Ffoo&signup-intent=followArtist&service=apple"
       )
     })
   })

--- a/src/Utils/Hooks/useScrollToOpenArtistAuthModal.ts
+++ b/src/Utils/Hooks/useScrollToOpenArtistAuthModal.ts
@@ -79,7 +79,6 @@ export const useScrollToOpenArtistAuthModal = () => {
           openAuthModal(mediator, {
             contextModule: ContextModule.popUpModal,
             copy: `Sign up to discover new works by ${artist.name} and more artists you love`,
-            destination: location.href,
             // TODO: Onboarding is triggered based on contents of redirectTo
             // prop. Move this to `afterSignupAction` prop
             redirectTo: location.href,


### PR DESCRIPTION
I guess at some point this must have done something, but no longer. Previously whatever was passed as `destination` was set as a cookie named `"destination"`. This cookie is never actually checked anywhere.
