### PR TITLE
feat(FX-4639): User adds artworks to new list — mutation and toast

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/AddArtworksModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/AddArtworksModal.tsx
@@ -7,7 +7,7 @@ import createLogger from "Utils/logger"
 import { ArtworkList } from "./CreateNewListModal"
 
 interface AddArtworksModalProps {
-  onComplete: (artworkList: ArtworkList) => void
+  onComplete: () => void
   artworkList: ArtworkList
 }
 
@@ -42,7 +42,7 @@ export const AddArtworksModal: FC<AddArtworksModalProps> = ({
         },
       })
 
-      onComplete(artworkList)
+      onComplete()
     } catch (error) {
       logger.error(error)
 
@@ -71,7 +71,7 @@ export const AddArtworksModal: FC<AddArtworksModalProps> = ({
         height: ["100%", "auto"],
         maxHeight: [null, 800],
       }}
-      onClose={() => onComplete(artworkList)}
+      onClose={onComplete}
       title={t("collectorSaves.addArtworksModal.modalTitle", {
         value: artworkList.name,
       })}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/ArtworksList.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/ArtworksList.tsx
@@ -24,9 +24,8 @@ const ArtworksList: FC<ArtworksListProps> = ({
     <GridColumns>
       {extractNodes(artworks).map(artwork => {
         return (
-          <Column span={[6, 4]}>
+          <Column span={[6, 4]} key={artwork.internalID}>
             <ArtworkItem
-              key={artwork.internalID}
               item={artwork}
               selected={selectedIds.includes(artwork.internalID)}
               onItemClick={handleItemClick}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
@@ -23,15 +23,15 @@ export interface CreateNewListValues {
   name: string
 }
 
-export interface NewAddedList {
-  id: string
+export interface ArtworkList {
+  internalID: string
   name: string
 }
 
 interface CreateNewListModalProps {
   artwork?: ArtworkEntity
   onClose: () => void
-  onComplete: (data: NewAddedList) => void
+  onComplete: (data: ArtworkList) => void
   onBackClick?: () => void
 }
 
@@ -83,7 +83,7 @@ export const CreateNewListModal: React.FC<CreateNewListModalProps> = ({
       })
 
       onComplete({
-        id: createCollection?.responseOrError?.collection?.internalID!,
+        internalID: createCollection?.responseOrError?.collection?.internalID!,
         name: values.name,
       })
     } catch (error) {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModalForManageArtwork.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModalForManageArtwork.tsx
@@ -1,6 +1,6 @@
 import {
   CreateNewListModal,
-  NewAddedList,
+  ArtworkList,
 } from "Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal"
 import {
   ListKey,
@@ -20,7 +20,7 @@ export const CreateNewListModalForManageArtwork: FC = () => {
     })
   }
 
-  const onNewListCreated = (payload: NewAddedList) => {
+  const onNewListCreated = (payload: ArtworkList) => {
     dispatch({
       type: "SET_RECENTLY_ADDED_LIST",
       payload,
@@ -29,7 +29,7 @@ export const CreateNewListModalForManageArtwork: FC = () => {
       type: "ADD_OR_REMOVE_LIST_ID",
       payload: {
         listKey: ListKey.AddingListIDs,
-        listID: payload.id,
+        listID: payload.internalID,
       },
     })
     openSelectListsForArtworkModal()

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModalWizard.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModalWizard.tsx
@@ -1,9 +1,9 @@
 import { FC, useState } from "react"
-import { CreateNewListModal, NewAddedList } from "./CreateNewListModal"
+import { CreateNewListModal, ArtworkList } from "./CreateNewListModal"
 import { AddArtworksModal } from "./AddArtworksModal"
 
 export interface CreateNewListModalWizardProps {
-  onComplete: () => void
+  onComplete: (artworkList: ArtworkList) => void
   onClose: () => void
 }
 
@@ -11,22 +11,21 @@ export const CreateNewListModalWizard: FC<CreateNewListModalWizardProps> = ({
   onComplete,
   onClose,
 }) => {
-  const [listName, setListName] = useState<string | null>(null)
+  const [artworkList, setArtworkList] = useState<ArtworkList | null>(null)
 
-  const handleCreateListComplete = (list: NewAddedList) => {
-    setListName(list.name)
+  const handleCreateListComplete = (list: ArtworkList) => {
+    setArtworkList(list)
   }
 
-  const handleAddArtworksComplete = () => {
-    onComplete()
+  const handleAddArtworksComplete = (list: ArtworkList) => {
+    onComplete(list)
   }
 
-  if (listName !== null) {
+  if (artworkList !== null) {
     return (
       <AddArtworksModal
-        onClose={onComplete}
         onComplete={handleAddArtworksComplete}
-        listName={listName}
+        artworkList={artworkList}
       />
     )
   }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModalWizard.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModalWizard.tsx
@@ -17,8 +17,8 @@ export const CreateNewListModalWizard: FC<CreateNewListModalWizardProps> = ({
     setArtworkList(list)
   }
 
-  const handleAddArtworksComplete = (list: ArtworkList) => {
-    onComplete(list)
+  const handleAddArtworksComplete = () => {
+    onComplete(artworkList!)
   }
 
   if (artworkList !== null) {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/AddArtworksModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/AddArtworksModal.jest.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+
+import { useMutation } from "Utils/Hooks/useMutation"
+import { AddArtworksModal } from "Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/AddArtworksModal"
+
+jest.mock("Utils/Hooks/useMutation")
+
+describe("AddArtworksModal", () => {
+  let onComplete: jest.Mock
+  let submitMutation: jest.Mock
+
+  beforeEach(() => {
+    onComplete = jest.fn()
+    submitMutation = jest.fn()
+    ;(useMutation as jest.Mock).mockImplementation(() => {
+      return { submitMutation }
+    })
+  })
+
+  it("renders the modal content", async () => {
+    const list = {
+      internalID: "collectionID",
+      name: "Sculpture",
+    }
+    render(<AddArtworksModal artworkList={list} onComplete={onComplete} />)
+
+    expect(
+      screen.getByText("Sculpture created. Add saved works to the list.")
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Save/ })).toBeInTheDocument()
+  })
+
+  it("calls the mutation when the Save button is clicked", async () => {
+    const list = {
+      internalID: "collectionID",
+      name: "Sculpture",
+    }
+
+    render(<AddArtworksModal artworkList={list} onComplete={onComplete} />)
+
+    const saveButton = screen.getByRole("button", { name: /Save/ })
+    fireEvent.click(saveButton)
+
+    await waitFor(() => expect(submitMutation).toHaveBeenCalledTimes(1))
+
+    expect(submitMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: {
+          input: {
+            artworkIDs: [],
+            addToCollectionIDs: ["collectionID"],
+          },
+        },
+      })
+    )
+  })
+})

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/AddArtworksModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/AddArtworksModal.jest.tsx
@@ -24,9 +24,10 @@ describe("AddArtworksModal", () => {
     }
     render(<AddArtworksModal artworkList={list} onComplete={onComplete} />)
 
-    expect(
-      screen.getByText("Sculpture created. Add saved works to the list.")
-    ).toBeInTheDocument()
+    const title = screen.getByText(
+      "Sculpture created. Add saved works to the list."
+    )
+    expect(title).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /Save/ })).toBeInTheDocument()
   })
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/useAddArtworksToCollection.ts
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/useAddArtworksToCollection.ts
@@ -13,18 +13,8 @@ export const useAddArtworksToCollection = () => {
             ... on ArtworksCollectionsBatchUpdateSuccess {
               addedToCollections {
                 internalID
-                artworksCount
                 default
-
-                artworksConnection(first: 4) {
-                  edges {
-                    node {
-                      image {
-                        url(version: "square")
-                      }
-                    }
-                  }
-                }
+                ...SavesItem_item
               }
             }
             ... on ArtworksCollectionsBatchUpdateFailure {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/useAddArtworksToCollection.ts
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/useAddArtworksToCollection.ts
@@ -1,0 +1,40 @@
+import { useMutation } from "Utils/Hooks/useMutation"
+import { useAddArtworksToCollectionMutation } from "__generated__/useAddArtworksToCollectionMutation.graphql"
+import { graphql } from "react-relay"
+
+export const useAddArtworksToCollection = () => {
+  return useMutation<useAddArtworksToCollectionMutation>({
+    mutation: graphql`
+      mutation useAddArtworksToCollectionMutation(
+        $input: ArtworksCollectionsBatchUpdateInput!
+      ) {
+        artworksCollectionsBatchUpdate(input: $input) {
+          responseOrError {
+            ... on ArtworksCollectionsBatchUpdateSuccess {
+              addedToCollections {
+                internalID
+                artworksCount
+                default
+
+                artworksConnection(first: 4) {
+                  edges {
+                    node {
+                      image {
+                        url(version: "square")
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ... on ArtworksCollectionsBatchUpdateFailure {
+              mutationError {
+                statusCode
+              }
+            }
+          }
+        }
+      }
+    `,
+  })
+}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SavesHeader.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SavesHeader.tsx
@@ -3,6 +3,7 @@ import { Box, Text, Spacer, Button, Join } from "@artsy/palette"
 import { useToasts } from "@artsy/palette"
 import { useTranslation } from "react-i18next"
 import { CreateNewListModalWizard } from "./CreateNewListModal/CreateNewListModalWizard"
+import { ArtworkList } from "./CreateNewListModal/CreateNewListModal"
 
 export const SavesHeader: FC = () => {
   const { t } = useTranslation()
@@ -13,12 +14,14 @@ export const SavesHeader: FC = () => {
     setModalIsOpened(true)
   }
 
-  const handleComplete = () => {
+  const handleComplete = (artworkList: ArtworkList) => {
     setModalIsOpened(false)
 
     sendToast({
       variant: "success",
-      message: t("collectorSaves.savesHeader.listCreated"),
+      message: t("collectorSaves.savesHeader.listCreated", {
+        listName: artworkList.name,
+      }),
     })
   }
 

--- a/src/Components/Artwork/ManageArtworkForSaves.tsx
+++ b/src/Components/Artwork/ManageArtworkForSaves.tsx
@@ -1,5 +1,5 @@
 import { useToasts } from "@artsy/palette"
-import { NewAddedList } from "Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal"
+import { ArtworkList } from "Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal"
 import { CreateNewListModalForManageArtwork } from "Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModalForManageArtwork"
 import { SelectListsForArtworkModalQueryRender } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal"
 import {
@@ -23,7 +23,7 @@ type State = {
   artwork: ArtworkEntity | null
   addingListIDs: string[]
   removingListIDs: string[]
-  recentlyAddedList: NewAddedList | null
+  recentlyAddedList: ArtworkList | null
 }
 
 export enum ListKey {
@@ -33,7 +33,7 @@ export enum ListKey {
 
 type Action =
   | { type: "SET_MODAL_KEY"; payload: ModalKey }
-  | { type: "SET_RECENTLY_ADDED_LIST"; payload: NewAddedList | null }
+  | { type: "SET_RECENTLY_ADDED_LIST"; payload: ArtworkList | null }
   | { type: "SET_ARTWORK"; payload: ArtworkEntity | null }
   | { type: "RESET" }
   | {

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -118,7 +118,7 @@
       "artworkWithCount_other": "{{count}} Artworks"
     },
     "savesHeader": {
-      "listCreated": "List Created",
+      "listCreated": "{{listName}} Created",
       "savedArtworks": "Saved Artworks",
       "curateYourList": "Curate your own lists of the works you love",
       "createNewListButton": "Create New List"

--- a/src/__generated__/useAddArtworksToCollectionMutation.graphql.ts
+++ b/src/__generated__/useAddArtworksToCollectionMutation.graphql.ts
@@ -1,0 +1,345 @@
+/**
+ * @generated SignedSource<<bd87a5b518993397512f6208c531eacc>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type ArtworksCollectionsBatchUpdateInput = {
+  addToCollectionIDs?: ReadonlyArray<string> | null;
+  artworkIDs: ReadonlyArray<string>;
+  clientMutationId?: string | null;
+  removeFromCollectionIDs?: ReadonlyArray<string> | null;
+};
+export type useAddArtworksToCollectionMutation$variables = {
+  input: ArtworksCollectionsBatchUpdateInput;
+};
+export type useAddArtworksToCollectionMutation$data = {
+  readonly artworksCollectionsBatchUpdate: {
+    readonly responseOrError: {
+      readonly addedToCollections?: ReadonlyArray<{
+        readonly artworksConnection: {
+          readonly edges: ReadonlyArray<{
+            readonly node: {
+              readonly image: {
+                readonly url: string | null;
+              } | null;
+            } | null;
+          } | null> | null;
+        } | null;
+        readonly artworksCount: number;
+        readonly default: boolean;
+        readonly internalID: string;
+      } | null> | null;
+      readonly mutationError?: {
+        readonly statusCode: number | null;
+      } | null;
+    } | null;
+  } | null;
+};
+export type useAddArtworksToCollectionMutation = {
+  response: useAddArtworksToCollectionMutation$data;
+  variables: useAddArtworksToCollectionMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "artworksCount",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "default",
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 4
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "version",
+          "value": "square"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "url",
+      "storageKey": "url(version:\"square\")"
+    }
+  ],
+  "storageKey": null
+},
+v7 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GravityMutationError",
+      "kind": "LinkedField",
+      "name": "mutationError",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "statusCode",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "ArtworksCollectionsBatchUpdateFailure",
+  "abstractKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useAddArtworksToCollectionMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtworksCollectionsBatchUpdatePayload",
+        "kind": "LinkedField",
+        "name": "artworksCollectionsBatchUpdate",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "responseOrError",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Collection",
+                    "kind": "LinkedField",
+                    "name": "addedToCollections",
+                    "plural": true,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": (v5/*: any*/),
+                        "concreteType": "ArtworkConnection",
+                        "kind": "LinkedField",
+                        "name": "artworksConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "kind": "LinkedField",
+                            "name": "edges",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "kind": "LinkedField",
+                                "name": "node",
+                                "plural": false,
+                                "selections": [
+                                  (v6/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "artworksConnection(first:4)"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "ArtworksCollectionsBatchUpdateSuccess",
+                "abstractKey": null
+              },
+              (v7/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useAddArtworksToCollectionMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtworksCollectionsBatchUpdatePayload",
+        "kind": "LinkedField",
+        "name": "artworksCollectionsBatchUpdate",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "responseOrError",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Collection",
+                    "kind": "LinkedField",
+                    "name": "addedToCollections",
+                    "plural": true,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": (v5/*: any*/),
+                        "concreteType": "ArtworkConnection",
+                        "kind": "LinkedField",
+                        "name": "artworksConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "kind": "LinkedField",
+                            "name": "edges",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "kind": "LinkedField",
+                                "name": "node",
+                                "plural": false,
+                                "selections": [
+                                  (v6/*: any*/),
+                                  (v8/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "artworksConnection(first:4)"
+                      },
+                      (v8/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "ArtworksCollectionsBatchUpdateSuccess",
+                "abstractKey": null
+              },
+              (v7/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "a26f50fccab03bfd8fe826eeeaddf755",
+    "id": null,
+    "metadata": {},
+    "name": "useAddArtworksToCollectionMutation",
+    "operationKind": "mutation",
+    "text": "mutation useAddArtworksToCollectionMutation(\n  $input: ArtworksCollectionsBatchUpdateInput!\n) {\n  artworksCollectionsBatchUpdate(input: $input) {\n    responseOrError {\n      __typename\n      ... on ArtworksCollectionsBatchUpdateSuccess {\n        addedToCollections {\n          internalID\n          artworksCount\n          default\n          artworksConnection(first: 4) {\n            edges {\n              node {\n                image {\n                  url(version: \"square\")\n                }\n                id\n              }\n            }\n          }\n          id\n        }\n      }\n      ... on ArtworksCollectionsBatchUpdateFailure {\n        mutationError {\n          statusCode\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "6c458bc52ef2c591e6714a857d958fd9";
+
+export default node;

--- a/src/__generated__/useAddArtworksToCollectionMutation.graphql.ts
+++ b/src/__generated__/useAddArtworksToCollectionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bd87a5b518993397512f6208c531eacc>>
+ * @generated SignedSource<<9011646d0b72d899a83689887f7f3a3d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Mutation } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type ArtworksCollectionsBatchUpdateInput = {
   addToCollectionIDs?: ReadonlyArray<string> | null;
   artworkIDs: ReadonlyArray<string>;
@@ -22,18 +23,9 @@ export type useAddArtworksToCollectionMutation$data = {
   readonly artworksCollectionsBatchUpdate: {
     readonly responseOrError: {
       readonly addedToCollections?: ReadonlyArray<{
-        readonly artworksConnection: {
-          readonly edges: ReadonlyArray<{
-            readonly node: {
-              readonly image: {
-                readonly url: string | null;
-              } | null;
-            } | null;
-          } | null> | null;
-        } | null;
-        readonly artworksCount: number;
         readonly default: boolean;
         readonly internalID: string;
+        readonly " $fragmentSpreads": FragmentRefs<"SavesItem_item">;
       } | null> | null;
       readonly mutationError?: {
         readonly statusCode: number | null;
@@ -72,48 +64,10 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "artworksCount",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "default",
   "storageKey": null
 },
-v5 = [
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 4
-  }
-],
-v6 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Image",
-  "kind": "LinkedField",
-  "name": "image",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "version",
-          "value": "square"
-        }
-      ],
-      "kind": "ScalarField",
-      "name": "url",
-      "storageKey": "url(version:\"square\")"
-    }
-  ],
-  "storageKey": null
-},
-v7 = {
+v4 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -138,7 +92,7 @@ v7 = {
   "type": "ArtworksCollectionsBatchUpdateFailure",
   "abstractKey": null
 },
-v8 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -181,40 +135,10 @@ return {
                     "selections": [
                       (v2/*: any*/),
                       (v3/*: any*/),
-                      (v4/*: any*/),
                       {
-                        "alias": null,
-                        "args": (v5/*: any*/),
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  (v6/*: any*/)
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:4)"
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "SavesItem_item"
                       }
                     ],
                     "storageKey": null
@@ -223,7 +147,7 @@ return {
                 "type": "ArtworksCollectionsBatchUpdateSuccess",
                 "abstractKey": null
               },
-              (v7/*: any*/)
+              (v4/*: any*/)
             ],
             "storageKey": null
           }
@@ -276,10 +200,29 @@ return {
                     "selections": [
                       (v2/*: any*/),
                       (v3/*: any*/),
-                      (v4/*: any*/),
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "artworksCount",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "first",
+                            "value": 4
+                          }
+                        ],
                         "concreteType": "ArtworkConnection",
                         "kind": "LinkedField",
                         "name": "artworksConnection",
@@ -301,8 +244,31 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v6/*: any*/),
-                                  (v8/*: any*/)
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": "square"
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:\"square\")"
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  (v5/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -312,7 +278,7 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:4)"
                       },
-                      (v8/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -320,7 +286,7 @@ return {
                 "type": "ArtworksCollectionsBatchUpdateSuccess",
                 "abstractKey": null
               },
-              (v7/*: any*/)
+              (v4/*: any*/)
             ],
             "storageKey": null
           }
@@ -330,16 +296,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a26f50fccab03bfd8fe826eeeaddf755",
+    "cacheID": "ffcdf4e3da25243fbfb0558794f3ae73",
     "id": null,
     "metadata": {},
     "name": "useAddArtworksToCollectionMutation",
     "operationKind": "mutation",
-    "text": "mutation useAddArtworksToCollectionMutation(\n  $input: ArtworksCollectionsBatchUpdateInput!\n) {\n  artworksCollectionsBatchUpdate(input: $input) {\n    responseOrError {\n      __typename\n      ... on ArtworksCollectionsBatchUpdateSuccess {\n        addedToCollections {\n          internalID\n          artworksCount\n          default\n          artworksConnection(first: 4) {\n            edges {\n              node {\n                image {\n                  url(version: \"square\")\n                }\n                id\n              }\n            }\n          }\n          id\n        }\n      }\n      ... on ArtworksCollectionsBatchUpdateFailure {\n        mutationError {\n          statusCode\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation useAddArtworksToCollectionMutation(\n  $input: ArtworksCollectionsBatchUpdateInput!\n) {\n  artworksCollectionsBatchUpdate(input: $input) {\n    responseOrError {\n      __typename\n      ... on ArtworksCollectionsBatchUpdateSuccess {\n        addedToCollections {\n          internalID\n          default\n          ...SavesItem_item\n          id\n        }\n      }\n      ... on ArtworksCollectionsBatchUpdateFailure {\n        mutationError {\n          statusCode\n        }\n      }\n    }\n  }\n}\n\nfragment SavesItem_item on Collection {\n  default\n  name\n  internalID\n  artworksCount\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6c458bc52ef2c591e6714a857d958fd9";
+(node as any).hash = "1598a0cf72415741193cb25f9ddd0167";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [FX-4639]

### Description

- Pressing Save commits the mutation
- A confirmation toast is displayed

### Demo

- [Review app](https://create-list-mutation.artsy.net/)

| Desktop | Mobile Web |
|---|---|
| <video src="https://user-images.githubusercontent.com/3934579/225592240-6b48fe89-2a8a-4aa9-a830-8abdd2eed5b3.mp4" /> | <video src="https://user-images.githubusercontent.com/3934579/225592260-165456b3-de5b-4e40-aed4-d157b757e1a8.mp4" /> |

[FX-4639]: https://artsyproduct.atlassian.net/browse/FX-4639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ