### PR TITLE
refactor(cleanup): remove artist-artwork-grid-keyword-search

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -11,7 +11,6 @@ import { MaterialsFilter } from "Components/ArtworkFilter/ArtworkFilters/Materia
 import { PartnersFilter } from "Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
 import { ArtistsFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistsFilter"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { useSystemContext } from "System/useSystemContext"
 import { Join, Spacer } from "@artsy/palette"
@@ -24,11 +23,9 @@ export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props =
   const { relayEnvironment } = props
   const { user } = useSystemContext()
 
-  const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
-
   return (
     <Join separator={<Spacer y={4} />}>
-      {showKeywordFilter && <KeywordFilter />}
+      <KeywordFilter />
       <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
       <AttributionClassFilter expanded />
       <MediumFilter expanded />

--- a/src/Apps/ArtistSeries/__tests__/ArtistSeriesArtworksFilter.jest.tsx
+++ b/src/Apps/ArtistSeries/__tests__/ArtistSeriesArtworksFilter.jest.tsx
@@ -76,6 +76,10 @@ describe("ArtistSeriesArtworksFilter", () => {
     const filterWrappers = wrapper.find("FilterExpandable")
     const filters = [
       {
+        label: "Keyword Search",
+        expanded: true,
+      },
+      {
         label: "Rarity",
         expanded: true,
       },

--- a/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -13,7 +13,6 @@ import { useSystemContext } from "System/useSystemContext"
 import { AuctionArtworkFilter_viewer$data } from "__generated__/AuctionArtworkFilter_viewer.graphql"
 import { ActiveFilterPills } from "Components/SavedSearchAlert/Components/ActiveFilterPills"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { Join, Spacer } from "@artsy/palette"
 
 interface AuctionArtworkFilterProps {
@@ -26,7 +25,6 @@ const AuctionArtworkFilter: React.FC<AuctionArtworkFilterProps> = ({
 }) => {
   const { user } = useSystemContext()
   const { match } = useRouter()
-  const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
 
   if (!viewer.sidebarAggregations) return null
 
@@ -53,7 +51,7 @@ const AuctionArtworkFilter: React.FC<AuctionArtworkFilterProps> = ({
         viewer={viewer}
         Filters={
           <Join separator={<Spacer y={4} />}>
-            {showKeywordFilter && <KeywordFilter />}
+            <KeywordFilter />
             <ArtistsFilter expanded />
             <PriceRangeFilter expanded />
             <MediumFilter expanded />

--- a/src/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/Apps/Fair/Routes/FairArtworks.tsx
@@ -23,7 +23,6 @@ import { ArtworkLocationFilter } from "Components/ArtworkFilter/ArtworkFilters/A
 import { SizeFilter } from "Components/ArtworkFilter/ArtworkFilters/SizeFilter"
 import { ActiveFilterPills } from "Components/SavedSearchAlert/Components/ActiveFilterPills"
 import { useSystemContext } from "System/useSystemContext"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
 import { Join, Spacer } from "@artsy/palette"
 
@@ -36,7 +35,6 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   const { relay, fair } = props
   const { match } = useRouter()
   const { userPreferences } = useSystemContext()
-  const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
   const { filtered_artworks, sidebarAggregations } = fair
 
   const hasFilter = filtered_artworks && filtered_artworks.id
@@ -53,7 +51,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   // in <ArtistsFilter />. So, pass as props for now.
   const Filters = (
     <Join separator={<Spacer y={4} />}>
-      {showKeywordFilter && <KeywordFilter />}
+      <KeywordFilter />
       <PartnersFilter label="Exhibitors" expanded />
       <ArtistsFilter fairID={fair.internalID} expanded />
       <AttributionClassFilter expanded />

--- a/src/Apps/Gene/Components/__tests__/GeneArtworkFilter.jest.tsx
+++ b/src/Apps/Gene/Components/__tests__/GeneArtworkFilter.jest.tsx
@@ -78,6 +78,10 @@ describe("GeneArtworkFilter", () => {
     const filterWrappers = wrapper.find("FilterExpandable")
     const filters = [
       {
+        label: "Keyword Search",
+        expanded: true,
+      },
+      {
         label: "Artists",
         expanded: true,
       },

--- a/src/Apps/Partner/Routes/__tests__/Works.jest.tsx
+++ b/src/Apps/Partner/Routes/__tests__/Works.jest.tsx
@@ -101,6 +101,10 @@ describe("PartnerArtworks", () => {
     const filterWrappers = wrapper.find("FilterExpandable")
     const filters = [
       {
+        label: "Keyword Search",
+        expanded: true,
+      },
+      {
         label: "Artists",
         expanded: true,
       },

--- a/src/Apps/Show/__tests__/ShowArtworks.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowArtworks.jest.tsx
@@ -77,6 +77,10 @@ describe("ShowArtworks", () => {
     const filterWrappers = wrapper.find("FilterExpandable")
     const filters = [
       {
+        label: "Keyword Search",
+        expanded: true,
+      },
+      {
         label: "Artists",
         expanded: true,
       },

--- a/src/Apps/Tag/Components/__tests__/TagArtworkFilter.jest.tsx
+++ b/src/Apps/Tag/Components/__tests__/TagArtworkFilter.jest.tsx
@@ -78,6 +78,10 @@ describe("TagArtworkFilter", () => {
     const filterWrappers = wrapper.find("FilterExpandable")
     const filters = [
       {
+        label: "Keyword Search",
+        expanded: true,
+      },
+      {
         label: "Artists",
         expanded: true,
       },

--- a/src/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -13,7 +13,6 @@ import { PartnersFilter } from "./PartnersFilter"
 import { ArtistsFilter } from "./ArtistsFilter"
 import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { Join, Spacer } from "@artsy/palette"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
 
 interface ArtworkFiltersProps {
@@ -24,11 +23,10 @@ interface ArtworkFiltersProps {
 // Some filters will be rendered only if there is the necessary data in aggregations (for example, ArtistsFilter)
 export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
   const { user, relayEnvironment } = props
-  const showKeywordFilter = useFeatureFlag("artist-artwork-grid-keyword-search")
 
   return (
     <Join separator={<Spacer y={4} />}>
-      {showKeywordFilter && <KeywordFilter />}
+      <KeywordFilter />
       <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
       <AttributionClassFilter expanded />
       <MediumFilter expanded />


### PR DESCRIPTION
The type of this PR is: **Refactor**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4668]

### Description

Clean up `artist-artwork-grid-keyword-search` flag

#### Next Steps

We need to archive the flag after this is deployed

<!-- Implementation description -->

[FX-4668]: https://artsyproduct.atlassian.net/browse/FX-4668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ