### PR TITLE
fix(FX-4554): fixes overflowing artwork screen in firefox

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -192,7 +192,12 @@ export const ArtworkApp: React.FC<Props> = props => {
       <ArtworkTopContextBarFragmentContainer artwork={artwork} />
 
       <GridColumns>
-        <Column span={8}>
+        <Column
+          span={8}
+          // Fix for issue in Firefox where contents overflow container.
+          // Safe to remove once artwork masonry uses CSS grid.
+          width="100%"
+        >
           <ArtworkImageBrowserFragmentContainer artwork={artwork} />
 
           <Media greaterThanOrEqual="sm">


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4554]

Review app: [fixes-for-artwork-screen](https://fixes-for-artwork-screen.artsy.net/)

### Description
Layout is broken when you open artwork screen in firefox and change the window width from `~750px` to `~1250px`

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/213516640-ab652720-d255-4235-983c-eae0dcaf97ff.mp4

#### After
https://user-images.githubusercontent.com/3513494/213516747-a9f0a972-c052-4f1c-ab3d-17def352100b.mp4

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-4554]: https://artsyproduct.atlassian.net/browse/FX-4554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ