### PR TITLE
feat(FX-4707): Track `editedArtworkList` event when a user edits an artwork list

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
@@ -13,6 +13,8 @@ import { Form, Formik } from "formik"
 import * as Yup from "yup"
 import { useUpdateArtworkList } from "./Mutations/useUpdateArtworkList"
 import createLogger from "Utils/logger"
+import { useTracking } from "react-tracking"
+import { ActionType, EditedArtworkList, OwnerType } from "@artsy/cohesion"
 
 export interface EditArtworkListEntity {
   internalID: string
@@ -37,6 +39,7 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
   onClose,
 }) => {
   const { t } = useTranslation()
+  const { trackEvent } = useTracking()
 
   const initialValues: FormikValues = {
     name: artworkList.name,
@@ -51,6 +54,16 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
   const { submitMutation } = useUpdateArtworkList()
 
   const { sendToast } = useToasts()
+
+  const trackAnalyticsEvent = () => {
+    const event: EditedArtworkList = {
+      action: ActionType.editedArtworkList,
+      context_owner_type: OwnerType.saves,
+      owner_id: artworkList.internalID,
+    }
+
+    trackEvent(event)
+  }
 
   const handleSubmit = async (formikValues: FormikValues) => {
     try {
@@ -74,6 +87,8 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
         variant: "success",
         message: t("collectorSaves.editListModal.success"),
       })
+
+      trackAnalyticsEvent()
     } catch (error) {
       logger.error(error)
       sendToast({

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
@@ -55,7 +55,7 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
 
   const { sendToast } = useToasts()
 
-  const trackAnalyticsEvent = () => {
+  const trackAnalyticEvent = () => {
     const event: EditedArtworkList = {
       action: ActionType.editedArtworkList,
       context_owner_type: OwnerType.saves,
@@ -88,7 +88,7 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
         message: t("collectorSaves.editListModal.success"),
       })
 
-      trackAnalyticsEvent()
+      trackAnalyticEvent()
     } catch (error) {
       logger.error(error)
       sendToast({

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/EditArtworkListModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/EditArtworkListModal.jest.tsx
@@ -5,6 +5,7 @@ import {
   EditArtworkListModal,
   EditArtworkListEntity,
 } from "Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal"
+import { useTracking } from "react-tracking"
 
 jest.mock("Utils/Hooks/useMutation")
 
@@ -22,6 +23,9 @@ const setup = () => {
 }
 
 describe("EditArtworkListModal", () => {
+  const mockUseTracking = useTracking as jest.Mock
+  const trackEvent = jest.fn()
+
   let closeEditModal: jest.Mock
   let submitMutation: jest.Mock
 
@@ -31,6 +35,10 @@ describe("EditArtworkListModal", () => {
     ;(useMutation as jest.Mock).mockImplementation(() => {
       return { submitMutation }
     })
+
+    mockUseTracking.mockImplementation(() => ({
+      trackEvent,
+    }))
   })
 
   it("renders the modal content", async () => {
@@ -134,5 +142,41 @@ describe("EditArtworkListModal", () => {
     })
 
     expect(saveButton).toBeEnabled()
+  })
+
+  it("tracks event", async () => {
+    submitMutation.mockImplementation(() => ({
+      updateCollection: {
+        responseOrError: {
+          __typename: "UpdateCollectionSuccess",
+          artworkList: {
+            internalID: "artwork-list",
+            name: "All saves",
+          },
+        },
+      },
+    }))
+
+    render(
+      <EditArtworkListModal
+        artworkList={artworkList}
+        onClose={closeEditModal}
+      />
+    )
+    const { nameInputField, saveButton } = setup()
+
+    fireEvent.change(nameInputField, {
+      target: { value: "Foo Bar!" },
+    })
+
+    fireEvent.click(saveButton)
+
+    await waitFor(() =>
+      expect(trackEvent).toHaveBeenLastCalledWith({
+        action: "editedArtworkList",
+        context_owner_type: "saves",
+        owner_id: artworkList.internalID,
+      })
+    )
   })
 })

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/EditArtworkListModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/EditArtworkListModal.jest.tsx
@@ -144,7 +144,7 @@ describe("EditArtworkListModal", () => {
     expect(saveButton).toBeEnabled()
   })
 
-  it("tracks event", async () => {
+  it("tracks event when artwork list was edited", async () => {
     submitMutation.mockImplementation(() => ({
       updateCollection: {
         responseOrError: {


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4707]

### Description
```javascript
{
  action: ActionType.editedArtworkList,
  context_owner_type: OwnerType.saves,
  owner_id: string // id of the list
}
```

### Demo
https://user-images.githubusercontent.com/3513494/229127899-1df98088-06aa-43eb-82ae-250c36f6c2ca.mp4

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4707]: https://artsyproduct.atlassian.net/browse/FX-4707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ