### PR TITLE
fix(CX-3284): Update Setting icon size in Collector Profile

### DIFF
--- a/src/Apps/CollectorProfile/Components/CollectorProfileHeader/CollectorProfileHeader.tsx
+++ b/src/Apps/CollectorProfile/Components/CollectorProfileHeader/CollectorProfileHeader.tsx
@@ -33,7 +33,7 @@ const CollectorProfileHeader: React.FC<CollectorProfileHeaderProps> = ({
 
         <Media lessThan="sm">
           <RouterLink to="/settings/edit-settings">
-            <SettingsIcon />
+            <SettingsIcon height={24} width={24} />
           </RouterLink>
         </Media>
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3284]

### Description
This PR updates the Settings icon size on the Collector Profile

### Screenshots
| Before | After |
|--|--|
| ![image](https://user-images.githubusercontent.com/20655703/209391162-5fd94b94-e268-4aa6-8506-9b9174dee2ed.png) | ![image](https://user-images.githubusercontent.com/20655703/209391149-ae126fb5-174e-41ab-b221-65a22de0052a.png) |

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3284]: https://artsyproduct.atlassian.net/browse/CX-3284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ