### PR TITLE
fix(CX-3224): Remove "Back to Collector Profile" button

### DIFF
--- a/src/Apps/Settings/SettingsApp.tsx
+++ b/src/Apps/Settings/SettingsApp.tsx
@@ -2,13 +2,11 @@ import { Text } from "@artsy/palette"
 import { MyCollectionRouteLoggedOutState } from "Apps/Settings/Routes/MyCollection/MyCollectionRouteLoggedOutState"
 import { MetaTags } from "Components/MetaTags"
 import { RouteTab, RouteTabs } from "Components/RouteTabs"
-import { TopContextBar } from "Components/TopContextBar"
 import { compact } from "lodash"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "System"
 import { useFeatureFlag } from "System/useFeatureFlag"
-import { Media } from "Utils/Responsive"
 import { SettingsApp_me$data } from "__generated__/SettingsApp_me.graphql"
 
 export const SETTINGS_ROUTE_TABS_MARGIN = [2, 4]
@@ -53,28 +51,9 @@ const SettingsApp: React.FC<SettingsAppProps> = ({ me, children }) => {
     <>
       <MetaTags title="Settings | Artsy" />
 
-      {isCollectorProfileEnabled ? (
-        <>
-          <Media greaterThan="xs">
-            <TopContextBar
-              displayBackArrow
-              useWithoutSeparator
-              href="/collector-profile" // TODO: use onClick and router or
-              // something else to make sure we're coming back to the correct
-              // tab of collector profile
-            >
-              Back to Collector Profile
-            </TopContextBar>
-          </Media>
-          <Text variant={["lg-display", "lg-display"]} mb={[4, 6]} mt={[2, 4]}>
-            Settings
-          </Text>
-        </>
-      ) : (
-        <Text variant={["lg-display", "xl"]} mt={4}>
-          Hi, {me.name}
-        </Text>
-      )}
+      <Text variant={["lg-display", "xl"]} mt={[2, 4]}>
+        {isCollectorProfileEnabled ? "Settings" : `Hi, ${me.name}`}
+      </Text>
 
       <RouteTabs my={SETTINGS_ROUTE_TABS_MARGIN}>
         {isCollectorProfileEnabled

--- a/src/Components/TopContextBar.tsx
+++ b/src/Components/TopContextBar.tsx
@@ -19,7 +19,7 @@ export interface TopContextBarProps {
   src?: string | null
   rightContent?: React.ReactNode
   onClick?(): void
-  useWithoutSeparator?: boolean
+  hideSeparator?: boolean
 }
 
 export const TopContextBar: React.FC<TopContextBarProps> = ({
@@ -30,7 +30,7 @@ export const TopContextBar: React.FC<TopContextBarProps> = ({
   src,
   rightContent,
   onClick,
-  useWithoutSeparator,
+  hideSeparator = false,
 }) => {
   const image = src ? cropped(src, { width: 60, height: 60 }) : null
 
@@ -87,7 +87,7 @@ export const TopContextBar: React.FC<TopContextBarProps> = ({
         {rightContent}
       </Flex>
 
-      {!useWithoutSeparator && (
+      {!hideSeparator && (
         <FullBleed>
           <Separator as="hr" color="black15" />
         </FullBleed>


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3224]

### Description
This PR removes the Back to Collector Profile button in the Settings App header

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3224]: https://artsyproduct.atlassian.net/browse/CX-3224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ