### PR TITLE
refactor(phase 4): standardise and use `ArtworkList` terminology

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -1,6 +1,6 @@
 import { Shelf, Spacer } from "@artsy/palette"
 import { ArtworkListContentQueryRenderer } from "./Components/ArtworkListContent"
-import { SavesHeader } from "./Components/SavesHeader"
+import { ArtworkListsHeader } from "./Components/ArtworkListsHeader"
 import { ArtworkListItemFragmentContainer } from "./Components/ArtworkListItem"
 import { FC, useRef } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -42,7 +42,7 @@ const CollectorProfileSaves2Route: FC<CollectorProfileSaves2RouteProps> = ({
 
   return (
     <>
-      <SavesHeader />
+      <ArtworkListsHeader />
 
       <Spacer y={4} />
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListItem.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListItem.tsx
@@ -1,6 +1,6 @@
 import { Box, DROP_SHADOW, Flex, Text } from "@artsy/palette"
-import { FourUpImageLayout } from "Apps/CollectorProfile/Routes/Saves2/Components/FourUpImageLayout"
-import { StackedImageLayout } from "Apps/CollectorProfile/Routes/Saves2/Components/StackedImageLayout"
+import { FourUpImageLayout } from "./Images/FourUpImageLayout"
+import { StackedImageLayout } from "./Images/StackedImageLayout"
 import { FC } from "react"
 import { useTranslation } from "react-i18next"
 import { createFragmentContainer, graphql } from "react-relay"

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListsHeader.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListsHeader.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next"
 import { CreateNewListModalWizard } from "./CreateNewListModal/CreateNewListModalWizard"
 import { ArtworkList } from "./CreateNewListModal/CreateNewListModal"
 
-export const SavesHeader: FC = () => {
+export const ArtworkListsHeader: FC = () => {
   const { t } = useTranslation()
   const { sendToast } = useToasts()
   const [modalIsOpened, setModalIsOpened] = useState(false)
@@ -19,7 +19,7 @@ export const SavesHeader: FC = () => {
 
     sendToast({
       variant: "success",
-      message: t("collectorSaves.savesHeader.listCreated", {
+      message: t("collectorSaves.artworkListsHeader.listCreated", {
         listName: artworkList.name,
       }),
     })
@@ -40,7 +40,7 @@ export const SavesHeader: FC = () => {
 
       <Join separator={<Spacer y={0.5} />}>
         <Text variant="lg-display">
-          {t("collectorSaves.savesHeader.savedArtworks")}
+          {t("collectorSaves.artworkListsHeader.savedArtworks")}
         </Text>
 
         <Box
@@ -50,7 +50,7 @@ export const SavesHeader: FC = () => {
           alignItems={["stretch", "center"]}
         >
           <Text variant="sm-display" color="black60">
-            {t("collectorSaves.savesHeader.curateYourList")}
+            {t("collectorSaves.artworkListsHeader.curateYourList")}
           </Text>
 
           <Button
@@ -59,7 +59,7 @@ export const SavesHeader: FC = () => {
             onClick={handleCreateNewListClick}
             mt={[2, 0]}
           >
-            {t("collectorSaves.savesHeader.createNewListButton")}
+            {t("collectorSaves.artworkListsHeader.createNewListButton")}
           </Button>
         </Box>
       </Join>

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/ArtworkListNoImage.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/ArtworkListNoImage.tsx
@@ -3,7 +3,7 @@ import { FC } from "react"
 
 const NO_ICON_SIZE = 18
 
-export const SavesNoImage: FC<FlexProps> = props => {
+export const ArtworkListNoImage: FC<FlexProps> = props => {
   return (
     <Flex
       bg="black5"

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/FourUpImageLayout.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/FourUpImageLayout.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Image, Spacer } from "@artsy/palette"
-import { SavesNoImage } from "Apps/CollectorProfile/Routes/Saves2/Components/SavesNoImage"
+import { ArtworkListNoImage } from "./ArtworkListNoImage"
 import { prepareImageURLs } from "Apps/CollectorProfile/Routes/Saves2/Utils/prepareImageURLs"
 import { FC } from "react"
 import { cropped } from "Utils/resized"
@@ -44,7 +44,7 @@ const RowImage: FC<RowImageProps> = ({ url }) => {
   const SIZE = [SMALL_IMAGE_SIZE, LARGE_IMAGE_SIZE]
 
   if (url === null) {
-    return <SavesNoImage width={SIZE} height={SIZE} />
+    return <ArtworkListNoImage width={SIZE} height={SIZE} />
   }
 
   const image = cropped(url, {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/StackedImageLayout.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/StackedImageLayout.tsx
@@ -1,5 +1,5 @@
 import { Box, Image } from "@artsy/palette"
-import { SavesNoImage } from "Apps/CollectorProfile/Routes/Saves2/Components/SavesNoImage"
+import { ArtworkListNoImage } from "./ArtworkListNoImage"
 import { prepareImageURLs } from "Apps/CollectorProfile/Routes/Saves2/Utils/prepareImageURLs"
 import { FC } from "react"
 import { cropped } from "Utils/resized"
@@ -46,7 +46,7 @@ const StackImage: FC<StackImageProps> = ({ url, index }) => {
 
   if (url === null) {
     return (
-      <SavesNoImage
+      <ArtworkListNoImage
         width={SIZE}
         height={SIZE}
         position="absolute"

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/__tests__/FourUpImageLayout.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/__tests__/FourUpImageLayout.jest.tsx
@@ -1,23 +1,23 @@
 import { render, screen } from "@testing-library/react"
-import { StackedImageLayout } from "Apps/CollectorProfile/Routes/Saves2/Components/StackedImageLayout"
+import { FourUpImageLayout } from "Apps/CollectorProfile/Routes/Saves2/Components/Images/FourUpImageLayout"
 
-describe("StackedImageLayout", () => {
+describe("FourUpImageLayout", () => {
   it("should render all passed images", () => {
     render(
-      <StackedImageLayout imageURLs={["url-1", "url-2", "url-3", "url-4"]} />
+      <FourUpImageLayout imageURLs={["url-1", "url-2", "url-3", "url-4"]} />
     )
 
     expect(screen.getAllByAltText("")).toHaveLength(4)
   })
 
   it("should render image placeholders if nothing is passed", () => {
-    render(<StackedImageLayout imageURLs={[]} />)
+    render(<FourUpImageLayout imageURLs={[]} />)
 
     expect(screen.getAllByLabelText("Image placeholder")).toHaveLength(4)
   })
 
   it("should render image placeholders and images", () => {
-    render(<StackedImageLayout imageURLs={["url-1", null, null, "url-4"]} />)
+    render(<FourUpImageLayout imageURLs={["url-1", null, null, "url-4"]} />)
 
     expect(screen.getAllByLabelText("Image placeholder")).toHaveLength(2)
     expect(screen.getAllByAltText("")).toHaveLength(2)

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/__tests__/StackedImageLayout.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/__tests__/StackedImageLayout.jest.tsx
@@ -1,23 +1,23 @@
 import { render, screen } from "@testing-library/react"
-import { FourUpImageLayout } from "Apps/CollectorProfile/Routes/Saves2/Components/FourUpImageLayout"
+import { StackedImageLayout } from "Apps/CollectorProfile/Routes/Saves2/Components/Images/StackedImageLayout"
 
-describe("FourUpImageLayout", () => {
+describe("StackedImageLayout", () => {
   it("should render all passed images", () => {
     render(
-      <FourUpImageLayout imageURLs={["url-1", "url-2", "url-3", "url-4"]} />
+      <StackedImageLayout imageURLs={["url-1", "url-2", "url-3", "url-4"]} />
     )
 
     expect(screen.getAllByAltText("")).toHaveLength(4)
   })
 
   it("should render image placeholders if nothing is passed", () => {
-    render(<FourUpImageLayout imageURLs={[]} />)
+    render(<StackedImageLayout imageURLs={[]} />)
 
     expect(screen.getAllByLabelText("Image placeholder")).toHaveLength(4)
   })
 
   it("should render image placeholders and images", () => {
-    render(<FourUpImageLayout imageURLs={["url-1", null, null, "url-4"]} />)
+    render(<StackedImageLayout imageURLs={["url-1", null, null, "url-4"]} />)
 
     expect(screen.getAllByLabelText("Image placeholder")).toHaveLength(2)
     expect(screen.getAllByAltText("")).toHaveLength(2)

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SavesEntityImage.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SavesEntityImage.tsx
@@ -1,5 +1,5 @@
 import { Image } from "@artsy/palette"
-import { SavesNoImage } from "./SavesNoImage"
+import { ArtworkListNoImage } from "./Images/ArtworkListNoImage"
 import { FC } from "react"
 import { cropped } from "Utils/resized"
 
@@ -13,7 +13,7 @@ export const SavesEntityImage: FC<SavesEntityImageProps> = ({
   size = 60,
 }) => {
   if (url === null) {
-    return <SavesNoImage width={size} height={size} />
+    return <ArtworkListNoImage width={size} height={size} />
   }
 
   const image = cropped(url, {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/__tests__/ArtworkListsHeader.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/__tests__/ArtworkListsHeader.jest.tsx
@@ -1,9 +1,9 @@
 import { render, screen, fireEvent } from "@testing-library/react"
-import { SavesHeader } from "Apps/CollectorProfile/Routes/Saves2/Components/SavesHeader"
+import { ArtworkListsHeader } from "Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListsHeader"
 
-describe("SavesHeader", () => {
+describe("ArtworkListsHeader", () => {
   it("renders header text and creates button", () => {
-    render(<SavesHeader />)
+    render(<ArtworkListsHeader />)
 
     const title = "Saved Artworks"
     const description = "Curate your own lists of the works you love"
@@ -13,7 +13,7 @@ describe("SavesHeader", () => {
   })
 
   it("opens the 'Create a new list' modal", () => {
-    render(<SavesHeader />)
+    render(<ArtworkListsHeader />)
 
     const button = screen.getByText("Create New List")
     fireEvent.click(button)

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -119,7 +119,7 @@
       "artworkWithCount_one": "{{count}} Artwork",
       "artworkWithCount_other": "{{count}} Artworks"
     },
-    "savesHeader": {
+    "artworkListsHeader": {
       "listCreated": "{{listName}} Created",
       "savedArtworks": "Saved Artworks",
       "curateYourList": "Curate your own lists of the works you love",


### PR DESCRIPTION
The type of this PR is: **Refactor**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

Notion: [Card](https://www.notion.so/artsy/Artworks-list-I-think-we-ve-got-a-confusing-mix-of-terms-in-our-codebase-for-Artwork-Lists-collec-03de616986ab4cd4a839ec6aed989d3d)

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ