### PR TITLE
feat: add analytics on search artist quickaction btns

### DIFF
--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -124,7 +124,7 @@ const QuickNavigation: React.FC<{
   const handleArtworksItemClicked = () => {
     trackEvent(
       tracks.quickNavigationItemClicked({
-        destinationPath: "works-for-sale",
+        destinationPath: `${href}/works-for-sale`,
         label: "Artworks",
       })
     )
@@ -133,25 +133,10 @@ const QuickNavigation: React.FC<{
   const handleAuctionResultsItemClicked = () => {
     trackEvent(
       tracks.quickNavigationItemClicked({
-        destinationPath: "auction-results",
+        destinationPath: `${href}/auction-results`,
         label: "Auction Results",
       })
     )
-  }
-
-  const tracks = {
-    quickNavigationItemClicked: ({
-      destinationPath,
-      label,
-    }: {
-      destinationPath: string
-      label: "Auction Results" | "Artworks"
-    }): SelectedSearchSuggestionQuickNavigationItem => ({
-      context_module: ContextModule.header,
-      destination_path: `${href}/${destinationPath}`,
-      action: ActionType.selectedSearchSuggestionQuickNavigationItem,
-      label,
-    }),
   }
 
   if (!showArtworksButton && !showAuctionResultsButton) return null
@@ -201,4 +186,19 @@ const QuickNavigationItem: React.FC<QuickNavigationItemProps & PillProps> = ({
   }
 
   return <Pill onClick={handleClick} mt={1} mr={1} {...rest} />
+}
+
+const tracks = {
+  quickNavigationItemClicked: ({
+    destinationPath,
+    label,
+  }: {
+    destinationPath: string
+    label: "Auction Results" | "Artworks"
+  }): SelectedSearchSuggestionQuickNavigationItem => ({
+    context_module: ContextModule.header,
+    destination_path: destinationPath,
+    action: ActionType.selectedSearchSuggestionQuickNavigationItem,
+    label,
+  }),
 }

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -1,4 +1,9 @@
 import {
+  ActionType,
+  ContextModule,
+  SearchSuggestionQuickNavigationItemSelected,
+} from "@artsy/cohesion"
+import {
   ArtworkIcon,
   AuctionIcon,
   Flex,
@@ -9,6 +14,7 @@ import {
 import match from "autosuggest-highlight/match"
 import parse from "autosuggest-highlight/parse"
 import * as React from "react"
+import { useTracking } from "react-tracking"
 import styled from "styled-components"
 import { RouterLink } from "System/Router/RouterLink"
 
@@ -113,17 +119,44 @@ const QuickNavigation: React.FC<{
   showArtworksButton: boolean
   showAuctionResultsButton: boolean
 }> = ({ href, showArtworksButton, showAuctionResultsButton }) => {
+  const { trackEvent } = useTracking()
   if (!showArtworksButton && !showAuctionResultsButton) return null
 
   return (
     <Flex flexWrap="wrap">
       {!!showArtworksButton && (
-        <QuickNavigationItem to={`${href}/works-for-sale`} Icon={ArtworkIcon}>
+        <QuickNavigationItem
+          handleClick={() => {
+            const trackingEvent: SearchSuggestionQuickNavigationItemSelected = {
+              context_module: ContextModule.header,
+              destination_path: `${href}/works-for-sale`,
+              action: ActionType.searchSuggestionQuickNavigationItemSelected,
+              label: "Artworks",
+            }
+
+            trackEvent(trackingEvent)
+          }}
+          to={`${href}/works-for-sale`}
+          Icon={ArtworkIcon}
+        >
           Artworks
         </QuickNavigationItem>
       )}
       {!!showAuctionResultsButton && (
-        <QuickNavigationItem to={`${href}/auction-results`} Icon={AuctionIcon}>
+        <QuickNavigationItem
+          handleClick={() => {
+            const trackingEvent: SearchSuggestionQuickNavigationItemSelected = {
+              context_module: ContextModule.header,
+              destination_path: `${href}/auction-results`,
+              action: ActionType.searchSuggestionQuickNavigationItemSelected,
+              label: "Auction Results",
+            }
+
+            trackEvent(trackingEvent)
+          }}
+          to={`${href}/auction-results`}
+          Icon={AuctionIcon}
+        >
           Auction Results
         </QuickNavigationItem>
       )}
@@ -131,14 +164,21 @@ const QuickNavigation: React.FC<{
   )
 }
 
-const QuickNavigationItem: React.FC<{ to: string } & PillProps> = ({
+interface QuickNavigationItemProps {
+  to: string
+  handleClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
+}
+
+const QuickNavigationItem: React.FC<QuickNavigationItemProps & PillProps> = ({
   to,
+  handleClick,
   ...rest
 }) => {
   const onClick = event => {
     // Stopping the event from propagating to prevent SearchBar from navigation to the main suggestion item url.
     event.stopPropagation()
     event.preventDefault()
+    handleClick?.(event)
 
     // FIXME: Using `window.location.assign(to)` instead of `router.push(to)` to prevent a bug where the search bar won't hide anymore.
     window.location.assign(to)

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -1,7 +1,7 @@
 import {
   ActionType,
   ContextModule,
-  SearchSuggestionQuickNavigationItemSelected,
+  SelectedSearchSuggestionQuickNavigationItem,
 } from "@artsy/cohesion"
 import {
   ArtworkIcon,
@@ -121,19 +121,37 @@ const QuickNavigation: React.FC<{
 }> = ({ href, showArtworksButton, showAuctionResultsButton }) => {
   const { trackEvent } = useTracking()
 
-  const handleQuickNavigationClick = (type: "artworks" | "auction-results") => {
-    const label = type === "artworks" ? "Artworks" : "Auction Results"
-    const destinationPath =
-      type === "artworks" ? "/works-for-sale" : "/auction-results"
+  const handleArtworksItemClicked = () => {
+    trackEvent(
+      tracks.quickNavigationItemClicked({
+        destinationPath: "works-for-sale",
+        label: "Artworks",
+      })
+    )
+  }
 
-    const trackingEvent: SearchSuggestionQuickNavigationItemSelected = {
-      context_module: ContextModule.header,
-      destination_path: href + destinationPath,
-      action: ActionType.searchSuggestionQuickNavigationItemSelected,
+  const handleAuctionResultsItemClicked = () => {
+    trackEvent(
+      tracks.quickNavigationItemClicked({
+        destinationPath: "auction-results",
+        label: "Auction Results",
+      })
+    )
+  }
+
+  const tracks = {
+    quickNavigationItemClicked: ({
+      destinationPath,
       label,
-    }
-
-    trackEvent(trackingEvent)
+    }: {
+      destinationPath: string
+      label: "Auction Results" | "Artworks"
+    }): SelectedSearchSuggestionQuickNavigationItem => ({
+      context_module: ContextModule.header,
+      destination_path: `${href}/${destinationPath}`,
+      action: ActionType.selectedSearchSuggestionQuickNavigationItem,
+      label,
+    }),
   }
 
   if (!showArtworksButton && !showAuctionResultsButton) return null
@@ -142,7 +160,7 @@ const QuickNavigation: React.FC<{
     <Flex flexWrap="wrap">
       {!!showArtworksButton && (
         <QuickNavigationItem
-          onClick={() => handleQuickNavigationClick("artworks")}
+          onClick={handleArtworksItemClicked}
           to={`${href}/works-for-sale`}
           Icon={ArtworkIcon}
         >
@@ -151,7 +169,7 @@ const QuickNavigation: React.FC<{
       )}
       {!!showAuctionResultsButton && (
         <QuickNavigationItem
-          onClick={() => handleQuickNavigationClick("auction-results")}
+          onClick={handleAuctionResultsItemClicked}
           to={`${href}/auction-results`}
           Icon={AuctionIcon}
         >

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -126,7 +126,7 @@ const QuickNavigation: React.FC<{
     <Flex flexWrap="wrap">
       {!!showArtworksButton && (
         <QuickNavigationItem
-          handleClick={() => {
+          onClick={() => {
             const trackingEvent: SearchSuggestionQuickNavigationItemSelected = {
               context_module: ContextModule.header,
               destination_path: `${href}/works-for-sale`,
@@ -144,7 +144,7 @@ const QuickNavigation: React.FC<{
       )}
       {!!showAuctionResultsButton && (
         <QuickNavigationItem
-          handleClick={() => {
+          onClick={() => {
             const trackingEvent: SearchSuggestionQuickNavigationItemSelected = {
               context_module: ContextModule.header,
               destination_path: `${href}/auction-results`,
@@ -166,23 +166,23 @@ const QuickNavigation: React.FC<{
 
 interface QuickNavigationItemProps {
   to: string
-  handleClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
 }
 
 const QuickNavigationItem: React.FC<QuickNavigationItemProps & PillProps> = ({
   to,
-  handleClick,
+  onClick,
   ...rest
 }) => {
-  const onClick = event => {
+  const handleClick = event => {
     // Stopping the event from propagating to prevent SearchBar from navigation to the main suggestion item url.
     event.stopPropagation()
     event.preventDefault()
-    handleClick?.(event)
+    onClick?.(event)
 
     // FIXME: Using `window.location.assign(to)` instead of `router.push(to)` to prevent a bug where the search bar won't hide anymore.
     window.location.assign(to)
   }
 
-  return <Pill onClick={onClick} mt={1} mr={1} {...rest} />
+  return <Pill onClick={handleClick} mt={1} mr={1} {...rest} />
 }

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -120,22 +120,29 @@ const QuickNavigation: React.FC<{
   showAuctionResultsButton: boolean
 }> = ({ href, showArtworksButton, showAuctionResultsButton }) => {
   const { trackEvent } = useTracking()
+
+  const handleQuickNavigationClick = (type: "artworks" | "auction-results") => {
+    const label = type === "artworks" ? "Artworks" : "Auction Results"
+    const destinationPath =
+      type === "artworks" ? "/works-for-sale" : "/auction-results"
+
+    const trackingEvent: SearchSuggestionQuickNavigationItemSelected = {
+      context_module: ContextModule.header,
+      destination_path: href + destinationPath,
+      action: ActionType.searchSuggestionQuickNavigationItemSelected,
+      label,
+    }
+
+    trackEvent(trackingEvent)
+  }
+
   if (!showArtworksButton && !showAuctionResultsButton) return null
 
   return (
     <Flex flexWrap="wrap">
       {!!showArtworksButton && (
         <QuickNavigationItem
-          onClick={() => {
-            const trackingEvent: SearchSuggestionQuickNavigationItemSelected = {
-              context_module: ContextModule.header,
-              destination_path: `${href}/works-for-sale`,
-              action: ActionType.searchSuggestionQuickNavigationItemSelected,
-              label: "Artworks",
-            }
-
-            trackEvent(trackingEvent)
-          }}
+          onClick={() => handleQuickNavigationClick("artworks")}
           to={`${href}/works-for-sale`}
           Icon={ArtworkIcon}
         >
@@ -144,16 +151,7 @@ const QuickNavigation: React.FC<{
       )}
       {!!showAuctionResultsButton && (
         <QuickNavigationItem
-          onClick={() => {
-            const trackingEvent: SearchSuggestionQuickNavigationItemSelected = {
-              context_module: ContextModule.header,
-              destination_path: `${href}/auction-results`,
-              action: ActionType.searchSuggestionQuickNavigationItemSelected,
-              label: "Auction Results",
-            }
-
-            trackEvent(trackingEvent)
-          }}
+          onClick={() => handleQuickNavigationClick("auction-results")}
           to={`${href}/auction-results`}
           Icon={AuctionIcon}
         >


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4631]

### Description

Adding analytics on the quick action `Artwork` and `Auction Results` buttons on the Artist autosuggest element.

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4631]: https://artsyproduct.atlassian.net/browse/FX-4631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ