### PR TITLE
fix(GRO-1588): re-check auth on tab focus

### DIFF
--- a/src/Utils/Hooks/useAuthValidation.ts
+++ b/src/Utils/Hooks/useAuthValidation.ts
@@ -20,12 +20,31 @@ export const useAuthValidation = () => {
       ).toPromise()
 
       if (data?.authenticationStatus === "INVALID") {
-        await logout()
+        try {
+          await logout()
+        } catch (e) {
+          console.error(e)
+        }
+
         window.location.reload()
         return
       }
     }
 
+    // Check on mount
     exec()
+
+    const check = () => {
+      if (document.visibilityState === "visible") {
+        exec()
+      }
+    }
+
+    // Re-check on tab changes since you may have logged out in another tab
+    document.addEventListener("visibilitychange", check)
+
+    return () => {
+      document.removeEventListener("visibilitychange", check)
+    }
   }, [relayEnvironment])
 }


### PR DESCRIPTION
Closes [GRO-1588](https://artsyproduct.atlassian.net/browse/GRO-1588)

If you log out in one tab you'll remain logged in in other open tabs. Further navigation in those tabs will lead to sporadic errors. So here I just am adding an additional check when a tab regains focus.


[GRO-1588]: https://artsyproduct.atlassian.net/browse/GRO-1588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ