### PR TITLE
feat(devx): add package script to pretty-print i18n translations

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -32,7 +32,7 @@ const { t } = useTranslation()
 ### Adding a static string
 
 1. Add the string to [translation.json](https://github.com/artsy/force/blob/main/src/System/i18n/locales/en-US/translation.json) following the Naming conventions.
-2. Use it in any component by calling ``{t`<path-for-the-key>`}`` (example: ``{t`navbar.shows`}``)
+2. Use it in any component by calling `` {t`<path-for-the-key>`} `` (example: `` {t`navbar.shows`} ``)
 
 ### Adding a dynamic string
 
@@ -57,6 +57,27 @@ We always use:
 - Short definitions: maximum length of 5 words;
 
 For translations used in several spots, we might want to create a `shared` namespace.
+
+## Finding a component that contains a given string
+
+If you are trying to locate a component based on its user-facing strings,
+you can use the `yarn translations` script to output strings and their matching
+`t(…)` translation keys:
+
+```sh
+yarn translations | grep "Delete Widget?"
+```
+
+This will output something like this:
+
+<pre>
+…
+<span style="color:blue">widgetApp.deleteModal.deleteButton</span> <span style="color: #ccc">|</span> <strong>Delete Widget?</strong>
+…
+</pre>
+
+You can than search the codebase for `widgetApp.deleteModal.deleteButton` to
+locate the component in question.
 
 ## Further improvements
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test": "scripts/jest.sh",
     "test:smoke": "scripts/smoke_test.sh",
     "test:smoke:spec": "./node_modules/.bin/cypress run -s",
+    "translations": "node scripts/list-translations",
     "type-check": "tsc",
     "stats:client": "WEBPACK_STATS=normal yarn build:client:prod --profile --json > stats-client.json",
     "stats:server": "WEBPACK_STATS=normal yarn build:server:prod --profile --json > stats-server.json",

--- a/scripts/list-translations.js
+++ b/scripts/list-translations.js
@@ -1,0 +1,54 @@
+const { readFileSync } = require("fs")
+const chalk = require("chalk")
+
+const PATH_TO_TRANSLATIONS = "./src/System/i18n/locales/en-US/translation.json"
+
+/**
+ * Recursively descend into all leaf nodes of the translations object,
+ * and return an array of [path, value] pairs.
+ *
+ * @param {Object} obj - The translations object or sub-object currently being traversed
+ * @param {string} prefix  - The prefix to prepend to the current path, representing the path to the current object
+ *
+ * @return {string[][]} An array of [path, value] pairs
+ *
+ */
+function getLeafNodes(obj, prefix = "") {
+  let leafNodes = []
+  for (let key in obj) {
+    let path = prefix + key
+    if (typeof obj[key] === "object") {
+      leafNodes = leafNodes.concat(getLeafNodes(obj[key], path + "."))
+    } else {
+      leafNodes.push([path, obj[key]])
+    }
+  }
+  return leafNodes
+}
+
+/**
+ * Pretty print a resulting array of [path, value] pairs
+ *
+ * @param {string[][]} translations - leaf nodes of the translation config object, formatted as [path, value] pairs
+ *
+ */
+function prettyPrint(translations) {
+  translations.forEach(([path, value]) => {
+    const prettyPath = chalk.blue(path)
+    const separator = chalk.hex("#cccccc")("|")
+    const prettyValue = chalk.bold(value.replace(/\n+/g, " "))
+
+    console.log(`${prettyPath} ${separator} ${prettyValue}`)
+  })
+}
+
+/* main */
+
+// read the translations
+const translationConfig = JSON.parse(readFileSync(PATH_TO_TRANSLATIONS, "utf8"))
+
+// extract the leaf nodes
+const translations = getLeafNodes(translationConfig)
+
+// print the results
+prettyPrint(translations)


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Adds a little devx feature that I was missing while reviewing a PR just now.

We are seeing increasing adoption of the i18n pattern in Force. That adds some indirection/friction to the process of identifying a component by its user-facing labels, and then locating its source code.

This PR aims to make things easier by adding a `yarn translations` command that exposes the fully qualified path names for each i18n string, so that you can search for e.g. `collectorSaves.savesHeader.listCreated` and find the component in question.

Output is designed to be very skimmable by default:

<img width="1620" alt="basic" src="https://user-images.githubusercontent.com/140521/223223531-bdfe0ff1-12e3-435f-bf25-6afc4d81ee1e.png">

And also grep-friendly:

<img width="1620" alt="grep3" src="https://user-images.githubusercontent.com/140521/223225282-439226a7-a406-4521-a703-1418807410b4.png">

I skimmed https://www.i18next.com and didn't see anything like this included by default, but correct me if I'm wrong.