### PR TITLE
feat(auth): tracks social logins

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -8,13 +8,8 @@ if [ ! -f ".env" ]; then
     cp .env.oss .env
 fi
 
-# prepare a production build
-if [ ! -f server.dist.js ]; then
-    yarn build
-fi
-
-# start server in the background in production mode
-NODE_ENV=production nohup yarn start &
+# start server in the background in development mode
+NODE_ENV=development nohup yarn start &
 
 # Leverage the server boot time to begin the cypress install.
 ./node_modules/.bin/cypress install

--- a/src/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
+++ b/src/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
@@ -13,20 +13,26 @@ import { getENV } from "Utils/getENV"
 jest.mock("Apps/Authentication/Legacy/Server/checkForRedirect", () => ({
   checkForRedirect: jest.fn(),
 }))
+
 jest.mock("Apps/Authentication/Legacy/Server/setReferer", () => ({
   setReferer: jest.fn(),
 }))
+
 jest.mock("Apps/Authentication/Legacy/Server/redirectIfLoggedIn", () => ({
   redirectIfLoggedIn: jest.fn(),
 }))
+
 jest.mock("Utils/EnableRecaptcha", () => ({
   EnableRecaptcha: () => "EnableRecaptcha",
 }))
+
 jest.mock("Apps/Authentication/Legacy/Utils/helpers", () => ({
   ...jest.requireActual("Apps/Authentication/Legacy/Utils/helpers"),
   setCookies: jest.fn(),
 }))
+
 jest.mock("Utils/Hooks/useAuthValidation")
+
 jest.mock("Utils/getENV", () => ({
   getENV: jest.fn(),
 }))

--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -11,6 +11,7 @@ import { useAuthValidation } from "Utils/Hooks/useAuthValidation"
 import { useOnboardingModal } from "Utils/Hooks/useOnboardingModal"
 import { useImagePerformanceObserver } from "Utils/Hooks/useImagePerformanceObserver"
 import { Layout } from "Apps/Components/Layouts"
+import { useSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
 
 const logger = createLogger("Apps/Components/AppShell")
 interface AppShellProps {
@@ -25,6 +26,7 @@ export const AppShell: React.FC<AppShellProps> = props => {
 
   useRunAuthIntent()
   useAuthValidation()
+  useSocialAuthTracking()
 
   const { children, match } = props
   const routeConfig = match ? findCurrentRoute(match) : null

--- a/src/Apps/Components/__tests__/AppShell.jest.tsx
+++ b/src/Apps/Components/__tests__/AppShell.jest.tsx
@@ -17,6 +17,13 @@ jest.mock("react-tracking", () => ({
   }),
 }))
 
+// jest.mock(
+//   "Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl",
+//   () => ({
+//     useAfterAuthenticationRedirectUrl: () => ({}),
+//   })
+// )
+
 describe("AppShell", () => {
   it("renders a NavBar", async () => {
     const { ClientApp } = await buildClientApp({

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
@@ -148,10 +148,12 @@ const SettingsEditSettingsLinkedAccountsButton: FC<SettingsEditSettingsLinkedAcc
     } catch (err) {
       console.error(err)
 
+      const error = Array.isArray(err) ? err[0] : err
+
       sendToast({
         variant: "error",
         message: "There was an error disconnecting your account.",
-        description: err.message,
+        description: error.message,
       })
 
       setMode("Connected")

--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -52,6 +52,7 @@ export const AuthDialogSocial: FC = () => {
         as="a"
         href={`${applePath}?${query}`}
         onClick={handleClick("apple")}
+        rel="nofollow"
       >
         Continue with Apple
       </Button>
@@ -64,6 +65,7 @@ export const AuthDialogSocial: FC = () => {
         as="a"
         href={`${googlePath}?${query}`}
         onClick={handleClick("google")}
+        rel="nofollow"
       >
         Continue with Google
       </Button>
@@ -76,6 +78,7 @@ export const AuthDialogSocial: FC = () => {
         as="a"
         href={`${facebookPath}?${query}`}
         onClick={handleClick("facebook")}
+        rel="nofollow"
       >
         Continue with Facebook
       </Button>

--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -7,6 +7,7 @@ import {
   FacebookIcon,
 } from "@artsy/palette"
 import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+import { setSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
 import { stringify } from "qs"
 import { FC } from "react"
 import { getENV } from "Utils/getENV"
@@ -16,7 +17,7 @@ export const AuthDialogSocial: FC = () => {
   const { applePath, facebookPath, googlePath } = getENV("AP")
 
   const {
-    state: { options, analytics },
+    state: { options, analytics, mode },
   } = useAuthDialogContext()
 
   // These params are handled by the routes in the Passport app,
@@ -34,6 +35,13 @@ export const AuthDialogSocial: FC = () => {
     { skipNulls: true }
   )
 
+  const handleClick = (service: "facebook" | "apple" | "google") => () => {
+    setSocialAuthTracking({
+      action: { Login: "loggedIn", SignUp: "signedUp" }[mode],
+      service,
+    })
+  }
+
   return (
     <Join separator={<Spacer y={1} />}>
       <Button
@@ -43,6 +51,7 @@ export const AuthDialogSocial: FC = () => {
         // @ts-ignore
         as="a"
         href={`${applePath}?${query}`}
+        onClick={handleClick("apple")}
       >
         Continue with Apple
       </Button>
@@ -54,6 +63,7 @@ export const AuthDialogSocial: FC = () => {
         // @ts-ignore
         as="a"
         href={`${googlePath}?${query}`}
+        onClick={handleClick("google")}
       >
         Continue with Google
       </Button>
@@ -65,6 +75,7 @@ export const AuthDialogSocial: FC = () => {
         // @ts-ignore
         as="a"
         href={`${facebookPath}?${query}`}
+        onClick={handleClick("facebook")}
       >
         Continue with Facebook
       </Button>

--- a/src/Components/AuthDialog/Hooks/__tests__/useSocialAuthTracking.jest.ts
+++ b/src/Components/AuthDialog/Hooks/__tests__/useSocialAuthTracking.jest.ts
@@ -1,0 +1,82 @@
+import Cookies from "cookies-js"
+import { renderHook } from "@testing-library/react-hooks"
+import { useSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
+import { useAuthDialogTracking } from "Components/AuthDialog/Hooks/useAuthDialogTracking"
+import { useRouter } from "System/Router/useRouter"
+
+jest.mock("System/Router/useRouter", () => ({
+  useRouter: jest.fn().mockImplementation(() => ({ match: { location: {} } })),
+}))
+
+jest.mock("System/useSystemContext", () => ({
+  useSystemContext: () => ({ user: { id: "example" } }),
+}))
+
+jest.mock("cookies-js", () => ({ get: jest.fn(), expire: jest.fn() }))
+
+jest.mock("Components/AuthDialog/Hooks/useAuthDialogTracking", () => ({
+  useAuthDialogTracking: jest.fn().mockImplementation(() => ({
+    loggedIn: jest.fn(),
+    signedUp: jest.fn(),
+  })),
+}))
+
+describe("useSocialAuthTracking", () => {
+  const mockCookiesGet = Cookies.get as jest.Mock
+  const mockCookiesExpire = Cookies.expire as jest.Mock
+  const mockUseAuthDialogTracking = useAuthDialogTracking as jest.Mock
+  const mockUseRouter = useRouter as jest.Mock
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("calls the correct tracking function with the correct data and expires the cookie", () => {
+    const loggedIn = jest.fn()
+    mockUseAuthDialogTracking.mockImplementation(() => ({ loggedIn }))
+    mockCookiesExpire.mockImplementation(jest.fn())
+
+    mockCookiesGet.mockImplementation(() =>
+      JSON.stringify({ action: "loggedIn", service: "google" })
+    )
+
+    renderHook(useSocialAuthTracking)
+
+    expect(loggedIn).toBeCalledWith({ service: "google", userId: "example" })
+    expect(mockCookiesExpire).toBeCalledWith("useSocialAuthTracking")
+  })
+
+  it("does not call the tracking function if the cookie is invalid and expires the cookie", () => {
+    const loggedIn = jest.fn()
+    mockUseAuthDialogTracking.mockImplementation(() => ({ loggedIn }))
+    mockCookiesExpire.mockImplementation(jest.fn())
+
+    mockCookiesGet.mockImplementation(() =>
+      JSON.stringify({ action: "invalid" })
+    )
+
+    renderHook(useSocialAuthTracking)
+
+    expect(loggedIn).not.toBeCalled()
+    expect(mockCookiesExpire).toBeCalledWith("useSocialAuthTracking")
+  })
+
+  it("does not call the tracking function if the user is on an authentication route and expires the cookie", () => {
+    const loggedIn = jest.fn()
+    mockUseAuthDialogTracking.mockImplementation(() => ({ loggedIn }))
+    mockCookiesExpire.mockImplementation(jest.fn())
+
+    mockCookiesGet.mockImplementation(() =>
+      JSON.stringify({ action: "loggedIn", service: "google" })
+    )
+
+    mockUseRouter.mockImplementation(() => ({
+      match: { location: { pathname: "/login" } },
+    }))
+
+    renderHook(useSocialAuthTracking)
+
+    expect(loggedIn).not.toBeCalled()
+    expect(mockCookiesExpire).toBeCalledWith("useSocialAuthTracking")
+  })
+})

--- a/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
+++ b/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
@@ -18,7 +18,11 @@ export const useAfterAuthenticationRedirectUrl = () => {
 
   const redirectUrl = useMemo(() => {
     const redirect = options.redirectTo || defaultRedirect
-    const redirectUri = new URL(redirect, getENV("APP_URL"))
+
+    const redirectUri = new URL(
+      redirect,
+      getENV("APP_URL") ?? "https://www.artsy.net"
+    )
 
     if (isElligibleForOnboarding) {
       redirectUri.searchParams.append("onboarding", "true")
@@ -42,7 +46,7 @@ export const useAfterAuthenticationRedirectUrl = () => {
 }
 
 const useDefaultRedirect = () => {
-  const { loginPagePath, signupPagePath } = getENV("AP")
+  const { loginPagePath, signupPagePath } = getENV("AP") ?? {}
 
   const router = useRouter()
 

--- a/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
@@ -3,6 +3,7 @@ import {
   AuthImpression,
   AuthModalType,
   CreatedAccount,
+  Intent,
   ResetYourPassword,
   SuccessfullyLoggedIn,
 } from "@artsy/cohesion"
@@ -43,19 +44,21 @@ export const useAuthDialogTracking = () => {
     loggedIn: ({
       service = "email",
       userId,
+      intent = analytics.intent || Intent.login,
+      trigger = analytics.trigger || "click",
     }: {
       service: SuccessfullyLoggedIn["service"]
       userId: SuccessfullyLoggedIn["user_id"]
+      intent?: SuccessfullyLoggedIn["intent"]
+      trigger?: SuccessfullyLoggedIn["trigger"]
     }) => {
-      if (!analytics.intent || !analytics.trigger) return
-
       const payload: SuccessfullyLoggedIn = {
         action: ActionType.successfullyLoggedIn,
         auth_redirect: redirectUrl,
         context_module: analytics.contextModule,
-        intent: analytics.intent,
+        intent,
         service,
-        trigger: analytics.trigger,
+        trigger,
         type: AuthModalType.login,
         user_id: userId,
       }
@@ -66,20 +69,22 @@ export const useAuthDialogTracking = () => {
     signedUp: ({
       service = "email",
       userId,
+      intent = analytics.intent || Intent.signup,
+      trigger = analytics.trigger || "click",
     }: {
       service: CreatedAccount["service"]
       userId: CreatedAccount["user_id"]
+      intent?: CreatedAccount["intent"]
+      trigger?: CreatedAccount["trigger"]
     }) => {
-      if (!analytics.intent || !analytics.trigger) return
-
       const payload: CreatedAccount = {
         action: ActionType.createdAccount,
         auth_redirect: redirectUrl,
         context_module: analytics.contextModule,
-        intent: analytics.intent,
+        intent,
         onboarding: isElligibleForOnboarding,
         service,
-        trigger: analytics.trigger,
+        trigger,
         type: AuthModalType.signup,
         user_id: userId,
       }

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -1,0 +1,81 @@
+import { useAuthDialogTracking } from "Components/AuthDialog/Hooks/useAuthDialogTracking"
+import { useEffect } from "react"
+import { useSystemContext } from "System"
+import { useRouter } from "System/Router/useRouter"
+import * as Yup from "yup"
+
+const USE_SOCIAL_AUTH_TRACKING_KEY = "useSocialAuthTracking"
+
+/**
+ * Picks up on the cookie set by `setSocialAuthTracking` and logs
+ * the appropriate event once the user is redirected back to the app successfully.
+ */
+export const useSocialAuthTracking = () => {
+  const {
+    match: { location },
+  } = useRouter()
+
+  const { user } = useSystemContext()
+
+  const track = useAuthDialogTracking()
+
+  useEffect(() => {
+    // Skip if the user isn't logged in
+    if (!user || !user.id) return
+
+    const cookie = Cookies.get(USE_SOCIAL_AUTH_TRACKING_KEY)
+
+    // Skip if there's no cookie
+    if (!cookie) return
+
+    const value = parse(cookie)
+
+    // Skip if the cookie is invalid
+    if (!value) {
+      // Expire the cookie so we don't keep trying to parse it
+      Cookies.expire(USE_SOCIAL_AUTH_TRACKING_KEY)
+
+      return
+    }
+
+    // Skip if the user is on an authentication route, which likely means
+    // social authentication failed and returned an error
+    if (["/login", "/signup"].includes(location.pathname)) {
+      // Expire the cookie since authentication failed
+      Cookies.expire(USE_SOCIAL_AUTH_TRACKING_KEY)
+
+      return
+    }
+
+    track[value.action]({ service: value.service, userId: user.id })
+
+    Cookies.expire(USE_SOCIAL_AUTH_TRACKING_KEY)
+  }, [location.pathname, track, user])
+}
+
+const schema = Yup.object().shape({
+  action: Yup.string().oneOf(["loggedIn", "signedUp"]).required(),
+  service: Yup.string().oneOf(["apple", "google", "facebook"]).required(),
+})
+
+type Payload = Yup.InferType<typeof schema>
+
+const isValid = (value: any): value is Payload => {
+  return schema.isValidSync(value)
+}
+
+const parse = (value: any): Payload | null => {
+  try {
+    const parsed = JSON.parse(value)
+
+    if (!isValid(parsed)) return null
+
+    return parsed
+  } catch (err) {
+    return null
+  }
+}
+
+export const setSocialAuthTracking = (payload: Payload) => {
+  Cookies.set(USE_SOCIAL_AUTH_TRACKING_KEY, JSON.stringify(payload))
+}

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -1,8 +1,9 @@
+import * as Yup from "yup"
+import Cookies from "cookies-js"
 import { useAuthDialogTracking } from "Components/AuthDialog/Hooks/useAuthDialogTracking"
 import { useEffect } from "react"
 import { useSystemContext } from "System"
 import { useRouter } from "System/Router/useRouter"
-import * as Yup from "yup"
 
 const USE_SOCIAL_AUTH_TRACKING_KEY = "useSocialAuthTracking"
 
@@ -53,7 +54,7 @@ export const useSocialAuthTracking = () => {
   }, [location.pathname, track, user])
 }
 
-const schema = Yup.object().shape({
+const schema = Yup.object({
   action: Yup.string().oneOf(["loggedIn", "signedUp"]).required(),
   service: Yup.string().oneOf(["apple", "google", "facebook"]).required(),
 })

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogForgotPassword.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogForgotPassword.jest.tsx
@@ -1,4 +1,3 @@
-//
 import { screen, render, fireEvent, waitFor } from "@testing-library/react"
 import { AuthDialogForgotPassword } from "Components/AuthDialog/Views/AuthDialogForgotPassword"
 import { forgotPassword } from "Utils/auth"

--- a/src/System/Router/__tests__/buildServerApp.jest.tsx
+++ b/src/System/Router/__tests__/buildServerApp.jest.tsx
@@ -15,7 +15,7 @@ import { Media } from "Utils/Responsive"
 import { NextFunction, Request } from "express"
 import type { ArtsyResponse } from "Server/middleware/artsyExpress"
 import { createMockNetworkLayer } from "DevTools/createMockNetworkLayer"
-import { findRoutesByPath } from "../Utils/findRoutesByPath"
+import { findRoutesByPath } from "System/Router/Utils/findRoutesByPath"
 import { useTracking } from "react-tracking"
 
 jest.unmock("react-relay")

--- a/src/Utils/Hooks/useAuthIntent/__tests__/useAuthIntent.jest.ts
+++ b/src/Utils/Hooks/useAuthIntent/__tests__/useAuthIntent.jest.ts
@@ -1,5 +1,5 @@
 import { createMockEnvironment } from "relay-test-utils"
-import { runAuthIntent } from "Utils/Hooks/useAuthIntent/index"
+import { isValid, runAuthIntent } from "Utils/Hooks/useAuthIntent/index"
 import Cookies from "cookies-js"
 import { followGeneMutation } from "Utils/Hooks/useAuthIntent/mutations/AuthIntentFollowGeneMutation"
 import { followArtistMutation } from "Utils/Hooks/useAuthIntent/mutations/AuthIntentFollowArtistMutation"
@@ -371,5 +371,27 @@ describe("runAuthIntent", () => {
         expect(global.console.error).toBeCalled()
       })
     })
+  })
+})
+
+describe("isValid", () => {
+  it("validates the cookie object", () => {
+    expect(
+      isValid({ action: "follow", kind: "artist", objectId: "example" })
+    ).toBe(true)
+    expect(
+      isValid({ action: "save", kind: "artworks", objectId: "example" })
+    ).toBe(true)
+    expect(
+      isValid({ action: "follow", kind: "invalid", objectId: "example" })
+    ).toBe(false)
+    expect(isValid({ action: "follow", kind: "artist" })).toBe(false)
+    expect(isValid({ action: "follow", objectId: "example" })).toBe(false)
+    expect(isValid({ kind: "artist", objectId: "example" })).toBe(false)
+    expect(isValid({ action: "follow" })).toBe(false)
+    expect(isValid({ kind: "artist" })).toBe(false)
+    expect(isValid({ objectId: "example" })).toBe(false)
+    expect(isValid({})).toBe(false)
+    expect(isValid("")).toBe(false)
   })
 })


### PR DESCRIPTION
Closes: [GRO-1543](https://artsyproduct.atlassian.net/browse/GRO-1543)

Now when clicking on the social auth links, we set a cookie that then gets picked up by this hook when you land back in the app. It correctly checks to make sure the auth didn't error by ensuring you're not on the login or sign up paths.

[GRO-1543]: https://artsyproduct.atlassian.net/browse/GRO-1543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ