### PR TITLE
fix(art-quiz): remove footer from results page

### DIFF
--- a/src/Apps/ArtQuiz/artQuizRoutes.tsx
+++ b/src/Apps/ArtQuiz/artQuizRoutes.tsx
@@ -84,6 +84,7 @@ export const artQuizRoutes: AppRouteConfig[] = [
       {
         path: "results",
         getComponent: () => ArtQuizResults,
+        layout: "NavOnly",
         query: graphql`
           query artQuizRoutes_ArtQuizResultsQuery {
             me {


### PR DESCRIPTION
The type of this PR is: fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1506]

### Description
<!-- Implementation description -->
The goal of this PR is to remove the Artsy app download footer from the results page, so that users can focus on their artwork/artist recs and choices made during the quiz w/o distractions. 

https://user-images.githubusercontent.com/23108927/213530192-50a0d6f0-fb9b-4593-a740-118fdd189e13.mp4



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1506]: https://artsyproduct.atlassian.net/browse/GRO-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ