### PR TITLE
fix: Hide collected artists when not existing in upload flow

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtistStep.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtistStep.tsx
@@ -108,27 +108,31 @@ export const MyCollectionArtworkFormArtistStep: React.FC<MyCollectionArtworkForm
 
       <Spacer y={4} />
 
-      <Text variant="xs">Artists in My Collection</Text>
+      {collectedArtists.length > 0 && (
+        <>
+          <Text variant="xs">Artists in My Collection</Text>
 
-      <Spacer y={1} />
+          <Spacer y={1} />
 
-      <GridColumns width="100%">
-        {collectedArtists.map((artist, index) => (
-          <Column span={[6, 4]} key={index}>
-            <Clickable
-              onClick={() =>
-                onSelect({
-                  artistId: artist.internalID,
-                  artistName: artist.displayLabel,
-                })
-              }
-              data-testid={`artist-${artist.internalID}`}
-            >
-              <ArtistGridItemFragmentContainer artist={artist} />
-            </Clickable>
-          </Column>
-        ))}
-      </GridColumns>
+          <GridColumns width="100%">
+            {collectedArtists.map((artist, index) => (
+              <Column span={[6, 4]} key={index}>
+                <Clickable
+                  onClick={() =>
+                    onSelect({
+                      artistId: artist.internalID,
+                      artistName: artist.displayLabel,
+                    })
+                  }
+                  data-testid={`artist-${artist.internalID}`}
+                >
+                  <ArtistGridItemFragmentContainer artist={artist} />
+                </Clickable>
+              </Column>
+            ))}
+          </GridColumns>
+        </>
+      )}
     </AppContainer>
   )
 }


### PR DESCRIPTION
## Description

Hide the collected artists section when the user hasn't collected any artists yet in the artwork upload flow (according to the Figma design).