### PR TITLE
feat(FX-4603): Activity Panel Editorial prefix should be grey

### DIFF
--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -10,7 +10,11 @@ import { useTracking } from "react-tracking"
 import { useSystemContext } from "System"
 import createLogger from "Utils/logger"
 import { markNotificationAsRead } from "Components/Notifications/Mutations/markNotificationAsRead"
-import { isArtworksBasedNotification } from "./util"
+import {
+  isArtworksBasedNotification,
+  shouldDisplayNotificationTypeLabel,
+} from "./util"
+import { NotificationTypeLabel } from "./NotificationTypeLabel"
 
 const logger = createLogger("NotificationItem")
 
@@ -28,18 +32,6 @@ const NotificationItem: React.FC<NotificationItemProps> = ({ item }) => {
   const shouldDisplayCounts =
     isArtworksBasedNotification(item.notificationType) &&
     remainingArtworksCount > 0
-
-  const getNotificationType = () => {
-    if (item.notificationType === "ARTWORK_ALERT") {
-      return "Alert"
-    }
-    if (item.notificationType === "ARTICLE_FEATURED_ARTIST") {
-      return "Artsy Editorial"
-    }
-
-    return null
-  }
-  const notificationTypeLabel = getNotificationType()
 
   const markAsRead = async () => {
     if (!relayEnvironment) {
@@ -76,12 +68,8 @@ const NotificationItem: React.FC<NotificationItemProps> = ({ item }) => {
     <NotificationItemLink to={item.targetHref} onClick={handlePress}>
       <Flex flex={1} flexDirection="column">
         <Text variant="xs" color="black60">
-          {notificationTypeLabel && (
-            <NotificationTypeLabel
-              aria-label={`Notification type: ${notificationTypeLabel}`}
-            >
-              {notificationTypeLabel} •{" "}
-            </NotificationTypeLabel>
+          {shouldDisplayNotificationTypeLabel(item.notificationType) && (
+            <NotificationTypeLabel notificationType={item.notificationType} />
           )}
           {item.publishedAt}
         </Text>
@@ -172,10 +160,6 @@ export const NotificationItemFragmentContainer = createFragmentContainer(
     `,
   }
 )
-
-const NotificationTypeLabel = styled.span`
-  color: ${themeGet("colors.blue100")};
-`
 
 const NotificationItemLink = styled(RouterLink)`
   display: flex;

--- a/src/Components/Notifications/NotificationTypeLabel.tsx
+++ b/src/Components/Notifications/NotificationTypeLabel.tsx
@@ -1,0 +1,33 @@
+import { Box } from "@artsy/palette"
+
+interface Props {
+  notificationType: string
+}
+
+export const NotificationTypeLabel: React.FC<Props> = ({
+  notificationType,
+}) => {
+  const getNotificationType = () => {
+    if (notificationType === "ARTWORK_ALERT") {
+      return "Alert"
+    }
+    if (notificationType === "ARTICLE_FEATURED_ARTIST") {
+      return "Artsy Editorial"
+    }
+
+    return null
+  }
+  const notificationTypeLabel = getNotificationType()
+  const notificationTypeColor =
+    notificationType == "ARTWORK_ALERT" ? "blue100" : "black60"
+
+  return (
+    <Box
+      as="span"
+      aria-label={`Notification type: ${notificationTypeLabel}`}
+      color={notificationTypeColor}
+    >
+      {notificationTypeLabel} •{" "}
+    </Box>
+  )
+}

--- a/src/Components/Notifications/util.ts
+++ b/src/Components/Notifications/util.ts
@@ -14,3 +14,9 @@ export const isArtworksBasedNotification = (
 ) => {
   return ["ARTWORK_ALERT", "ARTWORK_PUBLISHED"].includes(notificationType)
 }
+
+export const shouldDisplayNotificationTypeLabel = (
+  notificationType: string
+) => {
+  return ["ARTWORK_ALERT", "ARTICLE_FEATURED_ARTIST"].includes(notificationType)
+}


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [FX-4603]

### Description

Editorial notification - "Artsy Editorial" should be grey, not blue

### Demo
| Before | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/3513494/217545967-f2c7ca1f-84fe-4392-9c4e-8f46817aedf2.png) | ![after](https://user-images.githubusercontent.com/3513494/217546011-90ffbc1c-16ab-4c65-99b6-1fccf75bba1c.png) |



[FX-4603]: https://artsyproduct.atlassian.net/browse/FX-4603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ