### PR TITLE
perf: temporarily disable RelatedWorks rail

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -31,7 +31,7 @@ import { CascadingEndTimesBannerFragmentContainer } from "Components/CascadingEn
 import { UnlistedArtworkBannerFragmentContainer } from "Components/UnlistedArtworkBanner"
 import { useCallback, useEffect } from "react"
 import { ArtworkSidebarFragmentContainer } from "./Components/ArtworkSidebar/ArtworkSidebar"
-import { RelatedWorksQueryRenderer } from "Apps/Artwork/Components/RelatedWorks"
+// import { RelatedWorksQueryRenderer } from "Apps/Artwork/Components/RelatedWorks"
 import { ArtworkDetailsPartnerInfoQueryRenderer } from "Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsPartnerInfo"
 
 export interface Props {
@@ -230,7 +230,8 @@ export const ArtworkApp: React.FC<Props> = props => {
 
       <Spacer y={6} />
 
-      <RelatedWorksQueryRenderer slug={artwork.slug} />
+      {/* Temporarily suppressed while we investigate performance. See PLATFORM-4980  */}
+      {/* <RelatedWorksQueryRenderer slug={artwork.slug} /> */}
 
       {artwork.artist && (
         <>


### PR DESCRIPTION
The type of this PR is: **Perf**

This PR solves [PLATFORM-4980]

### Description

Temporarily suppresses the artwork page's `RelatedWorks` rail, which appears to be implicated in the increasing frequency of ES alerts. 

See Slack threads [here](https://artsy.slack.com/archives/CA8SANW3W/p1676999056487519) and [here](https://artsy.slack.com/archives/C9SATFLUU/p1677253352997539).

Effects can be monitored [here](https://artsy.slack.com/archives/C9SATFLUU/p1677533281286779?thread_ts=1677253352.997539&cid=C9SATFLUU).

[PLATFORM-4980]: https://artsyproduct.atlassian.net/browse/PLATFORM-4980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ