### PR TITLE
fix: Filter out null saved searches GRO-1525

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -55,7 +55,7 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [sort, setSort] = useState("CREATED_AT_DESC")
   const [loading, setLoading] = useState(false)
-  const alerts = extractNodes(me.savedSearchesConnection)
+  const alerts = extractNodes(me.savedSearchesConnection).filter(Boolean)
   const isEditMode = editAlertEntity !== null
 
   const closeEditForm = () => {


### PR DESCRIPTION
After some exploration that I've documented in the Jira ticket, I'm left scratching my head but I can fix the problem by filtering out nulls. I think that's worth doing, right? I'm ccing the FX team here in case this rings any bells for them...

https://artsyproduct.atlassian.net/browse/GRO-1525

/cc @artsy/grow-devs @artsy/fx-devs 