### PR TITLE
feat: Launch Braze Content Cards GRO-1324

### DIFF
--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -1,9 +1,8 @@
 import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
 
 describe("Home", () => {
-  // add this back in once we revert the suppression
   it("/", () => {
     visitWithStatusRetries("/")
-    cy.get("h1").should("contain", "Collect art by the world’s leading artists")
+    cy.get("h1").should("contain", "Post-War and Contemporary")
   })
 })

--- a/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
@@ -29,17 +29,28 @@ export const HomeContentCards: React.FC = () => {
   const cardsLengthRef = useRef(cards.length)
 
   useEffect(() => {
-    window.analytics?.ready(() => {
+    if (appboy) return
+
+    if (window.appboy) {
       setAppboy(window.appboy)
-    })
-  })
+    } else if (window.analytics) {
+      window.analytics.ready(() => {
+        setAppboy(window.appboy)
+      })
+    } else {
+      setExceededTimeout(true)
+    }
+  }, [appboy])
 
   useEffect(() => {
     if (!appboy) return
 
     const subscriptionId = appboy.subscribeToContentCardsUpdates(() => {
+      if (cardsLengthRef.current > 0) return
+
       const response = appboy.getCachedContentCards()
       const sortedCards = response.cards.sort(sortCards)
+      cardsLengthRef.current = sortedCards.length
       setCards(sortedCards as Braze.CaptionedImage[])
     })
 
@@ -57,10 +68,6 @@ export const HomeContentCards: React.FC = () => {
       clearTimeout(timeout)
     }
   }, [appboy, timeoutAmount])
-
-  useEffect(() => {
-    cardsLengthRef.current = cards.length
-  }, [cards])
 
   const hasBrazeCards = appboy && cardsLengthRef.current > 0
 

--- a/src/Apps/Home/Components/HomeContentCards/PlaceholderCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/PlaceholderCards.tsx
@@ -10,65 +10,107 @@ import {
 import { Media } from "Utils/Responsive"
 import { HeroCarousel } from "Components/HeroCarousel/HeroCarousel"
 
-const PlaceholderCard = () => {
-  return (
-    <GridColumns bg="black5" width="100%">
-      <Column span={6} bg="black30">
-        <>
-          <Media at="xs">
-            <ResponsiveBox aspectWidth={3} aspectHeight={2} maxWidth="100%" />
-          </Media>
-          <Media greaterThan="xs">
-            <Box height={[300, 400, 500]} />
-          </Media>
-        </>
-      </Column>
-      <Column span={6}>
-        <GridColumns height="100%">
-          <Column
-            start={[2, 3]}
-            span={[10, 8]}
-            display="flex"
-            justifyContent="center"
-            flexDirection="column"
-            py={4}
-          >
-            <Media greaterThan="xs">
-              <SkeletonText variant="xs">Artsy Auction</SkeletonText>
-              <Spacer mt={2} />
-            </Media>
-            <SkeletonText variant={["lg-display", "xl", "xl"]}>
-              Post-War and Contemporary
-            </SkeletonText>
-            <Spacer mt={[1, 2]} />
-            <SkeletonText variant={["xs", "sm-display", "lg-display"]}>
-              Bid on works by Alice Neel, Ugo Rondinone, Robert Nava, and
-              more—and benefit the Immediate Abortion Access Fund to support
-              reproductive justice for all.
-            </SkeletonText>
-            <Media greaterThan="xs">
-              <Spacer
-                // Unconventional value here to keep visual rhythm
-                mt="30px"
-              />
-              <SkeletonBox mt={2} width={200} height={50} />
-            </Media>
-            <Media at="xs">
-              <Spacer mt={1} />
-              <SkeletonBox mt={2} width={200} height={50} />
-            </Media>
-          </Column>
-        </GridColumns>
-      </Column>
-    </GridColumns>
-  )
-}
-
 export const PlaceholderCards = () => {
   return (
     <HeroCarousel>
-      <PlaceholderCard />
-      <PlaceholderCard />
+      <GridColumns bg="black5" width="100%">
+        <Column span={6} bg="black30">
+          <>
+            <Media at="xs">
+              <ResponsiveBox aspectWidth={3} aspectHeight={2} maxWidth="100%" />
+            </Media>
+            <Media greaterThan="xs">
+              <Box height={[300, 400, 500]} />
+            </Media>
+          </>
+        </Column>
+        <Column span={6}>
+          <GridColumns height="100%">
+            <Column
+              start={[2, 3]}
+              span={[10, 8]}
+              display="flex"
+              justifyContent="center"
+              flexDirection="column"
+              py={4}
+            >
+              <Media greaterThan="xs">
+                <SkeletonText variant="xs">Artsy Auction</SkeletonText>
+                <Spacer mt={2} />
+              </Media>
+              <SkeletonText variant={["lg-display", "xl", "xl"]}>
+                <h1>Post-War and Contemporary</h1>
+              </SkeletonText>
+              <Spacer mt={[1, 2]} />
+              <SkeletonText variant={["xs", "sm-display", "lg-display"]}>
+                Bid on works by Alice Neel, Ugo Rondinone, Robert Nava, and
+                more—and benefit the Immediate Abortion Access Fund to support
+                reproductive justice for all.
+              </SkeletonText>
+              <Media greaterThan="xs">
+                <Spacer
+                  // Unconventional value here to keep visual rhythm
+                  mt="30px"
+                />
+                <SkeletonBox mt={2} width={200} height={50} />
+              </Media>
+              <Media at="xs">
+                <Spacer mt={1} />
+                <SkeletonBox mt={2} width={200} height={50} />
+              </Media>
+            </Column>
+          </GridColumns>
+        </Column>
+      </GridColumns>
+      <GridColumns bg="black5" width="100%">
+        <Column span={6} bg="black30">
+          <>
+            <Media at="xs">
+              <ResponsiveBox aspectWidth={3} aspectHeight={2} maxWidth="100%" />
+            </Media>
+            <Media greaterThan="xs">
+              <Box height={[300, 400, 500]} />
+            </Media>
+          </>
+        </Column>
+        <Column span={6}>
+          <GridColumns height="100%">
+            <Column
+              start={[2, 3]}
+              span={[10, 8]}
+              display="flex"
+              justifyContent="center"
+              flexDirection="column"
+              py={4}
+            >
+              <Media greaterThan="xs">
+                <SkeletonText variant="xs">Artsy Auction</SkeletonText>
+                <Spacer mt={2} />
+              </Media>
+              <SkeletonText variant={["lg-display", "xl", "xl"]}>
+                Post-War and Contemporary
+              </SkeletonText>
+              <Spacer mt={[1, 2]} />
+              <SkeletonText variant={["xs", "sm-display", "lg-display"]}>
+                Bid on works by Alice Neel, Ugo Rondinone, Robert Nava, and
+                more—and benefit the Immediate Abortion Access Fund to support
+                reproductive justice for all.
+              </SkeletonText>
+              <Media greaterThan="xs">
+                <Spacer
+                  // Unconventional value here to keep visual rhythm
+                  mt="30px"
+                />
+                <SkeletonBox mt={2} width={200} height={50} />
+              </Media>
+              <Media at="xs">
+                <Spacer mt={1} />
+                <SkeletonBox mt={2} width={200} height={50} />
+              </Media>
+            </Column>
+          </GridColumns>
+        </Column>
+      </GridColumns>
     </HeroCarousel>
   )
 }

--- a/src/Apps/Home/Components/HomeContentCards/__tests__/HomeContentCards.jest.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/__tests__/HomeContentCards.jest.tsx
@@ -41,7 +41,7 @@ describe("HomeContentCards", () => {
     expect(screen.getByText("FallbackCards")).toBeInTheDocument()
   })
 
-  it.skip("renders braze cards when they are returned", () => {
+  it("renders braze cards when they are returned", () => {
     const mockUpdater = callback => callback()
     window.appboy.subscribeToContentCardsUpdates = mockUpdater
     window.appboy.getCachedContentCards = () => ({ cards: [{}] } as any)

--- a/src/Apps/Home/HomeApp.tsx
+++ b/src/Apps/Home/HomeApp.tsx
@@ -3,7 +3,6 @@ import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { HomeApp_homePage$data } from "__generated__/HomeApp_homePage.graphql"
 import { HomeApp_featuredEventsOrderedSet$data } from "__generated__/HomeApp_featuredEventsOrderedSet.graphql"
-import { HomeHeroUnitsFragmentContainer } from "./Components/HomeHeroUnits/HomeHeroUnits"
 import { HomeFeaturedMarketNewsQueryRenderer } from "./Components/HomeFeaturedMarketNews"
 import { HomeFeaturedEventsRailFragmentContainer } from "./Components/HomeFeaturedEventsRail"
 import { HomeMeta } from "./Components/HomeMeta"
@@ -16,8 +15,6 @@ import { HomeAuctionLotsRailQueryRenderer } from "./Components/HomeAuctionLotsRa
 import { HomeWorksForYouTabBar } from "./Components/HomeWorksForYouTabBar"
 import { MyBidsQueryRenderer } from "Apps/Auctions/Components/MyBids/MyBids"
 import { HomeTroveArtworksRailQueryRenderer } from "./Components/HomeTroveArtworksRail"
-import { useRouter } from "System/Router/useRouter"
-import { paramsToCamelCase } from "Components/ArtworkFilter/Utils/urlBuilder"
 import { HomeContentCards } from "./Components/HomeContentCards"
 
 interface HomeAppProps {
@@ -29,13 +26,6 @@ export const HomeApp: React.FC<HomeAppProps> = ({
   homePage,
   featuredEventsOrderedSet,
 }) => {
-  const { match } = useRouter()
-  const { brazeContentCards } = paramsToCamelCase(match?.location.query) as {
-    brazeContentCards?: boolean
-  }
-  const showBrazeContentCards = !!brazeContentCards
-  const showHomeHeroUnits = !showBrazeContentCards && !!homePage
-
   return (
     <>
       <HomeMeta />
@@ -44,11 +34,7 @@ export const HomeApp: React.FC<HomeAppProps> = ({
 
       <Spacer mt={[2, 0]} />
 
-      {showBrazeContentCards && <HomeContentCards />}
-
-      {showHomeHeroUnits && (
-        <HomeHeroUnitsFragmentContainer homePage={homePage} />
-      )}
+      <HomeContentCards />
 
       <Spacer mt={[4, 6]} />
 


### PR DESCRIPTION
This PR will launch the Braze content cards on web! 🎉 

It also fixes (at least) two things:

1. A race condition where Braze cards aren't rendered
2. A bug where client-side routing breaks the call to Braze for cards

So yeah, let's merge this tomorrow morning and behold the glory.

ALSO

Over on https://github.com/artsy/force/pull/11456 I thought I was a real hotshot and knew it was fine to pend that spec but it turns out it was revealing that race condition bug. 😬 This fixes the bug and also makes the test pass IMAGINE THAT.

Finally I wanted to mention that in a follow up to this PR I will be deleting the `HomeHeroUnit` code. I could have done that here but for my sanity I want it to be easy to rollback in case something goes wrong.

https://artsyproduct.atlassian.net/browse/GRO-1324

/cc @artsy/grow-devs @isakelaris @jpoczik 