### PR TITLE
fix: make short description optional

### DIFF
--- a/src/Apps/Order/Components/ItemReview.tsx
+++ b/src/Apps/Order/Components/ItemReview.tsx
@@ -69,9 +69,11 @@ export const ItemReview: React.FC<ItemReviewProps> = ({
               dimensionsDisplay(artworkDimensions)}
           </Text>
         )}
-        <Text variant="sm" color="black60">
-          {attributionClass.shortDescription}
-        </Text>
+        {attributionClass && attributionClass.shortDscription && (
+          <Text variant="sm" color="black60">
+            {attributionClass.shortDescription}
+          </Text>
+        )}
       </Flex>
       {image && image.resized && (
         <Image


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

There is an issue with the artwork classification "Limited Edition Set" as when it changed to just "Limited Edition" we are no longer able to get the short description, erroring out the review page. This makes the "short description" optional on the review page. 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ