### PR TITLE
feat: add art quiz as an onboarding reward screen

### DIFF
--- a/src/Components/Onboarding/Components/OnboardingDebug.tsx
+++ b/src/Components/Onboarding/Components/OnboardingDebug.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Button } from "@artsy/palette"
 import { FC } from "react"
 import { useMode } from "Utils/Hooks/useMode"
-import { useOnboardingContext } from "../Hooks/useOnboardingContext"
+import { useOnboardingContext } from "Components/Onboarding/Hooks/useOnboardingContext"
 import { OnboardingModal } from "./OnboardingModal"
 import { OnboardingSteps } from "./OnboardingSteps"
 

--- a/src/Components/Onboarding/Components/OnboardingSteps.tsx
+++ b/src/Components/Onboarding/Components/OnboardingSteps.tsx
@@ -10,23 +10,30 @@ import {
   VIEW_FOLLOW_ARTISTS,
   VIEW_ARTISTS_ON_THE_RISE,
   VIEW_THANK_YOU,
-} from "../config"
-import { useOnboardingContext } from "../Hooks/useOnboardingContext"
-import { OnboardingWelcome } from "../Views/OnboardingWelcome"
-import { OnboardingQuestionOne } from "../Views/OnboardingQuestionOne"
-import { OnboardingQuestionThree } from "../Views/OnboardingQuestionThree"
-import { OnboardingQuestionTwo } from "../Views/OnboardingQuestionTwo"
-import { OnboardingFollowArtists } from "../Views/OnboardingFollowArtists"
-import { OnboardingTopAuctionLots } from "../Views/OnboardingTopAuctionLots"
-import { OnboardingCuratedArtworks } from "../Views/OnboardingCuratedArtworks"
-import { OnboardingArtistsOnTheRise } from "../Views/OnboardingArtistsOnTheRise"
-import { OnboardingFollowGalleries } from "../Views/OnboardingFollowGalleries"
-import { OnboardingThankYou } from "../Views/OnboardingThankYou"
+  VIEW_ART_QUIZ,
+} from "Components/Onboarding/config"
+import { useOnboardingContext } from "Components/Onboarding/Hooks/useOnboardingContext"
+import { OnboardingWelcome } from "Components/Onboarding/Views/OnboardingWelcome"
+import { OnboardingQuestionOne } from "Components/Onboarding/Views/OnboardingQuestionOne"
+import { OnboardingQuestionThree } from "Components/Onboarding/Views/OnboardingQuestionThree"
+import { OnboardingQuestionTwo } from "Components/Onboarding/Views/OnboardingQuestionTwo"
+import { OnboardingFollowArtists } from "Components/Onboarding/Views/OnboardingFollowArtists"
+import { OnboardingTopAuctionLots } from "Components/Onboarding/Views/OnboardingTopAuctionLots"
+import { OnboardingCuratedArtworks } from "Components/Onboarding/Views/OnboardingCuratedArtworks"
+import { OnboardingArtistsOnTheRise } from "Components/Onboarding/Views/OnboardingArtistsOnTheRise"
+import { OnboardingFollowGalleries } from "Components/Onboarding/Views/OnboardingFollowGalleries"
+import { OnboardingThankYou } from "Components/Onboarding/Views/OnboardingThankYou"
+import { useRouter } from "System/Router/useRouter"
+import { useOnboardingTracking } from "Components/Onboarding/Hooks/useOnboardingTracking"
 
 interface OnboardingStepsProps {}
 
 export const OnboardingSteps: FC<OnboardingStepsProps> = () => {
-  const { current } = useOnboardingContext()
+  const { router } = useRouter()
+
+  const tracking = useOnboardingTracking()
+
+  const { current, onComplete, onClose } = useOnboardingContext()
 
   switch (current) {
     case VIEW_WELCOME:
@@ -40,6 +47,14 @@ export const OnboardingSteps: FC<OnboardingStepsProps> = () => {
 
     case VIEW_QUESTION_THREE:
       return <OnboardingQuestionThree />
+
+    case VIEW_ART_QUIZ: {
+      tracking.userCompletedOnboarding()
+      onComplete()
+      onClose()
+      router.push("/art-quiz/welcome")
+      return null
+    }
 
     case VIEW_FOLLOW_ARTISTS:
       return <OnboardingFollowArtists />

--- a/src/Components/Onboarding/Hooks/useOnboardingContext.tsx
+++ b/src/Components/Onboarding/Hooks/useOnboardingContext.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-relative-import-paths/no-relative-import-paths */
 import {
   FC,
   createContext,
@@ -10,7 +9,7 @@ import {
 import { useSystemContext } from "System"
 import { useUpdateMyUserProfile } from "Utils/Hooks/Mutations/useUpdateMyUserProfile"
 import { WorkflowEngine } from "Utils/WorkflowEngine"
-import { useConfig } from "../config"
+import { useConfig } from "Components/Onboarding/config"
 
 export type State = {
   questionOne: string | null

--- a/src/Components/Onboarding/Hooks/useOnboardingContext.tsx
+++ b/src/Components/Onboarding/Hooks/useOnboardingContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-relative-import-paths/no-relative-import-paths */
 import {
   FC,
   createContext,

--- a/src/Components/Onboarding/Views/OnboardingQuestionOne.tsx
+++ b/src/Components/Onboarding/Views/OnboardingQuestionOne.tsx
@@ -2,16 +2,16 @@ import { Spacer, Text, Box, Join, Pill } from "@artsy/palette"
 import { FC } from "react"
 import { graphql } from "react-relay"
 import { useMutation } from "Utils/Hooks/useMutation"
-import { OnboardingFigure } from "../Components/OnboardingFigure"
-import { OnboardingQuestionPanel } from "../Components/OnboardingQuestionPanel"
+import { OnboardingFigure } from "Components/Onboarding/Components/OnboardingFigure"
+import { OnboardingQuestionPanel } from "Components/Onboarding/Components/OnboardingQuestionPanel"
 import {
   OPTION_NO_IM_JUST_STARTING_OUT,
   OPTION_YES_I_LOVE_COLLECTING_ART,
-} from "../config"
-import { useOnboardingFadeTransition } from "../Hooks/useOnboardingFadeTransition"
-import { useOnboardingContext } from "../Hooks/useOnboardingContext"
+} from "Components/Onboarding/config"
+import { useOnboardingFadeTransition } from "Components/Onboarding/Hooks/useOnboardingFadeTransition"
+import { useOnboardingContext } from "Components/Onboarding/Hooks/useOnboardingContext"
 import { OnboardingQuestionOneMutation } from "__generated__/OnboardingQuestionOneMutation.graphql"
-import { useOnboardingTracking } from "../Hooks/useOnboardingTracking"
+import { useOnboardingTracking } from "Components/Onboarding/Hooks/useOnboardingTracking"
 import { SplitLayout } from "Components/SplitLayout"
 
 export const OnboardingQuestionOne: FC = () => {

--- a/src/Components/Onboarding/Views/OnboardingQuestionThree.tsx
+++ b/src/Components/Onboarding/Views/OnboardingQuestionThree.tsx
@@ -1,9 +1,10 @@
 import { Spacer, Text, Join, Box, Pill } from "@artsy/palette"
 import { FC, useMemo } from "react"
-import { OnboardingFigure } from "../Components/OnboardingFigure"
-import { OnboardingQuestionPanel } from "../Components/OnboardingQuestionPanel"
+import { OnboardingFigure } from "Components/Onboarding/Components/OnboardingFigure"
+import { OnboardingQuestionPanel } from "Components/Onboarding/Components/OnboardingQuestionPanel"
 import {
   OPTION_ARTISTS_ON_THE_RISE,
+  OPTION_ART_QUIZ,
   OPTION_A_CURATED_SELECTION_OF_ARTWORKS,
   OPTION_COLLECTING_ART_THAT_MOVES_ME,
   OPTION_DEVELOPING_MY_ART_TASTES,
@@ -12,10 +13,10 @@ import {
   OPTION_FOLLOW_GALLERIES_I_LOVE,
   OPTION_KEEP_TRACK_OF_ART,
   OPTION_TOP_AUCTION_LOTS,
-} from "../config"
-import { useOnboardingFadeTransition } from "../Hooks/useOnboardingFadeTransition"
-import { useOnboardingContext } from "../Hooks/useOnboardingContext"
-import { useOnboardingTracking } from "../Hooks/useOnboardingTracking"
+} from "Components/Onboarding/config"
+import { useOnboardingFadeTransition } from "Components/Onboarding/Hooks/useOnboardingFadeTransition"
+import { useOnboardingContext } from "Components/Onboarding/Hooks/useOnboardingContext"
+import { useOnboardingTracking } from "Components/Onboarding/Hooks/useOnboardingTracking"
 import { SplitLayout } from "Components/SplitLayout"
 
 export const OnboardingQuestionThree: FC = () => {
@@ -28,6 +29,26 @@ export const OnboardingQuestionThree: FC = () => {
 
   const options = useMemo(() => {
     switch (true) {
+      case state.questionTwo.length > 2 &&
+        state.questionTwo.includes(OPTION_DEVELOPING_MY_ART_TASTES) &&
+        state.questionTwo.includes(OPTION_COLLECTING_ART_THAT_MOVES_ME) &&
+        state.questionTwo.includes(OPTION_FINDING_GREAT_INVESTMENTS):
+      case state.questionTwo.length > 1 &&
+        state.questionTwo.includes(OPTION_DEVELOPING_MY_ART_TASTES) &&
+        state.questionTwo.includes(OPTION_FINDING_GREAT_INVESTMENTS):
+      case state.questionTwo.length > 1 &&
+        state.questionTwo.includes(OPTION_COLLECTING_ART_THAT_MOVES_ME) &&
+        state.questionTwo.includes(OPTION_FINDING_GREAT_INVESTMENTS):
+      case state.questionTwo.length > 1 &&
+        state.questionTwo.includes(OPTION_DEVELOPING_MY_ART_TASTES) &&
+        state.questionTwo.includes(OPTION_COLLECTING_ART_THAT_MOVES_ME):
+        return [
+          OPTION_ART_QUIZ,
+          OPTION_TOP_AUCTION_LOTS,
+          OPTION_ARTISTS_ON_THE_RISE,
+          OPTION_A_CURATED_SELECTION_OF_ARTWORKS,
+        ]
+
       case state.questionTwo.length > 1:
         return [
           OPTION_FOLLOW_ARTISTS_IM_INTERESTED_IN,
@@ -38,6 +59,7 @@ export const OnboardingQuestionThree: FC = () => {
 
       case state.questionTwo[0] === OPTION_DEVELOPING_MY_ART_TASTES:
         return [
+          OPTION_ART_QUIZ,
           OPTION_TOP_AUCTION_LOTS,
           OPTION_A_CURATED_SELECTION_OF_ARTWORKS,
           OPTION_ARTISTS_ON_THE_RISE,
@@ -52,6 +74,7 @@ export const OnboardingQuestionThree: FC = () => {
       case state.questionTwo[0] === OPTION_FINDING_GREAT_INVESTMENTS:
       case state.questionTwo[0] === OPTION_COLLECTING_ART_THAT_MOVES_ME:
         return [
+          OPTION_ART_QUIZ,
           OPTION_FOLLOW_ARTISTS_IM_INTERESTED_IN,
           OPTION_TOP_AUCTION_LOTS,
           OPTION_ARTISTS_ON_THE_RISE,

--- a/src/Components/Onboarding/Views/OnboardingThankYou.tsx
+++ b/src/Components/Onboarding/Views/OnboardingThankYou.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-relative-import-paths/no-relative-import-paths */
 import { Flex, Spacer, Spinner, Text } from "@artsy/palette"
 import { FC, useEffect } from "react"
 import { useOnboardingContext } from "../Hooks/useOnboardingContext"

--- a/src/Components/Onboarding/Views/OnboardingThankYou.tsx
+++ b/src/Components/Onboarding/Views/OnboardingThankYou.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable no-relative-import-paths/no-relative-import-paths */
 import { Flex, Spacer, Spinner, Text } from "@artsy/palette"
 import { FC, useEffect } from "react"
-import { useOnboardingContext } from "../Hooks/useOnboardingContext"
-import { useOnboardingFadeTransition } from "../Hooks/useOnboardingFadeTransition"
+import { useOnboardingContext } from "Components/Onboarding/Hooks/useOnboardingContext"
+import { useOnboardingFadeTransition } from "Components/Onboarding/Hooks/useOnboardingFadeTransition"
 
 interface OnboardingThankYouProps {
   autoClose?: boolean

--- a/src/Components/Onboarding/config.ts
+++ b/src/Components/Onboarding/config.ts
@@ -17,6 +17,7 @@ export const useConfig = ({ basis, onClose }: UseConfig) => {
         VIEW_QUESTION_THREE,
         {
           [DECISION_WHERE_WOULD_YOU_LIKE_TO_DIVE_IN]: {
+            [OPTION_ART_QUIZ]: [VIEW_ART_QUIZ],
             [OPTION_TOP_AUCTION_LOTS]: [VIEW_TOP_AUCTION_LOTS],
             [OPTION_A_CURATED_SELECTION_OF_ARTWORKS]: [VIEW_CURATED_ARTWORKS],
             [OPTION_ARTISTS_ON_THE_RISE]: [VIEW_ARTISTS_ON_THE_RISE],
@@ -84,6 +85,7 @@ export const useConfig = ({ basis, onClose }: UseConfig) => {
 /* prettier-ignore */ export const OPTION_ARTISTS_ON_THE_RISE = "Artists on the rise"
 /* prettier-ignore */ export const OPTION_FOLLOW_ARTISTS_IM_INTERESTED_IN = "Artists I want to collect"
 /* prettier-ignore */ export const OPTION_FOLLOW_GALLERIES_I_LOVE = "Galleries I'm interested in"
+/* prettier-ignore */ export const OPTION_ART_QUIZ = "The Art Taste Quiz"
 
 /* prettier-ignore */ export const VIEW_WELCOME = "VIEW_WELCOME"
 /* prettier-ignore */ export const VIEW_QUESTION_ONE = "VIEW_QUESTION_ONE"
@@ -95,6 +97,7 @@ export const useConfig = ({ basis, onClose }: UseConfig) => {
 /* prettier-ignore */ export const VIEW_CURATED_ARTWORKS = "VIEW_CURATED_ARTWORKS"
 /* prettier-ignore */ export const VIEW_ARTISTS_ON_THE_RISE = "VIEW_ARTISTS_ON_THE_RISE"
 /* prettier-ignore */ export const VIEW_FOLLOW_GALLERIES = "VIEW_FOLLOW_GALLERIES"
+/* prettier-ignore */ export const VIEW_ART_QUIZ = "VIEW_ART_QUIZ"
 
 /* prettier-ignore */ export const VIEW_THANK_YOU = "VIEW_THANK_YOU"
 


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1252]

### Description

<!-- Implementation description -->
This PR contains the logic that conditionally adds the Art Quiz as an option to the user onboarding flow. The logic is outlined [here](https://www.figma.com/file/F12JFyxE0DR0qCGX2nap5E/Art-Quiz%3A-Onboarding-Phase-2?node-id=36%3A32&t=RXDUidcrzrM8Ffxb-0).

Tracking is implemented and follows the same patterns as previous onboarding reward screen options.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GRO-1252]: https://artsyproduct.atlassian.net/browse/GRO-1252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ