### PR TITLE
feat(FX-4476): activity panel notifications counts

### DIFF
--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -17,6 +17,7 @@ const UNREAD_INDICATOR_SIZE = 8
 const NotificationItem: React.FC<NotificationItemProps> = ({ item }) => {
   const { trackEvent } = useTracking()
   const artworks = extractNodes(item.artworksConnection)
+  const remainingArtworksCount = item.objectsCount - 4
 
   const getNotificationType = () => {
     if (item.notificationType === "ARTWORK_ALERT") {
@@ -75,6 +76,17 @@ const NotificationItem: React.FC<NotificationItemProps> = ({ item }) => {
               )
             })}
           </Join>
+
+          {remainingArtworksCount > 0 && (
+            <Text
+              variant="xs"
+              color="black60"
+              aria-label="Remaining artworks count"
+              ml={1}
+            >
+              + {remainingArtworksCount}
+            </Text>
+          )}
         </Flex>
       </Flex>
 
@@ -103,6 +115,7 @@ export const NotificationItemFragmentContainer = createFragmentContainer(
         targetHref
         isUnread
         notificationType
+        objectsCount
         artworksConnection(first: 4) {
           edges {
             node {

--- a/src/Components/Notifications/__tests__/NotificationItem.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationItem.jest.tsx
@@ -62,6 +62,31 @@ describe("NotificationItem", () => {
     expect(screen.getAllByRole("img")).toHaveLength(4)
   })
 
+  describe("the remaining artworks count", () => {
+    it("should NOT be rendered if there are less or equal to 4", () => {
+      renderWithRelay({
+        Notification: () => notification,
+      })
+
+      const label = screen.queryByLabelText("Remaining artworks count")
+      expect(label).not.toBeInTheDocument()
+    })
+
+    it("should be rendered if there are more than 4", () => {
+      renderWithRelay({
+        Notification: () => ({
+          ...notification,
+          objectsCount: 10,
+          artworksConnection: {
+            ...notification.artworksConnection,
+          },
+        }),
+      })
+
+      expect(screen.getByText("+ 6")).toBeInTheDocument()
+    })
+  })
+
   describe("Unread notification indicator", () => {
     it("should NOT be rendered by default", () => {
       renderWithRelay({
@@ -166,6 +191,7 @@ const notification = {
   publishedAt: "2 days ago",
   isUnread: false,
   notificationType: "ARTWORK_PUBLISHED",
+  objectsCount: 0,
   artworksConnection: {
     edges: artworks,
   },

--- a/src/__generated__/NotificationItem_item.graphql.ts
+++ b/src/__generated__/NotificationItem_item.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<19625adaf7953ef2040a8e491473c452>>
+ * @generated SignedSource<<eae5d144508edd8daae57f7f81eb7979>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,6 +29,7 @@ export type NotificationItem_item$data = {
   readonly isUnread: boolean;
   readonly message: string;
   readonly notificationType: NotificationTypesEnum;
+  readonly objectsCount: number;
   readonly publishedAt: string;
   readonly targetHref: string;
   readonly title: string;
@@ -93,6 +94,13 @@ return {
       "args": null,
       "kind": "ScalarField",
       "name": "notificationType",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "objectsCount",
       "storageKey": null
     },
     {
@@ -195,6 +203,6 @@ return {
 };
 })();
 
-(node as any).hash = "0c7fd1b2f003203f3cc4357db75fcccd";
+(node as any).hash = "1cd24fdc7ec71bb7334d69135fbfd0ce";
 
 export default node;

--- a/src/__generated__/NotificationItem_test_Query.graphql.ts
+++ b/src/__generated__/NotificationItem_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ed95c1958acc02a370c3f080531c906d>>
+ * @generated SignedSource<<336fecbab1445687adb43d59cc6f254d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -182,6 +182,13 @@ return {
                   },
                   {
                     "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "objectsCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
                     "args": [
                       {
                         "kind": "Literal",
@@ -288,7 +295,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6ce2b155e5ad31fe483b6902a8d7ef0b",
+    "cacheID": "bfe1b092fb363ea3d7b24e5250deb8c7",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -369,6 +376,12 @@ return {
           "plural": false,
           "type": "NotificationTypesEnum"
         },
+        "notificationsConnection.edges.node.objectsCount": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Int"
+        },
         "notificationsConnection.edges.node.publishedAt": (v4/*: any*/),
         "notificationsConnection.edges.node.targetHref": (v4/*: any*/),
         "notificationsConnection.edges.node.title": (v4/*: any*/)
@@ -376,7 +389,7 @@ return {
     },
     "name": "NotificationItem_test_Query",
     "operationKind": "query",
-    "text": "query NotificationItem_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...NotificationItem_item\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query NotificationItem_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...NotificationItem_item\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListNextQuery.graphql.ts
+++ b/src/__generated__/NotificationsListNextQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b6942897b6cab29301e05cc188fc723d>>
+ * @generated SignedSource<<0ec20181b93d2c8fbc095d7026fd1c1f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -226,6 +226,13 @@ return {
                       },
                       {
                         "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "objectsCount",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
                         "args": [
                           {
                             "kind": "Literal",
@@ -377,12 +384,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8b7bb08eff3c2455b22f420e691612d6",
+    "cacheID": "51a773a69571b7d93478e63469ae4eb0",
     "id": null,
     "metadata": {},
     "name": "NotificationsListNextQuery",
     "operationKind": "query",
-    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListQuery.graphql.ts
+++ b/src/__generated__/NotificationsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<222727561db0272756bae79f655beab2>>
+ * @generated SignedSource<<365fd1e6c363bef8b591fddea80c41e9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -199,6 +199,13 @@ return {
                       },
                       {
                         "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "objectsCount",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
                         "args": [
                           {
                             "kind": "Literal",
@@ -350,12 +357,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "41d9f90f809f5f7ee8f0cbe5f48fb861",
+    "cacheID": "a4c49c89168e88b4f7019ea83dc8e8fe",
     "id": null,
     "metadata": {},
     "name": "NotificationsListQuery",
     "operationKind": "query",
-    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsList_test_Query.graphql.ts
+++ b/src/__generated__/NotificationsList_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7914484a7684e6a566a9df00c94cc6a6>>
+ * @generated SignedSource<<154625b0ee6d03de3daeb001f2887890>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -208,6 +208,13 @@ return {
                       },
                       {
                         "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "objectsCount",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
                         "args": [
                           {
                             "kind": "Literal",
@@ -359,7 +366,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ded6c0a851f800d8211900c9416ad138",
+    "cacheID": "73a09bae02d633b7f50838bd7e73b047",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -441,6 +448,12 @@ return {
           "plural": false,
           "type": "NotificationTypesEnum"
         },
+        "viewer.notifications.edges.node.objectsCount": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Int"
+        },
         "viewer.notifications.edges.node.publishedAt": (v4/*: any*/),
         "viewer.notifications.edges.node.targetHref": (v4/*: any*/),
         "viewer.notifications.edges.node.title": (v4/*: any*/),
@@ -456,7 +469,7 @@ return {
     },
     "name": "NotificationsList_test_Query",
     "operationKind": "query",
-    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [FX-4476]

### Description

Re-introduces counts but using a new `objectsCount` field

![Screenshot 2022-12-02 at 14 45 59](https://user-images.githubusercontent.com/3934579/205309337-49a4e70a-6e52-497a-b681-4b58bc49d04a.png)

[FX-4476]: https://artsyproduct.atlassian.net/browse/FX-4476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ