### PR TITLE
fix(CX-3390):hide upcoming auctions when there are no upcoming auctions in auction results

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -253,7 +253,9 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
         <AuctionFilterMobileActionSheet
           onClose={() => toggleMobileActionSheet(false)}
         >
-          <AuctionFilters />
+          <AuctionFilters
+            hideUpcomingAuctionResults={upcomingAuctionResultsCount === 0}
+          />
         </AuctionFilterMobileActionSheet>
       )}
 

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -81,6 +81,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
   const upcomingAuctionResultsCount =
     artist.upcomingAuctionResults?.totalCount || 0
   const pastAuctionResultsCount = artist.pastAuctionResults?.totalCount || 0
+  const showUpcomingAuctionResults = upcomingAuctionResultsCount > 0
 
   const { match } = useRouter()
 
@@ -254,7 +255,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
           onClose={() => toggleMobileActionSheet(false)}
         >
           <AuctionFilters
-            hideUpcomingAuctionResults={upcomingAuctionResultsCount === 0}
+            showUpcomingAuctionResults={showUpcomingAuctionResults}
           />
         </AuctionFilterMobileActionSheet>
       )}
@@ -280,7 +281,9 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
       <GridColumns>
         <Column span={3}>
           <Media greaterThan="xs">
-            <TableSidebar />
+            <TableSidebar
+              showUpcomingAuctionResults={showUpcomingAuctionResults}
+            />
           </Media>
         </Column>
 

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
@@ -7,14 +7,16 @@ import { MediumFilter } from "./MediumFilter"
 import { SizeFilter } from "./SizeFilter"
 import { YearCreated } from "./YearCreated"
 
-export const AuctionFilters: React.FC = () => {
+export const AuctionFilters: React.FC<{
+  hideUpcomingAuctionResults: boolean
+}> = hideUpcomingAuctionResults => {
   const enableUpcomingAuctionsFilter = useFeatureFlag(
     "cx-upcoming-auctions-filter"
   )
 
   return (
     <>
-      {enableUpcomingAuctionsFilter && (
+      {enableUpcomingAuctionsFilter && !hideUpcomingAuctionResults && (
         <>
           <HideUpcomingFilter />
           <Spacer y={2} />

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
@@ -8,15 +8,15 @@ import { SizeFilter } from "./SizeFilter"
 import { YearCreated } from "./YearCreated"
 
 export const AuctionFilters: React.FC<{
-  hideUpcomingAuctionResults: boolean
-}> = hideUpcomingAuctionResults => {
+  showUpcomingAuctionResults: boolean
+}> = ({ showUpcomingAuctionResults }) => {
   const enableUpcomingAuctionsFilter = useFeatureFlag(
     "cx-upcoming-auctions-filter"
   )
 
   return (
     <>
-      {enableUpcomingAuctionsFilter && !hideUpcomingAuctionResults && (
+      {enableUpcomingAuctionsFilter && showUpcomingAuctionResults && (
         <>
           <HideUpcomingFilter />
           <Spacer y={2} />

--- a/src/Apps/Artist/Routes/AuctionResults/Components/TableSidebar.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/TableSidebar.tsx
@@ -1,10 +1,12 @@
 import { Flex } from "@artsy/palette"
 import { AuctionFilters } from "./AuctionFilters"
 
-export const TableSidebar = () => {
+export const TableSidebar: React.FC<{
+  showUpcomingAuctionResults: boolean
+}> = ({ showUpcomingAuctionResults }) => {
   return (
     <Flex flexDirection="column">
-      <AuctionFilters />
+      <AuctionFilters showUpcomingAuctionResults={showUpcomingAuctionResults} />
     </Flex>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3390]

### Description

<!-- Implementation description -->
before: 
<img width="399" alt="image" src="https://user-images.githubusercontent.com/36167539/220380436-c373351a-2b67-401b-a8d3-4b5babd297ee.png">

after:
<img width="418" alt="image" src="https://user-images.githubusercontent.com/36167539/220380298-c9ddd2c2-7414-424b-8639-4a3d9393309c.png">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3390]: https://artsyproduct.atlassian.net/browse/CX-3390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ