### PR TITLE
feat: app layouts

### DIFF
--- a/src/Apps/ArtQuiz/artQuizRoutes.tsx
+++ b/src/Apps/ArtQuiz/artQuizRoutes.tsx
@@ -22,7 +22,6 @@ const ArtQuizResults = loadable(() => import("./Routes/ArtQuizResults"), {
 export const artQuizRoutes: AppRouteConfig[] = [
   {
     path: "/art-quiz",
-    hideFooter: true,
     onServerSideRender: ({ res }) => {
       if (!res.locals.sd.FEATURE_FLAGS["art-quiz"].flagEnabled) {
         res.redirect("/")
@@ -39,7 +38,7 @@ export const artQuizRoutes: AppRouteConfig[] = [
       {
         path: "welcome",
         getComponent: () => ArtQuizWelcome,
-        hideFooter: true,
+        layout: "NavOnly",
         query: graphql`
           query artQuizRoutes_WelcomeQuery {
             me {
@@ -70,7 +69,7 @@ export const artQuizRoutes: AppRouteConfig[] = [
       {
         path: "artworks",
         getComponent: () => ArtQuizArtworks,
-        hideFooter: true,
+        layout: "NavOnly",
         onClientSideRender: () => {
           ArtQuizArtworks.preload()
         },
@@ -85,7 +84,7 @@ export const artQuizRoutes: AppRouteConfig[] = [
       {
         path: "results",
         getComponent: () => ArtQuizResults,
-        hideFooter: true,
+        layout: "NavOnly",
         query: graphql`
           query artQuizRoutes_ArtQuizResultsQuery {
             me {

--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -30,11 +30,7 @@ const ArtistApp: React.FC<ArtistAppProps> = ({ artist, children, match }) => {
 
   useScrollToOpenArtistAuthModal()
 
-  // A stand-alone page under the /artist route path
-  if (route.displayFullPage) {
-    return <PageWrapper artist={artist}>{children}</PageWrapper>
-  }
-
+  // FIXME: Instead of polluting the global route config, utilize two different parent apps
   // Sub-page with a back button
   if (route.hideNavigationTabs) {
     return (

--- a/src/Apps/Artist/__tests__/ArtistApp.jest.tsx
+++ b/src/Apps/Artist/__tests__/ArtistApp.jest.tsx
@@ -204,9 +204,6 @@ describe("ArtistApp", () => {
 
   describe("for `displayFullPage` routes", () => {
     it("renders correct components", () => {
-      mockfindCurrentRoute.mockImplementation(() => ({
-        displayFullPage: true,
-      }))
       const wrapper = getWrapper(
         {},
         { match: { params: { artworkId: undefined } } }

--- a/src/Apps/Artist/__tests__/ArtistApp.jest.tsx
+++ b/src/Apps/Artist/__tests__/ArtistApp.jest.tsx
@@ -202,18 +202,6 @@ describe("ArtistApp", () => {
     })
   })
 
-  describe("for `displayFullPage` routes", () => {
-    it("renders correct components", () => {
-      const wrapper = getWrapper(
-        {},
-        { match: { params: { artworkId: undefined } } }
-      )
-      expect(wrapper.find("ArtistMetaFragmentContainer").length).toBe(1)
-      expect(wrapper.find("ArtistHeaderFragmentContainer").length).toBe(0)
-      expect(wrapper.find("RouteTabs").length).toBe(0)
-    })
-  })
-
   describe("for `hideNavigationTabs` routes", () => {
     it("renders correct components", () => {
       mockfindCurrentRoute.mockImplementation(() => ({

--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -200,7 +200,6 @@ export const artistRoutes: AppRouteConfig[] = [
 
       {
         path: "consign",
-        displayFullPage: true,
         hideNavigationTabs: true,
         getComponent: () => ConsignRoute,
         onClientSideRender: () => {

--- a/src/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/Apps/Authentication/authenticationRoutes.tsx
@@ -46,8 +46,7 @@ const runAuthMiddleware = flow(checkForRedirect, setReferer)
 export const authenticationRoutes: AppRouteConfig[] = [
   {
     path: "/forgot",
-    hideNav: true,
-    hideFooter: true,
+    layout: "ContainerOnly",
     getComponent: () => ForgotPasswordRoute,
     onServerSideRender: ({ req, res }) => {
       res.locals.sd.RESET_PASSWORD_REDIRECT_TO =
@@ -61,8 +60,7 @@ export const authenticationRoutes: AppRouteConfig[] = [
   },
   {
     path: "/login",
-    hideNav: true,
-    hideFooter: true,
+    layout: "ContainerOnly",
     getComponent: () => LoginRoute,
     onServerSideRender: props => {
       // We need this check so we allow someone to log into the API even if they
@@ -87,8 +85,7 @@ export const authenticationRoutes: AppRouteConfig[] = [
   },
   {
     path: "/reset_password",
-    hideNav: true,
-    hideFooter: true,
+    layout: "ContainerOnly",
     getComponent: () => ResetPasswordRoute,
     onServerSideRender: ({ req, res }) => {
       // To avoid exposing the token to 3rd parties, we first put it in the session
@@ -124,8 +121,7 @@ export const authenticationRoutes: AppRouteConfig[] = [
   },
   {
     path: "/signup",
-    hideNav: true,
-    hideFooter: true,
+    layout: "ContainerOnly",
     getComponent: () => SignupRoute,
     onServerSideRender: props => {
       // We need this check so we allow someone to log into the API even if they

--- a/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
+++ b/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
@@ -169,8 +169,7 @@ export const collectorProfileRoutes: AppRouteConfig[] = [
   },
   {
     path: "/collector-profile/my-collection/artworks/new",
-    hideNav: true,
-    hideFooter: true,
+    layout: "ContainerOnly",
     getComponent: () => MyCollectionCreateArtwork,
     onClientSideRender: () => {
       MyCollectionCreateArtwork.preload()
@@ -202,8 +201,7 @@ export const collectorProfileRoutes: AppRouteConfig[] = [
   },
   {
     path: "/collector-profile/my-collection/artworks/:slug/edit",
-    hideNav: true,
-    hideFooter: true,
+    layout: "ContainerOnly",
     getComponent: () => MyCollectionEditArtwork,
     onClientSideRender: () => {
       MyCollectionEditArtwork.preload()
@@ -223,8 +221,7 @@ export const collectorProfileRoutes: AppRouteConfig[] = [
   },
   {
     path: "/collector-profile/my-collection/artwork/:artworkID/price-estimate",
-    hideNav: true,
-    hideFooter: true,
+    layout: "ContainerOnly",
     getComponent: () => PriceEstimateContactInformation,
     onClientSideRender: () => {
       PriceEstimateContactInformation.preload()
@@ -245,8 +242,7 @@ export const collectorProfileRoutes: AppRouteConfig[] = [
   {
     path:
       "/collector-profile/my-collection/artwork/:artworkID/price-estimate/success",
-    hideNav: true,
-    hideFooter: true,
+    layout: "ContainerOnly",
     getComponent: () => PriceEstimateConfirmation,
     onClientSideRender: () => {
       PriceEstimateConfirmation.preload()

--- a/src/Apps/Components/AppContainer.tsx
+++ b/src/Apps/Components/AppContainer.tsx
@@ -1,21 +1,22 @@
 import { Box, BoxProps, useTheme } from "@artsy/palette"
 import { ThemeV3 } from "@artsy/palette/dist/themes"
-import * as React from "react"
+import { FC, ElementType, HTMLAttributes } from "react"
 
-interface AppContainerProps extends BoxProps {}
+interface AppContainerProps extends BoxProps, HTMLAttributes<HTMLElement> {
+  as?: ElementType | keyof JSX.IntrinsicElements
+}
 
 /**
  * Handles the max-width of the application. That's it!
  */
-export const AppContainer: React.FC<AppContainerProps> = ({
+export const AppContainer: FC<AppContainerProps> = ({
   children,
-  maxWidth: defaultMaxWidth,
+  maxWidth,
   ...rest
 }) => {
   const { theme: { breakpoints = { lg: null } } = {} } = useTheme<ThemeV3>()
 
-  const maxWidth = breakpoints.lg
-  const appShellMaxWidth = defaultMaxWidth ?? maxWidth
+  const appShellMaxWidth = maxWidth ?? breakpoints.lg
 
   return (
     <Box width="100%" mx="auto" maxWidth={appShellMaxWidth} {...rest}>

--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -1,24 +1,18 @@
-import { Box, Flex } from "@artsy/palette"
 import { useNetworkOfflineMonitor } from "Utils/Hooks/useNetworkOfflineMonitor"
 import { findCurrentRoute } from "System/Router/Utils/findCurrentRoute"
-import { NavBar } from "Components/NavBar"
 import { Match } from "found"
 import { isFunction } from "lodash"
-import { Footer } from "Components/Footer"
 import { useEffect } from "react"
 import * as React from "react"
 import createLogger from "Utils/logger"
-import { useSystemContext } from "System"
-import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
-import { AppContainer } from "./AppContainer"
 import { useRunAuthIntent } from "Utils/Hooks/useAuthIntent"
-import { AppToasts } from "./AppToasts"
-import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
 import { useProductionEnvironmentWarning } from "Utils/Hooks/useProductionEnvironmentWarning"
 import { useAuthValidation } from "Utils/Hooks/useAuthValidation"
-import { Z } from "./constants"
 import { useOnboardingModal } from "Utils/Hooks/useOnboardingModal"
 import { useImagePerformanceObserver } from "Utils/Hooks/useImagePerformanceObserver"
+import { LayoutBlank } from "Apps/Components/Layouts/LayoutBlank"
+import { LayoutNavOnly } from "Apps/Components/Layouts/LayoutNavOnly"
+import { LayoutLogoOnly } from "Apps/Components/Layouts/LayoutLogoOnly"
 
 const logger = createLogger("Apps/Components/AppShell")
 interface AppShellProps {
@@ -36,10 +30,6 @@ export const AppShell: React.FC<AppShellProps> = props => {
 
   const { children, match } = props
   const routeConfig = match ? findCurrentRoute(match) : null
-  const { isEigen } = useSystemContext()
-  const showNav = !routeConfig?.hideNav
-  const showFooter = !isEigen && !routeConfig?.hideFooter
-  const appContainerMaxWidth = routeConfig?.displayFullPage ? "100%" : null
 
   // Check to see if a route has a onServerSideRender key; if so call it. Used
   // typically to preload bundle-split components (import()) while the route is
@@ -60,53 +50,14 @@ export const AppShell: React.FC<AppShellProps> = props => {
     document.body.setAttribute("data-test", "AppReady")
   }, [])
 
-  const { height: navBarHeight } = useNavBarHeight()
-
   useNetworkOfflineMonitor()
   useProductionEnvironmentWarning()
 
   return (
-    <Flex
-      width="100%"
-      // Prevents horizontal scrollbars from `FullBleed` + persistent vertical scrollbars
-      overflowX="hidden"
-      // Implements "Sticky footer" pattern
-      // https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/
-      minHeight="100vh"
-      flexDirection="column"
-    >
-      {showNav && (
-        <Box height={navBarHeight}>
-          <Box left={0} position="fixed" width="100%" zIndex={Z.globalNav}>
-            <NavBar />
-          </Box>
-        </Box>
-      )}
-
-      <AppToasts accomodateNav={showNav} />
-
-      <Flex
-        as="main"
-        id="main"
-        // Occupies available vertical space
-        flex={1}
-      >
-        <AppContainer maxWidth={appContainerMaxWidth}>
-          <HorizontalPadding>{children}</HorizontalPadding>
-        </AppContainer>
-      </Flex>
-
-      {showFooter && (
-        <Flex bg="white100" zIndex={Z.footer}>
-          <AppContainer>
-            <HorizontalPadding>
-              <Footer />
-            </HorizontalPadding>
-          </AppContainer>
-        </Flex>
-      )}
+    <>
+      <LayoutLogoOnly>{children}</LayoutLogoOnly>
 
       {onboardingComponent}
-    </Flex>
+    </>
   )
 }

--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -10,9 +10,7 @@ import { useProductionEnvironmentWarning } from "Utils/Hooks/useProductionEnviro
 import { useAuthValidation } from "Utils/Hooks/useAuthValidation"
 import { useOnboardingModal } from "Utils/Hooks/useOnboardingModal"
 import { useImagePerformanceObserver } from "Utils/Hooks/useImagePerformanceObserver"
-import { LayoutBlank } from "Apps/Components/Layouts/LayoutBlank"
-import { LayoutNavOnly } from "Apps/Components/Layouts/LayoutNavOnly"
-import { LayoutLogoOnly } from "Apps/Components/Layouts/LayoutLogoOnly"
+import { Layout } from "Apps/Components/Layouts"
 
 const logger = createLogger("Apps/Components/AppShell")
 interface AppShellProps {
@@ -55,7 +53,7 @@ export const AppShell: React.FC<AppShellProps> = props => {
 
   return (
     <>
-      <LayoutLogoOnly>{children}</LayoutLogoOnly>
+      <Layout variant={routeConfig?.layout}>{children}</Layout>
 
       {onboardingComponent}
     </>

--- a/src/Apps/Components/Layouts/Components/LayoutFooter.tsx
+++ b/src/Apps/Components/Layouts/Components/LayoutFooter.tsx
@@ -1,0 +1,20 @@
+import { AppContainer } from "Apps/Components/AppContainer"
+import { Z } from "Apps/Components/constants"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { Footer } from "Components/Footer"
+import { FC } from "react"
+import { useSystemContext } from "System"
+
+export const LayoutFooter: FC = () => {
+  const { isEigen } = useSystemContext()
+
+  if (isEigen) return null
+
+  return (
+    <AppContainer>
+      <HorizontalPadding>
+        <Footer zIndex={Z.footer} />
+      </HorizontalPadding>
+    </AppContainer>
+  )
+}

--- a/src/Apps/Components/Layouts/Components/LayoutMain.tsx
+++ b/src/Apps/Components/Layouts/Components/LayoutMain.tsx
@@ -1,0 +1,12 @@
+import { Box, BoxProps } from "@artsy/palette"
+import { FC } from "react"
+
+interface LayoutMainProps extends BoxProps {}
+
+export const LayoutMain: FC<LayoutMainProps> = ({ children, ...rest }) => {
+  return (
+    <Box as="main" id="main" overflowX="hidden" {...rest}>
+      {children}
+    </Box>
+  )
+}

--- a/src/Apps/Components/Layouts/Components/LayoutNav.tsx
+++ b/src/Apps/Components/Layouts/Components/LayoutNav.tsx
@@ -1,0 +1,24 @@
+import { Box } from "@artsy/palette"
+import { Z } from "Apps/Components/constants"
+import { NavBar } from "Components/NavBar"
+import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
+import { FC } from "react"
+import { useSystemContext } from "System"
+
+export const LayoutNav: FC = () => {
+  const { isEigen } = useSystemContext()
+  const { height: navBarHeight } = useNavBarHeight()
+
+  if (isEigen) return null
+
+  return (
+    <Box
+      // Occupy space for fixed position `NavBar`
+      height={navBarHeight}
+    >
+      <Box left={0} position="fixed" width="100%" zIndex={Z.globalNav}>
+        <NavBar />
+      </Box>
+    </Box>
+  )
+}

--- a/src/Apps/Components/Layouts/LayoutBlank.tsx
+++ b/src/Apps/Components/Layouts/LayoutBlank.tsx
@@ -1,0 +1,14 @@
+import { FC } from "react"
+import { AppToasts } from "Apps/Components/AppToasts"
+import { BaseLayoutProps } from "Apps/Components/Layouts"
+import { LayoutMain } from "Apps/Components/Layouts/Components/LayoutMain"
+
+export const LayoutBlank: FC<BaseLayoutProps> = ({ children }) => {
+  return (
+    <>
+      <AppToasts accomodateNav={false} />
+
+      <LayoutMain>{children}</LayoutMain>
+    </>
+  )
+}

--- a/src/Apps/Components/Layouts/LayoutContainerOnly.tsx
+++ b/src/Apps/Components/Layouts/LayoutContainerOnly.tsx
@@ -1,0 +1,20 @@
+import { FC } from "react"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { AppToasts } from "Apps/Components/AppToasts"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { BaseLayoutProps } from "Apps/Components/Layouts"
+import { LayoutMain } from "Apps/Components/Layouts/Components/LayoutMain"
+
+export const LayoutContainerOnly: FC<BaseLayoutProps> = ({ children }) => {
+  return (
+    <>
+      <AppToasts accomodateNav={false} />
+
+      <LayoutMain>
+        <AppContainer>
+          <HorizontalPadding>{children}</HorizontalPadding>
+        </AppContainer>
+      </LayoutMain>
+    </>
+  )
+}

--- a/src/Apps/Components/Layouts/LayoutDefault.tsx
+++ b/src/Apps/Components/Layouts/LayoutDefault.tsx
@@ -1,0 +1,36 @@
+import { FC } from "react"
+import { Flex, Spacer } from "@artsy/palette"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { AppToasts } from "Apps/Components/AppToasts"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { LayoutFooter } from "Apps/Components/Layouts/Components/LayoutFooter"
+import { LayoutNav } from "Apps/Components/Layouts/Components/LayoutNav"
+import { BaseLayoutProps } from "Apps/Components/Layouts"
+
+export const LayoutDefault: FC<BaseLayoutProps> = ({ children }) => {
+  return (
+    <>
+      <AppToasts accomodateNav />
+
+      <Flex
+        width="100%"
+        // Prevents horizontal scrollbars from `FullBleed` + persistent vertical scrollbars
+        overflowX="hidden"
+        // Implements "Sticky footer" pattern
+        // https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/
+        minHeight="100vh"
+        flexDirection="column"
+      >
+        <LayoutNav />
+
+        <AppContainer as="main" id="main" flex={1}>
+          <HorizontalPadding>{children}</HorizontalPadding>
+        </AppContainer>
+
+        <Spacer y={4} />
+
+        <LayoutFooter />
+      </Flex>
+    </>
+  )
+}

--- a/src/Apps/Components/Layouts/LayoutLogoOnly.tsx
+++ b/src/Apps/Components/Layouts/LayoutLogoOnly.tsx
@@ -1,0 +1,33 @@
+import { FC } from "react"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { AppToasts } from "Apps/Components/AppToasts"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { RouterLink } from "System/Router/RouterLink"
+import ArtsyLogoIcon from "@artsy/icons/ArtsyLogoIcon"
+import { Spacer } from "@artsy/palette"
+import { BaseLayoutProps } from "Apps/Components/Layouts"
+import { LayoutMain } from "Apps/Components/Layouts/Components/LayoutMain"
+
+export const LayoutLogoOnly: FC<BaseLayoutProps> = ({ children }) => {
+  return (
+    <>
+      <AppToasts accomodateNav={false} />
+
+      <LayoutMain>
+        <AppContainer>
+          <HorizontalPadding>
+            <Spacer y={4} />
+
+            <RouterLink to="/" display="block">
+              <ArtsyLogoIcon />
+            </RouterLink>
+
+            <Spacer y={4} />
+
+            {children}
+          </HorizontalPadding>
+        </AppContainer>
+      </LayoutMain>
+    </>
+  )
+}

--- a/src/Apps/Components/Layouts/LayoutNavOnly.tsx
+++ b/src/Apps/Components/Layouts/LayoutNavOnly.tsx
@@ -1,0 +1,23 @@
+import { FC } from "react"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { AppToasts } from "Apps/Components/AppToasts"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { LayoutNav } from "Apps/Components/Layouts/Components/LayoutNav"
+import { BaseLayoutProps } from "Apps/Components/Layouts"
+import { LayoutMain } from "Apps/Components/Layouts/Components/LayoutMain"
+
+export const LayoutNavOnly: FC<BaseLayoutProps> = ({ children }) => {
+  return (
+    <>
+      <AppToasts accomodateNav />
+
+      <LayoutNav />
+
+      <LayoutMain>
+        <AppContainer>
+          <HorizontalPadding>{children}</HorizontalPadding>
+        </AppContainer>
+      </LayoutMain>
+    </>
+  )
+}

--- a/src/Apps/Components/Layouts/README.md
+++ b/src/Apps/Components/Layouts/README.md
@@ -1,0 +1,17 @@
+# Layouts
+
+## Available Layouts
+
+- `Default`: current layout with fixed nav and footer. Contained by app container.
+- `NavOnly`: Same as default but without the footer.
+- `ContainerOnly`: Same as default but without the nav and without the footer.
+- `Blank`: Completely empty layout
+- `LogoOnly`: App container + our logotype. Used in the error pages. Should probably be used by the order app and various pages on the my collection app.
+
+## Adding a Layout
+
+Feel free to add a custom layout for your route(s), but meet the following criteria:
+
+- Must include `AppToasts` component
+- Some element must be a `main` tag with an `id="main` (prefer `LayoutMain`)
+- A full-width element must have `overflowX="hidden"` to prevent scrollbars when used with `FullBleed`

--- a/src/Apps/Components/Layouts/__stories__/Layout.story.tsx
+++ b/src/Apps/Components/Layouts/__stories__/Layout.story.tsx
@@ -1,0 +1,35 @@
+import { Box, Text } from "@artsy/palette"
+import { Layout } from "Apps/Components/Layouts"
+
+export default {
+  title: "Components/Layouts",
+  parameters: {
+    layout: "fullscreen",
+  },
+}
+
+const EXAMPLE_CONTENT = (
+  <Box bg="black10" px={2} py={1} flexGrow={1}>
+    <Text variant="xs">Example content</Text>
+  </Box>
+)
+
+export const Default = () => {
+  return <Layout variant="Default">{EXAMPLE_CONTENT}</Layout>
+}
+
+export const Blank = () => {
+  return <Layout variant="Blank">{EXAMPLE_CONTENT}</Layout>
+}
+
+export const LogoOnly = () => {
+  return <Layout variant="LogoOnly">{EXAMPLE_CONTENT}</Layout>
+}
+
+export const NavOnly = () => {
+  return <Layout variant="NavOnly">{EXAMPLE_CONTENT}</Layout>
+}
+
+export const ContainerOnly = () => {
+  return <Layout variant="ContainerOnly">{EXAMPLE_CONTENT}</Layout>
+}

--- a/src/Apps/Components/Layouts/index.tsx
+++ b/src/Apps/Components/Layouts/index.tsx
@@ -1,0 +1,30 @@
+import { LayoutBlank } from "Apps/Components/Layouts/LayoutBlank"
+import { LayoutContainerOnly } from "Apps/Components/Layouts/LayoutContainerOnly"
+import { LayoutDefault } from "Apps/Components/Layouts/LayoutDefault"
+import { LayoutLogoOnly } from "Apps/Components/Layouts/LayoutLogoOnly"
+import { LayoutNavOnly } from "Apps/Components/Layouts/LayoutNavOnly"
+import { FC, ReactNode } from "react"
+
+export interface BaseLayoutProps {
+  children: ReactNode
+}
+
+export interface LayoutProps extends BaseLayoutProps {
+  variant?: LayoutVariant
+}
+
+export const LAYOUTS = {
+  Blank: LayoutBlank,
+  ContainerOnly: LayoutContainerOnly,
+  Default: LayoutDefault,
+  LogoOnly: LayoutLogoOnly,
+  NavOnly: LayoutNavOnly,
+} as const
+
+export type LayoutVariant = keyof typeof LAYOUTS
+
+export const Layout: FC<LayoutProps> = ({ variant = "Default", children }) => {
+  const Component = LAYOUTS[variant]
+
+  return <Component>{children}</Component>
+}

--- a/src/Apps/Consign/consignFromCollectorProfileMyCollectionRoutes.tsx
+++ b/src/Apps/Consign/consignFromCollectorProfileMyCollectionRoutes.tsx
@@ -134,7 +134,7 @@ export const consignFromCollectorProfileMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: "faq",
-        hideFooter: true,
+        layout: "NavOnly",
         getComponent: () => FAQApp,
         onClientSideRender: () => {
           FAQApp.preload()
@@ -185,8 +185,7 @@ export const consignFromCollectorProfileMyCollectionRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "artwork-details/:artworkId",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ArtworkDetailsFragmentContainer,
         onClientSideRender: () => {
           ArtworkDetailsFragmentContainer.preload()
@@ -204,8 +203,7 @@ export const consignFromCollectorProfileMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/artwork-details/:artworkId",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ArtworkDetailsFragmentContainer,
         onClientSideRender: () => {
           ArtworkDetailsFragmentContainer.preload()
@@ -235,8 +233,7 @@ export const consignFromCollectorProfileMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/upload-photos/:artworkId",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => UploadPhotosFragmentContainer,
         onClientSideRender: () => {
           UploadPhotosFragmentContainer.preload()
@@ -266,8 +263,7 @@ export const consignFromCollectorProfileMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/contact-information/:artworkId?",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ContactInformation,
         onClientSideRender: () => {
           ContactInformation.preload()
@@ -296,8 +292,7 @@ export const consignFromCollectorProfileMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: "/contact-information/:artworkId?",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ContactInformation,
         onClientSideRender: () => {
           ContactInformation.preload()
@@ -314,8 +309,7 @@ export const consignFromCollectorProfileMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/thank-you/:artworkId?",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ThankYouWhenFromMyCollection,
         onClientSideRender: () => {
           ThankYouWhenFromMyCollection.preload()

--- a/src/Apps/Consign/consignFromMyCollectionRoutes.tsx
+++ b/src/Apps/Consign/consignFromMyCollectionRoutes.tsx
@@ -134,7 +134,7 @@ export const consignFromMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: "faq",
-        hideFooter: true,
+        layout: "NavOnly",
         getComponent: () => FAQApp,
         onClientSideRender: () => {
           FAQApp.preload()
@@ -181,8 +181,7 @@ export const consignFromMyCollectionRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "artwork-details/:artworkId",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ArtworkDetailsFragmentContainer,
         onClientSideRender: () => {
           ArtworkDetailsFragmentContainer.preload()
@@ -200,8 +199,7 @@ export const consignFromMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/artwork-details/:artworkId",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ArtworkDetailsFragmentContainer,
         onClientSideRender: () => {
           ArtworkDetailsFragmentContainer.preload()
@@ -231,8 +229,7 @@ export const consignFromMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/upload-photos/:artworkId",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => UploadPhotosFragmentContainer,
         onClientSideRender: () => {
           UploadPhotosFragmentContainer.preload()
@@ -262,8 +259,7 @@ export const consignFromMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/contact-information/:artworkId?",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ContactInformation,
         onClientSideRender: () => {
           ContactInformation.preload()
@@ -292,8 +288,7 @@ export const consignFromMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: "/contact-information/:artworkId?",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ContactInformation,
         onClientSideRender: () => {
           ContactInformation.preload()
@@ -310,8 +305,7 @@ export const consignFromMyCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/thank-you/:artworkId?",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ThankYouWhenFromMyCollection,
         onClientSideRender: () => {
           ThankYouWhenFromMyCollection.preload()

--- a/src/Apps/Consign/consignRoutes.tsx
+++ b/src/Apps/Consign/consignRoutes.tsx
@@ -189,7 +189,7 @@ export const consignRoutes: AppRouteConfig[] = [
       },
       {
         path: "faq",
-        hideFooter: true,
+        layout: "NavOnly",
         getComponent: () => FAQApp,
         onClientSideRender: () => {
           FAQApp.preload()
@@ -227,8 +227,7 @@ export const consignRoutes: AppRouteConfig[] = [
       {
         path: "/",
         getComponent: () => ConsignmentInquiryApp,
-        hideFooter: true,
-        hideNav: true,
+        layout: "ContainerOnly",
         onClientSideRender: () => {
           ConsignmentInquiryApp.preload()
         },
@@ -243,9 +242,7 @@ export const consignRoutes: AppRouteConfig[] = [
       },
       {
         path: "sent",
-        hideFooter: true,
-        hideNav: true,
-        hideNavigationTabs: true,
+        layout: "ContainerOnly",
         getComponent: () => ConsignmentInquiryConfirmationApp,
         onClientSideRender: () => {
           ConsignmentInquiryConfirmationApp.preload()
@@ -269,8 +266,7 @@ export const consignRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "artwork-details",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ArtworkDetails,
         onClientSideRender: () => {
           ArtworkDetails.preload()
@@ -278,8 +274,7 @@ export const consignRoutes: AppRouteConfig[] = [
       },
       {
         path: "contact-information",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ContactInformation,
         onClientSideRender: () => {
           ContactInformation.preload()
@@ -290,8 +285,7 @@ export const consignRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/artwork-details",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ArtworkDetailsFragmentContainer,
         onClientSideRender: () => {
           ArtworkDetailsFragmentContainer.preload()
@@ -317,8 +311,7 @@ export const consignRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/upload-photos",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => UploadPhotosFragmentContainer,
         onClientSideRender: () => {
           UploadPhotosFragmentContainer.preload()
@@ -344,8 +337,7 @@ export const consignRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/contact-information",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ContactInformation,
         onClientSideRender: () => {
           ContactInformation.preload()
@@ -356,8 +348,7 @@ export const consignRoutes: AppRouteConfig[] = [
       },
       {
         path: ":id/thank-you",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => ThankYou,
         onClientSideRender: () => {
           ThankYou.preload()

--- a/src/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/Apps/Conversation/Routes/Conversation/index.tsx
@@ -1,13 +1,6 @@
 import { useState } from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
-import {
-  Box,
-  Flex,
-  FullBleed,
-  Title,
-  ThemeProviderV3,
-  breakpoints,
-} from "@artsy/palette"
+import { Box, Flex, Title, breakpoints } from "@artsy/palette"
 import { Match } from "found"
 import styled from "styled-components"
 import { themeGet } from "@styled-system/theme-get"
@@ -62,32 +55,29 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
   const [showDetails, setShowDetails] = useState(false)
   return (
     <>
-      <ThemeProviderV3>
-        <FullBleed>
-          <Title>Inbox | Artsy</Title>
-          <ConstrainedHeightContainer>
-            <ConversationContainer>
-              <ConversationListWrapper>
-                <ConversationList
-                  me={me as any}
-                  selectedConversationID={me?.conversation?.internalID ?? ""}
-                />
-              </ConversationListWrapper>
-              <Conversation
-                conversation={me.conversation!}
-                showDetails={showDetails}
-                setShowDetails={setShowDetails}
-                refetch={props.relay.refetch}
-              />
-              <DetailsSidebarFragmentContainer
-                conversation={me.conversation!}
-                showDetails={showDetails}
-                setShowDetails={setShowDetails}
-              />
-            </ConversationContainer>
-          </ConstrainedHeightContainer>
-        </FullBleed>
-      </ThemeProviderV3>
+      <Title>Inbox | Artsy</Title>
+
+      <ConstrainedHeightContainer>
+        <ConversationContainer>
+          <ConversationListWrapper>
+            <ConversationList
+              me={me as any}
+              selectedConversationID={me?.conversation?.internalID ?? ""}
+            />
+          </ConversationListWrapper>
+          <Conversation
+            conversation={me.conversation!}
+            showDetails={showDetails}
+            setShowDetails={setShowDetails}
+            refetch={props.relay.refetch}
+          />
+          <DetailsSidebarFragmentContainer
+            conversation={me.conversation!}
+            showDetails={showDetails}
+            setShowDetails={setShowDetails}
+          />
+        </ConversationContainer>
+      </ConstrainedHeightContainer>
     </>
   )
 }

--- a/src/Apps/Conversation/conversationRoutes.tsx
+++ b/src/Apps/Conversation/conversationRoutes.tsx
@@ -5,8 +5,7 @@ import { graphql } from "react-relay"
 export const conversationRoutes: AppRouteConfig[] = [
   {
     path: "/user/conversations",
-    displayFullPage: true,
-    hideFooter: true,
+    layout: "NavOnly",
     getComponent: () =>
       loadable(
         () =>
@@ -36,8 +35,7 @@ export const conversationRoutes: AppRouteConfig[] = [
   },
   {
     path: "/user/conversations/:conversationID",
-    displayFullPage: true,
-    hideFooter: true,
+    layout: "NavOnly",
     ignoreScrollBehavior: true,
     Component: loadable(
       () =>

--- a/src/Apps/MyCollection/myCollectionRoutes.tsx
+++ b/src/Apps/MyCollection/myCollectionRoutes.tsx
@@ -76,8 +76,7 @@ export const myCollectionRoutes: AppRouteConfig[] = [
   },
   {
     path: "/my-collection/artwork/:artworkID/price-estimate",
-    hideNav: true,
-    hideFooter: true,
+    layout: "ContainerOnly",
     getComponent: () => PriceEstimateContactInformation,
     onClientSideRender: () => {
       PriceEstimateContactInformation.preload()
@@ -97,8 +96,7 @@ export const myCollectionRoutes: AppRouteConfig[] = [
   },
   {
     path: "/my-collection/artwork/:artworkID/price-estimate/success",
-    hideNav: true,
-    hideFooter: true,
+    layout: "ContainerOnly",
     getComponent: () => PriceEstimateConfirmation,
     onClientSideRender: () => {
       PriceEstimateConfirmation.preload()
@@ -109,8 +107,7 @@ export const myCollectionRoutes: AppRouteConfig[] = [
     children: [
       {
         path: "artworks/new",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => MyCollectionCreateArtwork,
         onClientSideRender: () => {
           MyCollectionCreateArtwork.preload()
@@ -128,8 +125,7 @@ export const myCollectionRoutes: AppRouteConfig[] = [
       },
       {
         path: "artworks/:slug/edit",
-        hideNav: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         getComponent: () => MyCollectionEditArtwork,
         onClientSideRender: () => {
           MyCollectionEditArtwork.preload()

--- a/src/Apps/MyCollectionInsights/myCollectionInsightsCollectorProfileRoutes.tsx
+++ b/src/Apps/MyCollectionInsights/myCollectionInsightsCollectorProfileRoutes.tsx
@@ -37,7 +37,6 @@ export const myCollectionInsightsCollectorProfileRoutes: AppRouteConfig[] = [
     cacheConfig: {
       force: true,
     },
-    // hideNav: true, // TODO: Hide/Unhide depending on the conversation with the #design team
-    // hideFooter: true, // TODO: Hide/Unhide depending on the conversation with the #design team
+    // layout: "ContainerOnly", // TODO: Change layout depending on the conversation with the #design team
   },
 ]

--- a/src/Apps/MyCollectionInsights/myCollectionInsightsRoutes.tsx
+++ b/src/Apps/MyCollectionInsights/myCollectionInsightsRoutes.tsx
@@ -30,7 +30,6 @@ export const myCollectionInsightsRoutes: AppRouteConfig[] = [
     cacheConfig: {
       force: true,
     },
-    // hideNav: true, // TODO: Hide/Unhide depending on the conversation with the #design team
-    // hideFooter: true, // TODO: Hide/Unhide depending on the conversation with the #design team
+    // layout: "ContainerOnly", // TODO: Switch layout depending on the conversation with the #design team
   },
 ]

--- a/src/Apps/Order/orderRoutes.tsx
+++ b/src/Apps/Order/orderRoutes.tsx
@@ -89,7 +89,7 @@ export const orderRoutes: AppRouteConfig[] = [
   {
     // TODO: Still need order2?
     path: "/order(2|s)/:orderID",
-    hideFooter: true,
+    layout: "ContainerOnly",
     Component: OrderApp,
     onClientSideRender: () => {
       OrderApp.preload()
@@ -155,7 +155,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "respond",
         Component: RespondRoute,
         shouldWarnBeforeLeaving: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         query: graphql`
           query orderRoutes_RespondQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -171,7 +171,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "offer",
         Component: OfferRoute,
         shouldWarnBeforeLeaving: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         query: graphql`
           query orderRoutes_OfferQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -187,7 +187,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "shipping",
         Component: ShippingRoute,
         shouldWarnBeforeLeaving: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         query: graphql`
           query orderRoutes_ShippingQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -206,7 +206,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "payment",
         Component: PaymentRoute,
         shouldWarnBeforeLeaving: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         query: graphql`
           query orderRoutes_PaymentQuery($orderID: ID!) {
             me {
@@ -225,7 +225,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "payment/new",
         Component: NewPaymentRoute,
         shouldWarnBeforeLeaving: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         query: graphql`
           query orderRoutes_NewPaymentQuery($orderID: ID!) {
             me {
@@ -244,7 +244,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "review/counter",
         Component: CounterRoute,
         shouldWarnBeforeLeaving: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         query: graphql`
           query orderRoutes_CounterQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -260,7 +260,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "review",
         Component: ReviewRoute,
         shouldWarnBeforeLeaving: true,
-        hideFooter: true,
+        layout: "ContainerOnly",
         query: graphql`
           query orderRoutes_ReviewQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -275,7 +275,7 @@ export const orderRoutes: AppRouteConfig[] = [
       {
         path: "review/accept",
         Component: AcceptRoute,
-        hideFooter: true,
+        layout: "ContainerOnly",
         query: graphql`
           query orderRoutes_AcceptQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -290,7 +290,7 @@ export const orderRoutes: AppRouteConfig[] = [
       {
         path: "review/decline",
         Component: DeclineRoute,
-        hideFooter: true,
+        layout: "ContainerOnly",
         query: graphql`
           query orderRoutes_RejectQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -302,7 +302,7 @@ export const orderRoutes: AppRouteConfig[] = [
       {
         path: "status",
         Component: StatusRoute,
-        hideFooter: true,
+        layout: "ContainerOnly",
         query: graphql`
           query orderRoutes_StatusQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -27,14 +27,20 @@ import WeChatIcon from "@artsy/icons/WeChatIcon"
 import InstagramIcon from "@artsy/icons/InstagramIcon"
 import TikTokIcon from "@artsy/icons/TikTokIcon"
 import SpotifyIcon from "@artsy/icons/SpotifyIcon"
+import { useSystemContext } from "System"
 
 interface FooterProps extends BoxProps {}
 
 export const Footer: React.FC<FooterProps> = props => {
+  const { isEigen } = useSystemContext()
+
+  if (isEigen) {
+    return null
+  }
+
   return (
     <Box
       id="download-app-banner"
-      mt={6}
       borderTop="1px solid"
       borderColor="black10"
       {...props}

--- a/src/Components/NavBar/MinimalNavBar.tsx
+++ b/src/Components/NavBar/MinimalNavBar.tsx
@@ -9,6 +9,9 @@ interface MinimalNavBarProps {
   isBlank?: boolean
 }
 
+/**
+ * @deprecated Use `layout: "LogoOnly"` instead
+ */
 export const MinimalNavBar: React.FC<MinimalNavBarProps> = props => {
   const { isEigen } = useSystemContext()
   return (

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -66,11 +66,6 @@ export const NavBar: React.FC = track(
   const isCollectorProfileEnabled = useFeatureFlag("cx-collector-profile")
   const { mediator, user, isEigen } = useSystemContext()
 
-  // FIXME: Doesn't follow rules of hooks
-  if (isEigen) {
-    return null
-  }
-
   const { jumpTo } = useJump({ behavior: "smooth" })
   const { trackEvent } = useTracking()
   const { t } = useTranslation()
@@ -129,6 +124,10 @@ export const NavBar: React.FC = track(
     }
 
     return <NavBarMobileMenuNotificationsIndicatorQueryRenderer />
+  }
+
+  if (isEigen) {
+    return null
   }
 
   return (

--- a/src/System/Router/ErrorBoundary.tsx
+++ b/src/System/Router/ErrorBoundary.tsx
@@ -2,10 +2,8 @@ import * as React from "react"
 import { ErrorWithMetadata } from "Utils/errors"
 import createLogger from "Utils/logger"
 import { ErrorPage } from "Components/ErrorPage"
-import { AppContainer } from "Apps/Components/AppContainer"
-import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
-import { ArtsyLogoBlackIcon, Button, ThemeProviderV3 } from "@artsy/palette"
-import { RouterLink } from "./RouterLink"
+import { Button, ThemeProviderV3 } from "@artsy/palette"
+import { LayoutLogoOnly } from "Apps/Components/Layouts/LayoutLogoOnly"
 
 const logger = createLogger()
 
@@ -79,50 +77,44 @@ export class ErrorBoundary extends React.Component<Props, State> {
     if (isError) {
       return (
         <ThemeProviderV3>
-          <AppContainer my={4}>
-            <HorizontalPadding>
-              <RouterLink to="/" display="block" mb={4}>
-                <ArtsyLogoBlackIcon />
-              </RouterLink>
-
-              {(() => {
-                switch (true) {
-                  case asyncChunkLoadError: {
-                    return (
-                      <ErrorPage
-                        code={500}
-                        message="Please check your network connection and try again."
+          <LayoutLogoOnly>
+            {(() => {
+              switch (true) {
+                case asyncChunkLoadError: {
+                  return (
+                    <ErrorPage
+                      code={500}
+                      message="Please check your network connection and try again."
+                    >
+                      <Button
+                        mt={2}
+                        size="small"
+                        variant="secondaryBlack"
+                        onClick={() => window.location.reload()}
                       >
-                        <Button
-                          mt={2}
-                          size="small"
-                          variant="secondaryBlack"
-                          onClick={() => window.location.reload()}
-                        >
-                          Reload
-                        </Button>
-                      </ErrorPage>
-                    )
-                  }
-
-                  case genericError: {
-                    return (
-                      <ErrorPage code={500} message={message} detail={detail}>
-                        <Button
-                          mt={2}
-                          size="small"
-                          variant="secondaryBlack"
-                          onClick={() => window.location.reload()}
-                        >
-                          Reload
-                        </Button>
-                      </ErrorPage>
-                    )
-                  }
+                        Reload
+                      </Button>
+                    </ErrorPage>
+                  )
                 }
-              })()}
-            </HorizontalPadding>
-          </AppContainer>
+
+                case genericError: {
+                  return (
+                    <ErrorPage code={500} message={message} detail={detail}>
+                      <Button
+                        mt={2}
+                        size="small"
+                        variant="secondaryBlack"
+                        onClick={() => window.location.reload()}
+                      >
+                        Reload
+                      </Button>
+                    </ErrorPage>
+                  )
+                }
+              }
+            })()}
+          </LayoutLogoOnly>
         </ThemeProviderV3>
       )
     }

--- a/src/System/Router/Route.tsx
+++ b/src/System/Router/Route.tsx
@@ -1,35 +1,38 @@
 import { RouteSpinner } from "System/Relay/renderWithLoadProgress"
 import { RouteConfig, HttpError, Match } from "found"
 import BaseRoute from "found/Route"
-import * as React from "react";
-import { CacheConfig, GraphQLTaggedNode } from "relay-runtime";
-import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress";
-import { NextFunction } from "express";
+import * as React from "react"
+import { CacheConfig, GraphQLTaggedNode } from "relay-runtime"
+import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
+import { NextFunction } from "express"
+import { LayoutVariant } from "Apps/Components/Layouts"
+import { RemoveIndex } from "Utils/typeSupport"
 
 interface RouteConfigProps extends RouteConfig {
   cacheConfig?: CacheConfig
   children?: AppRouteConfig[]
-  displayFullPage?: boolean
   fetchIndicator?: FetchIndicator
-  hideNav?: boolean
-  hideFooter?: boolean
+  /** FIXME: Remove. Avoid poluting global route config with application specific concerns */
   hideNavigationTabs?: boolean
   ignoreScrollBehavior?: boolean
   ignoreScrollBehaviorBetweenChildren?: boolean
+  layout?: LayoutVariant
   onClientSideRender?: (props: { match: Match }) => void
-  onServerSideRender?: (props: { req: ArtsyRequest, res: ArtsyResponse, next: NextFunction, route: AppRouteConfig }) => void
+  onServerSideRender?: (props: {
+    req: ArtsyRequest
+    res: ArtsyResponse
+    next: NextFunction
+    route: AppRouteConfig
+  }) => void
   prepareVariables?: (params: any, props: any) => object
   query?: GraphQLTaggedNode
   scrollToTop?: boolean
+  /** FIXME: Remove. Avoid poluting global route config with application specific concerns */
   shouldWarnBeforeLeaving?: boolean
 }
 
 // Strip the index prop from `found`'s RouteConfig so that we can lock the
 // config to the above definition
-type RemoveIndex<T> = {
-  [P in keyof T as string extends P ? never : number extends P ? never : P]: T[P]
-};
-
 export type AppRouteConfig = RemoveIndex<RouteConfigProps>
 
 type FetchIndicator = "spinner" | "overlay"

--- a/src/System/Router/Utils/findCurrentRoute.tsx
+++ b/src/System/Router/Utils/findCurrentRoute.tsx
@@ -1,4 +1,4 @@
-import { AppRouteConfig } from "../Route"
+import { AppRouteConfig } from "System/Router/Route"
 
 export const findCurrentRoute = (match): AppRouteConfig => {
   if (!match) {

--- a/src/Utils/typeSupport.ts
+++ b/src/Utils/typeSupport.ts
@@ -53,3 +53,7 @@ export type CleanRelayFragment<T> = Omit<
   T,
   "$refType" | " $fragmentRefs" | " $fragmentSpreads" | " $fragmentType"
 >
+
+export type RemoveIndex<T> = {
+  [P in keyof T as string extends P ? never : number extends P ? never : P]: T[P]
+};


### PR DESCRIPTION
I don't particularly feel like merging a site wide change like this before the holiday break but please leave some feedback.

The problem I noticed was that the layout in `AppShell` is difficult to work with. Sometimes hiding footer/navigation is confusing. There's a `displayFullPage` flag that is pointless. And there's a need for alternate layouts that were achieved in hacky ways (see the Order app, for instance).

So this just removes those flags and introduces a few different layouts which can be opted into at the route level. They are simple to understand. I think the naming could use some work but 🤷 .

## Layouts

* `Default`: current layout with fixed nav and footer. Contained by app container.
* `NavOnly`: Same as default but without the footer.
* `ContainerOnly`: Same as default but without the nav and without the footer.
* `Blank`: Completely empty layout
* `LogoOnly`: App container + our logotype. Used in the error pages. Should probably be used by the order app and various pages on the my collection app.