### PR TITLE
chore: improvements for edit list and create new list modals

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditSavesModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditSavesModal.tsx
@@ -123,26 +123,21 @@ export const EditSavesModal: React.FC<EditSavesModalProps> = ({
               </Text>
               <Spacer y={2} />
               <Flex
-                justifyContent={["space-between"]}
+                justifyContent={["flex-start", "space-between"]}
                 flexDirection={["column", "row-reverse"]}
               >
                 <Button
                   type="submit"
-                  mb={[1, 0]}
                   loading={!!isSubmitting}
                   disabled={!dirty || !isValid}
                 >
                   {t("collectorSaves.editListModal.save")}
                 </Button>
 
-                <Button
-                  variant="secondaryBlack"
-                  onClick={onClose}
-                  display={["block", "none"]} // TODO: intentionally hidden on desktop?
-                >
-                  {
-                    t("collectorSaves.editListModal.back") // TODO: "back" vs "cancel"?
-                  }
+                <Spacer y={[1, 0]} />
+
+                <Button variant="secondaryBlack" onClick={onClose}>
+                  {t("common.buttons.cancel")}
                 </Button>
               </Flex>
             </Form>

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/EditSavesModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/EditSavesModal.jest.tsx
@@ -14,9 +14,9 @@ const collection = {
 const setup = () => {
   const nameInputField = screen.getByRole("textbox")
   const saveButton = screen.getByRole("button", { name: /Save/ })
-  const backButton = screen.getByRole("button", { name: /Back/ })
+  const cancelButton = screen.getByRole("button", { name: /Cancel/ })
 
-  return { nameInputField, saveButton, backButton }
+  return { nameInputField, saveButton, cancelButton }
 }
 
 describe("EditSavesModal", () => {
@@ -35,15 +35,15 @@ describe("EditSavesModal", () => {
     render(<EditSavesModal collection={collection} onClose={closeEditModal} />)
 
     expect(screen.getByText("Edit your list")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /Back/ })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Cancel/ })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /Save/ })).toBeInTheDocument()
   })
 
   it("dismisses when the Cancel button is clicked", async () => {
     render(<EditSavesModal collection={collection} onClose={closeEditModal} />)
-    const { backButton } = setup()
+    const { cancelButton } = setup()
 
-    fireEvent.click(backButton)
+    fireEvent.click(cancelButton)
 
     expect(closeEditModal).toHaveBeenCalled()
   })

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
@@ -141,50 +141,27 @@ export const CreateNewListModal: FC<CreateNewListModalProps> = ({
               artwork ? <CreateNewListModalHeader artwork={artwork} /> : null
             }
             footer={
-              <>
-                {/* Desktop view */}
-                <Media greaterThanOrEqual="sm">
-                  <Flex justifyContent="space-between">
-                    <Button
-                      variant="secondaryBlack"
-                      onClick={handleBackOnCancelClick}
-                    >
-                      {backOrCancelLabel}
-                    </Button>
+              <Flex
+                justifyContent={["flex-start", "space-between"]}
+                flexDirection={["column", "row-reverse"]}
+              >
+                <Button
+                  disabled={isCreateButtonDisabled}
+                  loading={isSubmitting}
+                  onClick={() => handleSubmit()}
+                >
+                  {t("collectorSaves.createNewListModal.createListButton")}
+                </Button>
 
-                    <Button
-                      disabled={isCreateButtonDisabled}
-                      loading={isSubmitting}
-                      onClick={() => handleSubmit()}
-                      alignSelf="flex-end"
-                    >
-                      {t("collectorSaves.createNewListModal.createListButton")}
-                    </Button>
-                  </Flex>
-                </Media>
+                <Spacer y={[1, 0]} />
 
-                {/* Mobile view */}
-                <Media lessThan="sm">
-                  <Button
-                    disabled={isCreateButtonDisabled}
-                    loading={isSubmitting}
-                    onClick={() => handleSubmit()}
-                    width="100%"
-                  >
-                    {t("collectorSaves.createNewListModal.createListButton")}
-                  </Button>
-
-                  <Spacer y={1} />
-
-                  <Button
-                    variant="secondaryBlack"
-                    width="100%"
-                    onClick={handleBackOnCancelClick}
-                  >
-                    {backOrCancelLabel}
-                  </Button>
-                </Media>
-              </>
+                <Button
+                  variant="secondaryBlack"
+                  onClick={handleBackOnCancelClick}
+                >
+                  {backOrCancelLabel}
+                </Button>
+              </Flex>
             }
           >
             <LabeledInput


### PR DESCRIPTION
The type of this PR is: **Chore**, **Refactor**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

Review app: [modal-buttons](https://modal-buttons.artsy.net/collector-profile/saves2)

### Description
* Added improvements/changes to edit list modal based on [this comment](https://artsy.slack.com/archives/C9SATFLUU/p1678099239933699?thread_ts=1677803388.476209&cid=C9SATFLUU)
* Small refactor and improvements for edit/create list modals

### Demo / Edit list modal
#### Desktop view
| Before | After |
| ------------- | ------------- |
| <img width="952" alt="before-edit-desktop" src="https://user-images.githubusercontent.com/3513494/224754274-148d6ec4-f72c-490f-a571-6076ef46a242.png"> | <img width="952" alt="after-edit-desktop" src="https://user-images.githubusercontent.com/3513494/224754344-33a0acee-e5dc-45d5-9556-ed414d1aee3e.png"> | 

#### Mobile view
| Before | After |
| ------------- | ------------- |
| <img width="377" alt="before-edit-mobile" src="https://user-images.githubusercontent.com/3513494/224754686-058fc856-22db-45cb-b472-ed5e5b9dad72.png"> | <img width="377" alt="after-edit-mobile" src="https://user-images.githubusercontent.com/3513494/224754725-393d4619-dbf4-4a01-b1e5-493194860e97.png"> | 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ