### PR TITLE
fix(app-shell): temporarily removes height/overflow

### DIFF
--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -92,9 +92,7 @@ export const AppShell: React.FC<AppShellProps> = props => {
         flex={1}
       >
         <AppContainer maxWidth={appContainerMaxWidth}>
-          <HorizontalPadding height="100%" overflow="hidden">
-            {children}
-          </HorizontalPadding>
+          <HorizontalPadding>{children}</HorizontalPadding>
         </AppContainer>
       </Flex>
 


### PR DESCRIPTION
Removing this temporarily as it's effecting the `clip` usage in the `FullBleedHeader` (interesting). I'm going to do a bit more of a comprehensive overhaul of the way the `AppShell` is structured along with some test routes and stories. This was only added to support the art-quiz; which isn't in production yet. So I'll just get that back to normal tomorrow morning.