### PR TITLE
feat(TX-962): Prompt users to fix their number while editing an address

### DIFF
--- a/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
+++ b/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
@@ -51,6 +51,17 @@ const VALIDATION_SCHEMA = Yup.object().shape({
     phoneNumber: Yup.string()
       .required("Phone Number is required")
       .test({
+        name: "national-number-is-pure",
+        message:
+          "Please remove the country code from your number and select it on the left",
+        test: national => {
+          if (national?.includes("+")) {
+            return false
+          }
+          return true
+        },
+      })
+      .test({
         name: "phone-number-is-valid",
         message: "Please enter a valid phone number",
         test: (national, context) => {
@@ -310,7 +321,7 @@ export const SettingsShippingAddressForm: FC<SettingsShippingAddressFormProps> =
                       name: "attributes.phoneNumber",
                       onBlur: handleBlur,
                       onChange: handleChange,
-                      placeholder: "(000) 000 0000",
+                      placeholder: "000 000 0000",
                       value: values.attributes.phoneNumber,
                     }}
                     selectProps={{

--- a/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
+++ b/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
@@ -54,12 +54,7 @@ const VALIDATION_SCHEMA = Yup.object().shape({
         name: "national-number-is-pure",
         message:
           "Please remove the country code from your number and select it on the left",
-        test: national => {
-          if (national?.includes("+")) {
-            return false
-          }
-          return true
-        },
+        test: national => !national?.includes("+"),
       })
       .test({
         name: "phone-number-is-valid",


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [TX-962]

### Description
This PR adds a simple validation case for the phone number input in user settings' saved addresses. 

When a user is trying to edit their previously saved address and they have a single string with country code saved on that address, the phone number input looks like +1 +1XXXX, like so: 
<img width="755" alt="Screenshot 2022-12-16 at 13 33 05" src="https://user-images.githubusercontent.com/42584148/208099138-7a9d6d5b-a102-4c1d-98b1-240694f14703.png">

Although this is not a severe problem, it's not ideal – especially considering the fact that the address might be used to make a purchase and the phone number might be passed to 3rd parties like ARTA. 

This PR adds a validation that if the national number includes + sign, we are prompting the user to remove it and select it from the countries dropdown. 
<img width="745" alt="Screenshot 2022-12-16 at 13 34 24" src="https://user-images.githubusercontent.com/42584148/208099473-09d473e6-2cb3-4d23-9869-d49d46d03422.png">



[TX-962]: https://artsyproduct.atlassian.net/browse/TX-962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ