### PR TITLE
refactor(auction): alters add to calendar to behave like a dropdown menu

### DIFF
--- a/src/Apps/Auction/Components/AuctionDetails/AddToCalendar.tsx
+++ b/src/Apps/Auction/Components/AuctionDetails/AddToCalendar.tsx
@@ -1,7 +1,8 @@
-import { Button, Join, Popover, Spacer, Text } from "@artsy/palette"
+import { Box, Button, Dropdown, Text } from "@artsy/palette"
 import { AddToCalendar as AddToCalendarEvent } from "@artsy/cohesion"
 import { generateGoogleCalendarUrl, generateIcsCalendarUrl } from "./helpers"
-import { useAuctionTracking } from "../../Hooks/useAuctionTracking"
+import { useAuctionTracking } from "Apps/Auction/Hooks/useAuctionTracking"
+import { NavBarMenuItemLink } from "Components/NavBar/Menus/NavBarMenuItem"
 
 export interface AddToCalendarProps {
   title: string
@@ -15,7 +16,11 @@ export interface AddToCalendarProps {
 
 export const AddToCalendar: React.FC<AddToCalendarProps> = props => {
   return (
-    <Popover placement="bottom" popover={<PopoverLinks {...props} />}>
+    <Dropdown
+      dropdown={<AddToCalendarLinks {...props} />}
+      placement="bottom"
+      openDropdownByClick
+    >
       {({ onVisible, anchorRef }) => {
         return (
           <Button
@@ -28,11 +33,11 @@ export const AddToCalendar: React.FC<AddToCalendarProps> = props => {
           </Button>
         )
       }}
-    </Popover>
+    </Dropdown>
   )
 }
 
-export const PopoverLinks: React.FC<AddToCalendarProps> = props => {
+export const AddToCalendarLinks: React.FC<AddToCalendarProps> = props => {
   const googleUrl = generateGoogleCalendarUrl(props)
   const icsUrl = generateIcsCalendarUrl(props)
 
@@ -43,22 +48,22 @@ export const PopoverLinks: React.FC<AddToCalendarProps> = props => {
   }
 
   return (
-    <Text variant="xs" width={300}>
-      <Join separator={<Spacer y={1} />}>
-        <a
-          href={googleUrl}
-          onClick={() => trackClick("google")}
-          target="_blank"
-        >
-          Google
-        </a>
-        <a href={icsUrl} onClick={() => trackClick("iCal")}>
-          iCal
-        </a>
-        <a href={icsUrl} onClick={() => trackClick("outlook")}>
-          Outlook
-        </a>
-      </Join>
-    </Text>
+    <Box minWidth={200}>
+      <NavBarMenuItemLink
+        to={googleUrl}
+        onClick={() => trackClick("google")}
+        target="_blank"
+      >
+        Google
+      </NavBarMenuItemLink>
+
+      <NavBarMenuItemLink to={icsUrl} onClick={() => trackClick("iCal")}>
+        iCal
+      </NavBarMenuItemLink>
+
+      <NavBarMenuItemLink to={icsUrl} onClick={() => trackClick("outlook")}>
+        Outlook
+      </NavBarMenuItemLink>
+    </Box>
   )
 }

--- a/src/Apps/Auction/Components/AuctionDetails/__tests__/AddToCalendar.jest.tsx
+++ b/src/Apps/Auction/Components/AuctionDetails/__tests__/AddToCalendar.jest.tsx
@@ -1,7 +1,10 @@
 import { ContextModule } from "@artsy/cohesion"
 import { mount } from "enzyme"
 import { useAuctionTracking } from "Apps/Auction/Hooks/useAuctionTracking"
-import { AddToCalendar, PopoverLinks } from "../AddToCalendar"
+import {
+  AddToCalendar,
+  AddToCalendarLinks,
+} from "Apps/Auction/Components/AuctionDetails/AddToCalendar"
 
 jest.mock("Apps/Auction/Hooks/useAuctionTracking")
 
@@ -34,14 +37,14 @@ describe("AddToCalendar", () => {
     }
 
     const wrapper = getWrapper()
-    expect(wrapper.find("Popover").length).toBe(1)
+    expect(wrapper.find("Dropdown").length).toBe(1)
     expect(wrapper.find("Button").length).toBe(1)
     expect(wrapper.text()).toContain("Add to Calendar")
   })
 
   it("computs correct links", () => {
     const getWrapper = () => {
-      return mount(<PopoverLinks {...props} />)
+      return mount(<AddToCalendarLinks {...props} />)
     }
     const wrapper = getWrapper()
     expect(wrapper.find("a").length).toBe(3)
@@ -52,7 +55,7 @@ describe("AddToCalendar", () => {
 
   it("tracks events", () => {
     const getWrapper = () => {
-      return mount(<PopoverLinks {...props} />)
+      return mount(<AddToCalendarLinks {...props} />)
     }
     const wrapper = getWrapper()
 


### PR DESCRIPTION
Minor change; when we audited the use of `Popover` it was determined this should be a `Dropdown` instead:

## Before
https://user-images.githubusercontent.com/112297/211882449-5db4bd19-c14f-4431-9e1b-ec7ec200e3ac.mp4

## After
https://user-images.githubusercontent.com/112297/211882496-4d91032a-597d-47b4-acc3-298afc9381ac.mp4

