### PR TITLE
feat(FX-4706): Track `viewedArtworkList` event when a user clicks to view an artwork list

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -2,11 +2,13 @@ import { Shelf, Spacer } from "@artsy/palette"
 import { ArtworkListContentQueryRenderer } from "./Components/ArtworkListContent"
 import { ArtworkListsHeader } from "./Components/ArtworkListsHeader"
 import { ArtworkListItemFragmentContainer } from "./Components/ArtworkListItem"
-import { FC, useRef } from "react"
+import { FC, useEffect, useRef } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useRouter } from "System/Router/useRouter"
 import { extractNodes } from "Utils/extractNodes"
 import { CollectorProfileSaves2Route_me$data } from "__generated__/CollectorProfileSaves2Route_me.graphql"
+import { useTracking } from "react-tracking"
+import { ActionType, OwnerType, ViewedArtworkList } from "@artsy/cohesion"
 
 interface CollectorProfileSaves2RouteProps {
   me: CollectorProfileSaves2Route_me$data
@@ -16,12 +18,23 @@ const CollectorProfileSaves2Route: FC<CollectorProfileSaves2RouteProps> = ({
   me,
 }) => {
   const { match } = useRouter()
+  const { trackEvent } = useTracking()
   const initialArtworkListId = useRef(match.params.id)
   const { page, sort } = match.location.query ?? {}
   const allSavesArtworkList = me.allSavesArtworkList!
   const selectedArtworkListId =
     match.params.id ?? allSavesArtworkList.internalID
   let customArtworkLists = extractNodes(me.customArtworkLists)
+
+  useEffect(() => {
+    const event: ViewedArtworkList = {
+      action: ActionType.viewedArtworkList,
+      context_owner_type: OwnerType.saves,
+      owner_id: selectedArtworkListId,
+    }
+
+    trackEvent(event)
+  }, [selectedArtworkListId, trackEvent])
 
   if (initialArtworkListId.current !== undefined) {
     const index = customArtworkLists.findIndex(


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Acceptance Criteria
* Track event when a user clicks to view an artwork list
* Track event on mount for “All Saves” artwork list when user navigates to the `collector-profile/saves2` page

<!-- Implementation description -->
