### PR TITLE
fix(art-quiz): hide loader from results after user revisits 

### DIFF
--- a/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
@@ -21,13 +21,15 @@ import {
 } from "Apps/ArtQuiz/Components/ArtQuizCard"
 import { useSwipe } from "Apps/ArtQuiz/Hooks/useSwipe"
 import { useDislikeArtwork } from "Apps/ArtQuiz/Hooks/useDislikeArtwork"
-import { FC, useCallback, useMemo, useRef } from "react"
+
+import { FC, useCallback, useMemo, useRef, useState } from "react"
 import { RouterLink } from "System/Router/RouterLink"
 import { useRouter } from "System/Router/useRouter"
 import { FullscreenBox } from "Components/FullscreenBox"
 import { ArtQuizFullScreen } from "Apps/ArtQuiz/Components/ArtQuizFullscreen"
 import { useUpdateQuiz } from "Apps/ArtQuiz/Hooks/useUpdateQuiz"
 import { useSaveArtwork } from "Apps/ArtQuiz/Hooks/useSaveArtwork"
+import { ArtQuizResultsLoader } from "Apps/ArtQuiz/Components/ArtQuizResultsLoader"
 
 interface ArtQuizArtworksProps {
   me: ArtQuizArtworks_me$data
@@ -38,6 +40,7 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
   const { submitMutation: submitSave } = useSaveArtwork()
   const { submitMutation: submitUpdate } = useUpdateQuiz()
   const { router } = useRouter()
+  const [showLoader, setShowLoader] = useState(false)
 
   // clone to make the array writable for sorting
   const edges = me.quiz.quizArtworkConnection?.edges
@@ -105,6 +108,7 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
     }
 
     dispatch({ type: "Previous" })
+
     if (activeIndex === 0) {
       router.push("/art-quiz/welcome")
     }
@@ -157,8 +161,10 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
       }
 
       dispatch({ type: action })
+
       if (activeIndex === cards.length - 1) {
         router.push("/art-quiz/results")
+        setShowLoader(true)
       }
     },
     [
@@ -195,6 +201,14 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
   // prevents a false position from being displayed after the last quiz image, e.g. 17/16
   const positionDisplay =
     activeIndex + 1 > cards.length ? cards.length : activeIndex + 1
+
+  const handleReady = useCallback(() => {
+    router.push("/art-quiz/results")
+  }, [router])
+
+  if (showLoader) {
+    return <ArtQuizResultsLoader onReady={handleReady} />
+  }
 
   return (
     <ArtQuizFullScreen>

--- a/src/Apps/ArtQuiz/Routes/ArtQuizResults.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizResults.tsx
@@ -1,9 +1,7 @@
 import { ArtQuizResultsEmpty } from "Apps/ArtQuiz/Components/ArtQuizResultsEmpty"
-import { ArtQuizResultsLoader } from "Apps/ArtQuiz/Components/ArtQuizResultsLoader"
 import { ArtQuizResultsTabs } from "Apps/ArtQuiz/Components/ArtQuizResultsTabs"
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { useMode } from "Utils/Hooks/useMode"
 import { ArtQuizResults_me$data } from "__generated__/ArtQuizResults_me.graphql"
 
 interface ArtQuizResultsProps {
@@ -14,26 +12,13 @@ const ArtQuizResults: FC<ArtQuizResultsProps> = ({ me }) => {
   const savedQuizArtworksCount = me.quiz.savedArtworks.length
   const hasSavedArtworks = savedQuizArtworksCount > 0
 
-  const [mode, setMode] = useMode<"Empty" | "Loading" | "Ready">(
-    hasSavedArtworks ? "Loading" : "Empty"
-  )
-
-  const handleReady = () => {
-    setMode("Ready")
+  if (hasSavedArtworks) {
+    return (
+      <ArtQuizResultsTabs savedQuizArtworksCount={savedQuizArtworksCount} />
+    )
   }
 
-  switch (mode) {
-    case "Empty":
-      return <ArtQuizResultsEmpty />
-
-    case "Loading":
-      return <ArtQuizResultsLoader onReady={handleReady} />
-
-    case "Ready":
-      return (
-        <ArtQuizResultsTabs savedQuizArtworksCount={savedQuizArtworksCount} />
-      )
-  }
+  return <ArtQuizResultsEmpty />
 }
 
 export const ArtQuizResultsFragmentContainer = createFragmentContainer(

--- a/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
+++ b/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
@@ -44,16 +44,6 @@ describe("ArtQuizResults", () => {
         }),
       })
 
-      expect(screen.getByText("Calculating Results…")).toBeInTheDocument()
-
-      jest.advanceTimersByTime(2000)
-      await flushPromiseQueue()
-
-      expect(screen.getByText("Results Complete")).toBeInTheDocument()
-
-      jest.advanceTimersByTime(1000)
-      await flushPromiseQueue()
-
       expect(screen.getByText("Explore Your Quiz Results")).toBeInTheDocument()
       expect(
         screen.getByText(

--- a/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
+++ b/src/Apps/ArtQuiz/__tests__/ArtQuizResults.jest.tsx
@@ -1,6 +1,5 @@
 import { ArtQuizResultsFragmentContainer } from "Apps/ArtQuiz/Routes/ArtQuizResults"
 import { screen } from "@testing-library/react"
-import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 


### PR DESCRIPTION
Co-authored-by: Laura Bhayani <laurabeth@users.noreply.github.com>

The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1522]

<!-- Implementation description -->

The goal of this PR is to hide the loader from users who revisit their art quiz results, and makes for a better UI experience. Currently a WIP while another bug centralized around the `ArtQuizArtworks` is being investigated and is causing really strange behavior. 


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1522]: https://artsyproduct.atlassian.net/browse/GRO-1522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ