### PR TITLE
fix(NX-3209): Remove isActionable check from OrderModal

### DIFF
--- a/src/Apps/Conversation/Components/Conversation.tsx
+++ b/src/Apps/Conversation/Components/Conversation.tsx
@@ -284,18 +284,16 @@ const Conversation: React.FC<ConversationProps> = props => {
           createsOfferOrder={createsOfferOrder}
         />
       )}
-      {isActionable && (
-        <OrderModal
-          path={url!}
-          orderID={orderID}
-          title={modalTitle!}
-          show={showOrderModal}
-          closeModal={() => {
-            refreshData()
-            setShowOrderModal(false)
-          }}
-        />
-      )}
+      <OrderModal
+        path={url!}
+        orderID={orderID}
+        title={modalTitle!}
+        show={showOrderModal}
+        closeModal={() => {
+          refreshData()
+          setShowOrderModal(false)
+        }}
+      />
     </Flex>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Fix**
This PR solves [NX-3209]


### Description
Remove check that prevents order modal from being rendered proper inside a conversation.

* We rely on `isActionable` in order to determine whether the order modal should be displayed - [ref](https://github.com/artsy/force/blob/9413fd9f88ba360bed598d70391c0e1d07098d3d/src/Apps/Conversation/Components/Conversation.tsx#L287-L298)
* `isActionable` only returns `true` in case an Artwork fits into one of the following scenarios: MO, MOI, MOOAEA, CBN - [ref](https://github.com/artsy/force/blob/9413fd9f88ba360bed598d70391c0e1d07098d3d/src/Apps/Conversation/Components/Conversation.tsx#L80-L83)
* An artwork can only fit into any of the conditions above if its availability is listed as `for sale` - [ref](https://github.com/artsy/gravity/blob/b7ea7bcbbe1f42fae821c318211c56e78142fb64/app/models/util/for_sale.rb#L416)
* When the partner accepts an offer, in case the artwork has an inventory associated, we automatically deduct the inventory - [ref](https://github.com/artsy/exchange/blob/337ab1f9a2c9ea368a94e9976e217a09a0689009/app/services/offer_service.rb#L90)
* When deducting the inventory, we also update the availability to `sold` in case the count reaches 0 (which happens in most scenarios, as BNMO inventories for unique-classified artworks are always created with a count of 1) -
[ref](https://github.com/artsy/gravity/blob/000b3af443c8b770a0066875497efaf19dfdc2d5/app/services/inventory_service.rb#L34-L39)
* The artwork listed as sold will always return `false` for `isActionable` and because of this, the modal can’t be rendered.

### How was this tested?
- **Offer Accepted for MO artwork:** It wasn't working before these changes. It is working now
- **Counteroffer accepted for MO artwork:** It wasn't working before these changes. It is working now.
- **Counteroffer received for MO artwork:** It was working before these changes. It keeps working now
- **Offer Declined for MO artwork:** No modal is displayed and it keeps working in the same way after these changes
- **Counteroffer Declined for MO artwork:** No modal is displayed and it keeps working in the same way after these changes
- **Counteroffer Declined for MO artwork:**  No modal is displayed and it keeps working in the same way after these changes
- **Conversation without orders with a MO/BN/non-BNMO artwork**: No modal is displayed and it keeps working in the same way after these changes
- **Purchase through BN feature inside conversation**: No modal is displayed and it keeps working in the same way after these changes

[NX-3209]: https://artsyproduct.atlassian.net/browse/NX-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

We'll want to cover these tests with automated tests on integrity when working on [NX-3248](https://artsyproduct.atlassian.net/browse/NX-3248)

cc @artsy/negotiate-devs 