### PR TITLE
fix(TX-1009): review page will not error out if no image

### DIFF
--- a/src/Apps/Order/Components/ItemReview.tsx
+++ b/src/Apps/Order/Components/ItemReview.tsx
@@ -34,11 +34,9 @@ export const ItemReview: React.FC<ItemReviewProps> = ({
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       medium,
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      image: {
-        resized: { url },
-      },
+      image,
       // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      attributionClass: { shortDescription },
+      attributionClass,
     },
     editionSetId,
   },
@@ -72,10 +70,17 @@ export const ItemReview: React.FC<ItemReviewProps> = ({
           </Text>
         )}
         <Text variant="sm" color="black60">
-          {shortDescription}
+          {attributionClass.shortDescription}
         </Text>
       </Flex>
-      <Image maxHeight={375} width={185} src={url} alt={title} />
+      {image && image.resized && (
+        <Image
+          maxHeight={375}
+          width={185}
+          src={image.resized.url}
+          alt={title}
+        />
+      )}
     </BorderBox>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-1009]

### Description

This PR makes it so when the artwork version image "resized" is null on the review page, the UI will not error out. 
<!-- Implementation description -->
<img width="1742" alt="Screenshot 2023-01-20 at 9 52 44 AM" src="https://user-images.githubusercontent.com/50849237/213655273-40c2a8f9-d06a-4e68-8494-d520a1ee5751.png">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-1009]: https://artsyproduct.atlassian.net/browse/TX-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ