### PR TITLE
fix: track `clickedNotificationsBell` event when activity panel icon is tapped

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -50,6 +50,7 @@ import { useJump } from "Utils/Hooks/useJump"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { useRouter } from "System/Router/useRouter"
 import { NavBarLoggedOutActions } from "Components/NavBar/NavBarLoggedOutActions"
+import { ActionType } from "@artsy/cohesion"
 
 /**
  * NOTE: Fresnel doesn't work correctly here because this is included
@@ -128,6 +129,14 @@ export const NavBar: React.FC = track(
     }
 
     return <NavBarMobileMenuNotificationsIndicatorQueryRenderer />
+  }
+
+  const handleNotificationsClick = () => {
+    router.push("/notifications")
+
+    trackEvent({
+      action: ActionType.clickedNotificationsBell,
+    })
   }
 
   if (isEigen) {
@@ -277,7 +286,7 @@ export const NavBar: React.FC = track(
                       display="flex"
                       alignItems="center"
                       justifyContent="center"
-                      onClick={() => router.push("/notifications")}
+                      onClick={handleNotificationsClick}
                     >
                       <BellIcon aria-hidden="true" height={22} width={22} />
                       {renderNotificationsIndicator()}


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/213499077-712bfb23-9806-46d8-8a37-a0b14facc62b.mp4

#### After
https://user-images.githubusercontent.com/3513494/213499163-aab3d8cf-1e15-46c2-8a5b-90f349fd008c.mp4

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ