### PR TITLE
feat(CX-3363): remove the Talk to Specialists page link from the footer

### DIFF
--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -28,11 +28,15 @@ import InstagramIcon from "@artsy/icons/InstagramIcon"
 import TikTokIcon from "@artsy/icons/TikTokIcon"
 import SpotifyIcon from "@artsy/icons/SpotifyIcon"
 import { useSystemContext } from "System"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface FooterProps extends BoxProps {}
 
 export const Footer: React.FC<FooterProps> = props => {
   const { isEigen } = useSystemContext()
+  const enableNewSWALandingPage = useFeatureFlag(
+    "cx-swa-landing-page-redesign-2023"
+  )
 
   if (isEigen) {
     return null
@@ -131,10 +135,11 @@ export const Footer: React.FC<FooterProps> = props => {
             </Text>
 
             <Text variant="sm">
-              <FooterLink my={2} to="/meet-the-specialists">
-                Talk to a Specialist
-              </FooterLink>
-
+              {!enableNewSWALandingPage && (
+                <FooterLink my={2} to="/meet-the-specialists">
+                  Talk to a Specialist
+                </FooterLink>
+              )}
               <FooterLink my={2} to="https://support.artsy.net">
                 Visit our Help Center
               </FooterLink>


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3363]

### Description

<!-- Implementation description -->
Don't show the Talk to Specialists page link when cx-swa-landing-page-redesign-2023 ff is enabled

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3363]: https://artsyproduct.atlassian.net/browse/CX-3363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ