### PR TITLE
feat(TX-1015): order creation after auth

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -1,4 +1,13 @@
-import { Column, GridColumns, Join, Spacer } from "@artsy/palette"
+import {
+  Column,
+  GridColumns,
+  Join,
+  Spacer,
+  Flex,
+  Spinner,
+  Text,
+} from "@artsy/palette"
+import styled from "styled-components"
 import { createFragmentContainer, graphql } from "react-relay"
 import { getENV } from "Utils/getENV"
 import { ArtworkApp_artwork$data } from "__generated__/ArtworkApp_artwork.graphql"
@@ -77,6 +86,8 @@ const BelowTheFoldArtworkDetails: React.FC<BelowTheFoldArtworkDetailsProps> = ({
 
 export const ArtworkApp: React.FC<Props> = props => {
   const { artwork, me, referrer, tracking, shouldTrackPageView } = props
+  const { match } = useRouter()
+
   const showUnlistedArtworkBanner =
     artwork?.visibilityLevel == "UNLISTED" && artwork?.partner
 
@@ -175,6 +186,22 @@ export const ArtworkApp: React.FC<Props> = props => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldTrackPageView])
+
+  if (match?.location?.query?.creating_order) {
+    return (
+      <>
+        <Spacer y={6} />
+        <Flex flexDirection="column" alignItems="center" mb={12} mt={12}>
+          <SpinnerContainer>
+            <Spinner size="large" color="blue100" />
+          </SpinnerContainer>
+          <Text variant="md" color="blue100">
+            Loading...
+          </Text>
+        </Flex>
+      </>
+    )
+  }
 
   return (
     <>
@@ -295,6 +322,12 @@ const TrackingWrappedArtworkApp: React.FC<Props> = props => {
     </AnalyticsContext.Provider>
   )
 }
+
+const SpinnerContainer = styled.div`
+  width: 100%;
+  height: 100px;
+  position: relative;
+`
 
 export const ArtworkAppFragmentContainer = createFragmentContainer(
   withSystemContext(TrackingWrappedArtworkApp),

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -170,12 +170,18 @@ const ArtworkSidebarCommerialButtons: React.FC<ArtworkSidebarCommercialButtonsPr
         }
       )
     } else {
+      console.log({ XXXXX: "here in else" })
       showAuthDialog({
         mode: "SignUp",
         options: {
           title: mode => {
             const action = mode === "SignUp" ? "Sign up" : "Log in"
             return `${action} to buy art with ease`
+          },
+          afterAuthAction: {
+            action: "buyNow",
+            kind: "artworks",
+            objectId: artwork.internalID,
           },
         },
         analytics: {

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -170,7 +170,6 @@ const ArtworkSidebarCommerialButtons: React.FC<ArtworkSidebarCommercialButtonsPr
         }
       )
     } else {
-      console.log({ XXXXX: "here in else" })
       showAuthDialog({
         mode: "SignUp",
         options: {
@@ -183,6 +182,8 @@ const ArtworkSidebarCommerialButtons: React.FC<ArtworkSidebarCommercialButtonsPr
             kind: "artworks",
             objectId: artwork.internalID,
           },
+          // try to use this
+          redirectTo: "/yoyo",
         },
         analytics: {
           contextModule: ContextModule.artworkSidebar,

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -182,8 +182,8 @@ const ArtworkSidebarCommerialButtons: React.FC<ArtworkSidebarCommercialButtonsPr
             kind: "artworks",
             objectId: artwork.internalID,
           },
-          // try to use this
-          redirectTo: "/yoyo",
+          // TODO
+          redirectTo: "/",
         },
         analytics: {
           contextModule: ContextModule.artworkSidebar,

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -27,6 +27,7 @@ import { ContextModule, Intent } from "@artsy/cohesion"
 import currency from "currency.js"
 import { useTranslation } from "react-i18next"
 import { useAuthDialog } from "Components/AuthDialog"
+import { useRouter } from "System/Router/useRouter"
 
 interface SaleMessageProps {
   saleMessage: string | null
@@ -52,6 +53,7 @@ const ArtworkSidebarCommerialButtons: React.FC<ArtworkSidebarCommercialButtonsPr
   artwork,
 }) => {
   const { relayEnvironment, router, user } = useSystemContext()
+  const { match } = useRouter()
 
   const { t } = useTranslation()
 
@@ -182,8 +184,7 @@ const ArtworkSidebarCommerialButtons: React.FC<ArtworkSidebarCommercialButtonsPr
             kind: "artworks",
             objectId: artwork.internalID,
           },
-          // TODO
-          redirectTo: "/",
+          redirectTo: `${match?.location?.pathname}?creating_order=true`,
         },
         analytics: {
           contextModule: ContextModule.artworkSidebar,
@@ -267,6 +268,12 @@ const ArtworkSidebarCommerialButtons: React.FC<ArtworkSidebarCommercialButtonsPr
             const action = mode === "SignUp" ? "Sign up" : "Log in"
             return `${action} to make an offer`
           },
+          afterAuthAction: {
+            action: "makeOffer",
+            kind: "artworks",
+            objectId: artwork.internalID,
+          },
+          redirectTo: `${match?.location?.pathname}?creating_order=true`,
         },
         analytics: {
           contextModule: ContextModule.artworkSidebar,

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercialButtons.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercialButtons.jest.tsx
@@ -7,8 +7,11 @@ import { createMockEnvironment } from "relay-test-utils"
 import { MockBoot } from "DevTools/MockBoot"
 import { ArtworkSidebarCommercialButtonsFragmentContainer } from "Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons"
 import { useAuthDialog } from "Components/AuthDialog"
+import { useRouter } from "System/Router/useRouter"
 
 jest.unmock("react-relay")
+
+jest.mock("System/Router/useRouter")
 
 jest.mock("Components/AuthDialog/useAuthDialog", () => ({
   useAuthDialog: jest.fn().mockReturnValue({ showAuthDialog: jest.fn() }),
@@ -242,8 +245,16 @@ describe("ArtworkSidebarCommercialButtons", () => {
   })
 
   describe("authentication", () => {
+    const mockUseRouter = useRouter as jest.Mock
     const mockUseAuthDialog = useAuthDialog as jest.Mock
     mockUseAuthDialog.mockImplementation(() => ({ showAuthDialog: jest.fn() }))
+    mockUseRouter.mockImplementation(() => ({
+      match: {
+        location: {
+          pathname: "/artwork/artwork-1",
+        },
+      },
+    }))
 
     beforeEach(() => {
       user = undefined
@@ -255,6 +266,7 @@ describe("ArtworkSidebarCommercialButtons", () => {
 
       renderWithRelay({
         Artwork: () => ({
+          internalID: "artwork-1",
           isAcquireable: true,
           isInquireable: false,
           isOfferable: false,
@@ -268,6 +280,12 @@ describe("ArtworkSidebarCommercialButtons", () => {
         mode: "SignUp",
         options: {
           title: expect.any(Function),
+          afterAuthAction: {
+            action: "buyNow",
+            kind: "artworks",
+            objectId: "artwork-1",
+          },
+          redirectTo: `/artwork/artwork-1?creating_order=true`,
         },
         analytics: {
           contextModule: "artworkSidebar",
@@ -282,6 +300,7 @@ describe("ArtworkSidebarCommercialButtons", () => {
 
       renderWithRelay({
         Artwork: () => ({
+          internalID: "artwork-1",
           isOfferable: true,
         }),
       })
@@ -292,6 +311,12 @@ describe("ArtworkSidebarCommercialButtons", () => {
         mode: "SignUp",
         options: {
           title: expect.any(Function),
+          afterAuthAction: {
+            action: "makeOffer",
+            kind: "artworks",
+            objectId: "artwork-1",
+          },
+          redirectTo: `/artwork/artwork-1?creating_order=true`,
         },
         analytics: {
           contextModule: "artworkSidebar",

--- a/src/Utils/Hooks/useAuthIntent/index.tsx
+++ b/src/Utils/Hooks/useAuthIntent/index.tsx
@@ -76,8 +76,6 @@ export const runAuthIntent = async ({
       }
     })()
 
-    console.log({ XXXXXX: "here?" })
-
     onSuccess(value)
 
     Cookies.expire(AFTER_AUTH_ACTION_KEY)
@@ -137,7 +135,7 @@ export const setAfterAuthAction = (afterAuthAction: AfterAuthAction) => {
 
 const schema = Yup.object({
   action: Yup.string()
-    .oneOf(["associateSubmission", "createAlert", "follow", "save"])
+    .oneOf(["associateSubmission", "createAlert", "follow", "save", "buyNow"])
     .required(),
   kind: Yup.string()
     .oneOf(["artist", "artworks", "gene", "profile", "submission"])

--- a/src/Utils/Hooks/useAuthIntent/index.tsx
+++ b/src/Utils/Hooks/useAuthIntent/index.tsx
@@ -6,6 +6,7 @@ import { followArtistMutation } from "./mutations/AuthIntentFollowArtistMutation
 import { followGeneMutation } from "./mutations/AuthIntentFollowGeneMutation"
 import { followProfileMutation } from "./mutations/AuthIntentFollowProfileMutation"
 import { saveArtworkMutation } from "./mutations/AuthIntentSaveArtworkMutation"
+import { createOrderMutation } from "./mutations/AuthIntentCreateOrderMutation"
 import { associateSubmissionMutation } from "./mutations/AuthIntentAssociateSubmissionMutation"
 import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 
@@ -19,6 +20,7 @@ export type AfterAuthAction =
   | { action: "follow"; kind: "gene"; objectId: string }
   | { action: "follow"; kind: "profile"; objectId: string }
   | { action: "save"; kind: "artworks"; objectId: string }
+  | { action: "buyNow"; kind: "artworks"; objectId: string }
 
 export const runAuthIntent = async ({
   user,
@@ -66,10 +68,15 @@ export const runAuthIntent = async ({
         case "save":
           return saveArtworkMutation(relayEnvironment, value.objectId)
 
+        case "buyNow":
+          return createOrderMutation(relayEnvironment, value.objectId)
+
         case "associateSubmission":
           return associateSubmissionMutation(relayEnvironment, value.objectId)
       }
     })()
+
+    console.log({ XXXXXX: "here?" })
 
     onSuccess(value)
 

--- a/src/Utils/Hooks/useAuthIntent/index.tsx
+++ b/src/Utils/Hooks/useAuthIntent/index.tsx
@@ -7,6 +7,7 @@ import { followGeneMutation } from "./mutations/AuthIntentFollowGeneMutation"
 import { followProfileMutation } from "./mutations/AuthIntentFollowProfileMutation"
 import { saveArtworkMutation } from "./mutations/AuthIntentSaveArtworkMutation"
 import { createOrderMutation } from "./mutations/AuthIntentCreateOrderMutation"
+import { createOfferOrderMutation } from "./mutations/AuthIntentCreateOfferOrderMutation"
 import { associateSubmissionMutation } from "./mutations/AuthIntentAssociateSubmissionMutation"
 import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 
@@ -21,6 +22,7 @@ export type AfterAuthAction =
   | { action: "follow"; kind: "profile"; objectId: string }
   | { action: "save"; kind: "artworks"; objectId: string }
   | { action: "buyNow"; kind: "artworks"; objectId: string }
+  | { action: "makeOffer"; kind: "artworks"; objectId: string }
 
 export const runAuthIntent = async ({
   user,
@@ -70,6 +72,9 @@ export const runAuthIntent = async ({
 
         case "buyNow":
           return createOrderMutation(relayEnvironment, value.objectId)
+
+        case "makeOffer":
+          return createOfferOrderMutation(relayEnvironment, value.objectId)
 
         case "associateSubmission":
           return associateSubmissionMutation(relayEnvironment, value.objectId)
@@ -135,7 +140,14 @@ export const setAfterAuthAction = (afterAuthAction: AfterAuthAction) => {
 
 const schema = Yup.object({
   action: Yup.string()
-    .oneOf(["associateSubmission", "createAlert", "follow", "save", "buyNow"])
+    .oneOf([
+      "associateSubmission",
+      "createAlert",
+      "follow",
+      "save",
+      "buyNow",
+      "makeOffer",
+    ])
     .required(),
   kind: Yup.string()
     .oneOf(["artist", "artworks", "gene", "profile", "submission"])

--- a/src/Utils/Hooks/useAuthIntent/mutations/AuthIntentCreateOfferOrderMutation.ts
+++ b/src/Utils/Hooks/useAuthIntent/mutations/AuthIntentCreateOfferOrderMutation.ts
@@ -1,29 +1,30 @@
 import { commitMutation, Environment, graphql } from "relay-runtime"
 import { AuthIntentMutation } from "./types"
-import { AuthIntentCreateOrderMutation } from "__generated__/AuthIntentCreateOrderMutation.graphql"
+import { AuthIntentCreateOfferOrderMutation } from "__generated__/AuthIntentCreateOfferOrderMutation.graphql"
 
-export const createOrderMutation: AuthIntentMutation = (
+export const createOfferOrderMutation: AuthIntentMutation = (
   relayEnvironment: Environment,
   id: string
 ) => {
   return new Promise((resolve, reject) => {
-    commitMutation<AuthIntentCreateOrderMutation>(relayEnvironment, {
+    commitMutation<AuthIntentCreateOfferOrderMutation>(relayEnvironment, {
       onCompleted: (res, errors) => {
         if (errors !== null) {
           reject(errors)
           return
         }
         const orderID =
-          res.commerceCreateOrderWithArtwork?.orderOrError.order?.internalID
+          res.commerceCreateOfferOrderWithArtwork?.orderOrError.order
+            ?.internalID
 
         resolve(res)
-        window.location.assign(`/orders/${orderID}/shipping`)
+        window.location.assign(`/orders/${orderID}/offer`)
       },
       mutation: graphql`
-        mutation AuthIntentCreateOrderMutation(
-          $input: CommerceCreateOrderWithArtworkInput!
+        mutation AuthIntentCreateOfferOrderMutation(
+          $input: CommerceCreateOfferOrderWithArtworkInput!
         ) @raw_response_type {
-          commerceCreateOrderWithArtwork(input: $input) {
+          commerceCreateOfferOrderWithArtwork(input: $input) {
             orderOrError {
               ... on CommerceOrderWithMutationSuccess {
                 __typename

--- a/src/Utils/Hooks/useAuthIntent/mutations/AuthIntentCreateOrderMutation.ts
+++ b/src/Utils/Hooks/useAuthIntent/mutations/AuthIntentCreateOrderMutation.ts
@@ -1,0 +1,61 @@
+import { commitMutation, Environment, graphql } from "relay-runtime"
+import { AuthIntentMutation } from "./types"
+import { AuthIntentCreateOrderMutation } from "__generated__/AuthIntentCreateOrderMutation.graphql"
+
+export const createOrderMutation: AuthIntentMutation = (
+  relayEnvironment: Environment,
+  id: string
+) => {
+  return new Promise((resolve, reject) => {
+    commitMutation<AuthIntentCreateOrderMutation>(relayEnvironment, {
+      onCompleted: (res, errors) => {
+        console.log({ XXXXXX: res })
+        console.log({ XXXXXX: errors })
+        if (errors !== null) {
+          reject(errors)
+          return
+        }
+
+        resolve(res)
+      },
+      mutation: graphql`
+        mutation AuthIntentCreateOrderMutation(
+          $input: CommerceCreateOrderWithArtworkInput!
+        ) @raw_response_type {
+          commerceCreateOrderWithArtwork(input: $input) {
+            orderOrError {
+              ... on CommerceOrderWithMutationSuccess {
+                __typename
+                order {
+                  internalID
+                  mode
+                }
+              }
+              ... on CommerceOrderWithMutationFailure {
+                error {
+                  type
+                  code
+                  data
+                }
+              }
+            }
+          }
+        }
+      `,
+      // optimisticResponse: {
+      //   saveArtwork: {
+      //     artwork: {
+      //       id,
+      //       isSaved: true,
+      //     },
+      //   },
+      // },
+      variables: {
+        input: {
+          artworkId: id,
+          // editionSetId: selectedEditionSet?.internalID,
+        },
+      },
+    })
+  })
+}

--- a/src/Utils/Hooks/useAuthIntent/mutations/AuthIntentCreateOrderMutation.ts
+++ b/src/Utils/Hooks/useAuthIntent/mutations/AuthIntentCreateOrderMutation.ts
@@ -9,14 +9,15 @@ export const createOrderMutation: AuthIntentMutation = (
   return new Promise((resolve, reject) => {
     commitMutation<AuthIntentCreateOrderMutation>(relayEnvironment, {
       onCompleted: (res, errors) => {
-        console.log({ XXXXXX: res })
-        console.log({ XXXXXX: errors })
         if (errors !== null) {
           reject(errors)
           return
         }
+        const orderID =
+          res.commerceCreateOrderWithArtwork?.orderOrError.order?.internalID
 
         resolve(res)
+        window.location.assign(`/orders/${orderID}/shipping`)
       },
       mutation: graphql`
         mutation AuthIntentCreateOrderMutation(
@@ -42,6 +43,7 @@ export const createOrderMutation: AuthIntentMutation = (
           }
         }
       `,
+      // TODO
       // optimisticResponse: {
       //   saveArtwork: {
       //     artwork: {

--- a/src/__generated__/AuthIntentCreateOfferOrderMutation.graphql.ts
+++ b/src/__generated__/AuthIntentCreateOfferOrderMutation.graphql.ts
@@ -1,0 +1,270 @@
+/**
+ * @generated SignedSource<<8e4a430c4ddd4c6fb1628c193ec06e3d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
+export type CommerceCreateOfferOrderWithArtworkInput = {
+  artworkId: string;
+  clientMutationId?: string | null;
+  editionSetId?: string | null;
+  findActiveOrCreate?: boolean | null;
+  quantity?: number | null;
+};
+export type AuthIntentCreateOfferOrderMutation$variables = {
+  input: CommerceCreateOfferOrderWithArtworkInput;
+};
+export type AuthIntentCreateOfferOrderMutation$data = {
+  readonly commerceCreateOfferOrderWithArtwork: {
+    readonly orderOrError: {
+      readonly __typename: "CommerceOrderWithMutationSuccess";
+      readonly error?: {
+        readonly code: string;
+        readonly data: string | null;
+        readonly type: string;
+      };
+      readonly order?: {
+        readonly internalID: string;
+        readonly mode: CommerceOrderModeEnum | null;
+      };
+    };
+  } | null;
+};
+export type AuthIntentCreateOfferOrderMutation$rawResponse = {
+  readonly commerceCreateOfferOrderWithArtwork: {
+    readonly orderOrError: {
+      readonly __typename: "CommerceOrderWithMutationFailure";
+      readonly error: {
+        readonly code: string;
+        readonly data: string | null;
+        readonly type: string;
+      };
+    } | {
+      readonly __typename: "CommerceOrderWithMutationSuccess";
+      readonly order: {
+        readonly __typename: string;
+        readonly id: string;
+        readonly internalID: string;
+        readonly mode: CommerceOrderModeEnum | null;
+      };
+    } | {
+      readonly __typename: string;
+    };
+  } | null;
+};
+export type AuthIntentCreateOfferOrderMutation = {
+  rawResponse: AuthIntentCreateOfferOrderMutation$rawResponse;
+  response: AuthIntentCreateOfferOrderMutation$data;
+  variables: AuthIntentCreateOfferOrderMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "mode",
+  "storageKey": null
+},
+v5 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommerceApplicationError",
+      "kind": "LinkedField",
+      "name": "error",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "type",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "code",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "data",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "CommerceOrderWithMutationFailure",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuthIntentCreateOfferOrderMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CommerceCreateOfferOrderWithArtworkPayload",
+        "kind": "LinkedField",
+        "name": "commerceCreateOfferOrderWithArtwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "CommerceOrderWithMutationSuccess",
+                "abstractKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuthIntentCreateOfferOrderMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CommerceCreateOfferOrderWithArtworkPayload",
+        "kind": "LinkedField",
+        "name": "commerceCreateOfferOrderWithArtwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "CommerceOrderWithMutationSuccess",
+                "abstractKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d0bf9ad55a46e3c4b6b608dcbd0377b0",
+    "id": null,
+    "metadata": {},
+    "name": "AuthIntentCreateOfferOrderMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuthIntentCreateOfferOrderMutation(\n  $input: CommerceCreateOfferOrderWithArtworkInput!\n) {\n  commerceCreateOfferOrderWithArtwork(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          internalID\n          mode\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "71fa7d53aebe49d89e0e50ed4b2773fa";
+
+export default node;

--- a/src/__generated__/AuthIntentCreateOrderMutation.graphql.ts
+++ b/src/__generated__/AuthIntentCreateOrderMutation.graphql.ts
@@ -1,0 +1,269 @@
+/**
+ * @generated SignedSource<<4e1e33415b8f60aac6c4d6e2174282b8>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
+export type CommerceCreateOrderWithArtworkInput = {
+  artworkId: string;
+  clientMutationId?: string | null;
+  editionSetId?: string | null;
+  quantity?: number | null;
+};
+export type AuthIntentCreateOrderMutation$variables = {
+  input: CommerceCreateOrderWithArtworkInput;
+};
+export type AuthIntentCreateOrderMutation$data = {
+  readonly commerceCreateOrderWithArtwork: {
+    readonly orderOrError: {
+      readonly __typename: "CommerceOrderWithMutationSuccess";
+      readonly error?: {
+        readonly code: string;
+        readonly data: string | null;
+        readonly type: string;
+      };
+      readonly order?: {
+        readonly internalID: string;
+        readonly mode: CommerceOrderModeEnum | null;
+      };
+    };
+  } | null;
+};
+export type AuthIntentCreateOrderMutation$rawResponse = {
+  readonly commerceCreateOrderWithArtwork: {
+    readonly orderOrError: {
+      readonly __typename: "CommerceOrderWithMutationFailure";
+      readonly error: {
+        readonly code: string;
+        readonly data: string | null;
+        readonly type: string;
+      };
+    } | {
+      readonly __typename: "CommerceOrderWithMutationSuccess";
+      readonly order: {
+        readonly __typename: string;
+        readonly id: string;
+        readonly internalID: string;
+        readonly mode: CommerceOrderModeEnum | null;
+      };
+    } | {
+      readonly __typename: string;
+    };
+  } | null;
+};
+export type AuthIntentCreateOrderMutation = {
+  rawResponse: AuthIntentCreateOrderMutation$rawResponse;
+  response: AuthIntentCreateOrderMutation$data;
+  variables: AuthIntentCreateOrderMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "mode",
+  "storageKey": null
+},
+v5 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommerceApplicationError",
+      "kind": "LinkedField",
+      "name": "error",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "type",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "code",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "data",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "CommerceOrderWithMutationFailure",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuthIntentCreateOrderMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CommerceCreateOrderWithArtworkPayload",
+        "kind": "LinkedField",
+        "name": "commerceCreateOrderWithArtwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "CommerceOrderWithMutationSuccess",
+                "abstractKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuthIntentCreateOrderMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CommerceCreateOrderWithArtworkPayload",
+        "kind": "LinkedField",
+        "name": "commerceCreateOrderWithArtwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "CommerceOrderWithMutationSuccess",
+                "abstractKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "7389ba03183453be3a1176cb58236c06",
+    "id": null,
+    "metadata": {},
+    "name": "AuthIntentCreateOrderMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuthIntentCreateOrderMutation(\n  $input: CommerceCreateOrderWithArtworkInput!\n) {\n  commerceCreateOrderWithArtwork(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          internalID\n          mode\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a03458c234c3e5b3ae2ac5d40b5594c4";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [TX-1015]

### Description

This PR creates two new after auth action for BNMO clicks, so that an order/offer-order is created and users redirected to the shipping/offer step of the checkout flow after auth. 


[TX-1015]: https://artsyproduct.atlassian.net/browse/TX-1015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Video 

https://user-images.githubusercontent.com/42584148/225321040-b8fb2e26-481d-4e5c-8bad-bef3432a379b.mov