### PR TITLE
fix: Use fallback cards when segment is never ready GRO-1474

### DIFF
--- a/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
@@ -30,6 +30,18 @@ export const HomeContentCards: React.FC = () => {
   const cardsLengthRef = useRef(cards.length)
 
   useEffect(() => {
+    const overallTimeout = setTimeout(() => {
+      if (cardsLengthRef.current > 0) return
+
+      setRenderFallback(true)
+    }, timeoutAmount)
+
+    return () => {
+      clearTimeout(overallTimeout)
+    }
+  }, [timeoutAmount])
+
+  useEffect(() => {
     if (appboy) return
 
     if (window.appboy) {
@@ -56,7 +68,7 @@ export const HomeContentCards: React.FC = () => {
       setCards(sortedCards as Braze.CaptionedImage[])
     })
 
-    const timeout = setTimeout(() => {
+    const brazeTimeout = setTimeout(() => {
       if (cardsLengthRef.current > 0) return
 
       appboy.removeSubscription(subscriptionId)
@@ -67,14 +79,14 @@ export const HomeContentCards: React.FC = () => {
 
     return () => {
       appboy.removeSubscription(subscriptionId)
-      clearTimeout(timeout)
+      clearTimeout(brazeTimeout)
     }
   }, [appboy, timeoutAmount])
 
   const hasBrazeCards = appboy && cardsLengthRef.current > 0
 
-  if (!hasBrazeCards)
-    return renderFallback ? <FallbackCards /> : <PlaceholderCards />
+  if (renderFallback) return <FallbackCards />
+  if (!hasBrazeCards) return <PlaceholderCards />
 
   return <BrazeCards appboy={appboy} cards={cards} />
 }

--- a/src/Apps/Home/Components/HomeContentCards/__tests__/HomeContentCards.jest.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/__tests__/HomeContentCards.jest.tsx
@@ -41,6 +41,19 @@ describe("HomeContentCards", () => {
     expect(screen.getByText("FallbackCards")).toBeInTheDocument()
   })
 
+  it("switches to fallback cards when segment is never ready", () => {
+    window.appboy = undefined as any
+
+    window.analytics = {
+      ready: () => {},
+    } as any
+
+    render(<HomeContentCards />)
+    expect(screen.getByText("PlaceholderCards")).toBeInTheDocument()
+    jest.advanceTimersByTime(DEFAULT_TIMEOUT_AMOUNT)
+    expect(screen.getByText("FallbackCards")).toBeInTheDocument()
+  })
+
   it("switches to fallback cards when appboy never shows up", () => {
     const artificialSegmentDelay = 10
     window.appboy = undefined as any


### PR DESCRIPTION
We were able to reproduce this situation by returning an empty array of destinations and then supplying the Segment load function with an invalid write key. This sorta simulates getting Segment to be truthy but for the actual ready function to never fire. Ad blockers gonna block?

When I was pairing with @dzucconi we discussed whether that `brazeTimeout` is actually required and his feeling was that it would never do anything. I'm hesitant to remove it and I don't believe it will hurt anything so I'm leaving it but it's possible we could simplify things here by only having a single timeout. Seems like we should make incremental changes here on a Friday in the hopes of improving things and not introducing any regressions but maybe I'm being too cautious! 😝 

https://artsyproduct.atlassian.net/browse/GRO-1474

/cc @artsy/grow-devs @gkartalis @jpoczik 