### PR TITLE
fix: Clear local images when navigating back in artwork form

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext.tsx
@@ -47,13 +47,19 @@ export const useLocalImageState = () => {
 
     setLocalImages([...localImages, image])
   }
+
   const removeLocalImage = (photoID: string) => {
     setLocalImages(localImages.filter(image => image.photoID !== photoID))
+  }
+
+  const clearLocalImages = () => {
+    setLocalImages([])
   }
 
   return {
     localImages,
     addLocalImage,
     removeLocalImage,
+    clearLocalImages,
   }
 }

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionCreateArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionCreateArtwork.tsx
@@ -35,7 +35,12 @@ interface MyCollectionCreateArtworkProps {
 export const MyCollectionCreateArtwork: React.FC<MyCollectionCreateArtworkProps> = ({
   me,
 }) => {
-  const { localImages, addLocalImage, removeLocalImage } = useLocalImageState()
+  const {
+    localImages,
+    addLocalImage,
+    clearLocalImages,
+    removeLocalImage,
+  } = useLocalImageState()
 
   const isCollectorProfileEnabled = useFeatureFlag("cx-collector-profile")
   const enableNewMyCUploadFlow = useFeatureFlag(
@@ -72,6 +77,8 @@ export const MyCollectionCreateArtwork: React.FC<MyCollectionCreateArtworkProps>
   }
 
   const handleBack = () => {
+    clearLocalImages()
+
     if (currentStep === "artist-select" || !enableNewMyCUploadFlow) {
       router.push({
         pathname: isCollectorProfileEnabled

--- a/src/Utils/localImageHelpers.ts
+++ b/src/Utils/localImageHelpers.ts
@@ -2,7 +2,6 @@ import localforage from "localforage"
 import { useEffect, useState } from "react"
 
 // Expiration time is 5 minutes
-// TODO: Decrease number
 const EXPIRATION_TIME = 5 * 60 * 1000
 const IMAGE_KEY_PREFIX = "IMAGES"
 export const PROFILE_IMAGE_KEY = "PROFILE_IMAGE"


### PR DESCRIPTION
Addresses [CX-3391]

## Description

Clear local images when navigating back in artwork form.

[CX-3391]: https://artsyproduct.atlassian.net/browse/CX-3391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ