### PR TITLE
refactor: add comment to clarify usage of inputs in verifyID helper

### DIFF
--- a/src/Apps/Settings/Routes/EditProfile/helpers/verifyID.ts
+++ b/src/Apps/Settings/Routes/EditProfile/helpers/verifyID.ts
@@ -7,6 +7,7 @@ export const verifyID = async (relayEnvironment: Environment) => {
       onCompleted: (data, errors) =>
         errors && errors.length ? reject(errors) : done(data),
       onError: error => reject(error),
+      // we're not actually using any inputs atm, but pulling the user from the authenticated MP loader context
       mutation: graphql`
         mutation verifyIDMutation(
           $input: SendIdentityVerificationEmailMutationInput!


### PR DESCRIPTION
The type of this PR is: **Refactor**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves : N/A

### Description

This adds a comment to clarify that when `verifyID` helper is called, no inputs are passed with the mutation and the user is pulled from authenticated context, ultimately ending up [in this block of code](https://github.com/artsy/gravity/blob/b14ea0276391db2d3a4547b8175f1210251fb8c4/app/api/v1/identity_verifications_endpoint.rb#L72-L76) in gravity.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ