### PR TITLE
fix: Simplify MyC local image optimization

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
@@ -1,9 +1,7 @@
-import { MyCollectionArtworkFormImagesProps } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages"
-import { createContext, Ref, useContext, useState } from "react"
+import { createContext, useContext, useState } from "react"
 import { LocalImage } from "Utils/localImagesHelpers"
 
 interface MyCollectionArtworkFormContextProps {
-  artworkFormImagesRef: Ref<MyCollectionArtworkFormImagesProps> | undefined
   onBack: () => void
   onNext?: (options?: { skipNext: boolean }) => void
   onSkip?: () => void
@@ -14,7 +12,6 @@ interface MyCollectionArtworkFormContextProps {
 export const MyCollectionArtworkFormContext = createContext<
   MyCollectionArtworkFormContextProps
 >({
-  artworkFormImagesRef: undefined,
   onBack: () => {},
   onNext: () => {},
   onSkip: () => {},

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
@@ -1,5 +1,6 @@
 import { MyCollectionArtworkFormImagesProps } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages"
-import { createContext, Ref, useContext } from "react"
+import { createContext, Ref, useContext, useState } from "react"
+import { LocalImage } from "Utils/localImagesHelpers"
 
 interface MyCollectionArtworkFormContextProps {
   artworkFormImagesRef: Ref<MyCollectionArtworkFormImagesProps> | undefined
@@ -36,4 +37,23 @@ export const useMyCollectionArtworkFormContext = () => {
   const myCollectionArtworkFormContext =
     useContext(MyCollectionArtworkFormContext) ?? {}
   return myCollectionArtworkFormContext
+}
+
+export const useLocalImageState = () => {
+  const [localImages, setLocalImages] = useState<
+    Array<LocalImage & { photoID: string }>
+  >([])
+
+  const addLocalImage = (image: any) => {
+    setLocalImages([...localImages, image])
+  }
+  const removeLocalImage = (photoID: string) => {
+    setLocalImages(localImages.filter(i => i.photoID !== photoID))
+  }
+
+  return {
+    localImages,
+    addLocalImage,
+    removeLocalImage,
+  }
 }

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
@@ -5,8 +5,8 @@ interface MyCollectionArtworkFormContextProps {
   onBack: () => void
   onNext?: (options?: { skipNext: boolean }) => void
   onSkip?: () => void
-  addLocalImage: (image: any) => void
-  removeLocalImage: (image: any) => void
+  addLocalImage: (image: LocalImage) => void
+  removeLocalImage: (photoID: string) => void
 }
 
 export const MyCollectionArtworkFormContext = createContext<
@@ -37,15 +37,13 @@ export const useMyCollectionArtworkFormContext = () => {
 }
 
 export const useLocalImageState = () => {
-  const [localImages, setLocalImages] = useState<
-    Array<LocalImage & { photoID: string }>
-  >([])
+  const [localImages, setLocalImages] = useState<Array<LocalImage>>([])
 
-  const addLocalImage = (image: any) => {
+  const addLocalImage = (image: LocalImage) => {
     setLocalImages([...localImages, image])
   }
   const removeLocalImage = (photoID: string) => {
-    setLocalImages(localImages.filter(i => i.photoID !== photoID))
+    setLocalImages(localImages.filter(image => image.photoID !== photoID))
   }
 
   return {

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
@@ -6,6 +6,8 @@ interface MyCollectionArtworkFormContextProps {
   onBack: () => void
   onNext?: (options?: { skipNext: boolean }) => void
   onSkip?: () => void
+  addLocalImage: (image: any) => void
+  removeLocalImage: (image: any) => void
 }
 
 export const MyCollectionArtworkFormContext = createContext<
@@ -15,6 +17,8 @@ export const MyCollectionArtworkFormContext = createContext<
   onBack: () => {},
   onNext: () => {},
   onSkip: () => {},
+  addLocalImage: () => {},
+  removeLocalImage: () => {},
 })
 
 export const MyCollectionArtworkFormContextProvider: React.FC<MyCollectionArtworkFormContextProps> = ({

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
@@ -40,6 +40,11 @@ export const useLocalImageState = () => {
   const [localImages, setLocalImages] = useState<Array<LocalImage>>([])
 
   const addLocalImage = (image: LocalImage) => {
+    // Don't add duplicates
+    if (localImages.find(localImage => localImage.photoID === image.photoID)) {
+      return
+    }
+
     setLocalImages([...localImages, image])
   }
   const removeLocalImage = (photoID: string) => {

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages.tsx
@@ -1,4 +1,5 @@
 import { Text } from "@artsy/palette"
+import { useMyCollectionArtworkFormContext } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext"
 import { MyCollectionPhotoToPhoto } from "Apps/MyCollection/Routes/EditArtwork/Utils/artworkFormHelpers"
 import { ArtworkModel } from "Apps/MyCollection/Routes/EditArtwork/Utils/artworkModel"
 import { PhotoDropzone } from "Components/PhotoUpload/Components/PhotoDropzone"
@@ -10,10 +11,9 @@ import {
   uploadPhotoToS3,
 } from "Components/PhotoUpload/Utils/fileUtils"
 import { useFormikContext } from "formik"
-import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
+import { forwardRef, useEffect, useState } from "react"
 import { FileRejection } from "react-dropzone"
 import { useSystemContext } from "System"
-import { LocalImage, storeArtworkLocalImages } from "Utils/localImagesHelpers"
 
 export interface MyCollectionArtworkFormImagesProps {
   saveImagesToLocalStorage: (artworkId: string) => Promise<string | undefined>
@@ -23,35 +23,13 @@ export const MyCollectionArtworkFormImages = forwardRef<
   { isEditing?: boolean }
 >(({ isEditing = false }, formImagesRef) => {
   const [errors, setErrors] = useState<Array<FileRejection>>([])
-  const [localImages, setlocalImages] = useState<
-    Array<LocalImage & { photoID: string }>
-  >([])
+
+  const {
+    addLocalImage,
+    removeLocalImage,
+  } = useMyCollectionArtworkFormContext()
   const { relayEnvironment } = useSystemContext()
   const { values, setFieldValue } = useFormikContext<ArtworkModel>()
-
-  const saveImagesToLocalStorage = async (artworkId: string) => {
-    try {
-      // Store the artwork's local images in local storage
-      // and remove unnecessary fields
-      return await storeArtworkLocalImages(
-        artworkId,
-        localImages.map(({ photoID, ...rest }) => rest)
-      )
-    } catch (error) {
-      console.error("Error saving images to localforage storage", error)
-    }
-  }
-
-  useImperativeHandle(
-    formImagesRef,
-    () => {
-      return {
-        saveImagesToLocalStorage,
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [localImages, saveImagesToLocalStorage]
-  )
 
   const uploadPhoto = async (photo: Photo) => {
     photo.loading = true
@@ -125,33 +103,25 @@ export const MyCollectionArtworkFormImages = forwardRef<
       currentSrc,
     } = image.target as any
 
-    const imageAlreadyAdded = localImages.find(
-      localImage => localImage.photoID === photoID
-    )
-
     // Handle images added through the select artwork step
     if (!isEditing && currentSrc.includes("cloudfront.net")) {
-      setlocalImages(
-        localImages.concat({
-          data: currentSrc,
-          width,
-          height,
-          photoID,
-        })
-      )
+      addLocalImage({
+        data: currentSrc,
+        width,
+        height,
+        photoID,
+      })
     }
 
     // Handle images added locally
-    if (currentSrc.startsWith("data:image") && !imageAlreadyAdded) {
+    if (currentSrc.startsWith("data:image")) {
       // Save the image dimensions as well as local path to the localImages array
-      setlocalImages(
-        localImages.concat({
-          data: currentSrc,
-          width,
-          height,
-          photoID,
-        })
-      )
+      addLocalImage({
+        data: currentSrc,
+        width,
+        height,
+        photoID,
+      })
     }
   }
 
@@ -173,7 +143,7 @@ export const MyCollectionArtworkFormImages = forwardRef<
         values.newPhotos.filter(p => p.id !== photo.id)
       )
       // Remove images that have been removed from state
-      setlocalImages(localImages.filter(p => p.photoID !== photo.id))
+      removeLocalImage(photo.id)
     } else {
       // Mark photo in photos as removed
       const photoToDelete = {

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages.tsx
@@ -11,17 +11,17 @@ import {
   uploadPhotoToS3,
 } from "Components/PhotoUpload/Utils/fileUtils"
 import { useFormikContext } from "formik"
-import { forwardRef, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { FileRejection } from "react-dropzone"
 import { useSystemContext } from "System"
 
-export interface MyCollectionArtworkFormImagesProps {
-  saveImagesToLocalStorage: (artworkId: string) => Promise<string | undefined>
+interface MyCollectionArtworkFormImagesProps {
+  isEditing?: boolean
 }
-export const MyCollectionArtworkFormImages = forwardRef<
-  MyCollectionArtworkFormImagesProps,
-  { isEditing?: boolean }
->(({ isEditing = false }, formImagesRef) => {
+
+export const MyCollectionArtworkFormImages: React.FC<MyCollectionArtworkFormImagesProps> = ({
+  isEditing = false,
+}) => {
   const [errors, setErrors] = useState<Array<FileRejection>>([])
 
   const {
@@ -215,4 +215,4 @@ export const MyCollectionArtworkFormImages = forwardRef<
       ))}
     </>
   )
-})
+}

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormMain.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormMain.tsx
@@ -38,7 +38,7 @@ export const MyCollectionArtworkFormMain: React.FC<MyCollectionArtworkFormMainPr
   artwork,
 }) => {
   const isCollectorProfileEnabled = useFeatureFlag("cx-collector-profile")
-  const { artworkFormImagesRef, onBack } = useMyCollectionArtworkFormContext()
+  const { onBack } = useMyCollectionArtworkFormContext()
   const {
     deleteCollectedArtwork: trackDeleteCollectedArtwork,
   } = useMyCollectionTracking()
@@ -154,10 +154,7 @@ export const MyCollectionArtworkFormMain: React.FC<MyCollectionArtworkFormMainPr
 
             {!onlyPhotos && <MyCollectionArtworkFormDetails />}
             <Spacer y={4} />
-            <MyCollectionArtworkFormImages
-              ref={artworkFormImagesRef}
-              isEditing={isEditing}
-            />
+            <MyCollectionArtworkFormImages isEditing={isEditing} />
             <Spacer y={6} />
             {isEditing && !onlyPhotos && (
               <>

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionCreateArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionCreateArtwork.tsx
@@ -5,13 +5,12 @@ import {
   MyCollectionArtworkFormContextProvider,
   useLocalImageState,
 } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext"
-import { MyCollectionArtworkFormImagesProps } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages"
 import { MyCollectionArtworkFormMain } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormMain"
 import { useCreateOrUpdateArtwork } from "Apps/MyCollection/Routes/EditArtwork/Utils/useCreateOrUpdateArtwork"
 import { useMyCollectionTracking } from "Apps/MyCollection/Routes/Hooks/useMyCollectionTracking"
 import { MetaTags } from "Components/MetaTags"
 import { Formik } from "formik"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useRouter } from "System/Router/useRouter"
 import { useFeatureFlag } from "System/useFeatureFlag"
@@ -52,10 +51,6 @@ export const MyCollectionCreateArtwork: React.FC<MyCollectionCreateArtworkProps>
   const {
     saveCollectedArtwork: trackSaveCollectedArtwork,
   } = useMyCollectionTracking()
-
-  const artworkFormImagesRef = useRef<MyCollectionArtworkFormImagesProps | null>(
-    null
-  )
 
   const initialStep = enableNewMyCUploadFlow ? "artist-select" : "details"
 
@@ -154,7 +149,6 @@ export const MyCollectionCreateArtwork: React.FC<MyCollectionCreateArtworkProps>
       <MetaTags title="Upload Artwork | Artsy" />
 
       <MyCollectionArtworkFormContextProvider
-        artworkFormImagesRef={artworkFormImagesRef}
         onBack={handleBack}
         onNext={handleNextStep}
         onSkip={handleSkip}

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionCreateArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionCreateArtwork.tsx
@@ -117,10 +117,14 @@ export const MyCollectionCreateArtwork: React.FC<MyCollectionCreateArtworkProps>
 
       // Store images locally
       if (artworkId) {
-        storeArtworkLocalImages(
-          artworkId,
-          localImages.map(({ photoID, ...rest }) => rest)
-        )
+        try {
+          await storeArtworkLocalImages(
+            artworkId,
+            localImages.map(({ photoID, ...rest }) => rest)
+          )
+        } catch (error) {
+          console.error("Failed to store images locally.", error)
+        }
       }
 
       router.replace({

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionEditArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionEditArtwork.tsx
@@ -1,5 +1,8 @@
 import { useToasts } from "@artsy/palette"
-import { MyCollectionArtworkFormContextProvider } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext"
+import {
+  MyCollectionArtworkFormContextProvider,
+  useLocalImageState,
+} from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext"
 import { MyCollectionArtworkFormImagesProps } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages"
 import { MyCollectionArtworkFormMainFragmentContainer } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormMain"
 import { useDeleteArtworkImage } from "Apps/MyCollection/Routes/EditArtwork/Mutations/useDeleteArtworkImage"
@@ -7,12 +10,11 @@ import { useCreateOrUpdateArtwork } from "Apps/MyCollection/Routes/EditArtwork/U
 import { IMAGES_LOCAL_STORE_LAST_UPDATED_AT } from "Apps/Settings/Routes/MyCollection/constants"
 import { MetaTags } from "Components/MetaTags"
 import { Formik } from "formik"
-import { useRef, useState } from "react"
+import { useRef } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useRouter } from "System/Router/useRouter"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import {
-  LocalImage,
   setLocalImagesStoreLastUpdatedAt,
   storeArtworkLocalImages,
 } from "Utils/localImagesHelpers"
@@ -32,9 +34,8 @@ export interface MyCollectionEditArtworkProps {
 export const MyCollectionEditArtwork: React.FC<MyCollectionEditArtworkProps> = ({
   artwork,
 }) => {
-  const [localImages, setLocalImages] = useState<
-    Array<LocalImage & { photoID: string }>
-  >([])
+  const { localImages, addLocalImage, removeLocalImage } = useLocalImageState()
+
   const isCollectorProfileEnabled = useFeatureFlag("cx-collector-profile")
   const { router } = useRouter()
   const { sendToast } = useToasts()
@@ -134,10 +135,8 @@ export const MyCollectionEditArtwork: React.FC<MyCollectionEditArtworkProps> = (
       <MyCollectionArtworkFormContextProvider
         artworkFormImagesRef={artworkFormImagesRef}
         onBack={handleBack}
-        addLocalImage={image => setLocalImages([...localImages, image])}
-        removeLocalImage={photoID =>
-          setLocalImages(localImages.filter(i => i.photoID !== photoID))
-        }
+        addLocalImage={addLocalImage}
+        removeLocalImage={removeLocalImage}
       >
         <Formik<ArtworkModel>
           validateOnMount

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionEditArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionEditArtwork.tsx
@@ -3,21 +3,15 @@ import {
   MyCollectionArtworkFormContextProvider,
   useLocalImageState,
 } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext"
-import { MyCollectionArtworkFormImagesProps } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages"
 import { MyCollectionArtworkFormMainFragmentContainer } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormMain"
 import { useDeleteArtworkImage } from "Apps/MyCollection/Routes/EditArtwork/Mutations/useDeleteArtworkImage"
 import { useCreateOrUpdateArtwork } from "Apps/MyCollection/Routes/EditArtwork/Utils/useCreateOrUpdateArtwork"
-import { IMAGES_LOCAL_STORE_LAST_UPDATED_AT } from "Apps/Settings/Routes/MyCollection/constants"
 import { MetaTags } from "Components/MetaTags"
 import { Formik } from "formik"
-import { useRef } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useRouter } from "System/Router/useRouter"
 import { useFeatureFlag } from "System/useFeatureFlag"
-import {
-  setLocalImagesStoreLastUpdatedAt,
-  storeArtworkLocalImages,
-} from "Utils/localImagesHelpers"
+import { storeArtworkLocalImages } from "Utils/localImagesHelpers"
 import createLogger from "Utils/logger"
 import { wait } from "Utils/wait"
 import { MyCollectionEditArtwork_artwork$data } from "__generated__/MyCollectionEditArtwork_artwork.graphql"
@@ -41,22 +35,10 @@ export const MyCollectionEditArtwork: React.FC<MyCollectionEditArtworkProps> = (
   const { sendToast } = useToasts()
   const { createOrUpdateArtwork } = useCreateOrUpdateArtwork()
   const { submitMutation: deleteArtworkImage } = useDeleteArtworkImage()
-  const artworkFormImagesRef = useRef<MyCollectionArtworkFormImagesProps | null>(
-    null
-  )
 
   const handleSubmit = async (values: ArtworkModel) => {
     try {
       const artworkId = await createOrUpdateArtwork(values, artwork)
-
-      // Store images locally
-
-      if (artworkId && artworkFormImagesRef.current) {
-        await artworkFormImagesRef.current?.saveImagesToLocalStorage(artworkId)
-        await setLocalImagesStoreLastUpdatedAt(
-          IMAGES_LOCAL_STORE_LAST_UPDATED_AT
-        )
-      }
 
       // Wait until image processing has started
       if (values.newPhotos.length) {
@@ -133,7 +115,6 @@ export const MyCollectionEditArtwork: React.FC<MyCollectionEditArtworkProps> = (
       />
 
       <MyCollectionArtworkFormContextProvider
-        artworkFormImagesRef={artworkFormImagesRef}
         onBack={handleBack}
         addLocalImage={addLocalImage}
         removeLocalImage={removeLocalImage}

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionEditArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionEditArtwork.tsx
@@ -73,10 +73,14 @@ export const MyCollectionEditArtwork: React.FC<MyCollectionEditArtworkProps> = (
 
       // Store images locally
       if (artworkId) {
-        storeArtworkLocalImages(
-          artworkId,
-          localImages.map(({ photoID, ...rest }) => rest)
-        )
+        try {
+          await storeArtworkLocalImages(
+            artworkId,
+            localImages.map(({ photoID, ...rest }) => rest)
+          )
+        } catch (error) {
+          console.error("Failed to store images locally.", error)
+        }
       }
 
       router.replace({

--- a/src/Utils/localImagesHelpers.ts
+++ b/src/Utils/localImagesHelpers.ts
@@ -11,6 +11,7 @@ export interface LocalImage {
   width: number
   height: number
   expirationDate?: string
+  photoID?: string
 }
 
 export type StoredImage = LocalImage

--- a/src/Utils/localImagesHelpers.ts
+++ b/src/Utils/localImagesHelpers.ts
@@ -10,17 +10,14 @@ export interface LocalImage {
   data: string
   width: number
   height: number
+  expirationDate?: string
 }
 
-interface Expirable {
-  expirationDate: string
-}
-
-export type StoredImage = LocalImage & Expirable
+export type StoredImage = LocalImage
 
 export type StoredArtworkWithImages = {
   artworkID: string
-  images: StoredImage[]
+  images: LocalImage[]
 }
 
 const addMinutes = (date: Date, minutes: number) => {


### PR DESCRIPTION
Addresses [CX-3336]

## Description

This PR simplifies the My Collection local image optimization by moving the state where the images are stored into the context and removing the ref that was needed before. It's only a preparation for the next steps and needed to later store the images by image ID (which is returned from the create/update mutation).

[CX-3336]: https://artsyproduct.atlassian.net/browse/CX-3336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ