### PR TITLE
feat: update available payment methods for private sale orders

### DIFF
--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -68,44 +68,28 @@ export const PaymentContent: FC<Props> = props => {
     }
   }, [order, selectedPaymentMethod, tracking])
 
-  // we can be sure that when 1 method is available, it'll always be credit card
-  if (order.availablePaymentMethods.length === 1) {
-    return (
-      <>
-        <CreditCardPickerFragmentContainer
-          commitMutation={props.commitMutation}
-          me={me}
-          order={order}
-          innerRef={CreditCardPicker}
-        />
-        <Spacer y={4} />
-        <SaveAndContinueButton
-          media={{ greaterThan: "xs" }}
-          onClick={onSetPayment}
-        />
-        <Spacer y={2} />
-      </>
-    )
-  }
-
   return (
     <>
-      <Text variant="lg-display">Payment method</Text>
-      <Spacer y={2} />
-      <RadioGroup
-        data-test="payment-methods"
-        onSelect={val => {
-          setSelectedPaymentMethod(val as CommercePaymentMethodEnum)
-        }}
-        defaultValue={selectedPaymentMethod}
-      >
-        {getAvailablePaymentMethods(order.availablePaymentMethods).map(
-          method => method
-        )}
-      </RadioGroup>
-      <Spacer y={4} />
-      <Text variant="lg-display">Payment details</Text>
-      <Spacer y={2} />
+      {order.availablePaymentMethods.length > 1 && (
+        <>
+          <Text variant="lg-display">Payment method</Text>
+          <Spacer y={2} />
+          <RadioGroup
+            data-test="payment-methods"
+            onSelect={val => {
+              setSelectedPaymentMethod(val as CommercePaymentMethodEnum)
+            }}
+            defaultValue={selectedPaymentMethod}
+          >
+            {getAvailablePaymentMethods(order.availablePaymentMethods).map(
+              method => method
+            )}
+          </RadioGroup>
+          <Spacer y={4} />
+          <Text variant="lg-display">Payment details</Text>
+          <Spacer y={2} />
+        </>
+      )}
 
       {/* Credit card */}
       <Collapse open={selectedPaymentMethod === "CREDIT_CARD"}>
@@ -171,21 +155,25 @@ const getAvailablePaymentMethods = (
   availablePaymentMethods: readonly CommercePaymentMethodEnum[]
 ): ReactElement<RadioProps>[] => {
   let paymentMethod: CommercePaymentMethodEnum = "CREDIT_CARD"
-  const paymentMethods = [
-    <BorderedRadio
-      data-test-id="credit-card"
-      key="CREDIT_CARD"
-      value={paymentMethod}
-      label={
-        <>
-          <CreditCardIcon type="Unknown" fill="black100" />
-          <Text variant="sm-display" ml={0.5}>
-            Credit card
-          </Text>
-        </>
-      }
-    />,
-  ]
+  const paymentMethods: Array<ReactElement<RadioProps>> = []
+
+  if (availablePaymentMethods.includes("CREDIT_CARD")) {
+    paymentMethods.push(
+      <BorderedRadio
+        data-test-id="credit-card"
+        key="CREDIT_CARD"
+        value={paymentMethod}
+        label={
+          <>
+            <CreditCardIcon type="Unknown" fill="black100" />
+            <Text variant="sm-display" ml={0.5}>
+              Credit card
+            </Text>
+          </>
+        }
+      />
+    )
+  }
 
   // push wire transfer as the last option
   if (availablePaymentMethods.includes("WIRE_TRANSFER")) {
@@ -251,6 +239,7 @@ const getAvailablePaymentMethods = (
       </BorderedRadio>
     )
   }
+
   return paymentMethods
 }
 

--- a/src/Apps/Order/Utils/__tests__/orderUtils.jest.ts
+++ b/src/Apps/Order/Utils/__tests__/orderUtils.jest.ts
@@ -1,5 +1,4 @@
-import { getInitialPaymentMethodValue } from "./../orderUtils"
-import { isPaymentSet } from "../orderUtils"
+import { getInitialPaymentMethodValue, isPaymentSet } from "./../orderUtils"
 import {
   CommercePaymentMethodEnum,
   Payment_order$data,
@@ -84,6 +83,16 @@ describe("order utils", () => {
             availablePaymentMethods: ["CREDIT_CARD", "WIRE_TRANSFER"],
           } as unknown) as Payment_order$data)
         ).toEqual("CREDIT_CARD")
+      })
+
+      it("returns WIRE_TRANSFER if available payment methods doesn't include US_BANK_ACCOUNT and CREDIT_CARD", () => {
+        expect(
+          getInitialPaymentMethodValue(({
+            paymentMethodDetails: null,
+            paymentMethod: "CREDIT_CARD",
+            availablePaymentMethods: ["WIRE_TRANSFER"],
+          } as unknown) as Payment_order$data)
+        ).toEqual("WIRE_TRANSFER")
       })
     })
   })

--- a/src/Apps/Order/Utils/orderUtils.ts
+++ b/src/Apps/Order/Utils/orderUtils.ts
@@ -1,13 +1,14 @@
+import { BankAccountSelection } from "Apps/Order/Routes/Payment"
 import {
   CommercePaymentMethodEnum,
   Payment_order$data,
 } from "__generated__/Payment_order.graphql"
-import { BankAccountSelection } from "../Routes/Payment/index"
 
 const initialPaymentMethods: CommercePaymentMethodEnum[] = [
   "US_BANK_ACCOUNT",
   "SEPA_DEBIT",
   "CREDIT_CARD",
+  "WIRE_TRANSFER",
 ]
 
 export const isPaymentSet = (


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-992]

### Description

This PR updates the payment step to stop using credit cart as a default payment method.  


![Screenshot from 2023-01-24 15-51-09](https://user-images.githubusercontent.com/79979820/214302476-00fd8147-06be-4aaa-809f-b0cb7e5de797.png)
![Screenshot from 2023-01-24 15-50-42](https://user-images.githubusercontent.com/79979820/214302492-52e6264b-4f5e-41af-bc65-f6ff4ebeca73.png)


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-992]: https://artsyproduct.atlassian.net/browse/TX-992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ