### PR TITLE
chore: show only past auction results inside insights

### DIFF
--- a/src/Apps/Settings/Routes/Insights/Components/InsightsAuctionResults.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsAuctionResults.tsx
@@ -50,7 +50,7 @@ export const InsightsAuctionResultsFragmentContainer = createFragmentContainer(
   {
     me: graphql`
       fragment InsightsAuctionResults_me on Me {
-        myCollectionAuctionResults(first: 6) {
+        myCollectionAuctionResults(first: 6, state: PAST) {
           edges {
             node {
               ...ArtistAuctionResultItem_auctionResult


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3430]

### Description

Show only past auction results inside insights

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3430]: https://artsyproduct.atlassian.net/browse/CX-3430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ