### PR TITLE
chore: remove `renderSaveButton` prop

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -5,7 +5,6 @@ import { HighDemandIcon } from "Apps/MyCollection/Routes/MyCollectionArtwork/Com
 import { SaveArtworkToListsButtonFragmentContainer } from "Components/Artwork/SaveButton/SaveArtworkToListsButton"
 import { useArtworkGridContext } from "Components/ArtworkGrid/ArtworkGridContext"
 import { useAuctionWebsocket } from "Components/useAuctionWebsocket"
-import { isFunction } from "lodash"
 import * as React from "react"
 import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -31,7 +30,6 @@ interface DetailsProps {
   showHoverDetails?: boolean
   showSaveButton?: boolean
   enableSaveButtonForLists?: boolean
-  renderSaveButton?: (artworkId: string) => React.ReactNode
 }
 
 const ConditionalLink: React.FC<
@@ -224,7 +222,6 @@ export const Details: React.FC<DetailsProps> = ({
   showHoverDetails = true,
   showSaveButton,
   enableSaveButtonForLists,
-  renderSaveButton,
   ...rest
 }) => {
   const { isAuctionArtwork, hideLotLabel } = useArtworkGridContext()
@@ -240,10 +237,6 @@ export const Details: React.FC<DetailsProps> = ({
   const renderSaveButtonComponent = () => {
     if (!showSaveButton) {
       return null
-    }
-
-    if (isFunction(renderSaveButton)) {
-      return renderSaveButton(rest.artwork.internalID)
     }
 
     if (isArtworksListEnabled && enableSaveButtonForLists) {

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -28,7 +28,6 @@ interface ArtworkGridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   showSaveButton?: boolean
   to?: string | null
   savedListId?: string
-  renderSaveButton?: (artworkId: string) => React.ReactNode
 }
 
 export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
@@ -43,7 +42,6 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
   showSaveButton = true,
   to,
   savedListId,
-  renderSaveButton,
   ...rest
 }) => {
   const localImage = useLocalImage(artwork.image)
@@ -119,7 +117,6 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
           disableRouterLinking={disableRouterLinking}
           to={to}
           enableSaveButtonForLists
-          renderSaveButton={renderSaveButton}
         />
       </div>
     </ManageArtworkForSavesProvider>

--- a/src/Components/Artwork/Metadata.tsx
+++ b/src/Components/Artwork/Metadata.tsx
@@ -25,7 +25,6 @@ export interface MetadataProps
   showSaveButton?: boolean
   to?: string | null
   enableSaveButtonForLists?: boolean
-  renderSaveButton?: (artworkId: string) => React.ReactNode
 }
 
 export const Metadata: React.FC<MetadataProps> = ({
@@ -41,7 +40,6 @@ export const Metadata: React.FC<MetadataProps> = ({
   showHoverDetails,
   showSaveButton,
   enableSaveButtonForLists,
-  renderSaveButton,
   ...rest
 }) => {
   return (
@@ -63,7 +61,6 @@ export const Metadata: React.FC<MetadataProps> = ({
         showSaveButton={showSaveButton}
         contextModule={contextModule}
         enableSaveButtonForLists={enableSaveButtonForLists}
-        renderSaveButton={renderSaveButton}
       />
     </LinkContainer>
   )

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -54,7 +54,6 @@ interface ArtworkGridProps extends React.HTMLProps<HTMLDivElement> {
   emptyStateComponent?: ReactNode | boolean
   to?: (artwork: Artwork) => string | null
   savedListId?: string
-  renderSaveButton?: (artworkId: string) => React.ReactNode
 }
 
 export interface ArtworkGridContainerState {
@@ -186,7 +185,6 @@ export class ArtworkGridContainer extends React.Component<
             }
             to={to?.(artwork)}
             savedListId={this.props.savedListId}
-            renderSaveButton={this.props.renderSaveButton}
           />
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description
Removed unused the `renderSaveButton` prop, as it was decided to use a different approach with React Context (see this [PR](https://github.com/artsy/force/pull/11978/files))

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ