### PR TITLE
fix(artist): corrects logic for querying for fair booths

### DIFF
--- a/src/Apps/Artist/Routes/CV/ArtistCVRoute.tsx
+++ b/src/Apps/Artist/Routes/CV/ArtistCVRoute.tsx
@@ -41,23 +41,16 @@ export const ArtistCVRouteFragmentContainer = createFragmentContainer(
   ArtistCVRoute,
   {
     viewer: graphql`
-      fragment ArtistCVRoute_viewer on Viewer
-        @argumentDefinitions(
-          soloShowsAtAFair: { type: "Boolean", defaultValue: false }
-          soloShowsSoloShow: { type: "Boolean", defaultValue: true }
-          groupShowsAtAFair: { type: "Boolean", defaultValue: false }
-          fairBoothsAtAFair: { type: "Boolean", defaultValue: true }
-        ) {
+      fragment ArtistCVRoute_viewer on Viewer {
         soloShows: artist(id: $artistID) {
-          ...ArtistCVGroup_artist
-            @arguments(atAFair: $soloShowsAtAFair, soloShow: $soloShowsSoloShow)
+          ...ArtistCVGroup_artist @arguments(atAFair: false, soloShow: true)
           name
         }
         groupShows: artist(id: $artistID) {
-          ...ArtistCVGroup_artist @arguments(atAFair: $groupShowsAtAFair)
+          ...ArtistCVGroup_artist @arguments(atAFair: false, soloShow: false)
         }
         fairBooths: artist(id: $artistID) {
-          ...ArtistCVGroup_artist @arguments(atAFair: $fairBoothsAtAFair)
+          ...ArtistCVGroup_artist @arguments(atAFair: true)
         }
       }
     `,

--- a/src/Apps/Artist/Routes/CV/Components/ArtistCVGroup.tsx
+++ b/src/Apps/Artist/Routes/CV/Components/ArtistCVGroup.tsx
@@ -21,6 +21,7 @@ interface ArtistCVGroupProps {
 
 const ArtistCVGroup: FC<ArtistCVGroupProps> = ({ artist, relay, title }) => {
   const { t } = useTranslation()
+
   const [isLoading, setIsLoading] = useState(false)
   const hasMore = artist.showsConnection?.pageInfo.hasNextPage
 
@@ -44,6 +45,7 @@ const ArtistCVGroup: FC<ArtistCVGroupProps> = ({ artist, relay, title }) => {
         <Column span={12}>
           <Text variant="lg-display">{title}</Text>
         </Column>
+
         <Column span={8} start={4}>
           <Text variant="sm-display">
             {t("artistPage.cv.emptyState", { groupName: title.toLowerCase() })}
@@ -132,7 +134,7 @@ export const ArtistCVGroupRefetchContainer = createPaginationContainer(
           cursor: { type: "String" }
           sort: { type: "ShowSorts", defaultValue: START_AT_DESC }
           atAFair: { type: "Boolean", defaultValue: false }
-          soloShow: { type: "Boolean", defaultValue: false }
+          soloShow: { type: "Boolean" }
           isReference: { type: "Boolean", defaultValue: true }
           visibleToPublic: { type: "Boolean", defaultValue: false }
         ) {

--- a/src/__generated__/ArtistCVGroup_artist.graphql.ts
+++ b/src/__generated__/ArtistCVGroup_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1203e53e0587e09d63d364271f15663c>>
+ * @generated SignedSource<<1d95bd5e57963861e4b7834ab46db561>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -75,7 +75,7 @@ return {
       "name": "isReference"
     },
     {
-      "defaultValue": false,
+      "defaultValue": null,
       "kind": "LocalArgument",
       "name": "soloShow"
     },
@@ -273,6 +273,6 @@ return {
 };
 })();
 
-(node as any).hash = "54b80d5c989039c4be5cd687b5399c1e";
+(node as any).hash = "7b49bf81026b3aaff19cb0bfa7c3057a";
 
 export default node;

--- a/src/__generated__/ArtistCVRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistCVRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<49d026efd0762f8193d85d087ce24027>>
+ * @generated SignedSource<<fb9afea85cb7969a975dab3d76773960>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -235,20 +235,19 @@ v14 = [
   "isReference",
   "visibleToPublic"
 ],
-v15 = {
-  "kind": "Literal",
-  "name": "soloShow",
-  "value": false
-},
-v16 = [
+v15 = [
   (v3/*: any*/),
   (v4/*: any*/),
   (v5/*: any*/),
-  (v15/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "soloShow",
+    "value": false
+  },
   (v6/*: any*/),
   (v7/*: any*/)
 ],
-v17 = [
+v16 = [
   {
     "kind": "Literal",
     "name": "atAFair",
@@ -256,65 +255,64 @@ v17 = [
   },
   (v4/*: any*/),
   (v5/*: any*/),
-  (v15/*: any*/),
   (v6/*: any*/),
   (v7/*: any*/)
 ],
-v18 = {
+v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artist"
 },
-v19 = {
+v18 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v20 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ShowConnection"
 },
-v21 = {
+v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "ShowEdge"
 },
-v22 = {
+v21 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v23 = {
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Show"
 },
-v24 = {
+v23 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v25 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "PartnerTypes"
 },
-v26 = {
+v25 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "PageInfo"
 },
-v27 = {
+v26 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -405,7 +403,7 @@ return {
               (v2/*: any*/),
               {
                 "alias": null,
-                "args": (v16/*: any*/),
+                "args": (v15/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
@@ -415,7 +413,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v16/*: any*/),
+                "args": (v15/*: any*/),
                 "filters": (v14/*: any*/),
                 "handle": "connection",
                 "key": "ArtistCVGroup_showsConnection",
@@ -437,17 +435,17 @@ return {
               (v2/*: any*/),
               {
                 "alias": null,
-                "args": (v17/*: any*/),
+                "args": (v16/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": (v13/*: any*/),
-                "storageKey": "showsConnection(atAFair:true,first:10,isReference:true,soloShow:false,sort:\"START_AT_DESC\",visibleToPublic:false)"
+                "storageKey": "showsConnection(atAFair:true,first:10,isReference:true,sort:\"START_AT_DESC\",visibleToPublic:false)"
               },
               {
                 "alias": null,
-                "args": (v17/*: any*/),
+                "args": (v16/*: any*/),
                 "filters": (v14/*: any*/),
                 "handle": "connection",
                 "key": "ArtistCVGroup_showsConnection",
@@ -464,7 +462,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6d2a030a7240705d611b6453656c93fd",
+    "cacheID": "f5466baf211a4a9fa1b3b88b7795324f",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -474,78 +472,78 @@ return {
           "plural": false,
           "type": "Viewer"
         },
-        "viewer.fairBooths": (v18/*: any*/),
-        "viewer.fairBooths.id": (v19/*: any*/),
-        "viewer.fairBooths.showsConnection": (v20/*: any*/),
-        "viewer.fairBooths.showsConnection.edges": (v21/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.cursor": (v22/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node": (v23/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.__typename": (v22/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.city": (v24/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.href": (v24/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.id": (v19/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.name": (v24/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.partner": (v25/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.partner.__isNode": (v22/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.partner.__typename": (v22/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.partner.href": (v24/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.partner.id": (v19/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.partner.name": (v24/*: any*/),
-        "viewer.fairBooths.showsConnection.edges.node.startAt": (v24/*: any*/),
-        "viewer.fairBooths.showsConnection.pageInfo": (v26/*: any*/),
-        "viewer.fairBooths.showsConnection.pageInfo.endCursor": (v24/*: any*/),
-        "viewer.fairBooths.showsConnection.pageInfo.hasNextPage": (v27/*: any*/),
-        "viewer.fairBooths.slug": (v19/*: any*/),
-        "viewer.groupShows": (v18/*: any*/),
-        "viewer.groupShows.id": (v19/*: any*/),
-        "viewer.groupShows.showsConnection": (v20/*: any*/),
-        "viewer.groupShows.showsConnection.edges": (v21/*: any*/),
-        "viewer.groupShows.showsConnection.edges.cursor": (v22/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node": (v23/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.__typename": (v22/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.city": (v24/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.href": (v24/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.id": (v19/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.name": (v24/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.partner": (v25/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.partner.__isNode": (v22/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.partner.__typename": (v22/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.partner.href": (v24/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.partner.id": (v19/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.partner.name": (v24/*: any*/),
-        "viewer.groupShows.showsConnection.edges.node.startAt": (v24/*: any*/),
-        "viewer.groupShows.showsConnection.pageInfo": (v26/*: any*/),
-        "viewer.groupShows.showsConnection.pageInfo.endCursor": (v24/*: any*/),
-        "viewer.groupShows.showsConnection.pageInfo.hasNextPage": (v27/*: any*/),
-        "viewer.groupShows.slug": (v19/*: any*/),
-        "viewer.soloShows": (v18/*: any*/),
-        "viewer.soloShows.id": (v19/*: any*/),
-        "viewer.soloShows.name": (v24/*: any*/),
-        "viewer.soloShows.showsConnection": (v20/*: any*/),
-        "viewer.soloShows.showsConnection.edges": (v21/*: any*/),
-        "viewer.soloShows.showsConnection.edges.cursor": (v22/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node": (v23/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.__typename": (v22/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.city": (v24/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.href": (v24/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.id": (v19/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.name": (v24/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.partner": (v25/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.partner.__isNode": (v22/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.partner.__typename": (v22/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.partner.href": (v24/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.partner.id": (v19/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.partner.name": (v24/*: any*/),
-        "viewer.soloShows.showsConnection.edges.node.startAt": (v24/*: any*/),
-        "viewer.soloShows.showsConnection.pageInfo": (v26/*: any*/),
-        "viewer.soloShows.showsConnection.pageInfo.endCursor": (v24/*: any*/),
-        "viewer.soloShows.showsConnection.pageInfo.hasNextPage": (v27/*: any*/),
-        "viewer.soloShows.slug": (v19/*: any*/)
+        "viewer.fairBooths": (v17/*: any*/),
+        "viewer.fairBooths.id": (v18/*: any*/),
+        "viewer.fairBooths.showsConnection": (v19/*: any*/),
+        "viewer.fairBooths.showsConnection.edges": (v20/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.cursor": (v21/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node": (v22/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.__typename": (v21/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.city": (v23/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.href": (v23/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.id": (v18/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.name": (v23/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.partner": (v24/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.partner.__isNode": (v21/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.partner.__typename": (v21/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.partner.href": (v23/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.partner.id": (v18/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.partner.name": (v23/*: any*/),
+        "viewer.fairBooths.showsConnection.edges.node.startAt": (v23/*: any*/),
+        "viewer.fairBooths.showsConnection.pageInfo": (v25/*: any*/),
+        "viewer.fairBooths.showsConnection.pageInfo.endCursor": (v23/*: any*/),
+        "viewer.fairBooths.showsConnection.pageInfo.hasNextPage": (v26/*: any*/),
+        "viewer.fairBooths.slug": (v18/*: any*/),
+        "viewer.groupShows": (v17/*: any*/),
+        "viewer.groupShows.id": (v18/*: any*/),
+        "viewer.groupShows.showsConnection": (v19/*: any*/),
+        "viewer.groupShows.showsConnection.edges": (v20/*: any*/),
+        "viewer.groupShows.showsConnection.edges.cursor": (v21/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node": (v22/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.__typename": (v21/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.city": (v23/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.href": (v23/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.id": (v18/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.name": (v23/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.partner": (v24/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.partner.__isNode": (v21/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.partner.__typename": (v21/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.partner.href": (v23/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.partner.id": (v18/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.partner.name": (v23/*: any*/),
+        "viewer.groupShows.showsConnection.edges.node.startAt": (v23/*: any*/),
+        "viewer.groupShows.showsConnection.pageInfo": (v25/*: any*/),
+        "viewer.groupShows.showsConnection.pageInfo.endCursor": (v23/*: any*/),
+        "viewer.groupShows.showsConnection.pageInfo.hasNextPage": (v26/*: any*/),
+        "viewer.groupShows.slug": (v18/*: any*/),
+        "viewer.soloShows": (v17/*: any*/),
+        "viewer.soloShows.id": (v18/*: any*/),
+        "viewer.soloShows.name": (v23/*: any*/),
+        "viewer.soloShows.showsConnection": (v19/*: any*/),
+        "viewer.soloShows.showsConnection.edges": (v20/*: any*/),
+        "viewer.soloShows.showsConnection.edges.cursor": (v21/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node": (v22/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.__typename": (v21/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.city": (v23/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.href": (v23/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.id": (v18/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.name": (v23/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.partner": (v24/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.partner.__isNode": (v21/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.partner.__typename": (v21/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.partner.href": (v23/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.partner.id": (v18/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.partner.name": (v23/*: any*/),
+        "viewer.soloShows.showsConnection.edges.node.startAt": (v23/*: any*/),
+        "viewer.soloShows.showsConnection.pageInfo": (v25/*: any*/),
+        "viewer.soloShows.showsConnection.pageInfo.endCursor": (v23/*: any*/),
+        "viewer.soloShows.showsConnection.pageInfo.hasNextPage": (v26/*: any*/),
+        "viewer.soloShows.slug": (v18/*: any*/)
       }
     },
     "name": "ArtistCVRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistCVRoute_Test_Query(\n  $artistID: String!\n) {\n  viewer {\n    ...ArtistCVRoute_viewer\n  }\n}\n\nfragment ArtistCVGroup_artist_47e96d on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVGroup_artist_4DszuY on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVGroup_artist_ieWPx on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVRoute_viewer on Viewer {\n  soloShows: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_ieWPx\n    name\n    id\n  }\n  groupShows: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_4DszuY\n    id\n  }\n  fairBooths: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_47e96d\n    id\n  }\n}\n"
+    "text": "query ArtistCVRoute_Test_Query(\n  $artistID: String!\n) {\n  viewer {\n    ...ArtistCVRoute_viewer\n  }\n}\n\nfragment ArtistCVGroup_artist_47e96d on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVGroup_artist_8zYC6 on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVGroup_artist_ieWPx on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVRoute_viewer on Viewer {\n  soloShows: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_ieWPx\n    name\n    id\n  }\n  groupShows: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_8zYC6\n    id\n  }\n  fairBooths: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_47e96d\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistCVRoute_viewer.graphql.ts
+++ b/src/__generated__/ArtistCVRoute_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3088f8d8d8e3e9a3207e38201b2ce920>>
+ * @generated SignedSource<<51fdff715c3338dd98ad166952329751>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -35,32 +35,17 @@ var v0 = [
     "name": "id",
     "variableName": "artistID"
   }
-];
+],
+v1 = {
+  "kind": "Literal",
+  "name": "atAFair",
+  "value": false
+};
 return {
   "argumentDefinitions": [
     {
       "kind": "RootArgument",
       "name": "artistID"
-    },
-    {
-      "defaultValue": true,
-      "kind": "LocalArgument",
-      "name": "fairBoothsAtAFair"
-    },
-    {
-      "defaultValue": false,
-      "kind": "LocalArgument",
-      "name": "groupShowsAtAFair"
-    },
-    {
-      "defaultValue": false,
-      "kind": "LocalArgument",
-      "name": "soloShowsAtAFair"
-    },
-    {
-      "defaultValue": true,
-      "kind": "LocalArgument",
-      "name": "soloShowsSoloShow"
     }
   ],
   "kind": "Fragment",
@@ -77,15 +62,11 @@ return {
       "selections": [
         {
           "args": [
+            (v1/*: any*/),
             {
-              "kind": "Variable",
-              "name": "atAFair",
-              "variableName": "soloShowsAtAFair"
-            },
-            {
-              "kind": "Variable",
+              "kind": "Literal",
               "name": "soloShow",
-              "variableName": "soloShowsSoloShow"
+              "value": true
             }
           ],
           "kind": "FragmentSpread",
@@ -111,10 +92,11 @@ return {
       "selections": [
         {
           "args": [
+            (v1/*: any*/),
             {
-              "kind": "Variable",
-              "name": "atAFair",
-              "variableName": "groupShowsAtAFair"
+              "kind": "Literal",
+              "name": "soloShow",
+              "value": false
             }
           ],
           "kind": "FragmentSpread",
@@ -134,9 +116,9 @@ return {
         {
           "args": [
             {
-              "kind": "Variable",
+              "kind": "Literal",
               "name": "atAFair",
-              "variableName": "fairBoothsAtAFair"
+              "value": true
             }
           ],
           "kind": "FragmentSpread",
@@ -151,6 +133,6 @@ return {
 };
 })();
 
-(node as any).hash = "9779a6baedba0adc1ed197819481ce40";
+(node as any).hash = "238e15474108e4de0c916a2b6fe2dddf";
 
 export default node;

--- a/src/__generated__/artistRoutes_CVQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_CVQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2cbe81f5073d88060705c38f9674c08d>>
+ * @generated SignedSource<<49499d6965eaa9a7a4ea3c1d68a78901>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -235,20 +235,19 @@ v14 = [
   "isReference",
   "visibleToPublic"
 ],
-v15 = {
-  "kind": "Literal",
-  "name": "soloShow",
-  "value": false
-},
-v16 = [
+v15 = [
   (v3/*: any*/),
   (v4/*: any*/),
   (v5/*: any*/),
-  (v15/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "soloShow",
+    "value": false
+  },
   (v6/*: any*/),
   (v7/*: any*/)
 ],
-v17 = [
+v16 = [
   {
     "kind": "Literal",
     "name": "atAFair",
@@ -256,7 +255,6 @@ v17 = [
   },
   (v4/*: any*/),
   (v5/*: any*/),
-  (v15/*: any*/),
   (v6/*: any*/),
   (v7/*: any*/)
 ];
@@ -345,7 +343,7 @@ return {
               (v2/*: any*/),
               {
                 "alias": null,
-                "args": (v16/*: any*/),
+                "args": (v15/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
@@ -355,7 +353,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v16/*: any*/),
+                "args": (v15/*: any*/),
                 "filters": (v14/*: any*/),
                 "handle": "connection",
                 "key": "ArtistCVGroup_showsConnection",
@@ -377,17 +375,17 @@ return {
               (v2/*: any*/),
               {
                 "alias": null,
-                "args": (v17/*: any*/),
+                "args": (v16/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": (v13/*: any*/),
-                "storageKey": "showsConnection(atAFair:true,first:10,isReference:true,soloShow:false,sort:\"START_AT_DESC\",visibleToPublic:false)"
+                "storageKey": "showsConnection(atAFair:true,first:10,isReference:true,sort:\"START_AT_DESC\",visibleToPublic:false)"
               },
               {
                 "alias": null,
-                "args": (v17/*: any*/),
+                "args": (v16/*: any*/),
                 "filters": (v14/*: any*/),
                 "handle": "connection",
                 "key": "ArtistCVGroup_showsConnection",
@@ -404,12 +402,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1f38222ea383475cafef856668adbab1",
+    "cacheID": "418b379c3a81f3b6a1909acf916bd3ee",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_CVQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_CVQuery(\n  $artistID: String!\n) {\n  viewer {\n    ...ArtistCVRoute_viewer\n  }\n}\n\nfragment ArtistCVGroup_artist_47e96d on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVGroup_artist_4DszuY on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVGroup_artist_ieWPx on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVRoute_viewer on Viewer {\n  soloShows: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_ieWPx\n    name\n    id\n  }\n  groupShows: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_4DszuY\n    id\n  }\n  fairBooths: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_47e96d\n    id\n  }\n}\n"
+    "text": "query artistRoutes_CVQuery(\n  $artistID: String!\n) {\n  viewer {\n    ...ArtistCVRoute_viewer\n  }\n}\n\nfragment ArtistCVGroup_artist_47e96d on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVGroup_artist_8zYC6 on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVGroup_artist_ieWPx on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        name\n        startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ArtistCVRoute_viewer on Viewer {\n  soloShows: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_ieWPx\n    name\n    id\n  }\n  groupShows: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_8zYC6\n    id\n  }\n  fairBooths: artist(id: $artistID) {\n    ...ArtistCVGroup_artist_47e96d\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
@joeyAghion points out that

`solo_show=true` returns only solo shows
`solo_show=false` returns only group shows
Sending no `solo_show` parameter includes all results of either type

So this just restructures these arguments a bit to correctly return all fair booths, which may be classified as solo shows.