### PR TITLE
fix(art quiz): add messaging to empty state on artwork recs in results 

### DIFF
--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsRecommendedArtworks.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsRecommendedArtworks.tsx
@@ -5,7 +5,7 @@ import { ArtQuizResultsRecommendedArtworks_me$data } from "__generated__/ArtQuiz
 import { ArtQuizResultsRecommendedArtworksQuery } from "__generated__/ArtQuizResultsRecommendedArtworksQuery.graphql"
 import { Masonry } from "Components/Masonry"
 import ArtworkGridItemFragmentContainer from "Components/Artwork/GridItem"
-import { Spacer } from "@artsy/palette"
+import { Message, Spacer } from "@artsy/palette"
 import { uniqBy } from "lodash"
 import { ArtworkGridPlaceholder } from "Components/ArtworkGrid"
 import { extractNodes } from "Utils/extractNodes"
@@ -28,6 +28,12 @@ const ArtQuizResultsRecommendedArtworks: FC<ArtQuizResultsRecommendedArtworksPro
       "internalID"
     ),
   })
+
+  if (artworks.shuffled.length === 0) {
+    return (
+      <Message>We don't have any recommendations for you at this time.</Message>
+    )
+  }
 
   return (
     <Masonry columnCount={[2, 3, 4]}>

--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -13,7 +13,11 @@ import {
 } from "Apps/Consign/Routes/SubmissionFlow/Utils/validation"
 import { BackLink } from "Components/Links/BackLink"
 import { PhotoThumbnail } from "Components/PhotoUpload/Components/PhotoThumbnail"
-import { normalizePhoto, Photo } from "Components/PhotoUpload/Utils/fileUtils"
+import {
+  AUTOMATICALLY_ADDED_PHOTO_NAME,
+  normalizePhoto,
+  Photo,
+} from "Components/PhotoUpload/Utils/fileUtils"
 import { Form, Formik } from "formik"
 import { LocationDescriptor } from "found"
 import { findLast } from "lodash"
@@ -83,7 +87,7 @@ export const getUploadPhotosFormInitialValues = (
     photos =
       myCollectionArtwork?.images
         ?.map(image => ({
-          name: "Automatically added",
+          name: AUTOMATICALLY_ADDED_PHOTO_NAME,
           externalUrl: image?.url!,
           type: "image/jpg",
         }))

--- a/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoThumbnail.tsx
@@ -185,7 +185,7 @@ const PhotoThumbnailErrorState: React.FC<PhotoThumbnailStateProps> = ({
       <TruncatedLine variant="xs">{photo.name}</TruncatedLine>
     </Flex>
     <Flex alignItems="center" justifyContent="space-between">
-      <Text variant="xs">{formatFileSize(photo.size)}</Text>
+      <Text variant="xs">{formatFileSize(photo)}</Text>
       <RemoveButton withIconButton handleDelete={onDelete} />
     </Flex>
   </>
@@ -210,7 +210,7 @@ const PhotoThumbnailSuccessState: React.FC<
       <TruncatedLine variant="xs">{photo.name}</TruncatedLine>
     </Flex>
     <Flex alignItems="center" justifyContent="space-between">
-      <Text variant="xs">{formatFileSize(photo.size)}</Text>
+      <Text variant="xs">{formatFileSize(photo)}</Text>
       <RemoveButton handleDelete={onDelete} />
     </Flex>
   </>
@@ -239,7 +239,7 @@ const PhotoThumbnailProcessingState: React.FC<PhotoThumbnailStateProps> = ({
       <TruncatedLine variant="xs">{photo.name}</TruncatedLine>
     </Flex>
     <Flex alignItems="center" justifyContent="space-between">
-      <Text variant="xs">{formatFileSize(photo.size)}</Text>
+      <Text variant="xs">{formatFileSize(photo)}</Text>
       <RemoveButton handleDelete={onDelete} />
     </Flex>
   </>

--- a/src/Components/PhotoUpload/Utils/fileUtils.ts
+++ b/src/Components/PhotoUpload/Utils/fileUtils.ts
@@ -9,16 +9,27 @@ import { uploadFileToS3 } from "./uploadFileToS3"
 
 const logger = createLogger("PhotoUpload/fileUtils.ts")
 
+export const AUTOMATICALLY_ADDED_PHOTO_NAME = "Automatically added"
+
 export const KBSize = 1000
 export const MBSize = Math.pow(KBSize, 2)
 const NO_SIZE = ""
 
-export function formatFileSize(size?: number): string {
-  if (!size) {
+export function formatFileSize(photo: {
+  size?: number
+  name?: string
+}): string {
+  const { size, name } = photo
+
+  if (!size || name === AUTOMATICALLY_ADDED_PHOTO_NAME) {
     return NO_SIZE
   }
 
   const sizeInMB = (size / MBSize).toFixed(2)
+
+  if (sizeInMB === "0.00") {
+    return "< 0.01 MB"
+  }
 
   return `${sizeInMB} MB`
 }


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1453]

### Description

The intention of this code is to add a fallback state for users who take the art quiz and receive no artwork recs. After some chatter about this, was suggested to use a message in place of a collection because this issue seems to occur mostly on staging and will very rarely happen on prod. However, keeping this a draft PR until design approves messaging or asks for a collection to be included instead. Will hit merge on this once I know for sure. 

<!-- Implementation description -->
![Screen Shot 2023-02-03 at 12 35 32 PM](https://user-images.githubusercontent.com/23108927/216682827-debaaa38-866b-4420-ac15-e085a8def391.png)


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1453]: https://artsyproduct.atlassian.net/browse/GRO-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ