### PR TITLE
feat(TX-991): payment step for private sale orders

### DIFF
--- a/src/Apps/Order/Components/BuyerGuarantee.tsx
+++ b/src/Apps/Order/Components/BuyerGuarantee.tsx
@@ -45,6 +45,7 @@ export const BuyerGuarantee: React.FC<BuyerGuaranteeProps> = ({
         <Text variant="sm" color="black60">
           This purchase is subject to{" "}
           <a
+            style={{ textDecoration: "underline", color: "#000" }}
             href="https://www.artsy.net/partner/artsy-private-sales"
             target="_blank"
             rel="noopener noreferrer"

--- a/src/Apps/Order/Components/BuyerGuarantee.tsx
+++ b/src/Apps/Order/Components/BuyerGuarantee.tsx
@@ -42,10 +42,10 @@ export const BuyerGuarantee: React.FC<BuyerGuaranteeProps> = ({
         flexDirection="column"
         style={{ position: "relative", borderTop: "none" }}
       >
-        <Text variant="xs" color="black60">
+        <Text variant="sm" color="black60">
           This purchase is subject to{" "}
           <a
-            href="https://support.artsy.net/hc/en-us/articles/4413546314647-Will-my-order-be-subject-to-customs-fees-"
+            href="https://www.artsy.net/partner/artsy-private-sales"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/src/Apps/Order/Components/BuyerGuarantee.tsx
+++ b/src/Apps/Order/Components/BuyerGuarantee.tsx
@@ -1,5 +1,12 @@
 import { ActionType, ContextModule } from "@artsy/cohesion"
-import { CircleBlackCheckIcon, Flex, Link, Text } from "@artsy/palette"
+import {
+  CircleBlackCheckIcon,
+  Flex,
+  Link,
+  Text,
+  StackableBorderBox,
+  Spacer,
+} from "@artsy/palette"
 import * as React from "react"
 import { useTracking } from "react-tracking"
 
@@ -9,11 +16,13 @@ export const BUYER_GUARANTEE_URL =
 interface BuyerGuaranteeProps {
   contextModule: ContextModule
   contextPageOwnerType: string
+  orderSource?: string | null
 }
 
 export const BuyerGuarantee: React.FC<BuyerGuaranteeProps> = ({
   contextModule,
   contextPageOwnerType,
+  orderSource,
 }) => {
   const { trackEvent } = useTracking()
 
@@ -25,6 +34,45 @@ export const BuyerGuarantee: React.FC<BuyerGuaranteeProps> = ({
         context_page_owner_type: contextPageOwnerType,
       })
     }
+  }
+
+  if (orderSource === "private_sale") {
+    return (
+      <StackableBorderBox
+        flexDirection="column"
+        style={{ position: "relative", borderTop: "none" }}
+      >
+        <Text variant="xs" color="black60">
+          This purchase is subject to{" "}
+          <a
+            href="https://support.artsy.net/hc/en-us/articles/4413546314647-Will-my-order-be-subject-to-customs-fees-"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Artsy Private Sales LLC Conditions of Sale
+          </a>
+        </Text>
+
+        <Spacer y={4} />
+
+        <Text fontWeight="bold" variant="xs">
+          Additional conditions of sale
+        </Text>
+
+        <Spacer y={2} />
+
+        {/* TODO: will be pulled from Exchange when available */}
+        <Text variant="xs" color="black60">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi feugiat
+          aliquet commodo. Mauris ut elit tincidunt, aliquam dolor nec,
+          porttitor metus. Curabitur mi erat, sagittis porttitor augue sed,
+          consectetur iaculis elit. Etiam massa purus, tincidunt vel ipsum non,
+          venenatis iaculis nisi. Nam quis dapibus ante, id congue arcu.
+          Interdum et malesuada fames ac ante ipsum primis in faucibus curabitur
+          mi erat, sagittis porttitor.
+        </Text>
+      </StackableBorderBox>
+    )
   }
 
   return (

--- a/src/Apps/Order/Components/StickyFooter.tsx
+++ b/src/Apps/Order/Components/StickyFooter.tsx
@@ -9,12 +9,14 @@ import { useTracking } from "react-tracking"
 interface StickyFooterProps extends WithInquiryProps {
   artworkID: string
   orderType: string | null
+  orderSource: string | null
 }
 
 export const StickyFooter: FC<StickyFooterProps> = ({
   showInquiry,
   inquiryComponent,
   orderType,
+  orderSource,
 }) => {
   const { trackEvent } = useTracking()
 
@@ -48,22 +50,38 @@ export const StickyFooter: FC<StickyFooterProps> = ({
       <FooterContainer>
         <Text variant="xs" color="black60">
           Need help?{" "}
-          <Clickable
-            data-test="help-center-link"
-            textDecoration="underline"
-            onClick={onClickReadFAQ}
-          >
-            <Text variant="xs">Visit our help center</Text>
-          </Clickable>{" "}
-          or{" "}
-          <Clickable
-            data-test="ask-question-link"
-            textDecoration="underline"
-            onClick={onClickAskSpecialist}
-          >
-            <Text variant="xs">ask a question</Text>
-          </Clickable>
-          .
+          {orderSource === "private_sale" ? (
+            <>
+              {" "}
+              Email{" "}
+              <Clickable
+                data-test="private-sales-email-link"
+                textDecoration="underline"
+              >
+                <Text variant="xs">privatesales@artsy.net</Text>
+              </Clickable>
+              .
+            </>
+          ) : (
+            <>
+              <Clickable
+                data-test="help-center-link"
+                textDecoration="underline"
+                onClick={onClickReadFAQ}
+              >
+                <Text variant="xs">Visit our help center</Text>
+              </Clickable>{" "}
+              or{" "}
+              <Clickable
+                data-test="ask-question-link"
+                textDecoration="underline"
+                onClick={onClickAskSpecialist}
+              >
+                <Text variant="xs">ask a question</Text>
+              </Clickable>
+              .
+            </>
+          )}
         </Text>
         <Spacer y={2} />
       </FooterContainer>

--- a/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -220,7 +220,7 @@ export const TransactionDetailsSummaryItem: FC<TransactionDetailsSummaryItemProp
         data-test="buyerTotalDisplayAmount"
       />
       <Spacer y={2} />
-      <Text variant="xs" color="black60">
+      <Text variant="sm" color="black60">
         *Additional duties and taxes{" "}
         <a
           href="https://support.artsy.net/hc/en-us/articles/4413546314647-Will-my-order-be-subject-to-customs-fees-"

--- a/src/Apps/Order/Components/__tests__/BuyerGuarantee.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/BuyerGuarantee.jest.tsx
@@ -2,7 +2,7 @@ import { ContextModule } from "@artsy/cohesion"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { useTracking } from "react-tracking"
-import { BuyerGuarantee } from "../BuyerGuarantee"
+import { BuyerGuarantee } from "Apps/Order/Components/BuyerGuarantee"
 
 jest.mock("react-tracking")
 
@@ -56,5 +56,30 @@ describe("BuyerGuarantee", () => {
         expect(trackEvent).not.toHaveBeenCalled()
       })
     })
+  })
+})
+
+describe("with private sale orders", () => {
+  beforeEach(() => {
+    render(
+      <BuyerGuarantee
+        contextModule={ContextModule.ordersShipping}
+        contextPageOwnerType="test-owner"
+        orderSource="private_sale"
+      />
+    )
+  })
+
+  it("renders correct conditions of sale", () => {
+    expect(screen.getByText("This purchase is subject to")).toBeInTheDocument()
+    expect(
+      screen.getByText("Artsy Private Sales LLC Conditions of Sale")
+    ).toBeInTheDocument()
+  })
+
+  it("renders extra conditions of sale", () => {
+    expect(
+      screen.getByText("Additional conditions of sale")
+    ).toBeInTheDocument()
   })
 })

--- a/src/Apps/Order/Components/__tests__/StickyFooter.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/StickyFooter.jest.tsx
@@ -1,7 +1,10 @@
 import { SystemContextProvider } from "System"
 import { useTracking } from "react-tracking"
 import { mount } from "enzyme"
-import { StickyFooterWithInquiry, StickyFooter } from "../StickyFooter"
+import {
+  StickyFooterWithInquiry,
+  StickyFooter,
+} from "Apps/Order/Components/StickyFooter"
 import { mediator } from "Server/mediator"
 
 jest.mock("react-tracking")
@@ -22,7 +25,11 @@ describe("Sticky footer", () => {
 
   it("handles FAQ modal", () => {
     const component = mount(
-      <StickyFooterWithInquiry orderType="OFFER" artworkID="whatever" />
+      <StickyFooterWithInquiry
+        orderType="OFFER"
+        artworkID="whatever"
+        orderSource="artwork_page"
+      />
     )
 
     component.find("Clickable[data-test='help-center-link']").simulate("click")
@@ -39,6 +46,7 @@ describe("Sticky footer", () => {
     const component = mount(
       <SystemContextProvider>
         <StickyFooter
+          orderSource="artwork_page"
           orderType="OFFER"
           artworkID="whatever"
           showInquiry={showInquiry}
@@ -56,11 +64,32 @@ describe("Sticky footer", () => {
 
   it("displays the 'Need help?' message", () => {
     const component = mount(
-      <StickyFooterWithInquiry orderType="OFFER" artworkID="whatever" />
+      <StickyFooterWithInquiry
+        orderSource="artwork_page"
+        orderType="OFFER"
+        artworkID="whatever"
+      />
     )
     expect(component.text()).toContain(
       "Need help? Visit our help center or ask a question."
     )
+  })
+
+  describe("for private sale orders", () => {
+    it("renders private sale email link", () => {
+      const component = mount(
+        <StickyFooterWithInquiry
+          orderSource="private_sale"
+          orderType="BUY"
+          artworkID="whatever"
+        />
+      )
+      const privateSalesEmail = component.find(
+        "Clickable[data-test='private-sales-email-link']"
+      )
+
+      expect(privateSalesEmail).toBeTruthy()
+    })
   })
 
   describe("Analytics", () => {
@@ -68,7 +97,11 @@ describe("Sticky footer", () => {
       it("tracks click on 'Read our FAQ'", () => {
         // const { Component, dispatch } = mockTracking(StickyFooterWithInquiry)
         const component = mount(
-          <StickyFooterWithInquiry orderType="OFFER" artworkID="whatever" />
+          <StickyFooterWithInquiry
+            orderSource="artwork_page"
+            orderType="OFFER"
+            artworkID="whatever"
+          />
         )
         component
           .find("Clickable[data-test='help-center-link']")
@@ -84,7 +117,11 @@ describe("Sticky footer", () => {
       it("tracks click on 'ask a question'", () => {
         const component = mount(
           <SystemContextProvider>
-            <StickyFooterWithInquiry orderType="OFFER" artworkID="whatever" />
+            <StickyFooterWithInquiry
+              orderSource="artwork_page"
+              orderType="OFFER"
+              artworkID="whatever"
+            />
           </SystemContextProvider>
         )
         component
@@ -103,7 +140,11 @@ describe("Sticky footer", () => {
     describe("on a buy now page", () => {
       it("tracks click on 'Read our FAQ'", () => {
         const component = mount(
-          <StickyFooterWithInquiry orderType="BUY" artworkID="whatever" />
+          <StickyFooterWithInquiry
+            orderSource="artwork_page"
+            orderType="BUY"
+            artworkID="whatever"
+          />
         )
         component
           .find("Clickable[data-test='help-center-link']")
@@ -119,7 +160,11 @@ describe("Sticky footer", () => {
       it("tracks click on 'ask a question'", () => {
         const component = mount(
           <SystemContextProvider>
-            <StickyFooterWithInquiry orderType="BUY" artworkID="whatever" />
+            <StickyFooterWithInquiry
+              orderSource="artwork_page"
+              orderType="BUY"
+              artworkID="whatever"
+            />
           </SystemContextProvider>
         )
         component

--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -13,8 +13,8 @@ import { Elements } from "@stripe/react-stripe-js"
 import styled from "styled-components"
 import { ConnectedModalDialog } from "./Dialogs"
 import { ZendeskWrapper } from "Components/ZendeskWrapper"
-import { HorizontalPadding } from "../Components/HorizontalPadding"
-import { AppContainer } from "../Components/AppContainer"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { AppContainer } from "Apps/Components/AppContainer"
 import { isExceededZendeskThreshold } from "Utils/isExceededZendeskThreshold"
 import { getENV } from "Utils/getENV"
 import { extractNodes } from "Utils/extractNodes"
@@ -124,6 +124,7 @@ const OrderApp: FC<OrderAppProps> = props => {
         {!isModal && (
           <StickyFooterWithInquiry
             orderType={order.mode}
+            orderSource={order.source}
             artworkID={artwork?.slug!}
           />
         )}
@@ -137,6 +138,7 @@ export const OrderAppFragmentContainer = createFragmentContainer(OrderApp, {
   order: graphql`
     fragment OrderApp_order on CommerceOrder {
       mode
+      source
       currencyCode
       itemsTotalCents
       lineItems {

--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -151,7 +151,7 @@ export const PaymentContent: FC<Props> = props => {
 
       {/* Wire transfer */}
       <Collapse open={selectedPaymentMethod === "WIRE_TRANSFER"}>
-        {getPaymentMethodInfo(selectedPaymentMethod)}
+        {getPaymentMethodInfo(selectedPaymentMethod, order.source)}
         <Spacer y={4} />
         <SaveAndContinueButton
           media={{ greaterThan: "xs" }}
@@ -255,10 +255,26 @@ const getAvailablePaymentMethods = (
 }
 
 const getPaymentMethodInfo = (
-  paymentMethod: CommercePaymentMethodEnum | string
+  paymentMethod: CommercePaymentMethodEnum | string,
+  orderSource?: string
 ) => {
   switch (paymentMethod) {
     case "WIRE_TRANSFER":
+      if (orderSource === "private_sale") {
+        return (
+          <>
+            <Text color="black60" variant="sm">
+              • To pay by wire transfer, complete checkout to view banking
+              details and wire transfer instructions.
+            </Text>
+            <Text color="black60" variant="sm">
+              • Please inform your bank that you will be responsible for all
+              wire transfer fees.
+            </Text>
+          </>
+        )
+      }
+
       return (
         <>
           <Text color="black60" variant="sm">

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -410,6 +410,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
             <BuyerGuarantee
               contextModule={ContextModule.ordersPayment}
               contextPageOwnerType={OwnerType.ordersPayment}
+              orderSource={order.source}
             />
 
             {selectedPaymentMethod !== "US_BANK_ACCOUNT" && (

--- a/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -308,24 +308,6 @@ describe("Payment", () => {
     })
   })
 
-  describe("Private sale orders", () => {
-    let page: PaymentTestPage
-
-    beforeEach(() => {
-      const wrapper = getWrapper({
-        CommerceOrder: () => PrivateSaleOrderWithShippingDetails,
-      })
-      page = new PaymentTestPage(wrapper)
-    })
-
-    it("shows private sale stepper if the order source is private sale", () => {
-      expect(page.orderStepper.text()).toMatchInlineSnapshot(
-        `"PaymentNavigate rightReviewNavigate right"`
-      )
-      expect(page.orderStepperCurrentStep).toBe("Payment")
-    })
-  })
-
   describe("stripe ACH enabled", () => {
     let page: PaymentTestPage
 
@@ -585,6 +567,49 @@ describe("Payment", () => {
 
       expect(mockSetIsSavingPayment).toHaveBeenCalledWith(false)
       expect(pushMock).toHaveBeenCalledWith("/orders/1234/review")
+    })
+  })
+
+  describe("Private sale orders", () => {
+    let page: PaymentTestPage
+
+    const privateSaleOrderWithWire = {
+      ...PrivateSaleOrderWithShippingDetails,
+      availablePaymentMethods: [
+        "CREDIT_CARD",
+        "WIRE_TRANSFER",
+      ] as CommercePaymentMethodEnum[],
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+      ;(useOrderPaymentContext as jest.Mock).mockImplementation(() => {
+        return {
+          selectedPaymentMethod: "WIRE_TRANSFER",
+        }
+      })
+
+      const wrapper = getWrapper({
+        CommerceOrder: () => privateSaleOrderWithWire,
+      })
+      page = new PaymentTestPage(wrapper)
+    })
+
+    it("renders correct content for wire transfer", () => {
+      expect(page.text()).toContain(
+        "• To pay by wire transfer, complete checkout to view banking"
+      )
+
+      expect(page.text()).toContain(
+        "• Please inform your bank that you will be responsible for all wire transfer fees."
+      )
+    })
+
+    it("shows private sale stepper if the order source is private sale", () => {
+      expect(page.orderStepper.text()).toMatchInlineSnapshot(
+        `"PaymentNavigate rightReviewNavigate right"`
+      )
+      expect(page.orderStepperCurrentStep).toBe("Payment")
     })
   })
 })

--- a/src/__generated__/OrderApp_order.graphql.ts
+++ b/src/__generated__/OrderApp_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e49d0cb854fb785d5b21f9f9ae16e0ab>>
+ * @generated SignedSource<<62a646c1c58c9260d83f24947b2643c1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
+export type CommerceOrderSourceEnum = "artwork_page" | "inquiry" | "private_sale" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type OrderApp_order$data = {
   readonly currencyCode: string;
@@ -27,6 +28,7 @@ export type OrderApp_order$data = {
     } | null> | null;
   } | null;
   readonly mode: CommerceOrderModeEnum | null;
+  readonly source: CommerceOrderSourceEnum;
   readonly " $fragmentType": "OrderApp_order";
 };
 export type OrderApp_order$key = {
@@ -45,6 +47,13 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "ScalarField",
       "name": "mode",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "source",
       "storageKey": null
     },
     {
@@ -138,6 +147,6 @@ const node: ReaderFragment = {
   "abstractKey": "__isCommerceOrder"
 };
 
-(node as any).hash = "44860aea11d75dca20feda64a964481d";
+(node as any).hash = "2c498a2448d0c260a4ef509cc1b4548d";
 
 export default node;

--- a/src/__generated__/orderRoutes_OrderQuery.graphql.ts
+++ b/src/__generated__/orderRoutes_OrderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b91990bb45b149a2d0434c4d00f56957>>
+ * @generated SignedSource<<e9f5005bd468adf68377cedb0ffbc59b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -758,12 +758,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c630e89ea952b4f584729f79c6b49284",
+    "cacheID": "80133936039ba4d0f899faf333fbc2fd",
     "id": null,
     "metadata": {},
     "name": "orderRoutes_OrderQuery",
     "operationKind": "query",
-    "text": "query orderRoutes_OrderQuery(\n  $orderID: ID!\n) {\n  me {\n    name\n    id\n  }\n  order: commerceOrder(id: $orderID) @principalField {\n    __typename\n    __isCommerceOrder: __typename\n    bankAccountId\n    internalID\n    mode\n    state\n    source\n    lastTransactionFailed\n    ... on CommerceOfferOrder {\n      myLastOffer {\n        internalID\n        createdAt\n        id\n      }\n      lastOffer {\n        internalID\n        createdAt\n        id\n      }\n      awaitingResponseFrom\n    }\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            slug\n            id\n          }\n          shippingQuoteOptions {\n            edges {\n              node {\n                isSelected\n                id\n              }\n            }\n          }\n          id\n        }\n      }\n    }\n    creditCard {\n      internalID\n      id\n    }\n    paymentMethod\n    paymentMethodDetails {\n      __typename\n      ... on CreditCard {\n        id\n      }\n      ... on BankAccount {\n        id\n      }\n      ... on WireTransfer {\n        isManualPayment\n      }\n    }\n    ...OrderApp_order\n    id\n  }\n}\n\nfragment OrderApp_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  mode\n  currencyCode\n  itemsTotalCents\n  lineItems {\n    edges {\n      node {\n        artwork {\n          href\n          slug\n          is_acquireable: isAcquireable\n          is_offerable: isOfferable\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query orderRoutes_OrderQuery(\n  $orderID: ID!\n) {\n  me {\n    name\n    id\n  }\n  order: commerceOrder(id: $orderID) @principalField {\n    __typename\n    __isCommerceOrder: __typename\n    bankAccountId\n    internalID\n    mode\n    state\n    source\n    lastTransactionFailed\n    ... on CommerceOfferOrder {\n      myLastOffer {\n        internalID\n        createdAt\n        id\n      }\n      lastOffer {\n        internalID\n        createdAt\n        id\n      }\n      awaitingResponseFrom\n    }\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            slug\n            id\n          }\n          shippingQuoteOptions {\n            edges {\n              node {\n                isSelected\n                id\n              }\n            }\n          }\n          id\n        }\n      }\n    }\n    creditCard {\n      internalID\n      id\n    }\n    paymentMethod\n    paymentMethodDetails {\n      __typename\n      ... on CreditCard {\n        id\n      }\n      ... on BankAccount {\n        id\n      }\n      ... on WireTransfer {\n        isManualPayment\n      }\n    }\n    ...OrderApp_order\n    id\n  }\n}\n\nfragment OrderApp_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  mode\n  source\n  currencyCode\n  itemsTotalCents\n  lineItems {\n    edges {\n      node {\n        artwork {\n          href\n          slug\n          is_acquireable: isAcquireable\n          is_offerable: isOfferable\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [TX-991]

### Description

This PR updates the payment step for private sale orders. 
- Email at the footer is updated 
- Explanation texts updated for wire_transfer 
- Private conditions of sale link UI added 
- Extra conditions of sale is added 

Notes
1- We need to update the link for Private conditions of sale 
2- When Exchange offers, we need to pull the extra conditions of sale  from there 

#### Video 
https://user-images.githubusercontent.com/42584148/212628364-9d0f53f8-4eff-498e-b42b-d4f0f26f8a23.mov


[TX-991]: https://artsyproduct.atlassian.net/browse/TX-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ