### PR TITLE
fix(appshell): fixes double scroll area on footer-less pages

### DIFF
--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -92,7 +92,9 @@ export const AppShell: React.FC<AppShellProps> = props => {
         flex={1}
       >
         <AppContainer maxWidth={appContainerMaxWidth}>
-          <HorizontalPadding height="100%">{children}</HorizontalPadding>
+          <HorizontalPadding height="100%" overflow="hidden">
+            {children}
+          </HorizontalPadding>
         </AppContainer>
       </Flex>
 


### PR DESCRIPTION
Minor thing I noticed: with `hideFooter: true` the `HorizontalPadding` div would collapse a bit and create an overlapping scrollable div.