### PR TITLE
feat(CX-3255): Add tracking to edit profile page

### DIFF
--- a/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileFields.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileFields.tsx
@@ -15,6 +15,7 @@ import {
   SettingsEditProfileImageFragmentContainer,
   SettingsEditProfileImageRef,
 } from "Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileImage/SettingsEditProfileImage"
+import { useEditProfileTracking } from "Apps/Settings/Routes/EditProfile/Hooks/useEditProfileTracking"
 import {
   LocationAutocompleteInput,
   normalizePlace,
@@ -57,6 +58,7 @@ const SettingsEditProfileFields: React.FC<SettingsEditProfileFieldsProps> = ({
   const { sendToast } = useToasts()
   const { submitUpdateMyUserProfile } = useUpdateMyUserProfile()
   const { relayEnvironment } = useSystemContext()
+  const { editedUserProfile: trackEditProfile } = useEditProfileTracking()
 
   const initialValues: EditProfileFormModel = {
     name: me.name ?? "",
@@ -107,6 +109,8 @@ const SettingsEditProfileFields: React.FC<SettingsEditProfileFieldsProps> = ({
           await imageContainerRef.current.storeImageLocally()
         }
       }
+
+      trackEditProfile()
 
       sendToast({
         variant: "success",

--- a/src/Apps/Settings/Routes/EditProfile/Components/__tests__/SettingsEditProfileFields.jest.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Components/__tests__/SettingsEditProfileFields.jest.tsx
@@ -3,8 +3,10 @@ import { graphql } from "react-relay"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useUpdateMyUserProfile } from "Utils/Hooks/Mutations/useUpdateMyUserProfile"
 import { SettingsEditProfileFieldsFragmentContainer } from "Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileFields"
+import { useTracking } from "react-tracking"
 
 jest.unmock("react-relay")
+jest.mock("react-tracking")
 jest.mock("Utils/Hooks/Mutations/useUpdateMyUserProfile")
 
 const { renderWithRelay } = setupTestWrapperTL({
@@ -21,6 +23,12 @@ const { renderWithRelay } = setupTestWrapperTL({
 describe("SettingsEditProfileFields", () => {
   const mockUseUpdateMyUserProfile = useUpdateMyUserProfile as jest.Mock
   const mockSubmitUpdateMyUserProfile = jest.fn()
+  const mockUseTracking = useTracking as jest.Mock
+  const trackingSpy = jest.fn()
+
+  beforeAll(() => {
+    mockUseTracking.mockImplementation(() => ({ trackEvent: trackingSpy }))
+  })
 
   beforeEach(() => {
     mockUseUpdateMyUserProfile.mockImplementation(() => ({
@@ -81,6 +89,15 @@ describe("SettingsEditProfileFields", () => {
         profession: "Artist and Collector",
         otherRelevantPositions: "Positions",
         bio: "I collect",
+      })
+    })
+
+    await waitFor(() => {
+      expect(trackingSpy).toHaveBeenCalledWith({
+        action: "editedUserProfile",
+        context_screen: "collectorProfile",
+        context_screen_owner_type: "editProfile",
+        platform: "web",
       })
     })
   })

--- a/src/Apps/Settings/Routes/EditProfile/Hooks/__tests__/useEditProfileTracking.jest.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Hooks/__tests__/useEditProfileTracking.jest.tsx
@@ -1,0 +1,40 @@
+import { renderHook } from "@testing-library/react-hooks"
+import { useEditProfileTracking } from "Apps/Settings/Routes/EditProfile/Hooks/useEditProfileTracking"
+import { useTracking } from "react-tracking"
+
+jest.mock("react-tracking")
+
+describe("useEditProfileTracking", () => {
+  const mockUseTracking = useTracking as jest.Mock
+  const trackingSpy = jest.fn()
+
+  const setupHook = () => {
+    const { result } = renderHook(() => useEditProfileTracking())
+
+    if (result.error) {
+      throw result.error
+    }
+
+    const tracking = result.current
+    return tracking
+  }
+
+  beforeAll(() => {
+    mockUseTracking.mockImplementation(() => ({ trackEvent: trackingSpy }))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("#editedUserProfile", () => {
+    setupHook().editedUserProfile()
+
+    expect(trackingSpy).toBeCalledWith({
+      action: "editedUserProfile",
+      context_screen: "collectorProfile",
+      context_screen_owner_type: "editProfile",
+      platform: "web",
+    })
+  })
+})

--- a/src/Apps/Settings/Routes/EditProfile/Hooks/useEditProfileTracking.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Hooks/useEditProfileTracking.tsx
@@ -1,0 +1,24 @@
+import {
+  ActionType,
+  ContextModule,
+  EditedUserProfile,
+  OwnerType,
+} from "@artsy/cohesion"
+import { useTracking } from "react-tracking"
+
+export const useEditProfileTracking = () => {
+  const { trackEvent } = useTracking()
+
+  return {
+    editedUserProfile: () => {
+      const payload: EditedUserProfile = {
+        action: ActionType.editedUserProfile,
+        context_screen: ContextModule.collectorProfile,
+        context_screen_owner_type: OwnerType.editProfile,
+        platform: "web",
+      }
+
+      trackEvent(payload)
+    },
+  }
+}


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3255]

### Description
This is a follow-up on artsy/cohesion#383
This PR adds tracking to the Edit Profile page

<!-- Implementation description -->
