### PR TITLE
Revert "fix:prevent overlapping text on firefox"

### DIFF
--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtistList.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtistList.tsx
@@ -57,6 +57,7 @@ export const PartnerArtistList: React.FC<PartnerArtistListProps> = ({
                 height={OFFSET}
                 overflow="visible"
                 style={{
+                  breakBefore: "column",
                   whiteSpace: "nowrap",
                   transform: `translateY(-${OFFSET}px)`,
                 }}
@@ -102,7 +103,6 @@ export const PartnerArtistList: React.FC<PartnerArtistListProps> = ({
                 </RouterLink>
               )
             })}
-            <br />
           </React.Fragment>
         )
       })}


### PR DESCRIPTION
Reverts artsy/force#11498

The original fix breaks the column arrangement in Chrome:
![Ricardo Fernandes (1)](https://user-images.githubusercontent.com/7518671/207932486-477633d7-f1e8-464d-a1c2-d44b6cc7c41b.jpeg)

While not covering all cases in Firefox:
<img width="1783" alt="Screenshot 2022-12-15 at 14 45 31" src="https://user-images.githubusercontent.com/7518671/207932125-b1328c53-82d1-4ee7-9f1c-8508fa7eacf8.png">

Reverting the fix so we can return the proper display in Chrome while we figure out a cross-browser solution