### PR TITLE
chore(collector profile): change follow profiles copy

### DIFF
--- a/src/Apps/Settings/Routes/Saves/Components/SettingsSavesProfiles.tsx
+++ b/src/Apps/Settings/Routes/Saves/Components/SettingsSavesProfiles.tsx
@@ -52,7 +52,8 @@ const SettingsSavesProfiles: FC<SettingsSavesProfilesProps> = ({
   return (
     <>
       <Text variant={["md", "lg"]} mb={4}>
-        Followed Profiles {total > 0 && <Sup color="brand">{total}</Sup>}
+        Followed Galleries & Institutions{" "}
+        {total > 0 && <Sup color="brand">{total}</Sup>}
       </Text>
 
       {followedProfiles.length > 0 ? (

--- a/src/Apps/Settings/Routes/Saves/Components/__tests__/SettingsSavesProfiles.jest.tsx
+++ b/src/Apps/Settings/Routes/Saves/Components/__tests__/SettingsSavesProfiles.jest.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react"
 import { graphql } from "react-relay"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { SettingsSavesProfilesPaginationContainer } from "../SettingsSavesProfiles"
+import { SettingsSavesProfilesPaginationContainer } from "Apps/Settings/Routes/Saves/Components/SettingsSavesProfiles"
 
 jest.unmock("react-relay")
 
@@ -24,7 +24,9 @@ describe("SettingsSavesProfiles", () => {
       Partner: () => ({ name: "Example Profile" }),
     })
 
-    expect(screen.getByText("Followed Profiles")).toBeInTheDocument()
+    expect(
+      screen.getByText("Followed Galleries & Institutions")
+    ).toBeInTheDocument()
     expect(screen.getByText("Example Profile")).toBeInTheDocument()
   })
 
@@ -35,7 +37,9 @@ describe("SettingsSavesProfiles", () => {
       }),
     })
 
-    expect(screen.getByText("Followed Profiles")).toBeInTheDocument()
+    expect(
+      screen.getByText("Followed Galleries & Institutions")
+    ).toBeInTheDocument()
     expect(screen.getByText("Nothing yet.")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1581]

### Description

<!-- Implementation description -->
The goal of this PR is to update the copy on https://www.artsy.net/collector-profile/follows for gallery follows to prevent confusion for users as my collection grows. 

![Screen Shot 2023-03-01 at 9 09 42 AM](https://user-images.githubusercontent.com/23108927/222183156-85f383e5-7e4d-4ddf-a3da-6f9250ef2c10.png)


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1581]: https://artsyproduct.atlassian.net/browse/GRO-1581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ