### PR TITLE
chore: redirect artwork-details nav request to main sell tab

### DIFF
--- a/src/Apps/Consign/Hooks/useSubmissionFlowSteps.ts
+++ b/src/Apps/Consign/Hooks/useSubmissionFlowSteps.ts
@@ -1,5 +1,4 @@
 import { themeProps } from "@artsy/palette"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 
 type MobileSteps = "Artwork" | "Photos" | "Contact"
@@ -19,18 +18,9 @@ export const submissionFlowStepsMobile: MobileSteps[] = [
 ]
 
 export const useSubmissionFlowSteps = (): DesktopSteps[] | MobileSteps[] => {
-  const enableFlowReorder = useFeatureFlag(
-    "reorder-swa-artwork-submission-flow"
-  )
   const isMobile = __internal__useMatchMedia(themeProps.mediaQueries.xs)
-  if (enableFlowReorder && isMobile) {
+  if (isMobile) {
     return ["Contact", "Artwork", "Photos"]
   }
-  if (enableFlowReorder) {
-    return ["Contact Information", "Artwork Details", "Upload Photos"]
-  }
-  if (isMobile) {
-    return submissionFlowStepsMobile
-  }
-  return submissionFlowSteps
+  return ["Contact Information", "Artwork Details", "Upload Photos"]
 }

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
@@ -204,7 +204,10 @@ describe("ArtworkDetails", () => {
 
       expect(
         screen.getAllByRole("link").find(c => c.textContent?.includes("Back"))
-      ).toHaveAttribute("href", "/sell")
+      ).toHaveAttribute(
+        "href",
+        "/sell/submission/<ConsignmentSubmission-mock-id-1>/contact-information"
+      )
     })
 
     it("renders learn more link with correct href", () => {

--- a/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/__tests__/ContactInformation.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/__tests__/ContactInformation.jest.tsx
@@ -183,7 +183,7 @@ describe("Save and Continue button", () => {
   })
 
   // TODO: Bring back this test when we have a better way to validate the phone number
-  xdescribe("with an invalid phone number", () => {
+  describe.skip("with an invalid phone number", () => {
     beforeAll(() => {
       mockTracking.mockImplementation(() => ({
         trackEvent: mockTrackEvent,

--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/__tests__/UploadPhotos.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/__tests__/UploadPhotos.jest.tsx
@@ -153,7 +153,7 @@ describe("UploadPhotos", () => {
       "href",
       `/sell/submission/${submission.externalId}/artwork-details`
     )
-    expect(screen.getByText("Save and Continue")).toBeInTheDocument()
+    expect(screen.getByText("Submit Artwork")).toBeInTheDocument()
   })
 
   it.each([
@@ -308,14 +308,10 @@ describe("UploadPhotos", () => {
       expect(screen.getAllByTestId("photo-thumbnail").length).toEqual(1)
     })
 
-    fireEvent.click(screen.getByText("Save and Continue"))
+    fireEvent.click(screen.getByText("Submit Artwork"))
 
     await waitFor(() => {
       expect(mockAddAsset).toHaveBeenCalled()
-      expect(mockRouterPush).toHaveBeenCalled()
-      expect(mockRouterPush).toHaveBeenCalledWith(
-        `/sell/submission/${submission.externalId}/contact-information`
-      )
     })
   })
 

--- a/src/Apps/Consign/consignFromCollectorProfileMyCollectionRoutes.tsx
+++ b/src/Apps/Consign/consignFromCollectorProfileMyCollectionRoutes.tsx
@@ -169,18 +169,9 @@ export const consignFromCollectorProfileMyCollectionRoutes: AppRouteConfig[] = [
     path: "/collector-profile/my-collection/submission",
     getComponent: () => SubmissionLayout,
     onServerSideRender: ({ res }) => {
-      if (
-        res.locals.sd.FEATURE_FLAGS["reorder-swa-artwork-submission-flow"]
-          .flagEnabled
-      ) {
-        res.redirect(
-          "/collector-profile/my-collection/submission/contact-information"
-        )
-      } else {
-        res.redirect(
-          "/collector-profile/my-collection/submission/artwork-details"
-        )
-      }
+      res.redirect(
+        "/collector-profile/my-collection/submission/contact-information"
+      )
     },
     children: [
       {

--- a/src/Apps/Consign/consignFromMyCollectionRoutes.tsx
+++ b/src/Apps/Consign/consignFromMyCollectionRoutes.tsx
@@ -169,14 +169,7 @@ export const consignFromMyCollectionRoutes: AppRouteConfig[] = [
     path: "/my-collection/submission",
     getComponent: () => SubmissionLayout,
     onServerSideRender: ({ res }) => {
-      if (
-        res.locals.sd.FEATURE_FLAGS["reorder-swa-artwork-submission-flow"]
-          .flagEnabled
-      ) {
-        res.redirect("/my-collection/submission/contact-information")
-      } else {
-        res.redirect("/my-collection/submission/artwork-details")
-      }
+      res.redirect("/my-collection/submission/contact-information")
     },
     children: [
       {

--- a/src/Apps/Consign/consignRoutes.tsx
+++ b/src/Apps/Consign/consignRoutes.tsx
@@ -254,22 +254,15 @@ export const consignRoutes: AppRouteConfig[] = [
     path: "/sell/submission",
     getComponent: () => SubmissionLayout,
     onServerSideRender: ({ res }) => {
-      if (
-        res.locals.sd.FEATURE_FLAGS["reorder-swa-artwork-submission-flow"]
-          .flagEnabled
-      ) {
-        res.redirect("/sell/submission/contact-information")
-      } else {
-        res.redirect("/sell/submission/artwork-details")
-      }
+      res.redirect("/sell/submission/contact-information")
     },
     children: [
       {
         path: "artwork-details",
         layout: "ContainerOnly",
         getComponent: () => ArtworkDetails,
-        onClientSideRender: () => {
-          ArtworkDetails.preload()
+        onServerSideRender: ({ res }) => {
+          res.redirect("/sell/submission")
         },
       },
       {

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkImageBrowser/MyCollectionArtworkImageBrowser.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkImageBrowser/MyCollectionArtworkImageBrowser.tsx
@@ -26,7 +26,7 @@ const MyCollectionArtworkImageBrowser: React.FC<MyCollectionArtworkImageBrowserP
       .catch(error => {
         console.error("Error getting local images by artwork", error)
       })
-  }, [])
+  }, [artwork.internalID])
 
   if ((images ?? []).length === 0) {
     if (localArtworkImages && localArtworkImages.length) {

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/MyCollectionArtwork.tsx
@@ -66,15 +66,7 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
     "my-collection-web-phase-6-request-price-estimate"
   )
 
-  const enableFlowReorder = useFeatureFlag(
-    "reorder-swa-artwork-submission-flow"
-  )
-
   const isCollectorProfileEnabled = useFeatureFlag("cx-collector-profile")
-
-  const firstSubmissionStep = enableFlowReorder
-    ? "contact-information"
-    : "artwork-details"
 
   const EditArtworkButton = () => (
     <Button
@@ -162,8 +154,8 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
                 <MyCollectionArtworkSWASectionDesktopLayout
                   route={
                     isCollectorProfileEnabled
-                      ? `/collector-profile/my-collection/submission/${firstSubmissionStep}/${id}`
-                      : `/my-collection/submission/${firstSubmissionStep}/${id}`
+                      ? `/collector-profile/my-collection/submission/contact-information/${id}`
+                      : `/my-collection/submission/contact-information/${id}`
                   }
                   learnMore={() => setShowHowItWorksModal(true)}
                   slug={slug}
@@ -190,8 +182,8 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
                         <MyCollectionArtworkSWASectionMobileLayout
                           route={
                             isCollectorProfileEnabled
-                              ? `/collector-profile/my-collection/submission/${firstSubmissionStep}/${id}`
-                              : `/my-collection/submission/${firstSubmissionStep}/${id}`
+                              ? `/collector-profile/my-collection/submission/contact-information/${id}`
+                              : `/my-collection/submission/contact-information/${id}`
                           }
                           learnMore={() => setShowHowItWorksModal(true)}
                           slug={slug}


### PR DESCRIPTION
The type of this PR is: **chore**



### Description
This PR redirects the old traffic from `/sell/submission/artwork-details` to the main sell page now `sell/submission`. It also removes the feature flag.


**Before**

https://user-images.githubusercontent.com/11945712/210546100-df38ff42-6605-4dd2-9a3d-d1c12aca52df.mov


**After**

https://user-images.githubusercontent.com/11945712/210546122-b9e3d45d-4193-4825-bf7e-3f68581a4eaf.mov


<!-- Implementation description -->
