### PR TITLE
feat(artquiz): implements animation

### DIFF
--- a/src/Apps/ArtQuiz/Components/ArtQuizButton.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizButton.tsx
@@ -1,13 +1,14 @@
-import { Clickable, ClickableProps } from "@artsy/palette"
+import {
+  Clickable,
+  ClickableProps,
+  CloseIcon,
+  HeartFillIcon,
+  HeartIcon,
+} from "@artsy/palette"
 import React, { FC, useRef } from "react"
 import { useMode } from "Utils/Hooks/useMode"
 
 type Mode = "Pending" | "Animating" | "Done"
-
-interface ArtQuizButtonProps extends ClickableProps {
-  children: JSX.Element | ((props: { mode: Mode }) => JSX.Element)
-  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
-}
 
 const ANIMATION_DURATION = 250
 
@@ -23,7 +24,13 @@ const KEYFRAME_ANIMATION_OPTIONS: KeyframeAnimationOptions = {
   iterations: 1,
 }
 
+interface ArtQuizButtonProps extends ClickableProps {
+  variant: "Like" | "Dislike"
+  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
+}
+
 export const ArtQuizButton: FC<ArtQuizButtonProps> = ({
+  variant,
   children,
   onClick,
   ...rest
@@ -65,9 +72,18 @@ export const ArtQuizButton: FC<ArtQuizButtonProps> = ({
       py={4}
       px={6}
       onClick={handleClick}
+      aria-label={variant}
       {...rest}
     >
-      {typeof children === "function" ? children({ mode }) : children}
+      {variant === "Dislike" && <CloseIcon width={40} height={40} title="" />}
+
+      {variant === "Like" && mode === "Animating" && (
+        <HeartFillIcon width={40} height={40} title="" />
+      )}
+
+      {variant === "Like" && mode !== "Animating" && (
+        <HeartIcon width={40} height={40} title="" />
+      )}
     </Clickable>
   )
 }

--- a/src/Apps/ArtQuiz/Components/ArtQuizButton.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizButton.tsx
@@ -1,7 +1,6 @@
 import { Clickable, ClickableProps } from "@artsy/palette"
 import React, { FC, useRef } from "react"
 import { useMode } from "Utils/Hooks/useMode"
-import { wait } from "Utils/wait"
 
 type Mode = "Pending" | "Animating" | "Done"
 
@@ -27,6 +26,7 @@ const KEYFRAME_ANIMATION_OPTIONS: KeyframeAnimationOptions = {
 export const ArtQuizButton: FC<ArtQuizButtonProps> = ({
   children,
   onClick,
+  ...rest
 }) => {
   const [mode, setMode] = useMode<Mode>("Pending")
 
@@ -36,6 +36,9 @@ export const ArtQuizButton: FC<ArtQuizButtonProps> = ({
   const handleClick = async (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
+    // Click executes immediately
+    onClick(event)
+
     if (!nodeRef.current) return
 
     // Prevent animation pile ups
@@ -45,9 +48,6 @@ export const ArtQuizButton: FC<ArtQuizButtonProps> = ({
 
     setMode("Animating")
 
-    // Click executes immediately
-    onClick(event)
-
     // Animation plays on
     animationRef.current = nodeRef.current.animate(
       KEYFRAMES,
@@ -56,15 +56,17 @@ export const ArtQuizButton: FC<ArtQuizButtonProps> = ({
 
     await animationRef.current.finished
 
-    setMode("Done")
-
-    await wait(ANIMATION_DURATION)
-
     setMode("Pending")
   }
 
   return (
-    <Clickable ref={nodeRef as any} py={4} px={6} onClick={handleClick}>
+    <Clickable
+      ref={nodeRef as any}
+      py={4}
+      px={6}
+      onClick={handleClick}
+      {...rest}
+    >
       {typeof children === "function" ? children({ mode }) : children}
     </Clickable>
   )

--- a/src/Apps/ArtQuiz/Components/ArtQuizButton.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizButton.tsx
@@ -1,0 +1,71 @@
+import { Clickable, ClickableProps } from "@artsy/palette"
+import React, { FC, useRef } from "react"
+import { useMode } from "Utils/Hooks/useMode"
+import { wait } from "Utils/wait"
+
+type Mode = "Pending" | "Animating" | "Done"
+
+interface ArtQuizButtonProps extends ClickableProps {
+  children: JSX.Element | ((props: { mode: Mode }) => JSX.Element)
+  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
+}
+
+const ANIMATION_DURATION = 250
+
+const KEYFRAMES: Keyframe[] = [
+  { transform: "scale(1)" },
+  { transform: "scale(1.5)" },
+  { transform: "scale(1)" },
+]
+
+const KEYFRAME_ANIMATION_OPTIONS: KeyframeAnimationOptions = {
+  duration: ANIMATION_DURATION,
+  easing: "ease-out",
+  iterations: 1,
+}
+
+export const ArtQuizButton: FC<ArtQuizButtonProps> = ({
+  children,
+  onClick,
+}) => {
+  const [mode, setMode] = useMode<Mode>("Pending")
+
+  const nodeRef = useRef<HTMLButtonElement | null>(null)
+  const animationRef = useRef<Animation | null>(null)
+
+  const handleClick = async (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    if (!nodeRef.current) return
+
+    // Prevent animation pile ups
+    if (animationRef.current) {
+      animationRef.current.cancel()
+    }
+
+    setMode("Animating")
+
+    // Click executes immediately
+    onClick(event)
+
+    // Animation plays on
+    animationRef.current = nodeRef.current.animate(
+      KEYFRAMES,
+      KEYFRAME_ANIMATION_OPTIONS
+    )
+
+    await animationRef.current.finished
+
+    setMode("Done")
+
+    await wait(ANIMATION_DURATION)
+
+    setMode("Pending")
+  }
+
+  return (
+    <Clickable ref={nodeRef as any} py={4} px={6} onClick={handleClick}>
+      {typeof children === "function" ? children({ mode }) : children}
+    </Clickable>
+  )
+}

--- a/src/Apps/ArtQuiz/Components/ArtQuizCard.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizCard.tsx
@@ -1,0 +1,131 @@
+import { Box, BoxProps } from "@artsy/palette"
+import { FC, useReducer } from "react"
+import styled, { css } from "styled-components"
+
+export enum Mode {
+  Pending,
+  Active,
+  Liked,
+  Disliked,
+}
+
+interface ArtQuizCardProps extends BoxProps {
+  children: JSX.Element
+  mode: Mode
+}
+
+export const ArtQuizCard: FC<ArtQuizCardProps> = ({
+  children,
+  mode = Mode.Pending,
+  ...rest
+}) => {
+  return (
+    <Container mode={mode} {...rest}>
+      {children}
+    </Container>
+  )
+}
+
+const Container = styled(Box)<{ mode: Mode }>`
+  transition: transform 300ms ease-in-out, opacity 300ms ease-in-out;
+
+  ${({ mode }) => {
+    switch (mode) {
+      case Mode.Pending:
+        return css`
+          transform: translateX(0) scale(0.75) rotate(0deg);
+          opacity: 0;
+          z-index: 0;
+        `
+      case Mode.Active:
+        return css`
+          transform: translateX(0) scale(1) rotate(0deg);
+          opacity: 1;
+          z-index: 1;
+        `
+      case Mode.Liked:
+        return css`
+          transform: translateX(150%) scale(1) rotate(-5deg);
+          opacity: 0;
+          z-index: 1;
+        `
+      case Mode.Disliked:
+        return css`
+          transform: translateX(-150%) scale(1) rotate(5deg);
+          opacity: 0;
+          z-index: 1;
+        `
+    }
+  }}
+`
+
+interface State<T> {
+  index: number
+  cards: (T & { mode: Mode })[]
+}
+
+type Action =
+  | { type: "Next" }
+  | { type: "Previous" }
+  | { type: "Like" }
+  | { type: "Dislike" }
+
+const reducer = <T,>(state: State<T>, action: Action) => {
+  switch (action.type) {
+    case "Next":
+      return {
+        ...state,
+        index: state.index + 1,
+      }
+
+    case "Previous":
+      return {
+        ...state,
+        index: state.index - 1,
+      }
+
+    case "Like":
+      return {
+        ...state,
+        index: state.index + 1,
+        cards: state.cards.map((card, i) => {
+          if (i === state.index) {
+            return { ...card, mode: Mode.Liked }
+          }
+
+          return card
+        }),
+      }
+
+    case "Dislike":
+      return {
+        ...state,
+        index: state.index + 1,
+        cards: state.cards.map((card, i) => {
+          if (i === state.index) {
+            return { ...card, mode: Mode.Disliked }
+          }
+
+          return card
+        }),
+      }
+  }
+}
+
+interface UseArtQuizCards<T> {
+  cards: T[]
+}
+
+export const useArtQuizCards = <T,>({ cards = [] }: UseArtQuizCards<T>) => {
+  const [state, dispatch] = useReducer(reducer, {
+    cards: cards.map(card => ({ ...card, mode: Mode.Pending })),
+    index: 0,
+  })
+
+  return {
+    activeCard: state.cards[state.index] as T & { mode: Mode },
+    activeIndex: state.index,
+    cards: state.cards as (T & { mode: Mode })[],
+    dispatch,
+  }
+}

--- a/src/Apps/ArtQuiz/Components/ArtQuizMain.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizMain.tsx
@@ -5,9 +5,11 @@ import {
   CloseIcon,
   Flex,
   FullBleed,
+  HeartFillIcon,
   HeartIcon,
   Text,
 } from "@artsy/palette"
+import { ArtQuizButton } from "Apps/ArtQuiz/Components/ArtQuizButton"
 import { FC } from "react"
 import { RouterLink } from "System/Router/RouterLink"
 import { useRouter } from "System/Router/useRouter"
@@ -94,13 +96,19 @@ export const ArtQuizMain: FC<ArtQuizMainProps> = () => {
         </Flex>
 
         <Flex alignItems="stretch" justifyContent="center">
-          <Clickable py={4} px={6} onClick={onNext}>
+          <ArtQuizButton onClick={onNext}>
             <CloseIcon width={40} height={40} />
-          </Clickable>
+          </ArtQuizButton>
 
-          <Clickable py={4} px={6} onClick={onNext}>
-            <HeartIcon width={40} height={40} />
-          </Clickable>
+          <ArtQuizButton onClick={onNext}>
+            {({ mode }) => {
+              if (mode === "Done") {
+                return <HeartFillIcon width={40} height={40} />
+              }
+
+              return <HeartIcon width={40} height={40} />
+            }}
+          </ArtQuizButton>
         </Flex>
       </FullBleed>
     </>

--- a/src/Apps/ArtQuiz/Components/ArtQuizMain.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizMain.tsx
@@ -2,11 +2,8 @@ import {
   ArrowLeftIcon,
   Box,
   Clickable,
-  CloseIcon,
   Flex,
   FullBleed,
-  HeartFillIcon,
-  HeartIcon,
   Text,
 } from "@artsy/palette"
 import { ArtQuizButton } from "Apps/ArtQuiz/Components/ArtQuizButton"
@@ -127,19 +124,9 @@ export const ArtQuizMain: FC<ArtQuizMainProps> = () => {
         </Flex>
 
         <Flex alignItems="stretch" justifyContent="center">
-          <ArtQuizButton onClick={handleNext("Dislike")} aria-label="Dislike">
-            <CloseIcon width={40} height={40} />
-          </ArtQuizButton>
+          <ArtQuizButton variant="Dislike" onClick={handleNext("Dislike")} />
 
-          <ArtQuizButton onClick={handleNext("Like")} aria-label="Like">
-            {({ mode }) => {
-              if (mode === "Animating") {
-                return <HeartFillIcon width={40} height={40} title="" />
-              }
-
-              return <HeartIcon width={40} height={40} title="" />
-            }}
-          </ArtQuizButton>
+          <ArtQuizButton variant="Like" onClick={handleNext("Like")} />
         </Flex>
       </FullBleed>
     </>

--- a/src/Apps/ArtQuiz/Components/ArtQuizMain.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizMain.tsx
@@ -15,7 +15,8 @@ import {
   Mode,
   useArtQuizCards,
 } from "Apps/ArtQuiz/Components/ArtQuizCard"
-import { FC } from "react"
+import { useSwipe } from "Apps/ArtQuiz/Hooks/useSwipe"
+import { FC, useCallback } from "react"
 import { RouterLink } from "System/Router/RouterLink"
 import { useRouter } from "System/Router/useRouter"
 
@@ -42,15 +43,23 @@ export const ArtQuizMain: FC<ArtQuizMainProps> = () => {
     dispatch({ type: "Previous" })
   }
 
-  const handleNext = (action: "Like" | "Dislike") => () => {
-    if (activeIndex === cards.length - 1) {
-      router.push("/art-quiz/results")
+  const handleNext = useCallback(
+    (action: "Like" | "Dislike") => () => {
+      if (activeIndex === cards.length - 1) {
+        router.push("/art-quiz/results")
 
-      return
-    }
+        return
+      }
 
-    dispatch({ type: action })
-  }
+      dispatch({ type: action })
+    },
+    [activeIndex, cards.length, dispatch, router]
+  )
+
+  useSwipe({
+    onLeft: handleNext("Dislike"),
+    onRight: handleNext("Like"),
+  })
 
   return (
     <>

--- a/src/Apps/ArtQuiz/Components/ArtQuizMain.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizMain.tsx
@@ -10,38 +10,46 @@ import {
   Text,
 } from "@artsy/palette"
 import { ArtQuizButton } from "Apps/ArtQuiz/Components/ArtQuizButton"
+import {
+  ArtQuizCard,
+  Mode,
+  useArtQuizCards,
+} from "Apps/ArtQuiz/Components/ArtQuizCard"
 import { FC } from "react"
 import { RouterLink } from "System/Router/RouterLink"
 import { useRouter } from "System/Router/useRouter"
-import { useCursor } from "use-cursor"
 
-const TOTAL = 10
+const EXAMPLE_CARDS = [...new Array(16)].map(_ => ({
+  id: Math.random().toString(26).slice(2),
+}))
 
 interface ArtQuizMainProps {}
 
 export const ArtQuizMain: FC<ArtQuizMainProps> = () => {
   const { router } = useRouter()
 
-  const { handleNext, handlePrev, index } = useCursor({ max: TOTAL })
+  const { cards, activeIndex, dispatch } = useArtQuizCards({
+    cards: EXAMPLE_CARDS,
+  })
 
-  const onPrevious = () => {
-    if (index === 0) {
+  const handlePrevious = () => {
+    if (activeIndex === 0) {
       router.push("/art-quiz/welcome")
 
       return
     }
 
-    handlePrev()
+    dispatch({ type: "Previous" })
   }
 
-  const onNext = () => {
-    if (index === TOTAL - 1) {
+  const handleNext = (action: "Like" | "Dislike") => () => {
+    if (activeIndex === cards.length - 1) {
       router.push("/art-quiz/results")
 
       return
     }
 
-    handleNext()
+    dispatch({ type: action })
   }
 
   return (
@@ -49,7 +57,7 @@ export const ArtQuizMain: FC<ArtQuizMainProps> = () => {
       <FullBleed height="100%" display="flex" flexDirection="column">
         <Flex alignItems="stretch">
           <Clickable
-            onClick={onPrevious}
+            onClick={handlePrevious}
             p={4}
             flex={1}
             display="flex"
@@ -66,7 +74,7 @@ export const ArtQuizMain: FC<ArtQuizMainProps> = () => {
             alignItems="center"
             justifyContent="center"
           >
-            {index + 1} / {TOTAL}
+            {activeIndex + 1} / {cards.length}
           </Text>
 
           <RouterLink
@@ -82,31 +90,45 @@ export const ArtQuizMain: FC<ArtQuizMainProps> = () => {
           </RouterLink>
         </Flex>
 
-        <Flex justifyContent="center" alignItems="center" flex={1}>
-          <Box
-            width={400}
-            height={400}
-            bg="black10"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-          >
-            <Text variant="xxl">{index + 1}</Text>
-          </Box>
+        <Flex
+          position="relative"
+          justifyContent="center"
+          alignItems="center"
+          flex={1}
+          flexDirection="column"
+        >
+          {cards.map((card, i) => {
+            const mode = i === activeIndex ? Mode.Active : card.mode
+
+            return (
+              <ArtQuizCard key={card.id} mode={mode} position="absolute">
+                <Box
+                  width={400}
+                  height={400}
+                  bg="black10"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  <Text variant="xl">{card.id}</Text>
+                </Box>
+              </ArtQuizCard>
+            )
+          })}
         </Flex>
 
         <Flex alignItems="stretch" justifyContent="center">
-          <ArtQuizButton onClick={onNext}>
+          <ArtQuizButton onClick={handleNext("Dislike")} aria-label="Dislike">
             <CloseIcon width={40} height={40} />
           </ArtQuizButton>
 
-          <ArtQuizButton onClick={onNext}>
+          <ArtQuizButton onClick={handleNext("Like")} aria-label="Like">
             {({ mode }) => {
-              if (mode === "Done") {
-                return <HeartFillIcon width={40} height={40} />
+              if (mode === "Animating") {
+                return <HeartFillIcon width={40} height={40} title="" />
               }
 
-              return <HeartIcon width={40} height={40} />
+              return <HeartIcon width={40} height={40} title="" />
             }}
           </ArtQuizButton>
         </Flex>

--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsLoader.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsLoader.tsx
@@ -10,7 +10,6 @@ import {
 import { SplitLayout } from "Components/SplitLayout"
 import { useState, useEffect, FC } from "react"
 import { useTranslation } from "react-i18next"
-import { wait } from "Utils/wait"
 
 interface ArtQuizResultsLoaderProps {
   onReady(): void
@@ -24,17 +23,19 @@ export const ArtQuizResultsLoader: FC<ArtQuizResultsLoaderProps> = ({
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    const exec = async () => {
-      await wait(2000)
+    const timeouts: ReturnType<typeof setTimeout>[] = []
 
-      setLoading(false)
+    // TODO: Add support for cancellation in `wait` util
+    timeouts.push(
+      setTimeout(() => {
+        setLoading(false)
+        timeouts.push(setTimeout(onReady, 1000))
+      }, 2000)
+    )
 
-      await wait(1000)
-
-      onReady()
+    return () => {
+      timeouts.forEach(clearTimeout)
     }
-
-    exec()
   }, [onReady])
 
   return (

--- a/src/Apps/ArtQuiz/Hooks/useSwipe.ts
+++ b/src/Apps/ArtQuiz/Hooks/useSwipe.ts
@@ -1,0 +1,46 @@
+import { useEffect } from "react"
+
+interface UseSwipe {
+  onLeft: () => void
+  onRight: () => void
+  /** Distance in pixels to trigger swipe */
+  distance?: number
+}
+
+export const useSwipe = ({ onLeft, onRight, distance = 50 }: UseSwipe) => {
+  useEffect(() => {
+    let startX = 0
+    let endX = 0
+    let numberOfFingers = 0
+
+    const handleTouchStart = (event: TouchEvent) => {
+      numberOfFingers = event.touches.length
+      startX = event.changedTouches[0].clientX
+    }
+
+    const handleTouchEnd = (event: TouchEvent) => {
+      endX = event.changedTouches[0].clientX
+
+      // Ignore multi-touch
+      if (numberOfFingers !== 1) return
+
+      if (endX < startX && startX - endX > distance) {
+        onLeft()
+        return
+      }
+
+      if (endX > startX && endX - startX > distance) {
+        onRight()
+        return
+      }
+    }
+
+    document.addEventListener("touchstart", handleTouchStart)
+    document.addEventListener("touchend", handleTouchEnd)
+
+    return () => {
+      document.removeEventListener("touchstart", handleTouchStart)
+      document.removeEventListener("touchend", handleTouchEnd)
+    }
+  }, [distance, onLeft, onRight])
+}


### PR DESCRIPTION
I thought I'd open this early as draft and update it as I approach the problem, since we don't do animation that often.

I'm approaching this in 3 steps:
- [x] Animate the buttons
- [x] Animate the cards on desktop
- [x] Animate the cards on mobile via swipe

I'll be using the Web Animations API (edit: used simple transitions for the swipes for now), which is quite nice and well supported with our user base. I'll leave comments on these individual steps.