### PR TITLE
chore(quiz): add data test id for integration testing

### DIFF
--- a/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
+++ b/src/Apps/ArtQuiz/Routes/ArtQuizArtworks.tsx
@@ -234,6 +234,7 @@ export const ArtQuizArtworks: FC<ArtQuizArtworksProps> = ({ me }) => {
             display="flex"
             alignItems="center"
             justifyContent="center"
+            data-testid="artworks-count"
           >
             {positionDisplay} / {cards.length}
           </Text>


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

Adding a data-test id to the artwork cards count for testing in Cypress. 


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ