### PR TITLE
fix(TX-1071): improve checkout flow tab accessibility

### DIFF
--- a/src/Apps/Order/Components/CreditCardPicker.tsx
+++ b/src/Apps/Order/Components/CreditCardPicker.tsx
@@ -339,6 +339,7 @@ export class CreditCardPicker extends React.Component<
             <Collapse open={this.needsAddress()}>
               <Spacer y={2} />
               <AddressForm
+                tabIndex={this.needsAddress() ? 0 : -1}
                 value={address}
                 errors={addressErrors}
                 touched={addressTouched}

--- a/src/Apps/Order/Components/PhoneNumberForm.tsx
+++ b/src/Apps/Order/Components/PhoneNumberForm.tsx
@@ -13,6 +13,7 @@ export interface PhoneNumberFormProps {
   errors: PhoneNumberError
   touched: PhoneNumberTouched
   label: string
+  tabIndex?: number
 }
 
 export const PhoneNumberForm: FC<PhoneNumberFormProps> = ({
@@ -21,6 +22,7 @@ export const PhoneNumberForm: FC<PhoneNumberFormProps> = ({
   errors,
   label,
   value,
+  tabIndex,
 }) => {
   const changeEventHandler = () => (ev: React.FormEvent<HTMLInputElement>) => {
     onChange(ev.currentTarget.value)
@@ -33,6 +35,7 @@ export const PhoneNumberForm: FC<PhoneNumberFormProps> = ({
   return (
     <Flex flexDirection="column" mb={2}>
       <Input
+        tabIndex={tabIndex}
         id="PhoneNumberForm_phoneNumber"
         title="Phone number"
         type="tel"

--- a/src/Apps/Order/Components/SaveAndContinueButton.tsx
+++ b/src/Apps/Order/Components/SaveAndContinueButton.tsx
@@ -8,7 +8,15 @@ export const SaveAndContinueButton: FC<{
   media?: { [key: string]: string }
   loading?: boolean
   disabled?: boolean
-}> = ({ testId, onClick, media, loading = false, disabled = false }) => {
+  tabIndex?: number
+}> = ({
+  testId,
+  onClick,
+  media,
+  loading = false,
+  disabled = false,
+  tabIndex,
+}) => {
   return (
     <>
       {media ? (
@@ -20,6 +28,7 @@ export const SaveAndContinueButton: FC<{
             width={["100%", "50%"]}
             loading={loading}
             disabled={disabled}
+            tabIndex={tabIndex}
           >
             Save and Continue
           </Button>
@@ -32,6 +41,7 @@ export const SaveAndContinueButton: FC<{
           width={["100%", "50%"]}
           loading={loading}
           disabled={disabled}
+          tabIndex={tabIndex}
         >
           Save and Continue
         </Button>

--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -93,16 +93,24 @@ export const PaymentContent: FC<Props> = props => {
 
       {/* Credit card */}
       <Collapse open={selectedPaymentMethod === "CREDIT_CARD"}>
-        <CreditCardPickerFragmentContainer
-          commitMutation={commitMutation}
-          me={me}
-          order={order}
-          innerRef={CreditCardPicker}
-        />
+        <Flex
+          style={{
+            display:
+              selectedPaymentMethod === "CREDIT_CARD" ? "inline" : "none",
+          }}
+        >
+          <CreditCardPickerFragmentContainer
+            commitMutation={commitMutation}
+            me={me}
+            order={order}
+            innerRef={CreditCardPicker}
+          />
+        </Flex>
         <Spacer y={4} />
         <SaveAndContinueButton
           media={{ greaterThan: "xs" }}
           onClick={onSetPayment}
+          tabIndex={selectedPaymentMethod === "CREDIT_CARD" ? 0 : -1}
         />
         <Spacer y={2} />
       </Collapse>
@@ -112,11 +120,18 @@ export const PaymentContent: FC<Props> = props => {
         {getPaymentMethodInfo(selectedPaymentMethod)}
         <Spacer y={2} />
         {selectedPaymentMethod === "US_BANK_ACCOUNT" && (
-          <BankAccountPickerFragmentContainer
-            me={me}
-            order={order}
-            onError={props.onError}
-          />
+          <Flex
+            style={{
+              display:
+                selectedPaymentMethod === "US_BANK_ACCOUNT" ? "inline" : "none",
+            }}
+          >
+            <BankAccountPickerFragmentContainer
+              me={me}
+              order={order}
+              onError={props.onError}
+            />
+          </Flex>
         )}
       </Collapse>
 
@@ -124,13 +139,19 @@ export const PaymentContent: FC<Props> = props => {
       <Collapse open={selectedPaymentMethod === "SEPA_DEBIT"}>
         {getPaymentMethodInfo(selectedPaymentMethod)}
         <Spacer y={2} />
-        {selectedPaymentMethod === "SEPA_DEBIT" && (
-          <BankAccountPickerFragmentContainer
-            me={me}
-            order={order}
-            onError={props.onError}
-          />
-        )}
+        <Flex
+          style={{
+            display: selectedPaymentMethod === "SEPA_DEBIT" ? "inline" : "none",
+          }}
+        >
+          {selectedPaymentMethod === "SEPA_DEBIT" && (
+            <BankAccountPickerFragmentContainer
+              me={me}
+              order={order}
+              onError={props.onError}
+            />
+          )}
+        </Flex>
       </Collapse>
 
       {/* Wire transfer */}
@@ -144,6 +165,7 @@ export const PaymentContent: FC<Props> = props => {
         <SaveAndContinueButton
           media={{ greaterThan: "xs" }}
           onClick={onSetPayment}
+          tabIndex={selectedPaymentMethod === "WIRE_TRANSFER" ? 0 : -1}
         />
         <Spacer y={2} />
       </Collapse>

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -565,11 +565,11 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     !artwork?.pickup_available || shippingOption === "SHIP"
   const showAddressForm =
     shippingSelected && (isCreateNewAddress() || addressList?.length === 0)
-
   const showSavedAddresses =
     shippingSelected && addressList && addressList.length > 0
-
   const isArtsyShipping = checkIfArtsyShipping()
+  const showArtsyShipping =
+    isArtsyShipping && !!shippingQuotes && shippingQuotes.length > 0
 
   const useDefaultArtsyShippingQuote =
     isArtsyShipping &&
@@ -609,7 +609,6 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                     Delivery method
                   </Text>
                   <BorderedRadio value="SHIP" label="Shipping" />
-
                   <BorderedRadio
                     value="PICKUP"
                     label="Arrange for pickup (free)"
@@ -648,13 +647,13 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                 onAddressEdit={handleAddressEdit}
               />
             </Collapse>
-
             <Collapse data-test="addressFormCollapse" open={showAddressForm}>
               {isArtsyShipping &&
                 shippingQuotes &&
                 shippingQuotes.length === 0 &&
                 renderArtaErrorMessage()}
               <AddressForm
+                tabIndex={showAddressForm ? 0 : -1}
                 value={address}
                 errors={addressErrors}
                 touched={addressTouched}
@@ -666,6 +665,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
               />
               <Spacer y={2} />
               <PhoneNumberForm
+                tabIndex={showAddressForm ? 0 : -1}
                 value={phoneNumber}
                 errors={phoneNumberError}
                 touched={phoneNumberTouched}
@@ -673,6 +673,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                 label="Required for shipping logistics"
               />
               <Checkbox
+                tabIndex={showAddressForm ? 0 : -1}
                 onSelect={selected => setSaveAddress(selected)}
                 selected={saveAddress}
                 data-test="save-address-checkbox"
@@ -681,12 +682,12 @@ export const ShippingRoute: FC<ShippingProps> = props => {
               </Checkbox>
               <Spacer y={4} />
             </Collapse>
-
             <Collapse
               data-test="phoneNumberCollapse"
               open={shippingOption === "PICKUP"}
             >
               <PhoneNumberForm
+                tabIndex={shippingOption === "PICKUP" ? 0 : -1}
                 data-test="pickupPhoneNumberForm"
                 value={phoneNumber}
                 errors={phoneNumberError}
@@ -696,12 +697,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
               />
               <Spacer y={4} />
             </Collapse>
-
-            <Collapse
-              open={
-                isArtsyShipping && !!shippingQuotes && shippingQuotes.length > 0
-              }
-            >
+            <Collapse open={showArtsyShipping}>
               <Text variant="sm">Artsy shipping options</Text>
               <Text variant="xs" mb="1" color="black60">
                 All options are eligible for Artsy’s Buyer Protection policy,
@@ -716,7 +712,6 @@ export const ShippingRoute: FC<ShippingProps> = props => {
               />
               <Spacer y={4} />
             </Collapse>
-
             <Media greaterThan="xs">
               <Button
                 onClick={onContinueButtonPressed}

--- a/src/Components/AddressForm.tsx
+++ b/src/Components/AddressForm.tsx
@@ -55,6 +55,7 @@ export interface AddressFormProps {
   shippingCountry?: string
   errors: AddressErrors
   touched: AddressTouched
+  tabIndex?: number
 }
 
 export const AddressForm: React.FC<AddressFormProps> = ({
@@ -67,6 +68,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
   shippingCountry,
   errors,
   touched,
+  tabIndex,
 }) => {
   const [address, setAddress] = React.useState({ ...emptyAddress, ...value })
   const [key, setKey] = React.useState<keyof Address>()
@@ -117,6 +119,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
     <Join separator={<Spacer y={2} />}>
       <Flex flexDirection="column">
         <Input
+          tabIndex={tabIndex}
           id="AddressForm_name"
           placeholder="Add full name"
           title={billing ? "Name on card" : "Full name"}
@@ -126,14 +129,13 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           error={getError("name")}
         />
       </Flex>
-
       <TwoColumnSplit>
         <Flex flexDirection="column" pb={1}>
           <Text mb={0.5} variant="xs" color="black100">
             Country
           </Text>
-
           <CountrySelect
+            tabIndex={tabIndex}
             selected={
               lockCountryToOrigin || (lockCountriesToEU && !address.country)
                 ? shippingCountry
@@ -143,7 +145,6 @@ export const AddressForm: React.FC<AddressFormProps> = ({
             disabled={lockCountryToOrigin}
             euShippingOnly={lockCountriesToEU}
           />
-
           {(lockCountryToOrigin || lockCountriesToEU) && (
             <>
               <Spacer x={0.5} y={0.5} />
@@ -155,9 +156,9 @@ export const AddressForm: React.FC<AddressFormProps> = ({
             </>
           )}
         </Flex>
-
         <Flex flexDirection="column">
           <Input
+            tabIndex={tabIndex}
             id="AddressForm_postalCode"
             placeholder="Add postal code"
             title="Postal code"
@@ -172,6 +173,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
       <TwoColumnSplit>
         <Flex flexDirection="column">
           <Input
+            tabIndex={tabIndex}
             id="AddressForm_addressLine1"
             placeholder="Add street address"
             title="Address line 1"
@@ -180,9 +182,9 @@ export const AddressForm: React.FC<AddressFormProps> = ({
             error={getError("addressLine1")}
           />
         </Flex>
-
         <Flex flexDirection="column">
           <Input
+            tabIndex={tabIndex}
             id="AddressForm_addressLine2"
             placeholder="Add apt, floor, suite, etc."
             title="Address line 2 (optional)"
@@ -195,6 +197,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
       <TwoColumnSplit>
         <Flex flexDirection="column">
           <Input
+            tabIndex={tabIndex}
             id="AddressForm_city"
             placeholder="Add city"
             title="City"
@@ -203,9 +206,9 @@ export const AddressForm: React.FC<AddressFormProps> = ({
             error={getError("city")}
           />
         </Flex>
-
         <Flex flexDirection="column">
           <Input
+            tabIndex={tabIndex}
             id="AddressForm_region"
             placeholder="Add State, province, or region"
             title="State, province, or region"
@@ -220,6 +223,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <>
           <Flex flexDirection="column">
             <Input
+              tabIndex={tabIndex}
               id="AddressForm_phoneNumber"
               title="Phone number"
               type="tel"

--- a/src/Components/CountrySelect.tsx
+++ b/src/Components/CountrySelect.tsx
@@ -3,14 +3,17 @@ import { FC } from "react"
 
 export interface CountrySelectProps extends Omit<SelectProps, "options"> {
   euShippingOnly?: boolean
+  tabIndex?: number
 }
 
 export const CountrySelect: FC<CountrySelectProps> = ({
   euShippingOnly,
+  tabIndex,
   ...rest
 }) => {
   return (
     <Select
+      tabIndex={tabIndex}
       options={
         euShippingOnly ? EU_COUNTRY_SELECT_OPTIONS : COUNTRY_SELECT_OPTIONS
       }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-1071]

### Description

This PR fixes the tab selection for the checkout flow as the selectable fields inside the `Collapse` components can be selected even when they are hidden. 

This set a conditional `tabIndex` for input and buttons inside relevant Collapses. For Stripe components that don't support `tabIndex`, I set `display: "none"` when they are hidden, disabling the tab selection. 

More discussion on this issue[ here](https://artsy.slack.com/archives/C2TQ4PT8R/p1676472354876629). 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-1071]: https://artsyproduct.atlassian.net/browse/TX-1071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ