### PR TITLE
fix(signup): uses a placeholder to only render form once we are ready

### DIFF
--- a/src/Components/Authentication/Components/AuthenticationSignUpPlaceholder.tsx
+++ b/src/Components/Authentication/Components/AuthenticationSignUpPlaceholder.tsx
@@ -1,0 +1,70 @@
+import {
+  Box,
+  Button,
+  Join,
+  Skeleton,
+  SkeletonBox,
+  SkeletonText,
+  Spacer,
+} from "@artsy/palette"
+import { FC } from "react"
+
+export const AuthenticationSignUpPlaceholder: FC = () => {
+  return (
+    <Skeleton>
+      <Join separator={<Spacer y={2} />}>
+        <SkeletonInput name="Name" />
+
+        <SkeletonInput name="Email" />
+
+        <SkeletonInput name="Password">
+          <Spacer y={0.5} />
+
+          <SkeletonText variant="xs">
+            Password must be at least 8 characters and include a lowercase
+            letter, uppercase letter, and digit.
+          </SkeletonText>
+        </SkeletonInput>
+
+        <Button width="100%" disabled />
+
+        <SkeletonText textAlign="center">or</SkeletonText>
+
+        <Button variant="secondaryBlack" width="100%" disabled />
+        <Button variant="secondaryBlack" width="100%" disabled />
+        <Button variant="secondaryBlack" width="100%" disabled />
+
+        <Join separator={<Spacer y={1} />}>
+          <SkeletonText variant="xs" textAlign="center" mt={-1}>
+            Already have an account? Log in.
+          </SkeletonText>
+
+          <SkeletonText variant="xs" textAlign="center">
+            By clicking Sign up or Continue with Apple, Google, or Facebook, you
+            agree to Artsy’s Terms of Use and Privacy Policy and to receiving
+            emails from Artsy.
+          </SkeletonText>
+
+          <SkeletonText variant="xs" textAlign="center">
+            This site is protected by reCAPTCHA and the Google Privacy Policy
+            and Terms of Service apply.
+          </SkeletonText>
+        </Join>
+      </Join>
+    </Skeleton>
+  )
+}
+
+const SkeletonInput: FC<{ name: string }> = ({ name, children }) => {
+  return (
+    <Box>
+      <SkeletonText variant="xs">{name}</SkeletonText>
+
+      <Spacer y={0.5} />
+
+      <SkeletonBox height={50} />
+
+      {children}
+    </Box>
+  )
+}

--- a/src/Components/Authentication/Views/SignUpForm.tsx
+++ b/src/Components/Authentication/Views/SignUpForm.tsx
@@ -18,6 +18,7 @@ import { AuthenticationPasswordInput } from "Components/Authentication/Component
 import { AuthenticationCheckbox } from "Components/Authentication/Components/AuthenticationCheckbox"
 import { AuthenticationFooter } from "Components/Authentication/Components/AuthenticationFooter"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import { AuthenticationSignUpPlaceholder } from "Components/Authentication/Components/AuthenticationSignUpPlaceholder"
 
 const gdprCountries = [
   "AT",
@@ -245,18 +246,23 @@ export const SignUpFormQueryRenderer: React.FC<FormProps> = passedProps => {
           }
         }
       `}
-      placeholder={<SignUpForm {...passedProps} />}
+      placeholder={<AuthenticationSignUpPlaceholder />}
       render={({ error, props }) => {
-        if (error || !props || !props.requestLocation) {
-          return <SignUpFormFragmentContainer {...passedProps} />
-        } else {
-          return (
-            <SignUpFormFragmentContainer
-              {...passedProps}
-              requestLocation={props.requestLocation}
-            />
-          )
+        if (error) {
+          console.error(error)
+          return <SignUpForm {...passedProps} />
         }
+
+        if (!props?.requestLocation) {
+          return <AuthenticationSignUpPlaceholder />
+        }
+
+        return (
+          <SignUpFormFragmentContainer
+            {...passedProps}
+            requestLocation={props.requestLocation}
+          />
+        )
       }}
     />
   )


### PR DESCRIPTION
The bug was/is that the form was rendering initially with an empty `requestLocation`, this caused `isAutomaticallySubscribed` to be `false`, which set the initial value of `agreed_to_receive_emails` to `false`. Later on the `requestLocation` comes back with, say, `"US"` as the value; causing the form to render without the checkbox, but since the initial value is already set within Formik, it's not updated. So the form submits with the erroneous initial value.

I'm not entirely sure what caused this problem to manifest or how it was working previously but https://github.com/artsy/metaphysics/pull/4692 fixed cases in which this query would sometimes error, and we were previously always rendering the fragment container, with or without the `requestLocation`.

This PR sets it up so that we see a loading placeholder if the query is loading and only render the form once we actually have the data. This ensures that the initial value is set correctly.