### PR TITLE
feat(authentication): removes explicit terms checkbox

### DIFF
--- a/src/Components/Authentication/Components/AuthenticationFooter.tsx
+++ b/src/Components/Authentication/Components/AuthenticationFooter.tsx
@@ -12,7 +12,8 @@ import {
 } from "@artsy/palette"
 import * as React from "react"
 import styled from "styled-components"
-import { ModalType } from "../Types"
+import { isTouch } from "Utils/device"
+import { ModalType } from "Components/Authentication/Types"
 
 interface AuthenticationFooterProps extends BoxProps {
   handleTypeChange?: (modalType: ModalType) => void
@@ -21,6 +22,7 @@ interface AuthenticationFooterProps extends BoxProps {
   onFacebookLogin?: (e: any) => void
   onGoogleLogin?: (e: any) => void
   showRecaptchaDisclaimer?: boolean
+  isAutomaticallySubscribed?: boolean
 }
 
 export const AuthenticationFooter: React.FC<AuthenticationFooterProps> = ({
@@ -30,6 +32,7 @@ export const AuthenticationFooter: React.FC<AuthenticationFooterProps> = ({
   onFacebookLogin,
   onGoogleLogin,
   showRecaptchaDisclaimer,
+  isAutomaticallySubscribed,
   ...rest
 }) => {
   return (
@@ -155,6 +158,22 @@ export const AuthenticationFooter: React.FC<AuthenticationFooterProps> = ({
                     Log in.
                   </Clickable>
                 </Box>
+
+                <Text variant="xs" color="black60" textAlign="center">
+                  By {isTouch ? "tapping" : "clicking"} Sign up or Continue with
+                  Apple, Google, or Facebook, you agree to Artsy’s{" "}
+                  <a href="/terms" target="_blank">
+                    Terms of Use
+                  </a>{" "}
+                  and{" "}
+                  <a href="/privacy" target="_blank">
+                    Privacy Policy
+                  </a>
+                  {isAutomaticallySubscribed && (
+                    <> and to receiving emails from Artsy</>
+                  )}
+                  .
+                </Text>
 
                 {showRecaptchaDisclaimer && (
                   <Box>

--- a/src/Components/Authentication/FormSwitcher.tsx
+++ b/src/Components/Authentication/FormSwitcher.tsx
@@ -158,8 +158,7 @@ export class FormSwitcher extends Component<FormSwitcherProps, State> {
     const { handleSubmit, onBackButtonClicked, values } = this.props
 
     const defaultValues = {
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      accepted_terms_of_service: values.accepted_terms_of_service || false,
+      accepted_terms_of_service: true,
       email: this.getEmailValue(),
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       name: values.name || "",

--- a/src/Components/Authentication/Views/SignUpForm.tsx
+++ b/src/Components/Authentication/Views/SignUpForm.tsx
@@ -75,15 +75,16 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
   }
 
   render() {
-    const initialValues = {
-      accepted_terms_of_service: false,
-      agreed_to_receive_emails: false,
-      ...this.props.values,
-    }
-
     const countryCode = this.props.requestLocation?.countryCode || ""
-    const collapseCheckboxes =
+    const isAutomaticallySubscribed = !!(
       countryCode && !gdprCountries.includes(countryCode)
+    )
+
+    const initialValues = {
+      ...this.props.values,
+      agreed_to_receive_emails: isAutomaticallySubscribed,
+      accepted_terms_of_service: true,
+    }
 
     return (
       <Formik
@@ -100,10 +101,8 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
           isSubmitting,
           setFieldValue,
           setStatus,
-          setTouched,
           status,
           touched,
-          validateForm,
           values,
         }: FormikProps<InputValues>) => {
           const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -115,9 +114,6 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
           const emailErrorMessage = touched.email ? errors.email : ""
           const passwordErrorMessage = touched.password ? errors.password : ""
           const nameErrorMessage = touched.name ? errors.name : ""
-          const termsErrorMessage = touched.accepted_terms_of_service
-            ? errors.accepted_terms_of_service
-            : ""
 
           return (
             <Box
@@ -177,62 +173,7 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                   <Banner variant="error">{status.error}</Banner>
                 )}
 
-                {collapseCheckboxes ? (
-                  <AuthenticationCheckbox
-                    error={!!termsErrorMessage}
-                    selected={values.accepted_terms_of_service}
-                    onSelect={selected => {
-                      setFieldValue("agreed_to_receive_emails", selected)
-                      setFieldValue("accepted_terms_of_service", selected)
-                    }}
-                    data-test="agreeToTerms"
-                  >
-                    {"I agree to the "}
-                    <a href="https://www.artsy.net/terms" target="_blank">
-                      Terms of Use
-                    </a>
-                    {", "}
-                    <a href="https://www.artsy.net/privacy" target="_blank">
-                      Privacy Policy
-                    </a>
-                    {", and "}
-                    <a
-                      href="https://www.artsy.net/conditions-of-sale"
-                      target="_blank"
-                    >
-                      Conditions of Sale
-                    </a>
-                    {" and to receiving emails from Artsy."}
-                  </AuthenticationCheckbox>
-                ) : (
-                  <AuthenticationCheckbox
-                    error={!!termsErrorMessage}
-                    selected={values.accepted_terms_of_service}
-                    onSelect={selected => {
-                      setFieldValue("accepted_terms_of_service", selected)
-                    }}
-                    data-test="agreeToTerms"
-                  >
-                    {"By checking this box, you consent to our "}
-                    <a href="https://www.artsy.net/terms" target="_blank">
-                      Terms of Use
-                    </a>
-                    {", "}
-                    <a href="https://www.artsy.net/privacy" target="_blank">
-                      Privacy Policy
-                    </a>
-                    {", and "}
-                    <a
-                      href="https://www.artsy.net/conditions-of-sale"
-                      target="_blank"
-                    >
-                      Conditions of Sale
-                    </a>
-                    {"."}
-                  </AuthenticationCheckbox>
-                )}
-
-                {!collapseCheckboxes && (
+                {!isAutomaticallySubscribed && (
                   <AuthenticationCheckbox
                     selected={values.agreed_to_receive_emails}
                     onSelect={selected => {
@@ -260,32 +201,18 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                   }
                   onAppleLogin={async e => {
                     e.preventDefault()
-                    if (!values.accepted_terms_of_service) {
-                      setTouched({ accepted_terms_of_service: true })
-                      await validateForm()
-                    } else {
-                      this.props.onAppleLogin?.(e)
-                    }
+                    this.props.onAppleLogin?.(e)
                   }}
                   onFacebookLogin={async e => {
                     e.preventDefault()
-                    if (!values.accepted_terms_of_service) {
-                      setTouched({ accepted_terms_of_service: true })
-                      await validateForm()
-                    } else {
-                      this.props.onFacebookLogin?.(e)
-                    }
+                    this.props.onFacebookLogin?.(e)
                   }}
                   onGoogleLogin={async e => {
                     e.preventDefault()
-                    if (!values.accepted_terms_of_service) {
-                      setTouched({ accepted_terms_of_service: true })
-                      await validateForm()
-                    } else {
-                      this.props.onGoogleLogin?.(e)
-                    }
+                    this.props.onGoogleLogin?.(e)
                   }}
                   showRecaptchaDisclaimer={this.props.showRecaptchaDisclaimer}
+                  isAutomaticallySubscribed={isAutomaticallySubscribed}
                 />
               </Join>
             </Box>

--- a/src/Components/Authentication/__tests__/Views/SignUpForm.jest.tsx
+++ b/src/Components/Authentication/__tests__/Views/SignUpForm.jest.tsx
@@ -2,7 +2,7 @@
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 import { tests } from "Components/Authentication/Views/SignUpForm"
-import { SignupValues } from "../fixtures"
+import { SignupValues } from "Components/Authentication/__tests__/fixtures"
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { flushPromiseQueue } from "DevTools"
 
@@ -64,14 +64,11 @@ describe("SignUpForm", () => {
   describe("with a GDPR country code", () => {
     const countryCode = "GB"
 
-    it("uses the GDPR label and shows the email checkbox", () => {
+    it("shows the email checkbox", () => {
       const wrapper = getWrapper({
         RequestLocation: () => ({ countryCode }),
       })
 
-      expect(wrapper.text()).toContain(
-        "By checking this box, you consent to our"
-      )
       expect(wrapper.text()).toContain(
         "Dive deeper into the art market with Artsy emails."
       )
@@ -81,12 +78,13 @@ describe("SignUpForm", () => {
   describe("with a non-GDPR country code", () => {
     const countryCode = "US"
 
-    it("uses the fallback label and hides the email checkbox", () => {
+    it("hides the email checkbox and includes copy about emails in the agreement", () => {
       const wrapper = getWrapper({
         RequestLocation: () => ({ countryCode }),
       })
 
-      expect(wrapper.text()).toContain("I agree to the")
+      expect(wrapper.text()).toContain("and to receiving emails from Artsy.")
+
       expect(wrapper.text()).not.toContain(
         "Dive deeper into the art market with Artsy emails."
       )
@@ -96,14 +94,11 @@ describe("SignUpForm", () => {
   describe("with a missing country code", () => {
     const countryCode = null
 
-    it("uses the GDPR label and shows the email checkbox", () => {
+    it("shows the email checkbox", () => {
       const wrapper = getWrapper({
         RequestLocation: () => ({ countryCode }),
       })
 
-      expect(wrapper.text()).toContain(
-        "By checking this box, you consent to our"
-      )
       expect(wrapper.text()).toContain(
         "Dive deeper into the art market with Artsy emails."
       )
@@ -169,23 +164,6 @@ describe("SignUpForm", () => {
 
       setTimeout(() => {
         expect(passedProps.onGoogleLogin).toHaveBeenCalled()
-        done()
-      })
-    })
-
-    it("does not call apple callback without accepting terms", done => {
-      passedProps.values.accepted_terms_of_service = false
-      const wrapper = getWrapper()
-
-      const appleLink = wrapper
-        .find("Button")
-        .findWhere(node => node.text().includes("Continue with Apple"))
-        .first()
-
-      appleLink.simulate("click")
-
-      setTimeout(() => {
-        expect(passedProps.onAppleLogin).not.toHaveBeenCalled()
         done()
       })
     })


### PR DESCRIPTION
This removes the terms checkbox as it's no longer explicitly needed. Will open an Integrity pull request before merging.

| GDPR | Non-GDPR |
| ---- | ---- |
| ![](https://static.damonzucconi.com/_capture/GJWmbIg4.png) | ![](https://static.damonzucconi.com/_capture/6BGaEBGN.png)