### PR TITLE
chore: show existing artwork images from local store

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages.tsx
@@ -19,8 +19,9 @@ export interface MyCollectionArtworkFormImagesProps {
   saveImagesToLocalStorage: (artworkId: string) => Promise<string | undefined>
 }
 export const MyCollectionArtworkFormImages = forwardRef<
-  MyCollectionArtworkFormImagesProps
->((_, formImagesRef) => {
+  MyCollectionArtworkFormImagesProps,
+  { isEditing?: boolean }
+>(({ isEditing = false }, formImagesRef) => {
   const [errors, setErrors] = useState<Array<FileRejection>>([])
   const [localImages, setlocalImages] = useState<
     Array<LocalImage & { photoID: string }>
@@ -48,6 +49,7 @@ export const MyCollectionArtworkFormImages = forwardRef<
         saveImagesToLocalStorage,
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [localImages, saveImagesToLocalStorage]
   )
 
@@ -92,6 +94,7 @@ export const MyCollectionArtworkFormImages = forwardRef<
 
       setFieldValue("newPhotos", [...values.newPhotos])
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [values.newPhotos])
 
   const handleDrop = (acceptedFiles: File[]) => {
@@ -125,6 +128,20 @@ export const MyCollectionArtworkFormImages = forwardRef<
     const imageAlreadyAdded = localImages.find(
       localImage => localImage.photoID === photoID
     )
+
+    // Handle images added through the select artwork step
+    if (!isEditing && currentSrc.includes("cloudfront.net")) {
+      setlocalImages(
+        localImages.concat({
+          data: currentSrc,
+          width,
+          height,
+          photoID,
+        })
+      )
+    }
+
+    // Handle images added locally
     if (currentSrc.startsWith("data:image") && !imageAlreadyAdded) {
       // Save the image dimensions as well as local path to the localImages array
       setlocalImages(

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormMain.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormMain.tsx
@@ -148,7 +148,10 @@ export const MyCollectionArtworkFormMain: React.FC<MyCollectionArtworkFormMainPr
 
             {!onlyPhotos && <MyCollectionArtworkFormDetails />}
             <Spacer y={4} />
-            <MyCollectionArtworkFormImages ref={artworkFormImagesRef} />
+            <MyCollectionArtworkFormImages
+              ref={artworkFormImagesRef}
+              isEditing={isEditing}
+            />
             <Spacer y={6} />
             {isEditing && !onlyPhotos && (
               <>


### PR DESCRIPTION
The type of this PR is: **feat**

### Description
This PR resolves [CX-3296]

https://user-images.githubusercontent.com/11945712/210832556-fd7a38a7-bb65-46e3-9680-7b35888afff0.mov

Images take a while to be first in queue in Gemini and it's why they take a while to be fully ready

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CX-3296]: https://artsyproduct.atlassian.net/browse/CX-3296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ