### PR TITLE
feat(TX-1073): Select list price as default offer option

### DIFF
--- a/src/Apps/Order/Components/PriceOptions.tsx
+++ b/src/Apps/Order/Components/PriceOptions.tsx
@@ -37,7 +37,16 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
   const listPrice = artwork?.listPrice
 
   useEffect(() => {
+    if (listPrice?.major && !toggle && !customValue) {
+      onChange(listPrice?.major)
+      setSelectedRadio("price-option-0")
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [listPrice, toggle, customValue])
+
+  useEffect(() => {
     if (!!customValue) onChange(customValue)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [customValue])
 
   useEffect(() => {
@@ -49,6 +58,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
 
   useEffect(() => {
     if (toggle) trackClick("Different amount", 0)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [toggle])
 
   const trackClick = (offer: string, amount: number) => {
@@ -143,7 +153,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
             label="Different amount"
             error={showError}
             onSelect={() => {
-              customValue && onChange(customValue)
+              onChange(customValue || 0)
               !toggle && setToggle(true)
             }}
           >

--- a/src/Apps/Order/Routes/__tests__/Offer.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Offer.jest.tsx
@@ -261,37 +261,13 @@ describe("Offer InitialMutation", () => {
   })
 
   describe("mutation", () => {
-    it("doesn't let the user continue if they haven't clicked any option", async () => {
-      let wrapper = getWrapper({
-        CommerceOrder: () => testOffer,
-      })
-      let page = new OrderAppTestPage(wrapper)
-      await page.clickSubmit()
-
-      expect(mockCommitMutation).not.toHaveBeenCalled()
-      expect(page.offerInput.text()).toMatch("Offer amount missing or invalid.")
-    })
-
-    it("doesn't let the user continue if they haven't typed anything in", async () => {
+    it("doesn't let the user continue if custom amount is invalid", async () => {
       let wrapper = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
       page.selectCustomAmount()
 
-      expect(page.offerInput.text()).not.toMatch(
-        "Offer amount missing or invalid."
-      )
-      await page.clickSubmit()
-      expect(mockCommitMutation).not.toHaveBeenCalled()
-      expect(page.offerInput.text()).toMatch("Offer amount missing or invalid.")
-    })
-
-    it("doesn't let the user continue if the offer value is not positive", async () => {
-      let wrapper = getWrapper({
-        CommerceOrder: () => testOffer,
-      })
-      let page = new OrderAppTestPage(wrapper)
       await page.setOfferAmount(0)
 
       expect(page.offerInput.text()).not.toMatch(
@@ -300,6 +276,17 @@ describe("Offer InitialMutation", () => {
       await page.clickSubmit()
       expect(mockCommitMutation).not.toHaveBeenCalled()
       expect(page.offerInput.text()).toMatch("Offer amount missing or invalid.")
+    })
+
+    it("lets the user continue with list price as offer if they haven't clicked any option", async () => {
+      let wrapper = getWrapper({
+        CommerceOrder: () => testOffer,
+      })
+      let page = new OrderAppTestPage(wrapper)
+      await page.setOfferAmount(16000)
+      await page.clickSubmit()
+
+      expect(mockCommitMutation).toHaveBeenCalled()
     })
 
     it("routes to shipping screen after mutation completes - option", async () => {


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [TX-1073]

### Description

This PR updates the offer step in the checkout flow, by selecting artwork list price as the default option among the readio buttons. 

#### Video
https://user-images.githubusercontent.com/42584148/222149148-748e0f7f-6564-401e-9e86-dfcc9e30d46a.mov


[TX-1073]: https://artsyproduct.atlassian.net/browse/TX-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ