### PR TITLE
feat(CX-3177): add saved and follows to collector profile

### DIFF
--- a/src/Apps/CollectorProfile/Routes/SavesAndFollows/CollectorProfileSavesAndFollowsRoute.tsx
+++ b/src/Apps/CollectorProfile/Routes/SavesAndFollows/CollectorProfileSavesAndFollowsRoute.tsx
@@ -1,14 +1,40 @@
-import { Text } from "@artsy/palette"
-import { useFeatureFlag } from "System/useFeatureFlag"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { Join, Separator } from "@artsy/palette"
+import { CollectorProfileSavesAndFollowsRoute_me$data } from "__generated__/CollectorProfileSavesAndFollowsRoute_me.graphql"
 
-const CollectorProfileSavesAndFollowsRoute: React.FC = () => {
-  const isCollectorProfileEnabled = useFeatureFlag("cx-collector-profile")
+import { SettingsSavesArtworksQueryRenderer } from "Apps/Settings/Routes/Saves/Components/SettingsSavesArtworks"
+import { SettingsSavesArtistsQueryRenderer } from "Apps/Settings/Routes/Saves/Components/SettingsSavesArtists"
+import { SettingsSavesCategoriesQueryRenderer } from "Apps/Settings/Routes/Saves/Components/SettingsSavesCategories"
+import { SettingsSavesProfilesQueryRenderer } from "Apps/Settings/Routes/Saves/Components/SettingsSavesProfiles"
 
-  if (!isCollectorProfileEnabled) {
-    return null
-  }
-
-  return <Text>Yo!</Text>
+interface CollectorProfileSavesAndFollowsRouteProps {
+  me: CollectorProfileSavesAndFollowsRoute_me$data
 }
 
-export const CollectorProfileSavesAndFollowsRouteFragmentContainer = CollectorProfileSavesAndFollowsRoute
+const CollectorProfileSavesAndFollowsRoute: React.FC<CollectorProfileSavesAndFollowsRouteProps> = ({
+  me,
+}) => {
+  return (
+    <Join separator={<Separator my={4} />}>
+      <SettingsSavesArtworksQueryRenderer />
+
+      <SettingsSavesArtistsQueryRenderer />
+
+      <SettingsSavesProfilesQueryRenderer />
+
+      <SettingsSavesCategoriesQueryRenderer />
+    </Join>
+  )
+}
+
+export const CollectorProfileSavesAndFollowsRouteFragmentContainer = createFragmentContainer(
+  CollectorProfileSavesAndFollowsRoute,
+  {
+    me: graphql`
+      fragment CollectorProfileSavesAndFollowsRoute_me on Me {
+        name
+      }
+    `,
+  }
+)

--- a/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
+++ b/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
@@ -46,6 +46,11 @@ const SavesAndFollowsRoute = loadable(
   }
 )
 
+// Redirect home if the user is not logged in
+const handleServerSideRender = () => {
+  // TODO: Redirect to the logged out experience once released
+}
+
 export const collectorProfileRoutes: AppRouteConfig[] = [
   {
     path: "/collector-profile",
@@ -81,6 +86,14 @@ export const collectorProfileRoutes: AppRouteConfig[] = [
         onClientSideRender: () => {
           SavesAndFollowsRoute.preload()
         },
+        onServerSideRender: handleServerSideRender,
+        query: graphql`
+          query collectorProfileRoutes_SavesAndFollowsRouteQuery {
+            me {
+              ...CollectorProfileSavesAndFollowsRoute_me
+            }
+          }
+        `,
       },
     ],
   },

--- a/src/__generated__/CollectorProfileSavesAndFollowsRoute_me.graphql.ts
+++ b/src/__generated__/CollectorProfileSavesAndFollowsRoute_me.graphql.ts
@@ -1,0 +1,42 @@
+/**
+ * @generated SignedSource<<5fdf99768b4a67e915b91e4610b3382e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type CollectorProfileSavesAndFollowsRoute_me$data = {
+  readonly name: string | null;
+  readonly " $fragmentType": "CollectorProfileSavesAndFollowsRoute_me";
+};
+export type CollectorProfileSavesAndFollowsRoute_me$key = {
+  readonly " $data"?: CollectorProfileSavesAndFollowsRoute_me$data;
+  readonly " $fragmentSpreads": FragmentRefs<"CollectorProfileSavesAndFollowsRoute_me">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "CollectorProfileSavesAndFollowsRoute_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+
+(node as any).hash = "97c8a50cf95502644e4213758343c691";
+
+export default node;

--- a/src/__generated__/collectorProfileRoutes_SavesAndFollowsRouteQuery.graphql.ts
+++ b/src/__generated__/collectorProfileRoutes_SavesAndFollowsRouteQuery.graphql.ts
@@ -1,0 +1,96 @@
+/**
+ * @generated SignedSource<<4a77cdea89ca6539ed2a9579895764e1>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type collectorProfileRoutes_SavesAndFollowsRouteQuery$variables = {};
+export type collectorProfileRoutes_SavesAndFollowsRouteQuery$data = {
+  readonly me: {
+    readonly " $fragmentSpreads": FragmentRefs<"CollectorProfileSavesAndFollowsRoute_me">;
+  } | null;
+};
+export type collectorProfileRoutes_SavesAndFollowsRouteQuery = {
+  response: collectorProfileRoutes_SavesAndFollowsRouteQuery$data;
+  variables: collectorProfileRoutes_SavesAndFollowsRouteQuery$variables;
+};
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "collectorProfileRoutes_SavesAndFollowsRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "CollectorProfileSavesAndFollowsRoute_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "collectorProfileRoutes_SavesAndFollowsRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "bba9de1ea104af9c9384e5ccf4abe793",
+    "id": null,
+    "metadata": {},
+    "name": "collectorProfileRoutes_SavesAndFollowsRouteQuery",
+    "operationKind": "query",
+    "text": "query collectorProfileRoutes_SavesAndFollowsRouteQuery {\n  me {\n    ...CollectorProfileSavesAndFollowsRoute_me\n    id\n  }\n}\n\nfragment CollectorProfileSavesAndFollowsRoute_me on Me {\n  name\n}\n"
+  }
+};
+
+(node as any).hash = "f0e0b1013ccf061a1e794c0e3952d8e7";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3177]

### Description

- Add saved and follows to the collector profile

**Note:**

Follow up work once this is released
- [ ] Move the components to saves and follows route
- [ ] Redirect users from the old route to the new one


<img width="1918" alt="Screenshot 2022-11-30 at 18 05 57" src="https://user-images.githubusercontent.com/11945712/204862227-7a2d0499-ba39-428e-94db-f210e0f5404b.png">

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3177]: https://artsyproduct.atlassian.net/browse/CX-3177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ