### PR TITLE
Update tests to match new nav item order

### DIFF
--- a/src/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
+++ b/src/Components/NavBar/__tests__/NavBarSubMenu.jest.tsx
@@ -37,14 +37,14 @@ describe("NavBarSubMenu", () => {
       "/collection/curators-picks-emerging"
     )
 
-    expect(linkMenuItems.at(1).text()).toContain("Top Auction Lots")
+    expect(linkMenuItems.at(1).text()).toContain("Curators’ Picks: Blue-Chip")
     expect(linkMenuItems.at(1).prop("href")).toEqual(
-      "/collection/top-auction-lots"
+      "/collection/curators-picks-blue-chip"
     )
 
-    expect(linkMenuItems.at(2).text()).toContain("Curators’ Picks: Blue-Chip")
+    expect(linkMenuItems.at(2).text()).toContain("Top Auction Lots")
     expect(linkMenuItems.at(2).prop("href")).toEqual(
-      "/collection/curators-picks-blue-chip"
+      "/collection/top-auction-lots"
     )
 
     expect(linkMenuItems.at(3).text()).toContain("Best of Prints & Editions")


### PR DESCRIPTION
I'm grumpy that somehow https://github.com/artsy/force/pull/11844 was merged when it def failed on CI! This PR gets us back in working order.

/cc @artsy/grow-devs 