### PR TITLE
Catch more content card errors

### DIFF
--- a/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
@@ -5,6 +5,7 @@ import { FallbackCards } from "./FallbackCards"
 import { PlaceholderCards } from "./PlaceholderCards"
 import { useRouter } from "System/Router/useRouter"
 import { paramsToCamelCase } from "Components/ArtworkFilter/Utils/urlBuilder"
+import { HomeErrorBoundary } from "./HomeErrorBoundary"
 
 const sortCards = (lhs, rhs) => {
   const lhsPosition = (lhs.extras || {}).position || lhs.id
@@ -75,4 +76,12 @@ export const HomeContentCards: React.FC = () => {
     return exceededTimeout ? <FallbackCards /> : <PlaceholderCards />
 
   return <BrazeCards appboy={appboy} cards={cards} />
+}
+
+export const SafeHomeContentCards = () => {
+  return (
+    <HomeErrorBoundary>
+      <HomeContentCards />
+    </HomeErrorBoundary>
+  )
 }

--- a/src/Apps/Home/Components/HomeContentCards/HomeErrorBoundary.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/HomeErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+import { ErrorWithMetadata } from "Utils/errors"
+import createLogger from "Utils/logger"
+import { FallbackCards } from "./FallbackCards"
+
+const logger = createLogger()
+
+interface Props {
+  children?: any
+}
+
+interface State {
+  isError: boolean
+}
+
+export class HomeErrorBoundary extends React.Component<Props, State> {
+  state: State = { isError: false }
+
+  componentDidCatch(error: Error, errorInfo) {
+    logger.error(new ErrorWithMetadata(error.message, errorInfo))
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { isError: true }
+  }
+
+  render() {
+    if (this.state.isError) return <FallbackCards />
+
+    return this.props.children
+  }
+}

--- a/src/Apps/Home/HomeApp.tsx
+++ b/src/Apps/Home/HomeApp.tsx
@@ -15,7 +15,7 @@ import { HomeAuctionLotsRailQueryRenderer } from "./Components/HomeAuctionLotsRa
 import { HomeWorksForYouTabBar } from "./Components/HomeWorksForYouTabBar"
 import { MyBidsQueryRenderer } from "Apps/Auctions/Components/MyBids/MyBids"
 import { HomeTroveArtworksRailQueryRenderer } from "./Components/HomeTroveArtworksRail"
-import { HomeContentCards } from "./Components/HomeContentCards"
+import { SafeHomeContentCards } from "./Components/HomeContentCards"
 
 interface HomeAppProps {
   homePage: HomeApp_homePage$data | null
@@ -34,7 +34,7 @@ export const HomeApp: React.FC<HomeAppProps> = ({
 
       <Spacer y={[2, 0]} />
 
-      <HomeContentCards />
+      <SafeHomeContentCards />
 
       <Spacer y={[4, 6]} />
 


### PR DESCRIPTION
This PR adds an [Error Boundary](https://reactjs.org/docs/error-boundaries.html) to the rendering of the Braze content cards on the homepage. When an error is thrown, it'll catch it, log it and then render the fallback cards.

This doesn't really solve the problem but it's a better user experience. What I hope to see is for these errors to show up in Sentry so my next step after this lands is to figure out why we aren't seeing that.

/cc @artsy/grow-devs @isakelaris 