### PR TITLE
feat: ignore header offset when `isEigen` is true

### DIFF
--- a/src/Components/NavBar/useNavBarHeight.ts
+++ b/src/Components/NavBar/useNavBarHeight.ts
@@ -6,10 +6,15 @@ import {
 } from "./constants"
 
 export const useNavBarHeight = () => {
-  const { isLoggedIn } = useSystemContext()
+  const { isLoggedIn, isEigen } = useSystemContext()
 
-  const mobile = isLoggedIn ? MOBILE_LOGGED_IN_NAV_HEIGHT : MOBILE_NAV_HEIGHT
-  const desktop = DESKTOP_NAV_BAR_HEIGHT
+  let mobile = isLoggedIn ? MOBILE_LOGGED_IN_NAV_HEIGHT : MOBILE_NAV_HEIGHT
+  let desktop = DESKTOP_NAV_BAR_HEIGHT
+
+  if (isEigen) {
+    mobile = 0
+    desktop = 0
+  }
 
   return { height: [mobile, desktop], mobile, desktop }
 }

--- a/src/Components/Sticky/Sticky.tsx
+++ b/src/Components/Sticky/Sticky.tsx
@@ -4,7 +4,6 @@ import ReactSticky, { Props as ReactStickyProps } from "react-stickynode"
 import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
 import { useSticky } from "./StickyProvider"
-import { useSystemContext } from "System"
 
 /**
  * Wrap a component to have it stick below the main nav.
@@ -33,15 +32,10 @@ export const Sticky: React.FC<
     withoutHeaderOffset?: boolean
     children: ReactNode | (({ stuck }: { stuck: boolean }) => ReactNode)
   }
-> = ({
-  children,
-  bottomBoundary,
-  withoutHeaderOffset: _withoutHeaderOffset,
-}) => {
+> = ({ children, bottomBoundary, withoutHeaderOffset }) => {
   const { offsetTop, registerSticky, deregisterSticky } = useSticky()
 
   const { desktop, mobile } = useNavBarHeight()
-  const { isEigen } = useSystemContext()
 
   const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
 
@@ -49,7 +43,6 @@ export const Sticky: React.FC<
 
   const containerRef = useRef<HTMLDivElement | null>(null)
 
-  const withoutHeaderOffset = _withoutHeaderOffset ?? isEigen
   const headerOffset = withoutHeaderOffset ? 0 : isMobile ? mobile : desktop
 
   useEffect(() => {

--- a/src/Components/Sticky/Sticky.tsx
+++ b/src/Components/Sticky/Sticky.tsx
@@ -4,6 +4,7 @@ import ReactSticky, { Props as ReactStickyProps } from "react-stickynode"
 import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
 import { useSticky } from "./StickyProvider"
+import { useSystemContext } from "System"
 
 /**
  * Wrap a component to have it stick below the main nav.
@@ -32,10 +33,15 @@ export const Sticky: React.FC<
     withoutHeaderOffset?: boolean
     children: ReactNode | (({ stuck }: { stuck: boolean }) => ReactNode)
   }
-> = ({ children, bottomBoundary, withoutHeaderOffset }) => {
+> = ({
+  children,
+  bottomBoundary,
+  withoutHeaderOffset: _withoutHeaderOffset,
+}) => {
   const { offsetTop, registerSticky, deregisterSticky } = useSticky()
 
   const { desktop, mobile } = useNavBarHeight()
+  const { isEigen } = useSystemContext()
 
   const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
 
@@ -43,6 +49,7 @@ export const Sticky: React.FC<
 
   const containerRef = useRef<HTMLDivElement | null>(null)
 
+  const withoutHeaderOffset = _withoutHeaderOffset ?? isEigen
   const headerOffset = withoutHeaderOffset ? 0 : isMobile ? mobile : desktop
 
   useEffect(() => {


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

Review app: [ignore-header-offset](https://ignore-header-offset.artsy.net/)

### Description
Ignore header offset in sticky when `isEigen` is true, since the nav bar menu [will not be rendered](https://github.com/artsy/force/blob/aa217617287577dff6e9c2b2710df63fdcd195f0/src/Components/NavBar/NavBar.tsx#L58-L60)


### Demo
#### Before
https://user-images.githubusercontent.com/3513494/209139712-b7888df4-5338-4897-a807-46c0422d4e69.mp4

#### After
https://user-images.githubusercontent.com/3513494/209139795-d34d6a14-da3e-44e3-afaf-a7f91514f1be.mp4

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ