### PR TITLE
feat(FX-4555): add `/collector-profile/saves2/*` routes

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2ByIdRoute.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2ByIdRoute.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@artsy/palette"
+import { FC } from "react"
+import { useRouter } from "System/Router/useRouter"
+
+export const CollectorProfileSaves2ByIdRoute: FC = () => {
+  const { match } = useRouter()
+
+  return <Text>{`/collector-profile/saves2/${match.params.id}`}</Text>
+}

--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -1,0 +1,6 @@
+import { Text } from "@artsy/palette"
+import { FC } from "react"
+
+export const CollectorProfileSaves2Route: FC = () => {
+  return <Text>/collector-profile/saves2</Text>
+}

--- a/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
+++ b/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
@@ -46,6 +46,16 @@ const SavesAndFollowsRoute = loadable(
   }
 )
 
+const Saves2 = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "collectorProfileBundle" */ "./Routes/Saves2/CollectorProfileSaves2Route"
+    ),
+  {
+    resolveComponent: component => component.CollectorProfileSaves2Route,
+  }
+)
+
 const FollowsRoute = loadable(
   () =>
     import(
@@ -175,6 +185,13 @@ export const collectorProfileRoutes: AppRouteConfig[] = [
             }
           }
         `,
+      },
+      {
+        path: "saves2",
+        getComponent: () => Saves2,
+        onClientSideRender: () => {
+          Saves2.preload()
+        },
       },
       {
         path: "follows",

--- a/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
+++ b/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
@@ -56,6 +56,16 @@ const Saves2 = loadable(
   }
 )
 
+const Saves2ById = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "collectorProfileBundle" */ "./Routes/Saves2/CollectorProfileSaves2ByIdRoute"
+    ),
+  {
+    resolveComponent: component => component.CollectorProfileSaves2ByIdRoute,
+  }
+)
+
 const FollowsRoute = loadable(
   () =>
     import(
@@ -191,6 +201,13 @@ export const collectorProfileRoutes: AppRouteConfig[] = [
         getComponent: () => Saves2,
         onClientSideRender: () => {
           Saves2.preload()
+        },
+      },
+      {
+        path: "saves2/:id",
+        getComponent: () => Saves2ById,
+        onClientSideRender: () => {
+          Saves2ById.preload()
         },
       },
       {

--- a/src/Server/middleware/userRequiredMiddleware.ts
+++ b/src/Server/middleware/userRequiredMiddleware.ts
@@ -9,6 +9,7 @@ const USER_REQUIRED_ROUTES = [
   "/settings/purchases(.*)",
   "/settings/shipping",
   "/user/conversations(.*)",
+  "/collector-profile/saves2(.*)",
 ]
 
 const isRequestRequiringUser = req => {


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4555]

Review app: [collector-profile-saves2-routes](https://collector-profile-saves2-routes.artsy.net/)

### Routes (you must be logged in to your account)
* [/collector-profile/saves2](https://collector-profile-saves2-routes.artsy.net/collector-profile/saves2)
* [/collector-profile/saves2/:id](https://collector-profile-saves2-routes.artsy.net/collector-profile/saves2/hello)

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4555]: https://artsyproduct.atlassian.net/browse/FX-4555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ