### PR TITLE
feat(artwork lists): contextual action menu + delete action

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/DeleteSavesModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/DeleteSavesModal.tsx
@@ -1,0 +1,104 @@
+import { Button, Flex, ModalDialog, Text, useToasts } from "@artsy/palette"
+import { useTranslation } from "react-i18next"
+import { graphql } from "react-relay"
+import { useMutation } from "Utils/Hooks/useMutation"
+import { DeleteSavesModalMutation } from "__generated__/DeleteSavesModalMutation.graphql"
+import { SavesArtworks_collection$data } from "__generated__/SavesArtworks_collection.graphql"
+
+interface Props {
+  collection: SavesArtworks_collection$data
+  setIsDeleteModalOpen: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+export const DeleteSavesModal: React.FC<Props> = ({
+  collection,
+  setIsDeleteModalOpen,
+}) => {
+  const { t } = useTranslation()
+
+  const { submitMutation } = useMutation<DeleteSavesModalMutation>({
+    mutation: graphql`
+      mutation DeleteSavesModalMutation($input: deleteCollectionInput!) {
+        deleteCollection(input: $input) {
+          responseOrError {
+            __typename # DeleteCollectionSuccess or DeleteCollectionFailure
+            ... on DeleteCollectionFailure {
+              mutationError {
+                message
+                statusCode
+              }
+            }
+          }
+        }
+      }
+    `,
+  })
+
+  const { sendToast } = useToasts()
+
+  const handleDeletePress = async () => {
+    try {
+      await submitMutation({
+        variables: {
+          input: {
+            id: collection.internalID,
+          },
+        },
+        rejectIf: res => {
+          const result = res.deleteCollection?.responseOrError
+
+          return result?.__typename === "DeleteCollectionFailure"
+            ? result.mutationError
+            : false
+        },
+      })
+
+      sendToast({
+        variant: "success",
+        message: t("collectorSaves.deleteListModal.success"),
+      })
+    } catch (err) {
+      console.error(err)
+      sendToast({
+        variant: "error",
+        message: err.message ?? "Something went wrong",
+      })
+    } finally {
+      setIsDeleteModalOpen(false)
+    }
+  }
+
+  return (
+    <ModalDialog
+      title={t("collectorSaves.deleteListModal.title", {
+        name: collection.name,
+      })}
+      onClose={() => {
+        setIsDeleteModalOpen(false)
+      }}
+      footer={
+        <Flex
+          justifyContent={"space-between"}
+          flexDirection={["column-reverse", "row"]}
+        >
+          <Button
+            variant="secondaryBlack"
+            onClick={() => setIsDeleteModalOpen(false)}
+          >
+            {t("collectorSaves.deleteListModal.cancel")}
+          </Button>
+
+          <Button mb={[1, 0]} onClick={handleDeletePress}>
+            {t("collectorSaves.deleteListModal.delete")}
+          </Button>
+        </Flex>
+      }
+      width={[
+        "100%",
+        753, // vs. 713px for create and edit modals and 673px for manage-artworks modal -- should be consistent (700?) or maybe just "auto"?
+      ]}
+    >
+      <Text>{t("collectorSaves.deleteListModal.message")}</Text>
+    </ModalDialog>
+  )
+}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/SavesContextualMenu.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/SavesContextualMenu.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react"
+import {
+  ContextualMenu,
+  ContextualMenuDivider,
+  ContextualMenuItem,
+} from "Components/ContextualMenu"
+import { SavesArtworks_collection$data } from "__generated__/SavesArtworks_collection.graphql"
+import { DeleteSavesModal } from "./DeleteSavesModal"
+import { useTranslation } from "react-i18next"
+
+interface Props {
+  collection: SavesArtworks_collection$data
+}
+
+export const SavesContextualMenu: React.FC<Props> = ({ collection }) => {
+  const { t } = useTranslation()
+
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+
+  const handleEditList = () => {
+    alert("Unimplemented — see FX-4552")
+  }
+
+  const handleDeleteList = () => {
+    setIsDeleteModalOpen(true)
+  }
+
+  return (
+    <>
+      {isDeleteModalOpen && (
+        <DeleteSavesModal
+          collection={collection}
+          setIsDeleteModalOpen={setIsDeleteModalOpen}
+        />
+      )}
+
+      <ContextualMenu>
+        <ContextualMenuItem onClick={handleEditList}>
+          {t("collectorSaves.contextualMenu.edit")}
+        </ContextualMenuItem>
+
+        <ContextualMenuDivider />
+
+        <ContextualMenuItem onClick={handleDeleteList}>
+          {t("collectorSaves.contextualMenu.delete")}
+        </ContextualMenuItem>
+      </ContextualMenu>
+    </>
+  )
+}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/DeleteSavesModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/DeleteSavesModal.jest.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+
+import { useMutation } from "Utils/Hooks/useMutation"
+import { DeleteSavesModal } from "Apps/CollectorProfile/Routes/Saves2/Components/Actions/DeleteSavesModal"
+import { SavesArtworks_collection$data } from "__generated__/SavesArtworks_collection.graphql"
+
+jest.mock("Utils/Hooks/useMutation")
+
+const collection = {
+  internalID: "foobar",
+  name: "Foo Bar",
+} as SavesArtworks_collection$data
+
+describe("DeleteSavesModal", () => {
+  let setIsDeleteModalOpen: jest.Mock
+  let submitMutation: jest.Mock
+
+  beforeEach(() => {
+    setIsDeleteModalOpen = jest.fn()
+    submitMutation = jest.fn()
+    ;(useMutation as jest.Mock).mockImplementation(() => {
+      return { submitMutation }
+    })
+  })
+
+  it("renders the modal content", async () => {
+    render(
+      <DeleteSavesModal
+        collection={collection}
+        setIsDeleteModalOpen={setIsDeleteModalOpen}
+      />
+    )
+
+    expect(screen.getByText("Delete Foo Bar list?")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Cancel/ })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Delete/ })).toBeInTheDocument()
+  })
+
+  it("dismisses when the Cancel button is clicked", async () => {
+    render(
+      <DeleteSavesModal
+        collection={collection}
+        setIsDeleteModalOpen={setIsDeleteModalOpen}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/ }))
+
+    expect(setIsDeleteModalOpen).toHaveBeenCalledWith(false)
+  })
+
+  it("calls the mutation when the Delete button is clicked", async () => {
+    render(
+      <DeleteSavesModal
+        collection={collection}
+        setIsDeleteModalOpen={setIsDeleteModalOpen}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Delete/ }))
+
+    expect(submitMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: {
+          input: { id: "foobar" },
+        },
+      })
+    )
+  })
+})

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/SavesContextualMenu.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/SavesContextualMenu.jest.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+
+import { SavesContextualMenu } from "Apps/CollectorProfile/Routes/Saves2/Components/Actions/SavesContextualMenu"
+import { SavesArtworks_collection$data } from "__generated__/SavesArtworks_collection.graphql"
+
+const collection = {
+  internalID: "foobar",
+  name: "Foo Bar",
+} as SavesArtworks_collection$data
+
+describe("SavesContextualMenu", () => {
+  it("renders the trigger and the menu items", async () => {
+    render(<SavesContextualMenu collection={collection} />)
+
+    const menuTriggerButton = screen.getByLabelText("Open contextual menu")
+    expect(menuTriggerButton).toBeInTheDocument()
+
+    fireEvent.click(menuTriggerButton)
+
+    expect(await screen.findByText("Edit List")).toBeInTheDocument()
+    expect(await screen.findByText("Delete List")).toBeInTheDocument()
+  })
+
+  it("opens the Delete modal", async () => {
+    render(<SavesContextualMenu collection={collection} />)
+
+    fireEvent.click(screen.getByLabelText("Open contextual menu"))
+    fireEvent.click(await screen.findByText("Delete List"))
+
+    expect(screen.getByText("Delete Foo Bar list?")).toBeInTheDocument()
+  })
+})

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SavesArtworks.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SavesArtworks.tsx
@@ -10,9 +10,10 @@ import { FC } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { useRouter } from "System/Router/useRouter"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { Flex, Join, MoreIcon, Spacer, Text } from "@artsy/palette"
+import { Flex, Join, Spacer, Text } from "@artsy/palette"
 import { updateUrl } from "Components/ArtworkFilter/Utils/urlBuilder"
 import { SavesArtworksGridPlaceholder } from "Apps/CollectorProfile/Routes/Saves2/Components/SavesPlaceholders"
+import { SavesContextualMenu } from "./Actions/SavesContextualMenu"
 
 interface SavesArtworksQueryRendererProps {
   collectionID: string
@@ -60,7 +61,9 @@ const SavesArtworks: FC<SavesArtworksProps> = ({ collection, relay }) => {
       >
         <Join separator={<Spacer x={2} />}>
           <Text variant="lg-display">{collection.name}</Text>
-          {!collection.default && <MoreIcon width="24px" height="24px" />}
+          {!collection.default && (
+            <SavesContextualMenu collection={collection} />
+          )}
         </Join>
       </Flex>
 
@@ -98,6 +101,7 @@ export const SavesArtworksRefetchContainer = createRefetchContainer(
           page: { type: "Int", defaultValue: 1 }
           sort: { type: "CollectionArtworkSorts" }
         ) {
+        internalID
         name
         default
         artworks: artworksConnection(first: 30, page: $page, sort: $sort) {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/__tests__/SavesArtworks.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/__tests__/SavesArtworks.jest.tsx
@@ -72,4 +72,24 @@ describe("SavesArtworks", () => {
       expect(screen.getByText(description)).toBeInTheDocument()
     })
   })
+
+  describe("Actions contextual menu", () => {
+    it("should not render for default collection", () => {
+      renderWithRelay({
+        Collection: () => ({ default: true }),
+      })
+
+      const menuTriggerButton = screen.queryByLabelText("Open contextual menu")
+      expect(menuTriggerButton).not.toBeInTheDocument()
+    })
+
+    it("should render for non-default collection", () => {
+      renderWithRelay({
+        Collection: () => ({ default: false }),
+      })
+
+      const menuTriggerButton = screen.queryByLabelText("Open contextual menu")
+      expect(menuTriggerButton).toBeInTheDocument()
+    })
+  })
 })

--- a/src/Components/ContextualMenu/ContextualMenu.tsx
+++ b/src/Components/ContextualMenu/ContextualMenu.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement } from "react"
+
+import MoreIcon from "@artsy/icons/MoreIcon"
+import { Clickable, Dropdown } from "@artsy/palette"
+import { ContextualMenuItem } from "Components/ContextualMenu/ContextualMenuItem"
+
+interface ContextualMenuProps {
+  /** Supply `ContextualMenuItem`s and `ContextualMenuDivider`s as needed  */
+  children: React.ReactNode
+}
+
+/**
+ * Creates a contextual menu by composing a MoreIcon (⋯) trigger
+ * and a Dropdown component from Palette.
+ */
+export const ContextualMenu: React.FC<ContextualMenuProps> = ({ children }) => {
+  return (
+    <Dropdown
+      openDropdownByClick
+      placement="bottom-end"
+      offset={0}
+      dropdown={({ onHide }) => {
+        /*
+         * Each ContextualMenuItem must be able to close this
+         * parent ContextualMenu's Dropdown when it is clicked.
+         */
+        return React.Children.map(children, (child: ReactElement) => {
+          if (child.type === ContextualMenuItem) {
+            const onClick = () => {
+              onHide()
+              child.props.onClick?.()
+            }
+            return React.cloneElement(child, {
+              onClick,
+            })
+          } else {
+            return child
+          }
+        })
+      }}
+    >
+      {({ anchorRef, anchorProps }) => {
+        return (
+          <Clickable
+            // @ts-expect-error TODO: fix this ref type error
+            ref={anchorRef}
+            {...anchorProps}
+            px={2}
+            pt={1}
+            tras
+            aria-label="Open contextual menu"
+          >
+            <MoreIcon width={[24, 32]} height={[24, 32]} />
+          </Clickable>
+        )
+      }}
+    </Dropdown>
+  )
+}

--- a/src/Components/ContextualMenu/ContextualMenu.tsx
+++ b/src/Components/ContextualMenu/ContextualMenu.tsx
@@ -2,11 +2,30 @@ import React, { ReactElement } from "react"
 
 import MoreIcon from "@artsy/icons/MoreIcon"
 import { Clickable, Dropdown } from "@artsy/palette"
-import { ContextualMenuItem } from "Components/ContextualMenu/ContextualMenuItem"
+import {
+  ContextualMenuDivider,
+  ContextualMenuItem,
+} from "Components/ContextualMenu/ContextualMenuItem"
+
+const MORE_ICON_SIZE = [24, 32]
 
 interface ContextualMenuProps {
   /** Supply `ContextualMenuItem`s and `ContextualMenuDivider`s as needed  */
   children: React.ReactNode
+}
+
+const validateChildren = (children: React.ReactNode) => {
+  const childTypes =
+    React.Children.map(children, (child: ReactElement) => child.type) || []
+
+  const hasOnlyValidChildren = childTypes.every(
+    t => t === ContextualMenuItem || t === ContextualMenuDivider
+  )
+
+  if (!hasOnlyValidChildren)
+    throw new Error(
+      "ContextualMenu accepts only ContextualMenuItem and ContextualMenuDivider as children."
+    )
 }
 
 /**
@@ -14,6 +33,8 @@ interface ContextualMenuProps {
  * and a Dropdown component from Palette.
  */
 export const ContextualMenu: React.FC<ContextualMenuProps> = ({ children }) => {
+  validateChildren(children)
+
   return (
     <Dropdown
       openDropdownByClick
@@ -47,10 +68,9 @@ export const ContextualMenu: React.FC<ContextualMenuProps> = ({ children }) => {
             {...anchorProps}
             px={2}
             pt={1}
-            tras
             aria-label="Open contextual menu"
           >
-            <MoreIcon width={[24, 32]} height={[24, 32]} />
+            <MoreIcon width={MORE_ICON_SIZE} height={MORE_ICON_SIZE} />
           </Clickable>
         )
       }}

--- a/src/Components/ContextualMenu/ContextualMenuItem.tsx
+++ b/src/Components/ContextualMenu/ContextualMenuItem.tsx
@@ -1,0 +1,41 @@
+import styled from "styled-components"
+
+import { themeGet } from "@styled-system/theme-get"
+import { Clickable, ClickableProps, Separator } from "@artsy/palette"
+
+export interface ContextualMenuItemProps extends ClickableProps {
+  children: React.ReactNode
+  onClick?: () => void
+}
+
+export const ContextualMenuItem: React.FC<ContextualMenuItemProps> = ({
+  children,
+  onClick,
+  padding = 2,
+  ...rest
+}) => {
+  return (
+    <ContextualMenuItemContent
+      onClick={onClick}
+      display="block"
+      width="100%"
+      padding={padding}
+      {...rest}
+    >
+      {children}
+    </ContextualMenuItemContent>
+  )
+}
+
+const ContextualMenuItemContent = styled(Clickable)`
+  user-select: none;
+
+  transition: background-color 150ms;
+  &:hover {
+    background-color: ${themeGet("colors.black5")};
+  }
+`
+
+export const ContextualMenuDivider: React.FC = () => {
+  return <Separator color="black10" as="hr" width="100%" />
+}

--- a/src/Components/ContextualMenu/ContextualMenuItem.tsx
+++ b/src/Components/ContextualMenu/ContextualMenuItem.tsx
@@ -30,7 +30,7 @@ export const ContextualMenuItem: React.FC<ContextualMenuItemProps> = ({
 const ContextualMenuItemContent = styled(Clickable)`
   user-select: none;
 
-  transition: background-color 150ms;
+  transition: background-color 250ms;
   &:hover {
     background-color: ${themeGet("colors.black5")};
   }

--- a/src/Components/ContextualMenu/__stories__/ContextualMenu.story.tsx
+++ b/src/Components/ContextualMenu/__stories__/ContextualMenu.story.tsx
@@ -1,0 +1,158 @@
+import {
+  Avatar,
+  Box,
+  Flex,
+  Text,
+  Toasts,
+  ToastsProvider,
+  useToasts,
+} from "@artsy/palette"
+import { ComponentStory } from "@storybook/react"
+
+import {
+  ContextualMenu,
+  ContextualMenuItem,
+  ContextualMenuDivider,
+} from "Components/ContextualMenu"
+
+export default {
+  title: "Components/ContextualMenu",
+  decorators: [
+    Story => {
+      return (
+        <ToastsProvider>
+          <Flex>
+            <Flex flex={2} justifyContent="center" alignItems="flex-start">
+              <Story />
+            </Flex>
+            <Box flex={1}>
+              <Toasts />
+            </Box>
+          </Flex>
+        </ToastsProvider>
+      )
+    },
+  ],
+}
+
+const useConfirmation = () => {
+  const { sendToast } = useToasts()
+
+  const confirmIt = () => {
+    sendToast({
+      variant: "success",
+      message: "You selected a contextual menu item",
+      ttl: 5000,
+    })
+  }
+
+  return { confirmIt }
+}
+
+export const Basic: ComponentStory<typeof ContextualMenu> = () => {
+  const { confirmIt } = useConfirmation()
+
+  return (
+    <ContextualMenu>
+      <ContextualMenuItem onClick={confirmIt}>
+        Lorem ipsum dolor
+      </ContextualMenuItem>
+
+      <ContextualMenuItem onClick={confirmIt}>
+        Dolor sit amet
+      </ContextualMenuItem>
+
+      <ContextualMenuItem onClick={confirmIt}>
+        Consectetur adipisicing
+      </ContextualMenuItem>
+
+      <ContextualMenuItem onClick={confirmIt}>
+        Quisquam et quod
+      </ContextualMenuItem>
+    </ContextualMenu>
+  )
+}
+
+export const WithDividers: ComponentStory<typeof ContextualMenu> = () => {
+  const { confirmIt } = useConfirmation()
+
+  return (
+    <ContextualMenu>
+      <ContextualMenuItem onClick={confirmIt}>
+        Lorem ipsum dolor
+      </ContextualMenuItem>
+
+      <ContextualMenuDivider />
+
+      <ContextualMenuItem onClick={confirmIt}>
+        Dolor sit amet
+      </ContextualMenuItem>
+
+      <ContextualMenuDivider />
+
+      <ContextualMenuItem onClick={confirmIt}>
+        Consectetur adipisicing
+      </ContextualMenuItem>
+
+      <ContextualMenuDivider />
+
+      <ContextualMenuItem onClick={confirmIt}>
+        Quisquam et quod
+      </ContextualMenuItem>
+    </ContextualMenu>
+  )
+}
+
+export const RichContent: ComponentStory<typeof ContextualMenu> = () => {
+  const { confirmIt } = useConfirmation()
+
+  return (
+    <ContextualMenu>
+      <ContextualMenuItem onClick={confirmIt}>
+        <Text color="blue100">Styled</Text> <em>Lorem</em> <code>ipsum</code>{" "}
+        <strong>dolor</strong>
+      </ContextualMenuItem>
+
+      <ContextualMenuDivider />
+
+      <ContextualMenuItem onClick={confirmIt}>
+        <>
+          <Text color="blue100">Nested</Text>
+          <Flex alignItems="center" mt={1}>
+            <Box mr={1}>
+              <Avatar
+                size="sm"
+                src="https://picsum.photos/seed/example/110/110"
+                initials="TK"
+              />
+            </Box>
+            <Text>Dolor sit amet</Text>
+          </Flex>
+        </>
+      </ContextualMenuItem>
+
+      <ContextualMenuDivider />
+
+      <ContextualMenuItem onClick={confirmIt} padding={0}>
+        <Box
+          backgroundImage={'url("https://picsum.photos/seed/example19/250/75")'}
+          backgroundColor="#00000000"
+          backgroundSize="cover"
+          padding={2}
+        >
+          <Text color="white" fontWeight="bold">
+            Illustrated
+          </Text>
+          <Text color="white">Consectetur adipisicing</Text>
+        </Box>
+      </ContextualMenuItem>
+
+      <ContextualMenuDivider />
+
+      <ContextualMenuItem onClick={confirmIt}>
+        <Text color="blue100">Basic</Text>
+        <Text>Quisquam et quod</Text>
+      </ContextualMenuItem>
+    </ContextualMenu>
+  )
+}

--- a/src/Components/ContextualMenu/__tests__/ContextualMenu.jest.tsx
+++ b/src/Components/ContextualMenu/__tests__/ContextualMenu.jest.tsx
@@ -57,4 +57,18 @@ describe("ContextualMenu", () => {
     expect(firstHandler).toHaveBeenCalledTimes(1)
     expect(secondHandler).toHaveBeenCalledTimes(1)
   })
+
+  it("only accepts permitted children", () => {
+    expect(() => {
+      render(
+        <ContextualMenu>
+          <ContextualMenuItem>Do the first thing</ContextualMenuItem>
+          <ContextualMenuItem>Do the second thing</ContextualMenuItem>
+          <div>Do the third thing</div>
+        </ContextualMenu>
+      )
+    }).toThrowError(
+      /ContextualMenu accepts only ContextualMenuItem and ContextualMenuDivider/
+    )
+  })
 })

--- a/src/Components/ContextualMenu/__tests__/ContextualMenu.jest.tsx
+++ b/src/Components/ContextualMenu/__tests__/ContextualMenu.jest.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+
+import { ContextualMenu, ContextualMenuItem } from "Components/ContextualMenu"
+
+describe("ContextualMenu", () => {
+  it("initially renders the trigger but not the menu", () => {
+    render(
+      <ContextualMenu>
+        <ContextualMenuItem>Do the first thing</ContextualMenuItem>
+        <ContextualMenuItem>Do the second thing</ContextualMenuItem>
+      </ContextualMenu>
+    )
+
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.queryByText("Do the first thing")).not.toBeInTheDocument()
+    expect(screen.queryByText("Do the second thing")).not.toBeInTheDocument()
+  })
+
+  it("reveals the menu when the trigger is clicked", async () => {
+    render(
+      <ContextualMenu>
+        <ContextualMenuItem>Do the first thing</ContextualMenuItem>
+        <ContextualMenuItem>Do the second thing</ContextualMenuItem>
+      </ContextualMenu>
+    )
+
+    fireEvent.click(screen.getByRole("button"))
+
+    expect(await screen.findByText("Do the first thing")).toBeInTheDocument()
+    expect(await screen.findByText("Do the second thing")).toBeInTheDocument()
+  })
+
+  it("invokes the onClick handler when a menu item is clicked", async () => {
+    const firstHandler = jest.fn()
+    const secondHandler = jest.fn()
+
+    render(
+      <ContextualMenu>
+        <ContextualMenuItem onClick={firstHandler}>
+          Do the first thing
+        </ContextualMenuItem>
+
+        <ContextualMenuItem onClick={secondHandler}>
+          Do the second thing
+        </ContextualMenuItem>
+      </ContextualMenu>
+    )
+
+    fireEvent.click(screen.getByRole("button"))
+
+    const firstItem = await screen.findByText("Do the first thing")
+    const secondItem = await screen.findByText("Do the second thing")
+
+    fireEvent.click(firstItem)
+    fireEvent.click(secondItem)
+
+    expect(firstHandler).toHaveBeenCalledTimes(1)
+    expect(secondHandler).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/Components/ContextualMenu/index.ts
+++ b/src/Components/ContextualMenu/index.ts
@@ -1,0 +1,2 @@
+export * from "./ContextualMenu"
+export * from "./ContextualMenuItem"

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -25,7 +25,7 @@
     },
     "title": "Art Taste Quiz",
     "results": {
-      "emailButton": "Email My Results",   
+      "emailButton": "Email My Results",
       "emailSuccess": "Results sent to {{email}}",
       "emailError": "Something went wrong. Please try again.",
       "empty": {
@@ -130,6 +130,17 @@
     "selectedListsForArtwork": {
       "listsCount_one": "{{count}} list selected",
       "listsCount_other": "{{count}} lists selected"
+    },
+    "contextualMenu": {
+      "edit": "Edit List",
+      "delete": "Delete List"
+    },
+    "deleteListModal": {
+      "title": "Delete {{name}} list?",
+      "message": "You’ll lose any works that are only saved on this list.",
+      "cancel": "Cancel",
+      "delete": "Yes, Delete List",
+      "success": "Changes saved"
     }
   },
   "navbar": {
@@ -178,7 +189,7 @@
     "meetTheSpecialists": "Meet the Specialists",
     "ourTeamIsReady": "Whether you’re seeking a specific work for your growing collection or wish to sell, our globe-spanning team is ready to source, sell, advise, and research on your behalf.",
     "privateSales": "Private Sales & Advisory"
-  }, 
+  },
   "searchApp": {
     "noResultsFound": "No results found.",
     "resultsCount_zero": "No results found for",

--- a/src/__generated__/DeleteSavesModalMutation.graphql.ts
+++ b/src/__generated__/DeleteSavesModalMutation.graphql.ts
@@ -1,0 +1,146 @@
+/**
+ * @generated SignedSource<<e213db694ab887324e37ad162705a8c7>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type deleteCollectionInput = {
+  clientMutationId?: string | null;
+  id: string;
+};
+export type DeleteSavesModalMutation$variables = {
+  input: deleteCollectionInput;
+};
+export type DeleteSavesModalMutation$data = {
+  readonly deleteCollection: {
+    readonly responseOrError: {
+      readonly __typename: "DeleteCollectionFailure";
+      readonly mutationError: {
+        readonly message: string;
+        readonly statusCode: number | null;
+      } | null;
+    } | {
+      // This will never be '%other', but we need some
+      // value in case none of the concrete values match.
+      readonly __typename: "%other";
+    } | null;
+  } | null;
+};
+export type DeleteSavesModalMutation = {
+  response: DeleteSavesModalMutation$data;
+  variables: DeleteSavesModalMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "deleteCollectionPayload",
+    "kind": "LinkedField",
+    "name": "deleteCollection",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "responseOrError",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "GravityMutationError",
+                "kind": "LinkedField",
+                "name": "mutationError",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "message",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "statusCode",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "DeleteCollectionFailure",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DeleteSavesModalMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "DeleteSavesModalMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "06286b93b30c0730a9415d12329e4ba1",
+    "id": null,
+    "metadata": {},
+    "name": "DeleteSavesModalMutation",
+    "operationKind": "mutation",
+    "text": "mutation DeleteSavesModalMutation(\n  $input: deleteCollectionInput!\n) {\n  deleteCollection(input: $input) {\n    responseOrError {\n      __typename\n      ... on DeleteCollectionFailure {\n        mutationError {\n          message\n          statusCode\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "59f147ada3d219e3c9b95dd32c1e6bc9";
+
+export default node;

--- a/src/__generated__/SavesArtworksQuery.graphql.ts
+++ b/src/__generated__/SavesArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4b732884ea7e5aa84a02144f8345be9c>>
+ * @generated SignedSource<<a14fbb7c5bda225d00068e04c6fc3280>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -65,26 +65,33 @@ v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "internalID",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cursor",
+  "name": "name",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v9 = [
-  (v7/*: any*/),
+v10 = [
   (v8/*: any*/),
+  (v9/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -93,28 +100,21 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v11 = [
-  (v10/*: any*/)
+v12 = [
+  (v11/*: any*/)
 ],
-v12 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
 v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "href",
   "storageKey": null
 },
 v14 = {
@@ -163,8 +163,8 @@ v19 = [
   }
 ],
 v20 = [
-  (v6/*: any*/),
-  (v10/*: any*/)
+  (v7/*: any*/),
+  (v11/*: any*/)
 ];
 return {
   "fragment": {
@@ -238,6 +238,7 @@ return {
             "plural": false,
             "selections": [
               (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -301,7 +302,7 @@ return {
                         "kind": "LinkedField",
                         "name": "around",
                         "plural": true,
-                        "selections": (v9/*: any*/),
+                        "selections": (v10/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -311,7 +312,7 @@ return {
                         "kind": "LinkedField",
                         "name": "first",
                         "plural": false,
-                        "selections": (v9/*: any*/),
+                        "selections": (v10/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -321,7 +322,7 @@ return {
                         "kind": "LinkedField",
                         "name": "last",
                         "plural": false,
-                        "selections": (v9/*: any*/),
+                        "selections": (v10/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -332,8 +333,8 @@ return {
                         "name": "previous",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
-                          (v8/*: any*/)
+                          (v8/*: any*/),
+                          (v9/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -355,7 +356,7 @@ return {
                         "kind": "LinkedField",
                         "name": "node",
                         "plural": false,
-                        "selections": (v11/*: any*/),
+                        "selections": (v12/*: any*/),
                         "storageKey": null
                       }
                     ],
@@ -394,8 +395,8 @@ return {
                                 "name": "slug",
                                 "storageKey": null
                               },
-                              (v12/*: any*/),
                               (v13/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": [
@@ -417,7 +418,7 @@ return {
                                     "name": "aspectRatio",
                                     "storageKey": null
                                   },
-                                  (v13/*: any*/),
+                                  (v6/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -558,7 +559,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -588,9 +589,9 @@ return {
                                 "name": "artists",
                                 "plural": true,
                                 "selections": [
-                                  (v10/*: any*/),
-                                  (v12/*: any*/),
-                                  (v6/*: any*/)
+                                  (v11/*: any*/),
+                                  (v13/*: any*/),
+                                  (v7/*: any*/)
                                 ],
                                 "storageKey": "artists(shallow:true)"
                               },
@@ -609,9 +610,9 @@ return {
                                 "name": "partner",
                                 "plural": false,
                                 "selections": [
-                                  (v6/*: any*/),
-                                  (v12/*: any*/),
-                                  (v10/*: any*/)
+                                  (v7/*: any*/),
+                                  (v13/*: any*/),
+                                  (v11/*: any*/)
                                 ],
                                 "storageKey": "partner(shallow:true)"
                               },
@@ -659,7 +660,7 @@ return {
                                     "name": "isClosed",
                                     "storageKey": null
                                   },
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "alias": "is_preview",
                                     "args": null,
@@ -747,7 +748,7 @@ return {
                                     "selections": (v19/*: any*/),
                                     "storageKey": null
                                   },
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -807,7 +808,7 @@ return {
                                   (v16/*: any*/),
                                   (v18/*: any*/),
                                   (v17/*: any*/),
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -823,7 +824,7 @@ return {
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v11/*: any*/),
+                            "selections": (v12/*: any*/),
                             "type": "Node",
                             "abstractKey": "__isNode"
                           }
@@ -837,24 +838,23 @@ return {
                 ],
                 "storageKey": null
               },
-              (v13/*: any*/),
-              (v10/*: any*/)
+              (v11/*: any*/)
             ],
             "storageKey": null
           },
-          (v10/*: any*/)
+          (v11/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "ca4f0740214801dee642d009a25177a3",
+    "cacheID": "8fa60b74597b0b77f57e429bc7d2dc13",
     "id": null,
     "metadata": {},
     "name": "SavesArtworksQuery",
     "operationKind": "query",
-    "text": "query SavesArtworksQuery(\n  $collectionID: String!\n  $sort: CollectionArtworkSorts\n  $page: Int\n) {\n  me {\n    collection(id: $collectionID) {\n      ...SavesArtworks_collection_20XdsY\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SavesArtworksGrid_artworks on ArtworkConnection {\n  pageInfo {\n    hasNextPage\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment SavesArtworksGrid_collection on Collection {\n  internalID\n  ...SavesEmptyState_collection\n}\n\nfragment SavesArtworks_collection_20XdsY on Collection {\n  name\n  default\n  artworks: artworksConnection(first: 30, page: $page, sort: $sort) {\n    totalCount\n    ...SavesArtworksGrid_artworks\n  }\n  ...SavesArtworksGrid_collection\n}\n\nfragment SavesEmptyState_collection on Collection {\n  default\n}\n"
+    "text": "query SavesArtworksQuery(\n  $collectionID: String!\n  $sort: CollectionArtworkSorts\n  $page: Int\n) {\n  me {\n    collection(id: $collectionID) {\n      ...SavesArtworks_collection_20XdsY\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SavesArtworksGrid_artworks on ArtworkConnection {\n  pageInfo {\n    hasNextPage\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment SavesArtworksGrid_collection on Collection {\n  internalID\n  ...SavesEmptyState_collection\n}\n\nfragment SavesArtworks_collection_20XdsY on Collection {\n  internalID\n  name\n  default\n  artworks: artworksConnection(first: 30, page: $page, sort: $sort) {\n    totalCount\n    ...SavesArtworksGrid_artworks\n  }\n  ...SavesArtworksGrid_collection\n}\n\nfragment SavesEmptyState_collection on Collection {\n  default\n}\n"
   }
 };
 })();

--- a/src/__generated__/SavesArtworks_Test_Query.graphql.ts
+++ b/src/__generated__/SavesArtworks_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<422aa590ee819a71aaf7be87da45d5f3>>
+ * @generated SignedSource<<2588a9bd228bc8ebc15fd1d76db797b4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -35,26 +35,33 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "internalID",
   "storageKey": null
 },
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cursor",
+  "name": "name",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v4 = [
-  (v2/*: any*/),
+v5 = [
   (v3/*: any*/),
+  (v4/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -63,28 +70,21 @@ v4 = [
     "storageKey": null
   }
 ],
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = [
-  (v5/*: any*/)
+v7 = [
+  (v6/*: any*/)
 ],
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "href",
   "storageKey": null
 },
 v9 = {
@@ -133,8 +133,8 @@ v14 = [
   }
 ],
 v15 = [
-  (v1/*: any*/),
-  (v5/*: any*/)
+  (v2/*: any*/),
+  (v6/*: any*/)
 ],
 v16 = {
   "enumValues": null,
@@ -251,6 +251,7 @@ return {
             "plural": false,
             "selections": [
               (v1/*: any*/),
+              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -317,7 +318,7 @@ return {
                         "kind": "LinkedField",
                         "name": "around",
                         "plural": true,
-                        "selections": (v4/*: any*/),
+                        "selections": (v5/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -327,7 +328,7 @@ return {
                         "kind": "LinkedField",
                         "name": "first",
                         "plural": false,
-                        "selections": (v4/*: any*/),
+                        "selections": (v5/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -337,7 +338,7 @@ return {
                         "kind": "LinkedField",
                         "name": "last",
                         "plural": false,
-                        "selections": (v4/*: any*/),
+                        "selections": (v5/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -348,8 +349,8 @@ return {
                         "name": "previous",
                         "plural": false,
                         "selections": [
-                          (v2/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -371,7 +372,7 @@ return {
                         "kind": "LinkedField",
                         "name": "node",
                         "plural": false,
-                        "selections": (v6/*: any*/),
+                        "selections": (v7/*: any*/),
                         "storageKey": null
                       }
                     ],
@@ -410,8 +411,8 @@ return {
                                 "name": "slug",
                                 "storageKey": null
                               },
-                              (v7/*: any*/),
                               (v8/*: any*/),
+                              (v1/*: any*/),
                               {
                                 "alias": null,
                                 "args": [
@@ -433,7 +434,7 @@ return {
                                     "name": "aspectRatio",
                                     "storageKey": null
                                   },
-                                  (v8/*: any*/),
+                                  (v1/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -574,7 +575,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -604,9 +605,9 @@ return {
                                 "name": "artists",
                                 "plural": true,
                                 "selections": [
-                                  (v5/*: any*/),
-                                  (v7/*: any*/),
-                                  (v1/*: any*/)
+                                  (v6/*: any*/),
+                                  (v8/*: any*/),
+                                  (v2/*: any*/)
                                 ],
                                 "storageKey": "artists(shallow:true)"
                               },
@@ -625,9 +626,9 @@ return {
                                 "name": "partner",
                                 "plural": false,
                                 "selections": [
-                                  (v1/*: any*/),
-                                  (v7/*: any*/),
-                                  (v5/*: any*/)
+                                  (v2/*: any*/),
+                                  (v8/*: any*/),
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": "partner(shallow:true)"
                               },
@@ -675,7 +676,7 @@ return {
                                     "name": "isClosed",
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/),
+                                  (v6/*: any*/),
                                   {
                                     "alias": "is_preview",
                                     "args": null,
@@ -763,7 +764,7 @@ return {
                                     "selections": (v14/*: any*/),
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -823,7 +824,7 @@ return {
                                   (v11/*: any*/),
                                   (v13/*: any*/),
                                   (v12/*: any*/),
-                                  (v5/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -839,7 +840,7 @@ return {
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v6/*: any*/),
+                            "selections": (v7/*: any*/),
                             "type": "Node",
                             "abstractKey": "__isNode"
                           }
@@ -853,19 +854,18 @@ return {
                 ],
                 "storageKey": "artworksConnection(first:30,page:1)"
               },
-              (v8/*: any*/),
-              (v5/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": "collection(id:\"collectionID\")"
           },
-          (v5/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "cc33e49a03ba2d94e1afc945de1d1f55",
+    "cacheID": "5b816a4564bf93e5c2cd041c5654d36a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1116,7 +1116,7 @@ return {
     },
     "name": "SavesArtworks_Test_Query",
     "operationKind": "query",
-    "text": "query SavesArtworks_Test_Query {\n  me {\n    collection(id: \"collectionID\") {\n      ...SavesArtworks_collection\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SavesArtworksGrid_artworks on ArtworkConnection {\n  pageInfo {\n    hasNextPage\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment SavesArtworksGrid_collection on Collection {\n  internalID\n  ...SavesEmptyState_collection\n}\n\nfragment SavesArtworks_collection on Collection {\n  name\n  default\n  artworks: artworksConnection(first: 30, page: 1) {\n    totalCount\n    ...SavesArtworksGrid_artworks\n  }\n  ...SavesArtworksGrid_collection\n}\n\nfragment SavesEmptyState_collection on Collection {\n  default\n}\n"
+    "text": "query SavesArtworks_Test_Query {\n  me {\n    collection(id: \"collectionID\") {\n      ...SavesArtworks_collection\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  is_saved: isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SavesArtworksGrid_artworks on ArtworkConnection {\n  pageInfo {\n    hasNextPage\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment SavesArtworksGrid_collection on Collection {\n  internalID\n  ...SavesEmptyState_collection\n}\n\nfragment SavesArtworks_collection on Collection {\n  internalID\n  name\n  default\n  artworks: artworksConnection(first: 30, page: 1) {\n    totalCount\n    ...SavesArtworksGrid_artworks\n  }\n  ...SavesArtworksGrid_collection\n}\n\nfragment SavesEmptyState_collection on Collection {\n  default\n}\n"
   }
 };
 })();

--- a/src/__generated__/SavesArtworks_collection.graphql.ts
+++ b/src/__generated__/SavesArtworks_collection.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0973b61ded8c0463627b43f2060f8a61>>
+ * @generated SignedSource<<0bd595e8ef95e326135f927419eb9e18>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type SavesArtworks_collection$data = {
     readonly " $fragmentSpreads": FragmentRefs<"SavesArtworksGrid_artworks">;
   } | null;
   readonly default: boolean;
+  readonly internalID: string;
   readonly name: string;
   readonly " $fragmentSpreads": FragmentRefs<"SavesArtworksGrid_collection">;
   readonly " $fragmentType": "SavesArtworks_collection";
@@ -42,6 +43,13 @@ const node: ReaderFragment = {
   "metadata": null,
   "name": "SavesArtworks_collection",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -105,6 +113,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "ef853f001261c2ce1049bfa3600e3858";
+(node as any).hash = "9985cab2ec012cead080d8066b864ca5";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [FX-4553]

This adds the ability to delete an Artwork List.

## Contextual Menu

In order to get there I needed a new kind of [contextual menu](https://www.nngroup.com/articles/contextual-menus/) that is triggered from a ⋯ icon. 

I extracted this into what is now the first commit. (If desired I can further extract this new component into a separate PR.)

I was going for a simple API that can be used like this:

```jsx
const SomeContextualMenu = () => (
  <ContextualMenu>
    <ContextualMenuItem onClick={doSomething}>Item one</ContextualMenuItem>
    <ContextualMenuDivider />
    <ContextualMenuItem onClick={doSomething}>Item two</ContextualMenuItem>
    <ContextualMenuDivider />
    <ContextualMenuItem onClick={doSomething}>Item three</ContextualMenuItem>
  </ContextualMenu>
);
```

This now lives in `src/Components/ContextualMenu`, is completely generic, and is documented in the Force storybook:

<img width="100%" alt="story" src="https://user-images.githubusercontent.com/140521/219902626-fcce76b3-ee15-4c5e-aed5-fd666ba40159.png">

That can then be wired up with the the new Delete modal as follows.

## Desktop

https://user-images.githubusercontent.com/140521/219853242-498cd312-9c39-42d2-802c-36e2a169593a.mov

## mWeb

https://user-images.githubusercontent.com/140521/219853245-234e78ae-b855-4cd5-99cb-872d428cee88.mov

[FX-4553]: https://artsyproduct.atlassian.net/browse/FX-4553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

