### PR TITLE
feat(FX-4538): Hide AP blue dot indicator if there are no new notifications

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -7130,6 +7130,8 @@ input CreateFeatureMutationInput {
   description: String
   layout: FeatureLayouts
   name: String!
+  sourceBucket: String
+  sourceKey: String
   subheadline: String
 }
 
@@ -7646,11 +7648,6 @@ type CurrentEvent {
 # Date in YYYY-MM-DD format
 scalar Date
 
-# A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the
-# `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO
-# 8601 standard for representation of dates and times using the Gregorian calendar.
-scalar DateTime
-
 type DaySchedule {
   dayOfWeek: String
   endTime: Int
@@ -7713,6 +7710,30 @@ type DeleteBankAccountPayload {
   bankAccountOrError: BankAccountMutationType
   clientMutationId: String
   me: Me
+}
+
+type DeleteCollectionFailure {
+  mutationError: GravityMutationError
+}
+
+input deleteCollectionInput {
+  clientMutationId: String
+  id: String!
+}
+
+type deleteCollectionPayload {
+  clientMutationId: String
+
+  # On success: the deleted collection
+  responseOrError: DeleteCollectionResponseOrError
+}
+
+union DeleteCollectionResponseOrError =
+    DeleteCollectionFailure
+  | DeleteCollectionSuccess
+
+type DeleteCollectionSuccess {
+  collection: Collection
 }
 
 type DeleteConversationFailure {
@@ -10751,7 +10772,9 @@ type MarkNotificationsAsSeenFailure {
 
 input MarkNotificationsAsSeenInput {
   clientMutationId: String
-  until: DateTime!
+
+  # Until what point of time notifications were seen. ISO8601 standard-formatted string.
+  until: String!
 }
 
 type MarkNotificationsAsSeenPayload {
@@ -11705,6 +11728,9 @@ type Mutation {
   # Remove a bank account
   deleteBankAccount(input: DeleteBankAccountInput!): DeleteBankAccountPayload
 
+  # Delete a collection
+  deleteCollection(input: deleteCollectionInput!): deleteCollectionPayload
+
   # Soft-delete a conversation.
   deleteConversation(
     input: DeleteConversationMutationInput!
@@ -11907,6 +11933,9 @@ type Mutation {
   updateCMSLastAccessTimestamp(
     input: UpdateCMSLastAccessTimestampMutationInput!
   ): UpdateCMSLastAccessTimestampMutationPayload
+
+  # Update a collection
+  updateCollection(input: updateCollectionInput!): updateCollectionPayload
 
   # Updating a collector profile (loyalty applicant status).
   updateCollectorProfile(
@@ -16773,6 +16802,31 @@ type UpdateCMSLastAccessTimestampSuccess {
   partner: Partner
 }
 
+type UpdateCollectionFailure {
+  mutationError: GravityMutationError
+}
+
+input updateCollectionInput {
+  clientMutationId: String
+
+  # The internal ID of the collection
+  id: String!
+  name: String!
+}
+
+type updateCollectionPayload {
+  clientMutationId: String
+  responseOrError: UpdateCollectionResponseOrError
+}
+
+union UpdateCollectionResponseOrError =
+    UpdateCollectionFailure
+  | UpdateCollectionSuccess
+
+type UpdateCollectionSuccess {
+  collection: Collection
+}
+
 input UpdateCollectorProfileInput {
   # List of affiliated auction house ids, referencing Galaxy.
   affiliatedAuctionHouseIds: [String]
@@ -16983,13 +17037,15 @@ type UpdateFeatureFailure {
 }
 
 input UpdateFeatureMutationInput {
-  active: Boolean!
+  active: Boolean
   callout: String
   clientMutationId: String
   description: String
   id: String!
   layout: FeatureLayouts
-  name: String!
+  name: String
+  sourceBucket: String
+  sourceKey: String
   subheadline: String
 }
 

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -7646,6 +7646,11 @@ type CurrentEvent {
 # Date in YYYY-MM-DD format
 scalar Date
 
+# A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the
+# `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO
+# 8601 standard for representation of dates and times using the Gregorian calendar.
+scalar DateTime
+
 type DaySchedule {
   dayOfWeek: String
   endTime: Int
@@ -10740,6 +10745,28 @@ type MarkNotificationAsReadSuccess {
   success: Boolean
 }
 
+type MarkNotificationsAsSeenFailure {
+  mutationError: GravityMutationError
+}
+
+input MarkNotificationsAsSeenInput {
+  clientMutationId: String
+  until: DateTime!
+}
+
+type MarkNotificationsAsSeenPayload {
+  clientMutationId: String
+  responseOrError: MarkNotificationsAsSeenResponseOrError
+}
+
+union MarkNotificationsAsSeenResponseOrError =
+    MarkNotificationsAsSeenFailure
+  | MarkNotificationsAsSeenSuccess
+
+type MarkNotificationsAsSeenSuccess {
+  success: Boolean
+}
+
 union Match =
     Article
   | Artist
@@ -11241,6 +11268,9 @@ type Me implements Node {
 
   # A count of unread notifications.
   unreadNotificationsCount: Int!
+
+  # A count of unseen notifications.
+  unseenNotificationsCount: Int!
 
   # A list of lots a user is watching.
   watchedLotConnection(
@@ -11773,6 +11803,11 @@ type Mutation {
     input: MarkNotificationAsReadInput!
   ): MarkNotificationAsReadPayload
 
+  # Mark notifications as seen
+  markNotificationsAsSeen(
+    input: MarkNotificationsAsSeenInput!
+  ): MarkNotificationsAsSeenPayload
+
   # Merge multiple artist records in order to deduplicate artists
   mergeArtists(input: MergeArtistsMutationInput!): MergeArtistsMutationPayload
 
@@ -12239,6 +12274,11 @@ type NotificationCounts {
     label: String
   ): FormattedNumber
   unread(
+    # Returns a `String` when format is specified. e.g.`'0,0.0000''`
+    format: String
+    label: String
+  ): FormattedNumber
+  unseen(
     # Returns a `String` when format is specified. e.g.`'0,0.0000''`
     format: String
     label: String

--- a/src/Components/NavBar/NavBarLoggedInActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedInActions.tsx
@@ -24,8 +24,11 @@ export const NavBarLoggedInActions: React.FC<Partial<
   const { trackEvent } = useTracking()
   const unreadNotificationsCount = me?.unreadNotificationsCount ?? 0
   const unreadConversationCount = me?.unreadConversationCount ?? 0
+  const unseenNotificationsCount = me?.unseenNotificationsCount ?? 0
   const hasConversations = unreadConversationCount > 0
   const hasNotifications = unreadNotificationsCount > 0
+  const hasUnseenNotifications = unseenNotificationsCount > 0
+  const displayBlueDot = hasNotifications && hasUnseenNotifications
 
   return (
     <>
@@ -60,7 +63,7 @@ export const NavBarLoggedInActions: React.FC<Partial<
           >
             <BellIcon title="Notifications" fill="currentColor" />
 
-            {hasNotifications && (
+            {displayBlueDot && (
               <NavBarNotificationIndicator
                 position="absolute"
                 top="15px"
@@ -125,6 +128,7 @@ export const NavBarLoggedInActionsQueryRenderer: React.FC<{}> = () => {
         query NavBarLoggedInActionsQuery {
           me {
             unreadNotificationsCount
+            unseenNotificationsCount
             unreadConversationCount
             followsAndSaves {
               notifications: bundledArtworksByArtistConnection(

--- a/src/Components/NavBar/NavBarLoggedInActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedInActions.tsx
@@ -28,7 +28,7 @@ export const NavBarLoggedInActions: React.FC<Partial<
   const hasConversations = unreadConversationCount > 0
   const hasNotifications = unreadNotificationsCount > 0
   const hasUnseenNotifications = unseenNotificationsCount > 0
-  const displayBlueDot = hasNotifications && hasUnseenNotifications
+  const shouldDisplayBlueDot = hasNotifications && hasUnseenNotifications
 
   return (
     <>
@@ -63,7 +63,7 @@ export const NavBarLoggedInActions: React.FC<Partial<
           >
             <BellIcon title="Notifications" fill="currentColor" />
 
-            {displayBlueDot && (
+            {shouldDisplayBlueDot && (
               <NavBarNotificationIndicator
                 position="absolute"
                 top="15px"

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotifications.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotifications.tsx
@@ -25,8 +25,11 @@ export const NavBarMobileMenuNotifications: React.FC<NavBarMobileMenuNotificatio
   const { trackEvent } = useTracking()
   const unreadConversationCount = me?.unreadConversationCount ?? 0
   const unreadNotificationsCount = me?.unreadNotificationsCount ?? 0
+  const unseenNotificationsCount = me?.unseenNotificationsCount ?? 0
   const hasConversations = unreadConversationCount > 0
   const hasNotifications = unreadNotificationsCount > 0
+  const hasUnseenNotifications = unseenNotificationsCount > 0
+  const displayBlueDot = hasNotifications && hasUnseenNotifications
 
   return (
     <>
@@ -51,7 +54,7 @@ export const NavBarMobileMenuNotifications: React.FC<NavBarMobileMenuNotificatio
             }}
           >
             Activity
-            {hasNotifications && <Indicator />}
+            {displayBlueDot && <Indicator />}
           </NavBarMobileMenuItemLink>
           <NavBarMobileMenuItemLink
             to="/user/conversations"
@@ -76,6 +79,7 @@ const NavBarMobileMenuNotificationsFragmentContainer = createFragmentContainer(
       fragment NavBarMobileMenuNotifications_me on Me {
         unreadNotificationsCount
         unreadConversationCount
+        unseenNotificationsCount
       }
     `,
   }

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotifications.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotifications.tsx
@@ -29,7 +29,7 @@ export const NavBarMobileMenuNotifications: React.FC<NavBarMobileMenuNotificatio
   const hasConversations = unreadConversationCount > 0
   const hasNotifications = unreadNotificationsCount > 0
   const hasUnseenNotifications = unseenNotificationsCount > 0
-  const displayBlueDot = hasNotifications && hasUnseenNotifications
+  const shouldDisplayBlueDot = hasNotifications && hasUnseenNotifications
 
   return (
     <>
@@ -54,7 +54,7 @@ export const NavBarMobileMenuNotifications: React.FC<NavBarMobileMenuNotificatio
             }}
           >
             Activity
-            {displayBlueDot && <Indicator />}
+            {shouldDisplayBlueDot && <Indicator />}
           </NavBarMobileMenuItemLink>
           <NavBarMobileMenuItemLink
             to="/user/conversations"

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator.tsx
@@ -16,9 +16,12 @@ export const NavBarMobileMenuNotificationsIndicator: React.FC<NavBarMobileMenuNo
 }) => {
   const unreadConversationCount = me?.unreadConversationCount ?? 0
   const unreadNotificationsCount = me?.unreadNotificationsCount ?? 0
+  const unseenNotificationsCount = me?.unseenNotificationsCount ?? 0
   const hasConversations = unreadConversationCount > 0
   const hasNotifications = unreadNotificationsCount > 0
-  const shouldDisplayIndicator = hasConversations || hasNotifications
+  const hasUnseenNotifications = unseenNotificationsCount > 0
+  const shouldDisplayIndicator =
+    hasConversations || (hasNotifications && hasUnseenNotifications)
 
   if (!shouldDisplayIndicator) {
     return null
@@ -41,6 +44,7 @@ export const NavBarMobileMenuNotificationsIndicatorFragmentContainer = createFra
       fragment NavBarMobileMenuNotificationsIndicator_me on Me {
         unreadConversationCount
         unreadNotificationsCount
+        unseenNotificationsCount
       }
     `,
   }

--- a/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenuNotificationsIndicator.jest.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenuNotificationsIndicator.jest.tsx
@@ -23,6 +23,7 @@ describe("NavBarMobileMenuNotificationsIndicator", () => {
       Me: () => ({
         unreadConversationCount: 0,
         unreadNotificationsCount: 0,
+        unseenNotificationsCount: 0,
       }),
     })
 
@@ -47,6 +48,7 @@ describe("NavBarMobileMenuNotificationsIndicator", () => {
       Me: () => ({
         unreadConversationCount: 0,
         unreadNotificationsCount: 5,
+        unseenNotificationsCount: 1,
       }),
     })
 

--- a/src/Components/Notifications/Mutations/markNotificationsAsSeen.ts
+++ b/src/Components/Notifications/Mutations/markNotificationsAsSeen.ts
@@ -1,0 +1,64 @@
+import {
+  markNotificationsAsSeenMutation,
+  markNotificationsAsSeenMutation$data,
+} from "__generated__/markNotificationsAsSeenMutation.graphql"
+import {
+  commitMutation,
+  Environment,
+  graphql,
+  RecordSourceSelectorProxy,
+} from "relay-runtime"
+
+const updater = (
+  store: RecordSourceSelectorProxy<markNotificationsAsSeenMutation$data>
+) => {
+  const root = store.getRoot()
+  const me = root.getLinkedRecord("me")
+
+  if (!me) {
+    return
+  }
+  // Set unread notifications count to 0
+  me.setValue(0, "unseenNotificationsCount")
+}
+
+export const markNotificationsAsSeen = (
+  until: string,
+  environment: Environment
+): Promise<markNotificationsAsSeenMutation$data> => {
+  return new Promise((resolve, reject) => {
+    commitMutation<markNotificationsAsSeenMutation>(environment, {
+      mutation: graphql`
+        mutation markNotificationsAsSeenMutation(
+          $input: MarkNotificationsAsSeenInput!
+        ) {
+          markNotificationsAsSeen(input: $input) {
+            responseOrError {
+              ... on MarkNotificationsAsSeenSuccess {
+                success
+              }
+              ... on MarkNotificationsAsSeenFailure {
+                mutationError {
+                  message
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: {
+        input: {
+          until,
+        },
+      },
+      updater: updater,
+      optimisticUpdater: updater,
+      onCompleted: response => {
+        resolve(response)
+      },
+      onError: error => {
+        reject(error)
+      },
+    })
+  })
+}

--- a/src/Components/Notifications/Mutations/markNotificationsAsSeen.ts
+++ b/src/Components/Notifications/Mutations/markNotificationsAsSeen.ts
@@ -18,7 +18,7 @@ const updater = (
   if (!me) {
     return
   }
-  // Set unread notifications count to 0
+  // Set unseen notifications count to 0
   me.setValue(0, "unseenNotificationsCount")
 }
 

--- a/src/Components/Notifications/Notifications.tsx
+++ b/src/Components/Notifications/Notifications.tsx
@@ -2,6 +2,13 @@ import { Tab } from "@artsy/palette"
 import { NofiticationsTabs, NofiticationsTabsProps } from "./NotificationsTabs"
 import { NotificationsListQueryRenderer } from "./NotificationsList"
 import { NotificationPaginationType } from "./types"
+import { useEffect, useCallback } from "react"
+import { DateTime } from "luxon"
+import { markNotificationsAsSeen } from "./Mutations/markNotificationsAsSeen"
+import { useSystemContext } from "System"
+import createLogger from "Utils/logger"
+
+const logger = createLogger("MarkNotificationsAsSeen")
 
 interface NotificationsProps extends NofiticationsTabsProps {
   paginationType?: NotificationPaginationType
@@ -11,6 +18,32 @@ export const Notifications: React.FC<NotificationsProps> = ({
   paginationType,
   ...rest
 }) => {
+  const { relayEnvironment } = useSystemContext()
+
+  const markAsSeen = useCallback(async () => {
+    if (!relayEnvironment) {
+      return
+    }
+
+    try {
+      const until = DateTime.local().toISO()
+      const response = await markNotificationsAsSeen(until, relayEnvironment)
+      const errorMessage =
+        response.markNotificationsAsSeen?.responseOrError?.mutationError
+          ?.message
+
+      if (errorMessage) {
+        throw new Error(errorMessage)
+      }
+    } catch (error) {
+      logger.error(error)
+    }
+  }, [relayEnvironment])
+
+  useEffect(() => {
+    markAsSeen()
+  }, [markAsSeen])
+
   return (
     <NofiticationsTabs {...rest}>
       <Tab name="All">

--- a/src/Components/Notifications/Notifications.tsx
+++ b/src/Components/Notifications/Notifications.tsx
@@ -2,13 +2,13 @@ import { Tab } from "@artsy/palette"
 import { NofiticationsTabs, NofiticationsTabsProps } from "./NotificationsTabs"
 import { NotificationsListQueryRenderer } from "./NotificationsList"
 import { NotificationPaginationType } from "./types"
-import { useEffect, useCallback } from "react"
+import { useEffect } from "react"
 import { DateTime } from "luxon"
 import { markNotificationsAsSeen } from "./Mutations/markNotificationsAsSeen"
 import { useSystemContext } from "System"
 import createLogger from "Utils/logger"
 
-const logger = createLogger("MarkNotificationsAsSeen")
+const logger = createLogger("Notifications")
 
 interface NotificationsProps extends NofiticationsTabsProps {
   paginationType?: NotificationPaginationType
@@ -20,7 +20,7 @@ export const Notifications: React.FC<NotificationsProps> = ({
 }) => {
   const { relayEnvironment } = useSystemContext()
 
-  const markAsSeen = useCallback(async () => {
+  const markAsSeen = async () => {
     if (!relayEnvironment) {
       return
     }
@@ -38,11 +38,12 @@ export const Notifications: React.FC<NotificationsProps> = ({
     } catch (error) {
       logger.error(error)
     }
-  }, [relayEnvironment])
+  }
 
   useEffect(() => {
     markAsSeen()
-  }, [markAsSeen])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <NofiticationsTabs {...rest}>

--- a/src/__generated__/NavBarLoggedInActionsQuery.graphql.ts
+++ b/src/__generated__/NavBarLoggedInActionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<04a3b7e7cc31ac700e9702f6a2a2e6e1>>
+ * @generated SignedSource<<ea279867831cc0dd622b3abd694c7bb2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,7 @@ export type NavBarLoggedInActionsQuery$data = {
     } | null;
     readonly unreadConversationCount: number;
     readonly unreadNotificationsCount: number;
+    readonly unseenNotificationsCount: number;
   } | null;
 };
 export type NavBarLoggedInActionsQuery = {
@@ -50,36 +51,43 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "unreadConversationCount",
+  "name": "unseenNotificationsCount",
   "storageKey": null
 },
 v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "unreadConversationCount",
+  "storageKey": null
+},
+v3 = {
   "kind": "Literal",
   "name": "sort",
   "value": "PUBLISHED_AT_DESC"
 },
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "summary",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artists",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": "published_at",
   "args": [
     {
@@ -92,7 +100,7 @@ v6 = {
   "name": "publishedAt",
   "storageKey": "publishedAt(format:\"MMM DD\")"
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
@@ -132,21 +140,21 @@ v7 = {
   ],
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -171,15 +179,15 @@ v10 = {
   ],
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 10
   },
-  (v2/*: any*/)
+  (v3/*: any*/)
 ],
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -203,6 +211,7 @@ return {
         "selections": [
           (v0/*: any*/),
           (v1/*: any*/),
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -214,7 +223,7 @@ return {
               {
                 "alias": "notifications",
                 "args": [
-                  (v2/*: any*/)
+                  (v3/*: any*/)
                 ],
                 "concreteType": "FollowedArtistsArtworksGroupConnection",
                 "kind": "LinkedField",
@@ -237,20 +246,20 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
                           (v4/*: any*/),
                           (v5/*: any*/),
                           (v6/*: any*/),
                           (v7/*: any*/),
-                          (v8/*: any*/)
+                          (v8/*: any*/),
+                          (v9/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v9/*: any*/)
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v10/*: any*/)
+                  (v11/*: any*/)
                 ],
                 "storageKey": "__WorksForYou_notifications_connection(sort:\"PUBLISHED_AT_DESC\")"
               }
@@ -280,6 +289,7 @@ return {
         "selections": [
           (v0/*: any*/),
           (v1/*: any*/),
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -290,7 +300,7 @@ return {
             "selections": [
               {
                 "alias": "notifications",
-                "args": (v11/*: any*/),
+                "args": (v12/*: any*/),
                 "concreteType": "FollowedArtistsArtworksGroupConnection",
                 "kind": "LinkedField",
                 "name": "bundledArtworksByArtistConnection",
@@ -312,27 +322,27 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
                           (v4/*: any*/),
                           (v5/*: any*/),
                           (v6/*: any*/),
                           (v7/*: any*/),
-                          (v12/*: any*/),
-                          (v8/*: any*/)
+                          (v8/*: any*/),
+                          (v13/*: any*/),
+                          (v9/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v9/*: any*/)
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v10/*: any*/)
+                  (v11/*: any*/)
                 ],
                 "storageKey": "bundledArtworksByArtistConnection(first:10,sort:\"PUBLISHED_AT_DESC\")"
               },
               {
                 "alias": "notifications",
-                "args": (v11/*: any*/),
+                "args": (v12/*: any*/),
                 "filters": [
                   "sort"
                 ],
@@ -344,14 +354,14 @@ return {
             ],
             "storageKey": null
           },
-          (v12/*: any*/)
+          (v13/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "e33df2ccda5da57dddd8577e0fca1fbe",
+    "cacheID": "741ac8db9b028c230d18d567cbd45803",
     "id": null,
     "metadata": {
       "connection": [
@@ -369,11 +379,11 @@ return {
     },
     "name": "NavBarLoggedInActionsQuery",
     "operationKind": "query",
-    "text": "query NavBarLoggedInActionsQuery {\n  me {\n    unreadNotificationsCount\n    unreadConversationCount\n    followsAndSaves {\n      notifications: bundledArtworksByArtistConnection(sort: PUBLISHED_AT_DESC, first: 10) {\n        edges {\n          node {\n            href\n            summary\n            artists\n            published_at: publishedAt(format: \"MMM DD\")\n            image {\n              resized(height: 40, width: 40) {\n                url\n              }\n            }\n            id\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query NavBarLoggedInActionsQuery {\n  me {\n    unreadNotificationsCount\n    unseenNotificationsCount\n    unreadConversationCount\n    followsAndSaves {\n      notifications: bundledArtworksByArtistConnection(sort: PUBLISHED_AT_DESC, first: 10) {\n        edges {\n          node {\n            href\n            summary\n            artists\n            published_at: publishedAt(format: \"MMM DD\")\n            image {\n              resized(height: 40, width: 40) {\n                url\n              }\n            }\n            id\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "cfcc4ec76e30e889d67960d77123214d";
+(node as any).hash = "dde19a2842ab4ce44cc48b6b6868b8e3";
 
 export default node;

--- a/src/__generated__/NavBarMobileMenuNotificationsIndicatorQuery.graphql.ts
+++ b/src/__generated__/NavBarMobileMenuNotificationsIndicatorQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<27373a86c5908e268a5675f0033a37bc>>
+ * @generated SignedSource<<ec8625a1b35dc13513ad57b001689984>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -80,6 +80,13 @@ const node: ConcreteRequest = {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "unseenNotificationsCount",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -89,12 +96,12 @@ const node: ConcreteRequest = {
     ]
   },
   "params": {
-    "cacheID": "fcad35569728dba5274eae66eabbcd8d",
+    "cacheID": "ec976fe5ff6b59412b518bf94d4f33dd",
     "id": null,
     "metadata": {},
     "name": "NavBarMobileMenuNotificationsIndicatorQuery",
     "operationKind": "query",
-    "text": "query NavBarMobileMenuNotificationsIndicatorQuery {\n  me {\n    ...NavBarMobileMenuNotificationsIndicator_me\n    id\n  }\n}\n\nfragment NavBarMobileMenuNotificationsIndicator_me on Me {\n  unreadConversationCount\n  unreadNotificationsCount\n}\n"
+    "text": "query NavBarMobileMenuNotificationsIndicatorQuery {\n  me {\n    ...NavBarMobileMenuNotificationsIndicator_me\n    id\n  }\n}\n\nfragment NavBarMobileMenuNotificationsIndicator_me on Me {\n  unreadConversationCount\n  unreadNotificationsCount\n  unseenNotificationsCount\n}\n"
   }
 };
 

--- a/src/__generated__/NavBarMobileMenuNotificationsIndicator_me.graphql.ts
+++ b/src/__generated__/NavBarMobileMenuNotificationsIndicator_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<db15f425759c386db765f11c13e6946f>>
+ * @generated SignedSource<<baf5b81c96626cdbf0347221d2e4dd1a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ import { FragmentRefs } from "relay-runtime";
 export type NavBarMobileMenuNotificationsIndicator_me$data = {
   readonly unreadConversationCount: number;
   readonly unreadNotificationsCount: number;
+  readonly unseenNotificationsCount: number;
   readonly " $fragmentType": "NavBarMobileMenuNotificationsIndicator_me";
 };
 export type NavBarMobileMenuNotificationsIndicator_me$key = {
@@ -39,12 +40,19 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "unreadNotificationsCount",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "unseenNotificationsCount",
+      "storageKey": null
     }
   ],
   "type": "Me",
   "abstractKey": null
 };
 
-(node as any).hash = "8bfb3627d6825178d58a6ad8c2836d2d";
+(node as any).hash = "da97339ca68f35ba626818e5f885ed83";
 
 export default node;

--- a/src/__generated__/NavBarMobileMenuNotificationsIndicator_test_Query.graphql.ts
+++ b/src/__generated__/NavBarMobileMenuNotificationsIndicator_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<61b128d4f3c2fd252caaa4870613d135>>
+ * @generated SignedSource<<bbd961aa3bebca860e06dfdd336b58b0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -87,6 +87,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "unseenNotificationsCount",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -96,7 +103,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "37ccc0b48e759e445c0c355569c560bd",
+    "cacheID": "7e937619485679b0ea694a36eebcd8b5",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -113,12 +120,13 @@ return {
           "type": "ID"
         },
         "me.unreadConversationCount": (v0/*: any*/),
-        "me.unreadNotificationsCount": (v0/*: any*/)
+        "me.unreadNotificationsCount": (v0/*: any*/),
+        "me.unseenNotificationsCount": (v0/*: any*/)
       }
     },
     "name": "NavBarMobileMenuNotificationsIndicator_test_Query",
     "operationKind": "query",
-    "text": "query NavBarMobileMenuNotificationsIndicator_test_Query {\n  me {\n    ...NavBarMobileMenuNotificationsIndicator_me\n    id\n  }\n}\n\nfragment NavBarMobileMenuNotificationsIndicator_me on Me {\n  unreadConversationCount\n  unreadNotificationsCount\n}\n"
+    "text": "query NavBarMobileMenuNotificationsIndicator_test_Query {\n  me {\n    ...NavBarMobileMenuNotificationsIndicator_me\n    id\n  }\n}\n\nfragment NavBarMobileMenuNotificationsIndicator_me on Me {\n  unreadConversationCount\n  unreadNotificationsCount\n  unseenNotificationsCount\n}\n"
   }
 };
 })();

--- a/src/__generated__/NavBarMobileMenuNotificationsQuery.graphql.ts
+++ b/src/__generated__/NavBarMobileMenuNotificationsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<747746856dd96664527fde19964c617a>>
+ * @generated SignedSource<<6ad97ba133c13e99aa99287bb6d7f99c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -80,6 +80,13 @@ const node: ConcreteRequest = {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "unseenNotificationsCount",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -89,12 +96,12 @@ const node: ConcreteRequest = {
     ]
   },
   "params": {
-    "cacheID": "39206ca2cdfd556ca2f6fe9de2325df5",
+    "cacheID": "ed6b3ad42600266fc4bff072e1aac6bc",
     "id": null,
     "metadata": {},
     "name": "NavBarMobileMenuNotificationsQuery",
     "operationKind": "query",
-    "text": "query NavBarMobileMenuNotificationsQuery {\n  me {\n    ...NavBarMobileMenuNotifications_me\n    id\n  }\n}\n\nfragment NavBarMobileMenuNotifications_me on Me {\n  unreadNotificationsCount\n  unreadConversationCount\n}\n"
+    "text": "query NavBarMobileMenuNotificationsQuery {\n  me {\n    ...NavBarMobileMenuNotifications_me\n    id\n  }\n}\n\nfragment NavBarMobileMenuNotifications_me on Me {\n  unreadNotificationsCount\n  unreadConversationCount\n  unseenNotificationsCount\n}\n"
   }
 };
 

--- a/src/__generated__/NavBarMobileMenuNotifications_me.graphql.ts
+++ b/src/__generated__/NavBarMobileMenuNotifications_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<256df34dea610f5b0f0c98e34048963f>>
+ * @generated SignedSource<<f3612dffe88ecd2b814abbdb3fa7efd4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ import { FragmentRefs } from "relay-runtime";
 export type NavBarMobileMenuNotifications_me$data = {
   readonly unreadConversationCount: number;
   readonly unreadNotificationsCount: number;
+  readonly unseenNotificationsCount: number;
   readonly " $fragmentType": "NavBarMobileMenuNotifications_me";
 };
 export type NavBarMobileMenuNotifications_me$key = {
@@ -39,12 +40,19 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "unreadConversationCount",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "unseenNotificationsCount",
+      "storageKey": null
     }
   ],
   "type": "Me",
   "abstractKey": null
 };
 
-(node as any).hash = "0064720241150f809384bc103216037a";
+(node as any).hash = "edc8de2d253d1ce56d8c58bfb45abe93";
 
 export default node;

--- a/src/__generated__/markNotificationsAsSeenMutation.graphql.ts
+++ b/src/__generated__/markNotificationsAsSeenMutation.graphql.ts
@@ -1,0 +1,175 @@
+/**
+ * @generated SignedSource<<77c6dff63895c0215af19752ad1d4140>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type MarkNotificationsAsSeenInput = {
+  clientMutationId?: string | null;
+  until: any;
+};
+export type markNotificationsAsSeenMutation$variables = {
+  input: MarkNotificationsAsSeenInput;
+};
+export type markNotificationsAsSeenMutation$data = {
+  readonly markNotificationsAsSeen: {
+    readonly responseOrError: {
+      readonly mutationError?: {
+        readonly message: string;
+      } | null;
+      readonly success?: boolean | null;
+    } | null;
+  } | null;
+};
+export type markNotificationsAsSeenMutation = {
+  response: markNotificationsAsSeenMutation$data;
+  variables: markNotificationsAsSeenMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "success",
+      "storageKey": null
+    }
+  ],
+  "type": "MarkNotificationsAsSeenSuccess",
+  "abstractKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GravityMutationError",
+      "kind": "LinkedField",
+      "name": "mutationError",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "message",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "MarkNotificationsAsSeenFailure",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "markNotificationsAsSeenMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "MarkNotificationsAsSeenPayload",
+        "kind": "LinkedField",
+        "name": "markNotificationsAsSeen",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "responseOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "markNotificationsAsSeenMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "MarkNotificationsAsSeenPayload",
+        "kind": "LinkedField",
+        "name": "markNotificationsAsSeen",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "responseOrError",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "16cb900fff6e2d536010fe0a0c0966f3",
+    "id": null,
+    "metadata": {},
+    "name": "markNotificationsAsSeenMutation",
+    "operationKind": "mutation",
+    "text": "mutation markNotificationsAsSeenMutation(\n  $input: MarkNotificationsAsSeenInput!\n) {\n  markNotificationsAsSeen(input: $input) {\n    responseOrError {\n      __typename\n      ... on MarkNotificationsAsSeenSuccess {\n        success\n      }\n      ... on MarkNotificationsAsSeenFailure {\n        mutationError {\n          message\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "471062a68c5acb14e8edfcadb817d96d";
+
+export default node;


### PR DESCRIPTION
Co-authored-by: Dima Tretyak <itretyak@ya.ru>

The type of this PR is: **Feat**

This PR solves [FX-4538]

### Description

As a user
Given I have unseen notifications
When I visit the activity panel
The top-level indicator goes away
And I continue to see unread indicators to individual notifications.

### Demo

- [Review app](https://notifications-bell.artsy.net/) - will work only after https://github.com/artsy/metaphysics/pull/4731 is merged

Might be convenient to use this mutation to imitative opening notifications feed in past:

```graphql
mutation {
	markNotificationsAsSeen(input: { until: "2023-01-28T11:05:19Z"}) {
		responseOrError {
			... on MarkNotificationsAsSeenSuccess {
				success
			}
			
			... on MarkNotificationsAsSeenFailure {
				mutationError {
					message
				}
			}
		}
	}
}
```

#### Before

https://user-images.githubusercontent.com/3934579/215535046-59477027-0543-4ca3-af60-2172089c2f08.mp4

#### After

https://user-images.githubusercontent.com/3934579/215535089-b831a64d-e8e2-4ac3-bf7b-370f3b08bcf2.mp4

[FX-4538]: https://artsyproduct.atlassian.net/browse/FX-4538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ