### PR TITLE
fix: event propagation for modal

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal.tsx
@@ -32,13 +32,23 @@ export const SelectListsForArtworkModal: React.FC<SelectListsForArtworkModalProp
     onClose()
   }
 
+  /**
+   * Workaround to solve this issue
+   * https://github.com/facebook/react/issues/11387
+   */
+  const stopPropagation = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
+    event.stopPropagation()
+  }
+
   return (
     <ModalDialog
       title="Select lists for this artwork"
       onClose={onClose}
-      onClick={event => {
-        event.preventDefault()
-      }}
+      onClick={stopPropagation}
+      onMouseEnter={stopPropagation}
+      onMouseLeave={stopPropagation}
       dialogProps={{
         width: ["100%", 700],
         height: ["100%", "auto"],


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description
This PR includes fix for the problem, which you can see in the demo video. This is due to the fact that the `ModalBase` component [uses](https://github.com/artsy/palette/blob/main/packages/palette/src/elements/Modal/ModalBase.tsx#L131) `createPortal` and we are facing [this problem](https://github.com/facebook/react/issues/11387) (example with [details](https://github.com/facebook/react/issues/11387#issuecomment-340127105))

### Problem
When you click on the modal content, the `click` event is propagated to parents and the `onClick` handlers are triggered. Navigation to the artwork page is performed in our case, since we render this modal inside the `Details` component and displays this modal when clicking on the heart icon 

### Demo
https://user-images.githubusercontent.com/3513494/220737267-84aaea3d-aa04-4b80-bb1c-c20669225f4b.mp4

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ