### PR TITLE
feat: area-based image resizing for artwork shelf

### DIFF
--- a/src/Components/Artwork/ShelfArtwork.tsx
+++ b/src/Components/Artwork/ShelfArtwork.tsx
@@ -6,36 +6,51 @@ import Metadata, { MetadataPlaceholder } from "Components/Artwork/Metadata"
 import { AuthContextModule } from "@artsy/cohesion"
 import { Box, Image, SkeletonBox } from "@artsy/palette"
 import { useHoverMetadata } from "Components/Artwork/useHoverMetadata"
-import { resized } from "Utils/resized"
 import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
+import { maxWidthByArea, resized } from "Utils/resized"
+
+const DEFAULT_AREA = 200 * 200
+const DEFAULT_MAX_IMG_HEIGHT = 250
+const DEFAULT_MAX_WIDTH = 500
 
 export interface ShelfArtworkProps
   extends Omit<RouterLinkProps, "to" | "width"> {
+  // Target number of pixels for image to occupy
+  area?: number
   artwork: ShelfArtwork_artwork$data
   children?: React.ReactNode
   contextModule?: AuthContextModule
   hideSaleInfo?: boolean
   lazyLoad?: boolean
+  maxImageHeight?: number
   onClick?: () => void
-  width?: number[]
 }
 
 const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
+  area = DEFAULT_AREA,
   artwork,
+  children,
   contextModule,
   hideSaleInfo,
   lazyLoad,
+  maxImageHeight = DEFAULT_MAX_IMG_HEIGHT,
+  maxWidth = DEFAULT_MAX_WIDTH,
   onClick,
-  width = [150, 175, 200],
-  children,
   ...rest
 }) => {
   const { isHovered, onMouseEnter, onMouseLeave } = useHoverMetadata()
 
-  // Resize image to largest width expected
-  const image = artwork.image?.src
-    ? resized(artwork.image.src, { width: width[width.length - 1] })
-    : null
+  if (!artwork.image?.src || !artwork.image.width || !artwork.image.height) {
+    return null
+  }
+
+  const width = maxWidthByArea({
+    area,
+    height: artwork.image.height,
+    width: artwork.image.width,
+  })
+
+  const image = resized(artwork.image.src, { width })
 
   const label =
     (artwork.title ?? "Artwork") +
@@ -56,12 +71,13 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
         data-testid="ShelfArtwork"
         aria-label={label}
         width={width}
+        maxWidth={maxWidth}
+        overflow="hidden"
         {...rest}
       >
-        {image ? (
+        <Box height={maxImageHeight} display="flex" alignItems="flex-end">
           <Box
-            maxHeight={[250, 320]}
-            maxWidth="100%"
+            width="100%"
             style={{
               aspectRatio: `${artwork.image?.width ?? 1} / ${
                 artwork.image?.height ?? 1
@@ -75,13 +91,11 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
               width="100%"
               height="100%"
               lazyLoad={lazyLoad}
-              style={{ objectFit: "contain" }}
+              style={{ display: "block", objectFit: "cover" }}
               alt=""
             />
           </Box>
-        ) : (
-          <Box style={{ aspectRatio: "1 / 1" }} maxWidth="100%" bg="black10" />
-        )}
+        </Box>
 
         <Metadata
           artwork={artwork}
@@ -119,27 +133,43 @@ export const ShelfArtworkFragmentContainer = createFragmentContainer(
 )
 
 interface ShelfArtworkPlaceholderProps
-  extends Pick<ShelfArtworkProps, "hideSaleInfo" | "children"> {
+  extends Pick<
+    ShelfArtworkProps,
+    "area" | "hideSaleInfo" | "children" | "maxImageHeight"
+  > {
   // Used to cycle through a set of placeholder heights
   index: number
-  width?: number[]
 }
 
 export const ShelfArtworkPlaceholder: React.FC<ShelfArtworkPlaceholderProps> = ({
   index,
-  width = [150, 175, 200],
+  hideSaleInfo,
+  area = DEFAULT_AREA,
+  maxImageHeight = DEFAULT_MAX_IMG_HEIGHT,
   children,
 }) => {
+  const width = [275, 200, 300, 250][index % 4]
+  const height = [200, 300, 250, 275][index % 4]
+
+  const maxWidth = maxWidthByArea({
+    area,
+    height,
+    width,
+  })
+  const scaledHeight = Math.round((height / width) * maxWidth)
+
   return (
     <Box
       display="flex"
       flexDirection="column"
       justifyContent="flex-end"
-      width={width}
+      width={maxWidth}
     >
-      <SkeletonBox width="100W%" height={[200, 300, 250, 275][index % 4]} />
+      <Box height={maxImageHeight} display="flex" alignItems="flex-end">
+        <SkeletonBox width={maxWidth} height={scaledHeight} />
+      </Box>
 
-      <MetadataPlaceholder />
+      <MetadataPlaceholder hideSaleInfo={hideSaleInfo} />
 
       {children}
     </Box>

--- a/src/Components/Artwork/__stories__/ShelfArtwork.story.tsx
+++ b/src/Components/Artwork/__stories__/ShelfArtwork.story.tsx
@@ -18,20 +18,16 @@ export const Default = () => {
         { id: "morris-louis-gamma-delta" },
         {
           id: "morris-louis-gamma-delta",
-          width: [100],
         },
         {
           id: "morris-louis-gamma-delta",
-          width: [400],
         },
         { id: "roni-horn-best-witchcraft-is-geometry" },
         {
           id: "roni-horn-best-witchcraft-is-geometry",
-          width: [100],
         },
         {
           id: "roni-horn-best-witchcraft-is-geometry",
-          width: [400],
         },
         // Very tall + narrow
         { id: "barnett-newman-the-moment-from-four-on-plexiglas" },

--- a/src/Utils/__tests__/resized.jest.ts
+++ b/src/Utils/__tests__/resized.jest.ts
@@ -1,4 +1,4 @@
-import { cropped, resized } from "Utils/resized"
+import { cropped, maxWidthByArea, resized } from "Utils/resized"
 
 jest.mock("sharify", () => ({
   data: {
@@ -62,5 +62,41 @@ describe("#resized", () => {
     expect(srcSet).toContain("2x")
     expect(srcSet).toContain("height=200")
     expect(srcSet).toContain("quality=80")
+  })
+})
+
+describe("maxWidthByArea", () => {
+  it("sets a max width for a proportional box", () => {
+    expect(
+      maxWidthByArea({
+        width: 100,
+        height: 100,
+        area: 10000,
+      })
+    ).toEqual(100)
+
+    expect(
+      maxWidthByArea({
+        width: 200,
+        height: 100,
+        area: 10000,
+      })
+    ).toEqual(141)
+
+    expect(
+      maxWidthByArea({
+        width: 100,
+        height: 200,
+        area: 10000,
+      })
+    ).toEqual(71)
+
+    expect(
+      maxWidthByArea({
+        width: 10,
+        height: 200,
+        area: 10000,
+      })
+    ).toEqual(22)
   })
 })

--- a/src/Utils/resized.ts
+++ b/src/Utils/resized.ts
@@ -90,3 +90,15 @@ export const cropped = (
     srcSet: `${_1x} 1x, ${_2x} 2x`,
   }
 }
+
+export const maxWidthByArea = ({
+  width,
+  height,
+  area,
+}: {
+  width: number
+  height: number
+  area: number
+}) => {
+  return Math.round(width * Math.sqrt(area / (width * height)))
+}


### PR DESCRIPTION
This PR picks up off of https://github.com/artsy/force/pull/11126 — we wound up pulling over all the placeholder work from that initial PR so this winds up being pretty easy to drop in.

| Before | After |
| ---- | ---- |
| ![www artsy net_artist_lee-krasner](https://user-images.githubusercontent.com/112297/228333934-8feead30-9b5b-417f-bb32-4963616b0eb1.png) |  ![localhost_5050_artist_lee-krasner](https://user-images.githubusercontent.com/112297/228333976-2433db81-a4e7-4b1f-9cd3-82d1edbb53b5.png) |
| ![staging artsy net_artist_jackson-pollock](https://user-images.githubusercontent.com/112297/228334190-24e53bfe-90b1-484b-a7a2-0e6bbeb571ca.png) | ![localhost_5050_artist_jackson-pollock](https://user-images.githubusercontent.com/112297/228334237-f212906a-d388-4b76-9583-f1af87e5653e.png) |
| ![staging artsy net_artist_julie-mehretu](https://user-images.githubusercontent.com/112297/228334371-20c0a833-7afa-47f9-8a3b-a7ad2f3c0c83.png) | ![localhost_5050_artist_julie-mehretu](https://user-images.githubusercontent.com/112297/228334409-262d279f-385d-4c3c-98f4-f2e9a640b93f.png) |
