### PR TITLE
feat(art-quiz): limit results related works

### DIFF
--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
@@ -2,7 +2,7 @@ import { Button, Spacer, Tab, Tabs, Text, useToasts } from "@artsy/palette"
 import { ArtQuizLikedArtworksQueryRenderer } from "Apps/ArtQuiz/Components/ArtQuizLikedArtworks"
 import { ArtQuizRecommendedArtistsQueryRenderer } from "Apps/ArtQuiz/Components/ArtQuizRecommendedArtists"
 import { ArtQuizResultsRecommendedArtworksQueryRenderer } from "Apps/ArtQuiz/Components/ArtQuizResultsRecommendedArtworks"
-import { FC, useCallback, useMemo } from "react"
+import { FC, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useSystemContext } from "System"
 
@@ -28,15 +28,11 @@ export const ArtQuizResultsTabs: FC<ArtQuizResultsTabsProps> = ({
     })
   }
 
-  const calculatePerArtworkRecommendationsLimit = useCallback(() => {
+  const limit = useMemo(() => {
     if (savedQuizArtworksCount <= 1) return 100
     if (savedQuizArtworksCount <= 3) return 8
     return 4
   }, [savedQuizArtworksCount])
-
-  const limit = useMemo(() => calculatePerArtworkRecommendationsLimit(), [
-    calculatePerArtworkRecommendationsLimit,
-  ])
 
   return (
     <>

--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
@@ -2,16 +2,16 @@ import { Button, Spacer, Tab, Tabs, Text, useToasts } from "@artsy/palette"
 import { ArtQuizLikedArtworksQueryRenderer } from "Apps/ArtQuiz/Components/ArtQuizLikedArtworks"
 import { ArtQuizRecommendedArtistsQueryRenderer } from "Apps/ArtQuiz/Components/ArtQuizRecommendedArtists"
 import { ArtQuizResultsRecommendedArtworksQueryRenderer } from "Apps/ArtQuiz/Components/ArtQuizResultsRecommendedArtworks"
-import { FC } from "react"
+import { FC, useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useSystemContext } from "System"
 
 interface ArtQuizResultsTabsProps {
-  savedQuizArtworksTotal: number
+  savedQuizArtworksCount: number
 }
 
 export const ArtQuizResultsTabs: FC<ArtQuizResultsTabsProps> = ({
-  savedQuizArtworksTotal,
+  savedQuizArtworksCount,
 }) => {
   const { t } = useTranslation()
 
@@ -28,11 +28,15 @@ export const ArtQuizResultsTabs: FC<ArtQuizResultsTabsProps> = ({
     })
   }
 
-  const calculateRecommendationsLimit = () => {
-    if (savedQuizArtworksTotal <= 3) return 8
-    if (savedQuizArtworksTotal > 3) return 4
-    return 100
-  }
+  const calculatePerArtworkRecommendationsLimit = useCallback(() => {
+    if (savedQuizArtworksCount <= 1) return 100
+    if (savedQuizArtworksCount <= 3) return 8
+    return 4
+  }, [savedQuizArtworksCount])
+
+  const limit = useMemo(() => calculatePerArtworkRecommendationsLimit(), [
+    calculatePerArtworkRecommendationsLimit,
+  ])
 
   return (
     <>
@@ -66,9 +70,7 @@ export const ArtQuizResultsTabs: FC<ArtQuizResultsTabsProps> = ({
         </Tab>
 
         <Tab name={t("artQuizPage.results.tabs.recommendedArtworks")}>
-          <ArtQuizResultsRecommendedArtworksQueryRenderer
-            limit={calculateRecommendationsLimit()}
-          />
+          <ArtQuizResultsRecommendedArtworksQueryRenderer limit={limit} />
         </Tab>
 
         <Tab name={t("artQuizPage.results.tabs.recommendedArtists")}>

--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
@@ -6,7 +6,13 @@ import { FC } from "react"
 import { useTranslation } from "react-i18next"
 import { useSystemContext } from "System"
 
-export const ArtQuizResultsTabs: FC = () => {
+interface ArtQuizResultsTabsProps {
+  savedQuizArtworksTotal: number
+}
+
+export const ArtQuizResultsTabs: FC<ArtQuizResultsTabsProps> = ({
+  savedQuizArtworksTotal,
+}) => {
   const { t } = useTranslation()
 
   const { user } = useSystemContext()
@@ -20,6 +26,12 @@ export const ArtQuizResultsTabs: FC = () => {
       variant: "success",
       message: t("artQuizPage.results.emailSuccess", { email: user?.email }),
     })
+  }
+
+  const calculateRecommendationsLimit = () => {
+    if (savedQuizArtworksTotal <= 3) return 8
+    if (savedQuizArtworksTotal > 3) return 4
+    return 100
   }
 
   return (
@@ -54,7 +66,9 @@ export const ArtQuizResultsTabs: FC = () => {
         </Tab>
 
         <Tab name={t("artQuizPage.results.tabs.recommendedArtworks")}>
-          <ArtQuizResultsRecommendedArtworksQueryRenderer />
+          <ArtQuizResultsRecommendedArtworksQueryRenderer
+            limit={calculateRecommendationsLimit()}
+          />
         </Tab>
 
         <Tab name={t("artQuizPage.results.tabs.recommendedArtists")}>

--- a/src/Apps/ArtQuiz/Routes/ArtQuizResults.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizResults.tsx
@@ -1,7 +1,7 @@
 import { ArtQuizResultsEmpty } from "Apps/ArtQuiz/Components/ArtQuizResultsEmpty"
 import { ArtQuizResultsLoader } from "Apps/ArtQuiz/Components/ArtQuizResultsLoader"
 import { ArtQuizResultsTabs } from "Apps/ArtQuiz/Components/ArtQuizResultsTabs"
-import { FC } from "react"
+import { FC, useMemo } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useMode } from "Utils/Hooks/useMode"
 import { ArtQuizResults_me$data } from "__generated__/ArtQuizResults_me.graphql"
@@ -11,7 +11,10 @@ interface ArtQuizResultsProps {
 }
 
 const ArtQuizResults: FC<ArtQuizResultsProps> = ({ me }) => {
-  const hasSavedArtworks = me.quiz.savedArtworks.length > 0
+  const savedQuizArtworksTotal = useMemo(() => me.quiz.savedArtworks.length, [
+    me.quiz.savedArtworks,
+  ])
+  const hasSavedArtworks = savedQuizArtworksTotal > 0
 
   const [mode, setMode] = useMode<"Empty" | "Loading" | "Ready">(
     hasSavedArtworks ? "Loading" : "Empty"
@@ -29,7 +32,9 @@ const ArtQuizResults: FC<ArtQuizResultsProps> = ({ me }) => {
       return <ArtQuizResultsLoader onReady={handleReady} />
 
     case "Ready":
-      return <ArtQuizResultsTabs />
+      return (
+        <ArtQuizResultsTabs savedQuizArtworksTotal={savedQuizArtworksTotal} />
+      )
   }
 }
 

--- a/src/Apps/ArtQuiz/Routes/ArtQuizResults.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizResults.tsx
@@ -1,7 +1,7 @@
 import { ArtQuizResultsEmpty } from "Apps/ArtQuiz/Components/ArtQuizResultsEmpty"
 import { ArtQuizResultsLoader } from "Apps/ArtQuiz/Components/ArtQuizResultsLoader"
 import { ArtQuizResultsTabs } from "Apps/ArtQuiz/Components/ArtQuizResultsTabs"
-import { FC, useMemo } from "react"
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useMode } from "Utils/Hooks/useMode"
 import { ArtQuizResults_me$data } from "__generated__/ArtQuizResults_me.graphql"
@@ -11,9 +11,7 @@ interface ArtQuizResultsProps {
 }
 
 const ArtQuizResults: FC<ArtQuizResultsProps> = ({ me }) => {
-  const savedQuizArtworksCount = useMemo(() => me.quiz.savedArtworks.length, [
-    me.quiz.savedArtworks,
-  ])
+  const savedQuizArtworksCount = me.quiz.savedArtworks.length
   const hasSavedArtworks = savedQuizArtworksCount > 0
 
   const [mode, setMode] = useMode<"Empty" | "Loading" | "Ready">(

--- a/src/Apps/ArtQuiz/Routes/ArtQuizResults.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizResults.tsx
@@ -11,10 +11,10 @@ interface ArtQuizResultsProps {
 }
 
 const ArtQuizResults: FC<ArtQuizResultsProps> = ({ me }) => {
-  const savedQuizArtworksTotal = useMemo(() => me.quiz.savedArtworks.length, [
+  const savedQuizArtworksCount = useMemo(() => me.quiz.savedArtworks.length, [
     me.quiz.savedArtworks,
   ])
-  const hasSavedArtworks = savedQuizArtworksTotal > 0
+  const hasSavedArtworks = savedQuizArtworksCount > 0
 
   const [mode, setMode] = useMode<"Empty" | "Loading" | "Ready">(
     hasSavedArtworks ? "Loading" : "Empty"
@@ -33,7 +33,7 @@ const ArtQuizResults: FC<ArtQuizResultsProps> = ({ me }) => {
 
     case "Ready":
       return (
-        <ArtQuizResultsTabs savedQuizArtworksTotal={savedQuizArtworksTotal} />
+        <ArtQuizResultsTabs savedQuizArtworksCount={savedQuizArtworksCount} />
       )
   }
 }

--- a/src/__generated__/ArtQuizResultsRecommendedArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtQuizResultsRecommendedArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<14f6a8267f2cd971195f43c8f7596979>>
+ * @generated SignedSource<<4b40768307539dead7f8c5b1d84a2206>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,7 +26,7 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
+  "name": "internalID",
   "storageKey": null
 },
 v1 = {
@@ -36,28 +36,35 @@ v1 = {
   "name": "id",
   "storageKey": null
 },
-v2 = [
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v3 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v5 = [
+v6 = [
   {
     "alias": null,
     "args": null,
@@ -66,8 +73,8 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = [
-  (v3/*: any*/),
+v7 = [
+  (v4/*: any*/),
   (v1/*: any*/)
 ];
 return {
@@ -165,374 +172,8 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "internalID",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "placeholder",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:[\"larger\",\"large\"])"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artistNames",
-                                    "storageKey": null
-                                  },
                                   (v0/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artist",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "ArtistTargetSupply",
-                                        "kind": "LinkedField",
-                                        "name": "targetSupply",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isP1",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v1/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkPriceInsights",
-                                    "kind": "LinkedField",
-                                    "name": "marketPriceInsights",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "demandRank",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v2/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v1/*: any*/),
-                                      (v0/*: any*/),
-                                      (v3/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v2/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v3/*: any*/),
-                                      (v0/*: any*/),
-                                      (v1/*: any*/)
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      (v4/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "cascadingEndTimeIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "startAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v1/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotID",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotLabel",
-                                        "storageKey": null
-                                      },
-                                      (v4/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingEndAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "formattedEndDateTime",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v5/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v5/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v1/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "slug",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_saved",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AttributionClass",
-                                    "kind": "LinkedField",
-                                    "name": "attributionClass",
-                                    "plural": false,
-                                    "selections": (v6/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkMedium",
-                                    "kind": "LinkedField",
-                                    "name": "mediumType",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Gene",
-                                        "kind": "LinkedField",
-                                        "name": "filterGene",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_biddable",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
-                                    "storageKey": null
-                                  }
+                                  (v1/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -545,6 +186,379 @@ return {
                       (v1/*: any*/)
                     ],
                     "storageKey": "layer(id:\"main\")"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "related",
+                    "plural": true,
+                    "selections": [
+                      (v0/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "imageTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "placeholder",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": [
+                                  "larger",
+                                  "large"
+                                ]
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:[\"larger\",\"large\"])"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "artistNames",
+                        "storageKey": null
+                      },
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artist",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtistTargetSupply",
+                            "kind": "LinkedField",
+                            "name": "targetSupply",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isP1",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          (v1/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkPriceInsights",
+                        "kind": "LinkedField",
+                        "name": "marketPriceInsights",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "demandRank",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v3/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v1/*: any*/),
+                          (v2/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v3/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v2/*: any*/),
+                          (v1/*: any*/)
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "cascadingEndTimeIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingIntervalMinutes",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "startAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v1/*: any*/),
+                          {
+                            "alias": "is_preview",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isPreview",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "display_timely_at",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "displayTimelyAt",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotID",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lotLabel",
+                            "storageKey": null
+                          },
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "extendedBiddingEndAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "formattedEndDateTime",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v6/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v6/*: any*/),
+                            "storageKey": null
+                          },
+                          (v1/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "AttributionClass",
+                        "kind": "LinkedField",
+                        "name": "attributionClass",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkMedium",
+                        "kind": "LinkedField",
+                        "name": "mediumType",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Gene",
+                            "kind": "LinkedField",
+                            "name": "filterGene",
+                            "plural": false,
+                            "selections": (v7/*: any*/),
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_biddable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isBiddable",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
                   },
                   (v1/*: any*/)
                 ],
@@ -561,12 +575,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "faa6abddef4b7ba05d8a674bf75fac67",
+    "cacheID": "325f98551feced79703aac72425cca78",
     "id": null,
     "metadata": {},
     "name": "ArtQuizResultsRecommendedArtworksQuery",
     "operationKind": "query",
-    "text": "query ArtQuizResultsRecommendedArtworksQuery {\n  me {\n    ...ArtQuizResultsRecommendedArtworks_me\n    id\n  }\n}\n\nfragment ArtQuizResultsRecommendedArtworks_me on Me {\n  quiz {\n    savedArtworks {\n      layer(id: \"main\") {\n        artworksConnection {\n          edges {\n            node {\n              ...GridItem_artwork\n              internalID\n              id\n            }\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image {\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query ArtQuizResultsRecommendedArtworksQuery {\n  me {\n    ...ArtQuizResultsRecommendedArtworks_me\n    id\n  }\n}\n\nfragment ArtQuizResultsRecommendedArtworks_me on Me {\n  quiz {\n    savedArtworks {\n      layer(id: \"main\") {\n        artworksConnection {\n          edges {\n            node {\n              internalID\n              id\n            }\n          }\n        }\n        id\n      }\n      related {\n        ...GridItem_artwork\n        internalID\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image {\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtQuizResultsRecommendedArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtQuizResultsRecommendedArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4b40768307539dead7f8c5b1d84a2206>>
+ * @generated SignedSource<<6918f250192977f0f29eb00946e3316b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,7 +26,7 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "href",
   "storageKey": null
 },
 v1 = {
@@ -36,35 +36,28 @@ v1 = {
   "name": "id",
   "storageKey": null
 },
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v3 = [
+v2 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -73,8 +66,8 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = [
-  (v4/*: any*/),
+v6 = [
+  (v3/*: any*/),
   (v1/*: any*/)
 ];
 return {
@@ -172,8 +165,374 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "internalID",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "title",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "imageTitle",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "placeholder",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "larger",
+                                              "large"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"larger\",\"large\"])"
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "aspectRatio",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "artistNames",
+                                    "storageKey": null
+                                  },
                                   (v0/*: any*/),
-                                  (v1/*: any*/)
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "date",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "sale_message",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "saleMessage",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "cultural_maker",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "culturalMaker",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Artist",
+                                    "kind": "LinkedField",
+                                    "name": "artist",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "ArtistTargetSupply",
+                                        "kind": "LinkedField",
+                                        "name": "targetSupply",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "isP1",
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      },
+                                      (v1/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "ArtworkPriceInsights",
+                                    "kind": "LinkedField",
+                                    "name": "marketPriceInsights",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "demandRank",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": (v2/*: any*/),
+                                    "concreteType": "Artist",
+                                    "kind": "LinkedField",
+                                    "name": "artists",
+                                    "plural": true,
+                                    "selections": [
+                                      (v1/*: any*/),
+                                      (v0/*: any*/),
+                                      (v3/*: any*/)
+                                    ],
+                                    "storageKey": "artists(shallow:true)"
+                                  },
+                                  {
+                                    "alias": "collecting_institution",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "collectingInstitution",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": (v2/*: any*/),
+                                    "concreteType": "Partner",
+                                    "kind": "LinkedField",
+                                    "name": "partner",
+                                    "plural": false,
+                                    "selections": [
+                                      (v3/*: any*/),
+                                      (v0/*: any*/),
+                                      (v1/*: any*/)
+                                    ],
+                                    "storageKey": "partner(shallow:true)"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Sale",
+                                    "kind": "LinkedField",
+                                    "name": "sale",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "cascadingEndTimeIntervalMinutes",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "extendedBiddingIntervalMinutes",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "startAt",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": "is_auction",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isAuction",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": "is_closed",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isClosed",
+                                        "storageKey": null
+                                      },
+                                      (v1/*: any*/),
+                                      {
+                                        "alias": "is_preview",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isPreview",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": "display_timely_at",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "displayTimelyAt",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "sale_artwork",
+                                    "args": null,
+                                    "concreteType": "SaleArtwork",
+                                    "kind": "LinkedField",
+                                    "name": "saleArtwork",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "lotID",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "lotLabel",
+                                        "storageKey": null
+                                      },
+                                      (v4/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "extendedBiddingEndAt",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "formattedEndDateTime",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkCounts",
+                                        "kind": "LinkedField",
+                                        "name": "counts",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": "bidder_positions",
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "bidderPositions",
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": "highest_bid",
+                                        "args": null,
+                                        "concreteType": "SaleArtworkHighestBid",
+                                        "kind": "LinkedField",
+                                        "name": "highestBid",
+                                        "plural": false,
+                                        "selections": (v5/*: any*/),
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": "opening_bid",
+                                        "args": null,
+                                        "concreteType": "SaleArtworkOpeningBid",
+                                        "kind": "LinkedField",
+                                        "name": "openingBid",
+                                        "plural": false,
+                                        "selections": (v5/*: any*/),
+                                        "storageKey": null
+                                      },
+                                      (v1/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  (v1/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "slug",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_saved",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isSaved",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "AttributionClass",
+                                    "kind": "LinkedField",
+                                    "name": "attributionClass",
+                                    "plural": false,
+                                    "selections": (v6/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "ArtworkMedium",
+                                    "kind": "LinkedField",
+                                    "name": "mediumType",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Gene",
+                                        "kind": "LinkedField",
+                                        "name": "filterGene",
+                                        "plural": false,
+                                        "selections": (v6/*: any*/),
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_biddable",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isBiddable",
+                                    "storageKey": null
+                                  }
                                 ],
                                 "storageKey": null
                               }
@@ -186,379 +545,6 @@ return {
                       (v1/*: any*/)
                     ],
                     "storageKey": "layer(id:\"main\")"
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Artwork",
-                    "kind": "LinkedField",
-                    "name": "related",
-                    "plural": true,
-                    "selections": [
-                      (v0/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "title",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "imageTitle",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "placeholder",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": [
-                                  "larger",
-                                  "large"
-                                ]
-                              }
-                            ],
-                            "kind": "ScalarField",
-                            "name": "url",
-                            "storageKey": "url(version:[\"larger\",\"large\"])"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "aspectRatio",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "artistNames",
-                        "storageKey": null
-                      },
-                      (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "date",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "sale_message",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "saleMessage",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "cultural_maker",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "culturalMaker",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Artist",
-                        "kind": "LinkedField",
-                        "name": "artist",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtistTargetSupply",
-                            "kind": "LinkedField",
-                            "name": "targetSupply",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isP1",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          (v1/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "ArtworkPriceInsights",
-                        "kind": "LinkedField",
-                        "name": "marketPriceInsights",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "demandRank",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v3/*: any*/),
-                        "concreteType": "Artist",
-                        "kind": "LinkedField",
-                        "name": "artists",
-                        "plural": true,
-                        "selections": [
-                          (v1/*: any*/),
-                          (v2/*: any*/),
-                          (v4/*: any*/)
-                        ],
-                        "storageKey": "artists(shallow:true)"
-                      },
-                      {
-                        "alias": "collecting_institution",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "collectingInstitution",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v3/*: any*/),
-                        "concreteType": "Partner",
-                        "kind": "LinkedField",
-                        "name": "partner",
-                        "plural": false,
-                        "selections": [
-                          (v4/*: any*/),
-                          (v2/*: any*/),
-                          (v1/*: any*/)
-                        ],
-                        "storageKey": "partner(shallow:true)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Sale",
-                        "kind": "LinkedField",
-                        "name": "sale",
-                        "plural": false,
-                        "selections": [
-                          (v5/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "cascadingEndTimeIntervalMinutes",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "extendedBiddingIntervalMinutes",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "startAt",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_auction",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isAuction",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_closed",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isClosed",
-                            "storageKey": null
-                          },
-                          (v1/*: any*/),
-                          {
-                            "alias": "is_preview",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isPreview",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "display_timely_at",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "displayTimelyAt",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "sale_artwork",
-                        "args": null,
-                        "concreteType": "SaleArtwork",
-                        "kind": "LinkedField",
-                        "name": "saleArtwork",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lotID",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lotLabel",
-                            "storageKey": null
-                          },
-                          (v5/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "extendedBiddingEndAt",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "formattedEndDateTime",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "SaleArtworkCounts",
-                            "kind": "LinkedField",
-                            "name": "counts",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": "bidder_positions",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "bidderPositions",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "highest_bid",
-                            "args": null,
-                            "concreteType": "SaleArtworkHighestBid",
-                            "kind": "LinkedField",
-                            "name": "highestBid",
-                            "plural": false,
-                            "selections": (v6/*: any*/),
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "opening_bid",
-                            "args": null,
-                            "concreteType": "SaleArtworkOpeningBid",
-                            "kind": "LinkedField",
-                            "name": "openingBid",
-                            "plural": false,
-                            "selections": (v6/*: any*/),
-                            "storageKey": null
-                          },
-                          (v1/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      (v1/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "is_saved",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isSaved",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "AttributionClass",
-                        "kind": "LinkedField",
-                        "name": "attributionClass",
-                        "plural": false,
-                        "selections": (v7/*: any*/),
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "ArtworkMedium",
-                        "kind": "LinkedField",
-                        "name": "mediumType",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Gene",
-                            "kind": "LinkedField",
-                            "name": "filterGene",
-                            "plural": false,
-                            "selections": (v7/*: any*/),
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "is_biddable",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isBiddable",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
                   },
                   (v1/*: any*/)
                 ],
@@ -575,12 +561,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "325f98551feced79703aac72425cca78",
+    "cacheID": "5845571b1aaa1c4aa3361111f3787631",
     "id": null,
     "metadata": {},
     "name": "ArtQuizResultsRecommendedArtworksQuery",
     "operationKind": "query",
-    "text": "query ArtQuizResultsRecommendedArtworksQuery {\n  me {\n    ...ArtQuizResultsRecommendedArtworks_me\n    id\n  }\n}\n\nfragment ArtQuizResultsRecommendedArtworks_me on Me {\n  quiz {\n    savedArtworks {\n      layer(id: \"main\") {\n        artworksConnection {\n          edges {\n            node {\n              internalID\n              id\n            }\n          }\n        }\n        id\n      }\n      related {\n        ...GridItem_artwork\n        internalID\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image {\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query ArtQuizResultsRecommendedArtworksQuery {\n  me {\n    ...ArtQuizResultsRecommendedArtworks_me\n    id\n  }\n}\n\nfragment ArtQuizResultsRecommendedArtworks_me on Me {\n  quiz {\n    savedArtworks {\n      layer(id: \"main\") {\n        artworksConnection {\n          edges {\n            node {\n              internalID\n              ...GridItem_artwork\n              id\n            }\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...NewSaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image {\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NewSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtQuizResultsRecommendedArtworks_me.graphql.ts
+++ b/src/__generated__/ArtQuizResultsRecommendedArtworks_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bb8169966a62e6f0d79835eea5808b80>>
+ * @generated SignedSource<<8332f97032bb8bd5c5a0ee92afe375fc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,14 +18,11 @@ export type ArtQuizResultsRecommendedArtworks_me$data = {
           readonly edges: ReadonlyArray<{
             readonly node: {
               readonly internalID: string;
+              readonly " $fragmentSpreads": FragmentRefs<"GridItem_artwork">;
             } | null;
           } | null> | null;
         } | null;
       } | null;
-      readonly related: ReadonlyArray<{
-        readonly internalID: string;
-        readonly " $fragmentSpreads": FragmentRefs<"GridItem_artwork">;
-      } | null> | null;
     }>;
   };
   readonly " $fragmentType": "ArtQuizResultsRecommendedArtworks_me";
@@ -35,15 +32,7 @@ export type ArtQuizResultsRecommendedArtworks_me$key = {
   readonly " $fragmentSpreads": FragmentRefs<"ArtQuizResultsRecommendedArtworks_me">;
 };
 
-const node: ReaderFragment = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-};
-return {
+const node: ReaderFragment = {
   "argumentDefinitions": [
     {
       "defaultValue": null,
@@ -87,7 +76,13 @@ return {
               "selections": [
                 {
                   "alias": null,
-                  "args": null,
+                  "args": [
+                    {
+                      "kind": "Variable",
+                      "name": "first",
+                      "variableName": "limit"
+                    }
+                  ],
                   "concreteType": "ArtworkConnection",
                   "kind": "LinkedField",
                   "name": "artworksConnection",
@@ -109,7 +104,18 @@ return {
                           "name": "node",
                           "plural": false,
                           "selections": [
-                            (v0/*: any*/)
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "internalID",
+                              "storageKey": null
+                            },
+                            {
+                              "args": null,
+                              "kind": "FragmentSpread",
+                              "name": "GridItem_artwork"
+                            }
                           ],
                           "storageKey": null
                         }
@@ -121,29 +127,6 @@ return {
                 }
               ],
               "storageKey": "layer(id:\"main\")"
-            },
-            {
-              "alias": null,
-              "args": [
-                {
-                  "kind": "Variable",
-                  "name": "size",
-                  "variableName": "limit"
-                }
-              ],
-              "concreteType": "Artwork",
-              "kind": "LinkedField",
-              "name": "related",
-              "plural": true,
-              "selections": [
-                {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "GridItem_artwork"
-                },
-                (v0/*: any*/)
-              ],
-              "storageKey": null
             }
           ],
           "storageKey": null
@@ -155,8 +138,7 @@ return {
   "type": "Me",
   "abstractKey": null
 };
-})();
 
-(node as any).hash = "92679aedabc0cbe316acf58870a33784";
+(node as any).hash = "815a9dddd6359196c24dd275a23c5225";
 
 export default node;

--- a/src/__generated__/ArtQuizResultsRecommendedArtworks_me.graphql.ts
+++ b/src/__generated__/ArtQuizResultsRecommendedArtworks_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e10004061a956fbb933224f791f4111e>>
+ * @generated SignedSource<<bb8169966a62e6f0d79835eea5808b80>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,11 +18,14 @@ export type ArtQuizResultsRecommendedArtworks_me$data = {
           readonly edges: ReadonlyArray<{
             readonly node: {
               readonly internalID: string;
-              readonly " $fragmentSpreads": FragmentRefs<"GridItem_artwork">;
             } | null;
           } | null> | null;
         } | null;
       } | null;
+      readonly related: ReadonlyArray<{
+        readonly internalID: string;
+        readonly " $fragmentSpreads": FragmentRefs<"GridItem_artwork">;
+      } | null> | null;
     }>;
   };
   readonly " $fragmentType": "ArtQuizResultsRecommendedArtworks_me";
@@ -32,8 +35,22 @@ export type ArtQuizResultsRecommendedArtworks_me$key = {
   readonly " $fragmentSpreads": FragmentRefs<"ArtQuizResultsRecommendedArtworks_me">;
 };
 
-const node: ReaderFragment = {
-  "argumentDefinitions": [],
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "limit"
+    }
+  ],
   "kind": "Fragment",
   "metadata": null,
   "name": "ArtQuizResultsRecommendedArtworks_me",
@@ -92,18 +109,7 @@ const node: ReaderFragment = {
                           "name": "node",
                           "plural": false,
                           "selections": [
-                            {
-                              "args": null,
-                              "kind": "FragmentSpread",
-                              "name": "GridItem_artwork"
-                            },
-                            {
-                              "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "internalID",
-                              "storageKey": null
-                            }
+                            (v0/*: any*/)
                           ],
                           "storageKey": null
                         }
@@ -115,6 +121,29 @@ const node: ReaderFragment = {
                 }
               ],
               "storageKey": "layer(id:\"main\")"
+            },
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Variable",
+                  "name": "size",
+                  "variableName": "limit"
+                }
+              ],
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "related",
+              "plural": true,
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "GridItem_artwork"
+                },
+                (v0/*: any*/)
+              ],
+              "storageKey": null
             }
           ],
           "storageKey": null
@@ -126,7 +155,8 @@ const node: ReaderFragment = {
   "type": "Me",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "63ded2fcdf927ee957dfa012f0461261";
+(node as any).hash = "92679aedabc0cbe316acf58870a33784";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1482]

### Description

After a user takes the art quiz we want to show them works related to the ones they saved. Acceptance criteria for this task were explained as follows:

- If user likes only 1 artwork, show ALL related
- If user likes less than 3 artworks, show [8] per liked
- If user likes more than 3 artworks, show [4] per liked

This set of criteria for the related works results, however, does not apply to the quiz results email, which will have a smaller subset of related works. That being said, it didn't feel too out of line to simply pass a size argument to the pre-existing query.

Maybe worth revisiting a `results` query that encapsulates all results data at some point in the future.

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GRO-1482]: https://artsyproduct.atlassian.net/browse/GRO-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ