### PR TITLE
fix: route inquiry wire offers to conversations

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -132,7 +132,9 @@ export const ReviewRoute: FC<ReviewProps> = props => {
         // TODO: replace usage with order.state === "IN_REVIEW" once buyerStatus
         // is implemented in Exchange.
         // See https://www.notion.so/artsy/2023-02-09-Platform-Practice-Meeting-Notes-87f4cc9987a7436c9c4b207847e318db?pvs=4
-        const orderInReviewFacsimile = order.paymentMethod === "WIRE_TRANSFER"
+        const orderInReviewFacsimile =
+          order.paymentMethod === "WIRE_TRANSFER" &&
+          order.source === "artwork_page"
 
         if (isEigen) {
           if (order.mode === "OFFER") {


### PR DESCRIPTION
When an offer-order is initiated from an ongoing conversation, we want the buyer to be redirected to that conversation when the offer-order is submitted. This behavior changed for offer-orders initiated from an artwork page in #11914, and this PR updates that to consider the conversation-initiated offer-orders as well.