### PR TITLE
Update fallback content card for Trove

### DIFF
--- a/src/Apps/Home/Components/HomeContentCards/FallbackCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/FallbackCards.tsx
@@ -45,16 +45,16 @@ const makeContentCard = ({
 
 const fallbackData = [
   {
-    credit: "Illustration by Artsy.",
+    credit:
+      "Yuan Yuan, The Unstable Fibonacci Sequence, 2022. Molly Green, Unfix, 2022. Tidawhitney Lek, Broken Glasses, 2022. Jacopo Pagin, Hide Me! with Transparency, 2022.",
     description:
-      "A weekly curated selection of the best works on Artsy by emerging and sought-after artists. All works available now.",
+      "The best works by rising talents on Artsy, all available now.",
     id: 1,
-    imageUrl:
-      "https://d32dm0rphc51dk.cloudfront.net/Ank3B35DVzxLcI9azZBK2w/untouched-jpg.jpg",
+    imageUrl: "https://files.artsy.net/images/Content+Card-CPE-Jan12.jpg",
     label: "Featured Collection",
     linkText: "Browse Works",
-    title: "Trove: Editor’s Picks",
-    url: "https://www.artsy.net/collection/trove-editors-picks",
+    title: "Curators’ Picks: Emerging",
+    url: "/collection/curators-picks-emerging",
   },
   {
     credit:


### PR DESCRIPTION
This is one of the last pieces of the Trove rebrand and it just updates the fallback cards. These should rarely be seen by users but it's still nice to call a job complete ya know?

<img width="1240" alt="Screen Shot 2023-01-19 at 2 49 54 PM" src="https://user-images.githubusercontent.com/79799/213556716-7b2c0117-6666-4cd8-abf1-5f8b6e69fcff.png">

/cc @artsy/grow-devs