### PR TITLE
fix: Guard against ready but no appboy GRO-1465

### DIFF
--- a/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
@@ -24,7 +24,7 @@ export const HomeContentCards: React.FC = () => {
 
   const timeoutAmount = brazeTimeoutAmount ?? DEFAULT_TIMEOUT_AMOUNT
 
-  const [exceededTimeout, setExceededTimeout] = useState(false)
+  const [renderFallback, setRenderFallback] = useState(false)
   const [appboy, setAppboy] = useState<typeof Braze | null>(null)
   const [cards, setCards] = useState<Braze.CaptionedImage[]>([])
   const cardsLengthRef = useRef(cards.length)
@@ -36,11 +36,11 @@ export const HomeContentCards: React.FC = () => {
       setAppboy(window.appboy)
     } else if (window.analytics) {
       window.analytics.ready(() => {
-        !window.appboy && setExceededTimeout(true)
+        !window.appboy && setRenderFallback(true)
         setAppboy(window.appboy)
       })
     } else {
-      setExceededTimeout(true)
+      setRenderFallback(true)
     }
   }, [appboy])
 
@@ -60,7 +60,7 @@ export const HomeContentCards: React.FC = () => {
       if (cardsLengthRef.current > 0) return
 
       appboy.removeSubscription(subscriptionId)
-      setExceededTimeout(true)
+      setRenderFallback(true)
     }, timeoutAmount)
 
     appboy.requestContentCardsRefresh()
@@ -74,7 +74,7 @@ export const HomeContentCards: React.FC = () => {
   const hasBrazeCards = appboy && cardsLengthRef.current > 0
 
   if (!hasBrazeCards)
-    return exceededTimeout ? <FallbackCards /> : <PlaceholderCards />
+    return renderFallback ? <FallbackCards /> : <PlaceholderCards />
 
   return <BrazeCards appboy={appboy} cards={cards} />
 }

--- a/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
@@ -36,6 +36,7 @@ export const HomeContentCards: React.FC = () => {
       setAppboy(window.appboy)
     } else if (window.analytics) {
       window.analytics.ready(() => {
+        !window.appboy && setExceededTimeout(true)
         setAppboy(window.appboy)
       })
     } else {

--- a/src/Apps/Home/Components/HomeContentCards/__tests__/HomeContentCards.jest.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/__tests__/HomeContentCards.jest.tsx
@@ -41,6 +41,24 @@ describe("HomeContentCards", () => {
     expect(screen.getByText("FallbackCards")).toBeInTheDocument()
   })
 
+  it("switches to fallback cards when appboy never shows up", () => {
+    const artificialSegmentDelay = 10
+    window.appboy = undefined as any
+
+    window.analytics = {
+      ready: callback => {
+        setTimeout(() => {
+          callback()
+        }, artificialSegmentDelay)
+      },
+    } as any
+
+    render(<HomeContentCards />)
+    expect(screen.getByText("PlaceholderCards")).toBeInTheDocument()
+    jest.advanceTimersByTime(artificialSegmentDelay)
+    expect(screen.getByText("FallbackCards")).toBeInTheDocument()
+  })
+
   it("renders braze cards when they are returned", () => {
     const mockUpdater = callback => callback()
     window.appboy.subscribeToContentCardsUpdates = mockUpdater


### PR DESCRIPTION
While doing some troubleshooting with @dzucconi we found that it was possible to have Segment fire the ready event for the the Braze SDK to not exist on window. This PR captures that case in a test and guards against it.

https://artsyproduct.atlassian.net/browse/GRO-1465

/cc @artsy/grow-devs