### PR TITLE
fix: Add space to High Demand icon on artwork grid

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -140,7 +140,7 @@ const HighDemandInfo = () => {
     <Flex flexDirection="row" alignItems="center">
       <HighDemandIcon width={16} height={16} />
       <Text variant="xs" color="blue100" ml={0.3}>
-        High Demand
+        &nbsp;High Demand
       </Text>
     </Flex>
   )


### PR DESCRIPTION
## Description

Add space to High Demand icon on artwork grid.

| Before | After |
| --- | --- |
|<img width="499" alt="Screenshot 2022-12-29 at 15 12 04" src="https://user-images.githubusercontent.com/4691889/209965597-303f4e23-1a11-47a0-9d75-6fe3a9d4855a.png"> |<img width="508" alt="Screenshot 2022-12-29 at 15 11 21" src="https://user-images.githubusercontent.com/4691889/209965630-f8456c74-d8e0-422a-8f82-360facae79f0.png"> |




