### PR TITLE
fix(passport): fixes linked account redirect

### DIFF
--- a/src/Apps/Settings/SettingsApp.tsx
+++ b/src/Apps/Settings/SettingsApp.tsx
@@ -1,11 +1,12 @@
-import { Text } from "@artsy/palette"
+import { Text, useToasts } from "@artsy/palette"
 import { MyCollectionRouteLoggedOutState } from "Apps/Settings/Routes/MyCollection/MyCollectionRouteLoggedOutState"
 import { MetaTags } from "Components/MetaTags"
 import { RouteTab, RouteTabs } from "Components/RouteTabs"
 import { compact } from "lodash"
-import React from "react"
+import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "System"
+import { useRouter } from "System/Router/useRouter"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { SettingsApp_me$data } from "__generated__/SettingsApp_me.graphql"
 
@@ -17,7 +18,26 @@ interface SettingsAppProps {
 
 const SettingsApp: React.FC<SettingsAppProps> = ({ me, children }) => {
   const { isLoggedIn } = useSystemContext()
+
   const isCollectorProfileEnabled = useFeatureFlag("cx-collector-profile")
+
+  const { sendToast } = useToasts()
+
+  const {
+    match: { location },
+  } = useRouter()
+
+  // Errors might come back from 3rd party authentication
+  // as a string in an `error` query param, so display them if present.
+  useEffect(() => {
+    if (!location.query.error) return
+
+    sendToast({
+      message: location.query.error,
+      variant: "error",
+      ttl: Infinity,
+    })
+  }, [location.query.error, sendToast])
 
   const tabsWhenCollectorProfileEnabled = compact([
     { name: "Edit Profile", url: "/settings/edit-profile" },

--- a/src/Server/passport/lib/app/lifecycle.js
+++ b/src/Server/passport/lib/app/lifecycle.js
@@ -156,8 +156,8 @@ module.exports.afterSocialAuth = provider =>
         err.response.body &&
         err.response.body.error === "Another Account Already Linked"
       ) {
-        alreadyLinkedParams = `?error=already-linked&provider=${providerName}`
-        return res.redirect(opts.settingsPagePath + alreadyLinkedParams)
+        msg = `${providerName} account previously linked to Artsy.`
+        return res.redirect(`${opts.settingsPagePath}?error=${msg}`)
       } else if (
         err &&
         err.message &&


### PR DESCRIPTION
Surfaced this via Sentry: https://sentry.io/organizations/artsynet/issues/3588012322/?project=28316&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h

I guess the original passport code wasn't in strict mode so this started to error once it was moved over. Converting our passport implementation to TypeScript would be well worth the effort.