### PR TITLE
fix(NX-3342): artwork detail wasn't closable on medium-size screens

### DIFF
--- a/src/Apps/Conversation/Components/ConversationHeader.tsx
+++ b/src/Apps/Conversation/Components/ConversationHeader.tsx
@@ -91,7 +91,22 @@ const LargeConversationHeader: FC<ConversationHeaderProps> = props => {
             <>{props.children}</>
           )}
         </Box>
-        <DetailIcon showDetails={showDetails} setShowDetails={setShowDetails} />
+        <Media lessThan="xl">
+          <DetailIcon
+            showDetails={showDetails}
+            setShowDetails={setShowDetails}
+          />
+        </Media>
+        {/* When opened, DetailsSidebar is positioned on top of the messages (on XL
+        layouts only). In those cases, DetailsHeader is redundant with DetailIcon */}
+        <Media at="xl">
+          {!showDetails && (
+            <DetailIcon
+              showDetails={showDetails}
+              setShowDetails={setShowDetails}
+            />
+          )}
+        </Media>
       </Flex>
       <Separator />
     </Flex>

--- a/src/Apps/Conversation/Components/DetailsHeader.tsx
+++ b/src/Apps/Conversation/Components/DetailsHeader.tsx
@@ -8,9 +8,11 @@ import {
   Box,
   InfoCircleIcon,
   Clickable,
+  themeProps,
 } from "@artsy/palette"
 
 import { LARGE_SCREEN_HEADER_HEIGHT } from "./ConversationHeader"
+import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 
 export interface DetailsProps {
   showDetails: boolean
@@ -21,15 +23,23 @@ interface DetailsHeaderProps extends DetailsProps {}
 
 export const DetailsHeader: FC<DetailsHeaderProps> = props => {
   const { showDetails, setShowDetails } = props
+  const isMobile =
+    __internal__useMatchMedia(themeProps.mediaQueries.xs) ||
+    __internal__useMatchMedia(themeProps.mediaQueries.sm)
+
+  if (isMobile) {
+    return null
+  }
+
   return (
     <StackableBorderBox
       p={0}
       flexDirection="column"
       width={showDetails ? "376px" : "0"}
       maxWidth={showDetails ? "auto" : "0"}
-      display={["none", "none", "flex", "flex", "flex"]}
       {...props}
       borderTop="none !important"
+      borderBottom="none !important"
     >
       <Flex
         flexDirection="row"
@@ -54,8 +64,16 @@ export const DetailsHeader: FC<DetailsHeaderProps> = props => {
 
 export const DetailIcon: React.FC<DetailsProps> = props => {
   const { showDetails, setShowDetails } = props
+  const isXL = __internal__useMatchMedia(themeProps.mediaQueries.xl)
+
+  // When opened, DetailsSidebar is positioned on top of the messages (on XL
+  // layouts only). In those cases, DetailsHeader is redundant with DetailIcon
+  if (showDetails && isXL) {
+    return null
+  }
+
   return (
-    <Box display={["initial", "initial", showDetails ? "none" : "inline"]}>
+    <Box>
       <Flex flexDirection="row" alignItems="center" pr={1}>
         <InfoCircleIcon />
         <Clickable cursor="pointer" textDecoration="underline">

--- a/src/Apps/Conversation/Components/DetailsHeader.tsx
+++ b/src/Apps/Conversation/Components/DetailsHeader.tsx
@@ -39,7 +39,6 @@ export const DetailsHeader: FC<DetailsHeaderProps> = props => {
       maxWidth={showDetails ? "auto" : "0"}
       {...props}
       borderTop="none !important"
-      borderBottom="none !important"
     >
       <Flex
         flexDirection="row"

--- a/src/Apps/Conversation/Components/DetailsHeader.tsx
+++ b/src/Apps/Conversation/Components/DetailsHeader.tsx
@@ -8,11 +8,10 @@ import {
   Box,
   InfoCircleIcon,
   Clickable,
-  themeProps,
 } from "@artsy/palette"
 
 import { LARGE_SCREEN_HEADER_HEIGHT } from "./ConversationHeader"
-import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
+import { Media } from "Utils/Responsive"
 
 export interface DetailsProps {
   showDetails: boolean
@@ -23,54 +22,40 @@ interface DetailsHeaderProps extends DetailsProps {}
 
 export const DetailsHeader: FC<DetailsHeaderProps> = props => {
   const { showDetails, setShowDetails } = props
-  const isMobile =
-    __internal__useMatchMedia(themeProps.mediaQueries.xs) ||
-    __internal__useMatchMedia(themeProps.mediaQueries.sm)
-
-  if (isMobile) {
-    return null
-  }
-
   return (
-    <StackableBorderBox
-      p={0}
-      flexDirection="column"
-      width={showDetails ? "376px" : "0"}
-      maxWidth={showDetails ? "auto" : "0"}
-      {...props}
-      borderTop="none !important"
-    >
-      <Flex
-        flexDirection="row"
-        height={LARGE_SCREEN_HEADER_HEIGHT}
-        justifyContent="space-between"
-        alignItems="flex-end"
-        pb={1}
+    <Media greaterThan="sm">
+      <StackableBorderBox
+        p={0}
+        flexDirection="column"
+        width={showDetails ? "376px" : "0"}
+        maxWidth={showDetails ? "auto" : "0"}
+        {...props}
+        borderTop="none !important"
       >
-        <Text variant="sm-display" ml={2}>
-          Details
-        </Text>
-        <CloseIcon
-          mr={1}
-          mt={0.5}
-          cursor="pointer"
-          onClick={() => setShowDetails(false)}
-        />
-      </Flex>
-    </StackableBorderBox>
+        <Flex
+          flexDirection="row"
+          height={LARGE_SCREEN_HEADER_HEIGHT}
+          justifyContent="space-between"
+          alignItems="flex-end"
+          pb={1}
+        >
+          <Text variant="sm-display" ml={2}>
+            Details
+          </Text>
+          <CloseIcon
+            mr={1}
+            mt={0.5}
+            cursor="pointer"
+            onClick={() => setShowDetails(false)}
+          />
+        </Flex>
+      </StackableBorderBox>
+    </Media>
   )
 }
 
 export const DetailIcon: React.FC<DetailsProps> = props => {
   const { showDetails, setShowDetails } = props
-  const isXL = __internal__useMatchMedia(themeProps.mediaQueries.xl)
-
-  // When opened, DetailsSidebar is positioned on top of the messages (on XL
-  // layouts only). In those cases, DetailsHeader is redundant with DetailIcon
-  if (showDetails && isXL) {
-    return null
-  }
-
   return (
     <Box>
       <Flex flexDirection="row" alignItems="center" pr={1}>


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [NX-3342]

### Description

<!-- Implementation description -->

- There was a mismatch between:
    - when we showed the sidebar positioned as absolute, and
    - when we showed the sidebar header to make it closable.
- The reason seems to be that using different values on the attributes (i.e.: `display={["none", "none", "flex", "flex"]`) wasn't applying the changes at the same widths as `breakpoints`. We use breakpoints to change the `position` of the sidebar ([see here](https://github.com/artsy/force/blob/main/src/Apps/Conversation/Components/DetailsSidebar.tsx#L34-L68))
- I made sure either DetailsHeader or DetailIcon is always visible (both allow you to close the sidebar)
- For that, I rewrote those attributes' media queries with useMatchMedia (still client-side queries), to match:
    - when the sidebar positions `absolute` covering the Details button,
    - then display the sidebar header with the X button
    - and vice versa

**Before**
<img width="1147" alt="image" src="https://user-images.githubusercontent.com/265560/208631591-02afb4e4-5e1b-48ca-afdf-2883cbc53aae.png">

**After**
| | xs / sm | md / lg | xl |
| --- | --- | --- | --- |
| Closed | <img width="779" alt="image" src="https://user-images.githubusercontent.com/265560/208630809-3381b9b3-0bbc-4de1-9cc6-cd52a2f150e7.png"> | <img width="1278" alt="image" src="https://user-images.githubusercontent.com/265560/208631089-02fa9468-2d9a-48f4-9ef0-1c1da0d8a3e1.png"> | <img width="1792" alt="image" src="https://user-images.githubusercontent.com/265560/208631260-fe1764b9-26e7-4f2e-8057-71f492efa998.png"> |
| Open | <img width="778" alt="image" src="https://user-images.githubusercontent.com/265560/208630904-28aac34f-2700-4983-a6ce-ff9ad2593730.png"> | <img width="1278" alt="image" src="https://user-images.githubusercontent.com/265560/208631007-70433820-750d-409f-a5b0-f6f03a38a940.png"> | <img width="1792" alt="image" src="https://user-images.githubusercontent.com/265560/208631361-663a8a1e-086e-4737-b612-666f42314d44.png"> |

cc @artsy/negotiate-devs 

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NX-3342]: https://artsyproduct.atlassian.net/browse/NX-3342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ