### PR TITLE
feat(FX-4590): Select lists for this artwork modal - connect backend

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/FourUpImageLayout.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/FourUpImageLayout.tsx
@@ -1,4 +1,5 @@
-import { Box, Flex, Image, NoArtworkIcon, Spacer } from "@artsy/palette"
+import { Box, Flex, Image, Spacer } from "@artsy/palette"
+import { SavesNoImage } from "Apps/CollectorProfile/Routes/Saves2/Components/SavesNoImage"
 import { prepareImageURLs } from "Apps/CollectorProfile/Routes/Saves2/Utils/prepareImageURLs"
 import { FC } from "react"
 import { cropped } from "Utils/resized"
@@ -43,21 +44,7 @@ const RowImage: FC<RowImageProps> = ({ url }) => {
   const SIZE = [SMALL_IMAGE_SIZE, LARGE_IMAGE_SIZE]
 
   if (url === null) {
-    return (
-      <Flex
-        width={SIZE}
-        height={SIZE}
-        bg="black5"
-        border="1px solid"
-        borderColor="black15"
-        aria-label="Image placeholder"
-        justifyContent="center"
-        alignItems="center"
-        flexShrink={0}
-      >
-        <NoArtworkIcon width="18px" height="18px" fill="black60" />
-      </Flex>
-    )
+    return <SavesNoImage width={SIZE} height={SIZE} />
   }
 
   const image = cropped(url, {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SavesArtworkSaveButton.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SavesArtworkSaveButton.tsx
@@ -1,4 +1,4 @@
-import { SelectListsForArtworkModal } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal"
+import { SelectListsForArtworkModalQueryRender } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal"
 import { SaveButtonBase } from "Components/Artwork/SaveButton/SaveButton"
 import { useState } from "react"
 
@@ -30,7 +30,12 @@ export const SavesArtworkSaveButton: React.FC<SavesArtworkSaveButtonProps> = ({
     <>
       <SaveButtonBase isSaved onClick={handleClick} />
 
-      {visible && <SelectListsForArtworkModal onClose={handleCloseModal} />}
+      {visible && (
+        <SelectListsForArtworkModalQueryRender
+          artworkID={artworkId}
+          onClose={handleCloseModal}
+        />
+      )}
     </>
   )
 }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SavesNoImage.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SavesNoImage.tsx
@@ -1,0 +1,25 @@
+import { Flex, FlexProps, NoArtworkIcon } from "@artsy/palette"
+import { FC } from "react"
+
+const NO_ICON_SIZE = 18
+
+export const SavesNoImage: FC<FlexProps> = props => {
+  return (
+    <Flex
+      bg="black5"
+      border="1px solid"
+      borderColor="black15"
+      aria-label="Image placeholder"
+      justifyContent="center"
+      alignItems="center"
+      flexShrink={0}
+      {...props}
+    >
+      <NoArtworkIcon
+        width={NO_ICON_SIZE}
+        height={NO_ICON_SIZE}
+        fill="black60"
+      />
+    </Flex>
+  )
+}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
@@ -4,6 +4,8 @@ import { FC } from "react"
 import { useTranslation } from "react-i18next"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SelectListItem_item$data } from "__generated__/SelectListItem_item.graphql"
+import { SelectListItemImage } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItemImage"
+import { extractNodes } from "Utils/extractNodes"
 
 const ICON_SIZE = 24
 
@@ -19,6 +21,8 @@ const SelectListItem: FC<SelectListItemProps> = ({
   onClick,
 }) => {
   const { t } = useTranslation()
+  const nodes = extractNodes(item.artworksConnection)
+  const imageURL = nodes[0]?.image?.url ?? null
 
   return (
     <Clickable
@@ -32,7 +36,7 @@ const SelectListItem: FC<SelectListItemProps> = ({
       borderColor={isSelected ? "brand" : "transparent"}
       onClick={() => onClick(item.internalID)}
     >
-      <Flex width={60} height={60} bg="black10" flexShrink={0} />
+      <SelectListItemImage url={imageURL} />
 
       <Spacer x={1} />
 
@@ -64,6 +68,15 @@ export const SelectListItemFragmentContainer = createFragmentContainer(
         internalID
         name
         artworksCount
+        artworksConnection(first: 1) {
+          edges {
+            node {
+              image {
+                url(version: "square")
+              }
+            }
+          }
+        }
       }
     `,
   }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
@@ -12,7 +12,7 @@ const ICON_SIZE = 24
 interface SelectListItemProps {
   item: SelectListItem_item$data
   isSelected: boolean
-  onClick: (id: string) => void
+  onClick: () => void
 }
 
 const SelectListItem: FC<SelectListItemProps> = ({
@@ -34,7 +34,7 @@ const SelectListItem: FC<SelectListItemProps> = ({
       p={1}
       border="1px solid"
       borderColor={isSelected ? "brand" : "transparent"}
-      onClick={() => onClick(item.internalID)}
+      onClick={onClick}
     >
       <SelectListsForArtworkImage url={imageURL} />
 
@@ -65,7 +65,6 @@ export const SelectListItemFragmentContainer = createFragmentContainer(
   {
     item: graphql`
       fragment SelectListItem_item on Collection {
-        internalID
         name
         artworksCount
         artworksConnection(first: 1) {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
@@ -35,6 +35,8 @@ const SelectListItem: FC<SelectListItemProps> = ({
       border="1px solid"
       borderColor={isSelected ? "brand" : "transparent"}
       onClick={onClick}
+      role="option"
+      aria-selected={!!isSelected}
     >
       <SelectListsForArtworkImage url={imageURL} />
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
@@ -4,7 +4,7 @@ import { FC } from "react"
 import { useTranslation } from "react-i18next"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SelectListItem_item$data } from "__generated__/SelectListItem_item.graphql"
-import { SelectListItemImage } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItemImage"
+import { SelectListsForArtworkImage } from "./SelectListsForArtworkImage"
 import { extractNodes } from "Utils/extractNodes"
 
 const ICON_SIZE = 24
@@ -36,7 +36,7 @@ const SelectListItem: FC<SelectListItemProps> = ({
       borderColor={isSelected ? "brand" : "transparent"}
       onClick={() => onClick(item.internalID)}
     >
-      <SelectListItemImage url={imageURL} />
+      <SelectListsForArtworkImage url={imageURL} />
 
       <Spacer x={1} />
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
@@ -2,22 +2,18 @@ import { CheckCircleIcon, Clickable, Flex, Spacer, Text } from "@artsy/palette"
 import EmptyCheckCircleIcon from "@artsy/icons/EmptyCheckCircleIcon"
 import { FC } from "react"
 import { useTranslation } from "react-i18next"
+import { createFragmentContainer, graphql } from "react-relay"
+import { SelectListItem_item$data } from "__generated__/SelectListItem_item.graphql"
 
 const ICON_SIZE = 24
 
-export interface ListItemEntity {
-  id: string
-  title: string
-  count: number
-}
-
 interface SelectListItemProps {
-  item: ListItemEntity
+  item: SelectListItem_item$data
   isSelected: boolean
   onClick: (id: string) => void
 }
 
-export const SelectListItem: FC<SelectListItemProps> = ({
+const SelectListItem: FC<SelectListItemProps> = ({
   isSelected,
   item,
   onClick,
@@ -34,17 +30,17 @@ export const SelectListItem: FC<SelectListItemProps> = ({
       p={1}
       border="1px solid"
       borderColor={isSelected ? "brand" : "transparent"}
-      onClick={() => onClick(item.id)}
+      onClick={() => onClick(item.internalID)}
     >
       <Flex width={60} height={60} bg="black10" flexShrink={0} />
 
       <Spacer x={1} />
 
       <Flex flexDirection="column" flex={1}>
-        <Text variant="sm-display">{item.title}</Text>
+        <Text variant="sm-display">{item.name}</Text>
         <Text variant="sm-display" color="black60">
           {t("collectorSaves.artworkLists.artworkWithCount", {
-            count: item.count,
+            count: item.artworksCount,
           })}
         </Text>
       </Flex>
@@ -59,3 +55,16 @@ export const SelectListItem: FC<SelectListItemProps> = ({
     </Clickable>
   )
 }
+
+export const SelectListItemFragmentContainer = createFragmentContainer(
+  SelectListItem,
+  {
+    item: graphql`
+      fragment SelectListItem_item on Collection {
+        internalID
+        name
+        artworksCount
+      }
+    `,
+  }
+)

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem.tsx
@@ -69,7 +69,7 @@ export const SelectListItemFragmentContainer = createFragmentContainer(
       fragment SelectListItem_item on Collection {
         name
         artworksCount
-        artworksConnection(first: 1) {
+        artworksConnection(first: 1, sort: SAVED_AT_DESC) {
           edges {
             node {
               image {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItemImage.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItemImage.tsx
@@ -1,0 +1,31 @@
+import { Image } from "@artsy/palette"
+import { SavesNoImage } from "Apps/CollectorProfile/Routes/Saves2/Components/SavesNoImage"
+import { FC } from "react"
+import { cropped } from "Utils/resized"
+
+const IMAGE_SIZE = 60
+
+interface SelectListItemImageProps {
+  url: string | null
+}
+
+export const SelectListItemImage: FC<SelectListItemImageProps> = ({ url }) => {
+  if (url === null) {
+    return <SavesNoImage width={IMAGE_SIZE} height={IMAGE_SIZE} />
+  }
+
+  const image = cropped(url, {
+    width: IMAGE_SIZE,
+    height: IMAGE_SIZE,
+  })
+
+  return (
+    <Image
+      width={IMAGE_SIZE}
+      height={IMAGE_SIZE}
+      src={image.src}
+      srcSet={image.srcSet}
+      alt=""
+    />
+  )
+}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkFooter.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkFooter.tsx
@@ -4,11 +4,13 @@ import { useTranslation } from "react-i18next"
 
 interface SelectListsForArtworkFooterProps {
   selectedListsCount: number
+  hasChanges?: boolean
   onSaveClick: () => void
 }
 
 export const SelectListsForArtworkFooter: FC<SelectListsForArtworkFooterProps> = ({
   selectedListsCount,
+  hasChanges,
   onSaveClick,
 }) => {
   const { t } = useTranslation()
@@ -24,7 +26,7 @@ export const SelectListsForArtworkFooter: FC<SelectListsForArtworkFooterProps> =
           count: selectedListsCount,
         })}
       </Text>
-      <Button onClick={onSaveClick}>
+      <Button onClick={onSaveClick} disabled={!hasChanges}>
         {t("collectorSaves.selectedListsForArtwork.saveButton")}
       </Button>
     </Flex>

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkFooter.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkFooter.tsx
@@ -24,7 +24,9 @@ export const SelectListsForArtworkFooter: FC<SelectListsForArtworkFooterProps> =
           count: selectedListsCount,
         })}
       </Text>
-      <Button onClick={onSaveClick}>Save</Button>
+      <Button onClick={onSaveClick}>
+        {t("collectorSaves.selectedListsForArtwork.saveButton")}
+      </Button>
     </Flex>
   )
 }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkHeader.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkHeader.tsx
@@ -18,7 +18,7 @@ const SelectListsForArtworkHeader: FC<SelectListsForArtworkHeaderProps> = ({
       <Flex flex={1} flexDirection="row" alignItems="center">
         <SelectListsForArtworkImage size={50} url={imageURL} />
         <Spacer x={1} />
-        <Text>
+        <Text lineClamp={2}>
           {artwork.title}, {artwork.date}
         </Text>
       </Flex>

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkHeader.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkHeader.tsx
@@ -1,12 +1,26 @@
 import { Button, Flex, Spacer, Text } from "@artsy/palette"
+import { SelectListsForArtworkImage } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkImage"
+import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { SelectListsForArtworkHeader_artwork$data } from "__generated__/SelectListsForArtworkHeader_artwork.graphql"
 
-export const SelectListsForArtworkHeader = () => {
+interface SelectListsForArtworkHeaderProps {
+  artwork: SelectListsForArtworkHeader_artwork$data
+}
+
+const SelectListsForArtworkHeader: FC<SelectListsForArtworkHeaderProps> = ({
+  artwork,
+}) => {
+  const imageURL = artwork.image?.url ?? null
+
   return (
     <Flex flexDirection="row" alignItems="center">
       <Flex flex={1} flexDirection="row" alignItems="center">
-        <Flex flexShrink={0} width={50} height={50} bg="black10" />
+        <SelectListsForArtworkImage size={50} url={imageURL} />
         <Spacer x={1} />
-        <Text>Marie Pop, The NAR, 2016</Text>
+        <Text>
+          {artwork.title}, {artwork.date}
+        </Text>
       </Flex>
 
       <Spacer x={1} />
@@ -17,3 +31,18 @@ export const SelectListsForArtworkHeader = () => {
     </Flex>
   )
 }
+
+export const SelectListsForArtworkHeaderFragmentContainer = createFragmentContainer(
+  SelectListsForArtworkHeader,
+  {
+    artwork: graphql`
+      fragment SelectListsForArtworkHeader_artwork on Artwork {
+        title
+        date
+        image {
+          url(version: "square")
+        }
+      }
+    `,
+  }
+)

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkHeader.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkHeader.tsx
@@ -14,7 +14,11 @@ const SelectListsForArtworkHeader: FC<SelectListsForArtworkHeaderProps> = ({
   const imageURL = artwork.image?.url ?? null
 
   return (
-    <Flex flexDirection="row" alignItems="center">
+    <Flex
+      flexDirection={["column", "row"]}
+      alignItems={["stretch", "center"]}
+      mt={[-2, 0]}
+    >
       <Flex flex={1} flexDirection="row" alignItems="center">
         <SelectListsForArtworkImage size={50} url={imageURL} />
         <Spacer x={1} />
@@ -23,7 +27,7 @@ const SelectListsForArtworkHeader: FC<SelectListsForArtworkHeaderProps> = ({
         </Text>
       </Flex>
 
-      <Spacer x={1} />
+      <Spacer x={[0, 1]} y={[2, 0]} />
 
       <Button variant="secondaryBlack" size="small">
         Create New List

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkImage.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkImage.tsx
@@ -3,28 +3,28 @@ import { SavesNoImage } from "Apps/CollectorProfile/Routes/Saves2/Components/Sav
 import { FC } from "react"
 import { cropped } from "Utils/resized"
 
-const IMAGE_SIZE = 60
-
 interface SelectListsForArtworkImageProps {
   url: string | null
+  size?: number
 }
 
 export const SelectListsForArtworkImage: FC<SelectListsForArtworkImageProps> = ({
   url,
+  size = 60,
 }) => {
   if (url === null) {
-    return <SavesNoImage width={IMAGE_SIZE} height={IMAGE_SIZE} />
+    return <SavesNoImage width={size} height={size} />
   }
 
   const image = cropped(url, {
-    width: IMAGE_SIZE,
-    height: IMAGE_SIZE,
+    width: size,
+    height: size,
   })
 
   return (
     <Image
-      width={IMAGE_SIZE}
-      height={IMAGE_SIZE}
+      width={size}
+      height={size}
       src={image.src}
       srcSet={image.srcSet}
       alt=""

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkImage.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkImage.tsx
@@ -5,11 +5,13 @@ import { cropped } from "Utils/resized"
 
 const IMAGE_SIZE = 60
 
-interface SelectListItemImageProps {
+interface SelectListsForArtworkImageProps {
   url: string | null
 }
 
-export const SelectListItemImage: FC<SelectListItemImageProps> = ({ url }) => {
+export const SelectListsForArtworkImage: FC<SelectListsForArtworkImageProps> = ({
+  url,
+}) => {
   if (url === null) {
     return <SavesNoImage width={IMAGE_SIZE} height={IMAGE_SIZE} />
   }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -9,6 +9,7 @@ import { SelectListsForArtworkModal_me$data } from "__generated__/SelectListsFor
 import { SelectListsForArtworkModal_artwork$data } from "__generated__/SelectListsForArtworkModal_artwork.graphql"
 import { SelectListsForArtworkModalQuery } from "__generated__/SelectListsForArtworkModalQuery.graphql"
 import { extractNodes } from "Utils/extractNodes"
+import { SelectListsPlaceholder } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkPlaceholders"
 
 interface SelectListsForArtworkModalQueryRenderProps {
   artworkID: string
@@ -43,6 +44,29 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
     onClose()
   }
 
+  const renderContent = () => {
+    // Query is in progress
+    if (me === null) {
+      return <SelectListsPlaceholder />
+    }
+
+    return (
+      <Join separator={<Spacer y={1} />}>
+        {collections.map(item => {
+          const isSelected = selectedIds.includes(item.internalID)
+
+          return (
+            <SelectListItemFragmentContainer
+              item={item}
+              isSelected={isSelected}
+              onClick={handleItemSelected}
+            />
+          )
+        })}
+      </Join>
+    )
+  }
+
   return (
     <ModalDialog
       title="Select lists for this artwork"
@@ -64,19 +88,7 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
         />
       }
     >
-      <Join separator={<Spacer y={1} />}>
-        {collections.map(item => {
-          const isSelected = selectedIds.includes(item.internalID)
-
-          return (
-            <SelectListItemFragmentContainer
-              item={item}
-              isSelected={isSelected}
-              onClick={handleItemSelected}
-            />
-          )
-        })}
-      </Join>
+      {renderContent()}
     </ModalDialog>
   )
 }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -64,7 +64,6 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
   const handleItemPress = (item: typeof collections[0]) => {
     console.log("[debug] pressed", item)
 
-    // @ts-ignore
     if (item.isSavedArtwork) {
       const updatedIds = addOrRemoveCollectionIdFromIds(
         removeFromCollectionIDs,

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState } from "react"
-import { Spacer, Join, ModalDialog } from "@artsy/palette"
+import { Spacer, Join, ModalDialog, Box } from "@artsy/palette"
 import { SelectListItemFragmentContainer } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem"
 import { SelectListsForArtworkHeaderFragmentContainer } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkHeader"
 import { SelectListsForArtworkFooter } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkFooter"
@@ -118,17 +118,19 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
     }
 
     return (
-      <Join separator={<Spacer y={1} />}>
-        {collections.map(item => {
-          return (
-            <SelectListItemFragmentContainer
-              item={item}
-              isSelected={checkIsItemSelected(item)}
-              onClick={() => handleItemPress(item)}
-            />
-          )
-        })}
-      </Join>
+      <Box role="listbox">
+        <Join separator={<Spacer y={1} />}>
+          {collections.map(item => {
+            return (
+              <SelectListItemFragmentContainer
+                item={item}
+                isSelected={checkIsItemSelected(item)}
+                onClick={() => handleItemPress(item)}
+              />
+            )
+          })}
+        </Join>
+      </Box>
     )
   }
 
@@ -165,7 +167,7 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
   )
 }
 
-const SelectListsForArtworkModalFragmentContainer = createFragmentContainer(
+export const SelectListsForArtworkModalFragmentContainer = createFragmentContainer(
   SelectListsForArtworkModal,
   {
     me: graphql`

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -105,7 +105,7 @@ const SelectListsForArtworkModalFragmentContainer = createFragmentContainer(
   {
     me: graphql`
       fragment SelectListsForArtworkModal_me on Me {
-        collectionsConnection(first: 20) {
+        collectionsConnection(first: 30) {
           edges {
             node {
               internalID

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -167,7 +167,12 @@ export const SelectListsForArtworkModalFragmentContainer = createFragmentContain
           ...SelectListItem_item
         }
 
-        collectionsConnection(first: 30, default: false, saves: true) {
+        collectionsConnection(
+          first: 30
+          default: false
+          saves: true
+          sort: CREATED_AT_DESC
+        ) {
           edges {
             node {
               internalID

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -35,7 +35,9 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
   const [removeFromCollectionIDs, setRemoveFromCollectionIDs] = useState<
     string[]
   >([])
-  const collections = extractNodes(me?.collectionsConnection)
+  const savedCollection = me?.defaultSaves
+  const nodes = extractNodes(me?.collectionsConnection)
+  const collections = savedCollection ? [savedCollection, ...nodes] : nodes
   const selectedCollectionsByDefault = collections.filter(
     collection => collection.isSavedArtwork
   )
@@ -171,7 +173,13 @@ export const SelectListsForArtworkModalFragmentContainer = createFragmentContain
     me: graphql`
       fragment SelectListsForArtworkModal_me on Me
         @argumentDefinitions(artworkID: { type: "String!" }) {
-        collectionsConnection(first: 30) {
+        defaultSaves: collection(id: "saved-artwork") {
+          internalID
+          isSavedArtwork(artworkID: $artworkID)
+          ...SelectListItem_item
+        }
+
+        collectionsConnection(first: 30, default: false, saves: true) {
           edges {
             node {
               internalID

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -46,10 +46,6 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
   const hasChanges =
     addToCollectionIDs.length !== 0 || removeFromCollectionIDs.length !== 0
 
-  console.log("[debug] addToCollectionIDs", addToCollectionIDs)
-  console.log("[debug] removeFromCollectionIDs", removeFromCollectionIDs)
-  console.log("[debug] selectedCollectionIds", selectedCollectionIds)
-
   const addOrRemoveCollectionIdFromIds = (
     ids: string[],
     collectionId: string
@@ -62,8 +58,6 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
   }
 
   const handleItemPress = (item: typeof collections[0]) => {
-    console.log("[debug] pressed", item)
-
     if (item.isSavedArtwork) {
       const updatedIds = addOrRemoveCollectionIdFromIds(
         removeFromCollectionIDs,

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -13,7 +13,7 @@ import {
   SelectListsForArtworkHeaderPlaceholder,
   SelectListsPlaceholder,
 } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkPlaceholders"
-import { difference, uniq } from "lodash"
+import { getSelectedCollectionIds } from "Apps/CollectorProfile/Routes/Saves2/Utils/getSelectedCollectionIds"
 
 interface SelectListsForArtworkModalQueryRenderProps {
   artworkID: string
@@ -38,16 +38,11 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
   const savedCollection = me?.defaultSaves
   const nodes = extractNodes(me?.collectionsConnection)
   const collections = savedCollection ? [savedCollection, ...nodes] : nodes
-  const selectedCollectionsByDefault = collections.filter(
-    collection => collection.isSavedArtwork
-  )
-  const selectedCollectionIdsByDefault = selectedCollectionsByDefault.map(
-    collection => collection.internalID
-  )
-  const selectedCollectionIds = difference(
-    uniq([...addToCollectionIDs, ...selectedCollectionIdsByDefault]),
-    removeFromCollectionIDs
-  )
+  const selectedCollectionIds = getSelectedCollectionIds({
+    collections,
+    addToCollectionIDs,
+    removeFromCollectionIDs,
+  })
   const hasChanges =
     addToCollectionIDs.length !== 0 || removeFromCollectionIDs.length !== 0
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -37,7 +37,6 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
   >([])
   const collections = extractNodes(me?.collectionsConnection)
   const selectedCollectionsByDefault = collections.filter(
-    // @ts-ignore
     collection => collection.isSavedArtwork
   )
   const selectedCollectionIdsByDefault = selectedCollectionsByDefault.map(
@@ -107,7 +106,6 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
       return false
     }
 
-    // @ts-ignore
     return item.isSavedArtwork
   }
 
@@ -171,11 +169,13 @@ export const SelectListsForArtworkModalFragmentContainer = createFragmentContain
   SelectListsForArtworkModal,
   {
     me: graphql`
-      fragment SelectListsForArtworkModal_me on Me {
+      fragment SelectListsForArtworkModal_me on Me
+        @argumentDefinitions(artworkID: { type: "String!" }) {
         collectionsConnection(first: 30) {
           edges {
             node {
               internalID
+              isSavedArtwork(artworkID: $artworkID)
               ...SelectListItem_item
             }
           }
@@ -219,7 +219,7 @@ export const SelectListsForArtworkModalQueryRender: FC<SelectListsForArtworkModa
 const query = graphql`
   query SelectListsForArtworkModalQuery($artworkID: String!) {
     me {
-      ...SelectListsForArtworkModal_me
+      ...SelectListsForArtworkModal_me @arguments(artworkID: $artworkID)
     }
     artwork(id: $artworkID) {
       ...SelectListsForArtworkModal_artwork

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react"
-import { Spacer, Join, ModalDialog } from "@artsy/palette"
+import { Spacer, Join, ModalDialog, Text } from "@artsy/palette"
 import { SelectListItemFragmentContainer } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem"
-import { SelectListsForArtworkHeader } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkHeader"
+import { SelectListsForArtworkHeaderFragmentContainer } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkHeader"
 import { SelectListsForArtworkFooter } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkFooter"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -24,6 +24,7 @@ export interface SelectListsForArtworkModalProps {
 
 export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProps> = ({
   me,
+  artwork,
   onClose,
 }) => {
   const [selectedIds, setSelectedIds] = useState<string[]>([])
@@ -80,7 +81,13 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
         maxHeight: [null, 800],
       }}
       m={0}
-      header={<SelectListsForArtworkHeader />}
+      header={
+        artwork === null ? (
+          <Text>Placeholder</Text>
+        ) : (
+          <SelectListsForArtworkHeaderFragmentContainer artwork={artwork} />
+        )
+      }
       footer={
         <SelectListsForArtworkFooter
           selectedListsCount={selectedIds.length}
@@ -110,7 +117,7 @@ const SelectListsForArtworkModalFragmentContainer = createFragmentContainer(
     `,
     artwork: graphql`
       fragment SelectListsForArtworkModal_artwork on Artwork {
-        title
+        ...SelectListsForArtworkHeader_artwork
       }
     `,
   }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -47,6 +47,8 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
     uniq([...addToCollectionIDs, ...selectedCollectionIdsByDefault]),
     removeFromCollectionIDs
   )
+  const hasChanges =
+    addToCollectionIDs.length !== 0 || removeFromCollectionIDs.length !== 0
 
   console.log("[debug] addToCollectionIDs", addToCollectionIDs)
   console.log("[debug] removeFromCollectionIDs", removeFromCollectionIDs)
@@ -153,6 +155,7 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
       footer={
         <SelectListsForArtworkFooter
           selectedListsCount={selectedCollectionIds.length}
+          hasChanges={hasChanges}
           onSaveClick={handleSaveClicked}
         />
       }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState } from "react"
-import { Spacer, Join, ModalDialog, Text } from "@artsy/palette"
+import { Spacer, Join, ModalDialog } from "@artsy/palette"
 import { SelectListItemFragmentContainer } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListItem"
 import { SelectListsForArtworkHeaderFragmentContainer } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkHeader"
 import { SelectListsForArtworkFooter } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkFooter"
@@ -9,7 +9,10 @@ import { SelectListsForArtworkModal_me$data } from "__generated__/SelectListsFor
 import { SelectListsForArtworkModal_artwork$data } from "__generated__/SelectListsForArtworkModal_artwork.graphql"
 import { SelectListsForArtworkModalQuery } from "__generated__/SelectListsForArtworkModalQuery.graphql"
 import { extractNodes } from "Utils/extractNodes"
-import { SelectListsPlaceholder } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkPlaceholders"
+import {
+  SelectListsForArtworkHeaderPlaceholder,
+  SelectListsPlaceholder,
+} from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkPlaceholders"
 
 interface SelectListsForArtworkModalQueryRenderProps {
   artworkID: string
@@ -83,7 +86,7 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
       m={0}
       header={
         artwork === null ? (
-          <Text>Placeholder</Text>
+          <SelectListsForArtworkHeaderPlaceholder />
         ) : (
           <SelectListsForArtworkHeaderFragmentContainer artwork={artwork} />
         )

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkPlaceholders.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkPlaceholders.tsx
@@ -2,16 +2,20 @@ import { Flex, Join, SkeletonBox, SkeletonText, Spacer } from "@artsy/palette"
 
 export const SelectListsForArtworkHeaderPlaceholder = () => {
   return (
-    <Flex flexDirection="row" alignItems="center">
+    <Flex
+      flexDirection={["column", "row"]}
+      alignItems={["stretch", "center"]}
+      mt={[-2, 0]}
+    >
       <Flex flex={1} flexDirection="row" alignItems="center">
         <SkeletonBox width={50} height={50} />
         <Spacer x={1} />
         <SkeletonText>Artwork Title, 2022</SkeletonText>
       </Flex>
 
-      <Spacer x={1} />
+      <Spacer x={[0, 1]} y={[2, 0]} />
 
-      <SkeletonBox width={130} height={30} />
+      <SkeletonBox width={["100%", 130]} height={30} />
     </Flex>
   )
 }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkPlaceholders.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkPlaceholders.tsx
@@ -1,5 +1,21 @@
 import { Flex, Join, SkeletonBox, SkeletonText, Spacer } from "@artsy/palette"
 
+export const SelectListsForArtworkHeaderPlaceholder = () => {
+  return (
+    <Flex flexDirection="row" alignItems="center">
+      <Flex flex={1} flexDirection="row" alignItems="center">
+        <SkeletonBox width={50} height={50} />
+        <Spacer x={1} />
+        <SkeletonText>Artwork Title, 2022</SkeletonText>
+      </Flex>
+
+      <Spacer x={1} />
+
+      <SkeletonBox width={130} height={30} />
+    </Flex>
+  )
+}
+
 export const SelectListItemPlaceholder = () => {
   return (
     <Flex p={1} flexDirection="row" alignItems="center">

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkPlaceholders.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkPlaceholders.tsx
@@ -1,0 +1,30 @@
+import { Flex, Join, SkeletonBox, SkeletonText, Spacer } from "@artsy/palette"
+
+export const SelectListItemPlaceholder = () => {
+  return (
+    <Flex p={1} flexDirection="row" alignItems="center">
+      <SkeletonBox width={60} height={60} />
+
+      <Spacer x={1} />
+
+      <Flex flex={1} flexDirection="column">
+        <SkeletonText variant="sm-display">Collection Name</SkeletonText>
+        <SkeletonText variant="sm-display">6 artworks</SkeletonText>
+      </Flex>
+
+      <Spacer x={1} />
+
+      <SkeletonBox width={24} height={24} borderRadius={24} />
+    </Flex>
+  )
+}
+
+export const SelectListsPlaceholder = () => {
+  return (
+    <Join separator={<Spacer y={1} />}>
+      <SelectListItemPlaceholder />
+      <SelectListItemPlaceholder />
+      <SelectListItemPlaceholder />
+    </Join>
+  )
+}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
@@ -1,0 +1,162 @@
+import { graphql } from "react-relay"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { fireEvent, screen } from "@testing-library/react"
+import { SelectListsForArtworkModal_Test_Query } from "__generated__/SelectListsForArtworkModal_Test_Query.graphql"
+import { SelectListsForArtworkModalFragmentContainer } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal"
+
+jest.unmock("react-relay")
+
+const { renderWithRelay } = setupTestWrapperTL<
+  SelectListsForArtworkModal_Test_Query
+>({
+  Component: SelectListsForArtworkModalFragmentContainer,
+  query: graphql`
+    query SelectListsForArtworkModal_Test_Query @relay_test_operation {
+      me {
+        ...SelectListsForArtworkModal_me
+      }
+      artwork(id: "artworkID") {
+        ...SelectListsForArtworkModal_artwork
+      }
+    }
+  `,
+})
+
+describe("SelectListsForArtworkModal", () => {
+  it("should render artwork data", async () => {
+    renderWithRelay({
+      Artwork: () => artwork,
+    })
+
+    const entity = await screen.findByText("Artwork Title, 2023")
+    expect(entity).toBeInTheDocument()
+  })
+
+  it("should render collections", async () => {
+    renderWithRelay({
+      CollectionsConnection: () => collectionsConnection,
+    })
+
+    const collectionEntityOne = await screen.findByText("Collection 1")
+    const collectionEntityTwo = await screen.findByText("Collection 2")
+    const collectionEntityThree = await screen.findByText("Collection 3")
+
+    expect(collectionEntityOne).toBeInTheDocument()
+    expect(collectionEntityTwo).toBeInTheDocument()
+    expect(collectionEntityThree).toBeInTheDocument()
+  })
+
+  describe("where no selected collections by default", () => {
+    it("default state", async () => {
+      renderWithRelay({
+        CollectionsConnection: () => unselectedCollectionsConnection,
+      })
+
+      const entity = await screen.findByText("0 lists selected")
+      expect(entity).toBeInTheDocument()
+    })
+
+    describe("when user selected collections", () => {
+      it("one collection", async () => {
+        renderWithRelay({
+          CollectionsConnection: () => unselectedCollectionsConnection,
+        })
+
+        // Select flow
+        fireEvent.click(await screen.findByText("Collection 1"))
+
+        const selectedOptionsBefore = screen.queryAllByRole("option", {
+          selected: true,
+        })
+
+        expect(screen.getByText("1 list selected")).toBeInTheDocument()
+        expect(selectedOptionsBefore.length).toBe(1)
+        expect(selectedOptionsBefore[0]).toHaveTextContent("Collection 1")
+
+        // Unselect flow
+        fireEvent.click(await screen.findByText("Collection 1"))
+
+        const selectedOptionsAfter = screen.queryAllByRole("option", {
+          selected: true,
+        })
+
+        expect(screen.getByText("0 lists selected")).toBeInTheDocument()
+        expect(selectedOptionsAfter.length).toBe(0)
+      })
+
+      it("multiple collections", async () => {
+        renderWithRelay({
+          CollectionsConnection: () => unselectedCollectionsConnection,
+        })
+
+        // Select flow
+        fireEvent.click(await screen.findByText("Collection 1"))
+        fireEvent.click(await screen.findByText("Collection 2"))
+
+        const selectedOptionsBefore = screen.queryAllByRole("option", {
+          selected: true,
+        })
+
+        expect(screen.getByText("2 lists selected")).toBeInTheDocument()
+        expect(selectedOptionsBefore.length).toBe(2)
+        expect(selectedOptionsBefore[0]).toHaveTextContent("Collection 1")
+        expect(selectedOptionsBefore[1]).toHaveTextContent("Collection 2")
+
+        // Unselect flow
+        fireEvent.click(await screen.findByText("Collection 1"))
+        fireEvent.click(await screen.findByText("Collection 2"))
+
+        const selectedOptionsAfter = screen.queryAllByRole("option", {
+          selected: true,
+        })
+
+        expect(screen.getByText("0 lists selected")).toBeInTheDocument()
+        expect(selectedOptionsAfter.length).toBe(0)
+      })
+    })
+  })
+})
+
+const artwork = {
+  title: "Artwork Title",
+  date: "2023",
+}
+
+const collectionOne = {
+  internalID: "collection-one",
+  name: "Collection 1",
+  isSavedArtwork: true,
+}
+
+const collectionTwo = {
+  internalID: "collection-two",
+  name: "Collection 2",
+  isSavedArtwork: false,
+}
+
+const collectionThree = {
+  internalID: "collection-three",
+  name: "Collection 3",
+  isSavedArtwork: false,
+}
+
+const collectionsConnection = {
+  edges: [
+    { node: collectionOne },
+    { node: collectionTwo },
+    { node: collectionThree },
+  ],
+}
+
+const unselectedCollectionsConnection = {
+  edges: [
+    {
+      node: {
+        ...collectionOne,
+        isSavedArtwork: false,
+      },
+    },
+    { node: collectionTwo },
+    { node: collectionThree },
+  ],
+}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
@@ -13,7 +13,7 @@ const { renderWithRelay } = setupTestWrapperTL<
   query: graphql`
     query SelectListsForArtworkModal_Test_Query @relay_test_operation {
       me {
-        ...SelectListsForArtworkModal_me
+        ...SelectListsForArtworkModal_me @arguments(artworkID: "artworkID")
       }
       artwork(id: "artworkID") {
         ...SelectListsForArtworkModal_artwork

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
@@ -1,6 +1,6 @@
 import { graphql } from "react-relay"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { fireEvent, screen } from "@testing-library/react"
+import { fireEvent, screen, waitFor } from "@testing-library/react"
 import { SelectListsForArtworkModal_Test_Query } from "__generated__/SelectListsForArtworkModal_Test_Query.graphql"
 import { SelectListsForArtworkModalFragmentContainer } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal"
 
@@ -28,7 +28,9 @@ describe("SelectListsForArtworkModal", () => {
       Artwork: () => artwork,
     })
 
-    const entity = await screen.findByText("Artwork Title, 2023")
+    await waitForModalToBePresented()
+
+    const entity = screen.getByText("Artwork Title, 2023")
     expect(entity).toBeInTheDocument()
   })
 
@@ -37,9 +39,11 @@ describe("SelectListsForArtworkModal", () => {
       CollectionsConnection: () => collectionsConnection,
     })
 
-    const collectionEntityOne = await screen.findByText("Collection 1")
-    const collectionEntityTwo = await screen.findByText("Collection 2")
-    const collectionEntityThree = await screen.findByText("Collection 3")
+    await waitForModalToBePresented()
+
+    const collectionEntityOne = screen.getByText("Collection 1")
+    const collectionEntityTwo = screen.getByText("Collection 2")
+    const collectionEntityThree = screen.getByText("Collection 3")
 
     expect(collectionEntityOne).toBeInTheDocument()
     expect(collectionEntityTwo).toBeInTheDocument()
@@ -52,7 +56,9 @@ describe("SelectListsForArtworkModal", () => {
         CollectionsConnection: () => unselectedCollectionsConnection,
       })
 
-      const entity = await screen.findByText("0 lists selected")
+      await waitForModalToBePresented()
+
+      const entity = screen.getByText("0 lists selected")
       expect(entity).toBeInTheDocument()
     })
 
@@ -62,8 +68,10 @@ describe("SelectListsForArtworkModal", () => {
           CollectionsConnection: () => unselectedCollectionsConnection,
         })
 
+        await waitForModalToBePresented()
+
         // Select flow
-        fireEvent.click(await screen.findByText("Collection 1"))
+        fireEvent.click(screen.getByText("Collection 1"))
 
         const selectedOptionsBefore = screen.queryAllByRole("option", {
           selected: true,
@@ -74,7 +82,7 @@ describe("SelectListsForArtworkModal", () => {
         expect(selectedOptionsBefore[0]).toHaveTextContent("Collection 1")
 
         // Unselect flow
-        fireEvent.click(await screen.findByText("Collection 1"))
+        fireEvent.click(screen.getByText("Collection 1"))
 
         const selectedOptionsAfter = screen.queryAllByRole("option", {
           selected: true,
@@ -89,9 +97,11 @@ describe("SelectListsForArtworkModal", () => {
           CollectionsConnection: () => unselectedCollectionsConnection,
         })
 
+        await waitForModalToBePresented()
+
         // Select flow
-        fireEvent.click(await screen.findByText("Collection 1"))
-        fireEvent.click(await screen.findByText("Collection 2"))
+        fireEvent.click(screen.getByText("Collection 1"))
+        fireEvent.click(screen.getByText("Collection 2"))
 
         const selectedOptionsBefore = screen.queryAllByRole("option", {
           selected: true,
@@ -103,8 +113,8 @@ describe("SelectListsForArtworkModal", () => {
         expect(selectedOptionsBefore[1]).toHaveTextContent("Collection 2")
 
         // Unselect flow
-        fireEvent.click(await screen.findByText("Collection 1"))
-        fireEvent.click(await screen.findByText("Collection 2"))
+        fireEvent.click(screen.getByText("Collection 1"))
+        fireEvent.click(screen.getByText("Collection 2"))
 
         const selectedOptionsAfter = screen.queryAllByRole("option", {
           selected: true,
@@ -116,6 +126,10 @@ describe("SelectListsForArtworkModal", () => {
     })
   })
 })
+
+const waitForModalToBePresented = () => {
+  return waitFor(() => screen.getByText("Select lists for this artwork"))
+}
 
 const artwork = {
   title: "Artwork Title",

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
@@ -50,7 +50,7 @@ describe("SelectListsForArtworkModal", () => {
     expect(collectionEntityThree).toBeInTheDocument()
   })
 
-  describe("where no selected collections by default", () => {
+  describe("without selected collections by default", () => {
     it("default state", async () => {
       renderWithRelay({
         CollectionsConnection: () => unselectedCollectionsConnection,
@@ -62,80 +62,17 @@ describe("SelectListsForArtworkModal", () => {
       expect(entity).toBeInTheDocument()
     })
 
-    describe("when user selected collections", () => {
-      it("one collection", async () => {
-        renderWithRelay({
-          CollectionsConnection: () => unselectedCollectionsConnection,
-        })
-
-        await waitForModalToBePresented()
-
-        // Select flow
-        fireEvent.click(screen.getByText("Collection 1"))
-
-        const selectedOptionsBefore = screen.queryAllByRole("option", {
-          selected: true,
-        })
-
-        expect(screen.getByText("1 list selected")).toBeInTheDocument()
-        expect(selectedOptionsBefore.length).toBe(1)
-        expect(selectedOptionsBefore[0]).toHaveTextContent("Collection 1")
-
-        // Unselect flow
-        fireEvent.click(screen.getByText("Collection 1"))
-
-        const selectedOptionsAfter = screen.queryAllByRole("option", {
-          selected: true,
-        })
-
-        expect(screen.getByText("0 lists selected")).toBeInTheDocument()
-        expect(selectedOptionsAfter.length).toBe(0)
-      })
-
-      it("multiple collections", async () => {
-        renderWithRelay({
-          CollectionsConnection: () => unselectedCollectionsConnection,
-        })
-
-        await waitForModalToBePresented()
-
-        // Select flow
-        fireEvent.click(screen.getByText("Collection 1"))
-        fireEvent.click(screen.getByText("Collection 2"))
-
-        const selectedOptionsBefore = screen.queryAllByRole("option", {
-          selected: true,
-        })
-
-        expect(screen.getByText("2 lists selected")).toBeInTheDocument()
-        expect(selectedOptionsBefore.length).toBe(2)
-        expect(selectedOptionsBefore[0]).toHaveTextContent("Collection 1")
-        expect(selectedOptionsBefore[1]).toHaveTextContent("Collection 2")
-
-        // Unselect flow
-        fireEvent.click(screen.getByText("Collection 1"))
-        fireEvent.click(screen.getByText("Collection 2"))
-
-        const selectedOptionsAfter = screen.queryAllByRole("option", {
-          selected: true,
-        })
-
-        expect(screen.getByText("0 lists selected")).toBeInTheDocument()
-        expect(selectedOptionsAfter.length).toBe(0)
-      })
-    })
-  })
-
-  describe("selected collections by default", () => {
-    it("unselect the default selected collection", async () => {
+    it("select one collection", async () => {
       renderWithRelay({
-        CollectionsConnection: () => collectionsConnection,
+        CollectionsConnection: () => unselectedCollectionsConnection,
       })
 
       await waitForModalToBePresented()
 
-      // Before
-      const selectedOptionsBefore = screen.getAllByRole("option", {
+      // Select flow
+      fireEvent.click(screen.getByText("Collection 1"))
+
+      const selectedOptionsBefore = screen.queryAllByRole("option", {
         selected: true,
       })
 
@@ -143,7 +80,7 @@ describe("SelectListsForArtworkModal", () => {
       expect(selectedOptionsBefore.length).toBe(1)
       expect(selectedOptionsBefore[0]).toHaveTextContent("Collection 1")
 
-      // After
+      // Unselect flow
       fireEvent.click(screen.getByText("Collection 1"))
 
       const selectedOptionsAfter = screen.queryAllByRole("option", {
@@ -154,7 +91,74 @@ describe("SelectListsForArtworkModal", () => {
       expect(selectedOptionsAfter.length).toBe(0)
     })
 
-    it("select other collection", async () => {
+    it("select multiple collections", async () => {
+      renderWithRelay({
+        CollectionsConnection: () => unselectedCollectionsConnection,
+      })
+
+      await waitForModalToBePresented()
+
+      // Select flow
+      fireEvent.click(screen.getByText("Collection 1"))
+      fireEvent.click(screen.getByText("Collection 2"))
+
+      const selectedOptionsBefore = screen.queryAllByRole("option", {
+        selected: true,
+      })
+
+      expect(screen.getByText("2 lists selected")).toBeInTheDocument()
+      expect(selectedOptionsBefore.length).toBe(2)
+      expect(selectedOptionsBefore[0]).toHaveTextContent("Collection 1")
+      expect(selectedOptionsBefore[1]).toHaveTextContent("Collection 2")
+
+      // Unselect flow
+      fireEvent.click(screen.getByText("Collection 1"))
+      fireEvent.click(screen.getByText("Collection 2"))
+
+      const selectedOptionsAfter = screen.queryAllByRole("option", {
+        selected: true,
+      })
+
+      expect(screen.getByText("0 lists selected")).toBeInTheDocument()
+      expect(selectedOptionsAfter.length).toBe(0)
+    })
+  })
+
+  describe("with selected collections by default", () => {
+    it("default state", async () => {
+      renderWithRelay({
+        CollectionsConnection: () => collectionsConnection,
+      })
+
+      await waitForModalToBePresented()
+
+      const selectedOptions = screen.getAllByRole("option", {
+        selected: true,
+      })
+
+      expect(screen.getByText("1 list selected")).toBeInTheDocument()
+      expect(selectedOptions.length).toBe(1)
+      expect(selectedOptions[0]).toHaveTextContent("Collection 1")
+    })
+
+    it("unselect the default selected collection", async () => {
+      renderWithRelay({
+        CollectionsConnection: () => collectionsConnection,
+      })
+
+      await waitForModalToBePresented()
+
+      fireEvent.click(screen.getByText("Collection 1"))
+
+      const selectedOptionsAfter = screen.queryAllByRole("option", {
+        selected: true,
+      })
+
+      expect(screen.getByText("0 lists selected")).toBeInTheDocument()
+      expect(selectedOptionsAfter.length).toBe(0)
+    })
+
+    it("select some other collection", async () => {
       renderWithRelay({
         CollectionsConnection: () => collectionsConnection,
       })
@@ -171,6 +175,25 @@ describe("SelectListsForArtworkModal", () => {
       expect(selectedOptions.length).toBe(2)
       expect(selectedOptions[0]).toHaveTextContent("Collection 1")
       expect(selectedOptions[1]).toHaveTextContent("Collection 2")
+    })
+
+    it("unselect the default selected collection, select some other collection", async () => {
+      renderWithRelay({
+        CollectionsConnection: () => collectionsConnection,
+      })
+
+      await waitForModalToBePresented()
+
+      fireEvent.click(screen.getByText("Collection 1"))
+      fireEvent.click(screen.getByText("Collection 2"))
+
+      const selectedOptions = screen.getAllByRole("option", {
+        selected: true,
+      })
+
+      expect(screen.getByText("1 list selected")).toBeInTheDocument()
+      expect(selectedOptions.length).toBe(1)
+      expect(selectedOptions[0]).toHaveTextContent("Collection 2")
     })
   })
 })

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
@@ -125,6 +125,54 @@ describe("SelectListsForArtworkModal", () => {
       })
     })
   })
+
+  describe("selected collections by default", () => {
+    it("unselect the default selected collection", async () => {
+      renderWithRelay({
+        CollectionsConnection: () => collectionsConnection,
+      })
+
+      await waitForModalToBePresented()
+
+      // Before
+      const selectedOptionsBefore = screen.getAllByRole("option", {
+        selected: true,
+      })
+
+      expect(screen.getByText("1 list selected")).toBeInTheDocument()
+      expect(selectedOptionsBefore.length).toBe(1)
+      expect(selectedOptionsBefore[0]).toHaveTextContent("Collection 1")
+
+      // After
+      fireEvent.click(screen.getByText("Collection 1"))
+
+      const selectedOptionsAfter = screen.queryAllByRole("option", {
+        selected: true,
+      })
+
+      expect(screen.getByText("0 lists selected")).toBeInTheDocument()
+      expect(selectedOptionsAfter.length).toBe(0)
+    })
+
+    it("select other collection", async () => {
+      renderWithRelay({
+        CollectionsConnection: () => collectionsConnection,
+      })
+
+      await waitForModalToBePresented()
+
+      fireEvent.click(screen.getByText("Collection 2"))
+
+      const selectedOptions = screen.getAllByRole("option", {
+        selected: true,
+      })
+
+      expect(screen.getByText("2 lists selected")).toBeInTheDocument()
+      expect(selectedOptions.length).toBe(2)
+      expect(selectedOptions[0]).toHaveTextContent("Collection 1")
+      expect(selectedOptions[1]).toHaveTextContent("Collection 2")
+    })
+  })
 })
 
 const waitForModalToBePresented = () => {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/StackedImageLayout.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/StackedImageLayout.tsx
@@ -1,4 +1,5 @@
-import { Box, Flex, Image, NoArtworkIcon } from "@artsy/palette"
+import { Box, Image } from "@artsy/palette"
+import { SavesNoImage } from "Apps/CollectorProfile/Routes/Saves2/Components/SavesNoImage"
 import { prepareImageURLs } from "Apps/CollectorProfile/Routes/Saves2/Utils/prepareImageURLs"
 import { FC } from "react"
 import { cropped } from "Utils/resized"
@@ -45,22 +46,13 @@ const StackImage: FC<StackImageProps> = ({ url, index }) => {
 
   if (url === null) {
     return (
-      <Flex
+      <SavesNoImage
         width={SIZE}
         height={SIZE}
-        bg="black5"
         position="absolute"
         top={OFFSET_BY_INDEX}
         left={OFFSET_BY_INDEX}
-        border="1px solid"
-        borderColor="black15"
-        aria-label="Image placeholder"
-        justifyContent="center"
-        alignItems="center"
-        flexShrink={0}
-      >
-        <NoArtworkIcon width="18px" height="18px" fill="black60" />
-      </Flex>
+      />
     )
   }
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Utils/__tests__/getSelectedCollectionIds.jest.ts
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Utils/__tests__/getSelectedCollectionIds.jest.ts
@@ -1,0 +1,73 @@
+import { getSelectedCollectionIds } from "Apps/CollectorProfile/Routes/Saves2/Utils/getSelectedCollectionIds"
+
+describe("getSelectedCollectionIds", () => {
+  it("empty array", () => {
+    const result = getSelectedCollectionIds({
+      collections: [],
+      addToCollectionIDs: [],
+      removeFromCollectionIDs: [],
+    })
+
+    expect(result).toEqual([])
+  })
+
+  it("only selected ids", () => {
+    const result = getSelectedCollectionIds({
+      collections,
+      addToCollectionIDs: [],
+      removeFromCollectionIDs: [],
+    })
+
+    // for `bbb` collection the value of `isSavedArtwork` is set to `false`
+    expect(result).toEqual(["aaa", "ccc", "ddd"])
+  })
+
+  it("with `addToCollectionIDs`", () => {
+    const result = getSelectedCollectionIds({
+      collections,
+      addToCollectionIDs: ["aaa", "eee"],
+      removeFromCollectionIDs: [],
+    })
+
+    expect(result).toEqual(["aaa", "ccc", "ddd", "eee"])
+  })
+
+  it("without `removeFromCollectionIDs`", () => {
+    const result = getSelectedCollectionIds({
+      collections,
+      addToCollectionIDs: [],
+      removeFromCollectionIDs: ["aaa", "ddd"],
+    })
+
+    expect(result).toEqual(["ccc"])
+  })
+
+  it("with `addToCollectionIDs` and without `removeFromCollectionIDs`", () => {
+    const result = getSelectedCollectionIds({
+      collections,
+      addToCollectionIDs: ["aaa", "eee"],
+      removeFromCollectionIDs: ["ccc", "ddd"],
+    })
+
+    expect(result).toEqual(["aaa", "eee"])
+  })
+})
+
+const collections = [
+  {
+    isSavedArtwork: true,
+    internalID: "aaa",
+  },
+  {
+    isSavedArtwork: false,
+    internalID: "bbb",
+  },
+  {
+    isSavedArtwork: true,
+    internalID: "ccc",
+  },
+  {
+    isSavedArtwork: true,
+    internalID: "ddd",
+  },
+]

--- a/src/Apps/CollectorProfile/Routes/Saves2/Utils/getSelectedCollectionIds.ts
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Utils/getSelectedCollectionIds.ts
@@ -18,7 +18,7 @@ export const getSelectedCollectionIds = <T extends CollectionNode>(
   const selectedByDefault = collections.filter(node => node.isSavedArtwork)
   const selectedIdsByDefault = selectedByDefault.map(node => node.internalID)
   const selectedCollectionIds = difference(
-    uniq([...addToCollectionIDs, ...selectedIdsByDefault]),
+    uniq([...selectedIdsByDefault, ...addToCollectionIDs]),
     removeFromCollectionIDs
   )
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Utils/getSelectedCollectionIds.ts
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Utils/getSelectedCollectionIds.ts
@@ -1,0 +1,26 @@
+import { difference, uniq } from "lodash"
+
+interface CollectionNode {
+  isSavedArtwork: boolean
+  internalID: string
+}
+
+interface Options<T> {
+  collections: T[]
+  addToCollectionIDs: string[]
+  removeFromCollectionIDs: string[]
+}
+
+export const getSelectedCollectionIds = <T extends CollectionNode>(
+  options: Options<T>
+) => {
+  const { collections, addToCollectionIDs, removeFromCollectionIDs } = options
+  const selectedByDefault = collections.filter(node => node.isSavedArtwork)
+  const selectedIdsByDefault = selectedByDefault.map(node => node.internalID)
+  const selectedCollectionIds = difference(
+    uniq([...addToCollectionIDs, ...selectedIdsByDefault]),
+    removeFromCollectionIDs
+  )
+
+  return selectedCollectionIds
+}

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -129,7 +129,8 @@
     },
     "selectedListsForArtwork": {
       "listsCount_one": "{{count}} list selected",
-      "listsCount_other": "{{count}} lists selected"
+      "listsCount_other": "{{count}} lists selected",
+      "saveButton": "Save"
     },
     "contextualMenu": {
       "edit": "Edit List",

--- a/src/__generated__/SelectListItem_item.graphql.ts
+++ b/src/__generated__/SelectListItem_item.graphql.ts
@@ -1,0 +1,58 @@
+/**
+ * @generated SignedSource<<e93db2957326b07eed67ea2f967b0042>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SelectListItem_item$data = {
+  readonly artworksCount: number;
+  readonly internalID: string;
+  readonly name: string;
+  readonly " $fragmentType": "SelectListItem_item";
+};
+export type SelectListItem_item$key = {
+  readonly " $data"?: SelectListItem_item$data;
+  readonly " $fragmentSpreads": FragmentRefs<"SelectListItem_item">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SelectListItem_item",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artworksCount",
+      "storageKey": null
+    }
+  ],
+  "type": "Collection",
+  "abstractKey": null
+};
+
+(node as any).hash = "277abec86cfa010e4644d6720cfd5295";
+
+export default node;

--- a/src/__generated__/SelectListItem_item.graphql.ts
+++ b/src/__generated__/SelectListItem_item.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<32af1c21facd8adc6e36a082d28b17a4>>
+ * @generated SignedSource<<0967f63b7a37bb42f3bae7ab7cb850b5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,7 +21,6 @@ export type SelectListItem_item$data = {
     } | null> | null;
   } | null;
   readonly artworksCount: number;
-  readonly internalID: string;
   readonly name: string;
   readonly " $fragmentType": "SelectListItem_item";
 };
@@ -36,13 +35,6 @@ const node: ReaderFragment = {
   "metadata": null,
   "name": "SelectListItem_item",
   "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "internalID",
-      "storageKey": null
-    },
     {
       "alias": null,
       "args": null,
@@ -125,6 +117,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "82e8f954382f5165a82cd664a0b0ac01";
+(node as any).hash = "373729c726892165d91d80908b9129b1";
 
 export default node;

--- a/src/__generated__/SelectListItem_item.graphql.ts
+++ b/src/__generated__/SelectListItem_item.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e93db2957326b07eed67ea2f967b0042>>
+ * @generated SignedSource<<32af1c21facd8adc6e36a082d28b17a4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,15 @@
 import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type SelectListItem_item$data = {
+  readonly artworksConnection: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly image: {
+          readonly url: string | null;
+        } | null;
+      } | null;
+    } | null> | null;
+  } | null;
   readonly artworksCount: number;
   readonly internalID: string;
   readonly name: string;
@@ -47,12 +56,75 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "artworksCount",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "kind": "LinkedField",
+      "name": "artworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworkEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Image",
+                  "kind": "LinkedField",
+                  "name": "image",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": [
+                        {
+                          "kind": "Literal",
+                          "name": "version",
+                          "value": "square"
+                        }
+                      ],
+                      "kind": "ScalarField",
+                      "name": "url",
+                      "storageKey": "url(version:\"square\")"
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artworksConnection(first:1)"
     }
   ],
   "type": "Collection",
   "abstractKey": null
 };
 
-(node as any).hash = "277abec86cfa010e4644d6720cfd5295";
+(node as any).hash = "82e8f954382f5165a82cd664a0b0ac01";
 
 export default node;

--- a/src/__generated__/SelectListItem_item.graphql.ts
+++ b/src/__generated__/SelectListItem_item.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0967f63b7a37bb42f3bae7ab7cb850b5>>
+ * @generated SignedSource<<4277a6b6e769bb11ab3a05e67e2e4a35>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,6 +56,11 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "first",
           "value": 1
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "SAVED_AT_DESC"
         }
       ],
       "concreteType": "ArtworkConnection",
@@ -110,13 +115,13 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "artworksConnection(first:1)"
+      "storageKey": "artworksConnection(first:1,sort:\"SAVED_AT_DESC\")"
     }
   ],
   "type": "Collection",
   "abstractKey": null
 };
 
-(node as any).hash = "373729c726892165d91d80908b9129b1";
+(node as any).hash = "309b369b212bc93839029bb1fff7dc2c";
 
 export default node;

--- a/src/__generated__/SelectListsForArtworkHeader_artwork.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkHeader_artwork.graphql.ts
@@ -1,0 +1,77 @@
+/**
+ * @generated SignedSource<<bc558c01f608de60a3638baf0c059cca>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SelectListsForArtworkHeader_artwork$data = {
+  readonly date: string | null;
+  readonly image: {
+    readonly url: string | null;
+  } | null;
+  readonly title: string | null;
+  readonly " $fragmentType": "SelectListsForArtworkHeader_artwork";
+};
+export type SelectListsForArtworkHeader_artwork$key = {
+  readonly " $data"?: SelectListsForArtworkHeader_artwork$data;
+  readonly " $fragmentSpreads": FragmentRefs<"SelectListsForArtworkHeader_artwork">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SelectListsForArtworkHeader_artwork",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "date",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": "square"
+            }
+          ],
+          "kind": "ScalarField",
+          "name": "url",
+          "storageKey": "url(version:\"square\")"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Artwork",
+  "abstractKey": null
+};
+
+(node as any).hash = "744d7c0c031c743fd9d21218542c94ef";
+
+export default node;

--- a/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<70ea5ed22962b853ce2f8da947bed614>>
+ * @generated SignedSource<<5fec010050d679dce3b5b0b004c9fd0a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -135,7 +135,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "first",
-                "value": 20
+                "value": 30
               }
             ],
             "concreteType": "CollectionsConnection",
@@ -229,7 +229,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "collectionsConnection(first:20)"
+            "storageKey": "collectionsConnection(first:30)"
           },
           (v3/*: any*/)
         ],
@@ -265,12 +265,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e5c7ad965ebffd3df0ff3c291c94e3ba",
+    "cacheID": "a53fd019ad89ed458417636a39f37eb3",
     "id": null,
     "metadata": {},
     "name": "SelectListsForArtworkModalQuery",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  internalID\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  internalID\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 30) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<71691b6dd658933a7320d0b2b75a60d4>>
+ * @generated SignedSource<<d519790fe8ebd0af41a6d9230f1f54fb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -241,6 +241,11 @@ return {
                 "kind": "Literal",
                 "name": "saves",
                 "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "CREATED_AT_DESC"
               }
             ],
             "concreteType": "CollectionsConnection",
@@ -270,7 +275,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "collectionsConnection(default:false,first:30,saves:true)"
+            "storageKey": "collectionsConnection(default:false,first:30,saves:true,sort:\"CREATED_AT_DESC\")"
           },
           (v4/*: any*/)
         ],
@@ -306,12 +311,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "92e8f2cd655c90200956b4927b9cfd4a",
+    "cacheID": "f098219df974f7413efbf733f4ee8102",
     "id": null,
     "metadata": {},
     "name": "SelectListsForArtworkModalQuery",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me_2R6IMa\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_2R6IMa on Me {\n  defaultSaves: collection(id: \"saved-artwork\") {\n    internalID\n    isSavedArtwork(artworkID: $artworkID)\n    ...SelectListItem_item\n    id\n  }\n  collectionsConnection(first: 30, default: false, saves: true) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: $artworkID)\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me_2R6IMa\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_2R6IMa on Me {\n  defaultSaves: collection(id: \"saved-artwork\") {\n    internalID\n    isSavedArtwork(artworkID: $artworkID)\n    ...SelectListItem_item\n    id\n  }\n  collectionsConnection(first: 30, default: false, saves: true, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: $artworkID)\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5fec010050d679dce3b5b0b004c9fd0a>>
+ * @generated SignedSource<<2ed8af807b654216718a42f202b1ecb5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -265,12 +265,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a53fd019ad89ed458417636a39f37eb3",
+    "cacheID": "d53660abdac8e26ad2555cf8fc6d8825",
     "id": null,
     "metadata": {},
     "name": "SelectListsForArtworkModalQuery",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  internalID\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 30) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 30) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b74b91d0e5c6d4eaf4e11a98f16f7a65>>
+ * @generated SignedSource<<271bd70faaf226841e0d5976bedf003f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -156,6 +156,70 @@ return {
                         "name": "artworksCount",
                         "storageKey": null
                       },
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "first",
+                            "value": 1
+                          }
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "kind": "LinkedField",
+                        "name": "artworksConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "kind": "LinkedField",
+                            "name": "edges",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "kind": "LinkedField",
+                                "name": "node",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": "square"
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:\"square\")"
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  (v2/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "artworksConnection(first:1)"
+                      },
                       (v2/*: any*/)
                     ],
                     "storageKey": null
@@ -192,12 +256,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2ba6bf6786c43e4c66a179ab8a3d6ade",
+    "cacheID": "31e58a253b5d30a1b777e1b17083cf7a",
     "id": null,
     "metadata": {},
     "name": "SelectListsForArtworkModalQuery",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  internalID\n  name\n  artworksCount\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  title\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  internalID\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  title\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2ed8af807b654216718a42f202b1ecb5>>
+ * @generated SignedSource<<201e3f9570ca65a3f4e3b91da7b625b6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -37,11 +37,18 @@ var v0 = [
 v1 = [
   {
     "kind": "Variable",
+    "name": "artworkID",
+    "variableName": "artworkID"
+  }
+],
+v2 = [
+  {
+    "kind": "Variable",
     "name": "id",
     "variableName": "artworkID"
   }
 ],
-v2 = {
+v3 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
@@ -65,7 +72,7 @@ v2 = {
   ],
   "storageKey": null
 },
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -88,7 +95,7 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": null,
+            "args": (v1/*: any*/),
             "kind": "FragmentSpread",
             "name": "SelectListsForArtworkModal_me"
           }
@@ -97,7 +104,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v2/*: any*/),
         "concreteType": "Artwork",
         "kind": "LinkedField",
         "name": "artwork",
@@ -168,6 +175,13 @@ return {
                       },
                       {
                         "alias": null,
+                        "args": (v1/*: any*/),
+                        "kind": "ScalarField",
+                        "name": "isSavedArtwork",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "name",
@@ -210,8 +224,8 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v2/*: any*/),
-                                  (v3/*: any*/)
+                                  (v3/*: any*/),
+                                  (v4/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -221,7 +235,7 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:1)"
                       },
-                      (v3/*: any*/)
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -231,13 +245,13 @@ return {
             ],
             "storageKey": "collectionsConnection(first:30)"
           },
-          (v3/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v2/*: any*/),
         "concreteType": "Artwork",
         "kind": "LinkedField",
         "name": "artwork",
@@ -257,24 +271,24 @@ return {
             "name": "date",
             "storageKey": null
           },
-          (v2/*: any*/),
-          (v3/*: any*/)
+          (v3/*: any*/),
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "d53660abdac8e26ad2555cf8fc6d8825",
+    "cacheID": "313e501c1f699785277c117e9c03e58a",
     "id": null,
     "metadata": {},
     "name": "SelectListsForArtworkModalQuery",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 30) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me_2R6IMa\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_2R6IMa on Me {\n  collectionsConnection(first: 30) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: $artworkID)\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d499a0cdd5335a828461464327151cc0";
+(node as any).hash = "60909341344f6400c8392a24678f26c2";
 
 export default node;

--- a/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<271bd70faaf226841e0d5976bedf003f>>
+ * @generated SignedSource<<70ea5ed22962b853ce2f8da947bed614>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -42,6 +42,30 @@ v1 = [
   }
 ],
 v2 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "version",
+          "value": "square"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "url",
+      "storageKey": "url(version:\"square\")"
+    }
+  ],
+  "storageKey": null
+},
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -186,31 +210,8 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "square"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"square\")"
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v2/*: any*/)
+                                  (v2/*: any*/),
+                                  (v3/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -220,7 +221,7 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:1)"
                       },
-                      (v2/*: any*/)
+                      (v3/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -230,7 +231,7 @@ return {
             ],
             "storageKey": "collectionsConnection(first:20)"
           },
-          (v2/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": null
       },
@@ -249,19 +250,27 @@ return {
             "name": "title",
             "storageKey": null
           },
-          (v2/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "date",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "31e58a253b5d30a1b777e1b17083cf7a",
+    "cacheID": "e5c7ad965ebffd3df0ff3c291c94e3ba",
     "id": null,
     "metadata": {},
     "name": "SelectListsForArtworkModalQuery",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  internalID\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  title\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  internalID\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<201e3f9570ca65a3f4e3b91da7b625b6>>
+ * @generated SignedSource<<71691b6dd658933a7320d0b2b75a60d4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -78,7 +78,79 @@ v4 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-};
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "internalID",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": (v1/*: any*/),
+    "kind": "ScalarField",
+    "name": "isSavedArtwork",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "artworksCount",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Literal",
+        "name": "first",
+        "value": 1
+      }
+    ],
+    "concreteType": "ArtworkConnection",
+    "kind": "LinkedField",
+    "name": "artworksConnection",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ArtworkEdge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Artwork",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": "artworksConnection(first:1)"
+  },
+  (v4/*: any*/)
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -137,12 +209,38 @@ return {
         "plural": false,
         "selections": [
           {
+            "alias": "defaultSaves",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "id",
+                "value": "saved-artwork"
+              }
+            ],
+            "concreteType": "Collection",
+            "kind": "LinkedField",
+            "name": "collection",
+            "plural": false,
+            "selections": (v5/*: any*/),
+            "storageKey": "collection(id:\"saved-artwork\")"
+          },
+          {
             "alias": null,
             "args": [
               {
                 "kind": "Literal",
+                "name": "default",
+                "value": false
+              },
+              {
+                "kind": "Literal",
                 "name": "first",
                 "value": 30
+              },
+              {
+                "kind": "Literal",
+                "name": "saves",
+                "value": true
               }
             ],
             "concreteType": "CollectionsConnection",
@@ -165,85 +263,14 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v1/*: any*/),
-                        "kind": "ScalarField",
-                        "name": "isSavedArtwork",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "name",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "artworksCount",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 1
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  (v3/*: any*/),
-                                  (v4/*: any*/)
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:1)"
-                      },
-                      (v4/*: any*/)
-                    ],
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               }
             ],
-            "storageKey": "collectionsConnection(first:30)"
+            "storageKey": "collectionsConnection(default:false,first:30,saves:true)"
           },
           (v4/*: any*/)
         ],
@@ -279,12 +306,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "313e501c1f699785277c117e9c03e58a",
+    "cacheID": "92e8f2cd655c90200956b4927b9cfd4a",
     "id": null,
     "metadata": {},
     "name": "SelectListsForArtworkModalQuery",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me_2R6IMa\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_2R6IMa on Me {\n  collectionsConnection(first: 30) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: $artworkID)\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me_2R6IMa\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_2R6IMa on Me {\n  defaultSaves: collection(id: \"saved-artwork\") {\n    internalID\n    isSavedArtwork(artworkID: $artworkID)\n    ...SelectListItem_item\n    id\n  }\n  collectionsConnection(first: 30, default: false, saves: true) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: $artworkID)\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
@@ -1,0 +1,207 @@
+/**
+ * @generated SignedSource<<b74b91d0e5c6d4eaf4e11a98f16f7a65>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SelectListsForArtworkModalQuery$variables = {
+  artworkID: string;
+};
+export type SelectListsForArtworkModalQuery$data = {
+  readonly artwork: {
+    readonly " $fragmentSpreads": FragmentRefs<"SelectListsForArtworkModal_artwork">;
+  } | null;
+  readonly me: {
+    readonly " $fragmentSpreads": FragmentRefs<"SelectListsForArtworkModal_me">;
+  } | null;
+};
+export type SelectListsForArtworkModalQuery = {
+  response: SelectListsForArtworkModalQuery$data;
+  variables: SelectListsForArtworkModalQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "artworkID"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artworkID"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SelectListsForArtworkModalQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SelectListsForArtworkModal_me"
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SelectListsForArtworkModal_artwork"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SelectListsForArtworkModalQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 20
+              }
+            ],
+            "concreteType": "CollectionsConnection",
+            "kind": "LinkedField",
+            "name": "collectionsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CollectionsEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Collection",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "artworksCount",
+                        "storageKey": null
+                      },
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "collectionsConnection(first:20)"
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2ba6bf6786c43e4c66a179ab8a3d6ade",
+    "id": null,
+    "metadata": {},
+    "name": "SelectListsForArtworkModalQuery",
+    "operationKind": "query",
+    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  internalID\n  name\n  artworksCount\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  title\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "d499a0cdd5335a828461464327151cc0";
+
+export default node;

--- a/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d519790fe8ebd0af41a6d9230f1f54fb>>
+ * @generated SignedSource<<11a8eaec12136f8c3f5f671de527c916>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -115,6 +115,11 @@ v5 = [
         "kind": "Literal",
         "name": "first",
         "value": 1
+      },
+      {
+        "kind": "Literal",
+        "name": "sort",
+        "value": "SAVED_AT_DESC"
       }
     ],
     "concreteType": "ArtworkConnection",
@@ -147,7 +152,7 @@ v5 = [
         "storageKey": null
       }
     ],
-    "storageKey": "artworksConnection(first:1)"
+    "storageKey": "artworksConnection(first:1,sort:\"SAVED_AT_DESC\")"
   },
   (v4/*: any*/)
 ];
@@ -311,12 +316,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f098219df974f7413efbf733f4ee8102",
+    "cacheID": "84318eeecffd480b9c47b44d9c35111f",
     "id": null,
     "metadata": {},
     "name": "SelectListsForArtworkModalQuery",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me_2R6IMa\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_2R6IMa on Me {\n  defaultSaves: collection(id: \"saved-artwork\") {\n    internalID\n    isSavedArtwork(artworkID: $artworkID)\n    ...SelectListItem_item\n    id\n  }\n  collectionsConnection(first: 30, default: false, saves: true, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: $artworkID)\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModalQuery(\n  $artworkID: String!\n) {\n  me {\n    ...SelectListsForArtworkModal_me_2R6IMa\n    id\n  }\n  artwork(id: $artworkID) {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1, sort: SAVED_AT_DESC) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_2R6IMa on Me {\n  defaultSaves: collection(id: \"saved-artwork\") {\n    internalID\n    isSavedArtwork(artworkID: $artworkID)\n    ...SelectListItem_item\n    id\n  }\n  collectionsConnection(first: 30, default: false, saves: true, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: $artworkID)\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SelectListsForArtworkModal_Test_Query.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<de6c5377c67c773eb290150f72a949e5>>
+ * @generated SignedSource<<4df429cb8a0c1de10c184a9af1286f53>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -70,29 +70,137 @@ v3 = {
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "internalID",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": (v0/*: any*/),
+    "kind": "ScalarField",
+    "name": "isSavedArtwork",
+    "storageKey": "isSavedArtwork(artworkID:\"artworkID\")"
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "artworksCount",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Literal",
+        "name": "first",
+        "value": 1
+      }
+    ],
+    "concreteType": "ArtworkConnection",
+    "kind": "LinkedField",
+    "name": "artworksConnection",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ArtworkEdge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Artwork",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": "artworksConnection(first:1)"
+  },
+  (v3/*: any*/)
+],
+v5 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artwork"
 },
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v6 = {
+v7 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v7 = {
+v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
+},
+v9 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Collection"
+},
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "ArtworkConnection"
+},
+v11 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "ArtworkEdge"
+},
+v12 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+},
+v13 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Boolean"
+},
+v14 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
 };
 return {
   "fragment": {
@@ -152,12 +260,38 @@ return {
         "plural": false,
         "selections": [
           {
+            "alias": "defaultSaves",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "id",
+                "value": "saved-artwork"
+              }
+            ],
+            "concreteType": "Collection",
+            "kind": "LinkedField",
+            "name": "collection",
+            "plural": false,
+            "selections": (v4/*: any*/),
+            "storageKey": "collection(id:\"saved-artwork\")"
+          },
+          {
             "alias": null,
             "args": [
               {
                 "kind": "Literal",
+                "name": "default",
+                "value": false
+              },
+              {
+                "kind": "Literal",
                 "name": "first",
                 "value": 30
+              },
+              {
+                "kind": "Literal",
+                "name": "saves",
+                "value": true
               }
             ],
             "concreteType": "CollectionsConnection",
@@ -180,85 +314,14 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v0/*: any*/),
-                        "kind": "ScalarField",
-                        "name": "isSavedArtwork",
-                        "storageKey": "isSavedArtwork(artworkID:\"artworkID\")"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "name",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "artworksCount",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 1
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  (v2/*: any*/),
-                                  (v3/*: any*/)
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:1)"
-                      },
-                      (v3/*: any*/)
-                    ],
+                    "selections": (v4/*: any*/),
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               }
             ],
-            "storageKey": "collectionsConnection(first:30)"
+            "storageKey": "collectionsConnection(default:false,first:30,saves:true)"
           },
           (v3/*: any*/)
         ],
@@ -294,16 +357,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "72366eecd206a5f87548021b81ef4b65",
+    "cacheID": "718ae24644b6f1fae14330f5bfde0984",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "artwork": (v4/*: any*/),
-        "artwork.date": (v5/*: any*/),
-        "artwork.id": (v6/*: any*/),
-        "artwork.image": (v7/*: any*/),
-        "artwork.image.url": (v5/*: any*/),
-        "artwork.title": (v5/*: any*/),
+        "artwork": (v5/*: any*/),
+        "artwork.date": (v6/*: any*/),
+        "artwork.id": (v7/*: any*/),
+        "artwork.image": (v8/*: any*/),
+        "artwork.image.url": (v6/*: any*/),
+        "artwork.title": (v6/*: any*/),
         "me": {
           "enumValues": null,
           "nullable": true,
@@ -322,54 +385,36 @@ return {
           "plural": true,
           "type": "CollectionsEdge"
         },
-        "me.collectionsConnection.edges.node": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Collection"
-        },
-        "me.collectionsConnection.edges.node.artworksConnection": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkConnection"
-        },
-        "me.collectionsConnection.edges.node.artworksConnection.edges": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "ArtworkEdge"
-        },
-        "me.collectionsConnection.edges.node.artworksConnection.edges.node": (v4/*: any*/),
-        "me.collectionsConnection.edges.node.artworksConnection.edges.node.id": (v6/*: any*/),
-        "me.collectionsConnection.edges.node.artworksConnection.edges.node.image": (v7/*: any*/),
-        "me.collectionsConnection.edges.node.artworksConnection.edges.node.image.url": (v5/*: any*/),
-        "me.collectionsConnection.edges.node.artworksCount": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Int"
-        },
-        "me.collectionsConnection.edges.node.id": (v6/*: any*/),
-        "me.collectionsConnection.edges.node.internalID": (v6/*: any*/),
-        "me.collectionsConnection.edges.node.isSavedArtwork": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Boolean"
-        },
-        "me.collectionsConnection.edges.node.name": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "String"
-        },
-        "me.id": (v6/*: any*/)
+        "me.collectionsConnection.edges.node": (v9/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection": (v10/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges": (v11/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node": (v5/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node.id": (v7/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node.image": (v8/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node.image.url": (v6/*: any*/),
+        "me.collectionsConnection.edges.node.artworksCount": (v12/*: any*/),
+        "me.collectionsConnection.edges.node.id": (v7/*: any*/),
+        "me.collectionsConnection.edges.node.internalID": (v7/*: any*/),
+        "me.collectionsConnection.edges.node.isSavedArtwork": (v13/*: any*/),
+        "me.collectionsConnection.edges.node.name": (v14/*: any*/),
+        "me.defaultSaves": (v9/*: any*/),
+        "me.defaultSaves.artworksConnection": (v10/*: any*/),
+        "me.defaultSaves.artworksConnection.edges": (v11/*: any*/),
+        "me.defaultSaves.artworksConnection.edges.node": (v5/*: any*/),
+        "me.defaultSaves.artworksConnection.edges.node.id": (v7/*: any*/),
+        "me.defaultSaves.artworksConnection.edges.node.image": (v8/*: any*/),
+        "me.defaultSaves.artworksConnection.edges.node.image.url": (v6/*: any*/),
+        "me.defaultSaves.artworksCount": (v12/*: any*/),
+        "me.defaultSaves.id": (v7/*: any*/),
+        "me.defaultSaves.internalID": (v7/*: any*/),
+        "me.defaultSaves.isSavedArtwork": (v13/*: any*/),
+        "me.defaultSaves.name": (v14/*: any*/),
+        "me.id": (v7/*: any*/)
       }
     },
     "name": "SelectListsForArtworkModal_Test_Query",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModal_Test_Query {\n  me {\n    ...SelectListsForArtworkModal_me_42bAl0\n    id\n  }\n  artwork(id: \"artworkID\") {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_42bAl0 on Me {\n  collectionsConnection(first: 30) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: \"artworkID\")\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModal_Test_Query {\n  me {\n    ...SelectListsForArtworkModal_me_42bAl0\n    id\n  }\n  artwork(id: \"artworkID\") {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_42bAl0 on Me {\n  defaultSaves: collection(id: \"saved-artwork\") {\n    internalID\n    isSavedArtwork(artworkID: \"artworkID\")\n    ...SelectListItem_item\n    id\n  }\n  collectionsConnection(first: 30, default: false, saves: true) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: \"artworkID\")\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SelectListsForArtworkModal_Test_Query.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_Test_Query.graphql.ts
@@ -1,0 +1,359 @@
+/**
+ * @generated SignedSource<<3a58d5ef8708a3691c528749ea9a6c14>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SelectListsForArtworkModal_Test_Query$variables = {};
+export type SelectListsForArtworkModal_Test_Query$data = {
+  readonly artwork: {
+    readonly " $fragmentSpreads": FragmentRefs<"SelectListsForArtworkModal_artwork">;
+  } | null;
+  readonly me: {
+    readonly " $fragmentSpreads": FragmentRefs<"SelectListsForArtworkModal_me">;
+  } | null;
+};
+export type SelectListsForArtworkModal_Test_Query = {
+  response: SelectListsForArtworkModal_Test_Query$data;
+  variables: SelectListsForArtworkModal_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "artworkID"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "version",
+          "value": "square"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "url",
+      "storageKey": "url(version:\"square\")"
+    }
+  ],
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Artwork"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v5 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v6 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Image"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SelectListsForArtworkModal_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SelectListsForArtworkModal_me"
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SelectListsForArtworkModal_artwork"
+          }
+        ],
+        "storageKey": "artwork(id:\"artworkID\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SelectListsForArtworkModal_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 30
+              }
+            ],
+            "concreteType": "CollectionsConnection",
+            "kind": "LinkedField",
+            "name": "collectionsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CollectionsEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Collection",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "artworksCount",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "first",
+                            "value": 1
+                          }
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "kind": "LinkedField",
+                        "name": "artworksConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "kind": "LinkedField",
+                            "name": "edges",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "kind": "LinkedField",
+                                "name": "node",
+                                "plural": false,
+                                "selections": [
+                                  (v1/*: any*/),
+                                  (v2/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "artworksConnection(first:1)"
+                      },
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "collectionsConnection(first:30)"
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "date",
+            "storageKey": null
+          },
+          (v1/*: any*/),
+          (v2/*: any*/)
+        ],
+        "storageKey": "artwork(id:\"artworkID\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "58fec514416a77dda2d50e5c607381f2",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artwork": (v3/*: any*/),
+        "artwork.date": (v4/*: any*/),
+        "artwork.id": (v5/*: any*/),
+        "artwork.image": (v6/*: any*/),
+        "artwork.image.url": (v4/*: any*/),
+        "artwork.title": (v4/*: any*/),
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.collectionsConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CollectionsConnection"
+        },
+        "me.collectionsConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "CollectionsEdge"
+        },
+        "me.collectionsConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Collection"
+        },
+        "me.collectionsConnection.edges.node.artworksConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkConnection"
+        },
+        "me.collectionsConnection.edges.node.artworksConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArtworkEdge"
+        },
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node": (v3/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node.id": (v5/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node.image": (v6/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node.image.url": (v4/*: any*/),
+        "me.collectionsConnection.edges.node.artworksCount": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Int"
+        },
+        "me.collectionsConnection.edges.node.id": (v5/*: any*/),
+        "me.collectionsConnection.edges.node.internalID": (v5/*: any*/),
+        "me.collectionsConnection.edges.node.name": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "String"
+        },
+        "me.id": (v5/*: any*/)
+      }
+    },
+    "name": "SelectListsForArtworkModal_Test_Query",
+    "operationKind": "query",
+    "text": "query SelectListsForArtworkModal_Test_Query {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: \"artworkID\") {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 30) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "17e398bada5a3a6219de09265e8902d4";
+
+export default node;

--- a/src/__generated__/SelectListsForArtworkModal_Test_Query.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4df429cb8a0c1de10c184a9af1286f53>>
+ * @generated SignedSource<<b0352a3288b79479f676abdc813f41e0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -292,6 +292,11 @@ return {
                 "kind": "Literal",
                 "name": "saves",
                 "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "CREATED_AT_DESC"
               }
             ],
             "concreteType": "CollectionsConnection",
@@ -321,7 +326,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "collectionsConnection(default:false,first:30,saves:true)"
+            "storageKey": "collectionsConnection(default:false,first:30,saves:true,sort:\"CREATED_AT_DESC\")"
           },
           (v3/*: any*/)
         ],
@@ -357,7 +362,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "718ae24644b6f1fae14330f5bfde0984",
+    "cacheID": "4f2929c6eb170ab6298005865dedd2f8",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -414,7 +419,7 @@ return {
     },
     "name": "SelectListsForArtworkModal_Test_Query",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModal_Test_Query {\n  me {\n    ...SelectListsForArtworkModal_me_42bAl0\n    id\n  }\n  artwork(id: \"artworkID\") {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_42bAl0 on Me {\n  defaultSaves: collection(id: \"saved-artwork\") {\n    internalID\n    isSavedArtwork(artworkID: \"artworkID\")\n    ...SelectListItem_item\n    id\n  }\n  collectionsConnection(first: 30, default: false, saves: true) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: \"artworkID\")\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModal_Test_Query {\n  me {\n    ...SelectListsForArtworkModal_me_42bAl0\n    id\n  }\n  artwork(id: \"artworkID\") {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_42bAl0 on Me {\n  defaultSaves: collection(id: \"saved-artwork\") {\n    internalID\n    isSavedArtwork(artworkID: \"artworkID\")\n    ...SelectListItem_item\n    id\n  }\n  collectionsConnection(first: 30, default: false, saves: true, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: \"artworkID\")\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SelectListsForArtworkModal_Test_Query.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3a58d5ef8708a3691c528749ea9a6c14>>
+ * @generated SignedSource<<de6c5377c67c773eb290150f72a949e5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,11 +28,18 @@ const node: ConcreteRequest = (function(){
 var v0 = [
   {
     "kind": "Literal",
+    "name": "artworkID",
+    "value": "artworkID"
+  }
+],
+v1 = [
+  {
+    "kind": "Literal",
     "name": "id",
     "value": "artworkID"
   }
 ],
-v1 = {
+v2 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
@@ -56,32 +63,32 @@ v1 = {
   ],
   "storageKey": null
 },
-v2 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v3 = {
+v4 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artwork"
 },
-v4 = {
+v5 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v6 = {
+v7 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -103,7 +110,7 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": null,
+            "args": (v0/*: any*/),
             "kind": "FragmentSpread",
             "name": "SelectListsForArtworkModal_me"
           }
@@ -112,7 +119,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Artwork",
         "kind": "LinkedField",
         "name": "artwork",
@@ -183,6 +190,13 @@ return {
                       },
                       {
                         "alias": null,
+                        "args": (v0/*: any*/),
+                        "kind": "ScalarField",
+                        "name": "isSavedArtwork",
+                        "storageKey": "isSavedArtwork(artworkID:\"artworkID\")"
+                      },
+                      {
+                        "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "name",
@@ -225,8 +239,8 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v1/*: any*/),
-                                  (v2/*: any*/)
+                                  (v2/*: any*/),
+                                  (v3/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -236,7 +250,7 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:1)"
                       },
-                      (v2/*: any*/)
+                      (v3/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -246,13 +260,13 @@ return {
             ],
             "storageKey": "collectionsConnection(first:30)"
           },
-          (v2/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": null
       },
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Artwork",
         "kind": "LinkedField",
         "name": "artwork",
@@ -272,24 +286,24 @@ return {
             "name": "date",
             "storageKey": null
           },
-          (v1/*: any*/),
-          (v2/*: any*/)
+          (v2/*: any*/),
+          (v3/*: any*/)
         ],
         "storageKey": "artwork(id:\"artworkID\")"
       }
     ]
   },
   "params": {
-    "cacheID": "58fec514416a77dda2d50e5c607381f2",
+    "cacheID": "72366eecd206a5f87548021b81ef4b65",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "artwork": (v3/*: any*/),
-        "artwork.date": (v4/*: any*/),
-        "artwork.id": (v5/*: any*/),
-        "artwork.image": (v6/*: any*/),
-        "artwork.image.url": (v4/*: any*/),
-        "artwork.title": (v4/*: any*/),
+        "artwork": (v4/*: any*/),
+        "artwork.date": (v5/*: any*/),
+        "artwork.id": (v6/*: any*/),
+        "artwork.image": (v7/*: any*/),
+        "artwork.image.url": (v5/*: any*/),
+        "artwork.title": (v5/*: any*/),
         "me": {
           "enumValues": null,
           "nullable": true,
@@ -326,34 +340,40 @@ return {
           "plural": true,
           "type": "ArtworkEdge"
         },
-        "me.collectionsConnection.edges.node.artworksConnection.edges.node": (v3/*: any*/),
-        "me.collectionsConnection.edges.node.artworksConnection.edges.node.id": (v5/*: any*/),
-        "me.collectionsConnection.edges.node.artworksConnection.edges.node.image": (v6/*: any*/),
-        "me.collectionsConnection.edges.node.artworksConnection.edges.node.image.url": (v4/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node": (v4/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node.id": (v6/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node.image": (v7/*: any*/),
+        "me.collectionsConnection.edges.node.artworksConnection.edges.node.image.url": (v5/*: any*/),
         "me.collectionsConnection.edges.node.artworksCount": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Int"
         },
-        "me.collectionsConnection.edges.node.id": (v5/*: any*/),
-        "me.collectionsConnection.edges.node.internalID": (v5/*: any*/),
+        "me.collectionsConnection.edges.node.id": (v6/*: any*/),
+        "me.collectionsConnection.edges.node.internalID": (v6/*: any*/),
+        "me.collectionsConnection.edges.node.isSavedArtwork": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Boolean"
+        },
         "me.collectionsConnection.edges.node.name": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "String"
         },
-        "me.id": (v5/*: any*/)
+        "me.id": (v6/*: any*/)
       }
     },
     "name": "SelectListsForArtworkModal_Test_Query",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModal_Test_Query {\n  me {\n    ...SelectListsForArtworkModal_me\n    id\n  }\n  artwork(id: \"artworkID\") {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me on Me {\n  collectionsConnection(first: 30) {\n    edges {\n      node {\n        internalID\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModal_Test_Query {\n  me {\n    ...SelectListsForArtworkModal_me_42bAl0\n    id\n  }\n  artwork(id: \"artworkID\") {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_42bAl0 on Me {\n  collectionsConnection(first: 30) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: \"artworkID\")\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "17e398bada5a3a6219de09265e8902d4";
+(node as any).hash = "52e6f1c0ed33b9a79a06d3e314dbe8f8";
 
 export default node;

--- a/src/__generated__/SelectListsForArtworkModal_Test_Query.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b0352a3288b79479f676abdc813f41e0>>
+ * @generated SignedSource<<00691f1df6324e327ccca7bd373b8ef9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -106,6 +106,11 @@ v4 = [
         "kind": "Literal",
         "name": "first",
         "value": 1
+      },
+      {
+        "kind": "Literal",
+        "name": "sort",
+        "value": "SAVED_AT_DESC"
       }
     ],
     "concreteType": "ArtworkConnection",
@@ -138,7 +143,7 @@ v4 = [
         "storageKey": null
       }
     ],
-    "storageKey": "artworksConnection(first:1)"
+    "storageKey": "artworksConnection(first:1,sort:\"SAVED_AT_DESC\")"
   },
   (v3/*: any*/)
 ],
@@ -362,7 +367,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4f2929c6eb170ab6298005865dedd2f8",
+    "cacheID": "f52c7d7fc9f236ad4e72d2bc6b7b9f52",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -419,7 +424,7 @@ return {
     },
     "name": "SelectListsForArtworkModal_Test_Query",
     "operationKind": "query",
-    "text": "query SelectListsForArtworkModal_Test_Query {\n  me {\n    ...SelectListsForArtworkModal_me_42bAl0\n    id\n  }\n  artwork(id: \"artworkID\") {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_42bAl0 on Me {\n  defaultSaves: collection(id: \"saved-artwork\") {\n    internalID\n    isSavedArtwork(artworkID: \"artworkID\")\n    ...SelectListItem_item\n    id\n  }\n  collectionsConnection(first: 30, default: false, saves: true, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: \"artworkID\")\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SelectListsForArtworkModal_Test_Query {\n  me {\n    ...SelectListsForArtworkModal_me_42bAl0\n    id\n  }\n  artwork(id: \"artworkID\") {\n    ...SelectListsForArtworkModal_artwork\n    id\n  }\n}\n\nfragment SelectListItem_item on Collection {\n  name\n  artworksCount\n  artworksConnection(first: 1, sort: SAVED_AT_DESC) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectListsForArtworkHeader_artwork on Artwork {\n  title\n  date\n  image {\n    url(version: \"square\")\n  }\n}\n\nfragment SelectListsForArtworkModal_artwork on Artwork {\n  ...SelectListsForArtworkHeader_artwork\n}\n\nfragment SelectListsForArtworkModal_me_42bAl0 on Me {\n  defaultSaves: collection(id: \"saved-artwork\") {\n    internalID\n    isSavedArtwork(artworkID: \"artworkID\")\n    ...SelectListItem_item\n    id\n  }\n  collectionsConnection(first: 30, default: false, saves: true, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        isSavedArtwork(artworkID: \"artworkID\")\n        ...SelectListItem_item\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SelectListsForArtworkModal_artwork.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_artwork.graphql.ts
@@ -1,0 +1,42 @@
+/**
+ * @generated SignedSource<<1373b18682f9cf9bd7a4d3f325989923>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SelectListsForArtworkModal_artwork$data = {
+  readonly title: string | null;
+  readonly " $fragmentType": "SelectListsForArtworkModal_artwork";
+};
+export type SelectListsForArtworkModal_artwork$key = {
+  readonly " $data"?: SelectListsForArtworkModal_artwork$data;
+  readonly " $fragmentSpreads": FragmentRefs<"SelectListsForArtworkModal_artwork">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SelectListsForArtworkModal_artwork",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    }
+  ],
+  "type": "Artwork",
+  "abstractKey": null
+};
+
+(node as any).hash = "986318c3f047f0944b265aa063a3328e";
+
+export default node;

--- a/src/__generated__/SelectListsForArtworkModal_artwork.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_artwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1373b18682f9cf9bd7a4d3f325989923>>
+ * @generated SignedSource<<8698594dd63e1a39d26706ec05a31f0a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type SelectListsForArtworkModal_artwork$data = {
-  readonly title: string | null;
+  readonly " $fragmentSpreads": FragmentRefs<"SelectListsForArtworkHeader_artwork">;
   readonly " $fragmentType": "SelectListsForArtworkModal_artwork";
 };
 export type SelectListsForArtworkModal_artwork$key = {
@@ -26,17 +26,15 @@ const node: ReaderFragment = {
   "name": "SelectListsForArtworkModal_artwork",
   "selections": [
     {
-      "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "title",
-      "storageKey": null
+      "kind": "FragmentSpread",
+      "name": "SelectListsForArtworkHeader_artwork"
     }
   ],
   "type": "Artwork",
   "abstractKey": null
 };
 
-(node as any).hash = "986318c3f047f0944b265aa063a3328e";
+(node as any).hash = "ab60ad82ac3dfdc79737f09881626840";
 
 export default node;

--- a/src/__generated__/SelectListsForArtworkModal_me.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_me.graphql.ts
@@ -1,0 +1,93 @@
+/**
+ * @generated SignedSource<<0b565030f020ba3a4d9255a82cdd71db>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SelectListsForArtworkModal_me$data = {
+  readonly collectionsConnection: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly internalID: string;
+        readonly " $fragmentSpreads": FragmentRefs<"SelectListItem_item">;
+      } | null;
+    } | null> | null;
+  } | null;
+  readonly " $fragmentType": "SelectListsForArtworkModal_me";
+};
+export type SelectListsForArtworkModal_me$key = {
+  readonly " $data"?: SelectListsForArtworkModal_me$data;
+  readonly " $fragmentSpreads": FragmentRefs<"SelectListsForArtworkModal_me">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SelectListsForArtworkModal_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 20
+        }
+      ],
+      "concreteType": "CollectionsConnection",
+      "kind": "LinkedField",
+      "name": "collectionsConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "CollectionsEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Collection",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "SelectListItem_item"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "collectionsConnection(first:20)"
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+
+(node as any).hash = "cb4f666bb2286b5e227dc17a1ff3f0b7";
+
+export default node;

--- a/src/__generated__/SelectListsForArtworkModal_me.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a1e7774329ed58320a28ad29293e994f>>
+ * @generated SignedSource<<ab2da3757a685c6f78ade3f94a259267>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type SelectListsForArtworkModal_me$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly internalID: string;
+        readonly isSavedArtwork: boolean;
         readonly " $fragmentSpreads": FragmentRefs<"SelectListItem_item">;
       } | null;
     } | null> | null;
@@ -27,7 +28,13 @@ export type SelectListsForArtworkModal_me$key = {
 };
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "artworkID"
+    }
+  ],
   "kind": "Fragment",
   "metadata": null,
   "name": "SelectListsForArtworkModal_me",
@@ -70,6 +77,19 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
+                  "alias": null,
+                  "args": [
+                    {
+                      "kind": "Variable",
+                      "name": "artworkID",
+                      "variableName": "artworkID"
+                    }
+                  ],
+                  "kind": "ScalarField",
+                  "name": "isSavedArtwork",
+                  "storageKey": null
+                },
+                {
                   "args": null,
                   "kind": "FragmentSpread",
                   "name": "SelectListItem_item"
@@ -88,6 +108,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "4dc6040009cc30dbeb8c67c7fb7d2058";
+(node as any).hash = "d1da83c3584eb344b1d1617fd97a73eb";
 
 export default node;

--- a/src/__generated__/SelectListsForArtworkModal_me.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ab2da3757a685c6f78ade3f94a259267>>
+ * @generated SignedSource<<f5e82f403b228dfb873b0ff02a92d5c0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,6 +20,11 @@ export type SelectListsForArtworkModal_me$data = {
       } | null;
     } | null> | null;
   } | null;
+  readonly defaultSaves: {
+    readonly internalID: string;
+    readonly isSavedArtwork: boolean;
+    readonly " $fragmentSpreads": FragmentRefs<"SelectListItem_item">;
+  } | null;
   readonly " $fragmentType": "SelectListsForArtworkModal_me";
 };
 export type SelectListsForArtworkModal_me$key = {
@@ -27,7 +32,35 @@ export type SelectListsForArtworkModal_me$key = {
   readonly " $fragmentSpreads": FragmentRefs<"SelectListsForArtworkModal_me">;
 };
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "internalID",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "artworkID",
+        "variableName": "artworkID"
+      }
+    ],
+    "kind": "ScalarField",
+    "name": "isSavedArtwork",
+    "storageKey": null
+  },
+  {
+    "args": null,
+    "kind": "FragmentSpread",
+    "name": "SelectListItem_item"
+  }
+];
+return {
   "argumentDefinitions": [
     {
       "defaultValue": null,
@@ -40,12 +73,38 @@ const node: ReaderFragment = {
   "name": "SelectListsForArtworkModal_me",
   "selections": [
     {
+      "alias": "defaultSaves",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "id",
+          "value": "saved-artwork"
+        }
+      ],
+      "concreteType": "Collection",
+      "kind": "LinkedField",
+      "name": "collection",
+      "plural": false,
+      "selections": (v0/*: any*/),
+      "storageKey": "collection(id:\"saved-artwork\")"
+    },
+    {
       "alias": null,
       "args": [
         {
           "kind": "Literal",
+          "name": "default",
+          "value": false
+        },
+        {
+          "kind": "Literal",
           "name": "first",
           "value": 30
+        },
+        {
+          "kind": "Literal",
+          "name": "saves",
+          "value": true
         }
       ],
       "concreteType": "CollectionsConnection",
@@ -68,46 +127,21 @@ const node: ReaderFragment = {
               "kind": "LinkedField",
               "name": "node",
               "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "internalID",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": [
-                    {
-                      "kind": "Variable",
-                      "name": "artworkID",
-                      "variableName": "artworkID"
-                    }
-                  ],
-                  "kind": "ScalarField",
-                  "name": "isSavedArtwork",
-                  "storageKey": null
-                },
-                {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "SelectListItem_item"
-                }
-              ],
+              "selections": (v0/*: any*/),
               "storageKey": null
             }
           ],
           "storageKey": null
         }
       ],
-      "storageKey": "collectionsConnection(first:30)"
+      "storageKey": "collectionsConnection(default:false,first:30,saves:true)"
     }
   ],
   "type": "Me",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "d1da83c3584eb344b1d1617fd97a73eb";
+(node as any).hash = "5fd627ecd243cf2680f1e6dbe901cded";
 
 export default node;

--- a/src/__generated__/SelectListsForArtworkModal_me.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0b565030f020ba3a4d9255a82cdd71db>>
+ * @generated SignedSource<<a1e7774329ed58320a28ad29293e994f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -38,7 +38,7 @@ const node: ReaderFragment = {
         {
           "kind": "Literal",
           "name": "first",
-          "value": 20
+          "value": 30
         }
       ],
       "concreteType": "CollectionsConnection",
@@ -81,13 +81,13 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "collectionsConnection(first:20)"
+      "storageKey": "collectionsConnection(first:30)"
     }
   ],
   "type": "Me",
   "abstractKey": null
 };
 
-(node as any).hash = "cb4f666bb2286b5e227dc17a1ff3f0b7";
+(node as any).hash = "4dc6040009cc30dbeb8c67c7fb7d2058";
 
 export default node;

--- a/src/__generated__/SelectListsForArtworkModal_me.graphql.ts
+++ b/src/__generated__/SelectListsForArtworkModal_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f5e82f403b228dfb873b0ff02a92d5c0>>
+ * @generated SignedSource<<fa20c7b367cd6e460881092b04ad8bbb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -105,6 +105,11 @@ return {
           "kind": "Literal",
           "name": "saves",
           "value": true
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "CREATED_AT_DESC"
         }
       ],
       "concreteType": "CollectionsConnection",
@@ -134,7 +139,7 @@ return {
           "storageKey": null
         }
       ],
-      "storageKey": "collectionsConnection(default:false,first:30,saves:true)"
+      "storageKey": "collectionsConnection(default:false,first:30,saves:true,sort:\"CREATED_AT_DESC\")"
     }
   ],
   "type": "Me",
@@ -142,6 +147,6 @@ return {
 };
 })();
 
-(node as any).hash = "5fd627ecd243cf2680f1e6dbe901cded";
+(node as any).hash = "0a417c5fded1f7365a511ce16ed52af5";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4590]

Review app: [select-lists-for-artwork](https://select-lists-for-artwork.artsy.net/collector-profile/saves2)

### Demo
#### web
https://user-images.githubusercontent.com/3513494/220416936-1500e1b4-f68f-4298-8458-78f8b30a57e1.mp4

#### mWeb
https://user-images.githubusercontent.com/3513494/220654855-fc0de29b-2f17-4a8f-9451-befb4a2279c0.mp4

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4590]: https://artsyproduct.atlassian.net/browse/FX-4590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ