### PR TITLE
fix(TX-989): select correct pre-saved bank account when user navigates back t…

### DIFF
--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -113,6 +113,25 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
   }, [bankAccountSelection, selectedPaymentMethod])
 
   useEffect(() => {
+    const bankAccountsArray =
+      selectedPaymentMethod !== "SEPA_DEBIT"
+        ? extractNodes(me.bankAccounts)
+        : []
+
+    const bankAccountOnOrder = bankAccountsArray.find(
+      bank => bank.internalID === order.bankAccountId
+    )
+
+    if (bankAccountOnOrder?.internalID) {
+      setBankAccountSelection({
+        type: "existing",
+        id: bankAccountOnOrder.internalID,
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [order])
+
+  useEffect(() => {
     setSelectedPaymentMethod(getInitialPaymentMethodValue(order))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [order])


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [TX-989]

### Description

This PR fixes the problem that when a user links multiple bank accounts, selects one of them, continues to the review step and click 'Change payment' to go back to the the payment step, they see the wrong bank account. 

The solution is to check if there's a bankAccountid associated with the Order, and set it as the selected bank account if it exists. 

#### Video 
https://user-images.githubusercontent.com/42584148/211315460-bdf0c741-1576-4336-a111-637d3931f9a8.mov



[TX-989]: https://artsyproduct.atlassian.net/browse/TX-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ