### PR TITLE
fix: compacts artworks displayed in shelf

### DIFF
--- a/src/Components/RecentlyViewed/RecentlyViewed.tsx
+++ b/src/Components/RecentlyViewed/RecentlyViewed.tsx
@@ -12,6 +12,7 @@ import { ShelfArtworkFragmentContainer } from "Components/Artwork/ShelfArtwork"
 import { RecentlyViewedPlaceholder } from "./RecentlyViewedPlaceholder"
 import { Rail } from "Components/Rail/Rail"
 import { useTracking } from "react-tracking"
+import { compact } from "lodash"
 
 export interface RecentlyViewedProps {
   me: RecentlyViewed_me$data
@@ -32,17 +33,20 @@ export const RecentlyViewed: React.FC<RecentlyViewedProps> = ({ me }) => {
 
   const artworks = extractNodes(me.recentlyViewedArtworksConnection)
 
-  if (artworks.length === 0) return null
+  // FIXME: This field is sometimes returning null artworks; should locate root cause
+  const compactedArtworks = compact(artworks)
+
+  if (compactedArtworks.length === 0) return null
 
   return (
     <Rail
       title="Recently Viewed"
       getItems={() => {
-        return artworks.map(artwork => {
+        return compactedArtworks.map(artwork => {
           return (
             <ShelfArtworkFragmentContainer
               key={artwork.id}
-              lazyLoad={true}
+              lazyLoad
               artwork={artwork}
               onClick={trackClick}
               contextModule={ContextModule.recentlyViewedRail}


### PR DESCRIPTION
Unknown what the cause of this is but some nodes in this response are `null`. This fixes the front-end for now.