### PR TITLE
fix: remove title from insights page

### DIFF
--- a/src/Apps/Settings/Routes/Insights/Components/InsightsHeader.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsHeader.tsx
@@ -1,5 +1,5 @@
 import { OwnerType } from "@artsy/cohesion"
-import { Box, Button, DROP_SHADOW, Flex, FullBleed, Text } from "@artsy/palette"
+import { Box, Button, DROP_SHADOW, Flex, FullBleed } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import { useMyCollectionTracking } from "Apps/MyCollection/Routes/Hooks/useMyCollectionTracking"
@@ -24,14 +24,9 @@ export const InsightsHeader: React.FC = () => {
                 <HorizontalPadding>
                   <Flex
                     backgroundColor="white100"
-                    justifyContent="space-between"
+                    justifyContent="flex-end"
                     py={[1, 2]}
                   >
-                    <Flex flex={1} alignItems="center">
-                      <Text variant="lg-display">
-                        Gain deeper knowledge of your collection.
-                      </Text>
-                    </Flex>
                     <Button
                       // @ts-ignore
                       as={RouterLink}

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsHeader.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsHeader.jest.tsx
@@ -27,9 +27,6 @@ describe("InsightsHeader", () => {
   it("renders the Upload artwork CTA and the textual content", () => {
     renderComponent()
 
-    expect(
-      screen.getByText("Gain deeper knowledge of your collection.")
-    ).toBeInTheDocument()
     expect(screen.getByText("Upload Artwork")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description

<!-- Implementation description -->
Removed title from insights header
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/36167539/207605954-286417ea-53f9-4131-aefc-af0470dd3cb1.png">
<img width="418" alt="image" src="https://user-images.githubusercontent.com/36167539/207606022-dda351f4-e8b0-458d-b8be-87e1436e3787.png">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ