### PR TITLE
fix(quiz): switches artworks tab to use recommended artworks field

### DIFF
--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsRecommendedArtworks.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsRecommendedArtworks.tsx
@@ -6,9 +6,7 @@ import { ArtQuizResultsRecommendedArtworksQuery } from "__generated__/ArtQuizRes
 import { Masonry } from "Components/Masonry"
 import ArtworkGridItemFragmentContainer from "Components/Artwork/GridItem"
 import { Message, Spacer } from "@artsy/palette"
-import { uniqBy } from "lodash"
 import { ArtworkGridPlaceholder } from "Components/ArtworkGrid"
-import { extractNodes } from "Utils/extractNodes"
 import { useStableShuffle } from "Utils/Hooks/useStableShuffle"
 
 interface ArtQuizResultsRecommendedArtworksProps {
@@ -18,16 +16,7 @@ interface ArtQuizResultsRecommendedArtworksProps {
 const ArtQuizResultsRecommendedArtworks: FC<ArtQuizResultsRecommendedArtworksProps> = ({
   me,
 }) => {
-  const artworks = useStableShuffle({
-    items: uniqBy(
-      me.quiz.savedArtworks.flatMap(artwork => {
-        if (!artwork.layer) return []
-
-        return extractNodes(artwork.layer.artworksConnection)
-      }),
-      "internalID"
-    ),
-  })
+  const artworks = useStableShuffle({ items: [...me.quiz.recommendedArtworks] })
 
   if (artworks.shuffled.length === 0) {
     return (
@@ -53,20 +42,11 @@ export const ArtQuizResultsRecommendedArtworksFragmentContainer = createFragment
   ArtQuizResultsRecommendedArtworks,
   {
     me: graphql`
-      fragment ArtQuizResultsRecommendedArtworks_me on Me
-        @argumentDefinitions(limit: { type: "Int" }) {
+      fragment ArtQuizResultsRecommendedArtworks_me on Me {
         quiz {
-          savedArtworks {
-            layer(id: "main") {
-              artworksConnection(first: $limit) {
-                edges {
-                  node {
-                    internalID
-                    ...GridItem_artwork
-                  }
-                }
-              }
-            }
+          recommendedArtworks {
+            internalID
+            ...GridItem_artwork
           }
         }
       }
@@ -78,13 +58,7 @@ const ArtQuizResultsRecommendedArtworksPlaceholder: FC = () => {
   return <ArtworkGridPlaceholder columnCount={[2, 3, 4]} amount={16} />
 }
 
-interface ArtQuizResultsRecommendedArtworksQueryRendererProps {
-  limit: number
-}
-
-export const ArtQuizResultsRecommendedArtworksQueryRenderer: FC<ArtQuizResultsRecommendedArtworksQueryRendererProps> = ({
-  limit,
-}) => {
+export const ArtQuizResultsRecommendedArtworksQueryRenderer: FC = () => {
   return (
     <SystemQueryRenderer<ArtQuizResultsRecommendedArtworksQuery>
       query={graphql`
@@ -109,7 +83,6 @@ export const ArtQuizResultsRecommendedArtworksQueryRenderer: FC<ArtQuizResultsRe
           <ArtQuizResultsRecommendedArtworksFragmentContainer me={props.me} />
         )
       }}
-      variables={{ limit }}
     />
   )
 }

--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
@@ -3,44 +3,37 @@ import { ArtQuizLikedArtworksQueryRenderer } from "Apps/ArtQuiz/Components/ArtQu
 import { ArtQuizRecommendedArtistsQueryRenderer } from "Apps/ArtQuiz/Components/ArtQuizRecommendedArtists"
 import { ArtQuizResultsRecommendedArtworksQueryRenderer } from "Apps/ArtQuiz/Components/ArtQuizResultsRecommendedArtworks"
 import { TriggerCampaignButton } from "Apps/ArtQuiz/Components/TriggerCampaignButton"
-import { FC, useMemo } from "react"
+import { FC } from "react"
 import { useTranslation } from "react-i18next"
 
-interface ArtQuizResultsTabsProps {
-  savedQuizArtworksCount: number
-}
-
-export const ArtQuizResultsTabs: FC<ArtQuizResultsTabsProps> = ({
-  savedQuizArtworksCount,
-}) => {
+export const ArtQuizResultsTabs: FC = ({}) => {
   const { t } = useTranslation()
-
-  const limit = useMemo(() => {
-    if (savedQuizArtworksCount <= 1) return 100
-    if (savedQuizArtworksCount <= 3) return 8
-    return 4
-  }, [savedQuizArtworksCount])
 
   return (
     <>
       <Spacer y={[4, 6]} />
+
       <Text variant={["lg", "xl"]}>{t("artQuizPage.results.title")}</Text>
+
       <Spacer y={[0, 1]} />
+
       <Text color="black60" variant={["sm", "md"]}>
         {t("artQuizPage.results.subtitle")}
       </Text>
+
       <Spacer y={[2, 4]} />
 
       <TriggerCampaignButton />
 
       <Spacer y={[4, 6]} />
+
       <Tabs fill>
         <Tab name={t("artQuizPage.results.tabs.worksYouLiked")}>
           <ArtQuizLikedArtworksQueryRenderer />
         </Tab>
 
         <Tab name={t("artQuizPage.results.tabs.recommendedArtworks")}>
-          <ArtQuizResultsRecommendedArtworksQueryRenderer limit={limit} />
+          <ArtQuizResultsRecommendedArtworksQueryRenderer />
         </Tab>
 
         <Tab name={t("artQuizPage.results.tabs.recommendedArtists")}>

--- a/src/Apps/ArtQuiz/Routes/ArtQuizResults.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizResults.tsx
@@ -9,13 +9,8 @@ interface ArtQuizResultsProps {
 }
 
 const ArtQuizResults: FC<ArtQuizResultsProps> = ({ me }) => {
-  const savedQuizArtworksCount = me.quiz.savedArtworks.length
-  const hasSavedArtworks = savedQuizArtworksCount > 0
-
-  if (hasSavedArtworks) {
-    return (
-      <ArtQuizResultsTabs savedQuizArtworksCount={savedQuizArtworksCount} />
-    )
+  if (me.quiz.savedArtworks.length > 0) {
+    return <ArtQuizResultsTabs />
   }
 
   return <ArtQuizResultsEmpty />

--- a/src/__generated__/ArtQuizResultsRecommendedArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtQuizResultsRecommendedArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4b2f18844aca362581e69aa46cd8ae1c>>
+ * @generated SignedSource<<67fdc54c5bac990d0a5d931f2ddedbe5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -131,427 +131,129 @@ return {
                 "args": null,
                 "concreteType": "Artwork",
                 "kind": "LinkedField",
-                "name": "savedArtworks",
+                "name": "recommendedArtworks",
                 "plural": true,
                 "selections": [
+                  (v0/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "title",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "imageTitle",
+                    "storageKey": null
+                  },
                   {
                     "alias": null,
                     "args": [
                       {
                         "kind": "Literal",
-                        "name": "id",
-                        "value": "main"
+                        "name": "includeAll",
+                        "value": false
                       }
                     ],
-                    "concreteType": "ArtworkLayer",
+                    "concreteType": "Image",
                     "kind": "LinkedField",
-                    "name": "layer",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      (v0/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "placeholder",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": [
+                              "larger",
+                              "large"
+                            ]
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:[\"larger\",\"large\"])"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "aspectRatio",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "versions",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "image(includeAll:false)"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "artistNames",
+                    "storageKey": null
+                  },
+                  (v1/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "date",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_message",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "saleMessage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "cultural_maker",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "culturalMaker",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "artist",
                     "plural": false,
                     "selections": [
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ArtworkConnection",
+                        "concreteType": "ArtistTargetSupply",
                         "kind": "LinkedField",
-                        "name": "artworksConnection",
+                        "name": "targetSupply",
                         "plural": false,
                         "selections": [
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  (v0/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "includeAll",
-                                        "value": false
-                                      }
-                                    ],
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      (v0/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "placeholder",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:[\"larger\",\"large\"])"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "versions",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": "image(includeAll:false)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artistNames",
-                                    "storageKey": null
-                                  },
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artist",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "ArtistTargetSupply",
-                                        "kind": "LinkedField",
-                                        "name": "targetSupply",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isP1",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v2/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkPriceInsights",
-                                    "kind": "LinkedField",
-                                    "name": "marketPriceInsights",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "demandRank",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v3/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v2/*: any*/),
-                                      (v1/*: any*/),
-                                      (v4/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v3/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v4/*: any*/),
-                                      (v1/*: any*/),
-                                      (v2/*: any*/)
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "cascadingEndTimeIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "startAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v2/*: any*/),
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotID",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotLabel",
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingEndAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "formattedEndDateTime",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v2/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v2/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "slug",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_saved",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AttributionClass",
-                                    "kind": "LinkedField",
-                                    "name": "attributionClass",
-                                    "plural": false,
-                                    "selections": (v7/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkMedium",
-                                    "kind": "LinkedField",
-                                    "name": "mediumType",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Gene",
-                                        "kind": "LinkedField",
-                                        "name": "filterGene",
-                                        "plural": false,
-                                        "selections": (v7/*: any*/),
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_biddable",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
+                            "kind": "ScalarField",
+                            "name": "isP1",
                             "storageKey": null
                           }
                         ],
@@ -559,9 +261,255 @@ return {
                       },
                       (v2/*: any*/)
                     ],
-                    "storageKey": "layer(id:\"main\")"
+                    "storageKey": null
                   },
-                  (v2/*: any*/)
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ArtworkPriceInsights",
+                    "kind": "LinkedField",
+                    "name": "marketPriceInsights",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "demandRank",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v3/*: any*/),
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "artists",
+                    "plural": true,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v1/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": "artists(shallow:true)"
+                  },
+                  {
+                    "alias": "collecting_institution",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "collectingInstitution",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v3/*: any*/),
+                    "concreteType": "Partner",
+                    "kind": "LinkedField",
+                    "name": "partner",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      (v1/*: any*/),
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": "partner(shallow:true)"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Sale",
+                    "kind": "LinkedField",
+                    "name": "sale",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cascadingEndTimeIntervalMinutes",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "extendedBiddingIntervalMinutes",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "startAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_auction",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isAuction",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_closed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isClosed",
+                        "storageKey": null
+                      },
+                      (v2/*: any*/),
+                      {
+                        "alias": "is_preview",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isPreview",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "display_timely_at",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "displayTimelyAt",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_artwork",
+                    "args": null,
+                    "concreteType": "SaleArtwork",
+                    "kind": "LinkedField",
+                    "name": "saleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotLabel",
+                        "storageKey": null
+                      },
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "extendedBiddingEndAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "formattedEndDateTime",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "bidder_positions",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "bidderPositions",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "highest_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkHighestBid",
+                        "kind": "LinkedField",
+                        "name": "highestBid",
+                        "plural": false,
+                        "selections": (v6/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "opening_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkOpeningBid",
+                        "kind": "LinkedField",
+                        "name": "openingBid",
+                        "plural": false,
+                        "selections": (v6/*: any*/),
+                        "storageKey": null
+                      },
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slug",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "is_saved",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isSaved",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AttributionClass",
+                    "kind": "LinkedField",
+                    "name": "attributionClass",
+                    "plural": false,
+                    "selections": (v7/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ArtworkMedium",
+                    "kind": "LinkedField",
+                    "name": "mediumType",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Gene",
+                        "kind": "LinkedField",
+                        "name": "filterGene",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "is_biddable",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isBiddable",
+                    "storageKey": null
+                  }
                 ],
                 "storageKey": null
               },
@@ -576,12 +524,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2dca169caba843c5410c25e7303b44fb",
+    "cacheID": "f646227da32c39767ee44cd861ecc172",
     "id": null,
     "metadata": {},
     "name": "ArtQuizResultsRecommendedArtworksQuery",
     "operationKind": "query",
-    "text": "query ArtQuizResultsRecommendedArtworksQuery {\n  me {\n    ...ArtQuizResultsRecommendedArtworks_me\n    id\n  }\n}\n\nfragment ArtQuizResultsRecommendedArtworks_me on Me {\n  quiz {\n    savedArtworks {\n      layer(id: \"main\") {\n        artworksConnection {\n          edges {\n            node {\n              internalID\n              ...GridItem_artwork\n              id\n            }\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query ArtQuizResultsRecommendedArtworksQuery {\n  me {\n    ...ArtQuizResultsRecommendedArtworks_me\n    id\n  }\n}\n\nfragment ArtQuizResultsRecommendedArtworks_me on Me {\n  quiz {\n    recommendedArtworks {\n      internalID\n      ...GridItem_artwork\n      id\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtQuizResultsRecommendedArtworks_me.graphql.ts
+++ b/src/__generated__/ArtQuizResultsRecommendedArtworks_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8332f97032bb8bd5c5a0ee92afe375fc>>
+ * @generated SignedSource<<09a181fa25bb91394bcc04411105a221>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,17 +12,9 @@ import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtQuizResultsRecommendedArtworks_me$data = {
   readonly quiz: {
-    readonly savedArtworks: ReadonlyArray<{
-      readonly layer: {
-        readonly artworksConnection: {
-          readonly edges: ReadonlyArray<{
-            readonly node: {
-              readonly internalID: string;
-              readonly " $fragmentSpreads": FragmentRefs<"GridItem_artwork">;
-            } | null;
-          } | null> | null;
-        } | null;
-      } | null;
+    readonly recommendedArtworks: ReadonlyArray<{
+      readonly internalID: string;
+      readonly " $fragmentSpreads": FragmentRefs<"GridItem_artwork">;
     }>;
   };
   readonly " $fragmentType": "ArtQuizResultsRecommendedArtworks_me";
@@ -33,13 +25,7 @@ export type ArtQuizResultsRecommendedArtworks_me$key = {
 };
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "limit"
-    }
-  ],
+  "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "ArtQuizResultsRecommendedArtworks_me",
@@ -57,76 +43,20 @@ const node: ReaderFragment = {
           "args": null,
           "concreteType": "Artwork",
           "kind": "LinkedField",
-          "name": "savedArtworks",
+          "name": "recommendedArtworks",
           "plural": true,
           "selections": [
             {
               "alias": null,
-              "args": [
-                {
-                  "kind": "Literal",
-                  "name": "id",
-                  "value": "main"
-                }
-              ],
-              "concreteType": "ArtworkLayer",
-              "kind": "LinkedField",
-              "name": "layer",
-              "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": [
-                    {
-                      "kind": "Variable",
-                      "name": "first",
-                      "variableName": "limit"
-                    }
-                  ],
-                  "concreteType": "ArtworkConnection",
-                  "kind": "LinkedField",
-                  "name": "artworksConnection",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "concreteType": "ArtworkEdge",
-                      "kind": "LinkedField",
-                      "name": "edges",
-                      "plural": true,
-                      "selections": [
-                        {
-                          "alias": null,
-                          "args": null,
-                          "concreteType": "Artwork",
-                          "kind": "LinkedField",
-                          "name": "node",
-                          "plural": false,
-                          "selections": [
-                            {
-                              "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "internalID",
-                              "storageKey": null
-                            },
-                            {
-                              "args": null,
-                              "kind": "FragmentSpread",
-                              "name": "GridItem_artwork"
-                            }
-                          ],
-                          "storageKey": null
-                        }
-                      ],
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": null
-                }
-              ],
-              "storageKey": "layer(id:\"main\")"
+              "args": null,
+              "kind": "ScalarField",
+              "name": "internalID",
+              "storageKey": null
+            },
+            {
+              "args": null,
+              "kind": "FragmentSpread",
+              "name": "GridItem_artwork"
             }
           ],
           "storageKey": null
@@ -139,6 +69,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "815a9dddd6359196c24dd275a23c5225";
+(node as any).hash = "836b58194b33ed410b2c98db3a8d5c66";
 
 export default node;


### PR DESCRIPTION
Co-authored with @TMcMeans 

This switches the recommended artworks to use the 24 hour cached `recommendedArtworks` field.