### PR TITLE
feat(TX-995): redirect users to home page upon logo click

### DIFF
--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -99,7 +99,7 @@ const OrderApp: FC<OrderAppProps> = props => {
   const isModal = !!props.match?.location.query.isModal
   const artwork = extractNodes(order.lineItems!)[0].artwork
   const logoClickRedirectPath =
-    order.source === "private_sale" ? artwork?.href! : artwork?.href!
+    order.source === "private_sale" ? "/" : artwork?.href!
 
   return (
     <Box>

--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -98,10 +98,12 @@ const OrderApp: FC<OrderAppProps> = props => {
   const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
   const isModal = !!props.match?.location.query.isModal
   const artwork = extractNodes(order.lineItems!)[0].artwork
+  const logoClickRedirectPath =
+    order.source === "private_sale" ? artwork?.href! : artwork?.href!
 
   return (
     <Box>
-      <MinimalNavBar to={artwork?.href!} isBlank={isModal}>
+      <MinimalNavBar to={logoClickRedirectPath} isBlank={isModal}>
         <Title>Checkout | Artsy</Title>
         <Meta
           name="viewport"

--- a/src/Apps/Order/__tests__/OrderApp.jest.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.jest.tsx
@@ -664,4 +664,19 @@ describe("OrderApp", () => {
       "Sorry, the page you were looking for doesn’t exist at this URL."
     )
   })
+
+  it("redirects user to home page for private sale orders when Artsy logo is clicked", () => {
+    const props = getProps({
+      location: "/order/123/review",
+    })
+    const page = getWrapper({
+      context: { isEigen: false },
+      props: { ...props, order: PrivateSaleOrderWithShippingDetails },
+    })
+
+    const logo = page.find(`[data-test="logoLink"]`).first()
+    logo.simulate("click")
+
+    expect(window.location.pathname).toBe("/")
+  })
 })


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [TX-995]

### Description

This PR updates the redirect URL for the logo click when a user is on the checkout flow. For PS orders, users are redirected to the home page instead of the artwork page. 


[TX-995]: https://artsyproduct.atlassian.net/browse/TX-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ