### PR TITLE
Activity Panel: prefix artsy editorial notifications

### DIFF
--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -23,6 +23,9 @@ const NotificationItem: React.FC<NotificationItemProps> = ({ item }) => {
     if (item.notificationType === "ARTWORK_ALERT") {
       return "Alert"
     }
+    if (item.notificationType === "ARTICLE_FEATURED_ARTIST") {
+      return "Artsy Editorial"
+    }
 
     return null
   }

--- a/src/Components/Notifications/__tests__/NotificationItem.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationItem.jest.tsx
@@ -131,6 +131,18 @@ describe("NotificationItem", () => {
       const label = screen.getByLabelText("Notification type: Alert")
       expect(label).toBeInTheDocument()
     })
+
+    it("should render 'Artsy Editorial'", () => {
+      renderWithRelay({
+        Notification: () => ({
+          ...notification,
+          notificationType: "ARTICLE_FEATURED_ARTIST",
+        }),
+      })
+
+      const label = screen.getByLabelText("Notification type: Artsy Editorial")
+      expect(label).toBeInTheDocument()
+    })
   })
 })
 


### PR DESCRIPTION
The type of this PR is: **Feat**

Prefixes Artsy Editorial notifications. [Figma specs](https://www.figma.com/file/SlzmAJV6zqJDmAO8GoSjiC/Activity-%2F-Save-%2F-Follow-%2F-Create?node-id=2611%3A142945&t=4JqzzeUmmWVbyuWT-0)

![Screenshot 2023-01-17 at 15 30 23](https://user-images.githubusercontent.com/3934579/212925607-fe3ef47e-4409-4c30-ad35-6eb3eda13437.png)

Artist's name is missing on the screenshot because of the bug on gravity side. The fix is being deployed at the moment
