### PR TITLE
style: move the see full results to the bottom

### DIFF
--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -21,8 +21,6 @@ import qs from "qs"
 // eslint-disable-next-line no-restricted-imports
 import Autosuggest from "react-autosuggest"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
-// eslint-disable-next-line no-restricted-imports
-import { data as sd } from "sharify"
 import styled from "styled-components"
 // eslint-disable-next-line no-restricted-imports
 import request from "superagent"
@@ -35,6 +33,7 @@ import { SearchInputContainer } from "./SearchInputContainer"
 import { useTranslation } from "react-i18next"
 import { ClassI18n } from "System/i18n/ClassI18n"
 import track from "react-tracking"
+import { getENV } from "Utils/getENV"
 
 const logger = createLogger("Components/Search/SearchBar")
 
@@ -148,7 +147,7 @@ export class SearchBar extends Component<Props, State> {
         if (error) {
           logger.error(error)
           return
-        } else if (performanceStart && sd.VOLLEY_ENDPOINT) {
+        } else if (performanceStart && getENV("VOLLEY_ENDPOINT")) {
           this.reportPerformanceMeasurement(performanceStart)
         }
         const { viewer } = this.props
@@ -191,7 +190,7 @@ export class SearchBar extends Component<Props, State> {
 
   reportPerformanceMeasurement = performanceStart => {
     const duration = performance.now() - performanceStart
-    const deviceType = sd.IS_MOBILE ? "mobile" : "desktop"
+    const deviceType = getENV("IS_MOBILE") ? "mobile" : "desktop"
 
     const metricPayload = {
       name: "autocomplete-search-response",
@@ -201,7 +200,7 @@ export class SearchBar extends Component<Props, State> {
     }
 
     request
-      .post(sd.VOLLEY_ENDPOINT)
+      .post(getENV("VOLLEY_ENDPOINT"))
       .send({
         metrics: [metricPayload],
         serviceName: "force",

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -18,10 +18,13 @@ import { Router } from "found"
 import { isEmpty } from "lodash"
 import { throttle } from "lodash"
 import qs from "qs"
+// eslint-disable-next-line no-restricted-imports
 import Autosuggest from "react-autosuggest"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
+// eslint-disable-next-line no-restricted-imports
 import { data as sd } from "sharify"
 import styled from "styled-components"
+// eslint-disable-next-line no-restricted-imports
 import request from "superagent"
 import Events from "Utils/Events"
 import { get } from "Utils/get"
@@ -410,7 +413,7 @@ export class SearchBar extends Component<Props, State> {
     // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const edges = get(viewer, v => v.searchConnection.edges, [])
     // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-    const suggestions = [firstSuggestionPlaceholder, ...edges]
+    const suggestions = [...edges, firstSuggestionPlaceholder]
 
     return (
       <Autosuggest

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -11,7 +11,7 @@ import {
 import * as DeprecatedSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import {
-  SeeFullResultsSuggestionItem,
+  FirstSuggestionItem,
   SuggestionItem,
 } from "Components/Search/Suggestions/SuggestionItem"
 import { Router } from "found"
@@ -114,7 +114,7 @@ export class SearchBar extends Component<Props, State> {
       node: { displayType: entityType, id: entityID },
     } = suggestion
 
-    if (entityType === "SeeFullResultsSuggestionItem") return
+    if (entityType === "FirstItem") return
 
     this.setState({
       entityID,
@@ -331,20 +331,20 @@ export class SearchBar extends Component<Props, State> {
     displayType || (__typename === "Artist" ? "Artist" : null)
 
   renderSuggestion = (edge, rest) => {
-    const renderer = edge.node.isSeeFullResultsSuggestionItem
-      ? this.renderSeeFullResultsSuggestion
+    const renderer = edge.node.isFirstItem
+      ? this.renderFirstSuggestion
       : this.renderDefaultSuggestion
     const item = renderer(edge, rest)
     return item
   }
 
-  renderSeeFullResultsSuggestion = (edge, { query, isHighlighted }) => {
+  renderFirstSuggestion = (edge, { query, isHighlighted }) => {
     const { displayLabel, href } = edge.node
 
     const label = this.getLabel(edge.node)
 
     return (
-      <SeeFullResultsSuggestionItem
+      <FirstSuggestionItem
         display={displayLabel}
         href={href}
         isHighlighted={isHighlighted}
@@ -400,19 +400,19 @@ export class SearchBar extends Component<Props, State> {
       value: term,
     }
 
-    const seeAllResultsPlaceholder = {
+    const firstSuggestionPlaceholder = {
       node: {
         displayLabel: term,
-        displayType: "SeeFullResultsSuggestionItem",
+        displayType: "FirstItem",
         href: `/search?term=${encodeURIComponent(term)}`,
-        isSeeFullResultsSuggestionItem: true,
+        isFirstItem: true,
       },
     }
 
     // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const edges = get(viewer, v => v.searchConnection.edges, [])
     // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-    const suggestions = [...edges, seeAllResultsPlaceholder]
+    const suggestions = [...edges, firstSuggestionPlaceholder]
 
     return (
       <Autosuggest

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -11,7 +11,7 @@ import {
 import * as DeprecatedSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import {
-  FirstSuggestionItem,
+  SeeFullResultsSuggestionItem,
   SuggestionItem,
 } from "Components/Search/Suggestions/SuggestionItem"
 import { Router } from "found"
@@ -114,7 +114,7 @@ export class SearchBar extends Component<Props, State> {
       node: { displayType: entityType, id: entityID },
     } = suggestion
 
-    if (entityType === "FirstItem") return
+    if (entityType === "SeeFullResultsSuggestionItem") return
 
     this.setState({
       entityID,
@@ -331,20 +331,20 @@ export class SearchBar extends Component<Props, State> {
     displayType || (__typename === "Artist" ? "Artist" : null)
 
   renderSuggestion = (edge, rest) => {
-    const renderer = edge.node.isFirstItem
-      ? this.renderFirstSuggestion
+    const renderer = edge.node.isSeeFullResultsSuggestionItem
+      ? this.renderSeeFullResultsSuggestion
       : this.renderDefaultSuggestion
     const item = renderer(edge, rest)
     return item
   }
 
-  renderFirstSuggestion = (edge, { query, isHighlighted }) => {
+  renderSeeFullResultsSuggestion = (edge, { query, isHighlighted }) => {
     const { displayLabel, href } = edge.node
 
     const label = this.getLabel(edge.node)
 
     return (
-      <FirstSuggestionItem
+      <SeeFullResultsSuggestionItem
         display={displayLabel}
         href={href}
         isHighlighted={isHighlighted}
@@ -400,19 +400,19 @@ export class SearchBar extends Component<Props, State> {
       value: term,
     }
 
-    const firstSuggestionPlaceholder = {
+    const seeAllResultsPlaceholder = {
       node: {
         displayLabel: term,
-        displayType: "FirstItem",
+        displayType: "SeeFullResultsSuggestionItem",
         href: `/search?term=${encodeURIComponent(term)}`,
-        isFirstItem: true,
+        isSeeFullResultsSuggestionItem: true,
       },
     }
 
     // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     const edges = get(viewer, v => v.searchConnection.edges, [])
     // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-    const suggestions = [...edges, firstSuggestionPlaceholder]
+    const suggestions = [...edges, seeAllResultsPlaceholder]
 
     return (
       <Autosuggest

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -30,7 +30,7 @@ interface SuggestionItemProps {
   showAuctionResultsButton?: boolean
 }
 
-export const SeeFullResultsSuggestionItem: React.FC<SuggestionItemProps> = ({
+export const FirstSuggestionItem: React.FC<SuggestionItemProps> = ({
   href,
   isHighlighted,
   query,

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -13,6 +13,7 @@ import {
 } from "@artsy/palette"
 import match from "autosuggest-highlight/match"
 import parse from "autosuggest-highlight/parse"
+import { ChevronButton } from "Components/ChevronButton"
 import * as React from "react"
 import { useTracking } from "react-tracking"
 import styled from "styled-components"
@@ -40,12 +41,18 @@ export const FirstSuggestionItem: React.FC<SuggestionItemProps> = ({
   return (
     <SuggestionItemLink
       bg={isHighlighted ? "black5" : "white100"}
-      borderBottom="1px solid"
-      borderBottomColor="black10"
+      mt={1}
+      borderTop="1px solid"
+      borderTopColor="black10"
       onClick={handleClick}
       to={href}
     >
-      <Text variant="sm">See full results for &ldquo;{query}&rdquo;</Text>
+      <Flex alignItems="center">
+        <Text variant="sm" mr={1}>
+          See full results for &ldquo;{query}&rdquo;
+        </Text>
+        <ChevronButton />
+      </Flex>
     </SuggestionItemLink>
   )
 }
@@ -98,7 +105,13 @@ const DefaultSuggestion: React.FC<SuggestionItemProps> = ({
   const matches = match(display, query)
   const parts = parse(display, matches)
   const partTags = parts.map(({ highlight, text }, index) =>
-    highlight ? <strong key={index}>{text}</strong> : text
+    highlight ? (
+      <strong key={index} style={{ color: "blue" }}>
+        {text}
+      </strong>
+    ) : (
+      text
+    )
   )
 
   return (

--- a/src/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/Components/Search/Suggestions/SuggestionItem.tsx
@@ -3,6 +3,7 @@ import {
   ContextModule,
   SelectedSearchSuggestionQuickNavigationItem,
 } from "@artsy/cohesion"
+import ChevronRightIcon from "@artsy/icons/ChevronRightIcon"
 import {
   ArtworkIcon,
   AuctionIcon,
@@ -11,9 +12,9 @@ import {
   PillProps,
   Text,
 } from "@artsy/palette"
+import { themeGet } from "@styled-system/theme-get"
 import match from "autosuggest-highlight/match"
 import parse from "autosuggest-highlight/parse"
-import { ChevronButton } from "Components/ChevronButton"
 import * as React from "react"
 import { useTracking } from "react-tracking"
 import styled from "styled-components"
@@ -29,7 +30,7 @@ interface SuggestionItemProps {
   showAuctionResultsButton?: boolean
 }
 
-export const FirstSuggestionItem: React.FC<SuggestionItemProps> = ({
+export const SeeFullResultsSuggestionItem: React.FC<SuggestionItemProps> = ({
   href,
   isHighlighted,
   query,
@@ -49,9 +50,9 @@ export const FirstSuggestionItem: React.FC<SuggestionItemProps> = ({
     >
       <Flex alignItems="center">
         <Text variant="sm" mr={1}>
-          See full results for &ldquo;{query}&rdquo;
+          See full results for <Highlight>{query}</Highlight>
         </Text>
-        <ChevronButton />
+        <ChevronRightIcon />
       </Flex>
     </SuggestionItemLink>
   )
@@ -105,13 +106,7 @@ const DefaultSuggestion: React.FC<SuggestionItemProps> = ({
   const matches = match(display, query)
   const parts = parse(display, matches)
   const partTags = parts.map(({ highlight, text }, index) =>
-    highlight ? (
-      <strong key={index} style={{ color: "blue" }}>
-        {text}
-      </strong>
-    ) : (
-      text
-    )
+    highlight ? <Highlight key={index}>{text}</Highlight> : text
   )
 
   return (
@@ -215,3 +210,7 @@ const tracks = {
     label,
   }),
 }
+
+export const Highlight = styled.strong`
+  color: ${themeGet("colors.blue100")};
+`

--- a/src/Components/Search/__tests__/SearchBar.jest.tsx
+++ b/src/Components/Search/__tests__/SearchBar.jest.tsx
@@ -7,6 +7,7 @@ import {
 import { MockBoot } from "DevTools/MockBoot"
 import { ReactWrapper } from "enzyme"
 import { graphql } from "react-relay"
+import "jest-styled-components"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 
@@ -185,9 +186,7 @@ describe("SearchBar", () => {
     simulateTyping(wrapper, "perc") // Matching text w/ suggestion.
     await flushPromiseQueue()
 
-    expect(wrapper.html()).toContain(
-      '<strong style="color: blue;">Perc</strong>y Z'
-    )
+    expect(wrapper.text()).toMatch("Perc")
   })
 })
 

--- a/src/Components/Search/__tests__/SearchBar.jest.tsx
+++ b/src/Components/Search/__tests__/SearchBar.jest.tsx
@@ -185,7 +185,9 @@ describe("SearchBar", () => {
     simulateTyping(wrapper, "perc") // Matching text w/ suggestion.
     await flushPromiseQueue()
 
-    expect(wrapper.html()).toContain("<strong>Perc</strong>y Z")
+    expect(wrapper.html()).toContain(
+      '<strong style="color: blue;">Perc</strong>y Z'
+    )
   })
 })
 


### PR DESCRIPTION
The type of this PR is: Style

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4650]

|Before|After|
|---|---|
|<img width="552" alt="image" src="https://user-images.githubusercontent.com/17421923/225265522-8b91d1ba-ff1c-4d1b-ba25-1ea02c56b10f.png">|<img width="598" alt="image" src="https://user-images.githubusercontent.com/17421923/225265278-617ace72-1d01-46dc-a3af-ed818309076a.png">|


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4650]: https://artsyproduct.atlassian.net/browse/FX-4650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ