### PR TITLE
fix(NX-3408): Set the iframe to use the total width

### DIFF
--- a/src/Apps/Conversation/Components/OrderModal.tsx
+++ b/src/Apps/Conversation/Components/OrderModal.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components"
 
 export const StyledIframe = styled("iframe")`
   height: 60vh;
+  width: 100%;
   border: none;
 `
 


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [NX-3408]

### Description
After updating the deprecated `Modal` component to `ModalDialog` (#11301), the iframe being rendered inside the modal had its width affected.

Changes here ensure the iframe will use 100% of the available width when the modal is triggered (this seemed to be the usual behaviour when we were using the `Modal` component).

Is this the best way to go here? As I understand we don't use this component today in any other spot besides the conversation.

## Before
![before](https://user-images.githubusercontent.com/8002618/209341987-42d3eada-6d9a-4141-90e3-c1a673d65e75.png)

## After
![after](https://user-images.githubusercontent.com/8002618/209342002-976e99d4-5e18-47c0-ab71-99abf5764b54.png)

cc @artsy/negotiate-devs 

[NX-3408]: https://artsyproduct.atlassian.net/browse/NX-3408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ