### PR TITLE
fix(CX-3225): navigation menu, address comments

### DIFF
--- a/src/Components/NavBar/Menus/NavBarUserMenu.tsx
+++ b/src/Components/NavBar/Menus/NavBarUserMenu.tsx
@@ -61,20 +61,20 @@ export const NavBarUserMenu: React.FC = () => {
             CMS
           </NavBarMenuItemLink>
 
+          <NavBarMenuItemLink
+            aria-label="View your purchases"
+            to="/settings/purchases"
+            onClick={trackClick}
+          >
+            Order History
+          </NavBarMenuItemLink>
+
           <Separator as="hr" my={1} />
         </>
       )}
 
       {isCollectorProfileEnabled ? (
         <>
-          <NavBarMenuItemLink
-            aria-label="View your purchases"
-            to="/settings/purchases"
-            onClick={trackClick}
-          >
-            <ReceiptIcon mr={1} aria-hidden="true" /> Order History
-          </NavBarMenuItemLink>
-
           <NavBarMenuItemLink
             aria-label="View your Collection"
             to="/collector-profile/my-collection"

--- a/src/Components/NavBar/Menus/__tests__/NavBarUserMenu.jest.tsx
+++ b/src/Components/NavBar/Menus/__tests__/NavBarUserMenu.jest.tsx
@@ -111,7 +111,6 @@ describe("NavBarUserMenu with collector profile enabled", () => {
 
     expect(links.map(a => [a.prop("href"), a.text()])).toEqual([
       // Label also includes SVG image title
-      ["/settings/purchases", "Pending Order History"],
       ["/collector-profile/my-collection", "Artwork My Collection"],
       ["/collector-profile/insights", "View dashboard Insights"],
       ["/collector-profile/saves", "Save Saves & Follows"],

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -279,7 +279,7 @@ export const NavBar: React.FC = track(
                       justifyContent="center"
                       onClick={() => router.push("/settings/alerts")}
                     >
-                      <BellIcon aria-hidden="true" />
+                      <BellIcon aria-hidden="true" height={22} width={22} />
                       {renderNotificationsIndicator()}
                     </NavBarItemButton>
 
@@ -291,7 +291,7 @@ export const NavBar: React.FC = track(
                         router.push("/collector-profile/my-collection")
                       }
                     >
-                      <SoloIcon aria-hidden="true" />
+                      <SoloIcon aria-hidden="true" height={22} width={22} />
                     </NavBarItemButton>
                   </>
                 )}

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -277,7 +277,7 @@ export const NavBar: React.FC = track(
                       display="flex"
                       alignItems="center"
                       justifyContent="center"
-                      onClick={() => router.push("/settings/alerts")}
+                      onClick={() => router.push("/notifications")}
                     >
                       <BellIcon aria-hidden="true" height={22} width={22} />
                       {renderNotificationsIndicator()}

--- a/src/Components/Search/SearchInputContainer.tsx
+++ b/src/Components/Search/SearchInputContainer.tsx
@@ -47,7 +47,7 @@ export const SearchInputContainer: React.ForwardRefExoticComponent<
             }
           }}
         >
-          <MagnifyingGlassIcon />
+          <MagnifyingGlassIcon height={22} width={22} />
         </SearchButton>
       }
       {...props}


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3225]

### Description

<!-- Implementation description -->
1. Remove “order history”, show it only for Admins
2. increase icon size to 22px - Collector Profile, Activity, Search
3. On the mweb "bell icon" should navigate the user to the activity panel
![image](https://user-images.githubusercontent.com/36167539/209968823-0a4ae3cc-9596-47be-af9c-1ca6547e56dd.png)


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3225]: https://artsyproduct.atlassian.net/browse/CX-3225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ