### PR TITLE
feat(authdialog): adds analytics tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "superagent": "3.8.3"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.87.0",
+    "@artsy/cohesion": "4.88.0",
     "@artsy/commerce_helpers": "artsy/commerce_helpers",
     "@artsy/detect-responsive-traits": "^0.1.0",
     "@artsy/eigen-web-association": "^1.5.3",

--- a/src/Apps/Debug/DebugAuth.tsx
+++ b/src/Apps/Debug/DebugAuth.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, Intent } from "@artsy/cohesion"
+import { AuthIntent, ContextModule, Intent } from "@artsy/cohesion"
 import {
   Button,
   Checkbox,
@@ -15,6 +15,7 @@ import {
 import { useAuthDialog } from "Components/AuthDialog"
 import { FC, useState } from "react"
 import { Title } from "react-head"
+import { merge } from "lodash"
 
 export const DebugAuth: FC = () => {
   const { showAuthDialog } = useAuthDialog()
@@ -24,6 +25,9 @@ export const DebugAuth: FC = () => {
   >({
     mode: "Login",
     options: {},
+    analytics: {
+      contextModule: ContextModule.header,
+    },
   })
 
   return (
@@ -84,16 +88,15 @@ export const DebugAuth: FC = () => {
 
         <Select
           title="Intent"
-          value={state.options.intent}
+          value={state.analytics.intent}
           options={AUTH_INTENTS.map(intent => ({
             value: intent,
             text: intent,
           }))}
           onSelect={(intent: AuthIntent) => {
-            setState(prevState => ({
-              ...prevState,
-              options: { ...prevState.options, intent },
-            }))
+            setState(prevState =>
+              merge({}, prevState, { analytics: { intent } })
+            )
           }}
         />
 

--- a/src/Components/AuthDialog/AuthDialog.tsx
+++ b/src/Components/AuthDialog/AuthDialog.tsx
@@ -1,14 +1,18 @@
 import { ModalDialog, Image, Box } from "@artsy/palette"
 import {
   AuthDialogMode,
+  AUTH_MODAL_TYPES,
   useAuthDialogContext,
 } from "Components/AuthDialog/AuthDialogContext"
 import { AuthDialogLogin } from "Components/AuthDialog/Views/AuthDialogLogin"
 import { AuthDialogForgotPassword } from "Components/AuthDialog/Views/AuthDialogForgotPassword"
 import { AuthDialogSignUpQueryRenderer } from "Components/AuthDialog/Views/AuthDialogSignUp"
-import { FC } from "react"
+import { FC, useEffect } from "react"
 import { useRecaptcha } from "Utils/EnableRecaptcha"
 import { resized } from "Utils/resized"
+import { useTracking } from "react-tracking"
+import { ActionType, AuthImpression } from "@artsy/cohesion"
+import { useElligibleForOnboarding } from "Components/AuthDialog/Hooks/useElligibleForOnboarding"
 
 export interface AuthDialogProps {
   onClose: () => void
@@ -18,13 +22,42 @@ export const AuthDialog: FC<AuthDialogProps> = ({ onClose }) => {
   useRecaptcha()
 
   const {
-    state: { mode, options },
+    state: { mode, options, analytics },
   } = useAuthDialogContext()
+
+  const title = options.title || DEFAULT_TITLES[mode]
+
+  const { trackEvent } = useTracking()
+  const { isElligibleForOnboarding } = useElligibleForOnboarding()
+
+  useEffect(() => {
+    if (!analytics.intent || !analytics.trigger) return
+
+    const payload: AuthImpression = {
+      action: ActionType.authImpression,
+      context_module: analytics.contextModule,
+      intent: analytics.intent,
+      modal_copy: title,
+      onboarding: isElligibleForOnboarding,
+      trigger: analytics.trigger,
+      type: AUTH_MODAL_TYPES[mode],
+    }
+
+    trackEvent(payload)
+  }, [
+    analytics.contextModule,
+    analytics.intent,
+    analytics.trigger,
+    isElligibleForOnboarding,
+    mode,
+    title,
+    trackEvent,
+  ])
 
   return (
     <ModalDialog
       onClose={onClose}
-      title={options.title || DEFAULT_TITLES[mode]}
+      title={title}
       hasLogo
       {...(options.image
         ? {

--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -16,7 +16,7 @@ export const AuthDialogSocial: FC = () => {
   const { applePath, facebookPath, googlePath } = getENV("AP")
 
   const {
-    state: { options },
+    state: { options, analytics },
   } = useAuthDialogContext()
 
   // These params are handled by the routes in the Passport app,
@@ -26,7 +26,7 @@ export const AuthDialogSocial: FC = () => {
     {
       afterSignUpAction: options.afterAuthAction,
       "redirect-to": sanitizeRedirect(options.redirectTo),
-      "signup-intent": options.intent,
+      "signup-intent": analytics.intent,
       "signup-referer": null, // TODO: Add referer
       accepted_terms_of_service: true,
       agreed_to_receive_emails: true,

--- a/src/Components/AuthDialog/Hooks/useElligibleForOnboarding.ts
+++ b/src/Components/AuthDialog/Hooks/useElligibleForOnboarding.ts
@@ -12,14 +12,14 @@ export const COMMERCIAL_AUTH_INTENTS = [
 
 export const useElligibleForOnboarding = () => {
   const {
-    state: { mode, options },
+    state: { mode, analytics },
   } = useAuthDialogContext()
 
   const isElligibleForOnboarding =
     // Only trigger onboarding for sign ups...
     mode === "SignUp" &&
     // ...without a commercial intent
-    !(options.intent && COMMERCIAL_AUTH_INTENTS.includes(options.intent))
+    !(analytics.intent && COMMERCIAL_AUTH_INTENTS.includes(analytics.intent))
 
   return { isElligibleForOnboarding }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,10 +26,10 @@
     lodash "^4.17.21"
     prettier "^1.19.1"
 
-"@artsy/cohesion@4.87.0":
-  version "4.87.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.87.0.tgz#3e175dee9029e4a34dc5f86e202e90594c303860"
-  integrity sha512-2rSoC1637AxTvOF7B9np2GKM67PRMn5Q3EOiGLGRMroc2OPNweTsjox73qbmguAvslGwzbjGRDMBzQ6zmqO5NA==
+"@artsy/cohesion@4.88.0":
+  version "4.88.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.88.0.tgz#fe0a14a9231e5efdd285ea4d672be089440babb6"
+  integrity sha512-MUW6TpYCr3yg2viM5Dlf4xzZmku0r/UQSK9UMgEuhyz/reYAMctdJqhcU2MTS+//zzSYp12O8+6kUKkMHbxkrg==
   dependencies:
     core-js "3"
 


### PR DESCRIPTION
This PR adds `AuthImpression` tracking and makes a change to the API to accept an `analytics` configuration field for clarity.