### PR TITLE
feat(CX-3276): add new route for mediam sale price

### DIFF
--- a/src/Apps/MyCollectionInsights/myCollectionInsightsCollectorProfileRoutes.tsx
+++ b/src/Apps/MyCollectionInsights/myCollectionInsightsCollectorProfileRoutes.tsx
@@ -1,0 +1,43 @@
+import loadable from "@loadable/component"
+import { graphql } from "react-relay"
+import { AppRouteConfig } from "System/Router/Route"
+
+// TODO: when cleanning up collector-profile ff,
+// change the file name to myCollectionInsightsRoutes
+// and export name to myCollectionInsightsRoutes
+
+const MyCollectionInsightsMedianSalePriceAtAuction = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "myCollectionInsightsBundle" */ "./Routes/MyCollectionInsightsMedianSalePriceAtAuction/MyCollectionInsightsMedianSalePriceAtAuction"
+    ),
+  {
+    resolveComponent: component =>
+      component.MyCollectionInsightsMedianSalePriceAtAuction,
+  }
+)
+
+export const myCollectionInsightsCollectorProfileRoutes: AppRouteConfig[] = [
+  {
+    path:
+      "/collector-profile/my-collection/median-sale-price-at-auction/:artistID",
+    getComponent: () => MyCollectionInsightsMedianSalePriceAtAuction,
+    onClientSideRender: () => {
+      MyCollectionInsightsMedianSalePriceAtAuction.preload()
+    },
+    query: graphql`
+      query myCollectionInsightsCollectorProfileRoutesQuery(
+        $artistID: String!
+      ) {
+        artist(id: $artistID) @principalField {
+          ...MyCollectionInsightsMedianSalePriceAtAuction_artist
+        }
+      }
+    `,
+    cacheConfig: {
+      force: true,
+    },
+    // hideNav: true, // TODO: Hide/Unhide depending on the conversation with the #design team
+    // hideFooter: true, // TODO: Hide/Unhide depending on the conversation with the #design team
+  },
+]

--- a/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsMedianSalePrice.tsx
@@ -104,12 +104,16 @@ const ArtistRowWrapper: React.FC<{
   const enableMedianSalePriceGraphScreen = useFeatureFlag(
     "my-collection-web-phase-7-median-sale-price-graph"
   )
+  const isCollectorProfileEnabled = useFeatureFlag("cx-collector-profile")
+
   if (enableMedianSalePriceGraphScreen) {
     return (
       <ClickableArtistRow
         onClick={() =>
           router.push(
-            `/my-collection/median-sale-price-at-auction/${artistID}?medium=${medium}`
+            isCollectorProfileEnabled
+              ? `/collector-profile/my-collection/median-sale-price-at-auction/${artistID}?medium=${medium}`
+              : `/my-collection/median-sale-price-at-auction/${artistID}?medium=${medium}`
           )
         }
       >

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
@@ -69,9 +69,9 @@ describe("InsightsMedianSalePrice", () => {
           "my-collection-web-phase-7-median-sale-price-graph": {
             flagEnabled: true,
           },
-        },
-        "cx-collector-profile": {
-          flagEnabled: false,
+          "cx-collector-profile": {
+            flagEnabled: false,
+          },
         },
       }))
 
@@ -92,9 +92,9 @@ describe("InsightsMedianSalePrice", () => {
           "my-collection-web-phase-7-median-sale-price-graph": {
             flagEnabled: true,
           },
-        },
-        "cx-collector-profile": {
-          flagEnabled: true,
+          "cx-collector-profile": {
+            flagEnabled: true,
+          },
         },
       }))
 

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
@@ -70,6 +70,9 @@ describe("InsightsMedianSalePrice", () => {
             flagEnabled: true,
           },
         },
+        "cx-collector-profile": {
+          flagEnabled: false,
+        },
       }))
 
       renderWithRelay(mockResolver, false)
@@ -80,6 +83,29 @@ describe("InsightsMedianSalePrice", () => {
 
       expect(mockPush).toHaveBeenCalledWith(
         "/my-collection/median-sale-price-at-auction/takashi-murakami-id?medium=Print"
+      )
+    })
+
+    it("navigates to the median auction price screen when the median-sale-price-graph and collecto-profile feature flags are enabled", () => {
+      ;(useSystemContext as jest.Mock).mockImplementation(() => ({
+        featureFlags: {
+          "my-collection-web-phase-7-median-sale-price-graph": {
+            flagEnabled: true,
+          },
+        },
+        "cx-collector-profile": {
+          flagEnabled: true,
+        },
+      }))
+
+      renderWithRelay(mockResolver, false)
+
+      const artistRow = screen.getByText("Takashi Murakami")
+
+      fireEvent.click(artistRow)
+
+      expect(mockPush).toHaveBeenCalledWith(
+        "/collector-profile/my-collection/median-sale-price-at-auction/takashi-murakami-id?medium=Print"
       )
     })
   })

--- a/src/__generated__/myCollectionInsightsCollectorProfileRoutesQuery.graphql.ts
+++ b/src/__generated__/myCollectionInsightsCollectorProfileRoutesQuery.graphql.ts
@@ -1,0 +1,221 @@
+/**
+ * @generated SignedSource<<9aec199ab2c301941ef9e3ee01784386>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type myCollectionInsightsCollectorProfileRoutesQuery$variables = {
+  artistID: string;
+};
+export type myCollectionInsightsCollectorProfileRoutesQuery$data = {
+  readonly artist: {
+    readonly " $fragmentSpreads": FragmentRefs<"MyCollectionInsightsMedianSalePriceAtAuction_artist">;
+  } | null;
+};
+export type myCollectionInsightsCollectorProfileRoutesQuery = {
+  response: myCollectionInsightsCollectorProfileRoutesQuery$data;
+  variables: myCollectionInsightsCollectorProfileRoutesQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "artistID"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "myCollectionInsightsCollectorProfileRoutesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "MyCollectionInsightsMedianSalePriceAtAuction_artist"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "myCollectionInsightsCollectorProfileRoutesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "initials",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "formattedNationalityAndBirthday",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "artworks",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "forSaleArtworks",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": "avatar",
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 45
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 45
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "src",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "srcSet",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:45,width:45)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "fed3ccbbe425472da3b6cae6ef5d124b",
+    "id": null,
+    "metadata": {},
+    "name": "myCollectionInsightsCollectorProfileRoutesQuery",
+    "operationKind": "query",
+    "text": "query myCollectionInsightsCollectorProfileRoutesQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...MyCollectionInsightsMedianSalePriceAtAuction_artist\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment MyCollectionInsightsMedianSalePriceAtAuction_artist on Artist {\n  ...EntityHeaderArtist_artist\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a0949b74c5be0bd130ec8ceb20ee1fec";
+
+export default node;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -54,6 +54,7 @@ import { pressRoutes } from "./Apps/Press/pressRoutes"
 import { priceDatabaseRoutes } from "./Apps/PriceDatabase/priceDatabaseRoutes"
 import { tagRoutes } from "./Apps/Tag/tagRoutes"
 import { worksForYouRoutes } from "./Apps/WorksForYou/worksForYouRoutes"
+import { myCollectionInsightsCollectorProfileRoutes } from "Apps/MyCollectionInsights/myCollectionInsightsCollectorProfileRoutes"
 
 export const getAppRoutes = (): AppRouteConfig[] => {
   return buildAppRoutes([
@@ -92,6 +93,7 @@ export const getAppRoutes = (): AppRouteConfig[] => {
     { routes: meetTheSpecialistsRoutes },
     { routes: myCollectionRoutes },
     { routes: myCollectionInsightsRoutes },
+    { routes: myCollectionInsightsCollectorProfileRoutes },
     { routes: newForYouRoutes },
     { routes: notificationsRoutes },
     { routes: onboardingRoutes },


### PR DESCRIPTION
The type of this PR is: **Feat/Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3276]

### Description

<!-- Implementation description -->
Add a new route for median sale price
When assessing the page from collector profile, the URL should start with /collector-profile

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3276]: https://artsyproduct.atlassian.net/browse/CX-3276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ