### PR TITLE
fix(CX-322): /my-collection/artworks/new  is opening for logged out user

### DIFF
--- a/src/Server/middleware/userRequiredMiddleware.ts
+++ b/src/Server/middleware/userRequiredMiddleware.ts
@@ -3,6 +3,7 @@ import { match } from "path-to-regexp"
 const USER_REQUIRED_ROUTES = [
   "/notifications",
   "/orders(.*)",
+  "/my-collection/artworks(.*)",
   "/settings/alerts",
   "/settings/payments",
   "/settings/purchases(.*)",


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-322]

### Description

<!-- Implementation description -->
Added "/my-collection/artworks(.*)", to the USER_REQUIRED_ROUTES in the userRequirediddleWare

https://user-images.githubusercontent.com/36167539/206203347-dacefd92-dbd0-4407-8d62-45e09113b475.mov



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-322]: https://artsyproduct.atlassian.net/browse/CX-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ