### PR TITLE
feat(TX-1058): order app logo redirects to home page

### DIFF
--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -98,12 +98,10 @@ const OrderApp: FC<OrderAppProps> = props => {
   const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
   const isModal = !!props.match?.location.query.isModal
   const artwork = extractNodes(order.lineItems!)[0].artwork
-  const logoClickRedirectPath =
-    order.source === "private_sale" ? "/" : artwork?.href!
 
   return (
     <Box>
-      <MinimalNavBar to={logoClickRedirectPath} isBlank={isModal}>
+      <MinimalNavBar to="/" isBlank={isModal}>
         <Title>Checkout | Artsy</Title>
         <Meta
           name="viewport"

--- a/src/Apps/Order/__tests__/OrderApp.jest.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.jest.tsx
@@ -665,13 +665,13 @@ describe("OrderApp", () => {
     )
   })
 
-  it("redirects user to home page for private sale orders when Artsy logo is clicked", () => {
+  it("redirects user to home page when Artsy logo is clicked", () => {
     const props = getProps({
       location: "/order/123/review",
     })
     const page = getWrapper({
       context: { isEigen: false },
-      props: { ...props, order: PrivateSaleOrderWithShippingDetails },
+      props: { ...props, order: UntouchedBuyOrder },
     })
 
     const logo = page.find(`[data-test="logoLink"]`).first()


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-1058]

### Description

This PR updates the order app Artsy logo to always redirect to the homepage. 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-1058]: https://artsyproduct.atlassian.net/browse/TX-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ