### PR TITLE
feat(art-quiz): renders saved artworks

### DIFF
--- a/src/Apps/ArtQuiz/Components/ArtQuizLikedArtworks.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizLikedArtworks.tsx
@@ -1,0 +1,85 @@
+import { FC, Fragment } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import { ArtQuizLikedArtworks_me$data } from "__generated__/ArtQuizLikedArtworks_me.graphql"
+import { ArtQuizLikedArtworksQuery } from "__generated__/ArtQuizLikedArtworksQuery.graphql"
+import { extractNodes } from "Utils/extractNodes"
+import { Masonry } from "Components/Masonry"
+import ArtworkGridItemFragmentContainer from "Components/Artwork/GridItem"
+import { Spacer } from "@artsy/palette"
+import { ArtworkGridPlaceholder } from "Components/ArtworkGrid"
+
+interface ArtQuizLikedArtworksProps {
+  me: ArtQuizLikedArtworks_me$data
+}
+
+const ArtQuizLikedArtworks: FC<ArtQuizLikedArtworksProps> = ({ me }) => {
+  const artworks = extractNodes(me.quiz.quizArtworkConnection)
+  const likedArtworks = artworks.filter(artwork => artwork.isSaved)
+
+  return (
+    <Masonry columnCount={[2, 3, 4]}>
+      {likedArtworks.map(artwork => {
+        return (
+          <Fragment key={artwork.internalID}>
+            <ArtworkGridItemFragmentContainer artwork={artwork} />
+
+            <Spacer y={4} />
+          </Fragment>
+        )
+      })}
+    </Masonry>
+  )
+}
+
+const ArtQuizLikedArtworksFragmentContainer = createFragmentContainer(
+  ArtQuizLikedArtworks,
+  {
+    me: graphql`
+      fragment ArtQuizLikedArtworks_me on Me {
+        quiz {
+          quizArtworkConnection(first: 20) {
+            edges {
+              node {
+                ...GridItem_artwork
+                internalID
+                isSaved
+              }
+            }
+          }
+        }
+      }
+    `,
+  }
+)
+
+const ArtQuizLikedArtworksPlaceholder: FC = () => {
+  return <ArtworkGridPlaceholder columnCount={[2, 3, 4]} amount={6} />
+}
+
+export const ArtQuizLikedArtworksQueryRenderer = () => {
+  return (
+    <SystemQueryRenderer<ArtQuizLikedArtworksQuery>
+      placeholder={<ArtQuizLikedArtworksPlaceholder />}
+      query={graphql`
+        query ArtQuizLikedArtworksQuery {
+          me {
+            ...ArtQuizLikedArtworks_me
+          }
+        }
+      `}
+      render={({ props, error }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props || !props.me) {
+          return <ArtQuizLikedArtworksPlaceholder />
+        }
+
+        return <ArtQuizLikedArtworksFragmentContainer me={props.me} />
+      }}
+    />
+  )
+}

--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
@@ -1,4 +1,5 @@
 import { Button, Spacer, Tab, Tabs, Text, useToasts } from "@artsy/palette"
+import { ArtQuizLikedArtworksQueryRenderer } from "Apps/ArtQuiz/Components/ArtQuizLikedArtworks"
 import { FC } from "react"
 import { useTranslation } from "react-i18next"
 import { useSystemContext } from "System"
@@ -40,8 +41,12 @@ export const ArtQuizResultsTabs: FC = () => {
       <Spacer y={6} />
 
       <Tabs fill>
-        <Tab name={t("artQuizPage.results.tabs.worksYouLiked")} />
+        <Tab name={t("artQuizPage.results.tabs.worksYouLiked")}>
+          <ArtQuizLikedArtworksQueryRenderer />
+        </Tab>
+
         <Tab name={t("artQuizPage.results.tabs.recommendedCollections")} />
+
         <Tab name={t("artQuizPage.results.tabs.recommendedArtists")} />
       </Tabs>
     </>

--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
@@ -22,23 +22,29 @@ export const ArtQuizResultsTabs: FC = () => {
 
   return (
     <>
-      <Text mt={6} variant={["lg", "xl"]}>
+      <Spacer y={[4, 6]} />
+
+      <Text variant={["lg-display", "xl"]}>
         {t("artQuizPage.results.title")}
       </Text>
 
-      <Spacer y={1} />
+      <Spacer y={[0, 1]} />
 
-      <Text color="black60" variant={["sm", "md"]}>
+      <Text color="black60" variant={["lg-display", "md"]}>
         {t("artQuizPage.results.subtitle")}
       </Text>
 
-      <Spacer y={4} />
+      <Spacer y={[2, 4]} />
 
-      <Button variant="secondaryBlack" onClick={handleClick}>
+      <Button
+        variant="secondaryBlack"
+        size={["small", "large"]}
+        onClick={handleClick}
+      >
         {t("artQuizPage.results.emailButton")}
       </Button>
 
-      <Spacer y={6} />
+      <Spacer y={[4, 6]} />
 
       <Tabs fill>
         <Tab name={t("artQuizPage.results.tabs.worksYouLiked")}>

--- a/src/__generated__/ArtQuizLikedArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtQuizLikedArtworksQuery.graphql.ts
@@ -1,0 +1,559 @@
+/**
+ * @generated SignedSource<<1a049d387c1702e48b510c5905d5416d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtQuizLikedArtworksQuery$variables = {};
+export type ArtQuizLikedArtworksQuery$data = {
+  readonly me: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArtQuizLikedArtworks_me">;
+  } | null;
+};
+export type ArtQuizLikedArtworksQuery = {
+  response: ArtQuizLikedArtworksQuery$data;
+  variables: ArtQuizLikedArtworksQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v6 = [
+  (v3/*: any*/),
+  (v1/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtQuizLikedArtworksQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtQuizLikedArtworks_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtQuizLikedArtworksQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Quiz",
+            "kind": "LinkedField",
+            "name": "quiz",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 20
+                  }
+                ],
+                "concreteType": "QuizArtworkConnection",
+                "kind": "LinkedField",
+                "name": "quizArtworkConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "QuizArtworkEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "internalID",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "title",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "imageTitle",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "placeholder",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": [
+                                      "larger",
+                                      "large"
+                                    ]
+                                  }
+                                ],
+                                "kind": "ScalarField",
+                                "name": "url",
+                                "storageKey": "url(version:[\"larger\",\"large\"])"
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "aspectRatio",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "artistNames",
+                            "storageKey": null
+                          },
+                          (v0/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "date",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "sale_message",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "saleMessage",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "cultural_maker",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "culturalMaker",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artist",
+                            "kind": "LinkedField",
+                            "name": "artist",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "ArtistTargetSupply",
+                                "kind": "LinkedField",
+                                "name": "targetSupply",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isP1",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              (v1/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkPriceInsights",
+                            "kind": "LinkedField",
+                            "name": "marketPriceInsights",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "demandRank",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": (v2/*: any*/),
+                            "concreteType": "Artist",
+                            "kind": "LinkedField",
+                            "name": "artists",
+                            "plural": true,
+                            "selections": [
+                              (v1/*: any*/),
+                              (v0/*: any*/),
+                              (v3/*: any*/)
+                            ],
+                            "storageKey": "artists(shallow:true)"
+                          },
+                          {
+                            "alias": "collecting_institution",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "collectingInstitution",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": (v2/*: any*/),
+                            "concreteType": "Partner",
+                            "kind": "LinkedField",
+                            "name": "partner",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              (v0/*: any*/),
+                              (v1/*: any*/)
+                            ],
+                            "storageKey": "partner(shallow:true)"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Sale",
+                            "kind": "LinkedField",
+                            "name": "sale",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "cascadingEndTimeIntervalMinutes",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "extendedBiddingIntervalMinutes",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "startAt",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_auction",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isAuction",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_closed",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isClosed",
+                                "storageKey": null
+                              },
+                              (v1/*: any*/),
+                              {
+                                "alias": "is_preview",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isPreview",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "display_timely_at",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "displayTimelyAt",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "sale_artwork",
+                            "args": null,
+                            "concreteType": "SaleArtwork",
+                            "kind": "LinkedField",
+                            "name": "saleArtwork",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "lotID",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "lotLabel",
+                                "storageKey": null
+                              },
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "extendedBiddingEndAt",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "formattedEndDateTime",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "SaleArtworkCounts",
+                                "kind": "LinkedField",
+                                "name": "counts",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "bidder_positions",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "bidderPositions",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "highest_bid",
+                                "args": null,
+                                "concreteType": "SaleArtworkHighestBid",
+                                "kind": "LinkedField",
+                                "name": "highestBid",
+                                "plural": false,
+                                "selections": (v5/*: any*/),
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "opening_bid",
+                                "args": null,
+                                "concreteType": "SaleArtworkOpeningBid",
+                                "kind": "LinkedField",
+                                "name": "openingBid",
+                                "plural": false,
+                                "selections": (v5/*: any*/),
+                                "storageKey": null
+                              },
+                              (v1/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          (v1/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "slug",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_saved",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isSaved",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "AttributionClass",
+                            "kind": "LinkedField",
+                            "name": "attributionClass",
+                            "plural": false,
+                            "selections": (v6/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkMedium",
+                            "kind": "LinkedField",
+                            "name": "mediumType",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Gene",
+                                "kind": "LinkedField",
+                                "name": "filterGene",
+                                "plural": false,
+                                "selections": (v6/*: any*/),
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_biddable",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isBiddable",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isSaved",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "quizArtworkConnection(first:20)"
+              },
+              (v1/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "97d789fd3e2ef4bf98b6574d25d9dcfa",
+    "id": null,
+    "metadata": {},
+    "name": "ArtQuizLikedArtworksQuery",
+    "operationKind": "query",
+    "text": "query ArtQuizLikedArtworksQuery {\n  me {\n    ...ArtQuizLikedArtworks_me\n    id\n  }\n}\n\nfragment ArtQuizLikedArtworks_me on Me {\n  quiz {\n    quizArtworkConnection(first: 20) {\n      edges {\n        node {\n          ...GridItem_artwork\n          internalID\n          isSaved\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image {\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "bf734ace5f5172652927bf33442cf6fd";
+
+export default node;

--- a/src/__generated__/ArtQuizLikedArtworks_me.graphql.ts
+++ b/src/__generated__/ArtQuizLikedArtworks_me.graphql.ts
@@ -1,0 +1,114 @@
+/**
+ * @generated SignedSource<<90791b712ec54cb62a61211c69ad8128>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtQuizLikedArtworks_me$data = {
+  readonly quiz: {
+    readonly quizArtworkConnection: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly internalID: string;
+          readonly isSaved: boolean | null;
+          readonly " $fragmentSpreads": FragmentRefs<"GridItem_artwork">;
+        } | null;
+      } | null> | null;
+    } | null;
+  };
+  readonly " $fragmentType": "ArtQuizLikedArtworks_me";
+};
+export type ArtQuizLikedArtworks_me$key = {
+  readonly " $data"?: ArtQuizLikedArtworks_me$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ArtQuizLikedArtworks_me">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArtQuizLikedArtworks_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Quiz",
+      "kind": "LinkedField",
+      "name": "quiz",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 20
+            }
+          ],
+          "concreteType": "QuizArtworkConnection",
+          "kind": "LinkedField",
+          "name": "quizArtworkConnection",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "QuizArtworkEdge",
+              "kind": "LinkedField",
+              "name": "edges",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Artwork",
+                  "kind": "LinkedField",
+                  "name": "node",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "GridItem_artwork"
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "internalID",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "isSaved",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": "quizArtworkConnection(first:20)"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+
+(node as any).hash = "bf4cf7ee03d38f2a250c0a606a42928e";
+
+export default node;


### PR DESCRIPTION
Closes [GRO-1259](https://artsyproduct.atlassian.net/browse/GRO-1259)

![](https://static.damonzucconi.com/_capture/FmzSMjzM.png)

-----

Outside chance I'll be forced to rewrite our Masonry grid component to handle the sort order correctly because the legacy ArtworkGrid isn't compatible with this connection type and is a mess. But we'll see how that plays out.