### PR TITLE
feat(FX-4708): Track `deletedArtworkList` event when a user deletes an artwork list

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/DeleteArtworkListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/DeleteArtworkListModal.tsx
@@ -2,6 +2,8 @@ import { Button, Flex, ModalDialog, Text, useToasts } from "@artsy/palette"
 import { useDeleteArtworkList } from "./Mutations/useDeleteArtworkList"
 import { useTranslation } from "react-i18next"
 import { useRouter } from "System/Router/useRouter"
+import { useTracking } from "react-tracking"
+import { ActionType, DeletedArtworkList, OwnerType } from "@artsy/cohesion"
 
 export interface DeleteArtworkListEntity {
   internalID: string
@@ -19,10 +21,21 @@ export const DeleteArtworkListModal: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation()
   const { router } = useRouter()
+  const { trackEvent } = useTracking()
 
   const { submitMutation } = useDeleteArtworkList()
 
   const { sendToast } = useToasts()
+
+  const trackAnalyticEvent = () => {
+    const event: DeletedArtworkList = {
+      action: ActionType.deletedArtworkList,
+      context_owner_type: OwnerType.saves,
+      owner_id: artworkList.internalID,
+    }
+
+    trackEvent(event)
+  }
 
   const handleDeletePress = async () => {
     try {
@@ -46,6 +59,7 @@ export const DeleteArtworkListModal: React.FC<Props> = ({
         message: t("collectorSaves.deleteListModal.success"),
       })
 
+      trackAnalyticEvent()
       router.replace("/collector-profile/saves2")
     } catch (err) {
       console.error(err)


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4708]

### Description
```javascript
{
  action: ActionType.deletedArtworkList,
  context_owner_type: OwnerType.saves,
  owner_id: string // id of the list
}
```

### Demo
https://user-images.githubusercontent.com/3513494/229130795-44900bca-9218-4e2f-88bf-8fb1714e250d.mp4

<!-- Implementation description -->
