### PR TITLE
feat(error): improves messages for client-side errors

### DIFF
--- a/src/Components/ErrorPage.tsx
+++ b/src/Components/ErrorPage.tsx
@@ -10,7 +10,7 @@ import * as React from "react"
 import styled from "styled-components"
 
 interface ErrorPageProps extends BoxProps {
-  code: number
+  code: number | string
   message?: string
   detail?: string
 }
@@ -22,7 +22,9 @@ export const ErrorPage: React.FC<ErrorPageProps> = ({
   children,
   ...rest
 }) => {
-  const headline = ERROR_MESSAGES[code] || "Internal Server Error"
+  // We assume string codes are client exceptions
+  const headline =
+    typeof code === "number" ? ERROR_MESSAGES[code] : "Internal Error"
 
   return (
     <Box {...rest}>
@@ -50,7 +52,7 @@ export const ErrorPage: React.FC<ErrorPageProps> = ({
         </Column>
       </GridColumns>
 
-      {code >= 500 && (detail || message) && (
+      {(code >= 500 || typeof code === "string") && (detail || message) && (
         <>
           <Spacer y={4} />
 
@@ -99,7 +101,7 @@ const Detail = styled(Code).attrs({
   -webkit-overflow-scrolling: touch;
 `
 
-const ERROR_MESSAGES = {
+const ERROR_MESSAGES: Record<number, string> = {
   // 4×× Client Error
   400: "Bad Request",
   401: "Unauthorized",
@@ -119,7 +121,6 @@ const ERROR_MESSAGES = {
   415: "Unsupported Media Type",
   416: "Requested Range Not Satisfiable",
   417: "Expectation Failed",
-  418: "I'm a teapot",
   421: "Misdirected Request",
   422: "Unprocessable Entity",
   423: "Locked",

--- a/src/System/Router/ErrorBoundary.tsx
+++ b/src/System/Router/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { ErrorWithMetadata } from "Utils/errors"
 import createLogger from "Utils/logger"
 import { ErrorPage } from "Components/ErrorPage"
-import { Button, Spacer, ThemeProviderV3 } from "@artsy/palette"
+import { Button, Spacer } from "@artsy/palette"
 import { LayoutLogoOnly } from "Apps/Components/Layouts/LayoutLogoOnly"
 import { getENV } from "Utils/getENV"
 
@@ -75,44 +75,44 @@ Time: ${new Date().toUTCString()}`
     switch (kind) {
       case "AsyncChunkLoadError": {
         return (
-          <ThemeProviderV3>
-            <LayoutLogoOnly>
-              <ErrorPage
-                code={500}
-                message="Please check your network connection and try again."
-              >
-                <Spacer y={2} />
+          <LayoutLogoOnly>
+            <ErrorPage
+              code="Error Loading Script"
+              message="Please check your network connection and try again."
+            >
+              <Spacer y={2} />
 
-                <Button
-                  size="small"
-                  variant="secondaryBlack"
-                  onClick={handleClick}
-                >
-                  Reload
-                </Button>
-              </ErrorPage>
-            </LayoutLogoOnly>
-          </ThemeProviderV3>
+              <Button
+                size="small"
+                variant="secondaryBlack"
+                onClick={handleClick}
+              >
+                Reload
+              </Button>
+            </ErrorPage>
+          </LayoutLogoOnly>
         )
       }
 
       case "GenericError": {
         return (
-          <ThemeProviderV3>
-            <LayoutLogoOnly>
-              <ErrorPage code={500} message={message} detail={detail}>
-                <Spacer y={2} />
+          <LayoutLogoOnly>
+            <ErrorPage
+              code="Something Went Wrong"
+              message={message}
+              detail={detail}
+            >
+              <Spacer y={2} />
 
-                <Button
-                  size="small"
-                  variant="secondaryBlack"
-                  onClick={handleClick}
-                >
-                  Reload
-                </Button>
-              </ErrorPage>
-            </LayoutLogoOnly>
-          </ThemeProviderV3>
+              <Button
+                size="small"
+                variant="secondaryBlack"
+                onClick={handleClick}
+              >
+                Reload
+              </Button>
+            </ErrorPage>
+          </LayoutLogoOnly>
         )
       }
 


### PR DESCRIPTION
Just wanting to make error reports a bit less ambiguous; this makes it such that we'll only see error codes on actual server errors (or client-side "404s").

![](https://static.damonzucconi.com/_capture/Sv9qZ9Sn.png)