### PR TITLE
fix: update incorrect zip code in wire instructions

### DIFF
--- a/src/Apps/Order/Routes/__tests__/Status.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Status.jest.tsx
@@ -289,7 +289,7 @@ describe("Status", () => {
           expect(page.text()).toContain("Bank address")
           expect(page.text()).toContain("Wells Fargo Bank, N.A.")
           expect(page.text()).toContain("420 Montgomery Street")
-          expect(page.text()).toContain("San Francisco, CA 9410")
+          expect(page.text()).toContain("San Francisco, CA 94104")
         })
       })
 
@@ -734,7 +734,7 @@ describe("Status", () => {
           expect(page.text()).toContain("Bank address")
           expect(page.text()).toContain("Wells Fargo Bank, N.A.")
           expect(page.text()).toContain("420 Montgomery Street")
-          expect(page.text()).toContain("San Francisco, CA 9410")
+          expect(page.text()).toContain("San Francisco, CA 94104")
         })
 
         it("renders correct Artsy bank details for orders in GBP", async () => {

--- a/src/Apps/Order/Utils/getStatusCopy.tsx
+++ b/src/Apps/Order/Utils/getStatusCopy.tsx
@@ -497,7 +497,7 @@ export const wireTransferArtsyBankDetails = order => {
           <Spacer y={1} />
           <Text>Wells Fargo Bank, N.A.</Text>
           <Text>420 Montgomery Street</Text>
-          <Text>San Francisco, CA 9410</Text>
+          <Text>San Francisco, CA 94104</Text>
           <Spacer y={2} />
           <Text color="#1023D7">
             Add order number #{order.code} to the notes section in your wire


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-1104]

### Description
Update incorrect zip code in wire instructions.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-1104]: https://artsyproduct.atlassian.net/browse/TX-1104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ