### PR TITLE
style(art-quiz): adjust tooltip height

### DIFF
--- a/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
@@ -300,6 +300,7 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
         <Tooltip
           content="Like it? Hit the heart. Not for you? Choose X."
           variant="defaultDark"
+          offset={-10}
           pointer
           placement="top"
           textAlign="center"


### PR DESCRIPTION
The type of this PR is: **style**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description

This PR is a quick fix to the offset of the info tooltip on `art-quiz/artworks`. Adjusts the tooltip to be closer to the CTAs and overlay the edge of the artwork. 

(Merging even though the build is timing out, secure in the knowledge that @dzucconi is following up w/ a fix to the issue.)

<!-- Implementation description -->
![Screenshot 2023-01-26 at 10 07 17 AM](https://user-images.githubusercontent.com/14044896/214871542-c07c22c3-6f9f-4a79-8116-a411efad1da2.png)
![Screenshot 2023-01-26 at 10 09 40 AM](https://user-images.githubusercontent.com/14044896/214872089-c3b94464-bf97-4271-aacc-74fd0d1f80d4.png)


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ