### PR TITLE
fix: Allow HTML in collection description GRO-1536

### DIFF
--- a/src/Apps/ArtQuiz/Components/ArtQuizTrendingCollection.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizTrendingCollection.tsx
@@ -1,4 +1,4 @@
-import { Shelf, SkeletonText, Spacer, Text } from "@artsy/palette"
+import { HTML, Shelf, SkeletonText, Spacer, Text } from "@artsy/palette"
 import {
   ShelfArtworkFragmentContainer,
   ShelfArtworkPlaceholder,
@@ -23,9 +23,13 @@ const ArtQuizTrendingCollection: FC<ArtQuizTrendingCollectionProps> = ({
     <>
       <Text variant="lg-display">{collection.title}</Text>
 
-      <Text variant="lg-display" color="black60">
-        {collection.description}
-      </Text>
+      {collection.description && (
+        <HTML
+          color="black60"
+          html={collection.description}
+          variant="lg-display"
+        />
+      )}
 
       <Spacer y={[2, 4]} />
 


### PR DESCRIPTION
Just a quick PR to support collection descriptions that include HTML.

https://artsyproduct.atlassian.net/browse/GRO-1536

/cc @artsy/grow-devs