### PR TITLE
feat: update bidding starts copy

### DIFF
--- a/src/Utils/__tests__/getSaleOrLotTimerInfo.jest.ts
+++ b/src/Utils/__tests__/getSaleOrLotTimerInfo.jest.ts
@@ -1,4 +1,4 @@
-import { getSaleOrLotTimerInfo } from "../getSaleOrLotTimerInfo"
+import { getSaleOrLotTimerInfo } from "Utils/getSaleOrLotTimerInfo"
 
 describe("getSaleOrLotTimerInfo", () => {
   describe("when the timer info is on the sale", () => {
@@ -87,7 +87,7 @@ describe("getSaleOrLotTimerInfo", () => {
             lotsAreClosing,
             isSaleInfo,
           })
-          expect(saleTimerInfo.copy).toEqual("Bidding Starts Today")
+          expect(saleTimerInfo.copy).toEqual("20h 0m Until Bidding Starts")
           expect(saleTimerInfo.color).toEqual("blue100")
         })
       })
@@ -211,7 +211,7 @@ describe("getSaleOrLotTimerInfo", () => {
         const time = { days: "00", hours: "23", minutes: "01", seconds: "59" }
         it("shows '1 Day Until Bidding Starts'", () => {
           const lotTimerInfo = getSaleOrLotTimerInfo(time, { hasStarted })
-          expect(lotTimerInfo.copy).toEqual("Bidding Starts Today")
+          expect(lotTimerInfo.copy).toEqual("23h 1m Until Bidding Starts")
           expect(lotTimerInfo.color).toEqual("blue100")
         })
       })

--- a/src/Utils/getSaleOrLotTimerInfo.ts
+++ b/src/Utils/getSaleOrLotTimerInfo.ts
@@ -42,8 +42,12 @@ export const getSaleOrLotTimerInfo = (
   // Sale has not yet started
   if (!hasStarted) {
     if (parsedDays < 1) {
-      copy = "Bidding Starts Today"
       // Entered extended bidding
+      if (parsedHours >= 1) {
+        copy = `${parsedHours}h ${parsedMinutes}m Until Bidding Starts`
+      } else {
+        copy = `${parsedMinutes}m ${parsedSeconds}s Until Bidding Starts`
+      }
     } else {
       copy = `${parsedDays} Day${
         parsedDays > 1 ? "s" : ""


### PR DESCRIPTION


The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-1102]

### Description
In some cases, because of timezone issues, the copy would show "Bidding Starts Today" for starting tomorrow lots.

The intent here is to have the same logic we use in Eigen (src/app/utils/saleTime.ts).

**_Before_**
![image](https://user-images.githubusercontent.com/554507/226900011-72f496da-23fb-4521-84d9-d92f8a65bd7e.png)


**_After_**
![image](https://user-images.githubusercontent.com/554507/226899943-15da78ee-3e72-43d4-a6fa-3a1a3099052f.png)


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-1102]: https://artsyproduct.atlassian.net/browse/TX-1102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ