### PR TITLE
feat(CX-3496): use recipientEmail in get in touch flow

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2615,6 +2615,9 @@ type ArtworkVersion implements Node {
   # The Artwork Version attribution class
   attributionClass: AttributionClass
 
+  # Artwork condition description
+  condition_description: String
+
   # The Artwork Version formatted date
   date: String
 
@@ -2635,6 +2638,9 @@ type ArtworkVersion implements Node {
 
   # The Artwork Version medium
   medium: String
+
+  # Artwork provenance
+  provenance: String
 
   # Artwork title
   title: String
@@ -5809,6 +5815,9 @@ type ConsignmentInquiry {
   # Phone number of the inquirer
   phoneNumber: String
 
+  # An optional email from a member of the Collector Services team to whom the request was sent
+  recipientEmail: String
+
   # gravity user id if user is logged in
   userId: String
 }
@@ -7159,6 +7168,7 @@ input CreateConsignmentInquiryMutationInput {
   message: String!
   name: String!
   phoneNumber: String
+  recipientEmail: String
   userId: String
 }
 

--- a/src/Apps/Consign/Routes/ConsignmentInquiry/ConsignmentInquiry.tsx
+++ b/src/Apps/Consign/Routes/ConsignmentInquiry/ConsignmentInquiry.tsx
@@ -69,9 +69,7 @@ export const ConsignmentInquiry: React.FC<ConsignmentInquiryProps> = ({
   const handleRecaptcha = (action: RecaptchaAction) =>
     new Promise(resolve => recaptcha(action, resolve))
 
-  const recipientEmail = match.params.recipientEmail
-    ? match.params.recipientEmail
-    : null
+  const recipientEmail = match.params.recipientEmail ?? null
 
   const recipientName = SPECIALISTS.find(i => i.email === recipientEmail)
     ?.firstName
@@ -120,20 +118,9 @@ export const ConsignmentInquiry: React.FC<ConsignmentInquiryProps> = ({
         },
       })
 
-      console.log(
-        "[LOGD] input,  response, match, recipientEmail, !!recipientEmail= ",
-        input,
-        response,
-        match,
-        recipientEmail,
-        !!recipientEmail ? true : false
-      )
-
       const consignmentInquiryId =
         response.createConsignmentInquiry?.consignmentInquiryOrError
           ?.consignmentInquiry?.internalID
-
-      console.log("[LOGD] consignmentInquiryId = ", consignmentInquiryId)
 
       if (consignmentInquiryId) {
         trackEvent(tracks.sentConsignmentInquiry(consignmentInquiryId))
@@ -146,8 +133,6 @@ export const ConsignmentInquiry: React.FC<ConsignmentInquiryProps> = ({
         )
       }
     } catch (error) {
-      console.log("[LOGD] error = ", error)
-
       logger.error(error)
       if (typeof error === "string") {
         sendToast({

--- a/src/Apps/Consign/Routes/ConsignmentInquiry/ConsignmentInquiry.tsx
+++ b/src/Apps/Consign/Routes/ConsignmentInquiry/ConsignmentInquiry.tsx
@@ -22,6 +22,7 @@ import { CreateConsignmentInquiryMutationInput } from "__generated__/useCreateCo
 import { ConsignmentInquiryFormAbandonEditModal } from "Apps/Consign/Routes/ConsignmentInquiry/Components/ConsignmentInquiryFormAbandonEdit"
 import { useState } from "react"
 import { TopContextBar } from "Components/TopContextBar"
+import { SPECIALISTS } from "Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SpecialistsData"
 
 const logger = createLogger("ConsignmentInquiry/ConsignmentInquiry.tsx")
 
@@ -53,11 +54,12 @@ export const ConsignmentInquiry: React.FC<ConsignmentInquiryProps> = ({
 }) => {
   const [showExitModal, setShowExitModal] = useState(false)
   const { trackEvent } = useTracking()
-  const { router } = useRouter()
+  const { router, match } = useRouter()
   const { sendToast } = useToasts()
   const {
     submitMutation: createConsignmentInquiry,
   } = useCreateConsignmentInquiry()
+
   const initialValue = getContactInformationFormInitialValues(me)
   const initialErrors = validate(
     initialValue,
@@ -66,6 +68,13 @@ export const ConsignmentInquiry: React.FC<ConsignmentInquiryProps> = ({
 
   const handleRecaptcha = (action: RecaptchaAction) =>
     new Promise(resolve => recaptcha(action, resolve))
+
+  const recipientEmail = match.params.recipientEmail
+    ? match.params.recipientEmail
+    : null
+
+  const recipientName = SPECIALISTS.find(i => i.email === recipientEmail)
+    ?.firstName
 
   const handleSubmit = async ({
     name,
@@ -85,13 +94,22 @@ export const ConsignmentInquiry: React.FC<ConsignmentInquiryProps> = ({
       } ${phoneNumber.trim()}`
     }
 
-    const input: CreateConsignmentInquiryMutationInput = {
-      email,
-      message,
-      name,
-      phoneNumber: phoneNumberInternational,
-      userId: me?.internalID,
-    }
+    const input: CreateConsignmentInquiryMutationInput = !!recipientEmail
+      ? {
+          email,
+          message,
+          name,
+          phoneNumber: phoneNumberInternational,
+          userId: me?.internalID,
+          recipientEmail,
+        }
+      : {
+          email,
+          message,
+          name,
+          phoneNumber: phoneNumberInternational,
+          userId: me?.internalID,
+        }
 
     try {
       const response = await createConsignmentInquiry({
@@ -102,16 +120,34 @@ export const ConsignmentInquiry: React.FC<ConsignmentInquiryProps> = ({
         },
       })
 
+      console.log(
+        "[LOGD] input,  response, match, recipientEmail, !!recipientEmail= ",
+        input,
+        response,
+        match,
+        recipientEmail,
+        !!recipientEmail ? true : false
+      )
+
       const consignmentInquiryId =
         response.createConsignmentInquiry?.consignmentInquiryOrError
           ?.consignmentInquiry?.internalID
 
+      console.log("[LOGD] consignmentInquiryId = ", consignmentInquiryId)
+
       if (consignmentInquiryId) {
         trackEvent(tracks.sentConsignmentInquiry(consignmentInquiryId))
         router.replace({ pathname: "/sell" })
-        router.push("/sell/inquiry/sent")
+
+        router.push(
+          !!recipientEmail
+            ? `/sell/inquiry/${recipientEmail}/sent`
+            : "/sell/inquiry/sent"
+        )
       }
     } catch (error) {
+      console.log("[LOGD] error = ", error)
+
       logger.error(error)
       if (typeof error === "string") {
         sendToast({
@@ -186,7 +222,8 @@ export const ConsignmentInquiry: React.FC<ConsignmentInquiryProps> = ({
               Back
             </TopContextBar>
             <Text mt={4} variant="lg-display">
-              Contact a specialist
+              {"Contact "}
+              {`${recipientName || "a specialist"}`}
             </Text>
             <Spacer y={4} />
             <Form>

--- a/src/Apps/Consign/Routes/ConsignmentInquiry/__tests__/ConsignmentInquiry.jest.tsx
+++ b/src/Apps/Consign/Routes/ConsignmentInquiry/__tests__/ConsignmentInquiry.jest.tsx
@@ -135,7 +135,6 @@ describe("ConsignmentInquiry", () => {
               phoneNumber: mockMe.phone,
               message: "This is my message to you",
               userId: mockMe.internalID,
-              recipientEmail: null,
             },
           },
         })

--- a/src/Apps/Consign/Routes/ConsignmentInquiry/__tests__/ConsignmentInquiry.jest.tsx
+++ b/src/Apps/Consign/Routes/ConsignmentInquiry/__tests__/ConsignmentInquiry.jest.tsx
@@ -14,8 +14,11 @@ const mockRouterReplace = jest.fn()
 
 jest.mock("System/Router/useRouter", () => ({
   useRouter: jest.fn(() => ({
-    router: { push: mockRouterPush, replace: mockRouterReplace },
-    match: { params: { artworkId: undefined } },
+    router: {
+      push: mockRouterPush,
+      replace: mockRouterReplace,
+    },
+    match: { params: { artworkId: undefined, recipientEmail: null } },
   })),
 }))
 
@@ -132,6 +135,7 @@ describe("ConsignmentInquiry", () => {
               phoneNumber: mockMe.phone,
               message: "This is my message to you",
               userId: mockMe.internalID,
+              recipientEmail: null,
             },
           },
         })

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/MeetTheSpecialists.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/MeetTheSpecialists.tsx
@@ -22,6 +22,7 @@ import { RouterLink } from "System/Router/RouterLink"
 import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { useSystemContext } from "System/SystemContext"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { useRouter } from "System/Router/useRouter"
 
 interface PillData {
   type: Specialty
@@ -45,6 +46,7 @@ const pills: PillData[] = [
 
 export const MeetTheSpecialists: React.FC = () => {
   const { user } = useSystemContext()
+  const { router } = useRouter()
   const { contextPageOwnerType } = useAnalyticsContext()
   const { trackEvent } = useTracking()
   const enableSWAInquiryFlow = useFeatureFlag("swa-inquiry-flow")
@@ -82,6 +84,10 @@ export const MeetTheSpecialists: React.FC = () => {
     })
   }
 
+  const clickContactSpecialist = email => {
+    router.push(`/sell/inquiry/${email}`)
+    trackContactTheSpecialistClick()
+  }
   return (
     <>
       <Text mb={[0.5, 1]} variant={["lg-display", "xl", "xxl"]}>
@@ -158,13 +164,10 @@ export const MeetTheSpecialists: React.FC = () => {
                     {i.bio}
                   </Text>
                   <Button
-                    // @ts-ignore
-                    as={RouterLink}
                     variant="secondaryWhite"
                     mb={2}
-                    onClick={trackContactTheSpecialistClick}
+                    onClick={() => clickContactSpecialist(i.email)}
                     data-testid={`get-in-touch-button-${i.firstName}`}
-                    to={`mailto:${i.email}`}
                   >
                     Contact {i.firstName}
                   </Button>

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/MeetTheSpecialists.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/MeetTheSpecialists.tsx
@@ -22,7 +22,6 @@ import { RouterLink } from "System/Router/RouterLink"
 import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { useSystemContext } from "System/SystemContext"
 import { useFeatureFlag } from "System/useFeatureFlag"
-import { useRouter } from "System/Router/useRouter"
 
 interface PillData {
   type: Specialty
@@ -46,7 +45,6 @@ const pills: PillData[] = [
 
 export const MeetTheSpecialists: React.FC = () => {
   const { user } = useSystemContext()
-  const { router } = useRouter()
   const { contextPageOwnerType } = useAnalyticsContext()
   const { trackEvent } = useTracking()
   const enableSWAInquiryFlow = useFeatureFlag("swa-inquiry-flow")
@@ -84,8 +82,7 @@ export const MeetTheSpecialists: React.FC = () => {
     })
   }
 
-  const clickContactSpecialist = email => {
-    router.push(`/sell/inquiry/${email}`)
+  const clickContactSpecialist = () => {
     trackContactTheSpecialistClick()
   }
   return (
@@ -164,10 +161,13 @@ export const MeetTheSpecialists: React.FC = () => {
                     {i.bio}
                   </Text>
                   <Button
+                    // @ts-ignore
+                    as={RouterLink}
                     variant="secondaryWhite"
                     mb={2}
-                    onClick={() => clickContactSpecialist(i.email)}
+                    onClick={clickContactSpecialist}
                     data-testid={`get-in-touch-button-${i.firstName}`}
+                    to={`/sell/inquiry/${i.email}`}
                   >
                     Contact {i.firstName}
                   </Button>

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/MeetTheSpecialists.jest.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/MeetTheSpecialists.jest.tsx
@@ -11,9 +11,12 @@ jest.mock("System/Analytics/AnalyticsContext", () => ({
     contextPageOwnerType: "sell",
   })),
 }))
+
+const mockRouterPush = jest.fn()
 jest.mock("System/Router/useRouter", () => ({
   useRouter: jest.fn(() => ({
-    match: { params: { id: "1" } },
+    push: mockRouterPush,
+    match: { params: { id: "1", recipientEmail: "test@artsymail.com" } },
   })),
 }))
 
@@ -96,7 +99,7 @@ describe("MeetTheSpecialists", () => {
       const link = screen.getByTestId("get-in-touch-button-Shlomi")
 
       expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute("href", "mailto:shlomi.rabi@artsy.net")
+      expect(link).toHaveAttribute("href", "/sell/inquiry/test@artsymail.com")
     })
   })
 })

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/MeetTheSpecialists.jest.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/MeetTheSpecialists.jest.tsx
@@ -16,7 +16,7 @@ const mockRouterPush = jest.fn()
 jest.mock("System/Router/useRouter", () => ({
   useRouter: jest.fn(() => ({
     push: mockRouterPush,
-    match: { params: { id: "1", recipientEmail: "test@artsymail.com" } },
+    match: { params: { id: "1" } },
   })),
 }))
 
@@ -99,7 +99,10 @@ describe("MeetTheSpecialists", () => {
       const link = screen.getByTestId("get-in-touch-button-Shlomi")
 
       expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute("href", "/sell/inquiry/test@artsymail.com")
+      expect(link).toHaveAttribute(
+        "href",
+        "/sell/inquiry/shlomi.rabi@artsy.net"
+      )
     })
   })
 })

--- a/src/Apps/Consign/consignRoutes.tsx
+++ b/src/Apps/Consign/consignRoutes.tsx
@@ -251,6 +251,36 @@ export const consignRoutes: AppRouteConfig[] = [
     ],
   },
   {
+    path: "/sell/inquiry/:recipientEmail?",
+    getComponent: () => ConsignmentInquiryContainer,
+    children: [
+      {
+        path: "/",
+        getComponent: () => ConsignmentInquiryApp,
+        layout: "ContainerOnly",
+        onClientSideRender: () => {
+          ConsignmentInquiryApp.preload()
+        },
+        query: graphql`
+          query consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery {
+            me {
+              ...ConsignmentInquiry_me
+            }
+          }
+        `,
+        render: renderConsignmentInquiry,
+      },
+      {
+        path: "sent",
+        layout: "ContainerOnly",
+        getComponent: () => ConsignmentInquiryConfirmationApp,
+        onClientSideRender: () => {
+          ConsignmentInquiryConfirmationApp.preload()
+        },
+      },
+    ],
+  },
+  {
     path: "/sell/submission",
     getComponent: () => SubmissionLayout,
     onServerSideRender: ({ res }) => {

--- a/src/__generated__/consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery.graphql.ts
+++ b/src/__generated__/consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery.graphql.ts
@@ -1,0 +1,135 @@
+/**
+ * @generated SignedSource<<58d94a4cc6c966caf71c9067909d7cb8>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery$variables = {};
+export type consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery$data = {
+  readonly me: {
+    readonly " $fragmentSpreads": FragmentRefs<"ConsignmentInquiry_me">;
+  } | null;
+};
+export type consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery = {
+  response: consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery$data;
+  variables: consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery$variables;
+};
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ConsignmentInquiry_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "email",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "phone",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PhoneNumberType",
+            "kind": "LinkedField",
+            "name": "phoneNumber",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "regionCode",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "27b400da35bed3bbb03c1199f72166a8",
+    "id": null,
+    "metadata": {},
+    "name": "consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery",
+    "operationKind": "query",
+    "text": "query consignRoutes_ConsignmentInquiryWithRecipientEmailAppQuery {\n  me {\n    ...ConsignmentInquiry_me\n    id\n  }\n}\n\nfragment ConsignmentInquiry_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n}\n"
+  }
+};
+
+(node as any).hash = "5b5752f5738819c6d80f26079d09ba31";
+
+export default node;

--- a/src/__generated__/useCreateConsignmentInquiryMutation.graphql.ts
+++ b/src/__generated__/useCreateConsignmentInquiryMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<32e2efc3e05177857fbfc562ec52d395>>
+ * @generated SignedSource<<8c2282b6cd5921cb206a7f9ade104c79>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type CreateConsignmentInquiryMutationInput = {
   message: string;
   name: string;
   phoneNumber?: string | null;
+  recipientEmail?: string | null;
   userId?: string | null;
 };
 export type useCreateConsignmentInquiryMutation$variables = {


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3496]

### Description

<!-- Implementation description -->
If the user visits the get in touch flow via the "contact _NAME_" button, the specialist's name will be displayed in the title and the email will be sent to this specialist
Test here: https://swa-lp-redesign.artsy.net/

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3496]: https://artsyproduct.atlassian.net/browse/CX-3496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ