### PR TITLE
feat(FX-4709): Track `addedArtworkToArtworkList` event when a user adds an artwork to an artwork list

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/AddArtworksModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/AddArtworksModal.tsx
@@ -5,6 +5,12 @@ import { AddArtworksModalContentQueryRender } from "./AddArtworksModalContent"
 import { useAddArtworksToCollection } from "Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/useAddArtworksToCollection"
 import createLogger from "Utils/logger"
 import { ArtworkList } from "./CreateNewListModal"
+import { useTracking } from "react-tracking"
+import {
+  ActionType,
+  AddedArtworkToArtworkList,
+  OwnerType,
+} from "@artsy/cohesion"
 
 interface AddArtworksModalProps {
   onComplete: () => void
@@ -21,7 +27,19 @@ export const AddArtworksModal: FC<AddArtworksModalProps> = ({
   const { t } = useTranslation()
   const { sendToast } = useToasts()
   const { submitMutation } = useAddArtworksToCollection()
+  const { trackEvent } = useTracking()
   const [isSaving, setIsSaving] = useState(false)
+
+  const trackAnalyticEvent = () => {
+    const event: AddedArtworkToArtworkList = {
+      action: ActionType.addedArtworkToArtworkList,
+      context_owner_type: OwnerType.saves,
+      artwork_ids: selectedArtworkIds,
+      owner_ids: [artworkList.internalID],
+    }
+
+    trackEvent(event)
+  }
 
   const handleSave = async () => {
     try {
@@ -41,6 +59,10 @@ export const AddArtworksModal: FC<AddArtworksModalProps> = ({
           return !!error?.mutationError
         },
       })
+
+      if (selectedArtworkIds.length > 0) {
+        trackAnalyticEvent()
+      }
 
       onComplete()
     } catch (error) {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/AddArtworksModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/AddArtworksModal.jest.tsx
@@ -5,6 +5,7 @@ import { AddArtworksModal } from "Apps/CollectorProfile/Routes/Saves2/Components
 import { useTracking } from "react-tracking"
 import { useSystemContext } from "System/SystemContext"
 import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
+import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 
 jest.mock("Utils/Hooks/useMutation")
 jest.mock("System/useSystemContext")
@@ -80,7 +81,7 @@ describe("AddArtworksModal", () => {
       })
     }
 
-    it("doesn't track event if no artwork is selected", async () => {
+    it("doesn't track event if no artworks are selected", async () => {
       submitMutation.mockImplementation(() => ({
         artworksCollectionsBatchUpdate: {
           responseOrError: {
@@ -97,7 +98,8 @@ describe("AddArtworksModal", () => {
 
       fireEvent.click(screen.getByText("Save"))
 
-      await waitFor(() => expect(trackEvent).not.toHaveBeenCalled())
+      await flushPromiseQueue()
+      expect(trackEvent).not.toHaveBeenCalled()
     })
 
     it("tracks event when one artwork is selected", async () => {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/AddArtworksModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/AddArtworksModal.jest.tsx
@@ -1,11 +1,21 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 
 import { useMutation } from "Utils/Hooks/useMutation"
 import { AddArtworksModal } from "Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/AddArtworksModal"
+import { useTracking } from "react-tracking"
+import { useSystemContext } from "System/SystemContext"
+import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
 
 jest.mock("Utils/Hooks/useMutation")
+jest.mock("System/useSystemContext")
+jest.unmock("react-relay")
 
 describe("AddArtworksModal", () => {
+  const mockUseTracking = useTracking as jest.Mock
+  const mockUseSystemContext = useSystemContext as jest.Mock
+  const trackEvent = jest.fn()
+  const relayEnv = createMockEnvironment()
+
   let onComplete: jest.Mock
   let submitMutation: jest.Mock
 
@@ -15,14 +25,20 @@ describe("AddArtworksModal", () => {
     ;(useMutation as jest.Mock).mockImplementation(() => {
       return { submitMutation }
     })
+
+    mockUseTracking.mockImplementation(() => ({
+      trackEvent,
+    }))
+
+    mockUseSystemContext.mockImplementation(() => ({
+      relayEnvironment: relayEnv,
+    }))
   })
 
   it("renders the modal content", async () => {
-    const list = {
-      internalID: "collectionID",
-      name: "Sculpture",
-    }
-    render(<AddArtworksModal artworkList={list} onComplete={onComplete} />)
+    render(
+      <AddArtworksModal artworkList={artworkList} onComplete={onComplete} />
+    )
 
     const title = screen.getByText(
       "Sculpture created. Add saved works to the list."
@@ -32,12 +48,9 @@ describe("AddArtworksModal", () => {
   })
 
   it("calls the mutation when the Save button is clicked", async () => {
-    const list = {
-      internalID: "collectionID",
-      name: "Sculpture",
-    }
-
-    render(<AddArtworksModal artworkList={list} onComplete={onComplete} />)
+    render(
+      <AddArtworksModal artworkList={artworkList} onComplete={onComplete} />
+    )
 
     const saveButton = screen.getByRole("button", { name: /Save/ })
     fireEvent.click(saveButton)
@@ -49,10 +62,125 @@ describe("AddArtworksModal", () => {
         variables: {
           input: {
             artworkIDs: [],
-            addToCollectionIDs: ["collectionID"],
+            addToCollectionIDs: ["artwork-list-one"],
           },
         },
       })
     )
   })
+
+  describe("Analytics", () => {
+    const resolveMostRecentOperation = () => {
+      act(() => {
+        relayEnv.mock.resolveMostRecentOperation(operation => {
+          return MockPayloadGenerator.generate(operation, {
+            Me: () => mockedMe,
+          })
+        })
+      })
+    }
+
+    it("doesn't track event if no artwork is selected", async () => {
+      submitMutation.mockImplementation(() => ({
+        artworksCollectionsBatchUpdate: {
+          responseOrError: {
+            addedToCollections: [artworkList],
+          },
+        },
+      }))
+
+      render(
+        <AddArtworksModal artworkList={artworkList} onComplete={onComplete} />
+      )
+
+      resolveMostRecentOperation()
+
+      fireEvent.click(screen.getByText("Save"))
+
+      await waitFor(() => expect(trackEvent).not.toHaveBeenCalled())
+    })
+
+    it("tracks event when one artwork is selected", async () => {
+      submitMutation.mockImplementation(() => ({
+        artworksCollectionsBatchUpdate: {
+          responseOrError: {
+            addedToCollections: [artworkList],
+          },
+        },
+      }))
+
+      render(
+        <AddArtworksModal artworkList={artworkList} onComplete={onComplete} />
+      )
+
+      resolveMostRecentOperation()
+
+      fireEvent.click(screen.getByText("Artwork #1"))
+      fireEvent.click(screen.getByText("Save"))
+
+      await waitFor(() =>
+        expect(trackEvent).toHaveBeenLastCalledWith({
+          action: "addedArtworkToArtworkList",
+          context_owner_type: "saves",
+          artwork_ids: ["artwork-id-one"],
+          owner_ids: [artworkList.internalID],
+        })
+      )
+    })
+
+    it("tracks event when multiple artworks are selected", async () => {
+      submitMutation.mockImplementation(() => ({
+        artworksCollectionsBatchUpdate: {
+          responseOrError: {
+            addedToCollections: [artworkList],
+          },
+        },
+      }))
+
+      render(
+        <AddArtworksModal artworkList={artworkList} onComplete={onComplete} />
+      )
+
+      resolveMostRecentOperation()
+
+      fireEvent.click(screen.getByText("Artwork #1"))
+      fireEvent.click(screen.getByText("Artwork #2"))
+      fireEvent.click(screen.getByText("Save"))
+
+      await waitFor(() =>
+        expect(trackEvent).toHaveBeenLastCalledWith({
+          action: "addedArtworkToArtworkList",
+          context_owner_type: "saves",
+          artwork_ids: ["artwork-id-one", "artwork-id-two"],
+          owner_ids: [artworkList.internalID],
+        })
+      )
+    })
+  })
 })
+
+const mockedMe = {
+  collection: {
+    artworksConnection: {
+      edges: [
+        {
+          node: {
+            title: "Artwork #1",
+            internalID: "artwork-id-one",
+          },
+        },
+        {
+          node: {
+            title: "Artwork #2",
+            internalID: "artwork-id-two",
+          },
+        },
+      ],
+    },
+  },
+}
+
+const artworkList = {
+  internalID: "artwork-list-one",
+  name: "Sculpture",
+}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
@@ -1,11 +1,40 @@
 import { graphql } from "react-relay"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { fireEvent, screen, waitFor } from "@testing-library/react"
-import { SelectListsForArtworkModal_Test_Query } from "__generated__/SelectListsForArtworkModal_Test_Query.graphql"
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from "@testing-library/react"
+import {
+  SelectListsForArtworkModal_Test_Query,
+  SelectListsForArtworkModal_Test_Query$data,
+} from "__generated__/SelectListsForArtworkModal_Test_Query.graphql"
 import { SelectListsForArtworkModalFragmentContainer } from "Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/SelectListsForArtworkModal"
-import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
+import {
+  ManageArtworkForSavesProvider,
+  useManageArtworkForSavesContext,
+} from "Components/Artwork/ManageArtworkForSaves"
+import { useTracking } from "react-tracking"
+import { useMutation } from "Utils/Hooks/useMutation"
+import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { OwnerType } from "@artsy/cohesion"
+import { FC } from "react"
 
 jest.unmock("react-relay")
+jest.mock("Utils/Hooks/useMutation")
+
+const TestComponent: FC<SelectListsForArtworkModal_Test_Query$data> = props => {
+  const { state } = useManageArtworkForSavesContext()
+
+  // Modal is not displayed in the ManageArtworkForSaves component if artwork is null
+  if (!state.artwork) {
+    return null
+  }
+
+  return <SelectListsForArtworkModalFragmentContainer {...props} />
+}
 
 const { renderWithRelay } = setupTestWrapperTL<
   SelectListsForArtworkModal_Test_Query
@@ -16,9 +45,17 @@ const { renderWithRelay } = setupTestWrapperTL<
     }
 
     return (
-      <ManageArtworkForSavesProvider artwork={artwork}>
-        <SelectListsForArtworkModalFragmentContainer me={props.me} />
-      </ManageArtworkForSavesProvider>
+      <AnalyticsContext.Provider
+        value={{
+          contextPageOwnerId: "page-owner-id",
+          contextPageOwnerSlug: "page-owner-slug",
+          contextPageOwnerType: OwnerType.artist,
+        }}
+      >
+        <ManageArtworkForSavesProvider artwork={artwork}>
+          <TestComponent {...props} />
+        </ManageArtworkForSavesProvider>
+      </AnalyticsContext.Provider>
     )
   },
   query: graphql`
@@ -31,6 +68,21 @@ const { renderWithRelay } = setupTestWrapperTL<
 })
 
 describe("SelectListsForArtworkModal", () => {
+  const mockUseMutation = useMutation as jest.Mock
+  const mockUseTracking = useTracking as jest.Mock
+  const trackEvent = jest.fn()
+  const submitMutation = jest.fn()
+
+  beforeEach(() => {
+    mockUseMutation.mockImplementation(() => {
+      return { submitMutation }
+    })
+
+    mockUseTracking.mockImplementation(() => ({
+      trackEvent,
+    }))
+  })
+
   it("should render artwork data", async () => {
     renderWithRelay()
 
@@ -200,6 +252,73 @@ describe("SelectListsForArtworkModal", () => {
       expect(screen.getByText("1 list selected")).toBeInTheDocument()
       expect(selectedOptions.length).toBe(1)
       expect(selectedOptions[0]).toHaveTextContent("Collection 2")
+    })
+  })
+
+  describe("Analytics", () => {
+    it("doesn't track event when no new collections are selected", async () => {
+      renderWithRelay({
+        CollectionsConnection: () => collectionsConnection,
+      })
+
+      await waitForModalToBePresented()
+
+      // Make some changes (in our case we unselect previously selected collection)
+      // Otherwise, the "Save" button will be disabled
+      // and the mutation will not be performed when the button is clicked
+      fireEvent.click(screen.getByText("Collection 1"))
+      fireEvent.click(screen.getByText("Save"))
+
+      await waitForElementToBeRemoved(
+        screen.getByText("Select lists for this artwork")
+      )
+
+      expect(trackEvent).not.toHaveBeenCalled()
+    })
+
+    it("track event when one new collection is selected", async () => {
+      renderWithRelay({
+        CollectionsConnection: () => unselectedCollectionsConnection,
+      })
+
+      await waitForModalToBePresented()
+
+      fireEvent.click(screen.getByText("Collection 1"))
+      fireEvent.click(screen.getByText("Save"))
+
+      await waitFor(() =>
+        expect(trackEvent).toHaveBeenLastCalledWith({
+          action: "addedArtworkToArtworkList",
+          context_owner_id: "page-owner-id",
+          context_owner_slug: "page-owner-slug",
+          context_owner_type: "artist",
+          artwork_ids: [artwork.internalID],
+          owner_ids: ["collection-one"],
+        })
+      )
+    })
+
+    it("track event when multiple new collections are selected", async () => {
+      renderWithRelay({
+        CollectionsConnection: () => unselectedCollectionsConnection,
+      })
+
+      await waitForModalToBePresented()
+
+      fireEvent.click(screen.getByText("Collection 1"))
+      fireEvent.click(screen.getByText("Collection 2"))
+      fireEvent.click(screen.getByText("Save"))
+
+      await waitFor(() =>
+        expect(trackEvent).toHaveBeenLastCalledWith({
+          action: "addedArtworkToArtworkList",
+          context_owner_id: "page-owner-id",
+          context_owner_slug: "page-owner-slug",
+          context_owner_type: "artist",
+          artwork_ids: [artwork.internalID],
+          owner_ids: ["collection-one", "collection-two"],
+        })
+      )
     })
   })
 })

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectListsForArtworkModal/__tests__/SelectListsForArtworkModal.jest.tsx
@@ -1,12 +1,6 @@
 import { graphql } from "react-relay"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import {
-  act,
-  fireEvent,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from "@testing-library/react"
+import { fireEvent, screen, waitFor } from "@testing-library/react"
 import {
   SelectListsForArtworkModal_Test_Query,
   SelectListsForArtworkModal_Test_Query$data,
@@ -21,6 +15,7 @@ import { useMutation } from "Utils/Hooks/useMutation"
 import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { OwnerType } from "@artsy/cohesion"
 import { FC } from "react"
+import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 
 jest.unmock("react-relay")
 jest.mock("Utils/Hooks/useMutation")
@@ -269,10 +264,7 @@ describe("SelectListsForArtworkModal", () => {
       fireEvent.click(screen.getByText("Collection 1"))
       fireEvent.click(screen.getByText("Save"))
 
-      await waitForElementToBeRemoved(
-        screen.getByText("Select lists for this artwork")
-      )
-
+      await flushPromiseQueue()
       expect(trackEvent).not.toHaveBeenCalled()
     })
 


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Demo
**adding 1 artwork to N lists (e.g. from an artwork page)**
```javascript
{
  action: ActionType.addedArtworkToArtworkList,
  context_owner_id: string | undefined,
  context_owner_slug: string | undefined,
  context_owner_type: OwnerType,
  artwork_ids: string[], // ["artwork-id-one"] 👈 1 artwork id
  owner_ids: string[] // ["artwork-list-id-one", "artwork-list-id-two"] 👈 N list ids
}
```

<!-- Implementation description -->
