### PR TITLE
Drop production base path from fallback link

### DIFF
--- a/src/Apps/Home/Components/HomeContentCards/FallbackCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/FallbackCards.tsx
@@ -54,7 +54,7 @@ const fallbackData = [
     label: "Featured Collection",
     linkText: "Browse Works",
     title: "Trove: Editor’s Picks",
-    url: "https://www.artsy.net/collection/trove-editors-picks",
+    url: "/collection/trove-editors-picks",
   },
   {
     credit:


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Regardless of environment (staging, local) the trove fallback link on our homepage goes to production. This PR removes the base path to keep the user in their current environment.

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ