### PR TITLE
chore: Migrate to latest Braze sdk GRO-1327

### DIFF
--- a/src/Apps/Home/Components/HomeContentCards/BrazeCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/BrazeCards.tsx
@@ -4,21 +4,21 @@ import Braze from "@braze/web-sdk"
 import { HomeContentCard } from "./HomeContentCard"
 
 interface BrazeCardsProps {
-  appboy: typeof Braze
+  braze: typeof Braze
   cards: Braze.CaptionedImage[]
 }
 
-export const BrazeCards: React.FC<BrazeCardsProps> = ({ appboy, cards }) => {
+export const BrazeCards: React.FC<BrazeCardsProps> = ({ braze, cards }) => {
   const handleChange = index => {
     const card = cards[index]
-    appboy.logCardImpressions([card])
+    braze.logCardImpressions([card])
   }
 
   return (
     <HeroCarousel onChange={handleChange}>
       {cards.map((card, index) => {
         const handleClick = () => {
-          appboy.logCardClick(card)
+          braze.logCardClick(card)
         }
 
         return (

--- a/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
@@ -25,7 +25,7 @@ export const HomeContentCards: React.FC = () => {
   const timeoutAmount = brazeTimeoutAmount ?? DEFAULT_TIMEOUT_AMOUNT
 
   const [renderFallback, setRenderFallback] = useState(false)
-  const [appboy, setAppboy] = useState<typeof Braze | null>(null)
+  const [braze, setBraze] = useState<typeof Braze | undefined>(undefined)
   const [cards, setCards] = useState<Braze.CaptionedImage[]>([])
   const cardsLengthRef = useRef(cards.length)
 
@@ -42,27 +42,27 @@ export const HomeContentCards: React.FC = () => {
   }, [timeoutAmount])
 
   useEffect(() => {
-    if (appboy) return
+    if (braze) return
 
-    if (window.appboy) {
-      setAppboy(window.appboy)
+    if (window.braze) {
+      setBraze(window.braze)
     } else if (window.analytics) {
       window.analytics.ready(() => {
-        !window.appboy && setRenderFallback(true)
-        setAppboy(window.appboy)
+        !window.braze && setRenderFallback(true)
+        setBraze(window.braze)
       })
     } else {
       setRenderFallback(true)
     }
-  }, [appboy])
+  }, [braze])
 
   useEffect(() => {
-    if (!appboy) return
+    if (!braze) return
 
-    const subscriptionId = appboy.subscribeToContentCardsUpdates(() => {
+    const subscriptionId = braze.subscribeToContentCardsUpdates(() => {
       if (cardsLengthRef.current > 0) return
 
-      const response = appboy.getCachedContentCards()
+      const response = braze.getCachedContentCards()
       const sortedCards = response.cards.sort(sortCards)
       cardsLengthRef.current = sortedCards.length
       setCards(sortedCards as Braze.CaptionedImage[])
@@ -71,24 +71,24 @@ export const HomeContentCards: React.FC = () => {
     const brazeTimeout = setTimeout(() => {
       if (cardsLengthRef.current > 0) return
 
-      appboy.removeSubscription(subscriptionId)
+      braze.removeSubscription(subscriptionId)
       setRenderFallback(true)
     }, timeoutAmount)
 
-    appboy.requestContentCardsRefresh()
+    braze.requestContentCardsRefresh()
 
     return () => {
-      appboy.removeSubscription(subscriptionId)
+      braze.removeSubscription(subscriptionId)
       clearTimeout(brazeTimeout)
     }
-  }, [appboy, timeoutAmount])
+  }, [braze, timeoutAmount])
 
-  const hasBrazeCards = appboy && cardsLengthRef.current > 0
+  const hasBrazeCards = braze && cardsLengthRef.current > 0
 
   if (renderFallback) return <FallbackCards />
   if (!hasBrazeCards) return <PlaceholderCards />
 
-  return <BrazeCards appboy={appboy} cards={cards} />
+  return <BrazeCards braze={braze} cards={cards} />
 }
 
 export const SafeHomeContentCards = () => {

--- a/src/Apps/Home/Components/HomeContentCards/__tests__/HomeContentCards.jest.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/__tests__/HomeContentCards.jest.tsx
@@ -22,7 +22,7 @@ describe("HomeContentCards", () => {
   beforeEach(() => {
     window.analytics = { ready: callback => callback() } as any
 
-    window.appboy = {
+    window.braze = {
       removeSubscription: jest.fn(),
       requestContentCardsRefresh: jest.fn(),
       subscribeToContentCardsUpdates: jest.fn(),
@@ -42,7 +42,7 @@ describe("HomeContentCards", () => {
   })
 
   it("switches to fallback cards when segment is never ready", () => {
-    window.appboy = undefined as any
+    window.braze = undefined
 
     window.analytics = {
       ready: () => {},
@@ -54,9 +54,9 @@ describe("HomeContentCards", () => {
     expect(screen.getByText("FallbackCards")).toBeInTheDocument()
   })
 
-  it("switches to fallback cards when appboy never shows up", () => {
+  it("switches to fallback cards when braze never shows up", () => {
     const artificialSegmentDelay = 10
-    window.appboy = undefined as any
+    window.braze = undefined
 
     window.analytics = {
       ready: callback => {
@@ -74,8 +74,8 @@ describe("HomeContentCards", () => {
 
   it("renders braze cards when they are returned", () => {
     const mockUpdater = callback => callback()
-    window.appboy.subscribeToContentCardsUpdates = mockUpdater
-    window.appboy.getCachedContentCards = () => ({ cards: [{}] } as any)
+    window.braze!.subscribeToContentCardsUpdates = mockUpdater
+    window.braze!.getCachedContentCards = () => ({ cards: [{}] } as any)
 
     render(<HomeContentCards />)
 

--- a/src/Server/analytics/brazeMessagingIntegration.ts
+++ b/src/Server/analytics/brazeMessagingIntegration.ts
@@ -31,20 +31,13 @@ export const isMatchingRoute = (pathname): boolean => {
  * Subscribe valid paths to Braze In-App Messages
  */
 export const subscribeToInAppMessagesByPath = () => {
-  const { analytics, appboy, location } = window as typeof window & {
-    appboy: any
-  }
+  const { analytics, braze, location } = window
 
-  if (!analytics || !appboy || !location) return
+  if (!analytics || !braze || !location) return
 
-  appboy.subscribeToNewInAppMessages(inAppMessages => {
-    if (inAppMessages.length < 1 || !isMatchingRoute(location.pathname)) {
-      return inAppMessages
-    }
+  braze.subscribeToInAppMessage(inAppMessage => {
+    if (!isMatchingRoute(location.pathname)) return
 
-    appboy.display.showInAppMessage(inAppMessages[0])
-    {
-      return inAppMessages.slice(1)
-    }
+    braze.showInAppMessage(inAppMessage)
   })
 }

--- a/src/Server/analytics/segmentOneTrustIntegration/setSegmentDestinationPref.ts
+++ b/src/Server/analytics/segmentOneTrustIntegration/setSegmentDestinationPref.ts
@@ -8,6 +8,7 @@ export function setSegmentDestinationPref(
     AdWords: "C0004",
     "Amazon S3": "C0001",
     Appboy: "C0001",
+    "Braze Web Mode (Actions)": "C0001",
     "Facebook Pixel": "C0004",
     "Google Analytics": "C0002",
     Indicative: "C0002",

--- a/src/Typings/global.d.ts
+++ b/src/Typings/global.d.ts
@@ -38,7 +38,7 @@ declare global {
     __RELAY_BOOTSTRAP__: string
     _sift: any
     analytics: any
-    appboy: typeof Braze
+    braze?: typeof Braze
     desktopPageTimeTrackers: [{ path: string; reset: (path) => void }]
     grecaptcha: any
     OnetrustActiveGroups: string


### PR DESCRIPTION
This PR gets Force ready to use the latest Braze web sdk. The biggest change is that they renamed from `window.appboy` to `window.braze` but there were also a few breaking changes that this PR fixes. I have verified that the names of the cookies have NOT changed so nothing is needed to be done to add new cookies to our safelist.

Note: this will break things on production for some non-zero amount of time. Once this lands on production, then I will:

1. Sign into Segment's dashboard
2. Disable the old Braze integration for force-production
3. Enable the new Braze integration for force-production

Once the destinations have been updated then `window.braze` will be populated and we will have successfully migrated and Jon can go lay down. 😅 I'm assigning to myself and will usher this through tomorrow morning.

https://artsyproduct.atlassian.net/browse/GRO-1327

/cc @artsy/grow-devs @artsyjian 