### PR TITLE
fix(auth): uses our actual auth paths

### DIFF
--- a/src/Components/AuthDialog/Hooks/__tests__/useAfterAuthenticationRedirect.jest.ts
+++ b/src/Components/AuthDialog/Hooks/__tests__/useAfterAuthenticationRedirect.jest.ts
@@ -8,10 +8,6 @@ jest.mock("Utils/getENV", () => ({
     return {
       APP_URL: "https://www.artsy.net",
       API_URL: "https://api.artsy.net",
-      AP: {
-        loginPagePath: "/login",
-        signupPagePath: "/signup",
-      },
     }[key]
   }),
 }))

--- a/src/Components/AuthDialog/Hooks/__tests__/useAfterAuthenticationRedirectUrl.jest.ts
+++ b/src/Components/AuthDialog/Hooks/__tests__/useAfterAuthenticationRedirectUrl.jest.ts
@@ -8,10 +8,6 @@ jest.mock("Utils/getENV", () => ({
     return {
       APP_URL: "https://www.artsy.net",
       API_URL: "https://api.artsy.net",
-      AP: {
-        loginPagePath: "/login",
-        signupPagePath: "/signup",
-      },
     }[key]
   }),
 }))

--- a/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
+++ b/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
@@ -46,8 +46,6 @@ export const useAfterAuthenticationRedirectUrl = () => {
 }
 
 const useDefaultRedirect = () => {
-  const { loginPagePath, signupPagePath } = getENV("AP") ?? {}
-
   const router = useRouter()
 
   // In a client-side context we have the window.location object, but we won't have
@@ -57,9 +55,7 @@ const useDefaultRedirect = () => {
 
   // If we're on the login or sign up path; we should redirect to the default (index).
   // Otherwise stay on the same page.
-  const defaultRedirect = [loginPagePath, signupPagePath].includes(
-    location.pathname
-  )
+  const defaultRedirect = ["/login", "/signup"].includes(location.pathname)
     ? DEFAULT_AFTER_AUTH_REDIRECT_PATH
     : location.pathname + (location.search || "")
 


### PR DESCRIPTION
So apparently the `AP` environment variable is pointing to old paths, which is the reason why this was redirecting back to /login, technically. We don't really need to be using them though so I'm just removing this.

The reason the Integrity spec failed is because, typically, if you're logged in, you're gonna get redirected to the homepage if you hit that route. It didn't because as far as the state of the browser is concerned, you are not logged in.

I'm confident that login is actually succeeding because [there's this assertion](https://github.com/artsy/integrity/blob/8b81f9f288c8d305c97855a4766dc3b849719391/cypress/utils/loginToArtsyAsUser.ts#L34-L36) — and we can eliminate one redirect anyway by fixing this so specs should pass once this is on staging.

-----

We did uncover this very weird bug in Integrity though. Simplest replication: write a spec that logs in, logs out, then logs back in again. You won't be logged in that second time even though everything succeeds. You _are_ logged in because opening a new tab in the Cypress window demonstrates that you're logged in. We have no theories as to what's causing this. We tried pauses of various lengths, `cy.reload()`, subsequent navigation, reloading the frame manually, clearing all session/cookies/local state manually before logging in. Nothing appears to make a difference. Any theories are welcome.