### PR TITLE
[GRO-1457](art-quiz) add dislike mutation to frontend

### DIFF
--- a/src/Apps/ArtQuiz/ArtQuizMain.tsx
+++ b/src/Apps/ArtQuiz/ArtQuizMain.tsx
@@ -11,10 +11,8 @@ import {
   Text,
 } from "@artsy/palette"
 import { useArtQuizContext } from "Apps/ArtQuiz/ArtQuizContext"
-import {
-  ArtQuizDislikeButton,
-  ArtQuizSaveButton,
-} from "Apps/ArtQuiz/Components/ArtQuizButtons"
+import { ArtQuizSaveButton } from "Apps/ArtQuiz/Components/ArtQuizSaveButton"
+import { ArtQuizDislikeButton } from "Apps/ArtQuiz/Components/ArtQuizDislikeButton"
 import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
 import { FC, useEffect, useState } from "react"
 import { useWindowSize } from "Utils/Hooks/useWindowSize"
@@ -134,7 +132,7 @@ export const ArtQuizMain: FC = () => {
           alignItems="center"
           justifyContent="center"
         >
-          <ArtQuizDislikeButton px={6} />
+          <ArtQuizDislikeButton slug={currentArtwork.slug} px={6} />
           <ArtQuizSaveButton slug={currentArtwork.slug} px={6} />
         </Flex>
       </CSSGrid>

--- a/src/Apps/ArtQuiz/Components/ArtQuizButtons.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizButtons.tsx
@@ -7,7 +7,9 @@ import {
 } from "@artsy/palette"
 import { useArtQuizContext } from "Apps/ArtQuiz/ArtQuizContext"
 import { useSaveArtwork } from "Components/Artwork/SaveButton/useSaveArtwork"
+
 import { FC, MouseEvent, useState } from "react"
+import { graphql } from "react-relay"
 
 const BTN_WIDTH = 40
 const BTN_HEIGHT = 40
@@ -69,6 +71,21 @@ export const ArtQuizDislikeButton: FC<ClickableProps> = ({ ...rest }) => {
   const handleClick = () => {
     stepBackward()
   }
+
+  const { submitMutation } = useMutation<ArtQuizDislikeButtonMutation>({
+    mutation: graphql`
+      mutation ArtQuizDislikeButtonMutation($artworkID: String!) {
+        dislikeArtwork(input: { artworkID: $artworkID, remove: false }) {
+          artwork {
+            isDisliked
+            id
+          }
+        }
+      }
+    `,
+  })
+
+  // submit mutation on click w/ a try catch for error handling
 
   return (
     <Clickable

--- a/src/Apps/ArtQuiz/Components/ArtQuizDislikeButton.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizDislikeButton.tsx
@@ -1,0 +1,53 @@
+import { Clickable, ClickableProps, CloseIcon } from "@artsy/palette"
+import { FC } from "react"
+import { useMutation } from "Utils/Hooks/useMutation"
+import { graphql } from "react-relay"
+import { ArtQuizDislikeButtonMutation } from "Apps/ArtQuiz/__generated__/ArtQuizDislikeButtonMutation.graphql"
+
+interface ArtQuizDislikeButtonProps extends ClickableProps {
+  slug: string
+}
+// TODO: Add animation
+export const ArtQuizDislikeButton: FC<ArtQuizDislikeButtonProps> = ({
+  slug,
+  ...rest
+}) => {
+  const { submitMutation } = useMutation<ArtQuizDislikeButtonMutation>({
+    mutation: graphql`
+      mutation ArtQuizDislikeButtonMutation($artworkID: String!) {
+        dislikeArtwork(input: { artworkID: $artworkID, remove: false }) {
+          artwork {
+            isDisliked
+            id
+          }
+        }
+      }
+    `,
+  })
+
+  const handleClick = slug => {
+    try {
+      submitMutation({
+        variables: {
+          artworkID: slug,
+        },
+      })
+    } catch (err) {
+      // what kind of error handling to do here?
+    }
+  }
+
+  return (
+    <Clickable
+      display="flex"
+      p={0.5}
+      onClick={() => {
+        handleClick(slug)
+      }}
+      alignItems="center"
+      {...rest}
+    >
+      <CloseIcon height={40} width={40} />
+    </Clickable>
+  )
+}

--- a/src/Apps/ArtQuiz/Components/ArtQuizSaveButton.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizSaveButton.tsx
@@ -1,18 +1,12 @@
 import {
   Clickable,
   ClickableProps,
-  CloseIcon,
   HeartFillIcon,
   HeartIcon,
 } from "@artsy/palette"
 import { useArtQuizContext } from "Apps/ArtQuiz/ArtQuizContext"
 import { useSaveArtwork } from "Components/Artwork/SaveButton/useSaveArtwork"
-
 import { FC, MouseEvent, useState } from "react"
-import { graphql } from "react-relay"
-
-const BTN_WIDTH = 40
-const BTN_HEIGHT = 40
 
 // TODO: Re-evaluate necessity of this component
 // Maybe just add a size prop to existing button
@@ -21,6 +15,8 @@ export const ArtQuizSaveButton: FC<{ slug: string } & ClickableProps> = ({
   slug,
   ...rest
 }) => {
+  const BTN_WIDTH = 40
+  const BTN_HEIGHT = 40
   const [isHovered, setIsHovered] = useState(false)
   const { currentArtwork, stepForward } = useArtQuizContext()
 
@@ -60,42 +56,6 @@ export const ArtQuizSaveButton: FC<{ slug: string } & ClickableProps> = ({
       ) : (
         <HeartIcon height={BTN_HEIGHT} width={BTN_WIDTH} />
       )}
-    </Clickable>
-  )
-}
-
-// TODO: Add mutation and animation
-// Ask lois about possibility of a bold version of this icon
-export const ArtQuizDislikeButton: FC<ClickableProps> = ({ ...rest }) => {
-  const { stepBackward } = useArtQuizContext()
-  const handleClick = () => {
-    stepBackward()
-  }
-
-  const { submitMutation } = useMutation<ArtQuizDislikeButtonMutation>({
-    mutation: graphql`
-      mutation ArtQuizDislikeButtonMutation($artworkID: String!) {
-        dislikeArtwork(input: { artworkID: $artworkID, remove: false }) {
-          artwork {
-            isDisliked
-            id
-          }
-        }
-      }
-    `,
-  })
-
-  // submit mutation on click w/ a try catch for error handling
-
-  return (
-    <Clickable
-      display="flex"
-      p={0.5}
-      onClick={handleClick}
-      alignItems="center"
-      {...rest}
-    >
-      <CloseIcon height={BTN_HEIGHT} width={BTN_WIDTH} />
     </Clickable>
   )
 }

--- a/src/__generated__/ArtQuizDislikeButtonMutation.graphql.ts
+++ b/src/__generated__/ArtQuizDislikeButtonMutation.graphql.ts
@@ -1,0 +1,121 @@
+/**
+ * @generated SignedSource<<80627671d42bb4b504782e78aaa2f0a0>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type ArtQuizDislikeButtonMutation$variables = {
+  artworkID: string;
+};
+export type ArtQuizDislikeButtonMutation$data = {
+  readonly dislikeArtwork: {
+    readonly artwork: {
+      readonly id: string;
+      readonly isDisliked: boolean;
+    } | null;
+  } | null;
+};
+export type ArtQuizDislikeButtonMutation = {
+  response: ArtQuizDislikeButtonMutation$data;
+  variables: ArtQuizDislikeButtonMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "artworkID"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "fields": [
+          {
+            "kind": "Variable",
+            "name": "artworkID",
+            "variableName": "artworkID"
+          },
+          {
+            "kind": "Literal",
+            "name": "remove",
+            "value": false
+          }
+        ],
+        "kind": "ObjectValue",
+        "name": "input"
+      }
+    ],
+    "concreteType": "DislikeArtworkPayload",
+    "kind": "LinkedField",
+    "name": "dislikeArtwork",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isDisliked",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtQuizDislikeButtonMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArtQuizDislikeButtonMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "ec3ecdeed439a41ff33aa1c9649e21cb",
+    "id": null,
+    "metadata": {},
+    "name": "ArtQuizDislikeButtonMutation",
+    "operationKind": "mutation",
+    "text": "mutation ArtQuizDislikeButtonMutation(\n  $artworkID: String!\n) {\n  dislikeArtwork(input: {artworkID: $artworkID, remove: false}) {\n    artwork {\n      isDisliked\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3cf92b9175ee263b406a6876f72ef64a";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: feat

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1457]

### Description
The goal of this PR is to add a mutation on the dislike button, to add an artwork to the user's dislikes collection while interacting with the art quiz. Collecting the data is a preliminary first step towards making some use out of gathering negative signals on the user's art taste.

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1457]: https://artsyproduct.atlassian.net/browse/GRO-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ