### PR TITLE
chore: add some copy to the COS checkbox note

### DIFF
--- a/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
+++ b/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
@@ -22,7 +22,7 @@ export const ConditionsOfSaleCheckbox: React.FC = () => {
     <>
       <Checkbox selected={values.agreeToTerms} onSelect={handleCheckboxSelect}>
         <Text variant="sm-display" ml={0.5}>
-          Agree to{" "}
+          I agree to the{" "}
           <RouterLink
             display="inline"
             color="black100"
@@ -31,6 +31,7 @@ export const ConditionsOfSaleCheckbox: React.FC = () => {
           >
             Conditions of Sale
           </RouterLink>
+          . I understand that all bids are binding and may not be retracted.
         </Text>
       </Checkbox>
 

--- a/src/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
+++ b/src/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme"
 import { useFormContext } from "Apps/Auction/Hooks/useFormContext"
-import { ConditionsOfSaleCheckbox } from "../ConditionsOfSaleCheckbox"
+import { ConditionsOfSaleCheckbox } from "Apps/Auction/Components/Form/ConditionsOfSaleCheckbox"
 
 jest.mock("Apps/Auction/Hooks/useFormContext")
 
@@ -29,7 +29,9 @@ describe("ConditionsOfSaleCheckbox", () => {
   it("renders correct components", () => {
     const wrapper = getWrapper()
     expect(wrapper.find("Checkbox")).toHaveLength(1)
-    expect(wrapper.text()).toContain("Agree to Conditions of Sale")
+    expect(wrapper.text()).toContain(
+      "I agree to the Conditions of Sale. I understand that all bids are binding and may not be retracted."
+    )
   })
 
   it("shows error message if error", () => {


### PR DESCRIPTION
Minor hackathon project to add additional text stating that all bids are binding in the auction registration flows. I tried this with the checkbox top-aligned when text breaks into multiple lines (which it always does now). I think it looks better centered on a single line.

Let's wait to merge this until we have signoff from the auctions team.

### Description

<details><summary>New COS checkbox text</summary>
Ignore the blue color, i took the screenshot while in the hover state.

![image](https://user-images.githubusercontent.com/9088720/228948323-7af4c0c4-0304-4173-8ab8-355546bae8d1.png)
</details>

<details><summary>With the checkbox bumped up to stay aligned with the first line of text</summary>

![image](https://user-images.githubusercontent.com/9088720/228948255-3bd9f697-4b6f-4e8b-8ad5-4c97f39127b3.png)

</details>
<!-- Implementation description -->
