### PR TITLE
fix: Increase number of artworks in My Collection upload flow

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArworkSearch.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArworkSearch.tsx
@@ -28,7 +28,7 @@ export const MyCollectionArworkSearch: React.FC<MyCollectionArworkSearchProps> =
         $input: FilterArtworksInput
       ) {
         artist(id: $artistID) {
-          filterArtworksConnection(first: 30, input: $input) {
+          filterArtworksConnection(first: 40, input: $input) {
             edges {
               node {
                 medium
@@ -110,7 +110,11 @@ const NoResults: React.FC<{
     <Box my={4}>
       <Text variant={["xs", "sm-display"]} flexWrap="wrap">
         We couldn’t find a work named “
-        <Text display="inline-block" color="blue100">
+        <Text
+          variant={["xs", "sm-display"]}
+          display="inline-block"
+          color="blue100"
+        >
           {query}
         </Text>
         “


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3308]

### Description

This PR increases the number of artworks in My Collection upload flow "Select Artwork" step. Later we might implement pagination or infinite scrolling. 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3308]: https://artsyproduct.atlassian.net/browse/CX-3308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ