### PR TITLE
feat(FX-4667): Align modal width across different artwork list-related modals

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/DeleteArtworkListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/DeleteArtworkListModal.tsx
@@ -92,10 +92,7 @@ export const DeleteArtworkListModal: React.FC<Props> = ({
           </Button>
         </Flex>
       }
-      width={[
-        "100%",
-        753, // vs. 713px for create and edit modals and 673px for manage-artworks modal -- should be consistent (700?) or maybe just "auto"?
-      ]}
+      width={["100%", 700]}
     >
       <Text>{t("collectorSaves.deleteListModal.message")}</Text>
     </ModalDialog>

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/AddArtworksModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/AddArtworksModal.tsx
@@ -92,7 +92,7 @@ export const AddArtworksModal: FC<AddArtworksModalProps> = ({
 
   return (
     <ModalDialog
-      m={0}
+      m={[0, 2]}
       dialogProps={{
         width: ["100%", 700],
         height: ["100%", "auto"],

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectArtworkListsModal/SelectArtworkListsModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectArtworkListsModal/SelectArtworkListsModal.tsx
@@ -189,7 +189,7 @@ export const SelectArtworkListsModal: React.FC<SelectArtworkListsModalProps> = (
         height: ["100%", "auto"],
         maxHeight: [null, 800],
       }}
-      m={0}
+      m={[0, 2]}
       header={
         <Box mt={[-2, 0]} mb={-2}>
           <SelectArtworkListsHeader />


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4667]

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4667]: https://artsyproduct.atlassian.net/browse/FX-4667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ