### PR TITLE
refactor(art-quiz): compromise on the layout

### DIFF
--- a/src/Apps/ArtQuiz/ArtQuizApp.tsx
+++ b/src/Apps/ArtQuiz/ArtQuizApp.tsx
@@ -1,33 +1,12 @@
-import { Box } from "@artsy/palette"
-import { AppContainer } from "Apps/Components/AppContainer"
-import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
-import { MetaTags } from "Components/MetaTags"
-import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
 import { FC } from "react"
+import { MetaTags } from "Components/MetaTags"
 
 export const ArtQuizApp: FC = ({ children }) => {
-  const { height } = useNavBarHeight()
-
   return (
     <>
       <MetaTags title="Art Taste Quiz | Artsy" />
 
-      {/* TODO: Remove once we implement a footer-less layout that allows for filling out the height */}
-      <Box
-        position="fixed"
-        top={height}
-        right={0}
-        bottom={0}
-        left={0}
-        overflow="auto"
-        style={{
-          WebkitOverflowScrolling: "touch",
-        }}
-      >
-        <AppContainer height="100%">
-          <HorizontalPadding height="100%">{children}</HorizontalPadding>
-        </AppContainer>
-      </Box>
+      {children}
     </>
   )
 }

--- a/src/Apps/ArtQuiz/Components/ArtQuizFullscreen.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizFullscreen.tsx
@@ -1,0 +1,36 @@
+import { Box } from "@artsy/palette"
+import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
+import { FC, useEffect, useState } from "react"
+
+export const ArtQuizFullScreen: FC = ({ children }) => {
+  const { mobile, desktop } = useNavBarHeight()
+
+  /**
+   * We can't use 100vh because on mobile devices this does not
+   * include the browser's address/navigation bar.
+   *
+   * We could use `min-height: fill-available`, but it would require
+   * some adjustments to global CSS.
+   **/
+  const [height, setHeight] = useState(0)
+
+  useEffect(() => {
+    const handleResize = () => {
+      setHeight(window.innerHeight)
+    }
+
+    handleResize()
+
+    window.addEventListener("resize", handleResize, { passive: true })
+
+    return () => {
+      window.removeEventListener("resize", handleResize)
+    }
+  }, [])
+
+  return (
+    <Box height={[`${height - mobile}px`, `${height - desktop}px`]}>
+      {children}
+    </Box>
+  )
+}

--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsLoader.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsLoader.tsx
@@ -7,6 +7,7 @@ import {
   Spinner,
   Box,
 } from "@artsy/palette"
+import { ArtQuizFullScreen } from "Apps/ArtQuiz/Components/ArtQuizFullscreen"
 import { SplitLayout } from "Components/SplitLayout"
 import { useState, useEffect, FC } from "react"
 import { useTranslation } from "react-i18next"
@@ -39,41 +40,43 @@ export const ArtQuizResultsLoader: FC<ArtQuizResultsLoaderProps> = ({
   }, [onReady])
 
   return (
-    <FullBleed height="100%">
-      <SplitLayout
-        hideLogo
-        left={
-          <Flex height="100%" alignItems="center" justifyContent="center">
-            <ArtsyMarkBlackIcon height={65} width={65} fill="white100" />
-          </Flex>
-        }
-        leftProps={{ display: ["none", "block"] }}
-        right={
-          <Flex
-            width="100%"
-            flexDirection="column"
-            justifyContent="center"
-            alignItems="center"
-            p={[2, 4]}
-          >
-            <Box position="relative" height={25} width={25}>
-              <Spinner color="brand" />
-            </Box>
+    <ArtQuizFullScreen>
+      <FullBleed height="100%">
+        <SplitLayout
+          hideLogo
+          left={
+            <Flex height="100%" alignItems="center" justifyContent="center">
+              <ArtsyMarkBlackIcon height={65} width={65} fill="white100" />
+            </Flex>
+          }
+          leftProps={{ display: ["none", "block"] }}
+          right={
+            <Flex
+              width="100%"
+              flexDirection="column"
+              justifyContent="center"
+              alignItems="center"
+              p={[2, 4]}
+            >
+              <Box position="relative" height={25} width={25}>
+                <Spinner color="brand" />
+              </Box>
 
-            <Spacer y={2} />
+              <Spacer y={2} />
 
-            <Text variant={["lg", "xl"]}> {t("artQuizPage.title")}</Text>
+              <Text variant={["lg", "xl"]}> {t("artQuizPage.title")}</Text>
 
-            <Spacer y={2} />
+              <Spacer y={2} />
 
-            <Text variant={["sm", "md"]} color="black60">
-              {loading
-                ? t("artQuizPage.loadingScreen.calculatingResults")
-                : t("artQuizPage.loadingScreen.resultsComplete")}
-            </Text>
-          </Flex>
-        }
-      />
-    </FullBleed>
+              <Text variant={["sm", "md"]} color="black60">
+                {loading
+                  ? t("artQuizPage.loadingScreen.calculatingResults")
+                  : t("artQuizPage.loadingScreen.resultsComplete")}
+              </Text>
+            </Flex>
+          }
+        />
+      </FullBleed>
+    </ArtQuizFullScreen>
   )
 }

--- a/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
@@ -25,6 +25,7 @@ import { FC, useCallback, useRef } from "react"
 import { RouterLink } from "System/Router/RouterLink"
 import { useRouter } from "System/Router/useRouter"
 import { FullscreenBox } from "Components/FullscreenBox"
+import { ArtQuizFullScreen } from "Apps/ArtQuiz/Components/ArtQuizFullscreen"
 
 interface ArtQuizArtworksProps {
   me: ArtQuizArtworks_me$data
@@ -118,7 +119,7 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
   })
 
   return (
-    <>
+    <ArtQuizFullScreen>
       <FullBleed height="100%" display="flex" flexDirection="column">
         <Flex alignItems="stretch">
           <Clickable
@@ -208,7 +209,7 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
           />
         </Flex>
       </FullBleed>
-    </>
+    </ArtQuizFullScreen>
   )
 }
 

--- a/src/Apps/ArtQuiz/Routes/ArtQuizWelcome.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizWelcome.tsx
@@ -11,7 +11,7 @@ import { SplitLayout } from "Components/SplitLayout"
 import { FC } from "react"
 import { RouterLink } from "System/Router/RouterLink"
 import { useTranslation } from "react-i18next"
-import { MetaTags } from "Components/MetaTags"
+import { ArtQuizFullScreen } from "Apps/ArtQuiz/Components/ArtQuizFullscreen"
 
 interface ArtQuizWelcomeProps {
   onStartQuiz: () => void
@@ -21,9 +21,7 @@ export const ArtQuizWelcome: FC<ArtQuizWelcomeProps> = ({ onStartQuiz }) => {
   const { t } = useTranslation()
 
   return (
-    <>
-      <MetaTags title="Art Taste Quiz | Artsy" />
-
+    <ArtQuizFullScreen>
       <FullBleed height="100%">
         <SplitLayout
           hideLogo
@@ -80,6 +78,6 @@ export const ArtQuizWelcome: FC<ArtQuizWelcomeProps> = ({ onStartQuiz }) => {
           }
         />
       </FullBleed>
-    </>
+    </ArtQuizFullScreen>
   )
 }

--- a/src/Apps/ArtQuiz/artQuizRoutes.tsx
+++ b/src/Apps/ArtQuiz/artQuizRoutes.tsx
@@ -84,7 +84,6 @@ export const artQuizRoutes: AppRouteConfig[] = [
       {
         path: "results",
         getComponent: () => ArtQuizResults,
-        layout: "NavOnly",
         query: graphql`
           query artQuizRoutes_ArtQuizResultsQuery {
             me {

--- a/src/Components/NavBar/useNavBarHeight.ts
+++ b/src/Components/NavBar/useNavBarHeight.ts
@@ -5,16 +5,20 @@ import {
   DESKTOP_NAV_BAR_HEIGHT,
 } from "./constants"
 
-export const useNavBarHeight = () => {
+export const useNavBarHeight = (): {
+  height: [number, number]
+  mobile: number
+  desktop: number
+} => {
   const { isLoggedIn, isEigen } = useSystemContext()
 
-  let mobile = isLoggedIn ? MOBILE_LOGGED_IN_NAV_HEIGHT : MOBILE_NAV_HEIGHT
-  let desktop = DESKTOP_NAV_BAR_HEIGHT
-
+  // Navbar is disabled in Eigen
   if (isEigen) {
-    mobile = 0
-    desktop = 0
+    return { height: [0, 0], mobile: 0, desktop: 0 }
   }
+
+  const mobile = isLoggedIn ? MOBILE_LOGGED_IN_NAV_HEIGHT : MOBILE_NAV_HEIGHT
+  const desktop = DESKTOP_NAV_BAR_HEIGHT
 
   return { height: [mobile, desktop], mobile, desktop }
 }


### PR DESCRIPTION
OK, so this was a funny journey.

While although we can get the layout to naturally fill out the parent container now, it turns out we actually want to do something slightly different because of how `100vh` works on Mobile Safari. Basically: `top bar + document + bottom bar = 100vh`. Which means there would be a bit of overflow scrolling. So, where we need these fullscreen layouts we can use `ArtQuizFullscreen.tsx` which just — you guessed it — measures out the available viewport.

There actually _is_ a way to do this using the value `fill-available` but we'd need to patch this up to the `html` and `body` elements — which, I actually think we should. But for now this is going to work fine.

![](https://static.damonzucconi.com/_capture/lAfm0dQ7.png)