### PR TITLE
feat(TX-993): Checkout status page updates for private sale orders

### DIFF
--- a/src/Apps/Order/Routes/Status/index.tsx
+++ b/src/Apps/Order/Routes/Status/index.tsx
@@ -104,7 +104,10 @@ export const StatusRoute: FC<StatusProps> = ({ order, match }) => {
                     order={order}
                     useLastSubmittedOffer
                     showOfferNote={isSubmittedOffer}
-                    showCongratulationMessage={order.state === "SUBMITTED"}
+                    showCongratulationMessage={
+                      order.state === "SUBMITTED" &&
+                      order.source !== "private_sale"
+                    }
                   />
                 </Flex>
               ) : (

--- a/src/Apps/Order/Routes/__tests__/Status.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Status.jest.tsx
@@ -179,114 +179,114 @@ describe("Status", () => {
           expect(page.getMessageLength()).toBe(1)
         })
 
-        it("renders Message with alert variant and 'please proceed' message", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...OfferOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "WIRE_TRANSFER",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+        // it("renders Message with alert variant and 'please proceed' message", async () => {
+        //   const wrapper = getWrapper({
+        //     CommerceOrder: () => ({
+        //       ...OfferOrderWithShippingDetails,
+        //       displayState: "PROCESSING_APPROVAL",
+        //       paymentMethod: "WIRE_TRANSFER",
+        //     }),
+        //   })
+        //   const page = new StatusTestPage(wrapper)
 
-          expect(page.text()).toContain(
-            "Please proceed with the wire transfer to complete your purchase"
-          )
+        //   expect(page.text()).toContain(
+        //     "Please proceed with the wire transfer to complete your purchase"
+        //   )
 
-          const message = page.getMessage()
-          expect(message.props().variant).toBe("alert")
-        })
+        //   const message = page.getMessage()
+        //   expect(message.props().variant).toBe("alert")
+        // })
 
-        it("renders the alert Message with correct messages", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...OfferOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "WIRE_TRANSFER",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+        // it("renders the alert Message with correct messages", async () => {
+        //   const wrapper = getWrapper({
+        //     CommerceOrder: () => ({
+        //       ...OfferOrderWithShippingDetails,
+        //       displayState: "PROCESSING_APPROVAL",
+        //       paymentMethod: "WIRE_TRANSFER",
+        //     }),
+        //   })
+        //   const page = new StatusTestPage(wrapper)
 
-          expect(page.text()).toContain(
-            "Please provide your proof of payment within 7 days. After this period, your order will be eligible for cancellation by the gallery."
-          )
-          expect(page.text()).toContain(
-            "Find the order total and Artsy’s banking details below."
-          )
-          expect(page.text()).toContain(
-            "Please inform your bank that you will be responsible for all wire transfer fees."
-          )
-          expect(page.text()).toContain(
-            "Once you have made the transfer, please email orders@artsy.net with your proof of payment."
-          )
-        })
+        //   expect(page.text()).toContain(
+        //     "Please provide your proof of payment within 7 days. After this period, your order will be eligible for cancellation by the gallery."
+        //   )
+        //   expect(page.text()).toContain(
+        //     "Find the order total and Artsy’s banking details below."
+        //   )
+        //   expect(page.text()).toContain(
+        //     "Please inform your bank that you will be responsible for all wire transfer fees."
+        //   )
+        //   expect(page.text()).toContain(
+        //     "Once you have made the transfer, please email orders@artsy.net with your proof of payment."
+        //   )
+        // })
 
-        it("renders content for Artsy's bank details", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...OfferOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "WIRE_TRANSFER",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+        // it("renders content for Artsy's bank details", async () => {
+        //   const wrapper = getWrapper({
+        //     CommerceOrder: () => ({
+        //       ...OfferOrderWithShippingDetails,
+        //       displayState: "PROCESSING_APPROVAL",
+        //       paymentMethod: "WIRE_TRANSFER",
+        //     }),
+        //   })
+        //   const page = new StatusTestPage(wrapper)
 
-          expect(page.text()).toContain("Send wire transfer to")
-          expect(page.text()).toContain("Account name: Art.sy Inc.")
-          expect(page.text()).toContain("Account number: 4243851425")
-          expect(page.text()).toContain("Routing number: 121000248")
-          expect(page.text()).toContain("International SWIFT: WFBIUS6S")
-          expect(page.text()).toContain("Bank address")
-          expect(page.text()).toContain("Wells Fargo Bank, N.A.")
-          expect(page.text()).toContain("420 Montgomery Street")
-          expect(page.text()).toContain("San Francisco, CA 9410")
-        })
+        //   expect(page.text()).toContain("Send wire transfer to")
+        //   expect(page.text()).toContain("Account name: Art.sy Inc.")
+        //   expect(page.text()).toContain("Account number: 4243851425")
+        //   expect(page.text()).toContain("Routing number: 121000248")
+        //   expect(page.text()).toContain("International SWIFT: WFBIUS6S")
+        //   expect(page.text()).toContain("Bank address")
+        //   expect(page.text()).toContain("Wells Fargo Bank, N.A.")
+        //   expect(page.text()).toContain("420 Montgomery Street")
+        //   expect(page.text()).toContain("San Francisco, CA 9410")
+        // })
       })
 
-      describe("with non-wire payment methods", () => {
-        it("should say 'Offer accepted. Payment processing.' and have message box", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...OfferOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "CREDIT_CARD",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+      // describe("with non-wire payment methods", () => {
+      //   it("should say 'Offer accepted. Payment processing.' and have message box", async () => {
+      //     const wrapper = getWrapper({
+      //       CommerceOrder: () => ({
+      //         ...OfferOrderWithShippingDetails,
+      //         displayState: "PROCESSING_APPROVAL",
+      //         paymentMethod: "CREDIT_CARD",
+      //       }),
+      //     })
+      //     const page = new StatusTestPage(wrapper)
 
-          expect(page.text()).toContain("Offer accepted. Payment processing.")
-          expect(page.getMessageLength()).toBe(1)
-        })
+      //     expect(page.text()).toContain("Offer accepted. Payment processing.")
+      //     expect(page.getMessageLength()).toBe(1)
+      //   })
 
-        it("renders description", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...OfferOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "CREDIT_CARD",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+      //   it("renders description", async () => {
+      //     const wrapper = getWrapper({
+      //       CommerceOrder: () => ({
+      //         ...OfferOrderWithShippingDetails,
+      //         displayState: "PROCESSING_APPROVAL",
+      //         paymentMethod: "CREDIT_CARD",
+      //       }),
+      //     })
+      //     const page = new StatusTestPage(wrapper)
 
-          expect(page.text()).toContain(
-            "More delivery information will be available once your order ships."
-          )
-        })
+      //     expect(page.text()).toContain(
+      //       "More delivery information will be available once your order ships."
+      //     )
+      //   })
 
-        it("does not render an alert message", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...OfferOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "CREDIT_CARD",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+      //   it("does not render an alert message", async () => {
+      //     const wrapper = getWrapper({
+      //       CommerceOrder: () => ({
+      //         ...OfferOrderWithShippingDetails,
+      //         displayState: "PROCESSING_APPROVAL",
+      //         paymentMethod: "CREDIT_CARD",
+      //       }),
+      //     })
+      //     const page = new StatusTestPage(wrapper)
 
-          const message = page.getMessage()
-          expect(message.props().variant).not.toBe("alert")
-        })
-      })
+      //     const message = page.getMessage()
+      //     expect(message.props().variant).not.toBe("alert")
+      //   })
+      // })
     })
 
     describe("in transit", () => {
@@ -473,259 +473,259 @@ describe("Status", () => {
     })
   })
 
-  describe("orders", () => {
-    it("should should have a title containing status", async () => {
-      const wrapper = getWrapper({
-        CommerceOrder: () => BuyOrderWithShippingDetails,
-      })
+  // describe("orders", () => {
+  //   it("should should have a title containing status", async () => {
+  //     const wrapper = getWrapper({
+  //       CommerceOrder: () => BuyOrderWithShippingDetails,
+  //     })
 
-      expect(wrapper.find(Title).text()).toBe("Order status | Artsy")
-    })
+  //     expect(wrapper.find(Title).text()).toBe("Order status | Artsy")
+  //   })
 
-    describe("submitted", () => {
-      it("should say order submitted and have message box", async () => {
-        const wrapper = getWrapper({
-          CommerceOrder: () => ({
-            ...BuyOrderWithShippingDetails,
-            ...CreditCardPaymentDetails,
-            displayState: "SUBMITTED",
-          }),
-        })
-        const page = new StatusTestPage(wrapper)
+  //   describe("submitted", () => {
+  //     it("should say order submitted and have message box", async () => {
+  //       const wrapper = getWrapper({
+  //         CommerceOrder: () => ({
+  //           ...BuyOrderWithShippingDetails,
+  //           ...CreditCardPaymentDetails,
+  //           displayState: "SUBMITTED",
+  //         }),
+  //       })
+  //       const page = new StatusTestPage(wrapper)
 
-        expect(page.text()).toContain(
-          "Thank you, your order has been submitted"
-        )
-        expect(page.text()).toContain(
-          "You will receive a confirmation email by Jan 15"
-        )
-        expect(page.getMessageLength()).toBe(1)
-      })
-    })
+  //       expect(page.text()).toContain(
+  //         "Thank you, your order has been submitted"
+  //       )
+  //       expect(page.text()).toContain(
+  //         "You will receive a confirmation email by Jan 15"
+  //       )
+  //       expect(page.getMessageLength()).toBe(1)
+  //     })
+  //   })
 
-    describe("approved", () => {
-      it("should say confirmed", async () => {
-        const wrapper = getWrapper({
-          CommerceOrder: () => ({
-            ...BuyOrderWithShippingDetails,
-            ...CreditCardPaymentDetails,
-            displayState: "APPROVED",
-          }),
-        })
-        const page = new StatusTestPage(wrapper)
+  //   describe("approved", () => {
+  //     it("should say confirmed", async () => {
+  //       const wrapper = getWrapper({
+  //         CommerceOrder: () => ({
+  //           ...BuyOrderWithShippingDetails,
+  //           ...CreditCardPaymentDetails,
+  //           displayState: "APPROVED",
+  //         }),
+  //       })
+  //       const page = new StatusTestPage(wrapper)
 
-        expect(page.text()).toContain("Your order is confirmed")
-      })
-    })
+  //       expect(page.text()).toContain("Your order is confirmed")
+  //     })
+  //   })
 
-    describe("processing approval", () => {
-      describe("with wire payment method", () => {
-        it("should say 'Thank you, your offer has been accepted' and have message box", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...BuyOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "WIRE_TRANSFER",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+  //   describe("processing approval", () => {
+  //     describe("with wire payment method", () => {
+  //       it("should say 'Thank you, your offer has been accepted' and have message box", async () => {
+  //         const wrapper = getWrapper({
+  //           CommerceOrder: () => ({
+  //             ...BuyOrderWithShippingDetails,
+  //             displayState: "PROCESSING_APPROVAL",
+  //             paymentMethod: "WIRE_TRANSFER",
+  //           }),
+  //         })
+  //         const page = new StatusTestPage(wrapper)
 
-          expect(page.text()).toContain(
-            "Thank you, your order has been accepted"
-          )
-          expect(page.getMessageLength()).toBe(1)
-        })
+  //         expect(page.text()).toContain(
+  //           "Thank you, your order has been accepted"
+  //         )
+  //         expect(page.getMessageLength()).toBe(1)
+  //       })
 
-        it("renders Message with alert variant and 'please proceed' message", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...BuyOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "WIRE_TRANSFER",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+  //       it("renders Message with alert variant and 'please proceed' message", async () => {
+  //         const wrapper = getWrapper({
+  //           CommerceOrder: () => ({
+  //             ...BuyOrderWithShippingDetails,
+  //             displayState: "PROCESSING_APPROVAL",
+  //             paymentMethod: "WIRE_TRANSFER",
+  //           }),
+  //         })
+  //         const page = new StatusTestPage(wrapper)
 
-          expect(page.text()).toContain(
-            "Please proceed with the wire transfer to complete your purchase"
-          )
+  //         expect(page.text()).toContain(
+  //           "Please proceed with the wire transfer to complete your purchase"
+  //         )
 
-          const message = page.getMessage()
-          expect(message.props().variant).toBe("alert")
-        })
+  //         const message = page.getMessage()
+  //         expect(message.props().variant).toBe("alert")
+  //       })
 
-        it("renders the alert Message with correct messages", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...BuyOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "WIRE_TRANSFER",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+  //       it("renders the alert Message with correct messages", async () => {
+  //         const wrapper = getWrapper({
+  //           CommerceOrder: () => ({
+  //             ...BuyOrderWithShippingDetails,
+  //             displayState: "PROCESSING_APPROVAL",
+  //             paymentMethod: "WIRE_TRANSFER",
+  //           }),
+  //         })
+  //         const page = new StatusTestPage(wrapper)
 
-          expect(page.text()).toContain(
-            "Please provide your proof of payment within 7 days. After this period, your order will be eligible for cancellation by the gallery."
-          )
-          expect(page.text()).toContain(
-            "Find the order total and Artsy’s banking details below."
-          )
-          expect(page.text()).toContain(
-            "Please inform your bank that you will be responsible for all wire transfer fees."
-          )
-          expect(page.text()).toContain(
-            "Once you have made the transfer, please email orders@artsy.net with your proof of payment."
-          )
-        })
+  //         expect(page.text()).toContain(
+  //           "Please provide your proof of payment within 7 days. After this period, your order will be eligible for cancellation by the gallery."
+  //         )
+  //         expect(page.text()).toContain(
+  //           "Find the order total and Artsy’s banking details below."
+  //         )
+  //         expect(page.text()).toContain(
+  //           "Please inform your bank that you will be responsible for all wire transfer fees."
+  //         )
+  //         expect(page.text()).toContain(
+  //           "Once you have made the transfer, please email orders@artsy.net with your proof of payment."
+  //         )
+  //       })
 
-        it("renders content for Artsy's bank details", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...BuyOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "WIRE_TRANSFER",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+  //       it("renders content for Artsy's bank details", async () => {
+  //         const wrapper = getWrapper({
+  //           CommerceOrder: () => ({
+  //             ...BuyOrderWithShippingDetails,
+  //             displayState: "PROCESSING_APPROVAL",
+  //             paymentMethod: "WIRE_TRANSFER",
+  //           }),
+  //         })
+  //         const page = new StatusTestPage(wrapper)
 
-          expect(page.text()).toContain("Send wire transfer to")
-          expect(page.text()).toContain("Account name: Art.sy Inc.")
-          expect(page.text()).toContain("Account number: 4243851425")
-          expect(page.text()).toContain("Routing number: 121000248")
-          expect(page.text()).toContain("International SWIFT: WFBIUS6S")
-          expect(page.text()).toContain("Bank address")
-          expect(page.text()).toContain("Wells Fargo Bank, N.A.")
-          expect(page.text()).toContain("420 Montgomery Street")
-          expect(page.text()).toContain("San Francisco, CA 9410")
-        })
-      })
+  //         expect(page.text()).toContain("Send wire transfer to")
+  //         expect(page.text()).toContain("Account name: Art.sy Inc.")
+  //         expect(page.text()).toContain("Account number: 4243851425")
+  //         expect(page.text()).toContain("Routing number: 121000248")
+  //         expect(page.text()).toContain("International SWIFT: WFBIUS6S")
+  //         expect(page.text()).toContain("Bank address")
+  //         expect(page.text()).toContain("Wells Fargo Bank, N.A.")
+  //         expect(page.text()).toContain("420 Montgomery Street")
+  //         expect(page.text()).toContain("San Francisco, CA 9410")
+  //       })
+  //     })
 
-      describe("with non-wire payment methods", () => {
-        it("should say 'Your order is confirmed. Payment processing.' and have message box", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...BuyOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "CREDIT_CARD",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+  //     describe("with non-wire payment methods", () => {
+  //       it("should say 'Your order is confirmed. Payment processing.' and have message box", async () => {
+  //         const wrapper = getWrapper({
+  //           CommerceOrder: () => ({
+  //             ...BuyOrderWithShippingDetails,
+  //             displayState: "PROCESSING_APPROVAL",
+  //             paymentMethod: "CREDIT_CARD",
+  //           }),
+  //         })
+  //         const page = new StatusTestPage(wrapper)
 
-          expect(page.text()).toContain(
-            "Your order is confirmed. Payment processing."
-          )
-          expect(page.getMessageLength()).toBe(1)
-        })
+  //         expect(page.text()).toContain(
+  //           "Your order is confirmed. Payment processing."
+  //         )
+  //         expect(page.getMessageLength()).toBe(1)
+  //       })
 
-        it("renders description", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...BuyOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "CREDIT_CARD",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+  //       it("renders description", async () => {
+  //         const wrapper = getWrapper({
+  //           CommerceOrder: () => ({
+  //             ...BuyOrderWithShippingDetails,
+  //             displayState: "PROCESSING_APPROVAL",
+  //             paymentMethod: "CREDIT_CARD",
+  //           }),
+  //         })
+  //         const page = new StatusTestPage(wrapper)
 
-          expect(page.text()).toContain(
-            "More delivery information will be available once your order ships."
-          )
-        })
+  //         expect(page.text()).toContain(
+  //           "More delivery information will be available once your order ships."
+  //         )
+  //       })
 
-        it("does not render an alert message", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => ({
-              ...BuyOrderWithShippingDetails,
-              displayState: "PROCESSING_APPROVAL",
-              paymentMethod: "CREDIT_CARD",
-            }),
-          })
-          const page = new StatusTestPage(wrapper)
+  //       it("does not render an alert message", async () => {
+  //         const wrapper = getWrapper({
+  //           CommerceOrder: () => ({
+  //             ...BuyOrderWithShippingDetails,
+  //             displayState: "PROCESSING_APPROVAL",
+  //             paymentMethod: "CREDIT_CARD",
+  //           }),
+  //         })
+  //         const page = new StatusTestPage(wrapper)
 
-          const message = page.getMessage()
-          expect(message.props().variant).not.toBe("alert")
-        })
-      })
-    })
+  //         const message = page.getMessage()
+  //         expect(message.props().variant).not.toBe("alert")
+  //       })
+  //     })
+  //   })
 
-    describe("fulfilled (ship)", () => {
-      it("should say order has shipped and have message box", async () => {
-        const wrapper = getWrapper({
-          CommerceOrder: () => ({
-            ...BuyOrderWithShippingDetails,
-            ...CreditCardPaymentDetails,
-            displayState: "FULFILLED",
-          }),
-        })
-        const page = new StatusTestPage(wrapper)
+  //   describe("fulfilled (ship)", () => {
+  //     it("should say order has shipped and have message box", async () => {
+  //       const wrapper = getWrapper({
+  //         CommerceOrder: () => ({
+  //           ...BuyOrderWithShippingDetails,
+  //           ...CreditCardPaymentDetails,
+  //           displayState: "FULFILLED",
+  //         }),
+  //       })
+  //       const page = new StatusTestPage(wrapper)
 
-        expect(page.text()).toContain("Your order has shipped")
-        expect(page.getMessageLength()).toBe(1)
-      })
-    })
+  //       expect(page.text()).toContain("Your order has shipped")
+  //       expect(page.getMessageLength()).toBe(1)
+  //     })
+  //   })
 
-    describe("fulfilled (pickup)", () => {
-      it("should say order has been picked up and NOT have message box", async () => {
-        const wrapper = getWrapper({
-          CommerceOrder: () => ({
-            ...BuyOrderPickup,
-            ...CreditCardPaymentDetails,
-            displayState: "FULFILLED",
-          }),
-        })
-        const page = new StatusTestPage(wrapper)
+  //   describe("fulfilled (pickup)", () => {
+  //     it("should say order has been picked up and NOT have message box", async () => {
+  //       const wrapper = getWrapper({
+  //         CommerceOrder: () => ({
+  //           ...BuyOrderPickup,
+  //           ...CreditCardPaymentDetails,
+  //           displayState: "FULFILLED",
+  //         }),
+  //       })
+  //       const page = new StatusTestPage(wrapper)
 
-        expect(page.text()).toContain("Your order has been picked up")
-        expect(page.find(Message).length).toBe(0)
-      })
-    })
+  //       expect(page.text()).toContain("Your order has been picked up")
+  //       expect(page.find(Message).length).toBe(0)
+  //     })
+  //   })
 
-    describe("canceled (ship)", () => {
-      it("should say that order was canceled", async () => {
-        const wrapper = getWrapper({
-          CommerceOrder: () => ({
-            ...BuyOrderWithShippingDetails,
-            ...CreditCardPaymentDetails,
-            displayState: "CANCELED",
-          }),
-        })
-        const page = new StatusTestPage(wrapper)
+  //   describe("canceled (ship)", () => {
+  //     it("should say that order was canceled", async () => {
+  //       const wrapper = getWrapper({
+  //         CommerceOrder: () => ({
+  //           ...BuyOrderWithShippingDetails,
+  //           ...CreditCardPaymentDetails,
+  //           displayState: "CANCELED",
+  //         }),
+  //       })
+  //       const page = new StatusTestPage(wrapper)
 
-        expect(page.text()).toContain("Your order was canceled and refunded")
-        expect(page.getMessageLength()).toBe(1)
-      })
-    })
+  //       expect(page.text()).toContain("Your order was canceled and refunded")
+  //       expect(page.getMessageLength()).toBe(1)
+  //     })
+  //   })
 
-    describe("canceled (pickup)", () => {
-      it("should say that order was canceled", async () => {
-        const wrapper = getWrapper({
-          CommerceOrder: () => ({
-            ...BuyOrderPickup,
-            ...CreditCardPaymentDetails,
-            displayState: "CANCELED",
-          }),
-        })
-        const page = new StatusTestPage(wrapper)
+  //   describe("canceled (pickup)", () => {
+  //     it("should say that order was canceled", async () => {
+  //       const wrapper = getWrapper({
+  //         CommerceOrder: () => ({
+  //           ...BuyOrderPickup,
+  //           ...CreditCardPaymentDetails,
+  //           displayState: "CANCELED",
+  //         }),
+  //       })
+  //       const page = new StatusTestPage(wrapper)
 
-        expect(page.text()).toContain("Your order was canceled and refunded")
-        expect(page.getMessageLength()).toBe(1)
-      })
-    })
+  //       expect(page.text()).toContain("Your order was canceled and refunded")
+  //       expect(page.getMessageLength()).toBe(1)
+  //     })
+  //   })
 
-    describe("refunded", () => {
-      it("should say that order was canceled", async () => {
-        const wrapper = getWrapper({
-          CommerceOrder: () => ({
-            ...BuyOrderPickup,
-            ...CreditCardPaymentDetails,
-            displayState: "REFUNDED",
-          }),
-        })
-        const page = new StatusTestPage(wrapper)
+  //   describe("refunded", () => {
+  //     it("should say that order was canceled", async () => {
+  //       const wrapper = getWrapper({
+  //         CommerceOrder: () => ({
+  //           ...BuyOrderPickup,
+  //           ...CreditCardPaymentDetails,
+  //           displayState: "REFUNDED",
+  //         }),
+  //       })
+  //       const page = new StatusTestPage(wrapper)
 
-        expect(page.text()).toContain("Your order was canceled and refunded")
-        expect(page.getMessageLength()).toBe(1)
-      })
-    })
-  })
+  //       expect(page.text()).toContain("Your order was canceled and refunded")
+  //       expect(page.getMessageLength()).toBe(1)
+  //     })
+  //   })
+  // })
 })

--- a/src/Apps/Order/Routes/__tests__/Status.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Status.jest.tsx
@@ -473,259 +473,382 @@ describe("Status", () => {
     })
   })
 
-  // describe("orders", () => {
-  //   it("should should have a title containing status", async () => {
-  //     const wrapper = getWrapper({
-  //       CommerceOrder: () => BuyOrderWithShippingDetails,
-  //     })
+  describe("orders", () => {
+    it("should should have a title containing status", async () => {
+      const wrapper = getWrapper({
+        CommerceOrder: () => BuyOrderWithShippingDetails,
+      })
 
-  //     expect(wrapper.find(Title).text()).toBe("Order status | Artsy")
-  //   })
+      expect(wrapper.find(Title).text()).toBe("Order status | Artsy")
+    })
 
-  //   describe("submitted", () => {
-  //     it("should say order submitted and have message box", async () => {
-  //       const wrapper = getWrapper({
-  //         CommerceOrder: () => ({
-  //           ...BuyOrderWithShippingDetails,
-  //           ...CreditCardPaymentDetails,
-  //           displayState: "SUBMITTED",
-  //         }),
-  //       })
-  //       const page = new StatusTestPage(wrapper)
+    describe("submitted", () => {
+      it("should say order submitted and have message box", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...BuyOrderWithShippingDetails,
+            ...CreditCardPaymentDetails,
+            displayState: "SUBMITTED",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
 
-  //       expect(page.text()).toContain(
-  //         "Thank you, your order has been submitted"
-  //       )
-  //       expect(page.text()).toContain(
-  //         "You will receive a confirmation email by Jan 15"
-  //       )
-  //       expect(page.getMessageLength()).toBe(1)
-  //     })
-  //   })
+        expect(page.text()).toContain(
+          "Thank you, your order has been submitted"
+        )
+        expect(page.text()).toContain(
+          "You will receive a confirmation email by Jan 15"
+        )
+        expect(page.getMessageLength()).toBe(1)
+      })
+    })
 
-  //   describe("approved", () => {
-  //     it("should say confirmed", async () => {
-  //       const wrapper = getWrapper({
-  //         CommerceOrder: () => ({
-  //           ...BuyOrderWithShippingDetails,
-  //           ...CreditCardPaymentDetails,
-  //           displayState: "APPROVED",
-  //         }),
-  //       })
-  //       const page = new StatusTestPage(wrapper)
+    describe("approved", () => {
+      it("should say confirmed", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...BuyOrderWithShippingDetails,
+            ...CreditCardPaymentDetails,
+            displayState: "APPROVED",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
 
-  //       expect(page.text()).toContain("Your order is confirmed")
-  //     })
-  //   })
+        expect(page.text()).toContain("Your order is confirmed")
+      })
 
-  //   describe("processing approval", () => {
-  //     describe("with wire payment method", () => {
-  //       it("should say 'Thank you, your offer has been accepted' and have message box", async () => {
-  //         const wrapper = getWrapper({
-  //           CommerceOrder: () => ({
-  //             ...BuyOrderWithShippingDetails,
-  //             displayState: "PROCESSING_APPROVAL",
-  //             paymentMethod: "WIRE_TRANSFER",
-  //           }),
-  //         })
-  //         const page = new StatusTestPage(wrapper)
+      it("should render correct title for Private Sale orders", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...BuyOrderWithShippingDetails,
+            ...CreditCardPaymentDetails,
+            displayState: "APPROVED",
+            source: "private_sale",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
 
-  //         expect(page.text()).toContain(
-  //           "Thank you, your order has been accepted"
-  //         )
-  //         expect(page.getMessageLength()).toBe(1)
-  //       })
+        expect(page.text()).toContain(
+          "Thank you for working with Artsy Private Sales."
+        )
+      })
 
-  //       it("renders Message with alert variant and 'please proceed' message", async () => {
-  //         const wrapper = getWrapper({
-  //           CommerceOrder: () => ({
-  //             ...BuyOrderWithShippingDetails,
-  //             displayState: "PROCESSING_APPROVAL",
-  //             paymentMethod: "WIRE_TRANSFER",
-  //           }),
-  //         })
-  //         const page = new StatusTestPage(wrapper)
+      it("should render correct description for Private Sale orders", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...BuyOrderWithShippingDetails,
+            ...CreditCardPaymentDetails,
+            displayState: "APPROVED",
+            source: "private_sale",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
 
-  //         expect(page.text()).toContain(
-  //           "Please proceed with the wire transfer to complete your purchase"
-  //         )
+        expect(page.text()).toContain(
+          "You will receive an email from our team with next steps."
+        )
+      })
 
-  //         const message = page.getMessage()
-  //         expect(message.props().variant).toBe("alert")
-  //       })
+      it("should render help email in description for Private Sale orders", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...BuyOrderWithShippingDetails,
+            ...CreditCardPaymentDetails,
+            displayState: "APPROVED",
+            source: "private_sale",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
 
-  //       it("renders the alert Message with correct messages", async () => {
-  //         const wrapper = getWrapper({
-  //           CommerceOrder: () => ({
-  //             ...BuyOrderWithShippingDetails,
-  //             displayState: "PROCESSING_APPROVAL",
-  //             paymentMethod: "WIRE_TRANSFER",
-  //           }),
-  //         })
-  //         const page = new StatusTestPage(wrapper)
+        expect(page.text()).toContain("privatesales@artsy.net.")
+      })
+    })
 
-  //         expect(page.text()).toContain(
-  //           "Please provide your proof of payment within 7 days. After this period, your order will be eligible for cancellation by the gallery."
-  //         )
-  //         expect(page.text()).toContain(
-  //           "Find the order total and Artsy’s banking details below."
-  //         )
-  //         expect(page.text()).toContain(
-  //           "Please inform your bank that you will be responsible for all wire transfer fees."
-  //         )
-  //         expect(page.text()).toContain(
-  //           "Once you have made the transfer, please email orders@artsy.net with your proof of payment."
-  //         )
-  //       })
+    describe("processing approval", () => {
+      describe("with wire payment method", () => {
+        it("should render correct title and have message box", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "WIRE_TRANSFER",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-  //       it("renders content for Artsy's bank details", async () => {
-  //         const wrapper = getWrapper({
-  //           CommerceOrder: () => ({
-  //             ...BuyOrderWithShippingDetails,
-  //             displayState: "PROCESSING_APPROVAL",
-  //             paymentMethod: "WIRE_TRANSFER",
-  //           }),
-  //         })
-  //         const page = new StatusTestPage(wrapper)
+          expect(page.text()).toContain(
+            "Thank you, your order has been accepted"
+          )
+          expect(page.getMessageLength()).toBe(1)
+        })
 
-  //         expect(page.text()).toContain("Send wire transfer to")
-  //         expect(page.text()).toContain("Account name: Art.sy Inc.")
-  //         expect(page.text()).toContain("Account number: 4243851425")
-  //         expect(page.text()).toContain("Routing number: 121000248")
-  //         expect(page.text()).toContain("International SWIFT: WFBIUS6S")
-  //         expect(page.text()).toContain("Bank address")
-  //         expect(page.text()).toContain("Wells Fargo Bank, N.A.")
-  //         expect(page.text()).toContain("420 Montgomery Street")
-  //         expect(page.text()).toContain("San Francisco, CA 9410")
-  //       })
-  //     })
+        it("should render correct title for wire private sale orders", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "WIRE_TRANSFER",
+              source: "private_sale",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-  //     describe("with non-wire payment methods", () => {
-  //       it("should say 'Your order is confirmed. Payment processing.' and have message box", async () => {
-  //         const wrapper = getWrapper({
-  //           CommerceOrder: () => ({
-  //             ...BuyOrderWithShippingDetails,
-  //             displayState: "PROCESSING_APPROVAL",
-  //             paymentMethod: "CREDIT_CARD",
-  //           }),
-  //         })
-  //         const page = new StatusTestPage(wrapper)
+          expect(page.text()).toContain(
+            "Thank you for your purchase with Artsy Private Sales."
+          )
+        })
 
-  //         expect(page.text()).toContain(
-  //           "Your order is confirmed. Payment processing."
-  //         )
-  //         expect(page.getMessageLength()).toBe(1)
-  //       })
+        it("renders Message with alert variant and 'please proceed' message", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "WIRE_TRANSFER",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-  //       it("renders description", async () => {
-  //         const wrapper = getWrapper({
-  //           CommerceOrder: () => ({
-  //             ...BuyOrderWithShippingDetails,
-  //             displayState: "PROCESSING_APPROVAL",
-  //             paymentMethod: "CREDIT_CARD",
-  //           }),
-  //         })
-  //         const page = new StatusTestPage(wrapper)
+          expect(page.text()).toContain(
+            "Please proceed with the wire transfer to complete your purchase"
+          )
 
-  //         expect(page.text()).toContain(
-  //           "More delivery information will be available once your order ships."
-  //         )
-  //       })
+          const message = page.getMessage()
+          expect(message.props().variant).toBe("alert")
+        })
 
-  //       it("does not render an alert message", async () => {
-  //         const wrapper = getWrapper({
-  //           CommerceOrder: () => ({
-  //             ...BuyOrderWithShippingDetails,
-  //             displayState: "PROCESSING_APPROVAL",
-  //             paymentMethod: "CREDIT_CARD",
-  //           }),
-  //         })
-  //         const page = new StatusTestPage(wrapper)
+        it("should render correct instruction for wire private sale orders", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "WIRE_TRANSFER",
+              source: "private_sale",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-  //         const message = page.getMessage()
-  //         expect(message.props().variant).not.toBe("alert")
-  //       })
-  //     })
-  //   })
+          expect(page.text()).toContain("email proof of payment")
+        })
 
-  //   describe("fulfilled (ship)", () => {
-  //     it("should say order has shipped and have message box", async () => {
-  //       const wrapper = getWrapper({
-  //         CommerceOrder: () => ({
-  //           ...BuyOrderWithShippingDetails,
-  //           ...CreditCardPaymentDetails,
-  //           displayState: "FULFILLED",
-  //         }),
-  //       })
-  //       const page = new StatusTestPage(wrapper)
+        it("should not render any description for wire private sale orders", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "WIRE_TRANSFER",
+              source: "private_sale",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-  //       expect(page.text()).toContain("Your order has shipped")
-  //       expect(page.getMessageLength()).toBe(1)
-  //     })
-  //   })
+          expect(page.text()).not.toContain("Thank you for your purchase.")
+        })
 
-  //   describe("fulfilled (pickup)", () => {
-  //     it("should say order has been picked up and NOT have message box", async () => {
-  //       const wrapper = getWrapper({
-  //         CommerceOrder: () => ({
-  //           ...BuyOrderPickup,
-  //           ...CreditCardPaymentDetails,
-  //           displayState: "FULFILLED",
-  //         }),
-  //       })
-  //       const page = new StatusTestPage(wrapper)
+        it("renders the alert Message with correct messages", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "WIRE_TRANSFER",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-  //       expect(page.text()).toContain("Your order has been picked up")
-  //       expect(page.find(Message).length).toBe(0)
-  //     })
-  //   })
+          expect(page.text()).toContain(
+            "Please provide your proof of payment within 7 days. After this period, your order will be eligible for cancellation by the gallery."
+          )
+          expect(page.text()).toContain(
+            "Find the order total and Artsy’s banking details below."
+          )
+          expect(page.text()).toContain(
+            "Please inform your bank that you will be responsible for all wire transfer fees."
+          )
+          expect(page.text()).toContain(
+            "Once you have made the transfer, please email orders@artsy.net with your proof of payment."
+          )
+        })
 
-  //   describe("canceled (ship)", () => {
-  //     it("should say that order was canceled", async () => {
-  //       const wrapper = getWrapper({
-  //         CommerceOrder: () => ({
-  //           ...BuyOrderWithShippingDetails,
-  //           ...CreditCardPaymentDetails,
-  //           displayState: "CANCELED",
-  //         }),
-  //       })
-  //       const page = new StatusTestPage(wrapper)
+        it("renders content for Artsy's bank details", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "WIRE_TRANSFER",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-  //       expect(page.text()).toContain("Your order was canceled and refunded")
-  //       expect(page.getMessageLength()).toBe(1)
-  //     })
-  //   })
+          expect(page.text()).toContain("Send wire transfer to")
+          expect(page.text()).toContain("Account name: Art.sy Inc.")
+          expect(page.text()).toContain("Account number: 4243851425")
+          expect(page.text()).toContain("Routing number: 121000248")
+          expect(page.text()).toContain("International SWIFT: WFBIUS6S")
+          expect(page.text()).toContain("Bank address")
+          expect(page.text()).toContain("Wells Fargo Bank, N.A.")
+          expect(page.text()).toContain("420 Montgomery Street")
+          expect(page.text()).toContain("San Francisco, CA 9410")
+        })
+      })
 
-  //   describe("canceled (pickup)", () => {
-  //     it("should say that order was canceled", async () => {
-  //       const wrapper = getWrapper({
-  //         CommerceOrder: () => ({
-  //           ...BuyOrderPickup,
-  //           ...CreditCardPaymentDetails,
-  //           displayState: "CANCELED",
-  //         }),
-  //       })
-  //       const page = new StatusTestPage(wrapper)
+      describe("with non-wire payment methods", () => {
+        it("should say 'Your order is confirmed. Payment processing.' and have message box", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "CREDIT_CARD",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-  //       expect(page.text()).toContain("Your order was canceled and refunded")
-  //       expect(page.getMessageLength()).toBe(1)
-  //     })
-  //   })
+          expect(page.text()).toContain(
+            "Your order is confirmed. Payment processing."
+          )
+          expect(page.getMessageLength()).toBe(1)
+        })
 
-  //   describe("refunded", () => {
-  //     it("should say that order was canceled", async () => {
-  //       const wrapper = getWrapper({
-  //         CommerceOrder: () => ({
-  //           ...BuyOrderPickup,
-  //           ...CreditCardPaymentDetails,
-  //           displayState: "REFUNDED",
-  //         }),
-  //       })
-  //       const page = new StatusTestPage(wrapper)
+        it("should render correct title for private sale orders", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "CREDIT_CARD",
+              source: "private_sale",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-  //       expect(page.text()).toContain("Your order was canceled and refunded")
-  //       expect(page.getMessageLength()).toBe(1)
-  //     })
-  //   })
-  // })
+          expect(page.text()).toContain(
+            "Thank you for your purchase with Artsy Private Sales."
+          )
+        })
+
+        it("renders description", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "CREDIT_CARD",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
+
+          expect(page.text()).toContain(
+            "More delivery information will be available once your order ships."
+          )
+        })
+
+        it("should render correct description for private sale orders", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "CREDIT_CARD",
+              source: "private_sale",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
+
+          expect(page.text()).toContain(
+            "You will receive an email from our team with next steps."
+          )
+          expect(page.text()).toContain("privatesales@artsy.net.")
+        })
+
+        it("does not render an alert message", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...BuyOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "CREDIT_CARD",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
+
+          const message = page.getMessage()
+          expect(message.props().variant).not.toBe("alert")
+        })
+      })
+    })
+
+    describe("fulfilled (ship)", () => {
+      it("should say order has shipped and have message box", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...BuyOrderWithShippingDetails,
+            ...CreditCardPaymentDetails,
+            displayState: "FULFILLED",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
+
+        expect(page.text()).toContain("Your order has shipped")
+        expect(page.getMessageLength()).toBe(1)
+      })
+    })
+
+    describe("fulfilled (pickup)", () => {
+      it("should say order has been picked up and NOT have message box", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...BuyOrderPickup,
+            ...CreditCardPaymentDetails,
+            displayState: "FULFILLED",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
+
+        expect(page.text()).toContain("Your order has been picked up")
+        expect(page.find(Message).length).toBe(0)
+      })
+    })
+
+    describe("canceled (ship)", () => {
+      it("should say that order was canceled", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...BuyOrderWithShippingDetails,
+            ...CreditCardPaymentDetails,
+            displayState: "CANCELED",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
+
+        expect(page.text()).toContain("Your order was canceled and refunded")
+        expect(page.getMessageLength()).toBe(1)
+      })
+    })
+
+    describe("canceled (pickup)", () => {
+      it("should say that order was canceled", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...BuyOrderPickup,
+            ...CreditCardPaymentDetails,
+            displayState: "CANCELED",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
+
+        expect(page.text()).toContain("Your order was canceled and refunded")
+        expect(page.getMessageLength()).toBe(1)
+      })
+    })
+
+    describe("refunded", () => {
+      it("should say that order was canceled", async () => {
+        const wrapper = getWrapper({
+          CommerceOrder: () => ({
+            ...BuyOrderPickup,
+            ...CreditCardPaymentDetails,
+            displayState: "REFUNDED",
+          }),
+        })
+        const page = new StatusTestPage(wrapper)
+
+        expect(page.text()).toContain("Your order was canceled and refunded")
+        expect(page.getMessageLength()).toBe(1)
+      })
+    })
+  })
 })

--- a/src/Apps/Order/Routes/__tests__/Status.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Status.jest.tsx
@@ -179,114 +179,114 @@ describe("Status", () => {
           expect(page.getMessageLength()).toBe(1)
         })
 
-        // it("renders Message with alert variant and 'please proceed' message", async () => {
-        //   const wrapper = getWrapper({
-        //     CommerceOrder: () => ({
-        //       ...OfferOrderWithShippingDetails,
-        //       displayState: "PROCESSING_APPROVAL",
-        //       paymentMethod: "WIRE_TRANSFER",
-        //     }),
-        //   })
-        //   const page = new StatusTestPage(wrapper)
+        it("renders Message with alert variant and 'please proceed' message", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...OfferOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "WIRE_TRANSFER",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-        //   expect(page.text()).toContain(
-        //     "Please proceed with the wire transfer to complete your purchase"
-        //   )
+          expect(page.text()).toContain(
+            "Please proceed with the wire transfer to complete your purchase"
+          )
 
-        //   const message = page.getMessage()
-        //   expect(message.props().variant).toBe("alert")
-        // })
+          const message = page.getMessage()
+          expect(message.props().variant).toBe("alert")
+        })
 
-        // it("renders the alert Message with correct messages", async () => {
-        //   const wrapper = getWrapper({
-        //     CommerceOrder: () => ({
-        //       ...OfferOrderWithShippingDetails,
-        //       displayState: "PROCESSING_APPROVAL",
-        //       paymentMethod: "WIRE_TRANSFER",
-        //     }),
-        //   })
-        //   const page = new StatusTestPage(wrapper)
+        it("renders the alert Message with correct messages", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...OfferOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "WIRE_TRANSFER",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-        //   expect(page.text()).toContain(
-        //     "Please provide your proof of payment within 7 days. After this period, your order will be eligible for cancellation by the gallery."
-        //   )
-        //   expect(page.text()).toContain(
-        //     "Find the order total and Artsy’s banking details below."
-        //   )
-        //   expect(page.text()).toContain(
-        //     "Please inform your bank that you will be responsible for all wire transfer fees."
-        //   )
-        //   expect(page.text()).toContain(
-        //     "Once you have made the transfer, please email orders@artsy.net with your proof of payment."
-        //   )
-        // })
+          expect(page.text()).toContain(
+            "Please provide your proof of payment within 7 days. After this period, your order will be eligible for cancellation by the gallery."
+          )
+          expect(page.text()).toContain(
+            "Find the order total and Artsy’s banking details below."
+          )
+          expect(page.text()).toContain(
+            "Please inform your bank that you will be responsible for all wire transfer fees."
+          )
+          expect(page.text()).toContain(
+            "Once you have made the transfer, please email orders@artsy.net with your proof of payment."
+          )
+        })
 
-        // it("renders content for Artsy's bank details", async () => {
-        //   const wrapper = getWrapper({
-        //     CommerceOrder: () => ({
-        //       ...OfferOrderWithShippingDetails,
-        //       displayState: "PROCESSING_APPROVAL",
-        //       paymentMethod: "WIRE_TRANSFER",
-        //     }),
-        //   })
-        //   const page = new StatusTestPage(wrapper)
+        it("renders content for Artsy's bank details", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...OfferOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "WIRE_TRANSFER",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-        //   expect(page.text()).toContain("Send wire transfer to")
-        //   expect(page.text()).toContain("Account name: Art.sy Inc.")
-        //   expect(page.text()).toContain("Account number: 4243851425")
-        //   expect(page.text()).toContain("Routing number: 121000248")
-        //   expect(page.text()).toContain("International SWIFT: WFBIUS6S")
-        //   expect(page.text()).toContain("Bank address")
-        //   expect(page.text()).toContain("Wells Fargo Bank, N.A.")
-        //   expect(page.text()).toContain("420 Montgomery Street")
-        //   expect(page.text()).toContain("San Francisco, CA 9410")
-        // })
+          expect(page.text()).toContain("Send wire transfer to")
+          expect(page.text()).toContain("Account name: Art.sy Inc.")
+          expect(page.text()).toContain("Account number: 4243851425")
+          expect(page.text()).toContain("Routing number: 121000248")
+          expect(page.text()).toContain("International SWIFT: WFBIUS6S")
+          expect(page.text()).toContain("Bank address")
+          expect(page.text()).toContain("Wells Fargo Bank, N.A.")
+          expect(page.text()).toContain("420 Montgomery Street")
+          expect(page.text()).toContain("San Francisco, CA 9410")
+        })
       })
 
-      // describe("with non-wire payment methods", () => {
-      //   it("should say 'Offer accepted. Payment processing.' and have message box", async () => {
-      //     const wrapper = getWrapper({
-      //       CommerceOrder: () => ({
-      //         ...OfferOrderWithShippingDetails,
-      //         displayState: "PROCESSING_APPROVAL",
-      //         paymentMethod: "CREDIT_CARD",
-      //       }),
-      //     })
-      //     const page = new StatusTestPage(wrapper)
+      describe("with non-wire payment methods", () => {
+        it("should say 'Offer accepted. Payment processing.' and have message box", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...OfferOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "CREDIT_CARD",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-      //     expect(page.text()).toContain("Offer accepted. Payment processing.")
-      //     expect(page.getMessageLength()).toBe(1)
-      //   })
+          expect(page.text()).toContain("Offer accepted. Payment processing.")
+          expect(page.getMessageLength()).toBe(1)
+        })
 
-      //   it("renders description", async () => {
-      //     const wrapper = getWrapper({
-      //       CommerceOrder: () => ({
-      //         ...OfferOrderWithShippingDetails,
-      //         displayState: "PROCESSING_APPROVAL",
-      //         paymentMethod: "CREDIT_CARD",
-      //       }),
-      //     })
-      //     const page = new StatusTestPage(wrapper)
+        it("renders description", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...OfferOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "CREDIT_CARD",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-      //     expect(page.text()).toContain(
-      //       "More delivery information will be available once your order ships."
-      //     )
-      //   })
+          expect(page.text()).toContain(
+            "More delivery information will be available once your order ships."
+          )
+        })
 
-      //   it("does not render an alert message", async () => {
-      //     const wrapper = getWrapper({
-      //       CommerceOrder: () => ({
-      //         ...OfferOrderWithShippingDetails,
-      //         displayState: "PROCESSING_APPROVAL",
-      //         paymentMethod: "CREDIT_CARD",
-      //       }),
-      //     })
-      //     const page = new StatusTestPage(wrapper)
+        it("does not render an alert message", async () => {
+          const wrapper = getWrapper({
+            CommerceOrder: () => ({
+              ...OfferOrderWithShippingDetails,
+              displayState: "PROCESSING_APPROVAL",
+              paymentMethod: "CREDIT_CARD",
+            }),
+          })
+          const page = new StatusTestPage(wrapper)
 
-      //     const message = page.getMessage()
-      //     expect(message.props().variant).not.toBe("alert")
-      //   })
-      // })
+          const message = page.getMessage()
+          expect(message.props().variant).not.toBe("alert")
+        })
+      })
     })
 
     describe("in transit", () => {

--- a/src/Apps/Order/Utils/getStatusCopy.tsx
+++ b/src/Apps/Order/Utils/getStatusCopy.tsx
@@ -422,9 +422,10 @@ export const processingApprovalDescription = (
     )
   }
 
-  // non-private sale order with ACH (assumed)
-  return `Thank you for your purchase. ${deliverText(order)}More delivery
-  information will be available once your order ships.`
+  // non-private sale orders
+  return `Thank you for your purchase. ${deliverText(
+    order
+  )}More delivery information will be available once your order ships.`
 }
 
 export const deliverText = (order): React.ReactNode => {

--- a/src/Apps/Order/Utils/getStatusCopy.tsx
+++ b/src/Apps/Order/Utils/getStatusCopy.tsx
@@ -53,22 +53,12 @@ export const getStatusCopy = (order, logger?): StatusPageConfig => {
           }
     case "APPROVED":
       return {
-        title: approvedTitle(isOfferFlow),
-        description: isPickup ? (
-          <>
-            Thank you for your purchase. A specialist will contact you within 2
-            business days to coordinate pickup.
-          </>
-        ) : (
-          <>
-            Thank you for your purchase. You will be notified when the work has
-            shipped, typically within 5–7 business days.
-          </>
-        ),
+        title: approvedTitle(isOfferFlow, isPrivateSaleOrder),
+        description: approvedDescription(isPickup, isPrivateSaleOrder),
       }
     case "PROCESSING":
       return {
-        title: approvedTitle(isOfferFlow),
+        title: approvedTitle(isOfferFlow, false),
         description: (
           <>
             Thank you for your purchase. {deliverText(order)}More delivery
@@ -83,12 +73,11 @@ export const getStatusCopy = (order, logger?): StatusPageConfig => {
           isWireTransfer,
           isPrivateSaleOrder
         )}`,
-        description: `${processingApprovalDescription(
+        description: processingApprovalDescription(
           order,
           isWireTransfer,
-          isPrivateSaleOrder,
-          paymentMethod
-        )}`,
+          isPrivateSaleOrder
+        ),
         alertMessageTitle: isWireTransfer
           ? "Please proceed with the wire transfer to complete your purchase"
           : null,
@@ -352,8 +341,40 @@ export const shipmentDescription = (
 export const continueToInboxText =
   "Negotiation with the gallery will continue in the Inbox."
 
-export const approvedTitle = (isOfferFlow): string => {
-  return isOfferFlow ? "Offer accepted" : "Your order is confirmed"
+export const approvedTitle = (
+  isOfferFlow: boolean,
+  isPrivateSaleOrder: boolean
+): string => {
+  if (isOfferFlow) {
+    return "Offer accepted"
+  }
+
+  return isPrivateSaleOrder
+    ? "Thank you for working with Artsy Private Sales."
+    : "Your order is confirmed"
+}
+
+export const approvedDescription = (
+  isPickup: boolean,
+  isPrivateSaleOrder: boolean
+) => {
+  if (isPrivateSaleOrder) {
+    return (
+      <Text color="black100">
+        You will receive an email from our team with next steps. If you have any
+        questions about your purchase, email us at{" "}
+        <RouterLink to="privatesales@artsy.net">
+          privatesales@artsy.net.
+        </RouterLink>
+      </Text>
+    )
+  }
+
+  if (isPickup) {
+    return "Thank you for your purchase. A specialist will contact you within 2 business days to coordinate pickup."
+  }
+
+  return "Thank you for your purchase. You will be notified when the work has shipped, typically within 5–7 business days."
 }
 
 export const processingApprovalTitle = (
@@ -381,21 +402,27 @@ export const processingApprovalTitle = (
 export const processingApprovalDescription = (
   order,
   isWireTransfer,
-  isPrivateSaleOrder,
-  paymentMethod
-): string | null => {
+  isPrivateSaleOrder
+): string | JSX.Element | null => {
+  // if wire, return null regardless of isPrivateSaleOrder
   if (isWireTransfer) {
     return null
   }
 
+  // isPrivateSaleOrder and ACH (assumed)
   if (isPrivateSaleOrder) {
-    if (paymentMethod === "US_BANK_ACCOUNT") {
-      return "Find the details of your purchase below. We will email you with next steps shortly."
-    }
-
-    return "Thank you for your purchase. We will email you with next steps shortly."
+    return (
+      <Text color="black100">
+        You will receive an email from our team with next steps. If you have any
+        questions about your purchase, email us at{" "}
+        <RouterLink to="privatesales@artsy.net">
+          privatesales@artsy.net.
+        </RouterLink>
+      </Text>
+    )
   }
 
+  // non-private sale order with ACH (assumed)
   return `Thank you for your purchase. ${deliverText(order)}More delivery
   information will be available once your order ships.`
 }


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [TX-993]

### Description
This Pr updates the status page with the relevant copies for Private Sale orders. 


Credit Card 
<img width="1762" alt="CC status" src="https://user-images.githubusercontent.com/42584148/213461177-4c2493b9-8432-43fc-bcb7-6fd11920d668.png">

ACH 
<img width="1771" alt="ACH status" src="https://user-images.githubusercontent.com/42584148/213461197-15032a83-34a5-42e2-969b-b8c1ca43dd94.png">

Wire 
<img width="1779" alt="wire status" src="https://user-images.githubusercontent.com/42584148/213461232-a9c9f228-06f8-4358-8558-31eeca25f58b.png">



[TX-993]: https://artsyproduct.atlassian.net/browse/TX-993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ