### PR TITLE
chore: cleanup trending-sort-for-artist-artwork-grids feature flag

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilter.jest.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilter.jest.tsx
@@ -73,26 +73,4 @@ describe("ArtistArtworkFilter", () => {
     expect(option).toBeInTheDocument()
     expect(option).toHaveValue("-decayed_merch")
   })
-
-  it("should display trending sort for experiment variant", () => {
-    const { renderWithRelay } = getWrapper({
-      context: {
-        featureFlags: {
-          "trending-sort-for-artist-artwork-grids": {
-            flagEnabled: true,
-            variant: {
-              enabled: true,
-              name: "experiment",
-            },
-          },
-        },
-      },
-    })
-
-    renderWithRelay()
-    const option = screen.getByRole("option", { name: "Recommended" })
-
-    expect(option).toBeInTheDocument()
-    expect(option).toHaveValue("-decayed_merch")
-  })
 })


### PR DESCRIPTION
The type of this PR is: Chore

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4669]

### TODO : 

- [ ]  Archive the feature flag from unleash after this PR gets deployed


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-4669]: https://artsyproduct.atlassian.net/browse/FX-4669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ