### PR TITLE
fix:ensure artist carousel image is scoped to partner artist

### DIFF
--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
@@ -6,8 +6,8 @@ import { PartnerArtistsCarouselRendererQuery } from "__generated__/PartnerArtist
 import { PartnerArtistsCarousel_partner$data } from "__generated__/PartnerArtistsCarousel_partner.graphql"
 import { PartnerArtistsCarouselPlaceholder } from "./PartnerArtistsCarouselPlaceholder"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { CellArtistFragmentContainer } from "Components/Cells/CellArtist"
-import { extractNodes } from "Utils/extractNodes"
+import { CellPartnerArtistFragmentContainer } from "Components/Cells/CellPartnerArtist"
+import { compact } from "lodash"
 import { FollowArtistButtonQueryRenderer } from "Components/FollowButton/FollowArtistButton"
 import { ContextModule } from "@artsy/cohesion"
 
@@ -27,25 +27,27 @@ export const PartnerArtistsCarousel: React.FC<PartnerArtistsCarouselProps> = ({
   ) {
     return null
   }
-
-  const artists = extractNodes(partner.artistsConnection)
+  const { slug } = partner
+  const artists = compact(partner.artistsConnection.edges)
 
   return (
     <Shelf alignItems="flex-start">
-      {artists.map(artist => (
-        <CellArtistFragmentContainer
-          key={artist.internalID}
-          artist={artist}
-          to={`/partner/${partner.slug}/artists/${artist.slug}`}
-          FollowButton={
-            <FollowArtistButtonQueryRenderer
-              id={artist.internalID}
-              contextModule={ContextModule.recommendedArtistsRail}
-              size="small"
-            />
-          }
-        />
-      ))}
+      {artists
+        .filter(artist => artist !== null)
+        .map(artist => (
+          <CellPartnerArtistFragmentContainer
+            key={artist.node?.internalID}
+            artistPartnerEdge={artist}
+            to={`/partner/${slug}/artists/${artist.node?.slug}`}
+            FollowButton={
+              <FollowArtistButtonQueryRenderer
+                id={artist.node?.internalID!}
+                contextModule={ContextModule.recommendedArtistsRail}
+                size="small"
+              />
+            }
+          />
+        ))}
     </Shelf>
   )
 }
@@ -63,10 +65,11 @@ export const PartnerArtistsCarouselFragmentContainer = createFragmentContainer(
         ) {
           edges {
             node {
-              ...CellArtist_artist
+              id
               internalID
               slug
             }
+            ...CellPartnerArtist_partnerArtist
           }
         }
       }

--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
@@ -65,7 +65,6 @@ export const PartnerArtistsCarouselFragmentContainer = createFragmentContainer(
         ) {
           edges {
             node {
-              id
               internalID
               slug
             }

--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
@@ -8,8 +8,6 @@ import { PartnerArtistsCarouselPlaceholder } from "./PartnerArtistsCarouselPlace
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { CellPartnerArtistFragmentContainer } from "Components/Cells/CellPartnerArtist"
 import { compact } from "lodash"
-import { FollowArtistButtonQueryRenderer } from "Components/FollowButton/FollowArtistButton"
-import { ContextModule } from "@artsy/cohesion"
 
 const PAGE_SIZE = 20
 
@@ -27,27 +25,16 @@ export const PartnerArtistsCarousel: React.FC<PartnerArtistsCarouselProps> = ({
   ) {
     return null
   }
-  const { slug } = partner
   const artists = compact(partner.artistsConnection.edges)
 
   return (
     <Shelf alignItems="flex-start">
-      {artists
-        .filter(artist => artist !== null)
-        .map(artist => (
-          <CellPartnerArtistFragmentContainer
-            key={artist.node?.internalID}
-            artistPartnerEdge={artist}
-            to={`/partner/${slug}/artists/${artist.node?.slug}`}
-            FollowButton={
-              <FollowArtistButtonQueryRenderer
-                id={artist.node?.internalID!}
-                contextModule={ContextModule.recommendedArtistsRail}
-                size="small"
-              />
-            }
-          />
-        ))}
+      {artists.map(artist => (
+        <CellPartnerArtistFragmentContainer
+          key={artist.node?.internalID}
+          artistPartnerEdge={artist}
+        />
+      ))}
     </Shelf>
   )
 }

--- a/src/Components/Cells/CellPartnerArtist.tsx
+++ b/src/Components/Cells/CellPartnerArtist.tsx
@@ -1,0 +1,140 @@
+import {
+  Box,
+  Image,
+  ResponsiveBox,
+  SkeletonBox,
+  SkeletonText,
+  Text,
+} from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { RouterLink, RouterLinkProps } from "System/Router/RouterLink"
+import { CellPartnerArtist_partnerArtist$data } from "__generated__/CellPartnerArtist_partnerArtist.graphql"
+import { DEFAULT_CELL_WIDTH } from "./constants"
+import { EntityHeaderArtistFragmentContainer } from "Components/EntityHeaders/EntityHeaderArtist"
+import { FC } from "react"
+import { EntityHeaderPlaceholder } from "Components/EntityHeaders/EntityHeaderPlaceholder"
+import { extractNodes } from "Utils/extractNodes"
+
+export interface CellPartnerArtistProps extends Partial<RouterLinkProps> {
+  artistPartnerEdge: CellPartnerArtist_partnerArtist$data
+  /** Defaults to `"RAIL"` */
+  mode?: "GRID" | "RAIL"
+  displayCounts?: boolean
+  FollowButton?: JSX.Element
+}
+
+const CellPartnerArtist: FC<CellPartnerArtistProps> = ({
+  artistPartnerEdge,
+  mode = "RAIL",
+  displayCounts,
+  FollowButton,
+  ...rest
+}) => {
+  const width = mode === "GRID" ? "100%" : DEFAULT_CELL_WIDTH
+  const artwork = extractNodes(artistPartnerEdge.artworksConnection)
+  const image = artwork[0].image?.cropped
+
+  if (!artistPartnerEdge.artist) return null
+
+  return (
+    <RouterLink
+      to={artistPartnerEdge.artist.href!}
+      display="block"
+      textDecoration="none"
+      width={width}
+      {...rest}
+    >
+      <ResponsiveBox aspectWidth={4} aspectHeight={3} maxWidth="100%">
+        {image?.src ? (
+          <Image
+            src={image.src}
+            srcSet={image.srcSet}
+            width="100%"
+            height="100%"
+            alt=""
+            lazyLoad
+            style={{ display: "block" }}
+          />
+        ) : (
+          <Text
+            variant="lg-display"
+            bg="black10"
+            width="100%"
+            height="100%"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+          >
+            {artistPartnerEdge.artist?.initials}
+          </Text>
+        )}
+      </ResponsiveBox>
+
+      <EntityHeaderArtistFragmentContainer
+        artist={artistPartnerEdge.artist}
+        displayAvatar={false}
+        displayLink={false}
+        displayCounts={displayCounts}
+        FollowButton={FollowButton}
+        alignItems="flex-start"
+        mt={1}
+      />
+    </RouterLink>
+  )
+}
+
+type CellPartnerArtistPlaceholderProps = Pick<
+  CellPartnerArtistProps,
+  "mode" | "displayCounts"
+>
+
+export const CellPartnerArtistPlaceholder: FC<CellPartnerArtistPlaceholderProps> = ({
+  mode = "RAIL",
+  displayCounts,
+}) => {
+  const width = mode === "GRID" ? "100%" : DEFAULT_CELL_WIDTH
+
+  return (
+    <Box width={width}>
+      <ResponsiveBox aspectWidth={4} aspectHeight={3} maxWidth="100%">
+        <SkeletonBox width="100%" height="100%" />
+      </ResponsiveBox>
+
+      <EntityHeaderPlaceholder displayAvatar={false} mt={1} />
+
+      {displayCounts && (
+        <SkeletonText variant="xs">00 works, 0 for sale</SkeletonText>
+      )}
+    </Box>
+  )
+}
+
+export const CellPartnerArtistFragmentContainer = createFragmentContainer(
+  CellPartnerArtist,
+  {
+    artistPartnerEdge: graphql`
+      fragment CellPartnerArtist_partnerArtist on ArtistPartnerEdge {
+        artworksConnection(first: 1) {
+          edges {
+            node {
+              image {
+                cropped(width: 445, height: 334, version: ["larger", "large"]) {
+                  src
+                  srcSet
+                }
+              }
+            }
+          }
+        }
+        artist {
+          ...EntityHeaderArtist_artist
+          internalID
+          slug
+          name
+          href
+          initials
+        }
+      }
+    `,
+  }
+)

--- a/src/Components/Cells/CellPartnerArtist.tsx
+++ b/src/Components/Cells/CellPartnerArtist.tsx
@@ -31,14 +31,16 @@ const CellPartnerArtist: FC<CellPartnerArtistProps> = ({
   ...rest
 }) => {
   const width = mode === "GRID" ? "100%" : DEFAULT_CELL_WIDTH
-  const artwork = extractNodes(artistPartnerEdge.artworksConnection)
-  const image = artwork[0].image?.cropped
+  const [artwork] = extractNodes(artistPartnerEdge.artworksConnection)
+  const image = artwork.image?.cropped
+  const partnerSlug = artistPartnerEdge.partner?.slug
+  const artistSlug = artistPartnerEdge.artist?.slug
 
   if (!artistPartnerEdge.artist) return null
 
   return (
     <RouterLink
-      to={artistPartnerEdge.artist.href!}
+      to={`/partner/${partnerSlug}/artists/${artistSlug}`}
       display="block"
       textDecoration="none"
       width={width}
@@ -133,6 +135,9 @@ export const CellPartnerArtistFragmentContainer = createFragmentContainer(
           name
           href
           initials
+        }
+        partner {
+          slug
         }
       }
     `,

--- a/src/Components/Cells/__tests__/CellPartnerArtist.jest.tsx
+++ b/src/Components/Cells/__tests__/CellPartnerArtist.jest.tsx
@@ -1,0 +1,55 @@
+import { graphql } from "react-relay"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { CellPartnerArtistFragmentContainer_Test_Query } from "__generated__/CellPartnerArtistFragmentContainer_Test_Query.graphql"
+import { screen } from "@testing-library/react"
+import { CellPartnerArtistFragmentContainer } from "Components/Cells/CellPartnerArtist"
+
+jest.unmock("react-relay")
+
+const { renderWithRelay } = setupTestWrapperTL<
+  CellPartnerArtistFragmentContainer_Test_Query
+>({
+  Component: props => (
+    <CellPartnerArtistFragmentContainer
+      artistPartnerEdge={props.partner?.artistsConnection?.edges![0]!}
+    />
+  ),
+  query: graphql`
+    query CellPartnerArtistFragmentContainer_Test_Query @relay_test_operation {
+      partner(id: "foo") {
+        artistsConnection {
+          edges {
+            ...CellPartnerArtist_partnerArtist
+          }
+        }
+      }
+    }
+  `,
+})
+
+describe("CellPartnerArtist", () => {
+  it("renders the image from the partner artist level not the artist level", () => {
+    renderWithRelay({
+      Image: () => ({
+        cropped: {
+          src: "https://example.com/right_image.jpg",
+          srcSet: "https://example.com/right_image.jpg 1x",
+        },
+      }),
+      Artist: () => ({
+        name: "Example Artist",
+        image: {
+          cropped: {
+            src: "https://example.com/wrong_image.jpg",
+            srcSet: "https://example.com/wrong_image.jpg 1x",
+          },
+        },
+      }),
+    })
+    const displayedImage = screen.getByRole("img") as HTMLImageElement
+    expect(displayedImage.src).toContain("https://example.com/right_image.jpg")
+    expect(displayedImage.src).not.toContain(
+      "https://example.com/wrong_image.jpg"
+    )
+  })
+})

--- a/src/__generated__/CellPartnerArtistFragmentContainer_Test_Query.graphql.ts
+++ b/src/__generated__/CellPartnerArtistFragmentContainer_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e0fcd774b1ff7dc8ce2be9dd1a6f5dff>>
+ * @generated SignedSource<<d2d8a4687a3c7ce02369ec815a3cdf42>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -57,36 +57,49 @@ v2 = {
   "storageKey": null
 },
 v3 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Image"
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
 },
 v4 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "CroppedImageUrl"
+  "type": "Partner"
 },
 v5 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "String"
+  "type": "Image"
 },
 v6 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "FormattedNumber"
+  "type": "CroppedImageUrl"
 },
 v7 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FormattedNumber"
+},
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v8 = {
+v10 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -273,13 +286,7 @@ return {
                         "name": "href",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -362,6 +369,19 @@ return {
                     ],
                     "storageKey": null
                   },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Partner",
+                    "kind": "LinkedField",
+                    "name": "partner",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
                   (v2/*: any*/)
                 ],
                 "storageKey": null
@@ -376,16 +396,11 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cc574720478b9a4df15c84e57e1ad582",
+    "cacheID": "1b323a8de34df6b8cfcef024ddecfe03",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "partner": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Partner"
-        },
+        "partner": (v4/*: any*/),
         "partner.artistsConnection": {
           "enumValues": null,
           "nullable": true,
@@ -404,25 +419,25 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "partner.artistsConnection.edges.artist.avatar": (v3/*: any*/),
-        "partner.artistsConnection.edges.artist.avatar.cropped": (v4/*: any*/),
-        "partner.artistsConnection.edges.artist.avatar.cropped.src": (v5/*: any*/),
-        "partner.artistsConnection.edges.artist.avatar.cropped.srcSet": (v5/*: any*/),
+        "partner.artistsConnection.edges.artist.avatar": (v5/*: any*/),
+        "partner.artistsConnection.edges.artist.avatar.cropped": (v6/*: any*/),
+        "partner.artistsConnection.edges.artist.avatar.cropped.src": (v7/*: any*/),
+        "partner.artistsConnection.edges.artist.avatar.cropped.srcSet": (v7/*: any*/),
         "partner.artistsConnection.edges.artist.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtistCounts"
         },
-        "partner.artistsConnection.edges.artist.counts.artworks": (v6/*: any*/),
-        "partner.artistsConnection.edges.artist.counts.forSaleArtworks": (v6/*: any*/),
-        "partner.artistsConnection.edges.artist.formattedNationalityAndBirthday": (v7/*: any*/),
-        "partner.artistsConnection.edges.artist.href": (v7/*: any*/),
-        "partner.artistsConnection.edges.artist.id": (v8/*: any*/),
-        "partner.artistsConnection.edges.artist.initials": (v7/*: any*/),
-        "partner.artistsConnection.edges.artist.internalID": (v8/*: any*/),
-        "partner.artistsConnection.edges.artist.name": (v7/*: any*/),
-        "partner.artistsConnection.edges.artist.slug": (v8/*: any*/),
+        "partner.artistsConnection.edges.artist.counts.artworks": (v8/*: any*/),
+        "partner.artistsConnection.edges.artist.counts.forSaleArtworks": (v8/*: any*/),
+        "partner.artistsConnection.edges.artist.formattedNationalityAndBirthday": (v9/*: any*/),
+        "partner.artistsConnection.edges.artist.href": (v9/*: any*/),
+        "partner.artistsConnection.edges.artist.id": (v10/*: any*/),
+        "partner.artistsConnection.edges.artist.initials": (v9/*: any*/),
+        "partner.artistsConnection.edges.artist.internalID": (v10/*: any*/),
+        "partner.artistsConnection.edges.artist.name": (v9/*: any*/),
+        "partner.artistsConnection.edges.artist.slug": (v10/*: any*/),
         "partner.artistsConnection.edges.artworksConnection": {
           "enumValues": null,
           "nullable": true,
@@ -441,18 +456,21 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "partner.artistsConnection.edges.artworksConnection.edges.node.id": (v8/*: any*/),
-        "partner.artistsConnection.edges.artworksConnection.edges.node.image": (v3/*: any*/),
-        "partner.artistsConnection.edges.artworksConnection.edges.node.image.cropped": (v4/*: any*/),
-        "partner.artistsConnection.edges.artworksConnection.edges.node.image.cropped.src": (v5/*: any*/),
-        "partner.artistsConnection.edges.artworksConnection.edges.node.image.cropped.srcSet": (v5/*: any*/),
-        "partner.artistsConnection.edges.id": (v8/*: any*/),
-        "partner.id": (v8/*: any*/)
+        "partner.artistsConnection.edges.artworksConnection.edges.node.id": (v10/*: any*/),
+        "partner.artistsConnection.edges.artworksConnection.edges.node.image": (v5/*: any*/),
+        "partner.artistsConnection.edges.artworksConnection.edges.node.image.cropped": (v6/*: any*/),
+        "partner.artistsConnection.edges.artworksConnection.edges.node.image.cropped.src": (v7/*: any*/),
+        "partner.artistsConnection.edges.artworksConnection.edges.node.image.cropped.srcSet": (v7/*: any*/),
+        "partner.artistsConnection.edges.id": (v10/*: any*/),
+        "partner.artistsConnection.edges.partner": (v4/*: any*/),
+        "partner.artistsConnection.edges.partner.id": (v10/*: any*/),
+        "partner.artistsConnection.edges.partner.slug": (v10/*: any*/),
+        "partner.id": (v10/*: any*/)
       }
     },
     "name": "CellPartnerArtistFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query CellPartnerArtistFragmentContainer_Test_Query {\n  partner(id: \"foo\") {\n    artistsConnection {\n      edges {\n        ...CellPartnerArtist_partnerArtist\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment CellPartnerArtist_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  artist {\n    ...EntityHeaderArtist_artist\n    internalID\n    slug\n    name\n    href\n    initials\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n"
+    "text": "query CellPartnerArtistFragmentContainer_Test_Query {\n  partner(id: \"foo\") {\n    artistsConnection {\n      edges {\n        ...CellPartnerArtist_partnerArtist\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment CellPartnerArtist_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  artist {\n    ...EntityHeaderArtist_artist\n    internalID\n    slug\n    name\n    href\n    initials\n    id\n  }\n  partner {\n    slug\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/CellPartnerArtistFragmentContainer_Test_Query.graphql.ts
+++ b/src/__generated__/CellPartnerArtistFragmentContainer_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0d43a481fb20601facdd09811eace446>>
+ * @generated SignedSource<<e0fcd774b1ff7dc8ce2be9dd1a6f5dff>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,56 +10,30 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type PartnerArtistsCarouselRendererQuery$variables = {
-  partnerId: string;
-};
-export type PartnerArtistsCarouselRendererQuery$data = {
+export type CellPartnerArtistFragmentContainer_Test_Query$variables = {};
+export type CellPartnerArtistFragmentContainer_Test_Query$data = {
   readonly partner: {
-    readonly " $fragmentSpreads": FragmentRefs<"PartnerArtistsCarousel_partner">;
+    readonly artistsConnection: {
+      readonly edges: ReadonlyArray<{
+        readonly " $fragmentSpreads": FragmentRefs<"CellPartnerArtist_partnerArtist">;
+      } | null> | null;
+    } | null;
   } | null;
 };
-export type PartnerArtistsCarouselRendererQuery = {
-  response: PartnerArtistsCarouselRendererQuery$data;
-  variables: PartnerArtistsCarouselRendererQuery$variables;
+export type CellPartnerArtistFragmentContainer_Test_Query = {
+  response: CellPartnerArtistFragmentContainer_Test_Query$data;
+  variables: CellPartnerArtistFragmentContainer_Test_Query$variables;
 };
 
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "partnerId"
+    "kind": "Literal",
+    "name": "id",
+    "value": "foo"
   }
 ],
 v1 = [
-  {
-    "kind": "Variable",
-    "name": "id",
-    "variableName": "partnerId"
-  }
-],
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = [
   {
     "alias": null,
     "args": null,
@@ -74,68 +48,68 @@ v5 = [
     "name": "srcSet",
     "storageKey": null
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Image"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "CroppedImageUrl"
+},
+v5 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v6 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FormattedNumber"
+},
+v7 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+};
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "PartnerArtistsCarouselRendererQuery",
+    "name": "CellPartnerArtistFragmentContainer_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
         "plural": false,
         "selections": [
-          {
-            "args": null,
-            "kind": "FragmentSpread",
-            "name": "PartnerArtistsCarousel_partner"
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "type": "Query",
-    "abstractKey": null
-  },
-  "kind": "Request",
-  "operation": {
-    "argumentDefinitions": (v0/*: any*/),
-    "kind": "Operation",
-    "name": "PartnerArtistsCarouselRendererQuery",
-    "selections": [
-      {
-        "alias": null,
-        "args": (v1/*: any*/),
-        "concreteType": "Partner",
-        "kind": "LinkedField",
-        "name": "partner",
-        "plural": false,
-        "selections": [
-          (v2/*: any*/),
           {
             "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "displayOnPartnerProfile",
-                "value": true
-              },
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 20
-              },
-              {
-                "kind": "Literal",
-                "name": "hasPublishedArtworks",
-                "value": true
-              }
-            ],
+            "args": null,
             "concreteType": "ArtistPartnerConnection",
             "kind": "LinkedField",
             "name": "artistsConnection",
@@ -150,19 +124,53 @@ return {
                 "plural": true,
                 "selections": [
                   {
-                    "alias": null,
                     "args": null,
-                    "concreteType": "Artist",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      (v3/*: any*/),
-                      (v4/*: any*/),
-                      (v2/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
+                    "kind": "FragmentSpread",
+                    "name": "CellPartnerArtist_partnerArtist"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "partner(id:\"foo\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "CellPartnerArtistFragmentContainer_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistPartnerConnection",
+            "kind": "LinkedField",
+            "name": "artistsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtistPartnerEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
                   {
                     "alias": null,
                     "args": [
@@ -227,13 +235,13 @@ return {
                                     "kind": "LinkedField",
                                     "name": "cropped",
                                     "plural": false,
-                                    "selections": (v5/*: any*/),
+                                    "selections": (v1/*: any*/),
                                     "storageKey": "cropped(height:334,version:[\"larger\",\"large\"],width:445)"
                                   }
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v2/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -251,7 +259,13 @@ return {
                     "name": "artist",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -259,7 +273,13 @@ return {
                         "name": "href",
                         "storageKey": null
                       },
-                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -332,40 +352,111 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v5/*: any*/),
+                            "selections": (v1/*: any*/),
                             "storageKey": "cropped(height:45,width:45)"
                           }
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/)
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v3/*: any*/)
+                  (v2/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
-            "storageKey": "artistsConnection(displayOnPartnerProfile:true,first:20,hasPublishedArtworks:true)"
+            "storageKey": null
           },
-          (v3/*: any*/)
+          (v2/*: any*/)
         ],
-        "storageKey": null
+        "storageKey": "partner(id:\"foo\")"
       }
     ]
   },
   "params": {
-    "cacheID": "a8ee1695898bf7e65cd792861505aa6c",
+    "cacheID": "cc574720478b9a4df15c84e57e1ad582",
     "id": null,
-    "metadata": {},
-    "name": "PartnerArtistsCarouselRendererQuery",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "partner.artistsConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtistPartnerConnection"
+        },
+        "partner.artistsConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArtistPartnerEdge"
+        },
+        "partner.artistsConnection.edges.artist": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artist"
+        },
+        "partner.artistsConnection.edges.artist.avatar": (v3/*: any*/),
+        "partner.artistsConnection.edges.artist.avatar.cropped": (v4/*: any*/),
+        "partner.artistsConnection.edges.artist.avatar.cropped.src": (v5/*: any*/),
+        "partner.artistsConnection.edges.artist.avatar.cropped.srcSet": (v5/*: any*/),
+        "partner.artistsConnection.edges.artist.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtistCounts"
+        },
+        "partner.artistsConnection.edges.artist.counts.artworks": (v6/*: any*/),
+        "partner.artistsConnection.edges.artist.counts.forSaleArtworks": (v6/*: any*/),
+        "partner.artistsConnection.edges.artist.formattedNationalityAndBirthday": (v7/*: any*/),
+        "partner.artistsConnection.edges.artist.href": (v7/*: any*/),
+        "partner.artistsConnection.edges.artist.id": (v8/*: any*/),
+        "partner.artistsConnection.edges.artist.initials": (v7/*: any*/),
+        "partner.artistsConnection.edges.artist.internalID": (v8/*: any*/),
+        "partner.artistsConnection.edges.artist.name": (v7/*: any*/),
+        "partner.artistsConnection.edges.artist.slug": (v8/*: any*/),
+        "partner.artistsConnection.edges.artworksConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkConnection"
+        },
+        "partner.artistsConnection.edges.artworksConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArtworkEdge"
+        },
+        "partner.artistsConnection.edges.artworksConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "partner.artistsConnection.edges.artworksConnection.edges.node.id": (v8/*: any*/),
+        "partner.artistsConnection.edges.artworksConnection.edges.node.image": (v3/*: any*/),
+        "partner.artistsConnection.edges.artworksConnection.edges.node.image.cropped": (v4/*: any*/),
+        "partner.artistsConnection.edges.artworksConnection.edges.node.image.cropped.src": (v5/*: any*/),
+        "partner.artistsConnection.edges.artworksConnection.edges.node.image.cropped.srcSet": (v5/*: any*/),
+        "partner.artistsConnection.edges.id": (v8/*: any*/),
+        "partner.id": (v8/*: any*/)
+      }
+    },
+    "name": "CellPartnerArtistFragmentContainer_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerArtistsCarouselRendererQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistsCarousel_partner\n    id\n  }\n}\n\nfragment CellPartnerArtist_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  artist {\n    ...EntityHeaderArtist_artist\n    internalID\n    slug\n    name\n    href\n    initials\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment PartnerArtistsCarousel_partner on Partner {\n  slug\n  artistsConnection(first: 20, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      node {\n        id\n        internalID\n        slug\n      }\n      ...CellPartnerArtist_partnerArtist\n      id\n    }\n  }\n}\n"
+    "text": "query CellPartnerArtistFragmentContainer_Test_Query {\n  partner(id: \"foo\") {\n    artistsConnection {\n      edges {\n        ...CellPartnerArtist_partnerArtist\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment CellPartnerArtist_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  artist {\n    ...EntityHeaderArtist_artist\n    internalID\n    slug\n    name\n    href\n    initials\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4ea1c14baceebd785a7395bfe99f186d";
+(node as any).hash = "9adc8330829375454583382fb8004261";
 
 export default node;

--- a/src/__generated__/CellPartnerArtist_partnerArtist.graphql.ts
+++ b/src/__generated__/CellPartnerArtist_partnerArtist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<195aa26c82736caf967c4f01c9e8af1c>>
+ * @generated SignedSource<<c80255c07a02b22eaae35d53b515e815>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,9 @@ export type CellPartnerArtist_partnerArtist$data = {
       } | null;
     } | null> | null;
   } | null;
+  readonly partner: {
+    readonly slug: string;
+  } | null;
   readonly " $fragmentType": "CellPartnerArtist_partnerArtist";
 };
 export type CellPartnerArtist_partnerArtist$key = {
@@ -38,7 +41,15 @@ export type CellPartnerArtist_partnerArtist$key = {
   readonly " $fragmentSpreads": FragmentRefs<"CellPartnerArtist_partnerArtist">;
 };
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+};
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -158,13 +169,7 @@ const node: ReaderFragment = {
           "name": "internalID",
           "storageKey": null
         },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "slug",
-          "storageKey": null
-        },
+        (v0/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -188,12 +193,25 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Partner",
+      "kind": "LinkedField",
+      "name": "partner",
+      "plural": false,
+      "selections": [
+        (v0/*: any*/)
+      ],
+      "storageKey": null
     }
   ],
   "type": "ArtistPartnerEdge",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "7a4f059eb9251c901b915ff7cd6cfb0c";
+(node as any).hash = "9b89afc9b05920bb74367262ff9f6fc3";
 
 export default node;

--- a/src/__generated__/CellPartnerArtist_partnerArtist.graphql.ts
+++ b/src/__generated__/CellPartnerArtist_partnerArtist.graphql.ts
@@ -1,0 +1,199 @@
+/**
+ * @generated SignedSource<<195aa26c82736caf967c4f01c9e8af1c>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type CellPartnerArtist_partnerArtist$data = {
+  readonly artist: {
+    readonly href: string | null;
+    readonly initials: string | null;
+    readonly internalID: string;
+    readonly name: string | null;
+    readonly slug: string;
+    readonly " $fragmentSpreads": FragmentRefs<"EntityHeaderArtist_artist">;
+  } | null;
+  readonly artworksConnection: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly image: {
+          readonly cropped: {
+            readonly src: string;
+            readonly srcSet: string;
+          } | null;
+        } | null;
+      } | null;
+    } | null> | null;
+  } | null;
+  readonly " $fragmentType": "CellPartnerArtist_partnerArtist";
+};
+export type CellPartnerArtist_partnerArtist$key = {
+  readonly " $data"?: CellPartnerArtist_partnerArtist$data;
+  readonly " $fragmentSpreads": FragmentRefs<"CellPartnerArtist_partnerArtist">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "CellPartnerArtist_partnerArtist",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "kind": "LinkedField",
+      "name": "artworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworkEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Image",
+                  "kind": "LinkedField",
+                  "name": "image",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": [
+                        {
+                          "kind": "Literal",
+                          "name": "height",
+                          "value": 334
+                        },
+                        {
+                          "kind": "Literal",
+                          "name": "version",
+                          "value": [
+                            "larger",
+                            "large"
+                          ]
+                        },
+                        {
+                          "kind": "Literal",
+                          "name": "width",
+                          "value": 445
+                        }
+                      ],
+                      "concreteType": "CroppedImageUrl",
+                      "kind": "LinkedField",
+                      "name": "cropped",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "src",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "srcSet",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": "cropped(height:334,version:[\"larger\",\"large\"],width:445)"
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artworksConnection(first:1)"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Artist",
+      "kind": "LinkedField",
+      "name": "artist",
+      "plural": false,
+      "selections": [
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "EntityHeaderArtist_artist"
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "internalID",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "slug",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "href",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "initials",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "ArtistPartnerEdge",
+  "abstractKey": null
+};
+
+(node as any).hash = "7a4f059eb9251c901b915ff7cd6cfb0c";
+
+export default node;

--- a/src/__generated__/PartnerArtistsCarouselRendererQuery.graphql.ts
+++ b/src/__generated__/PartnerArtistsCarouselRendererQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0d43a481fb20601facdd09811eace446>>
+ * @generated SignedSource<<9b5bb7f0e197a7009d138ae611f2532c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -49,14 +49,14 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "internalID",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "id",
   "storageKey": null
 },
 v5 = [
@@ -158,8 +158,8 @@ return {
                     "plural": false,
                     "selections": [
                       (v3/*: any*/),
-                      (v4/*: any*/),
-                      (v2/*: any*/)
+                      (v2/*: any*/),
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -233,7 +233,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v4/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -251,7 +251,7 @@ return {
                     "name": "artist",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -338,30 +338,30 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/)
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v3/*: any*/)
+                  (v4/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,first:20,hasPublishedArtworks:true)"
           },
-          (v3/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "a8ee1695898bf7e65cd792861505aa6c",
+    "cacheID": "cd1117bbc36041bbdc09ea38202b67cb",
     "id": null,
     "metadata": {},
     "name": "PartnerArtistsCarouselRendererQuery",
     "operationKind": "query",
-    "text": "query PartnerArtistsCarouselRendererQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistsCarousel_partner\n    id\n  }\n}\n\nfragment CellPartnerArtist_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  artist {\n    ...EntityHeaderArtist_artist\n    internalID\n    slug\n    name\n    href\n    initials\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment PartnerArtistsCarousel_partner on Partner {\n  slug\n  artistsConnection(first: 20, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      node {\n        id\n        internalID\n        slug\n      }\n      ...CellPartnerArtist_partnerArtist\n      id\n    }\n  }\n}\n"
+    "text": "query PartnerArtistsCarouselRendererQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistsCarousel_partner\n    id\n  }\n}\n\nfragment CellPartnerArtist_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  artist {\n    ...EntityHeaderArtist_artist\n    internalID\n    slug\n    name\n    href\n    initials\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment PartnerArtistsCarousel_partner on Partner {\n  slug\n  artistsConnection(first: 20, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      node {\n        internalID\n        slug\n        id\n      }\n      ...CellPartnerArtist_partnerArtist\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerArtistsCarouselRendererQuery.graphql.ts
+++ b/src/__generated__/PartnerArtistsCarouselRendererQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9b5bb7f0e197a7009d138ae611f2532c>>
+ * @generated SignedSource<<36494bcf7e7cc99f5608a91b066fc17e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -342,6 +342,19 @@ return {
                     ],
                     "storageKey": null
                   },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Partner",
+                    "kind": "LinkedField",
+                    "name": "partner",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
                   (v4/*: any*/)
                 ],
                 "storageKey": null
@@ -356,12 +369,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cd1117bbc36041bbdc09ea38202b67cb",
+    "cacheID": "f2d900078a6a20d1ae0d289d4190a385",
     "id": null,
     "metadata": {},
     "name": "PartnerArtistsCarouselRendererQuery",
     "operationKind": "query",
-    "text": "query PartnerArtistsCarouselRendererQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistsCarousel_partner\n    id\n  }\n}\n\nfragment CellPartnerArtist_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  artist {\n    ...EntityHeaderArtist_artist\n    internalID\n    slug\n    name\n    href\n    initials\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment PartnerArtistsCarousel_partner on Partner {\n  slug\n  artistsConnection(first: 20, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      node {\n        internalID\n        slug\n        id\n      }\n      ...CellPartnerArtist_partnerArtist\n      id\n    }\n  }\n}\n"
+    "text": "query PartnerArtistsCarouselRendererQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistsCarousel_partner\n    id\n  }\n}\n\nfragment CellPartnerArtist_partnerArtist on ArtistPartnerEdge {\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  artist {\n    ...EntityHeaderArtist_artist\n    internalID\n    slug\n    name\n    href\n    initials\n    id\n  }\n  partner {\n    slug\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment PartnerArtistsCarousel_partner on Partner {\n  slug\n  artistsConnection(first: 20, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      node {\n        internalID\n        slug\n        id\n      }\n      ...CellPartnerArtist_partnerArtist\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerArtistsCarousel_partner.graphql.ts
+++ b/src/__generated__/PartnerArtistsCarousel_partner.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f5927a23c8c757080e40c12a0b4a7626>>
+ * @generated SignedSource<<f7c646b8571c7b83b5c3b077dd6005d7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,6 @@ export type PartnerArtistsCarousel_partner$data = {
   readonly artistsConnection: {
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly id: string;
         readonly internalID: string;
         readonly slug: string;
       } | null;
@@ -88,13 +87,6 @@ return {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "id",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
                   "name": "internalID",
                   "storageKey": null
                 },
@@ -119,6 +111,6 @@ return {
 };
 })();
 
-(node as any).hash = "bf6706f7c3451b1c2bd2d7347757ccd1";
+(node as any).hash = "5a2a04dc5419e09f9180b7b52bae6077";
 
 export default node;

--- a/src/__generated__/PartnerArtistsCarousel_partner.graphql.ts
+++ b/src/__generated__/PartnerArtistsCarousel_partner.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<736e947799c840b8ef0d535bd4854ba2>>
+ * @generated SignedSource<<f5927a23c8c757080e40c12a0b4a7626>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,10 +14,11 @@ export type PartnerArtistsCarousel_partner$data = {
   readonly artistsConnection: {
     readonly edges: ReadonlyArray<{
       readonly node: {
+        readonly id: string;
         readonly internalID: string;
         readonly slug: string;
-        readonly " $fragmentSpreads": FragmentRefs<"CellArtist_artist">;
       } | null;
+      readonly " $fragmentSpreads": FragmentRefs<"CellPartnerArtist_partnerArtist">;
     } | null> | null;
   } | null;
   readonly slug: string;
@@ -84,9 +85,11 @@ return {
               "plural": false,
               "selections": [
                 {
+                  "alias": null,
                   "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "CellArtist_artist"
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
                 },
                 {
                   "alias": null,
@@ -98,6 +101,11 @@ return {
                 (v0/*: any*/)
               ],
               "storageKey": null
+            },
+            {
+              "args": null,
+              "kind": "FragmentSpread",
+              "name": "CellPartnerArtist_partnerArtist"
             }
           ],
           "storageKey": null
@@ -111,6 +119,6 @@ return {
 };
 })();
 
-(node as any).hash = "29d1837af9e22e88c9fd85a64a7317f2";
+(node as any).hash = "bf6706f7c3451b1c2bd2d7347757ccd1";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: Fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PX-5309]
### Description

This PR addresses an issue where the artwork image on an artist rail is associated with an Artsy wide Artist instead of the PartnerArtist as it should be. 

Current incorrect image: 
![image](https://user-images.githubusercontent.com/8671643/204919684-7cf8119f-188c-4590-8c2b-d18269e514df.png)

![image](https://user-images.githubusercontent.com/8671643/204919841-45770780-f4ea-4810-badf-82c9df62285b.png)


After update Correct Image:
![image](https://user-images.githubusercontent.com/8671643/204919581-e532c855-021c-4287-8d7c-e84b0ed7d4b9.png)



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PX-5309]: https://artsyproduct.atlassian.net/browse/PX-5309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ