### PR TITLE
Feat(CX-3373): Collector Profile breadcrumb in Settings

### DIFF
--- a/src/Apps/Settings/SettingsApp.tsx
+++ b/src/Apps/Settings/SettingsApp.tsx
@@ -1,7 +1,15 @@
-import { Text, useToasts } from "@artsy/palette"
+import {
+  Breadcrumbs,
+  ChevronIcon,
+  Flex,
+  Spacer,
+  Text,
+  useToasts,
+} from "@artsy/palette"
 import { MyCollectionRouteLoggedOutState } from "Apps/Settings/Routes/MyCollection/MyCollectionRouteLoggedOutState"
 import { MetaTags } from "Components/MetaTags"
 import { RouteTab, RouteTabs } from "Components/RouteTabs"
+import { Link } from "found"
 import { compact } from "lodash"
 import React, { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -73,9 +81,31 @@ const SettingsApp: React.FC<SettingsAppProps> = ({ me, children }) => {
     <>
       <MetaTags title="Settings | Artsy" />
 
-      <Text variant={["lg-display", "xl"]} mt={[2, 4]}>
-        {isCollectorProfileEnabled ? "Settings" : `Hi, ${me.name}`}
-      </Text>
+      {isCollectorProfileEnabled ? (
+        <>
+          <Spacer y={2} />
+          <Breadcrumbs>
+            <Link to="/collector-profile/my-collection">
+              <Flex flexDirection="row" alignItems="center" py={2}>
+                <ChevronIcon
+                  direction="left"
+                  color="black100"
+                  height={14}
+                  width={18}
+                  mr={0.5}
+                />
+                <Text>Collector Profile</Text>
+              </Flex>
+            </Link>
+          </Breadcrumbs>
+          <Spacer y={4} />
+        </>
+      ) : (
+        <Text
+          variant={["lg-display", "xl"]}
+          mt={[2, 4]}
+        >{`Hi, ${me.name}`}</Text>
+      )}
 
       <RouteTabs my={SETTINGS_ROUTE_TABS_MARGIN}>
         {isCollectorProfileEnabled

--- a/src/Apps/Settings/SettingsApp.tsx
+++ b/src/Apps/Settings/SettingsApp.tsx
@@ -98,7 +98,7 @@ const SettingsApp: React.FC<SettingsAppProps> = ({ me, children }) => {
               </Flex>
             </Link>
           </Breadcrumbs>
-          <Spacer y={4} />
+          <Spacer y={6} />
         </>
       ) : (
         <Text


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3373]

### Description
- Replaces the Settings Heading with a collector profile breadcrumb.
- 
<!-- Implementation description -->

<img width="1566" alt="Screenshot 2023-02-06 at 18 47 52" src="https://user-images.githubusercontent.com/18648835/217081432-b11689ec-65c0-4431-b987-fe2c6585aae8.png">
<img width="380" alt="Screenshot 2023-02-06 at 18 47 29" src="https://user-images.githubusercontent.com/18648835/217081433-6c31cc17-4dab-4bc2-90d3-5d66b25f1154.png">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3373]: https://artsyproduct.atlassian.net/browse/CX-3373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ