### PR TITLE
chore(auth-dialog): migrates remaining triggers

### DIFF
--- a/src/Apps/Article/ArticleApp.tsx
+++ b/src/Apps/Article/ArticleApp.tsx
@@ -11,30 +11,14 @@ import { ArticleVideoFragmentContainer } from "./Components/ArticleVideo"
 import { ArticleAdProvider } from "./Components/ArticleAd"
 import { ArticleVisibilityMetadataFragmentContainer } from "./Components/ArticleVisibilityMetadata"
 import { ArticleMetaTagsFragmentContainer } from "./Components/ArticleMetaTags"
-import { useScrollToOpenAuthModal } from "Utils/Hooks/useScrollToOpenAuthModal"
-import { ContextModule, Intent } from "@artsy/cohesion"
-import { useRouter } from "System/Router/useRouter"
+import { useScrollToOpenEditorialAuthModal } from "Utils/Hooks/useScrollToOpenEditorialAuthModal"
 
 interface ArticleAppProps {
   article: ArticleApp_article$data
 }
 
 const ArticleApp: FC<ArticleAppProps> = ({ article }) => {
-  const {
-    match: { location },
-  } = useRouter()
-
-  useScrollToOpenAuthModal({
-    key: "editorial-signup-dismissed",
-    modalOptions: {
-      intent: Intent.viewEditorial,
-      contextModule: ContextModule.popUpModal,
-      copy: "Sign up for the latest in art market news",
-      // TODO: Onboarding is triggered based on contents of redirectTo
-      // prop. Move this to `afterSignupAction.action`
-      redirectTo: location.pathname,
-    },
-  })
+  useScrollToOpenEditorialAuthModal()
 
   return (
     <ArticleAdProvider>

--- a/src/Apps/Articles/ArticlesApp.tsx
+++ b/src/Apps/Articles/ArticlesApp.tsx
@@ -6,22 +6,14 @@ import { MetaTags } from "Components/MetaTags"
 import { ArticlesIndexArticlesPaginationContainer } from "./Components/ArticlesIndexArticles"
 import { getENV } from "Utils/getENV"
 import { ArticlesApp_viewer$data } from "__generated__/ArticlesApp_viewer.graphql"
-import { useScrollToOpenAuthModal } from "Utils/Hooks/useScrollToOpenAuthModal"
-import { ContextModule, Intent } from "@artsy/cohesion"
+import { useScrollToOpenEditorialAuthModal } from "Utils/Hooks/useScrollToOpenEditorialAuthModal"
 
 interface ArticlesAppProps {
   viewer: ArticlesApp_viewer$data
 }
 
 const ArticlesApp: FC<ArticlesAppProps> = ({ viewer }) => {
-  useScrollToOpenAuthModal({
-    key: "editorial-signup-dismissed",
-    modalOptions: {
-      intent: Intent.viewEditorial,
-      contextModule: ContextModule.popUpModal,
-      copy: "Sign up for the latest in art market news",
-    },
-  })
+  useScrollToOpenEditorialAuthModal()
 
   return (
     <>

--- a/src/Apps/Articles/NewsApp.tsx
+++ b/src/Apps/Articles/NewsApp.tsx
@@ -7,21 +7,14 @@ import { getENV } from "Utils/getENV"
 import { NewsApp_viewer$data } from "__generated__/NewsApp_viewer.graphql"
 import { NewsIndexArticlesPaginationContainer } from "./Components/NewsIndexArticles"
 import { ArticleAdProvider } from "Apps/Article/Components/ArticleAd"
-import { useScrollToOpenAuthModal } from "Utils/Hooks/useScrollToOpenAuthModal"
-import { ContextModule, Intent } from "@artsy/cohesion"
+import { useScrollToOpenEditorialAuthModal } from "Utils/Hooks/useScrollToOpenEditorialAuthModal"
+
 interface NewsAppProps {
   viewer: NewsApp_viewer$data
 }
 
 const NewsApp: FC<NewsAppProps> = ({ viewer }) => {
-  useScrollToOpenAuthModal({
-    key: "editorial-signup-dismissed",
-    modalOptions: {
-      intent: Intent.viewEditorial,
-      contextModule: ContextModule.popUpModal,
-      copy: "Sign up for the latest in art market news",
-    },
-  })
+  useScrollToOpenEditorialAuthModal()
 
   return (
     <ArticleAdProvider>

--- a/src/Components/AuthDialog/AuthDialog.tsx
+++ b/src/Components/AuthDialog/AuthDialog.tsx
@@ -33,9 +33,14 @@ export const AuthDialog: FC<AuthDialogProps> = ({ onClose }) => {
     track.impression({ title })
   }, [title, track])
 
+  const handleClose = () => {
+    onClose()
+    options.onClose?.()
+  }
+
   return (
     <ModalDialog
-      onClose={onClose}
+      onClose={handleClose}
       title={title}
       hasLogo
       m={[1, 2]}

--- a/src/Components/AuthDialog/AuthDialogContext.tsx
+++ b/src/Components/AuthDialog/AuthDialogContext.tsx
@@ -38,6 +38,8 @@ export type AuthDialogOptions = {
   redirectTo?: string
   /** Copy displayed in dialog header */
   title?: string | ((mode: AuthDialogMode) => string)
+  onClose?: () => void
+  onSuccess?: () => void
 }
 
 type AuthDialogAnalytics = {

--- a/src/Components/AuthDialog/Views/AuthDialogForgotPassword.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogForgotPassword.tsx
@@ -16,7 +16,10 @@ import { formatErrorMessage } from "Components/AuthDialog/Utils/formatErrorMessa
 import { useAuthDialogTracking } from "Components/AuthDialog/Hooks/useAuthDialogTracking"
 
 export const AuthDialogForgotPassword: FC = () => {
-  const { dispatch } = useAuthDialogContext()
+  const {
+    dispatch,
+    state: { options },
+  } = useAuthDialogContext()
 
   const track = useAuthDialogTracking()
 
@@ -35,6 +38,8 @@ export const AuthDialogForgotPassword: FC = () => {
           setFieldValue("mode", "Success")
 
           track.resetPassword()
+
+          options.onSuccess?.()
         } catch (err) {
           console.error(err)
 

--- a/src/Components/AuthDialog/Views/AuthDialogLogin.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogLogin.tsx
@@ -20,7 +20,10 @@ import { formatErrorMessage } from "Components/AuthDialog/Utils/formatErrorMessa
 import { useAuthDialogTracking } from "Components/AuthDialog/Hooks/useAuthDialogTracking"
 
 export const AuthDialogLogin: FC = () => {
-  const { dispatch } = useAuthDialogContext()
+  const {
+    dispatch,
+    state: { options },
+  } = useAuthDialogContext()
 
   const { runAfterAuthentication } = useAfterAuthentication()
 
@@ -51,6 +54,8 @@ export const AuthDialogLogin: FC = () => {
           setFieldValue("mode", "Success")
 
           track.loggedIn({ service: "email", userId: user.id })
+
+          options.onSuccess?.()
         } catch (err) {
           console.error(err)
 

--- a/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
@@ -34,7 +34,10 @@ interface AuthDialogSignUpProps {
 export const AuthDialogSignUp: FC<AuthDialogSignUpProps> = ({
   requestLocation,
 }) => {
-  const { dispatch } = useAuthDialogContext()
+  const {
+    dispatch,
+    state: { options },
+  } = useAuthDialogContext()
 
   const { runAfterAuthentication } = useAfterAuthentication()
 
@@ -73,6 +76,8 @@ export const AuthDialogSignUp: FC<AuthDialogSignUpProps> = ({
           setFieldValue("mode", "Success")
 
           track.signedUp({ service: "email", userId: user.id })
+
+          options.onSuccess?.()
         } catch (err) {
           console.error(err)
 

--- a/src/Utils/Hooks/useScrollToOpenAuthModal.ts
+++ b/src/Utils/Hooks/useScrollToOpenAuthModal.ts
@@ -1,19 +1,21 @@
 import { getENV } from "Utils/getENV"
 import { mediator } from "Server/mediator"
-import { ModalOptions, ModalType } from "Components/Authentication/Types"
-import { openAuthModal } from "Utils/openAuthModal"
 import { useEffect } from "react"
 import Cookies from "cookies-js"
+import { useAuthDialog, ShowAuthDialog } from "Components/AuthDialog"
+import { merge } from "lodash"
 
 interface UseScrollToOpenAuthModal {
   key: string
-  modalOptions: ModalOptions
+  options: Parameters<ShowAuthDialog>[0]
 }
 
 export const useScrollToOpenAuthModal = ({
   key,
-  modalOptions,
+  options,
 }: UseScrollToOpenAuthModal) => {
+  const { showAuthDialog } = useAuthDialog()
+
   useEffect(() => {
     // Does not display if previously dismissed, is mobile, or is logged in
     if (Cookies.get(key) || getENV("IS_MOBILE") || getENV("CURRENT_USER")) {
@@ -26,11 +28,19 @@ export const useScrollToOpenAuthModal = ({
 
     const handleScroll = () => {
       setTimeout(() => {
-        openAuthModal(mediator, {
-          mode: ModalType.signup,
-          triggerSeconds: 2,
-          ...modalOptions,
-        })
+        const payload = merge(
+          {
+            current: {
+              options: {
+                onClose: dismiss,
+                onSuccess: dismiss,
+              },
+            },
+          },
+          options
+        )
+
+        showAuthDialog(payload)
       }, 2000)
     }
 
@@ -43,5 +53,5 @@ export const useScrollToOpenAuthModal = ({
       mediator.off("modal:closed", dismiss)
       mediator.off("auth:sign_up:success", dismiss)
     }
-  }, [key, modalOptions])
+  }, [key, options, showAuthDialog])
 }

--- a/src/Utils/Hooks/useScrollToOpenEditorialAuthModal.ts
+++ b/src/Utils/Hooks/useScrollToOpenEditorialAuthModal.ts
@@ -1,0 +1,38 @@
+import { ContextModule, Intent } from "@artsy/cohesion"
+import { ModalType } from "Components/Authentication/Types"
+import { useRouter } from "found"
+import { useScrollToOpenAuthModal } from "Utils/Hooks/useScrollToOpenAuthModal"
+
+export const useScrollToOpenEditorialAuthModal = () => {
+  const {
+    match: { location },
+  } = useRouter()
+
+  useScrollToOpenAuthModal({
+    key: "editorial-signup-dismissed",
+    options: {
+      current: {
+        mode: "SignUp",
+        options: {
+          title: mode => {
+            const action = mode === "SignUp" ? "Sign up" : "Log in"
+            return `${action} for the latest in art market news`
+          },
+        },
+        analytics: {
+          contextModule: ContextModule.popUpModal,
+          intent: Intent.viewEditorial,
+          trigger: "scroll",
+        },
+      },
+      legacy: {
+        mode: ModalType.signup,
+        contextModule: ContextModule.popUpModal,
+        copy: "Sign up for the latest in art market news",
+        intent: Intent.viewEditorial,
+        redirectTo: location.pathname,
+        triggerSeconds: 2,
+      },
+    },
+  })
+}


### PR DESCRIPTION
With this PR 100% of the calls to open auth dialog are now wrapped in the rollout flag.