### PR TITLE
Fix: bump zindex to 1 to fix zendesk widget placement

### DIFF
--- a/src/Components/ZendeskWrapper.tsx
+++ b/src/Components/ZendeskWrapper.tsx
@@ -24,7 +24,7 @@ export const ZendeskWrapper: FC<ZendeskWrapperProps> = ({
       window.zESettings = {
         webWidget: {
           // keeping the widget below the cookie banner
-          zIndex: 0,
+          zIndex: 1,
         },
       }
       window.zEmbed?.show?.()


### PR DESCRIPTION
The type of this PR is: **Fix/Style**

[GRO-1511]

### Description

This PR moves the Zendesk widget to the right place, ie behind the cookie consent banner and above the rest of the site content.


[GRO-1511]: https://artsyproduct.atlassian.net/browse/GRO-1511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ