### PR TITLE
chore: correctly display image placeholders for saves/wishlist

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/FourUpImageLayout.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/FourUpImageLayout.tsx
@@ -53,6 +53,7 @@ const RowImage: FC<RowImageProps> = ({ url }) => {
         aria-label="Image placeholder"
         justifyContent="center"
         alignItems="center"
+        flexShrink={0}
       >
         <NoArtworkIcon width="18px" height="18px" fill="black60" />
       </Flex>

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/StackedImageLayout.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/StackedImageLayout.tsx
@@ -57,6 +57,7 @@ const StackImage: FC<StackImageProps> = ({ url, index }) => {
         aria-label="Image placeholder"
         justifyContent="center"
         alignItems="center"
+        flexShrink={0}
       >
         <NoArtworkIcon width="18px" height="18px" fill="black60" />
       </Flex>


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Demo
| Before | After |
| ------------- | ------------- |
| <img width="497" alt="before" src="https://user-images.githubusercontent.com/3513494/217311783-e809e61a-3f46-47b7-a8be-ad4b630994ce.png"> | <img width="497" alt="after" src="https://user-images.githubusercontent.com/3513494/217311829-d40c31c2-47c1-4aea-b667-e1adbb0284fd.png"> | 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ