### PR TITLE
fix(FX-4601): Do not display +n text in activity panel for non-artwork-based notifications

### DIFF
--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -10,6 +10,7 @@ import { useTracking } from "react-tracking"
 import { useSystemContext } from "System"
 import createLogger from "Utils/logger"
 import { markNotificationAsRead } from "Components/Notifications/Mutations/markNotificationAsRead"
+import { isArtworksBasedNotification } from "./util"
 
 const logger = createLogger("NotificationItem")
 
@@ -24,6 +25,9 @@ const NotificationItem: React.FC<NotificationItemProps> = ({ item }) => {
   const { relayEnvironment } = useSystemContext()
   const artworks = extractNodes(item.artworksConnection)
   const remainingArtworksCount = item.objectsCount - 4
+  const shouldDisplayCounts =
+    isArtworksBasedNotification(item.notificationType) &&
+    remainingArtworksCount > 0
 
   const getNotificationType = () => {
     if (item.notificationType === "ARTWORK_ALERT") {
@@ -109,7 +113,7 @@ const NotificationItem: React.FC<NotificationItemProps> = ({ item }) => {
             })}
           </Join>
 
-          {remainingArtworksCount > 0 && (
+          {shouldDisplayCounts && (
             <Text
               variant="xs"
               color="black60"

--- a/src/Components/Notifications/__tests__/NotificationItem.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationItem.jest.tsx
@@ -85,6 +85,19 @@ describe("NotificationItem", () => {
 
       expect(screen.getByText("+ 6")).toBeInTheDocument()
     })
+
+    it("should not be rendered when notification is not artwork-based", () => {
+      renderWithRelay({
+        Notification: () => ({
+          ...notification,
+          notificationType: "PARTNER_SHOW_OPENED",
+          objectsCount: 10,
+        }),
+      })
+
+      const label = screen.queryByLabelText("Remaining artworks count")
+      expect(label).not.toBeInTheDocument()
+    })
   })
 
   describe("Unread notification indicator", () => {

--- a/src/Components/Notifications/util.ts
+++ b/src/Components/Notifications/util.ts
@@ -9,7 +9,7 @@ export const shouldDisplayNotification = notification => {
   return artworksCount > 0
 }
 
-const isArtworksBasedNotification = (
+export const isArtworksBasedNotification = (
   notificationType: NotificationTypesEnum
 ) => {
   return ["ARTWORK_ALERT", "ARTWORK_PUBLISHED"].includes(notificationType)


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [FX-4601]

### Description

#### Before

<img width="419" alt="Screenshot 2023-02-07 at 12 00 00" src="https://user-images.githubusercontent.com/3934579/217227097-cbfddec5-12e9-4ae8-91b2-bd801e5ef0e7.png">

#### After

<img width="417" alt="Screenshot 2023-02-07 at 12 00 47" src="https://user-images.githubusercontent.com/3934579/217227120-0b9f5980-57f1-4f0a-86ca-2cfa21eb3fed.png">


[FX-4601]: https://artsyproduct.atlassian.net/browse/FX-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ