### PR TITLE
feat(CX-3373): Rm extra spacing

### DIFF
--- a/src/Apps/Settings/SettingsApp.tsx
+++ b/src/Apps/Settings/SettingsApp.tsx
@@ -83,7 +83,6 @@ const SettingsApp: React.FC<SettingsAppProps> = ({ me, children }) => {
 
       {isCollectorProfileEnabled ? (
         <>
-          <Spacer y={2} />
           <Breadcrumbs>
             <Link to="/collector-profile/my-collection">
               <Flex flexDirection="row" alignItems="center" py={2}>
@@ -91,10 +90,11 @@ const SettingsApp: React.FC<SettingsAppProps> = ({ me, children }) => {
                   direction="left"
                   color="black100"
                   height={14}
-                  width={18}
-                  mr={0.5}
+                  width={14}
                 />
-                <Text>Collector Profile</Text>
+                <Text variant="xs" pl={1}>
+                  Collector Profile
+                </Text>
               </Flex>
             </Link>
           </Breadcrumbs>


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3373]

### Description
Removes extra spacing in the Collector Profile Breadcrumb
<!-- Implementation description -->
<img width="1368" alt="Screenshot 2023-02-13 at 07 42 23" src="https://user-images.githubusercontent.com/18648835/218388831-4510b2a0-0ad7-4e7b-95e0-dc97dbc22bd7.png">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3373]: https://artsyproduct.atlassian.net/browse/CX-3373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ