### PR TITLE
feat(art-quiz): add mutation hooks

### DIFF
--- a/src/Apps/ArtQuiz/Hooks/useDislikeArtwork.ts
+++ b/src/Apps/ArtQuiz/Hooks/useDislikeArtwork.ts
@@ -1,16 +1,13 @@
 import { graphql } from "react-relay"
 import { useMutation } from "Utils/Hooks/useMutation"
-import { useDeleteArtworkMutation } from "__generated__/useDeleteArtworkMutation.graphql"
+import { useDislikeArtworkMutation } from "__generated__/useDislikeArtworkMutation.graphql"
 
 export const useDislikeArtwork = () => {
-  return useMutation<useDeleteArtworkMutation>({
+  return useMutation<useDislikeArtworkMutation>({
     mutation: graphql`
-      mutation useDislikeArtworkMutation($input: DislikeArtworkInput!)
-        @raw_response_type {
+      mutation useDislikeArtworkMutation($input: DislikeArtworkInput!) {
         dislikeArtwork(input: $input) {
           artwork {
-            id
-            slug
             isDisliked
           }
         }

--- a/src/Apps/ArtQuiz/Hooks/useSaveArtwork.ts
+++ b/src/Apps/ArtQuiz/Hooks/useSaveArtwork.ts
@@ -1,0 +1,17 @@
+import { graphql } from "react-relay"
+import { useMutation } from "Utils/Hooks/useMutation"
+import { useSaveArtworkMutation } from "__generated__/useSaveArtworkMutation.graphql"
+
+export const useSaveArtwork = () => {
+  return useMutation<useSaveArtworkMutation>({
+    mutation: graphql`
+      mutation useSaveArtworkMutation($input: SaveArtworkInput!) {
+        saveArtwork(input: $input) {
+          artwork {
+            isSaved
+          }
+        }
+      }
+    `,
+  })
+}

--- a/src/Apps/ArtQuiz/Hooks/useUpdateQuiz.ts
+++ b/src/Apps/ArtQuiz/Hooks/useUpdateQuiz.ts
@@ -1,0 +1,17 @@
+import { graphql } from "react-relay"
+import { useMutation } from "Utils/Hooks/useMutation"
+import { useUpdateQuizMutation } from "__generated__/useUpdateQuizMutation.graphql"
+
+export const useUpdateQuiz = () => {
+  return useMutation<useUpdateQuizMutation>({
+    mutation: graphql`
+      mutation useUpdateQuizMutation($input: updateQuizMutationInput!) {
+        updateQuiz(input: $input) {
+          quiz {
+            completedAt
+          }
+        }
+      }
+    `,
+  })
+}

--- a/src/__generated__/ArtQuizArtworks_me.graphql.ts
+++ b/src/__generated__/ArtQuizArtworks_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<52d017e796f72bf7061cd8736e09f20d>>
+ * @generated SignedSource<<d90ab1c286acc4be806f5f47579022c5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,7 @@
 import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtQuizArtworks_me$data = {
+  readonly id: string;
   readonly quiz: {
     readonly quizArtworkConnection: {
       readonly edges: ReadonlyArray<{
@@ -42,12 +43,21 @@ export type ArtQuizArtworks_me$key = {
   readonly " $fragmentSpreads": FragmentRefs<"ArtQuizArtworks_me">;
 };
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "ArtQuizArtworks_me",
   "selections": [
+    (v0/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -100,13 +110,7 @@ const node: ReaderFragment = {
                   "name": "node",
                   "plural": false,
                   "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "id",
-                      "storageKey": null
-                    },
+                    (v0/*: any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -228,7 +232,8 @@ const node: ReaderFragment = {
   "type": "Me",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "cfe32e7376f0b080b880055c77ba13ae";
+(node as any).hash = "201bf867fa8c594d506db56ee2e62d46";
 
 export default node;

--- a/src/__generated__/artQuizRoutes_ArtworksQuery.graphql.ts
+++ b/src/__generated__/artQuizRoutes_ArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<96b6b1d611f0d1d59573179b29c0eb52>>
+ * @generated SignedSource<<34e6b82b61d068d5c42c4e4c916760f1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -70,6 +70,7 @@ return {
         "name": "me",
         "plural": false,
         "selections": [
+          (v0/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -240,20 +241,19 @@ return {
               (v0/*: any*/)
             ],
             "storageKey": null
-          },
-          (v0/*: any*/)
+          }
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "7c5093956400a5f4c79c75a8ad7be385",
+    "cacheID": "540f4dcb29c417a208b53461376d6316",
     "id": null,
     "metadata": {},
     "name": "artQuizRoutes_ArtworksQuery",
     "operationKind": "query",
-    "text": "query artQuizRoutes_ArtworksQuery {\n  me {\n    ...ArtQuizArtworks_me\n    id\n  }\n}\n\nfragment ArtQuizArtworks_me on Me {\n  quiz {\n    quizArtworkConnection(first: 16) {\n      edges {\n        interactedAt\n        position\n        node {\n          id\n          internalID\n          image {\n            resized(width: 900, height: 900, version: [\"normalized\", \"larger\", \"large\"]) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          isDisliked\n          isSaved\n          slug\n          title\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query artQuizRoutes_ArtworksQuery {\n  me {\n    ...ArtQuizArtworks_me\n    id\n  }\n}\n\nfragment ArtQuizArtworks_me on Me {\n  id\n  quiz {\n    quizArtworkConnection(first: 16) {\n      edges {\n        interactedAt\n        position\n        node {\n          id\n          internalID\n          image {\n            resized(width: 900, height: 900, version: [\"normalized\", \"larger\", \"large\"]) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          isDisliked\n          isSaved\n          slug\n          title\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/useSaveArtworkMutation.graphql.ts
+++ b/src/__generated__/useSaveArtworkMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bd7a123f35ecb179df7363869718f31c>>
+ * @generated SignedSource<<446bf3716aa0071f4a2eceb7272e3646>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,24 +9,24 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Mutation } from 'relay-runtime';
-export type DislikeArtworkInput = {
-  artworkID: string;
+export type SaveArtworkInput = {
+  artworkID?: string | null;
   clientMutationId?: string | null;
-  remove: boolean;
+  remove?: boolean | null;
 };
-export type useDislikeArtworkMutation$variables = {
-  input: DislikeArtworkInput;
+export type useSaveArtworkMutation$variables = {
+  input: SaveArtworkInput;
 };
-export type useDislikeArtworkMutation$data = {
-  readonly dislikeArtwork: {
+export type useSaveArtworkMutation$data = {
+  readonly saveArtwork: {
     readonly artwork: {
-      readonly isDisliked: boolean;
+      readonly isSaved: boolean | null;
     } | null;
   } | null;
 };
-export type useDislikeArtworkMutation = {
-  response: useDislikeArtworkMutation$data;
-  variables: useDislikeArtworkMutation$variables;
+export type useSaveArtworkMutation = {
+  response: useSaveArtworkMutation$data;
+  variables: useSaveArtworkMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -48,7 +48,7 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isDisliked",
+  "name": "isSaved",
   "storageKey": null
 };
 return {
@@ -56,14 +56,14 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "useDislikeArtworkMutation",
+    "name": "useSaveArtworkMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "DislikeArtworkPayload",
+        "concreteType": "SaveArtworkPayload",
         "kind": "LinkedField",
-        "name": "dislikeArtwork",
+        "name": "saveArtwork",
         "plural": false,
         "selections": [
           {
@@ -89,14 +89,14 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "useDislikeArtworkMutation",
+    "name": "useSaveArtworkMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "DislikeArtworkPayload",
+        "concreteType": "SaveArtworkPayload",
         "kind": "LinkedField",
-        "name": "dislikeArtwork",
+        "name": "saveArtwork",
         "plural": false,
         "selections": [
           {
@@ -124,16 +124,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8eee1223c96bbb7eede14f840396f967",
+    "cacheID": "483c306986cf44f0dccca9d445b159df",
     "id": null,
     "metadata": {},
-    "name": "useDislikeArtworkMutation",
+    "name": "useSaveArtworkMutation",
     "operationKind": "mutation",
-    "text": "mutation useDislikeArtworkMutation(\n  $input: DislikeArtworkInput!\n) {\n  dislikeArtwork(input: $input) {\n    artwork {\n      isDisliked\n      id\n    }\n  }\n}\n"
+    "text": "mutation useSaveArtworkMutation(\n  $input: SaveArtworkInput!\n) {\n  saveArtwork(input: $input) {\n    artwork {\n      isSaved\n      id\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "26ad319c4083e5f2caa141cb66ee6d03";
+(node as any).hash = "71de0776dc3fda3028bd63f94d5970f0";
 
 export default node;

--- a/src/__generated__/useUpdateQuizMutation.graphql.ts
+++ b/src/__generated__/useUpdateQuizMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bd7a123f35ecb179df7363869718f31c>>
+ * @generated SignedSource<<95badcf92a86c440116f2bb178181aa2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,24 +9,25 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Mutation } from 'relay-runtime';
-export type DislikeArtworkInput = {
-  artworkID: string;
+export type updateQuizMutationInput = {
+  artworkId: string;
+  clearInteraction?: boolean | null;
   clientMutationId?: string | null;
-  remove: boolean;
+  userId: string;
 };
-export type useDislikeArtworkMutation$variables = {
-  input: DislikeArtworkInput;
+export type useUpdateQuizMutation$variables = {
+  input: updateQuizMutationInput;
 };
-export type useDislikeArtworkMutation$data = {
-  readonly dislikeArtwork: {
-    readonly artwork: {
-      readonly isDisliked: boolean;
+export type useUpdateQuizMutation$data = {
+  readonly updateQuiz: {
+    readonly quiz: {
+      readonly completedAt: string | null;
     } | null;
   } | null;
 };
-export type useDislikeArtworkMutation = {
-  response: useDislikeArtworkMutation$data;
-  variables: useDislikeArtworkMutation$variables;
+export type useUpdateQuizMutation = {
+  response: useUpdateQuizMutation$data;
+  variables: useUpdateQuizMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -48,7 +49,7 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isDisliked",
+  "name": "completedAt",
   "storageKey": null
 };
 return {
@@ -56,22 +57,22 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "useDislikeArtworkMutation",
+    "name": "useUpdateQuizMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "DislikeArtworkPayload",
+        "concreteType": "updateQuizMutationPayload",
         "kind": "LinkedField",
-        "name": "dislikeArtwork",
+        "name": "updateQuiz",
         "plural": false,
         "selections": [
           {
             "alias": null,
             "args": null,
-            "concreteType": "Artwork",
+            "concreteType": "Quiz",
             "kind": "LinkedField",
-            "name": "artwork",
+            "name": "quiz",
             "plural": false,
             "selections": [
               (v2/*: any*/)
@@ -89,22 +90,22 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "useDislikeArtworkMutation",
+    "name": "useUpdateQuizMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "DislikeArtworkPayload",
+        "concreteType": "updateQuizMutationPayload",
         "kind": "LinkedField",
-        "name": "dislikeArtwork",
+        "name": "updateQuiz",
         "plural": false,
         "selections": [
           {
             "alias": null,
             "args": null,
-            "concreteType": "Artwork",
+            "concreteType": "Quiz",
             "kind": "LinkedField",
-            "name": "artwork",
+            "name": "quiz",
             "plural": false,
             "selections": [
               (v2/*: any*/),
@@ -124,16 +125,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8eee1223c96bbb7eede14f840396f967",
+    "cacheID": "2f96b77a7ff92a55654ad4103f8710cd",
     "id": null,
     "metadata": {},
-    "name": "useDislikeArtworkMutation",
+    "name": "useUpdateQuizMutation",
     "operationKind": "mutation",
-    "text": "mutation useDislikeArtworkMutation(\n  $input: DislikeArtworkInput!\n) {\n  dislikeArtwork(input: $input) {\n    artwork {\n      isDisliked\n      id\n    }\n  }\n}\n"
+    "text": "mutation useUpdateQuizMutation(\n  $input: updateQuizMutationInput!\n) {\n  updateQuiz(input: $input) {\n    quiz {\n      completedAt\n      id\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "26ad319c4083e5f2caa141cb66ee6d03";
+(node as any).hash = "abfee44a773cd61f332a6e37f327102b";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-1487]

### Description

<!-- Implementation description -->
Adds necessary mutations: 
- Custom version of save artwork that doesn't allow for unsave on a second click. 
- updateQuiz 
- dislikeArtwork

Attached to save / dislike & close button.



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ