### PR TITLE
fix(art-quiz): prevents squashed buttons and short screen overflows

### DIFF
--- a/src/Apps/ArtQuiz/Components/ArtQuizFullscreen.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizFullscreen.tsx
@@ -1,6 +1,6 @@
-import { Box } from "@artsy/palette"
+import { Box, Spinner } from "@artsy/palette"
 import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
-import { FC, useEffect, useState } from "react"
+import { FC, useEffect, useRef, useState } from "react"
 
 export const ArtQuizFullScreen: FC = ({ children }) => {
   const { mobile, desktop } = useNavBarHeight()
@@ -14,9 +14,16 @@ export const ArtQuizFullScreen: FC = ({ children }) => {
    **/
   const [height, setHeight] = useState(0)
 
+  const childrenRef = useRef<HTMLDivElement | null>(null)
+
+  const [childrenHeight, setChildrenHeight] = useState(0)
+
   useEffect(() => {
     const handleResize = () => {
+      if (!childrenRef.current) return
+
       setHeight(window.innerHeight)
+      setChildrenHeight(childrenRef.current.clientHeight)
     }
 
     handleResize()
@@ -28,9 +35,29 @@ export const ArtQuizFullScreen: FC = ({ children }) => {
     }
   }, [])
 
+  const isLoading = height === 0
+  const isOverflowing = childrenHeight > height - desktop
+
   return (
-    <Box height={[`${height - mobile}px`, `${height - desktop}px`]}>
-      {children}
+    <Box
+      position="relative"
+      height={[
+        `${height - mobile}px`,
+        isOverflowing ? "100%" : `${height - desktop}px`,
+      ]}
+    >
+      {isLoading && <Spinner />}
+
+      <Box
+        ref={childrenRef as any}
+        height="100%"
+        style={{
+          opacity: isLoading ? 0 : 1,
+          transition: "opacity 250ms",
+        }}
+      >
+        {children}
+      </Box>
     </Box>
   )
 }

--- a/src/Apps/ArtQuiz/Routes/ArtQuizWelcome.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizWelcome.tsx
@@ -6,6 +6,7 @@ import {
   ArtsyMarkBlackIcon,
   FullBleed,
   ArtsyLogoIcon,
+  Box,
 } from "@artsy/palette"
 import { SplitLayout } from "Components/SplitLayout"
 import { FC } from "react"
@@ -33,7 +34,9 @@ export const ArtQuizWelcome: FC<ArtQuizWelcomeProps> = ({ onStartQuiz }) => {
           leftProps={{ display: ["none", "block"] }}
           right={
             <Flex flexDirection="column" justifyContent="center" p={[2, 4]}>
-              <ArtsyLogoIcon />
+              <Box flexShrink={0}>
+                <ArtsyLogoIcon />
+              </Box>
 
               <Spacer y={2} />
 
@@ -53,27 +56,29 @@ export const ArtQuizWelcome: FC<ArtQuizWelcomeProps> = ({ onStartQuiz }) => {
 
               <Spacer y={12} />
 
-              <Button
-                // @ts-ignore
-                as={RouterLink}
-                width="100%"
-                onClick={onStartQuiz}
-                to="/art-quiz/artworks"
-              >
-                {t("artQuizPage.welcomeScreen.getStartedButton")}
-              </Button>
+              <Box flexShrink={0}>
+                <Button
+                  // @ts-ignore
+                  as={RouterLink}
+                  width="100%"
+                  onClick={onStartQuiz}
+                  to="/art-quiz/artworks"
+                >
+                  {t("artQuizPage.welcomeScreen.getStartedButton")}
+                </Button>
 
-              <Spacer y={1} />
+                <Spacer y={1} />
 
-              <Button
-                // @ts-ignore
-                as={RouterLink}
-                variant="tertiary"
-                width="100%"
-                to="/"
-              >
-                {t("artQuizPage.welcomeScreen.skipButton")}
-              </Button>
+                <Button
+                  // @ts-ignore
+                  as={RouterLink}
+                  variant="tertiary"
+                  width="100%"
+                  to="/"
+                >
+                  {t("artQuizPage.welcomeScreen.skipButton")}
+                </Button>
+              </Box>
             </Flex>
           }
         />


### PR DESCRIPTION
Just a little polish on the welcome screen.

This fixes the shrunken buttons when the height is short. Also fixes the flash of content where the container isn't the correct height while the JS loads.


https://user-images.githubusercontent.com/112297/217666954-99ae9b43-cc7a-499d-a481-ec0575cef859.mov

