### PR TITLE
chore(art quiz): add save analytics to quiz save button

### DIFF
--- a/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
@@ -30,6 +30,8 @@ import { ArtQuizFullScreen } from "Apps/ArtQuiz/Components/ArtQuizFullscreen"
 import { useUpdateQuiz } from "Apps/ArtQuiz/Hooks/useUpdateQuiz"
 import { useSaveArtwork } from "Apps/ArtQuiz/Hooks/useSaveArtwork"
 import { ArtQuizResultsLoader } from "Apps/ArtQuiz/Components/ArtQuizResultsLoader"
+import { useTracking } from "react-tracking"
+import { ContextModule } from "@artsy/cohesion"
 
 interface ArtQuizArtworksProps {
   me: ArtQuizArtworks_me$data
@@ -39,6 +41,7 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
   const { submitMutation: submitDislike } = useDislikeArtwork()
   const { submitMutation: submitSave } = useSaveArtwork()
   const { submitMutation: submitUpdate } = useUpdateQuiz()
+  const { trackEvent } = useTracking()
   const { router } = useRouter()
   const [showLoader, setShowLoader] = useState(false)
 
@@ -137,6 +140,12 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
               },
             },
           })
+          trackEvent({
+            action: "Saved Artwork",
+            context_module: ContextModule.onboardingActivity,
+            entity_slug: currentArtwork.slug,
+            entity_id: currentArtwork.internalID,
+          })
         }
 
         if (action === "Dislike") {
@@ -175,6 +184,7 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
       submitUpdate,
       me.id,
       submitSave,
+      trackEvent,
       submitDislike,
       router,
     ]


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1516]

### Description

<!-- Implementation description -->

This PR adds a standard "Saved Artwork" tracker to the `/art-quiz/artworks` page. 

The second event mentioned in @abhitip's spreadsheet will have to be implemented during completion of [GRO-1252]. I've linked the tickets so this doesn't get lost. 


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1516]: https://artsyproduct.atlassian.net/browse/GRO-1516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1252]: https://artsyproduct.atlassian.net/browse/GRO-1252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ