### PR TITLE
feat(art-quiz): trigger button animations on swipe

### DIFF
--- a/src/Apps/ArtQuiz/ArtQuizApp.tsx
+++ b/src/Apps/ArtQuiz/ArtQuizApp.tsx
@@ -1,4 +1,6 @@
 import { Box } from "@artsy/palette"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import { MetaTags } from "Components/MetaTags"
 import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
 import { FC } from "react"
@@ -11,8 +13,20 @@ export const ArtQuizApp: FC = ({ children }) => {
       <MetaTags title="Art Taste Quiz | Artsy" />
 
       {/* TODO: Remove once we implement a footer-less layout that allows for filling out the height */}
-      <Box position="fixed" top={height} right={0} bottom={0} left={0}>
-        {children}
+      <Box
+        position="fixed"
+        top={height}
+        right={0}
+        bottom={0}
+        left={0}
+        overflow="auto"
+        style={{
+          WebkitOverflowScrolling: "touch",
+        }}
+      >
+        <AppContainer height="100%">
+          <HorizontalPadding height="100%">{children}</HorizontalPadding>
+        </AppContainer>
       </Box>
     </>
   )

--- a/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
@@ -9,7 +9,10 @@ import {
   FullBleed,
   Text,
 } from "@artsy/palette"
-import { ArtQuizButton } from "Apps/ArtQuiz/Components/ArtQuizButton"
+import {
+  ArtQuizButton,
+  ArtQuizButtonRef,
+} from "Apps/ArtQuiz/Components/ArtQuizButton"
 import {
   ArtQuizCard,
   Mode,
@@ -18,7 +21,7 @@ import {
 import { useSwipe } from "Apps/ArtQuiz/Hooks/useSwipe"
 import { useDislikeArtwork } from "Apps/ArtQuiz/Hooks/useDislikeArtwork"
 import { useSaveArtwork } from "Components/Artwork/SaveButton/useSaveArtwork"
-import { FC, useCallback } from "react"
+import { FC, useCallback, useRef } from "react"
 import { RouterLink } from "System/Router/RouterLink"
 import { useRouter } from "System/Router/useRouter"
 import { FullscreenBox } from "Components/FullscreenBox"
@@ -98,9 +101,20 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
     ]
   )
 
+  const dislikeRef = useRef<ArtQuizButtonRef | null>(null)
+  const likeRef = useRef<ArtQuizButtonRef | null>(null)
+
   useSwipe({
-    onLeft: handleNext("Dislike"),
-    onRight: handleNext("Like"),
+    onLeft: () => {
+      if (!dislikeRef.current) return
+      handleNext("Dislike")()
+      dislikeRef.current.triggerAnimation()
+    },
+    onRight: () => {
+      if (!likeRef.current) return
+      handleNext("Like")()
+      likeRef.current.triggerAnimation()
+    },
   })
 
   return (
@@ -181,9 +195,17 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
         </Flex>
 
         <Flex alignItems="stretch" justifyContent="center">
-          <ArtQuizButton variant="Dislike" onClick={handleNext("Dislike")} />
+          <ArtQuizButton
+            ref={dislikeRef}
+            variant="Dislike"
+            onClick={handleNext("Dislike")}
+          />
 
-          <ArtQuizButton variant="Like" onClick={handleNext("Like")} />
+          <ArtQuizButton
+            ref={likeRef}
+            variant="Like"
+            onClick={handleNext("Like")}
+          />
         </Flex>
       </FullBleed>
     </>


### PR DESCRIPTION
Just remembered this little missing piece. Turns out to be the first time I've ever had a need for the [`useImperitiveHandle`](https://beta.reactjs.org/apis/react/useImperativeHandle) hook... so that's semi-interesting.

https://user-images.githubusercontent.com/112297/208749448-99808ab4-9747-431b-8579-5b5d6c5627d3.mov

-----

@laurabeth I'll just wait for https://github.com/artsy/force/pull/11599 to be merged and will rebase and fix the conflicts.