### PR TITLE
CX-3493: Sort "Curator's Picks: Emerging" home rail by decayed merch

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,10 +12,10 @@ if [[ ! -z $NVM_DIR ]]; then # skip if nvm is not available
   nvm install
 fi
 
-echo "Installing dependencies from Homebrew..."
-brew bundle --file=- <<EOF
-brew 'redis', restart_service: true
-EOF
+# echo "Installing dependencies from Homebrew..."
+# brew bundle --file=- <<EOF
+# brew 'redis', restart_service: true
+# EOF
 
 echo "Installing dependencies..."
 yarn install || (npm install --global yarn@latest && yarn install)

--- a/src/Apps/Home/Components/HomeEmergingPicksArtworksRail.tsx
+++ b/src/Apps/Home/Components/HomeEmergingPicksArtworksRail.tsx
@@ -86,6 +86,7 @@ export const HomeEmergingPicksArtworksRailFragmentContainer = createFragmentCont
         artworksConnection(
           first: 12
           marketingCollectionID: "curators-picks-emerging"
+          input: { sort: "-decayed_merch" }
         ) {
           edges {
             node {

--- a/src/Apps/Home/Components/HomeEmergingPicksArtworksRail.tsx
+++ b/src/Apps/Home/Components/HomeEmergingPicksArtworksRail.tsx
@@ -86,7 +86,7 @@ export const HomeEmergingPicksArtworksRailFragmentContainer = createFragmentCont
         artworksConnection(
           first: 12
           marketingCollectionID: "curators-picks-emerging"
-          input: { sort: "-decayed_merch" }
+          sort: "-decayed_merch"
         ) {
           edges {
             node {

--- a/src/__generated__/HomeEmergingPicksArtworksRailQuery.graphql.ts
+++ b/src/__generated__/HomeEmergingPicksArtworksRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<123d8e0a350d04c0da15432680f61a10>>
+ * @generated SignedSource<<0280975ad251a49a3432e9cfe65315cc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -118,6 +118,13 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 12
+              },
+              {
+                "kind": "Literal",
+                "name": "input",
+                "value": {
+                  "sort": "-decayed_merch"
+                }
               },
               {
                 "kind": "Literal",
@@ -552,7 +559,7 @@ return {
               },
               (v1/*: any*/)
             ],
-            "storageKey": "artworksConnection(first:12,marketingCollectionID:\"curators-picks-emerging\")"
+            "storageKey": "artworksConnection(first:12,input:{\"sort\":\"-decayed_merch\"},marketingCollectionID:\"curators-picks-emerging\")"
           }
         ],
         "storageKey": null
@@ -560,12 +567,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "59a6e6570a1f16ceb4cc7225e37bad19",
+    "cacheID": "360c7db4689493f4252a187484c5acf2",
     "id": null,
     "metadata": {},
     "name": "HomeEmergingPicksArtworksRailQuery",
     "operationKind": "query",
-    "text": "query HomeEmergingPicksArtworksRailQuery {\n  viewer {\n    ...HomeEmergingPicksArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeEmergingPicksArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, marketingCollectionID: \"curators-picks-emerging\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  is_saved: isSaved\n  slug\n  title\n  date\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+    "text": "query HomeEmergingPicksArtworksRailQuery {\n  viewer {\n    ...HomeEmergingPicksArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeEmergingPicksArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, marketingCollectionID: \"curators-picks-emerging\", input: {sort: \"-decayed_merch\"}) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  is_saved: isSaved\n  slug\n  title\n  date\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeEmergingPicksArtworksRailQuery.graphql.ts
+++ b/src/__generated__/HomeEmergingPicksArtworksRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0280975ad251a49a3432e9cfe65315cc>>
+ * @generated SignedSource<<cf3a27b6bec5eebc6fb098d8b3cea110>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -121,15 +121,13 @@ return {
               },
               {
                 "kind": "Literal",
-                "name": "input",
-                "value": {
-                  "sort": "-decayed_merch"
-                }
+                "name": "marketingCollectionID",
+                "value": "curators-picks-emerging"
               },
               {
                 "kind": "Literal",
-                "name": "marketingCollectionID",
-                "value": "curators-picks-emerging"
+                "name": "sort",
+                "value": "-decayed_merch"
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -559,7 +557,7 @@ return {
               },
               (v1/*: any*/)
             ],
-            "storageKey": "artworksConnection(first:12,input:{\"sort\":\"-decayed_merch\"},marketingCollectionID:\"curators-picks-emerging\")"
+            "storageKey": "artworksConnection(first:12,marketingCollectionID:\"curators-picks-emerging\",sort:\"-decayed_merch\")"
           }
         ],
         "storageKey": null
@@ -567,12 +565,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "360c7db4689493f4252a187484c5acf2",
+    "cacheID": "c3cadd6d8a155073196ac0f21c24a6fd",
     "id": null,
     "metadata": {},
     "name": "HomeEmergingPicksArtworksRailQuery",
     "operationKind": "query",
-    "text": "query HomeEmergingPicksArtworksRailQuery {\n  viewer {\n    ...HomeEmergingPicksArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeEmergingPicksArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, marketingCollectionID: \"curators-picks-emerging\", input: {sort: \"-decayed_merch\"}) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  is_saved: isSaved\n  slug\n  title\n  date\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+    "text": "query HomeEmergingPicksArtworksRailQuery {\n  viewer {\n    ...HomeEmergingPicksArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeEmergingPicksArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, marketingCollectionID: \"curators-picks-emerging\", sort: \"-decayed_merch\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  is_saved: isSaved\n  slug\n  title\n  date\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeEmergingPicksArtworksRail_Test_Query.graphql.ts
+++ b/src/__generated__/HomeEmergingPicksArtworksRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<71423ae91e7d24c63f5e8f044c662fe5>>
+ * @generated SignedSource<<d28a1d1b1ddf0d6ae3378497068c767e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -151,15 +151,13 @@ return {
               },
               {
                 "kind": "Literal",
-                "name": "input",
-                "value": {
-                  "sort": "-decayed_merch"
-                }
+                "name": "marketingCollectionID",
+                "value": "curators-picks-emerging"
               },
               {
                 "kind": "Literal",
-                "name": "marketingCollectionID",
-                "value": "curators-picks-emerging"
+                "name": "sort",
+                "value": "-decayed_merch"
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -589,7 +587,7 @@ return {
               },
               (v1/*: any*/)
             ],
-            "storageKey": "artworksConnection(first:12,input:{\"sort\":\"-decayed_merch\"},marketingCollectionID:\"curators-picks-emerging\")"
+            "storageKey": "artworksConnection(first:12,marketingCollectionID:\"curators-picks-emerging\",sort:\"-decayed_merch\")"
           }
         ],
         "storageKey": null
@@ -597,7 +595,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2db24f350397dba7d9f5ba79862fbe62",
+    "cacheID": "d0e9d486faa70550944f7040d54ca551",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -771,7 +769,7 @@ return {
     },
     "name": "HomeEmergingPicksArtworksRail_Test_Query",
     "operationKind": "query",
-    "text": "query HomeEmergingPicksArtworksRail_Test_Query {\n  viewer {\n    ...HomeEmergingPicksArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeEmergingPicksArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, marketingCollectionID: \"curators-picks-emerging\", input: {sort: \"-decayed_merch\"}) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  is_saved: isSaved\n  slug\n  title\n  date\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+    "text": "query HomeEmergingPicksArtworksRail_Test_Query {\n  viewer {\n    ...HomeEmergingPicksArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeEmergingPicksArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, marketingCollectionID: \"curators-picks-emerging\", sort: \"-decayed_merch\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  is_saved: isSaved\n  slug\n  title\n  date\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeEmergingPicksArtworksRail_Test_Query.graphql.ts
+++ b/src/__generated__/HomeEmergingPicksArtworksRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ec1e4e92d878ca00bb609dc7e7d5d962>>
+ * @generated SignedSource<<71423ae91e7d24c63f5e8f044c662fe5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -148,6 +148,13 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 12
+              },
+              {
+                "kind": "Literal",
+                "name": "input",
+                "value": {
+                  "sort": "-decayed_merch"
+                }
               },
               {
                 "kind": "Literal",
@@ -582,7 +589,7 @@ return {
               },
               (v1/*: any*/)
             ],
-            "storageKey": "artworksConnection(first:12,marketingCollectionID:\"curators-picks-emerging\")"
+            "storageKey": "artworksConnection(first:12,input:{\"sort\":\"-decayed_merch\"},marketingCollectionID:\"curators-picks-emerging\")"
           }
         ],
         "storageKey": null
@@ -590,7 +597,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "96d287e63d5d5093b064ffd03e48bf3a",
+    "cacheID": "2db24f350397dba7d9f5ba79862fbe62",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -764,7 +771,7 @@ return {
     },
     "name": "HomeEmergingPicksArtworksRail_Test_Query",
     "operationKind": "query",
-    "text": "query HomeEmergingPicksArtworksRail_Test_Query {\n  viewer {\n    ...HomeEmergingPicksArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeEmergingPicksArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, marketingCollectionID: \"curators-picks-emerging\") {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  is_saved: isSaved\n  slug\n  title\n  date\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+    "text": "query HomeEmergingPicksArtworksRail_Test_Query {\n  viewer {\n    ...HomeEmergingPicksArtworksRail_viewer\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HomeEmergingPicksArtworksRail_viewer on Viewer {\n  artworksConnection(first: 12, marketingCollectionID: \"curators-picks-emerging\", input: {sort: \"-decayed_merch\"}) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  is_saved: isSaved\n  slug\n  title\n  date\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/HomeEmergingPicksArtworksRail_viewer.graphql.ts
+++ b/src/__generated__/HomeEmergingPicksArtworksRail_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<20b3421e3c63d87cc07d73a8f40a1958>>
+ * @generated SignedSource<<288cf1882b1b7eff88b00e17bb615fc9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -41,6 +41,13 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "first",
           "value": 12
+        },
+        {
+          "kind": "Literal",
+          "name": "input",
+          "value": {
+            "sort": "-decayed_merch"
+          }
         },
         {
           "kind": "Literal",
@@ -102,13 +109,13 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "artworksConnection(first:12,marketingCollectionID:\"curators-picks-emerging\")"
+      "storageKey": "artworksConnection(first:12,input:{\"sort\":\"-decayed_merch\"},marketingCollectionID:\"curators-picks-emerging\")"
     }
   ],
   "type": "Viewer",
   "abstractKey": null
 };
 
-(node as any).hash = "22aa4f34b83e83ffbbda0f8d2a4c231d";
+(node as any).hash = "d5f48677e76f7b2c0ab12ada6f79bee2";
 
 export default node;

--- a/src/__generated__/HomeEmergingPicksArtworksRail_viewer.graphql.ts
+++ b/src/__generated__/HomeEmergingPicksArtworksRail_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<288cf1882b1b7eff88b00e17bb615fc9>>
+ * @generated SignedSource<<1ef2591c654a8db51f0328e7988d8e2f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -44,15 +44,13 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Literal",
-          "name": "input",
-          "value": {
-            "sort": "-decayed_merch"
-          }
+          "name": "marketingCollectionID",
+          "value": "curators-picks-emerging"
         },
         {
           "kind": "Literal",
-          "name": "marketingCollectionID",
-          "value": "curators-picks-emerging"
+          "name": "sort",
+          "value": "-decayed_merch"
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -109,13 +107,13 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "artworksConnection(first:12,input:{\"sort\":\"-decayed_merch\"},marketingCollectionID:\"curators-picks-emerging\")"
+      "storageKey": "artworksConnection(first:12,marketingCollectionID:\"curators-picks-emerging\",sort:\"-decayed_merch\")"
     }
   ],
   "type": "Viewer",
   "abstractKey": null
 };
 
-(node as any).hash = "d5f48677e76f7b2c0ab12ada6f79bee2";
+(node as any).hash = "4e2d370aea9cb0046e59fa1aa60d2645";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3493]

### Description

Sort "Curator's Picks: Emerging" home rail by decayed merch to use the same sorting as on the collection page.

### Screenshots

| | |
| --- | --- |
| <img width="1020" alt="Screenshot 2023-03-14 at 14 57 26" src="https://user-images.githubusercontent.com/4691889/225024386-6c8b21c3-bdb6-4d18-a783-7f16ab705c6c.png"> | <img width="1025" alt="Screenshot 2023-03-14 at 14 57 34" src="https://user-images.githubusercontent.com/4691889/225024408-54408839-77cb-4269-8ef5-85de657593f1.png"> |



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3493]: https://artsyproduct.atlassian.net/browse/CX-3493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ