### PR TITLE
fix(art-quiz): adds footer space to help visually and fix double scroll

### DIFF
--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsEmpty.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsEmpty.tsx
@@ -36,6 +36,8 @@ export const ArtQuizResultsEmpty: FC = () => {
           <ArtQuizTrendingArtistsQueryRenderer />
         </Tab>
       </Tabs>
+
+      <Spacer y={[4, 6]} />
     </>
   )
 }

--- a/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
+++ b/src/Apps/ArtQuiz/Components/ArtQuizResultsTabs.tsx
@@ -42,6 +42,8 @@ export const ArtQuizResultsTabs: FC = ({}) => {
           <ArtQuizRecommendedArtistsQueryRenderer />
         </Tab>
       </Tabs>
+
+      <Spacer y={[4, 6]} />
     </>
   )
 }


### PR DESCRIPTION
A small issue I noticed is that on pages that had `Shelf` components in the quiz there would be a doubling up of the scroll area of exactly `10px`. This is because these pages don't have a footer and the `Shelf`'s scrollbar reaches past it's container `-10px` in order to have a larger hit area for it's scrollbar. This is usually fine but since there was no footer and _no_ extra whitespace at all, it was causing there to be 2 nested scroll areas, which was not good. It also just looks natural for there to be a bit of breathing room down there.