### PR TITLE
refactor(auction-results): removes usage of modal; clean up

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -222,6 +222,8 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
         onRendered={handleMarketStatsRendered}
       />
 
+      <Spacer y={6} />
+
       <Jump id="artistAuctionResultsTop" />
 
       <Text variant={["sm-display", "lg-display"]}>Auction Results</Text>

--- a/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -1,6 +1,6 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
-import { Box, Column, GridColumns, Select, Text } from "@artsy/palette"
+import { Column, GridColumns, Select, Text } from "@artsy/palette"
 import { formatSellThroughRate } from "Apps/Artwork/Utils/insightHelpers"
 import { rest } from "lodash"
 import * as React from "react"
@@ -29,7 +29,10 @@ export const MarketStats: React.FC<MarketStatsProps> = ({
 
   const priceInsights = extractNodes(priceInsightsConnection)
 
-  useEffect(() => onRendered?.(priceInsights.length > 0), [priceInsights])
+  useEffect(() => onRendered?.(priceInsights.length > 0), [
+    onRendered,
+    priceInsights,
+  ])
 
   const [selectedPriceInsight, setSelectedPriceInsight] = useState(
     priceInsights[0]
@@ -70,7 +73,7 @@ export const MarketStats: React.FC<MarketStatsProps> = ({
   )
 
   return (
-    <Box mb={[4, 12]} mt={[0, 6]}>
+    <>
       <Text variant={["sm-display", "lg-display"]}>
         Market Signals{" "}
         <MarketStatsInfoButton
@@ -205,7 +208,7 @@ export const MarketStats: React.FC<MarketStatsProps> = ({
           </GridColumns>
         </Column>
       </GridColumns>
-    </Box>
+    </>
   )
 }
 

--- a/src/Apps/Artist/Routes/AuctionResults/Components/MarketStatsInfoButton.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/MarketStatsInfoButton.tsx
@@ -1,10 +1,19 @@
-import { Box, InfoCircleIcon, Modal, Text } from "@artsy/palette"
-import { useState } from "react";
-import * as React from "react";
+import {
+  Box,
+  Clickable,
+  InfoCircleIcon,
+  Join,
+  ModalDialog,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { useState } from "react"
+import * as React from "react"
 
 interface MarketStatsInfoButtonProps {
   onClick?: () => void
 }
+
 export const MarketStatsInfoButton: React.FC<MarketStatsInfoButtonProps> = ({
   onClick,
 }) => {
@@ -12,80 +21,86 @@ export const MarketStatsInfoButton: React.FC<MarketStatsInfoButtonProps> = ({
 
   return (
     <>
-      <InfoCircleIcon
+      <Clickable
         onClick={() => {
           setShowModal(true)
           onClick?.()
         }}
-      />
-      <Modal
-        title="Market Signals"
-        show={showModal}
-        onClose={() => setShowModal(false)}
-        isWide
       >
-        <Box>
-          <Box pb={2}>
-            <Text variant="sm">
-              <p>
+        <InfoCircleIcon />
+      </Clickable>
+
+      {showModal && (
+        <ModalDialog title="Market Signals" onClose={() => setShowModal(false)}>
+          <Text variant="sm">
+            <Join separator={<Spacer y={2} />}>
+              <Box>
                 The following data points provide an overview of an artist’s
                 auction market for a specific medium (e.g., photography,
                 painting) over the past 36 months.
-              </p>
-              <p>
+              </Box>
+
+              <Box>
                 These market signals bring together data from top auction houses
                 around the world, including Christie’s, Sotheby’s, Phillips,
                 Bonhams, and Heritage.
-              </p>
-              <p>
+              </Box>
+
+              <Box>
                 In this data set, please note that the sale price includes the
                 hammer price and buyer’s premium, as well as any other
                 additional fees (e.g., Artist’s Resale Rights).
-              </p>
-            </Text>
-          </Box>
-          <Box>
-            <Box pb={2}>
-              <Text variant="sm" fontWeight="bold" pb={0.5}>
-                Yearly lots sold
-              </Text>
-              <Text variant="sm">
-                The average number of lots sold per year at auction over the
-                past 36 months.
-              </Text>
-            </Box>
-            <Box pb={2}>
-              <Text variant="sm" fontWeight="bold" pb={0.5}>
-                Sell-through rate
-              </Text>
-              <Text variant="sm">
-                The percentage of lots in auctions that sold over the past 36
-                months.
-              </Text>
-            </Box>
-            <Box pb={2}>
-              <Text variant="sm" fontWeight="bold" pb={0.5}>
-                Average sale price
-              </Text>
-              <Text variant="sm">
-                The average sale price of lots sold at auction over the past 36
-                months.
-              </Text>
-            </Box>
-            <Box pb={2}>
-              <Text variant="sm" fontWeight="bold" pb={0.5}>
-                Sale price over estimate
-              </Text>
-              <Text variant="sm">
-                The average percentage difference of the sale price over the
-                mid-estimate (the midpoint of the low and high estimates set by
-                the auction house before the auction takes place) for lots sold
-                at auction over the past 36 months.
-              </Text>
-            </Box>
-          </Box>
-        </Box>
-      </Modal>
+              </Box>
+
+              <Box>
+                <Box as="strong">Yearly lots sold</Box>
+
+                <Spacer y={0.5} />
+
+                <Box>
+                  The average number of lots sold per year at auction over the
+                  past 36 months.
+                </Box>
+              </Box>
+
+              <Box>
+                <Box as="strong">Sell-through rate</Box>
+
+                <Spacer y={0.5} />
+
+                <Box>
+                  The percentage of lots in auctions that sold over the past 36
+                  months.
+                </Box>
+              </Box>
+
+              <Box>
+                <Box as="strong">Average sale price</Box>
+
+                <Spacer y={0.5} />
+
+                <Box>
+                  The average sale price of lots sold at auction over the past
+                  36 months.
+                </Box>
+              </Box>
+
+              <Box>
+                <Box as="strong">Sale price over estimate</Box>
+
+                <Spacer y={0.5} />
+
+                <Box>
+                  The average percentage difference of the sale price over the
+                  mid-estimate (the midpoint of the low and high estimates set
+                  by the auction house before the auction takes place) for lots
+                  sold at auction over the past 36 months.
+                </Box>
+              </Box>
+            </Join>
+          </Text>
+        </ModalDialog>
+      )}
     </>
   )
 }


### PR DESCRIPTION
Currently going through great pains to remove our remaining legacy Force modal usage. This appears to be the last usage of the deprecated Palette Modal. After this is merged I'll release a canary with that removed to see.