### PR TITLE
fix: add play store signing sha to assetlinks.json

### DIFF
--- a/src/public/.well-known/assetlinks.json
+++ b/src/public/.well-known/assetlinks.json
@@ -1,9 +1,15 @@
-[{
-  "relation": ["delegate_permission/common.handle_all_urls"],
-  "target": {
-    "namespace": "android_app",
-    "package_name": "net.artsy.app",
-    "sha256_cert_fingerprints":
-    ["72:70:C3:1C:74:A4:86:D8:F7:31:08:E0:2E:72:D6:91:00:4D:57:35:16:8B:9C:DA:B1:65:5D:49:1D:33:2E:88"]
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "net.artsy.app",
+      "sha256_cert_fingerprints": [
+        "72:70:C3:1C:74:A4:86:D8:F7:31:08:E0:2E:72:D6:91:00:4D:57:35:16:8B:9C:DA:B1:65:5D:49:1D:33:2E:88",
+        "03:D2:5C:C6:22:D2:76:BA:D3:A5:A9:19:3C:EF:A6:D1:60:99:14:9B:AD:68:E7:FB:19:52:0D:76:3B:83:DE:87"
+      ]
+    }
   }
-}]
+]


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [MOPLAT-521]

### Description

<!-- Implementation description -->

Adds the signing cert sha for our playstore app to fix android app links. Play store console was complaining that our site was failing verification due to this missing. 


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOPLAT-521]: https://artsyproduct.atlassian.net/browse/MOPLAT-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ