### PR TITLE
fix:prevent overlapping text on firefox

### DIFF
--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtistList.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtistList.tsx
@@ -57,7 +57,6 @@ export const PartnerArtistList: React.FC<PartnerArtistListProps> = ({
                 height={OFFSET}
                 overflow="visible"
                 style={{
-                  breakBefore: "column",
                   whiteSpace: "nowrap",
                   transform: `translateY(-${OFFSET}px)`,
                 }}
@@ -103,6 +102,7 @@ export const PartnerArtistList: React.FC<PartnerArtistListProps> = ({
                 </RouterLink>
               )
             })}
+            <br />
           </React.Fragment>
         )
       })}


### PR DESCRIPTION
The type of this PR is: Fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves: [PX-5343]

### Description

This PR solves a problem where the text list for Partner Artists was overlapping on firefox. This is caused by [firefox not respecting break-before](https://developer.mozilla.org/en-US/docs/Web/CSS/break-before) in the same way that chrome and safari do. 

Firefox Old Screenshot:

![image](https://user-images.githubusercontent.com/8671643/205971665-95d1512a-1385-4e75-99d1-3cfa54e2e64c.png)

Firefox New Screeshot:
![image](https://user-images.githubusercontent.com/8671643/205971768-c5b37e71-5964-41f1-a522-52ddfc651f59.png)

Chrome Old Screenshot:
![image](https://user-images.githubusercontent.com/8671643/205971069-acfcaf72-dad9-4b2a-9f1e-6d6bdee7e6ee.png)

Chrome New Screenshot:
![image](https://user-images.githubusercontent.com/8671643/205971883-214acb79-9143-435c-b9cc-9fb90f62c38c.png)




<!-- Implementation description -->
