### PR TITLE
chore(authdialog): enables auth dialog wrapper for intentful buttons

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateAlertButton.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateAlertButton.tsx
@@ -10,7 +10,6 @@ import {
   SavedSearchEntityCriteria,
   SearchCriteriaAttributes,
 } from "Components/SavedSearchAlert/types"
-import { AuthModalOptions } from "Utils/openAuthModal"
 import { ArtworkSidebarCreateAlertButton_artwork$data } from "__generated__/ArtworkSidebarCreateAlertButton_artwork.graphql"
 
 interface ArtworkSidebarCreateAlertButtonProps {
@@ -70,30 +69,25 @@ const ArtworkSidebarCreateAlertButton: FC<ArtworkSidebarCreateAlertButtonProps> 
     additionalGeneIDs,
   }
 
-  const getAuthModalOptions = (): AuthModalOptions => {
-    return {
-      entity: {
-        name: artwork.title!,
-        slug: artwork.slug,
-      },
-      afterSignUpAction: {
-        action: "createAlert",
-        kind: "artworks",
-        objectId: artwork.internalID,
-      },
-      contextModule: ContextModule.artworkSidebar,
-      intent: Intent.createAlert,
-      redirectTo: location.href,
-      copy: "Sign up to create your alert",
-    }
-  }
-
   return (
     <SavedSearchCreateAlertButtonContainer
       entity={entity}
       criteria={criteria}
       aggregations={aggregations}
-      getAuthModalOptions={getAuthModalOptions}
+      authModalOptions={{
+        entity: {
+          name: artwork.title!,
+          slug: artwork.slug,
+        },
+        afterSignUpAction: {
+          action: "createAlert",
+          kind: "artworks",
+          objectId: artwork.internalID,
+        },
+        contextModule: ContextModule.artworkSidebar,
+        intent: Intent.createAlert,
+        copy: "Sign up to create your alert",
+      }}
       renderButton={({ onClick }) => (
         <Button width="100%" size="large" onClick={onClick}>
           Create Alert

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateArtworkAlert.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateArtworkAlert.tsx
@@ -11,7 +11,6 @@ import { getAllowedSearchCriteria } from "Components/SavedSearchAlert/Utils/save
 import { OwnerType } from "@artsy/cohesion"
 import { SavedSearchCreateAlertButton } from "Components/SavedSearchAlert/Components/SavedSearchCreateAlertButton"
 import { ContextModule, Intent } from "@artsy/cohesion"
-import { AuthModalOptions } from "Utils/openAuthModal"
 import { Aggregations } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { useTranslation } from "react-i18next"
 
@@ -76,24 +75,6 @@ const ArtworkSidebarCreateArtworkAlert: React.FC<ArtworkSidebarCreateArtworkAler
   }
   const allowedCriteria = getAllowedSearchCriteria(criteria)
 
-  const getAuthModalOptions = (): AuthModalOptions => {
-    return {
-      entity: {
-        name: artwork.title!,
-        slug: artwork.slug,
-      },
-      afterSignUpAction: {
-        action: "createAlert",
-        kind: "artworks",
-        objectId: artwork.internalID,
-      },
-      contextModule: ContextModule.artworkSidebar,
-      intent: Intent.createAlert,
-      redirectTo: location.href,
-      copy: "Sign up to create your alert",
-    }
-  }
-
   return (
     <>
       <Separator />
@@ -101,6 +82,7 @@ const ArtworkSidebarCreateArtworkAlert: React.FC<ArtworkSidebarCreateArtworkAler
         flexDirection="row"
         alignItems="center"
         justifyContent="space-between"
+        // FIXME: Remove
         my={2}
       >
         <Text variant="xs" mr={2}>
@@ -110,7 +92,20 @@ const ArtworkSidebarCreateArtworkAlert: React.FC<ArtworkSidebarCreateArtworkAler
           entity={entity}
           criteria={allowedCriteria}
           aggregations={aggregations}
-          getAuthModalOptions={getAuthModalOptions}
+          authModalOptions={{
+            entity: {
+              name: artwork.title!,
+              slug: artwork.slug,
+            },
+            afterSignUpAction: {
+              action: "createAlert",
+              kind: "artworks",
+              objectId: artwork.internalID,
+            },
+            contextModule: ContextModule.artworkSidebar,
+            intent: Intent.createAlert,
+            copy: "Sign up to create your alert",
+          }}
         />
       </Flex>
     </>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/CreateArtworkAlertSection.tsx
@@ -12,7 +12,6 @@ import { getAllowedSearchCriteria } from "Components/SavedSearchAlert/Utils/save
 import { OwnerType } from "@artsy/cohesion"
 import { SavedSearchCreateAlertButton } from "Components/SavedSearchAlert/Components/SavedSearchCreateAlertButton"
 import { ContextModule, Intent } from "@artsy/cohesion"
-import { AuthModalOptions } from "Utils/openAuthModal"
 import { Aggregations } from "Components/ArtworkFilter/ArtworkFilterContext"
 
 interface CreateArtworkAlertSectionProps {
@@ -73,32 +72,18 @@ export const CreateArtworkAlertSection: React.FC<CreateArtworkAlertSectionProps>
   }
   const allowedCriteria = getAllowedSearchCriteria(criteria)
 
-  const getAuthModalOptions = (): AuthModalOptions => {
-    return {
-      entity: {
-        name: artwork.title!,
-        slug: artwork.slug,
-      },
-      afterSignUpAction: {
-        action: "createAlert",
-        kind: "artworks",
-        objectId: artwork.internalID,
-      },
-      contextModule: ContextModule.artworkSidebar,
-      intent: Intent.createAlert,
-      redirectTo: location.href,
-      copy: "Sign up to create your alert",
-    }
-  }
-
   return (
     <>
-      <Separator mt={2} />
+      <Separator
+        // FIXME: Remove
+        mt={2}
+      />
       <Flex
         flexDirection="row"
         py={1}
         alignItems="center"
         justifyContent="space-between"
+        // FIXME: Remove
         my={2}
       >
         <Text variant="xs" mr={2}>
@@ -108,7 +93,20 @@ export const CreateArtworkAlertSection: React.FC<CreateArtworkAlertSectionProps>
           entity={entity}
           criteria={allowedCriteria}
           aggregations={aggregations}
-          getAuthModalOptions={getAuthModalOptions}
+          authModalOptions={{
+            entity: {
+              name: artwork.title!,
+              slug: artwork.slug,
+            },
+            afterSignUpAction: {
+              action: "createAlert",
+              kind: "artworks",
+              objectId: artwork.internalID,
+            },
+            contextModule: ContextModule.artworkSidebar,
+            intent: Intent.createAlert,
+            copy: "Sign up to create your alert",
+          }}
         />
       </Flex>
     </>

--- a/src/Components/FollowButton/FollowProfileButton.tsx
+++ b/src/Components/FollowButton/FollowProfileButton.tsx
@@ -4,7 +4,6 @@ import { useSystemContext } from "System/useSystemContext"
 import { FollowButton } from "./Button"
 import { FollowProfileButton_profile$data } from "__generated__/FollowProfileButton_profile.graphql"
 import { ButtonProps } from "@artsy/palette"
-import { openAuthToSatisfyIntent } from "Utils/openAuthModal"
 import {
   Intent,
   AuthContextModule,
@@ -15,6 +14,8 @@ import { useMutation } from "Utils/Hooks/useMutation"
 import { useFollowButtonTracking } from "./useFollowButtonTracking"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { FollowProfileButtonQuery } from "__generated__/FollowProfileButtonQuery.graphql"
+import { useAuthDialog } from "Components/AuthDialog"
+import { ModalType } from "Components/Authentication/Types"
 
 interface FollowProfileButtonProps extends Omit<ButtonProps, "variant"> {
   profile: FollowProfileButton_profile$data
@@ -28,7 +29,7 @@ const FollowProfileButton: React.FC<FollowProfileButtonProps> = ({
   onFollow,
   ...rest
 }) => {
-  const { isLoggedIn, mediator } = useSystemContext()
+  const { isLoggedIn } = useSystemContext()
 
   const { trackFollow } = useFollowButtonTracking({
     ownerType: OwnerType.profile,
@@ -58,16 +59,45 @@ const FollowProfileButton: React.FC<FollowProfileButtonProps> = ({
     },
   })
 
+  const { showAuthDialog } = useAuthDialog()
+
   const handleClick = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
     event.preventDefault()
 
     if (!isLoggedIn) {
-      openAuthToSatisfyIntent(mediator!, {
-        entity: { name: profile.name!, slug: profile.slug },
-        contextModule,
-        intent: Intent.followPartner,
+      showAuthDialog({
+        current: {
+          mode: "SignUp",
+          options: {
+            title: mode => {
+              const action = mode === "SignUp" ? "Sign up" : "Log in"
+              return `${action} to follow ${profile.name}`
+            },
+            afterAuthAction: {
+              action: "follow",
+              kind: "profile",
+              objectId: profile.slug,
+            },
+          },
+          analytics: {
+            intent: Intent.followPartner,
+            contextModule,
+          },
+        },
+        legacy: {
+          afterSignUpAction: {
+            action: "follow",
+            kind: "profile",
+            objectId: profile.slug,
+          },
+          contextModule,
+          copy: `Sign up to follow ${profile.name}`,
+          intent: Intent.followPartner,
+          mode: ModalType.signup,
+          redirectTo: window.location.href,
+        },
       })
 
       return

--- a/src/Components/SavedSearchAlert/Components/ActiveFilterPillsAndCreateAlert.tsx
+++ b/src/Components/SavedSearchAlert/Components/ActiveFilterPillsAndCreateAlert.tsx
@@ -1,13 +1,15 @@
 import React from "react"
 import { SavedSearchAlertPills } from "./SavedSearchAlertPills"
-import { FilterPill, SavedSearchEntity } from "../types"
-import { useActiveFilterPills } from "../useActiveFilterPills"
+import {
+  FilterPill,
+  SavedSearchEntity,
+} from "Components/SavedSearchAlert/types"
+import { useActiveFilterPills } from "Components/SavedSearchAlert/useActiveFilterPills"
 import { Flex, Spacer } from "@artsy/palette"
 import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { usePrepareFiltersForPills } from "Components/ArtworkFilter/Utils/usePrepareFiltersForPills"
-import { getSearchCriteriaFromFilters } from "../Utils/savedSearchCriteria"
+import { getSearchCriteriaFromFilters } from "Components/SavedSearchAlert/Utils/savedSearchCriteria"
 import { DEFAULT_METRIC } from "Utils/metrics"
-import { AuthModalOptions } from "Utils/openAuthModal"
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { SavedSearchCreateAlertButton } from "./SavedSearchCreateAlertButton"
 
@@ -26,28 +28,11 @@ export const ActiveFilterPillsAndCreateAlert: React.FC<ActiveFilterPillsAndCreat
   const criteria = getSearchCriteriaFromFilters(savedSearchEntity, filters)
   const metric = filters?.metric ?? DEFAULT_METRIC
 
-  const getAuthModalOptions = (): AuthModalOptions => {
-    return {
-      entity: {
-        name: savedSearchEntity.owner.name,
-        slug: savedSearchEntity.owner.slug,
-      },
-      afterSignUpAction: {
-        action: "createAlert",
-        kind: "artist",
-        objectId: savedSearchEntity.owner.slug,
-      },
-      contextModule: ContextModule.artworkGrid,
-      copy: "Sign up to create an alert",
-      intent: Intent.createAlert,
-      redirectTo: location.href,
-    }
-  }
-
   return (
     <Flex
       flexWrap="wrap"
       mx={-PILL_HORIZONTAL_MARGIN_SIZE}
+      // FIXME: Remove
       mb={4}
       data-testid="artworkGridFilterPills"
     >
@@ -60,7 +45,20 @@ export const ActiveFilterPillsAndCreateAlert: React.FC<ActiveFilterPillsAndCreat
         criteria={criteria}
         metric={metric}
         aggregations={aggregations}
-        getAuthModalOptions={getAuthModalOptions}
+        authModalOptions={{
+          entity: {
+            name: savedSearchEntity.owner.name,
+            slug: savedSearchEntity.owner.slug,
+          },
+          afterSignUpAction: {
+            action: "createAlert",
+            kind: "artist",
+            objectId: savedSearchEntity.owner.slug,
+          },
+          contextModule: ContextModule.artworkGrid,
+          copy: "Sign up to create an alert",
+          intent: Intent.createAlert,
+        }}
       />
     </Flex>
   )

--- a/src/Utils/__tests__/openAuthModal.jest.ts
+++ b/src/Utils/__tests__/openAuthModal.jest.ts
@@ -1,38 +1,7 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { ModalType } from "Components/Authentication/Types"
 import { mockLocation } from "DevTools/mockLocation"
-import {
-  AuthModalOptions,
-  openAuthModal,
-  openAuthToSatisfyIntent,
-} from "../openAuthModal"
-
-const artistArgs: AuthModalOptions = {
-  contextModule: ContextModule.artistHeader,
-  entity: {
-    name: "Andy Warhol",
-    slug: "andy-warhol",
-  },
-  intent: Intent.followArtist,
-}
-
-const partnerArgs: AuthModalOptions = {
-  contextModule: ContextModule.aboutTheWork,
-  entity: {
-    name: "David Zwirner",
-    slug: "david-zwirner",
-  },
-  intent: Intent.followPartner,
-}
-
-const artworkArgs: AuthModalOptions = {
-  contextModule: ContextModule.artworkGrid,
-  entity: {
-    name: "Skull",
-    slug: "andy-warhol-skull",
-  },
-  intent: Intent.saveArtwork,
-}
+import { openAuthModal } from "Utils/openAuthModal"
 
 describe("openAuth Helpers", () => {
   let mediator
@@ -61,61 +30,6 @@ describe("openAuth Helpers", () => {
         copy: "Sign up to do cool stuff",
         intent: "signup",
         mode: "signup",
-      })
-    })
-  })
-
-  describe("#openAuthToSatisfyIntent", () => {
-    describe("desktop", () => {
-      it("transforms args for following artists", () => {
-        openAuthToSatisfyIntent(mediator, artistArgs)
-
-        expect(mediator.trigger).toBeCalledWith("open:auth", {
-          afterSignUpAction: {
-            action: "follow",
-            kind: "artist",
-            objectId: "andy-warhol",
-          },
-          contextModule: "artistHeader",
-          copy: "Sign up to follow Andy Warhol",
-          intent: "followArtist",
-          mode: "signup",
-          redirectTo: "http://localhost/",
-        })
-      })
-
-      it("transforms args for following partners", () => {
-        openAuthToSatisfyIntent(mediator, partnerArgs)
-
-        expect(mediator.trigger).toBeCalledWith("open:auth", {
-          afterSignUpAction: {
-            action: "follow",
-            kind: "profile",
-            objectId: "david-zwirner",
-          },
-          contextModule: "aboutTheWork",
-          copy: "Sign up to follow David Zwirner",
-          intent: "followPartner",
-          mode: "signup",
-          redirectTo: "http://localhost/",
-        })
-      })
-
-      it("transforms args for saving artworks", () => {
-        openAuthToSatisfyIntent(mediator, artworkArgs)
-
-        expect(mediator.trigger).toBeCalledWith("open:auth", {
-          afterSignUpAction: {
-            action: "save",
-            kind: "artworks",
-            objectId: "andy-warhol-skull",
-          },
-          contextModule: "artworkGrid",
-          copy: "Sign up to save artworks",
-          intent: "saveArtwork",
-          mode: "signup",
-          redirectTo: "http://localhost/",
-        })
       })
     })
   })

--- a/src/Utils/openAuthModal.ts
+++ b/src/Utils/openAuthModal.ts
@@ -1,4 +1,4 @@
-import { AuthContextModule, AuthIntent, Intent } from "@artsy/cohesion"
+import { AuthContextModule, AuthIntent } from "@artsy/cohesion"
 import { ModalOptions, ModalType } from "Components/Authentication/Types"
 import qs from "qs"
 import { Mediator } from "Server/mediator"
@@ -32,107 +32,6 @@ export const triggerEvent = (
       clearInterval(intervalId)
     }
   }, 100)
-}
-
-export const openAuthToSatisfyIntent = (
-  mediator: Mediator,
-  options: AuthModalOptions
-) => {
-  let handled = false
-
-  if (mediator) {
-    const intent = getDesktopIntent(options)
-    if (intent) {
-      openAuthModal(mediator, {
-        mode: ModalType.signup,
-        ...intent,
-      })
-      handled = true
-    }
-  }
-
-  if (!handled) {
-    window.location.assign("/login")
-  }
-}
-
-const FOLLOW_INTENTS = {
-  [Intent.followArtist]: "artist",
-  [Intent.followPartner]: "profile",
-  [Intent.followGene]: "gene",
-}
-
-function getDesktopIntentToFollow({
-  contextModule,
-  entity,
-  intent,
-}: AuthModalOptions): ModalOptions {
-  const kind = FOLLOW_INTENTS[intent]
-
-  return {
-    afterSignUpAction: {
-      action: "follow",
-      kind,
-      objectId: entity.slug,
-    },
-    contextModule,
-    copy: `Sign up to follow ${entity.name}`,
-    intent,
-    mode: ModalType.signup,
-    redirectTo: window.location.href,
-  }
-}
-
-function getDesktopIntentToSaveArtwork({
-  contextModule,
-  entity,
-  intent,
-}: AuthModalOptions): ModalOptions {
-  return {
-    afterSignUpAction: {
-      action: "save",
-      kind: "artworks",
-      objectId: entity.slug,
-    },
-    contextModule,
-    copy: `Sign up to save artworks`,
-    intent,
-    mode: ModalType.signup,
-    redirectTo: window.location.href,
-  }
-}
-
-const getDesktopIntentToCreateAlert = ({
-  contextModule,
-  intent,
-  redirectTo,
-  afterSignUpAction,
-  copy,
-}: AuthModalOptions): ModalOptions => {
-  return {
-    afterSignUpAction,
-    contextModule,
-    intent,
-    redirectTo,
-    copy,
-    mode: ModalType.signup,
-  }
-}
-
-function getDesktopIntent(options: AuthModalOptions): ModalOptions {
-  switch (options.intent) {
-    case Intent.followArtist:
-    case Intent.followPartner:
-    case Intent.followGene:
-      return getDesktopIntentToFollow(options)
-    case Intent.saveArtwork:
-      return getDesktopIntentToSaveArtwork(options)
-    case Intent.createAlert:
-      return getDesktopIntentToCreateAlert(options)
-    default:
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      return undefined
-  }
 }
 
 export const getMobileAuthLink = (mode: ModalType, options: ModalOptions) => {


### PR DESCRIPTION
Continuing the auth dialog rollout (currently at 25% in just the top-right auth links), this PR expands the surface to auth dialogs that open when you click actions that have after authentication intents (save, follow, etc).