### PR TITLE
fix(authdialog): corrects how email sign up is passed

### DIFF
--- a/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
@@ -49,15 +49,23 @@ export const AuthDialogSignUp: FC<AuthDialogSignUpProps> = ({
       validateOnBlur={false}
       initialValues={{
         ...INITIAL_VALUES,
-        agreed_to_receive_emails: isAutomaticallySubscribed,
+        agreedToReceiveEmails: isAutomaticallySubscribed,
       }}
       validationSchema={VALIDATION_SCHEMA}
-      onSubmit={async ({ mode, ...values }, { setFieldValue, setStatus }) => {
+      onSubmit={async (
+        { mode, name, email, password, agreedToReceiveEmails },
+        { setFieldValue, setStatus }
+      ) => {
         setStatus({ error: null })
         setFieldValue("mode", "Loading")
 
         try {
-          const { user } = await signUp(values)
+          const { user } = await signUp({
+            email,
+            name,
+            password,
+            agreedToReceiveEmails,
+          })
 
           runAfterAuthentication({ accessToken: user.accessToken })
 
@@ -132,9 +140,9 @@ export const AuthDialogSignUp: FC<AuthDialogSignUpProps> = ({
 
               {!isAutomaticallySubscribed && (
                 <Checkbox
-                  selected={values.agreed_to_receive_emails}
+                  selected={values.agreedToReceiveEmails}
                   onSelect={selected => {
-                    setFieldValue("agreed_to_receive_emails", selected)
+                    setFieldValue("agreedToReceiveEmails", selected)
                   }}
                 >
                   <Text variant="xs">
@@ -262,8 +270,7 @@ export const INITIAL_VALUES = {
   name: "",
   email: "",
   password: "",
-  accepted_terms_of_service: true,
-  agreed_to_receive_emails: false,
+  agreedToReceiveEmails: false,
   mode: "Pending",
 }
 
@@ -282,9 +289,6 @@ const VALIDATION_SCHEMA = Yup.object().shape({
       /[A-Z]{1}/,
       "Your password must have at least 1 uppercase letter."
     ),
-  accepted_terms_of_service: Yup.boolean()
-    .required("You must agree to our terms to continue.")
-    .oneOf([true]),
 })
 
 const GDPR_COUNTRY_CODES = [

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
@@ -63,8 +63,7 @@ describe("AuthDialogSignUp", () => {
         name: "Test User",
         email: "example@example.com",
         password: "Secret000", // pragma: allowlist secret
-        accepted_terms_of_service: true,
-        agreed_to_receive_emails: false,
+        agreedToReceiveEmails: false,
       })
     })
   })

--- a/src/Utils/__tests__/auth.jest.ts
+++ b/src/Utils/__tests__/auth.jest.ts
@@ -157,11 +157,12 @@ describe("signUp", () => {
       name: "Example Example",
       email: "example@example.com",
       password: "secret",
+      agreedToReceiveEmails: true,
     })
 
     expect(mockFetch).toBeCalledWith("https://www.artsy.net/signup", {
       body:
-        '{"name":"Example Example","email":"example@example.com","password":"secret","session_id":"session_id","accepted_terms_of_service":true}',
+        '{"agreed_to_receive_emails":true,"accepted_terms_of_service":true,"email":"example@example.com","name":"Example Example","password":"secret","session_id":"session_id"}',
       credentials: "same-origin",
       headers: {
         Accept: "application/json",

--- a/src/Utils/auth.ts
+++ b/src/Utils/auth.ts
@@ -131,6 +131,7 @@ export const signUp = async (args: {
   name: string
   email: string
   password: string
+  agreedToReceiveEmails?: boolean
 }) => {
   const signUpUrl = `${getENV("APP_URL")}${getENV("AP").signupPagePath}`
 
@@ -145,13 +146,14 @@ export const signUp = async (args: {
     method: "POST",
     credentials: "same-origin",
     body: JSON.stringify({
-      name: args.name,
-      email: args.email,
-      password: args.password,
-      session_id: getENV("SESSION_ID"),
       _csrf: Cookies.get("CSRF_TOKEN"),
+      agreed_to_receive_emails: args.agreedToReceiveEmails,
       accepted_terms_of_service: true,
+      email: args.email,
+      name: args.name,
+      password: args.password,
       recaptcha_token: recaptchaToken,
+      session_id: getENV("SESSION_ID"),
     }),
   }).then(async response => {
     if (response.ok) {


### PR DESCRIPTION
I had made the assumption that the `signUp` function was just passing along the data it was given. As it happens it was selecting specific values, but the object I passed it still satisfied the type. So while the test was running we weren't including `agreed_to_receive_emails` in the registration payload.