### PR TITLE
feat(TX-1053): Get versioned artwork image

### DIFF
--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -79,13 +79,15 @@ interface SettingsPurchasesRowProps {
 
 const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
   const [lineItem] = extractNodes(order?.lineItems)
-  const { artwork, fulfillments } = lineItem
+  const { artwork, artworkVersion, fulfillments } = lineItem
   const { requestedFulfillment } = order
 
   const orderCreatedAt = DateTime.fromISO(order.createdAt)
   const isOrderActive = order.state !== "CANCELED" && order.state !== "REFUNDED"
   const trackingId = fulfillments?.edges?.[0]?.node?.trackingId
-  const image = artwork?.image?.cropped
+  const image = artworkVersion?.image?.cropped
+
+  const isPrivateSale = order.source === "private_sale"
 
   return (
     <Box border="1px solid" borderColor="black10">
@@ -155,14 +157,18 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
             </Text>
 
             <Text variant="xs" color="black60">
-              <RouterLink
-                to={artwork?.href!}
-                display="block"
-                color="black60"
-                textDecoration="none"
-              >
-                {artwork?.title}
-              </RouterLink>
+              {isPrivateSale ? (
+                artwork?.title
+              ) : (
+                <RouterLink
+                  to={artwork?.href!}
+                  display="block"
+                  color="black60"
+                  textDecoration="none"
+                >
+                  {artwork?.title}
+                </RouterLink>
+              )}
             </Text>
           </Box>
         </Column>
@@ -231,7 +237,7 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
 
         <Text variant="xs" color="black60">
           Need Help?{" "}
-          {order.source === "private_sale" ? (
+          {isPrivateSale ? (
             <RouterLink to="mailto:privatesales@artsy.net">
               privatesales@artsy.net
             </RouterLink>
@@ -275,14 +281,16 @@ export const SettingsPurchasesRowFragmentContainer = createFragmentContainer(
         lineItems {
           edges {
             node {
-              artwork {
-                href
+              artworkVersion {
                 image {
                   cropped(width: 45, height: 45) {
                     src
                     srcSet
                   }
                 }
+              }
+              artwork {
+                href
                 partner {
                   href
                   initials

--- a/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
@@ -33,24 +33,24 @@ describe("SettingsPurchases", () => {
     expect(screen.getByText("Contact Us.")).toBeInTheDocument()
   })
 
-  it("renders correct help email address for PS orders", () => {
-    renderWithRelay({
-      Me: () => ({
-        name: "jane doe",
-        orders: {
-          totalCount: 1,
-          edges: [
-            {
-              node: {
-                code: "123",
-                source: "private_sale",
+  describe("with private sale orders", () => {
+    it("renders correct help email address for PS orders", () => {
+      renderWithRelay({
+        Me: () => ({
+          orders: {
+            edges: [
+              {
+                node: {
+                  code: "123",
+                  source: "private_sale",
+                },
               },
-            },
-          ],
-        },
-      }),
-    })
+            ],
+          },
+        }),
+      })
 
-    expect(screen.getByText("privatesales@artsy.net")).toBeInTheDocument()
+      expect(screen.getByText("privatesales@artsy.net")).toBeInTheDocument()
+    })
   })
 })

--- a/src/__generated__/SettingsPurchasesQuery.graphql.ts
+++ b/src/__generated__/SettingsPurchasesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1abcd700d973a683bb30300400c1d726>>
+ * @generated SignedSource<<54bbc74cbaa8cc7a9c7875218079eed3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -105,14 +105,7 @@ v9 = {
   "name": "id",
   "storageKey": null
 },
-v10 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v11 = [
+v10 = [
   {
     "alias": null,
     "args": [
@@ -149,7 +142,14 @@ v11 = [
     ],
     "storageKey": "cropped(height:45,width:45)"
   }
-];
+],
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [
@@ -472,12 +472,11 @@ return {
                                   {
                                     "alias": null,
                                     "args": null,
-                                    "concreteType": "Artwork",
+                                    "concreteType": "ArtworkVersion",
                                     "kind": "LinkedField",
-                                    "name": "artwork",
+                                    "name": "artworkVersion",
                                     "plural": false,
                                     "selections": [
-                                      (v10/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -485,9 +484,22 @@ return {
                                         "kind": "LinkedField",
                                         "name": "image",
                                         "plural": false,
-                                        "selections": (v11/*: any*/),
+                                        "selections": (v10/*: any*/),
                                         "storageKey": null
                                       },
+                                      (v9/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Artwork",
+                                    "kind": "LinkedField",
+                                    "name": "artwork",
+                                    "plural": false,
+                                    "selections": [
+                                      (v11/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -496,7 +508,7 @@ return {
                                         "name": "partner",
                                         "plural": false,
                                         "selections": [
-                                          (v10/*: any*/),
+                                          (v11/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -520,7 +532,7 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "icon",
                                                 "plural": false,
-                                                "selections": (v11/*: any*/),
+                                                "selections": (v10/*: any*/),
                                                 "storageKey": null
                                               },
                                               (v9/*: any*/)
@@ -560,7 +572,7 @@ return {
                                         "name": "artists",
                                         "plural": true,
                                         "selections": [
-                                          (v10/*: any*/),
+                                          (v11/*: any*/),
                                           (v9/*: any*/)
                                         ],
                                         "storageKey": null
@@ -643,12 +655,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d8aba3df7582f2dff0205578c0089c36",
+    "cacheID": "7d1e702541ff92a9b93e7d56fa9b3a64",
     "id": null,
     "metadata": {},
     "name": "SettingsPurchasesQuery",
     "operationKind": "query",
-    "text": "query SettingsPurchasesQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $after: String\n) {\n  me {\n    ...SettingsPurchases_me_4tp0sF\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          href\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me_4tp0sF on Me {\n  name\n  orders(states: $states, first: $first, after: $after) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsPurchasesQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $after: String\n) {\n  me {\n    ...SettingsPurchases_me_4tp0sF\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me_4tp0sF on Me {\n  name\n  orders(states: $states, first: $first, after: $after) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsPurchasesRow_order.graphql.ts
+++ b/src/__generated__/SettingsPurchasesRow_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e38421086f679684a268f8f196843577>>
+ * @generated SignedSource<<7c412111c38544513f7c8058da7d0959>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,12 +29,6 @@ export type SettingsPurchasesRow_order$data = {
             readonly href: string | null;
           } | null> | null;
           readonly href: string | null;
-          readonly image: {
-            readonly cropped: {
-              readonly src: string;
-              readonly srcSet: string;
-            } | null;
-          } | null;
           readonly partner: {
             readonly href: string | null;
             readonly initials: string | null;
@@ -50,6 +44,14 @@ export type SettingsPurchasesRow_order$data = {
           } | null;
           readonly shippingOrigin: string | null;
           readonly title: string | null;
+        } | null;
+        readonly artworkVersion: {
+          readonly image: {
+            readonly cropped: {
+              readonly src: string;
+              readonly srcSet: string;
+            } | null;
+          } | null;
         } | null;
         readonly fulfillments: {
           readonly edges: ReadonlyArray<{
@@ -95,14 +97,7 @@ var v0 = {
   "name": "__typename",
   "storageKey": null
 },
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v2 = [
+v1 = [
   {
     "alias": null,
     "args": [
@@ -139,7 +134,14 @@ v2 = [
     ],
     "storageKey": "cropped(height:45,width:45)"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+};
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -301,12 +303,11 @@ return {
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "Artwork",
+                  "concreteType": "ArtworkVersion",
                   "kind": "LinkedField",
-                  "name": "artwork",
+                  "name": "artworkVersion",
                   "plural": false,
                   "selections": [
-                    (v1/*: any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -314,9 +315,21 @@ return {
                       "kind": "LinkedField",
                       "name": "image",
                       "plural": false,
-                      "selections": (v2/*: any*/),
+                      "selections": (v1/*: any*/),
                       "storageKey": null
-                    },
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Artwork",
+                  "kind": "LinkedField",
+                  "name": "artwork",
+                  "plural": false,
+                  "selections": [
+                    (v2/*: any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -325,7 +338,7 @@ return {
                       "name": "partner",
                       "plural": false,
                       "selections": [
-                        (v1/*: any*/),
+                        (v2/*: any*/),
                         {
                           "alias": null,
                           "args": null,
@@ -355,7 +368,7 @@ return {
                               "kind": "LinkedField",
                               "name": "icon",
                               "plural": false,
-                              "selections": (v2/*: any*/),
+                              "selections": (v1/*: any*/),
                               "storageKey": null
                             }
                           ],
@@ -393,7 +406,7 @@ return {
                       "name": "artists",
                       "plural": true,
                       "selections": [
-                        (v1/*: any*/)
+                        (v2/*: any*/)
                       ],
                       "storageKey": null
                     }
@@ -461,6 +474,6 @@ return {
 };
 })();
 
-(node as any).hash = "3a4c1cbefcb8dfa253df76b32a82c09f";
+(node as any).hash = "f241267fa70b8bb2bb0063509efa4860";
 
 export default node;

--- a/src/__generated__/SettingsPurchases_Test_Query.graphql.ts
+++ b/src/__generated__/SettingsPurchases_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<969148b347f8e1f5b36e68231e1ef4c7>>
+ * @generated SignedSource<<6b61413653d78096a8e3630a0285d1b7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -68,14 +68,7 @@ v5 = {
   "name": "id",
   "storageKey": null
 },
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v7 = [
+v6 = [
   {
     "alias": null,
     "args": [
@@ -113,6 +106,13 @@ v7 = [
     "storageKey": "cropped(height:45,width:45)"
   }
 ],
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
 v8 = {
   "enumValues": null,
   "nullable": false,
@@ -493,12 +493,11 @@ return {
                                   {
                                     "alias": null,
                                     "args": null,
-                                    "concreteType": "Artwork",
+                                    "concreteType": "ArtworkVersion",
                                     "kind": "LinkedField",
-                                    "name": "artwork",
+                                    "name": "artworkVersion",
                                     "plural": false,
                                     "selections": [
-                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -506,9 +505,22 @@ return {
                                         "kind": "LinkedField",
                                         "name": "image",
                                         "plural": false,
-                                        "selections": (v7/*: any*/),
+                                        "selections": (v6/*: any*/),
                                         "storageKey": null
                                       },
+                                      (v5/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Artwork",
+                                    "kind": "LinkedField",
+                                    "name": "artwork",
+                                    "plural": false,
+                                    "selections": [
+                                      (v7/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -517,7 +529,7 @@ return {
                                         "name": "partner",
                                         "plural": false,
                                         "selections": [
-                                          (v6/*: any*/),
+                                          (v7/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -541,7 +553,7 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "icon",
                                                 "plural": false,
-                                                "selections": (v7/*: any*/),
+                                                "selections": (v6/*: any*/),
                                                 "storageKey": null
                                               },
                                               (v5/*: any*/)
@@ -581,7 +593,7 @@ return {
                                         "name": "artists",
                                         "plural": true,
                                         "selections": [
-                                          (v6/*: any*/),
+                                          (v7/*: any*/),
                                           (v5/*: any*/)
                                         ],
                                         "storageKey": null
@@ -664,7 +676,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f8ac2a2e9098279660499d60b959f3fd",
+    "cacheID": "1ac19a04dae6a6212cdfaf04cfd4f83d",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -754,10 +766,6 @@ return {
         "me.orders.edges.node.lineItems.edges.node.artwork.artists.id": (v8/*: any*/),
         "me.orders.edges.node.lineItems.edges.node.artwork.href": (v9/*: any*/),
         "me.orders.edges.node.lineItems.edges.node.artwork.id": (v8/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.image": (v11/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.image.cropped": (v12/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.image.cropped.src": (v10/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.image.cropped.srcSet": (v10/*: any*/),
         "me.orders.edges.node.lineItems.edges.node.artwork.partner": {
           "enumValues": null,
           "nullable": true,
@@ -781,6 +789,17 @@ return {
         "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile.id": (v8/*: any*/),
         "me.orders.edges.node.lineItems.edges.node.artwork.shippingOrigin": (v9/*: any*/),
         "me.orders.edges.node.lineItems.edges.node.artwork.title": (v9/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkVersion"
+        },
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion.id": (v8/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image": (v11/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image.cropped": (v12/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image.cropped.src": (v10/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image.cropped.srcSet": (v10/*: any*/),
         "me.orders.edges.node.lineItems.edges.node.fulfillments": {
           "enumValues": null,
           "nullable": true,
@@ -890,7 +909,7 @@ return {
     },
     "name": "SettingsPurchases_Test_Query",
     "operationKind": "query",
-    "text": "query SettingsPurchases_Test_Query {\n  me {\n    ...SettingsPurchases_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          href\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsPurchases_Test_Query {\n  me {\n    ...SettingsPurchases_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/settingsRoutes_PurchasesRouteQuery.graphql.ts
+++ b/src/__generated__/settingsRoutes_PurchasesRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<805b600d390a62731d01dd7a1c2fa865>>
+ * @generated SignedSource<<e9a10fba59f8080dcb2a99f28ecbf45e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -68,14 +68,7 @@ v5 = {
   "name": "id",
   "storageKey": null
 },
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v7 = [
+v6 = [
   {
     "alias": null,
     "args": [
@@ -112,7 +105,14 @@ v7 = [
     ],
     "storageKey": "cropped(height:45,width:45)"
   }
-];
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [],
@@ -445,12 +445,11 @@ return {
                                   {
                                     "alias": null,
                                     "args": null,
-                                    "concreteType": "Artwork",
+                                    "concreteType": "ArtworkVersion",
                                     "kind": "LinkedField",
-                                    "name": "artwork",
+                                    "name": "artworkVersion",
                                     "plural": false,
                                     "selections": [
-                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -458,9 +457,22 @@ return {
                                         "kind": "LinkedField",
                                         "name": "image",
                                         "plural": false,
-                                        "selections": (v7/*: any*/),
+                                        "selections": (v6/*: any*/),
                                         "storageKey": null
                                       },
+                                      (v5/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Artwork",
+                                    "kind": "LinkedField",
+                                    "name": "artwork",
+                                    "plural": false,
+                                    "selections": [
+                                      (v7/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -469,7 +481,7 @@ return {
                                         "name": "partner",
                                         "plural": false,
                                         "selections": [
-                                          (v6/*: any*/),
+                                          (v7/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -493,7 +505,7 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "icon",
                                                 "plural": false,
-                                                "selections": (v7/*: any*/),
+                                                "selections": (v6/*: any*/),
                                                 "storageKey": null
                                               },
                                               (v5/*: any*/)
@@ -533,7 +545,7 @@ return {
                                         "name": "artists",
                                         "plural": true,
                                         "selections": [
-                                          (v6/*: any*/),
+                                          (v7/*: any*/),
                                           (v5/*: any*/)
                                         ],
                                         "storageKey": null
@@ -616,12 +628,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2578357e02fd2f2fa9dfaf9880c56425",
+    "cacheID": "b9fe1dd8609b11d7f9d62d3551a0ec6e",
     "id": null,
     "metadata": {},
     "name": "settingsRoutes_PurchasesRouteQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_PurchasesRouteQuery {\n  me {\n    ...SettingsPurchasesRoute_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRoute_me on Me {\n  ...SettingsPurchases_me\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          href\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_PurchasesRouteQuery {\n  me {\n    ...SettingsPurchasesRoute_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRoute_me on Me {\n  ...SettingsPurchases_me\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [TX-1053]

### Description

This PR gets the artwork image, displayed in the order row in user purchases, from the artwork version, since this section can now include private sale orders.

Additionally, I made the artwork's name un-clickable for private sale orders, since users cannot go to the artwork page. 

<img width="1069" alt="web" src="https://user-images.githubusercontent.com/42584148/218473494-1f8a0aeb-c2ae-48e5-95fb-116bff8796ec.png">



[TX-1053]: https://artsyproduct.atlassian.net/browse/TX-1053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ