### PR TITLE
fix: Hide artist selection skip button behind feature flag in MyC upload flow

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,28 +133,28 @@
         "filename": "src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionCreateArtwork.jest.tsx",
         "hashed_secret": "02bd777ac899d5a9f62414ca8583ae4a653a9381",
         "is_verified": false,
-        "line_number": 571
+        "line_number": 580
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionCreateArtwork.jest.tsx",
         "hashed_secret": "8a0d40fae82feee6c388b308182919a58edc8fd6",
         "is_verified": false,
-        "line_number": 608
+        "line_number": 617
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionCreateArtwork.jest.tsx",
         "hashed_secret": "83a49f46b4215a3bd6abc0e4ea2ab9ffa2aaf3b7",
         "is_verified": false,
-        "line_number": 644
+        "line_number": 653
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionCreateArtwork.jest.tsx",
         "hashed_secret": "8bb08c341079e79b4e17b3ac48e729e8bb3c25ad",
         "is_verified": false,
-        "line_number": 704
+        "line_number": 713
       }
     ],
     "src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionEditArtwork.jest.tsx": [
@@ -1264,5 +1264,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-03T11:20:59Z"
+  "generated_at": "2023-01-09T16:05:08Z"
 }

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtistStep.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtistStep.tsx
@@ -102,10 +102,10 @@ export const MyCollectionArtworkFormArtistStep: React.FC<MyCollectionArtworkForm
         placeholder="Search for artists on Artsy"
       />
 
+      <Spacer y={2} />
+
       {!!enablePersonalArtists && (
         <Flex flexDirection="row">
-          <Spacer y={2} />
-
           <Text variant="sm-display">
             Can't find the artist?&nbsp;
             <Clickable

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtistStep.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtistStep.tsx
@@ -18,6 +18,7 @@ import { useFormikContext } from "formik"
 import { sortBy } from "lodash"
 import { useState } from "react"
 import { graphql, useFragment } from "react-relay"
+import { useFeatureFlag } from "System/useFeatureFlag"
 import { extractNodes } from "Utils/extractNodes"
 import { MyCollectionArtworkFormArtistStep_me$key } from "__generated__/MyCollectionArtworkFormArtistStep_me.graphql"
 
@@ -36,6 +37,9 @@ export const MyCollectionArtworkFormArtistStep: React.FC<MyCollectionArtworkForm
     trackSelectArtist,
     trackSkipArtistSelection,
   } = useMyCollectionTracking()
+  const enablePersonalArtists = useFeatureFlag(
+    "cx-my-collection-personal-artists-for-web"
+  )
 
   const collectedArtists = sortBy(
     extractNodes(me?.myCollectionInfo?.collectedArtistsConnection),
@@ -98,23 +102,25 @@ export const MyCollectionArtworkFormArtistStep: React.FC<MyCollectionArtworkForm
         placeholder="Search for artists on Artsy"
       />
 
-      <Spacer y={2} />
+      {!!enablePersonalArtists && (
+        <Flex flexDirection="row">
+          <Spacer y={2} />
 
-      <Flex flexDirection="row">
-        <Text variant="sm-display">
-          Can't find the artist?&nbsp;
-          <Clickable
-            onClick={handleSkip}
-            textDecoration="underline"
-            data-testid="artist-select-skip-button"
-          >
-            <Text variant="sm-display" color="black100">
-              Add their name
-            </Text>
-          </Clickable>
-          .
-        </Text>
-      </Flex>
+          <Text variant="sm-display">
+            Can't find the artist?&nbsp;
+            <Clickable
+              onClick={handleSkip}
+              textDecoration="underline"
+              data-testid="artist-select-skip-button"
+            >
+              <Text variant="sm-display" color="black100">
+                Add their name
+              </Text>
+            </Clickable>
+            .
+          </Text>
+        </Flex>
+      )}
 
       <Spacer y={4} />
 

--- a/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionCreateArtwork.jest.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionCreateArtwork.jest.tsx
@@ -186,6 +186,9 @@ describe("MyCollectionCreateArtwork", () => {
             "cx-my-collection-uploading-flow-steps": {
               flagEnabled: true,
             },
+            "cx-my-collection-personal-artists-for-web": {
+              flagEnabled: true,
+            },
           },
         })
 
@@ -206,6 +209,9 @@ describe("MyCollectionCreateArtwork", () => {
         getWrapper({
           featureFlags: {
             "cx-my-collection-uploading-flow-steps": {
+              flagEnabled: true,
+            },
+            "cx-my-collection-personal-artists-for-web": {
               flagEnabled: true,
             },
           },
@@ -236,6 +242,9 @@ describe("MyCollectionCreateArtwork", () => {
           getWrapper({
             featureFlags: {
               "cx-my-collection-uploading-flow-steps": {
+                flagEnabled: true,
+              },
+              "cx-my-collection-personal-artists-for-web": {
                 flagEnabled: true,
               },
             },


### PR DESCRIPTION

## Description

We need to hide the artist selection **skip** button behind when the feature flag `"cx-my-collection-personal-artists-for-web"` is disabled. This is needed in case we want to enable the new uploading flow without allowing users to create artists (just in case 😄 )