### PR TITLE
feat(FX-4535): mark specific notification as read when clicking on an entry in the activity panel

### DIFF
--- a/src/Components/Notifications/Mutations/markNotificationAsRead.ts
+++ b/src/Components/Notifications/Mutations/markNotificationAsRead.ts
@@ -1,0 +1,66 @@
+import {
+  markNotificationAsReadMutation,
+  markNotificationAsReadMutation$data,
+} from "__generated__/markNotificationAsReadMutation.graphql"
+import {
+  commitMutation,
+  Environment,
+  graphql,
+  RecordSourceSelectorProxy,
+} from "relay-runtime"
+
+const updater = (
+  id: string,
+  store: RecordSourceSelectorProxy<markNotificationAsReadMutation$data>
+) => {
+  const notification = store.get(id)
+
+  notification?.setValue(false, "isUnread")
+}
+
+export const markNotificationAsRead = (
+  environment: Environment,
+  id: string,
+  internalId: string
+): Promise<markNotificationAsReadMutation$data> => {
+  return new Promise((resolve, reject) => {
+    commitMutation<markNotificationAsReadMutation>(environment, {
+      mutation: graphql`
+        mutation markNotificationAsReadMutation(
+          $input: MarkNotificationAsReadInput!
+        ) {
+          markNotificationAsRead(input: $input) {
+            responseOrError {
+              ... on MarkNotificationAsReadSuccess {
+                success
+              }
+
+              ... on MarkNotificationAsReadFailure {
+                mutationError {
+                  message
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: {
+        input: {
+          id: internalId,
+        },
+      },
+      updater: store => {
+        updater(id, store)
+      },
+      optimisticUpdater: store => {
+        updater(id, store)
+      },
+      onCompleted: response => {
+        resolve(response)
+      },
+      onError: error => {
+        reject(error)
+      },
+    })
+  })
+}

--- a/src/__generated__/NotificationItem_item.graphql.ts
+++ b/src/__generated__/NotificationItem_item.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4e2a3a9e0f3f74f582ca482cee08ac7c>>
+ * @generated SignedSource<<2281006f908d1c1176e0ee93af2d54fe>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,6 +26,8 @@ export type NotificationItem_item$data = {
       } | null;
     } | null> | null;
   } | null;
+  readonly id: string;
+  readonly internalID: string;
   readonly isUnread: boolean;
   readonly message: string;
   readonly notificationType: NotificationTypesEnum;
@@ -45,6 +47,13 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 };
@@ -54,7 +63,15 @@ return {
   "metadata": null,
   "name": "NotificationItem_item",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
     (v0/*: any*/),
+    (v1/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -133,14 +150,8 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "internalID",
-                  "storageKey": null
-                },
                 (v0/*: any*/),
+                (v1/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -203,6 +214,6 @@ return {
 };
 })();
 
-(node as any).hash = "1cd24fdc7ec71bb7334d69135fbfd0ce";
+(node as any).hash = "d329f50b2438b6a5cfd93b5cec50eb7b";
 
 export default node;

--- a/src/__generated__/NotificationItem_test_Query.graphql.ts
+++ b/src/__generated__/NotificationItem_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0de1f7a7e74797a55b05c2ae9498aea8>>
+ * @generated SignedSource<<d63e2fad8171e167710c29d3fffc90b2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -37,23 +37,30 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "title",
+  "name": "id",
   "storageKey": null
 },
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "internalID",
   "storageKey": null
 },
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v4 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v4 = {
+v5 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -139,6 +146,8 @@ return {
                 "plural": false,
                 "selections": [
                   (v1/*: any*/),
+                  (v2/*: any*/),
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -217,14 +226,8 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "internalID",
-                                "storageKey": null
-                              },
-                              (v1/*: any*/),
+                              (v2/*: any*/),
+                              (v3/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -272,7 +275,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v2/*: any*/)
+                              (v1/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -281,8 +284,7 @@ return {
                       }
                     ],
                     "storageKey": "artworksConnection(first:4)"
-                  },
-                  (v2/*: any*/)
+                  }
                 ],
                 "storageKey": null
               }
@@ -295,7 +297,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bfe1b092fb363ea3d7b24e5250deb8c7",
+    "cacheID": "db4938c2d9f94a779604a630062bafb3",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -335,7 +337,7 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "notificationsConnection.edges.node.artworksConnection.edges.node.id": (v3/*: any*/),
+        "notificationsConnection.edges.node.artworksConnection.edges.node.id": (v4/*: any*/),
         "notificationsConnection.edges.node.artworksConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -348,23 +350,24 @@ return {
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "notificationsConnection.edges.node.artworksConnection.edges.node.image.thumb.src": (v4/*: any*/),
-        "notificationsConnection.edges.node.artworksConnection.edges.node.image.thumb.srcSet": (v4/*: any*/),
-        "notificationsConnection.edges.node.artworksConnection.edges.node.internalID": (v3/*: any*/),
+        "notificationsConnection.edges.node.artworksConnection.edges.node.image.thumb.src": (v5/*: any*/),
+        "notificationsConnection.edges.node.artworksConnection.edges.node.image.thumb.srcSet": (v5/*: any*/),
+        "notificationsConnection.edges.node.artworksConnection.edges.node.internalID": (v4/*: any*/),
         "notificationsConnection.edges.node.artworksConnection.edges.node.title": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "String"
         },
-        "notificationsConnection.edges.node.id": (v3/*: any*/),
+        "notificationsConnection.edges.node.id": (v4/*: any*/),
+        "notificationsConnection.edges.node.internalID": (v4/*: any*/),
         "notificationsConnection.edges.node.isUnread": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "notificationsConnection.edges.node.message": (v4/*: any*/),
+        "notificationsConnection.edges.node.message": (v5/*: any*/),
         "notificationsConnection.edges.node.notificationType": {
           "enumValues": [
             "ARTICLE_FEATURED_ARTIST",
@@ -383,14 +386,14 @@ return {
           "plural": false,
           "type": "Int"
         },
-        "notificationsConnection.edges.node.publishedAt": (v4/*: any*/),
-        "notificationsConnection.edges.node.targetHref": (v4/*: any*/),
-        "notificationsConnection.edges.node.title": (v4/*: any*/)
+        "notificationsConnection.edges.node.publishedAt": (v5/*: any*/),
+        "notificationsConnection.edges.node.targetHref": (v5/*: any*/),
+        "notificationsConnection.edges.node.title": (v5/*: any*/)
       }
     },
     "name": "NotificationItem_test_Query",
     "operationKind": "query",
-    "text": "query NotificationItem_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...NotificationItem_item\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query NotificationItem_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...NotificationItem_item\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  id\n  internalID\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListNextQuery.graphql.ts
+++ b/src/__generated__/NotificationsListNextQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3803e62210aabf05a45130eacbab8b52>>
+ * @generated SignedSource<<ef05fc839090edde0736f51dd11a4e40>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -72,14 +72,14 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "title",
+  "name": "id",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "title",
   "storageKey": null
 };
 return {
@@ -190,6 +190,7 @@ return {
                         "storageKey": null
                       },
                       (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -262,7 +263,7 @@ return {
                                 "plural": false,
                                 "selections": [
                                   (v2/*: any*/),
-                                  (v3/*: any*/),
+                                  (v4/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -310,7 +311,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v4/*: any*/)
+                                  (v3/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -320,7 +321,6 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:4)"
                       },
-                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -384,12 +384,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "51a773a69571b7d93478e63469ae4eb0",
+    "cacheID": "f6e9417ffe5822537b03ebca761bd627",
     "id": null,
     "metadata": {},
     "name": "NotificationsListNextQuery",
     "operationKind": "query",
-    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  id\n  internalID\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListQuery.graphql.ts
+++ b/src/__generated__/NotificationsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1a911f20388d01f46222e407b4b7cb46>>
+ * @generated SignedSource<<f84ba9a41aab9f9a92c56f1ec0966f4a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -55,14 +55,14 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "title",
+  "name": "id",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "title",
   "storageKey": null
 };
 return {
@@ -163,6 +163,7 @@ return {
                         "storageKey": null
                       },
                       (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -235,7 +236,7 @@ return {
                                 "plural": false,
                                 "selections": [
                                   (v2/*: any*/),
-                                  (v3/*: any*/),
+                                  (v4/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -283,7 +284,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v4/*: any*/)
+                                  (v3/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -293,7 +294,6 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:4)"
                       },
-                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -357,12 +357,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a4c49c89168e88b4f7019ea83dc8e8fe",
+    "cacheID": "2bc13aeb61b8e5593a56bba8345ebcee",
     "id": null,
     "metadata": {},
     "name": "NotificationsListQuery",
     "operationKind": "query",
-    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  id\n  internalID\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsList_test_Query.graphql.ts
+++ b/src/__generated__/NotificationsList_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<76abf364005dcab209ff938d4cda78a2>>
+ * @generated SignedSource<<cf8706da77ae8e76f23db1a40a4abde3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -40,14 +40,14 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "title",
+  "name": "id",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "title",
   "storageKey": null
 },
 v4 = {
@@ -172,6 +172,7 @@ return {
                         "storageKey": null
                       },
                       (v2/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -244,7 +245,7 @@ return {
                                 "plural": false,
                                 "selections": [
                                   (v1/*: any*/),
-                                  (v2/*: any*/),
+                                  (v3/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -292,7 +293,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v3/*: any*/)
+                                  (v2/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -302,7 +303,6 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:4)"
                       },
-                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -366,7 +366,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "73a09bae02d633b7f50838bd7e73b047",
+    "cacheID": "b250814418491c9f7d51140c4a7f5857",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -470,7 +470,7 @@ return {
     },
     "name": "NotificationsList_test_Query",
     "operationKind": "query",
-    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  id\n  internalID\n  title\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/markNotificationAsReadMutation.graphql.ts
+++ b/src/__generated__/markNotificationAsReadMutation.graphql.ts
@@ -1,0 +1,175 @@
+/**
+ * @generated SignedSource<<6a5966d45e4046b146a7e33ceab6e4fa>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type MarkNotificationAsReadInput = {
+  clientMutationId?: string | null;
+  id: string;
+};
+export type markNotificationAsReadMutation$variables = {
+  input: MarkNotificationAsReadInput;
+};
+export type markNotificationAsReadMutation$data = {
+  readonly markNotificationAsRead: {
+    readonly responseOrError: {
+      readonly mutationError?: {
+        readonly message: string;
+      } | null;
+      readonly success?: boolean | null;
+    } | null;
+  } | null;
+};
+export type markNotificationAsReadMutation = {
+  response: markNotificationAsReadMutation$data;
+  variables: markNotificationAsReadMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "success",
+      "storageKey": null
+    }
+  ],
+  "type": "MarkNotificationAsReadSuccess",
+  "abstractKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GravityMutationError",
+      "kind": "LinkedField",
+      "name": "mutationError",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "message",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "MarkNotificationAsReadFailure",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "markNotificationAsReadMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "MarkNotificationAsReadPayload",
+        "kind": "LinkedField",
+        "name": "markNotificationAsRead",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "responseOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "markNotificationAsReadMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "MarkNotificationAsReadPayload",
+        "kind": "LinkedField",
+        "name": "markNotificationAsRead",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "responseOrError",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "cfddde13ce18d1d57aa870cdac33b394",
+    "id": null,
+    "metadata": {},
+    "name": "markNotificationAsReadMutation",
+    "operationKind": "mutation",
+    "text": "mutation markNotificationAsReadMutation(\n  $input: MarkNotificationAsReadInput!\n) {\n  markNotificationAsRead(input: $input) {\n    responseOrError {\n      __typename\n      ... on MarkNotificationAsReadSuccess {\n        success\n      }\n      ... on MarkNotificationAsReadFailure {\n        mutationError {\n          message\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "2e4b8c239d2a237aa6609268e51e78f0";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4535]

Review app: [mark-notification-as-read](https://mark-notification-as-read.artsy.net/)


### Demo
https://user-images.githubusercontent.com/3513494/213193037-3bdd51be-1f56-4058-a9d6-64c7c6d3cfe9.mp4

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4535]: https://artsyproduct.atlassian.net/browse/FX-4535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ