### PR TITLE
refactor: utilizes @artsy/img package to mint gemini urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@artsy/express-reloadable": "^1.7.0",
     "@artsy/fresnel": "3.5.0",
     "@artsy/icons": "3.1.3",
+    "@artsy/img": "0.1.2",
     "@artsy/multienv": "^1.2.0",
     "@artsy/palette": "27.0.0",
     "@artsy/palette-charts": "26.0.0",

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -79,7 +79,6 @@ export const FeaturedCollectionEntity: React.FC<FeaturedCollectionEntityProps> =
     width: 325,
     height: 244,
     quality: 75,
-    convert_to: "jpg",
   })
 
   return (

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
@@ -45,7 +45,6 @@ export const OtherCollectionEntity: React.FC<CollectionProps> = ({
     width: 325,
     height: 244,
     quality: 75,
-    convert_to: "jpg",
   })
 
   return (

--- a/src/Apps/Partner/Components/__tests__/PartnerViewingRooms/ViewingRoomCard.jest.tsx
+++ b/src/Apps/Partner/Components/__tests__/PartnerViewingRooms/ViewingRoomCard.jest.tsx
@@ -1,4 +1,4 @@
-import { ViewingRoomCardFragmentContainer } from "../../PartnerViewingRooms/ViewingRoomCard"
+import { ViewingRoomCardFragmentContainer } from "Apps/Partner/Components/PartnerViewingRooms/ViewingRoomCard"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -54,10 +54,10 @@ describe("ViewingRoomCard", () => {
       "/viewing-room/antonio-colombo-ceramic-girl-s"
     )
     expect(wrapper.find("img").props().src).toEqual(
-      "?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCTSbMK5RHzG9k8wJDp2jdw%2Fnormalized.jpg&width=263&height=222&quality=80"
+      "?height=222&quality=80&resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCTSbMK5RHzG9k8wJDp2jdw%2Fnormalized.jpg&width=263"
     )
     expect(wrapper.find("img").props().srcSet).toEqual(
-      "?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCTSbMK5RHzG9k8wJDp2jdw%2Fnormalized.jpg&width=263&height=222&quality=80 1x, ?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCTSbMK5RHzG9k8wJDp2jdw%2Fnormalized.jpg&width=526&height=444&quality=80 2x"
+      "?height=222&quality=80&resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCTSbMK5RHzG9k8wJDp2jdw%2Fnormalized.jpg&width=263 1x, ?height=444&quality=80&resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCTSbMK5RHzG9k8wJDp2jdw%2Fnormalized.jpg&width=526 2x"
     )
     expect(wrapper.find("img").props().alt).toEqual("Ceramic Girl(s)")
     expect(wrapper.find("h5").first().text()).toEqual("Viewing Room")

--- a/src/Components/__tests__/MetaTags.jest.tsx
+++ b/src/Components/__tests__/MetaTags.jest.tsx
@@ -1,5 +1,5 @@
 import { mount } from "enzyme"
-import { MetaTags } from "../MetaTags"
+import { MetaTags } from "Components/MetaTags"
 import { MockBoot } from "DevTools"
 
 jest.mock("Utils/getENV", () => ({
@@ -78,7 +78,7 @@ describe("MetaTags", () => {
         name: null,
         property: "og:image",
         content:
-          "?resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200&height=630&quality=80",
+          "?height=630&quality=80&resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200",
       },
       {
         content: "308278682573501",
@@ -107,7 +107,7 @@ describe("MetaTags", () => {
         name: null,
         property: "twitter:image",
         content:
-          "?resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200&height=630&quality=80",
+          "?height=630&quality=80&resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200",
       },
     ])
   })
@@ -156,7 +156,7 @@ describe("MetaTags", () => {
         name: null,
         property: "og:image",
         content:
-          "?resize_to=fill&src=https%3A%2F%2Fexample.com%2Fexample.jpg&width=1200&height=630&quality=80",
+          "?height=630&quality=80&resize_to=fill&src=https%3A%2F%2Fexample.com%2Fexample.jpg&width=1200",
       },
       {
         content: "308278682573501",
@@ -184,7 +184,7 @@ describe("MetaTags", () => {
         name: null,
         property: "twitter:image",
         content:
-          "?resize_to=fill&src=https%3A%2F%2Fexample.com%2Fexample.jpg&width=1200&height=630&quality=80",
+          "?height=630&quality=80&resize_to=fill&src=https%3A%2F%2Fexample.com%2Fexample.jpg&width=1200",
       },
     ])
   })
@@ -270,7 +270,7 @@ describe("MetaTags", () => {
         name: null,
         property: "og:image",
         content:
-          "?resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200&height=630&quality=80",
+          "?height=630&quality=80&resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200",
       },
       {
         content: "308278682573501",
@@ -299,7 +299,7 @@ describe("MetaTags", () => {
         name: null,
         property: "twitter:image",
         content:
-          "?resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200&height=630&quality=80",
+          "?height=630&quality=80&resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200",
       },
     ])
   })

--- a/src/Utils/__tests__/resized.jest.ts
+++ b/src/Utils/__tests__/resized.jest.ts
@@ -1,4 +1,4 @@
-import { cropped, resized } from "../resized"
+import { cropped, resized } from "Utils/resized"
 
 jest.mock("sharify", () => ({
   data: {
@@ -15,11 +15,17 @@ describe("#cropped", () => {
     })
 
     expect(src).toContain("d7hftxdivxxvm")
-    expect(src).toContain("&width=100&height=100&quality=80")
+    expect(src).toContain("width=100")
+    expect(src).toContain("height=100")
+    expect(src).toContain("quality=80")
     expect(srcSet).toContain("1x, ")
-    expect(srcSet).toContain("&width=100&height=100&quality=80")
+    expect(srcSet).toContain("width=100")
+    expect(srcSet).toContain("height=100")
+    expect(srcSet).toContain("quality=80")
     expect(srcSet).toContain("2x")
-    expect(srcSet).toContain("&width=200&height=200&quality=80")
+    expect(srcSet).toContain("width=200")
+    expect(srcSet).toContain("height=200")
+    expect(srcSet).toContain("quality=80")
   })
 })
 
@@ -30,12 +36,15 @@ describe("#resized", () => {
     })
 
     expect(src).toContain("d7hftxdivxxvm")
-    expect(src).toContain("&width=100&quality=80")
+    expect(src).toContain("quality=80")
+    expect(src).toContain("width=100")
     expect(src).toContain("resize_to=width")
     expect(srcSet).toContain("1x, ")
-    expect(srcSet).toContain("&width=100&quality=80")
+    expect(srcSet).toContain("width=100")
+    expect(srcSet).toContain("quality=80")
     expect(srcSet).toContain("2x")
-    expect(srcSet).toContain("&width=200&quality=80")
+    expect(srcSet).toContain("width=200")
+    expect(srcSet).toContain("quality=80")
   })
 
   it("resizeds to a height", () => {
@@ -44,11 +53,14 @@ describe("#resized", () => {
     })
 
     expect(src).toContain("d7hftxdivxxvm")
-    expect(src).toContain("&height=100&quality=80")
+    expect(src).toContain("height=100")
+    expect(src).toContain("quality=80")
     expect(src).toContain("resize_to=height")
     expect(srcSet).toContain("1x, ")
-    expect(srcSet).toContain("&height=100&quality=80")
+    expect(srcSet).toContain("height=100")
+    expect(srcSet).toContain("quality=80")
     expect(srcSet).toContain("2x")
-    expect(srcSet).toContain("&height=200&quality=80")
+    expect(srcSet).toContain("height=200")
+    expect(srcSet).toContain("quality=80")
   })
 })

--- a/src/Utils/__tests__/resizer.jest.ts
+++ b/src/Utils/__tests__/resizer.jest.ts
@@ -1,4 +1,4 @@
-import { crop, resize } from "../resizer"
+import { crop, resize } from "Utils/resizer"
 
 jest.mock("sharify", () => ({
   data: {
@@ -15,7 +15,9 @@ describe("resizer", () => {
         quality: 80,
       })
       expect(url).toMatch("d7hftxdivxxvm")
-      expect(url).toMatch("&width=100&height=100&quality=80")
+      expect(url).toMatch("width=100")
+      expect(url).toMatch("height=100")
+      expect(url).toMatch("quality=80")
     })
   })
 
@@ -25,7 +27,8 @@ describe("resizer", () => {
         width: 100,
       })
       expect(url).toMatch("d7hftxdivxxvm")
-      expect(url).toMatch("&width=100&quality=80")
+      expect(url).toMatch("width=100")
+      expect(url).toMatch("quality=80")
       expect(url).toMatch("resize_to=width")
     })
 
@@ -34,7 +37,8 @@ describe("resizer", () => {
         height: 100,
       })
       expect(url).toMatch("d7hftxdivxxvm")
-      expect(url).toMatch("&height=100&quality=80")
+      expect(url).toMatch("height=100")
+      expect(url).toMatch("quality=80")
       expect(url).toMatch("resize_to=height")
     })
   })

--- a/src/Utils/resized.ts
+++ b/src/Utils/resized.ts
@@ -35,7 +35,6 @@ export const resized = (
     width,
     ...rest
   }: {
-    convert_to?: string
     height?: number
     quality?: number | [number, number]
     width?: number
@@ -52,7 +51,6 @@ export const resized = (
   })
 
   return {
-    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     src: _1x,
     srcSet: `${_1x} 1x, ${_2x} 2x`,
   }
@@ -72,7 +70,6 @@ export const cropped = (
     width,
     ...rest
   }: {
-    convert_to?: string
     height: number
     quality?: number | [number, number]
     width: number
@@ -89,7 +86,6 @@ export const cropped = (
   })
 
   return {
-    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     src: _1x,
     srcSet: `${_1x} 1x, ${_2x} 2x`,
   }

--- a/src/Utils/resizer.ts
+++ b/src/Utils/resizer.ts
@@ -1,14 +1,14 @@
-import qs from "qs"
+import { configure } from "@artsy/img"
 import { getENV } from "./getENV"
 
 export const GEMINI_CLOUDFRONT_URL =
   getENV("GEMINI_CLOUDFRONT_URL") ?? "https://d7hftxdivxxvm.cloudfront.net"
 
-const warn = (message: string) => {
-  if (process.env.NODE_ENV === "development") {
-    console.warn(message)
-  }
-}
+const services = configure({
+  gemini: {
+    endpoint: GEMINI_CLOUDFRONT_URL,
+  },
+})
 
 export const crop = (
   src: string,
@@ -16,34 +16,13 @@ export const crop = (
     width: number
     height: number
     quality?: number
-    convert_to?: string
   }
 ) => {
-  const { width, height, quality, convert_to } = options
-
-  if (!src) return null
-
-  if (!width && !height) {
-    warn("requires width and height")
-    return src
-  } else if (width === 0) {
-    warn("width must be non-zero")
-    return src
-  } else if (height === 0) {
-    warn("height must be non-zero")
-    return src
-  }
-
-  const config = {
-    resize_to: "fill",
-    src,
-    width,
-    height,
-    quality: quality || 80,
-    convert_to,
-  }
-
-  return [GEMINI_CLOUDFRONT_URL, qs.stringify(config)].join("?")
+  return services.gemini.exec("crop", src, {
+    width: options.width,
+    height: options.height,
+    quality: options.quality,
+  })
 }
 
 export const resize = (
@@ -52,31 +31,11 @@ export const resize = (
     width?: number
     height?: number
     quality?: number
-    convert_to?: string
   }
 ) => {
-  const { width, height, quality, convert_to } = options
-
-  if (!src) return null
-
-  let resizeTo
-
-  if (width && !height) {
-    resizeTo = "width"
-  } else if (height && !width) {
-    resizeTo = "height"
-  } else {
-    resizeTo = "fit"
-  }
-
-  const config = {
-    resize_to: resizeTo,
-    src,
-    width,
-    height,
-    quality: quality || 80,
-    convert_to,
-  }
-
-  return [GEMINI_CLOUDFRONT_URL, qs.stringify(config)].join("?")
+  return services.gemini.exec("resize", src, {
+    width: options.width,
+    height: options.height,
+    quality: options.quality,
+  })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,6 +68,13 @@
   resolved "https://registry.yarnpkg.com/@artsy/icons/-/icons-3.1.3.tgz#2ecbcce843bfcbcebbc38990b55910fb0b7ef8eb"
   integrity sha512-yynmzMBv+sCzxIp7RzJeIaQM7bwlyLPyuF4eJKkHPA5UGcpPoMLuZ6b2bTCAzKig4GenocElJSWW4ZXxl6x4ug==
 
+"@artsy/img@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@artsy/img/-/img-0.1.2.tgz#8b55e6062fd6cc89415b5d08b7ccc4c4398bd35c"
+  integrity sha512-b6tqRUvBg03k2/PjCZMeLunR/mvvgP63ocI7fOLz0PdewPj7yrwfoPWhFw7t4SR7rrQq8XxWUb22yicNtAWOZQ==
+  dependencies:
+    md5 "^2.3.0"
+
 "@artsy/multienv@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@artsy/multienv/-/multienv-1.2.0.tgz#ff4bb0b86ee8bb1c2867e5d887931d274024e68a"
@@ -7308,6 +7315,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+charenc@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
+
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -8205,6 +8217,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypt@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
 crypto-browserify@^3.11.0, crypto-browserify@^3.12.0:
   version "3.12.0"
@@ -12514,7 +12531,7 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -15163,6 +15180,15 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+md5@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
+  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
+  dependencies:
+    charenc "0.0.2"
+    crypt "0.0.2"
+    is-buffer "~1.1.6"
 
 mdast-squeeze-paragraphs@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This switches our image proxy URL generation to use the new [@artsy/img](https://github.com/artsy/img) package.

I'm not expecting any differences or real errors though we'll probably see some spec failures as it now alphabetizes the query params. Let's see.