### PR TITLE
chore: Change "Market News" title on home page to "Artsy Editorial"

### DIFF
--- a/src/Apps/Home/Components/HomeFeaturedMarketNews.tsx
+++ b/src/Apps/Home/Components/HomeFeaturedMarketNews.tsx
@@ -125,7 +125,7 @@ const HomeFeaturedMarketNewsContainer: React.FC = ({ children }) => {
   return (
     <>
       <Flex justifyContent="space-between" alignItems="center">
-        <Text variant="xl">Market News</Text>
+        <Text variant="xl">Artsy Editorial</Text>
 
         <Text
           variant="sm-display"

--- a/src/Apps/Home/__tests__/HomeFeaturedMarketNews.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeFeaturedMarketNews.jest.tsx
@@ -38,7 +38,7 @@ describe("HomeFeaturedMarketNews", () => {
       }),
     })
 
-    expect(wrapper.text()).toContain("Market News")
+    expect(wrapper.text()).toContain("Artsy Editorial")
     expect(wrapper.text()).toContain("Explore Editorial")
     expect(wrapper.html()).toContain("/article/example-article")
   })


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4542]

### Demo
| Before | After |
| ------------- | ------------- |
| <img width="1920" alt="before" src="https://user-images.githubusercontent.com/3513494/212068538-f2692d8b-4a97-4339-8f13-6b6efdd80935.png"> | <img width="1920" alt="after" src="https://user-images.githubusercontent.com/3513494/212068607-77701c0c-f123-417e-a666-97f2a5543e1f.png"> | 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4542]: https://artsyproduct.atlassian.net/browse/FX-4542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ