### PR TITLE
feat(FX-4492): add lot label even when lot is closed

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar2/ArtworkSidebar2.tsx
@@ -80,8 +80,7 @@ export const ArtworkSidebar2: React.FC<ArtworkSidebarProps> = ({
     (isInAuction && lotIsClosed(sale, saleArtwork)) ||
     isSold
 
-  const isNotClosedSale = sale && !sale.isClosed
-  const shoudlDisplayLotLabel = isInAuction && isNotClosedSale && lotLabel
+  const shoudlDisplayLotLabel = !!isInAuction && !!lotLabel
 
   return (
     <Flex flexDirection="column" data-test={ContextModule.artworkSidebar}>


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4492]

### Description

Adds lot label even when bidding is closed to match eigen's behavior.

Screenshots:

|BiddingClosed||
|---|---|
|<img width="422" alt="Screenshot 2022-12-12 at 10 19 21" src="https://user-images.githubusercontent.com/21178754/207013955-01bcf93f-8af4-407e-9fff-27e3cefceff3.png">|<img width="1000" alt="Screenshot 2022-12-12 at 10 19 05" src="https://user-images.githubusercontent.com/21178754/207013965-ead70a1c-b8f4-4b52-ae58-895b838164fc.png">|




<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4492]: https://artsyproduct.atlassian.net/browse/FX-4492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ