### PR TITLE
fix(TX-988): correct phone number is committed for pickup orders

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -262,10 +262,11 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                 )!
           )
 
-      const shipToPhoneNumber = isCreateNewAddress()
-        ? phoneNumber
-        : addressList.find(address => address.internalID == selectedAddressID)
-            ?.phoneNumber
+      const shipToPhoneNumber =
+        isCreateNewAddress() || shippingOption === "PICKUP"
+          ? phoneNumber
+          : addressList.find(address => address.internalID == selectedAddressID)
+              ?.phoneNumber
 
       setShippingQuotes(null)
       setShippingQuoteId(undefined)

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -1075,6 +1075,37 @@ describe("Shipping", () => {
       ).toEqual("")
     })
 
+    it("commits correct phone number for pickup orders", async () => {
+      const mockPhoneNumber = "12345678"
+      await page.selectPickupOption()
+      fillInPhoneNumber(page.root, { isPickup: true, value: mockPhoneNumber })
+
+      await flushPromiseQueue()
+      await page.clickSubmit()
+
+      expect(mockCommitMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: {
+            input: {
+              fulfillmentType: "PICKUP",
+              id: "1234",
+              phoneNumber: mockPhoneNumber,
+              shipping: {
+                addressLine1: "401 Broadway",
+                addressLine2: "Floor 25",
+                city: "New York",
+                country: "US",
+                phoneNumber: "422-424-4242",
+                postalCode: "10013",
+                region: "NY",
+                name: "Test Name",
+              },
+            },
+          },
+        })
+      )
+    })
+
     it("lists the addresses and renders the add address option", async () => {
       expect(
         page


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [TX-988]

### Description
This PR fixes the problem reported by Applause in the new app release. the problem is that when users select pick-up shipping option, type in their phone number, and they have a saved address, we are storing the phone number from the saved address instead of the typed-in number. 


#### Video 
https://user-images.githubusercontent.com/42584148/210779467-d95a41cf-e954-4ed9-8974-df3c51cb449f.mov


[TX-988]: https://artsyproduct.atlassian.net/browse/TX-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ