### PR TITLE
feat(TX-994): Update email in order history for private sale orders

### DIFF
--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -232,7 +232,7 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
         <Text variant="xs" color="black60">
           Need Help?{" "}
           {order.source === "private_sale" ? (
-            <RouterLink to="privatesales@artsy.net">
+            <RouterLink to="mailto:privatesales@artsy.net">
               privatesales@artsy.net
             </RouterLink>
           ) : (

--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -231,7 +231,13 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
 
         <Text variant="xs" color="black60">
           Need Help?{" "}
-          <RouterLink to="mailto:support@artsy.net">Contact Us.</RouterLink>
+          {order.source === "private_sale" ? (
+            <RouterLink to="privatesales@artsy.net">
+              privatesales@artsy.net
+            </RouterLink>
+          ) : (
+            <RouterLink to="mailto:support@artsy.net">Contact Us.</RouterLink>
+          )}
         </Text>
       </Flex>
     </Box>
@@ -243,6 +249,7 @@ export const SettingsPurchasesRowFragmentContainer = createFragmentContainer(
   {
     order: graphql`
       fragment SettingsPurchasesRow_order on CommerceOrder {
+        source
         internalID
         code
         displayState

--- a/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react"
 import { graphql } from "react-relay"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { SettingsPurchasesFragmentContainer } from "../SettingsPurchases"
+import { SettingsPurchasesFragmentContainer } from "Apps/Settings/Routes/Purchases/Components/SettingsPurchases"
 
 jest.unmock("react-relay")
 jest.mock("Components/Pagination/CommercePagination", () => ({
@@ -25,5 +25,32 @@ describe("SettingsPurchases", () => {
 
     expect(screen.getByText("Track Order")).toBeInTheDocument()
     expect(screen.getByText("Need Help?")).toBeInTheDocument()
+  })
+
+  it("renders correct help email address for non-PS orders", () => {
+    renderWithRelay()
+
+    expect(screen.getByText("Contact Us.")).toBeInTheDocument()
+  })
+
+  it("renders correct help email address for PS orders", () => {
+    renderWithRelay({
+      Me: () => ({
+        name: "jane doe",
+        orders: {
+          totalCount: 1,
+          edges: [
+            {
+              node: {
+                code: "123",
+                source: "private_sale",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(screen.getByText("privatesales@artsy.net")).toBeInTheDocument()
   })
 })

--- a/src/__generated__/SettingsPurchasesQuery.graphql.ts
+++ b/src/__generated__/SettingsPurchasesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<64b2fdc07dc43fb18e1c1f24892dafeb>>
+ * @generated SignedSource<<1abcd700d973a683bb30300400c1d726>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -326,6 +326,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "source",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "internalID",
                         "storageKey": null
                       },
@@ -636,12 +643,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "81c5796979beb88b431512b5dc5a52f9",
+    "cacheID": "d8aba3df7582f2dff0205578c0089c36",
     "id": null,
     "metadata": {},
     "name": "SettingsPurchasesQuery",
     "operationKind": "query",
-    "text": "query SettingsPurchasesQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $after: String\n) {\n  me {\n    ...SettingsPurchases_me_4tp0sF\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          href\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me_4tp0sF on Me {\n  name\n  orders(states: $states, first: $first, after: $after) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsPurchasesQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $after: String\n) {\n  me {\n    ...SettingsPurchases_me_4tp0sF\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          href\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me_4tp0sF on Me {\n  name\n  orders(states: $states, first: $first, after: $after) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsPurchasesRow_order.graphql.ts
+++ b/src/__generated__/SettingsPurchasesRow_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1ba3f5ce166a14b57ab1f63965f32501>>
+ * @generated SignedSource<<e38421086f679684a268f8f196843577>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
 export type CommerceOrderDisplayStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "IN_TRANSIT" | "PENDING" | "PROCESSING" | "PROCESSING_APPROVAL" | "REFUNDED" | "SUBMITTED" | "%future added value";
+export type CommerceOrderSourceEnum = "artwork_page" | "inquiry" | "private_sale" | "%future added value";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "IN_REVIEW" | "PENDING" | "PROCESSING_APPROVAL" | "REFUNDED" | "SUBMITTED" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type SettingsPurchasesRow_order$data = {
@@ -77,6 +78,7 @@ export type SettingsPurchasesRow_order$data = {
   readonly requestedFulfillment: {
     readonly __typename: string;
   } | null;
+  readonly source: CommerceOrderSourceEnum;
   readonly state: CommerceOrderStateEnum;
   readonly " $fragmentType": "SettingsPurchasesRow_order";
 };
@@ -144,6 +146,13 @@ return {
   "metadata": null,
   "name": "SettingsPurchasesRow_order",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "source",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -452,6 +461,6 @@ return {
 };
 })();
 
-(node as any).hash = "358468f62a7ebc385fbba3df2a4390fb";
+(node as any).hash = "3a4c1cbefcb8dfa253df76b32a82c09f";
 
 export default node;

--- a/src/__generated__/SettingsPurchases_Test_Query.graphql.ts
+++ b/src/__generated__/SettingsPurchases_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0dcc9fbf78d794932607be42cb184032>>
+ * @generated SignedSource<<969148b347f8e1f5b36e68231e1ef4c7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -347,6 +347,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "source",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "internalID",
                         "storageKey": null
                       },
@@ -657,7 +664,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a2b3d3b0780c9b4d1216198496a0722d",
+    "cacheID": "f8ac2a2e9098279660499d60b959f3fd",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -813,6 +820,16 @@ return {
           "type": "CommerceRequestedFulfillmentUnion"
         },
         "me.orders.edges.node.requestedFulfillment.__typename": (v10/*: any*/),
+        "me.orders.edges.node.source": {
+          "enumValues": [
+            "artwork_page",
+            "inquiry",
+            "private_sale"
+          ],
+          "nullable": false,
+          "plural": false,
+          "type": "CommerceOrderSourceEnum"
+        },
         "me.orders.edges.node.state": {
           "enumValues": [
             "ABANDONED",
@@ -873,7 +890,7 @@ return {
     },
     "name": "SettingsPurchases_Test_Query",
     "operationKind": "query",
-    "text": "query SettingsPurchases_Test_Query {\n  me {\n    ...SettingsPurchases_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          href\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsPurchases_Test_Query {\n  me {\n    ...SettingsPurchases_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          href\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/settingsRoutes_PurchasesRouteQuery.graphql.ts
+++ b/src/__generated__/settingsRoutes_PurchasesRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<63c81f32a008e80d9b51ea8773cd3df8>>
+ * @generated SignedSource<<805b600d390a62731d01dd7a1c2fa865>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -294,6 +294,13 @@ return {
                       {
                         "kind": "TypeDiscriminator",
                         "abstractKey": "__isCommerceOrder"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "source",
+                        "storageKey": null
                       },
                       {
                         "alias": null,
@@ -609,12 +616,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4cfa5eb1949d94e5146fbd7a9430607f",
+    "cacheID": "2578357e02fd2f2fa9dfaf9880c56425",
     "id": null,
     "metadata": {},
     "name": "settingsRoutes_PurchasesRouteQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_PurchasesRouteQuery {\n  me {\n    ...SettingsPurchasesRoute_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRoute_me on Me {\n  ...SettingsPurchases_me\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          href\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_PurchasesRouteQuery {\n  me {\n    ...SettingsPurchasesRoute_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRoute_me on Me {\n  ...SettingsPurchases_me\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          href\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [TX-994]

### Description

This PR updates the help email displayed per order in user order history. For private sale orders, we are providing users with a different help email address. 

<img width="1743" alt="Screenshot 2023-01-18 at 11 59 12" src="https://user-images.githubusercontent.com/42584148/213154555-df38cfe8-01fc-41de-8697-9dd96ccada31.png">


[TX-994]: https://artsyproduct.atlassian.net/browse/TX-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ