### PR TITLE
fix(CX-3287): Show the Upload Artwork button only if the header is sticky

### DIFF
--- a/src/Apps/Settings/Routes/Insights/Components/InsightsHeader.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsHeader.tsx
@@ -30,22 +30,26 @@ export const InsightsHeader: React.FC = () => {
                     justifyContent="flex-end"
                     py={[1, 2]}
                   >
-                    <Button
-                      // @ts-ignore
-                      as={RouterLink}
-                      size={["small", "large"]}
-                      variant="primaryBlack"
-                      to={
-                        isCollectorProfileEnabled
-                          ? "/collector-profile/my-collection/artworks/new"
-                          : "/my-collection/artworks/new"
-                      }
-                      onClick={() =>
-                        trackAddCollectedArtwork(OwnerType.myCollectionInsights)
-                      }
-                    >
-                      Upload Artwork
-                    </Button>
+                    {stuck && (
+                      <Button
+                        // @ts-ignore
+                        as={RouterLink}
+                        size={["small", "large"]}
+                        variant="primaryBlack"
+                        to={
+                          isCollectorProfileEnabled
+                            ? "/collector-profile/my-collection/artworks/new"
+                            : "/my-collection/artworks/new"
+                        }
+                        onClick={() =>
+                          trackAddCollectedArtwork(
+                            OwnerType.myCollectionInsights
+                          )
+                        }
+                      >
+                        Upload Artwork
+                      </Button>
+                    )}
                   </Flex>
                 </HorizontalPadding>
               </AppContainer>

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsHeader.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsHeader.jest.tsx
@@ -7,6 +7,10 @@ jest.mock("System/useSystemContext")
 jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => false,
 }))
+jest.mock("Components/Sticky", () => ({
+  Sticky: ({ children }) => children({ stuck: true }),
+  StickyProvider: ({ children }) => children,
+}))
 
 describe("InsightsHeader", () => {
   const renderComponent = () =>


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3287]

### Description

<!-- Implementation description -->
Show the Upload Artwork button only of the header is sticky

https://user-images.githubusercontent.com/36167539/209970666-e0bfb852-a100-48e1-a992-e3c5efe3ee5c.MOV



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3287]: https://artsyproduct.atlassian.net/browse/CX-3287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ