### PR TITLE
feat: add verbosity to inline review app create/update script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,9 +109,12 @@ jobs:
       - run:
           name: "Create or update review app"
           command: |
+            set -x
             review_app_name=$(echo $CIRCLE_BRANCH | sed 's/review-app-//')
             kubectl config use-context staging
-            if $(kubectl get namespace | grep -qi $review_app_name); then
+            namespaces=$(kubectl get namespace)
+            echo
+            if echo "$namespaces" | grep -qi "$review_app_name"; then
               ./scripts/update_review_app.sh $review_app_name
             else
               ./scripts/build_review_app.sh $review_app_name

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Force
 
-[Force](https://github.com/artsy/force) is the Artsy website, [www.artsy.net](https://www.artsy.net)..
+[Force](https://github.com/artsy/force) is the Artsy website, [www.artsy.net](https://www.artsy.net).
 
 Are you an Engineer? Don't know what Artsy is? Check out [this overview](https://github.com/artsy/meta/blob/master/meta/what_is_artsy.md) and [more](https://github.com/artsy/meta/blob/master/README.md).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Force
 
-[Force](https://github.com/artsy/force) is the Artsy website, [www.artsy.net](https://www.artsy.net).
+[Force](https://github.com/artsy/force) is the Artsy website, [www.artsy.net](https://www.artsy.net)..
 
 Are you an Engineer? Don't know what Artsy is? Check out [this overview](https://github.com/artsy/meta/blob/master/meta/what_is_artsy.md) and [more](https://github.com/artsy/meta/blob/master/README.md).
 


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Today we experienced yet another [Review App Update failure](https://app.circleci.com/pipelines/github/artsy/force/46718/workflows/e4fc64f0-ed84-43df-8a2c-66611c942c13/jobs/351539), where the [inline script in CircleCI config](https://github.com/artsy/force/blob/8d92b46e732815e2d1864479def64146a08ece0b/.circleci/config.yml#L114) failed to realize that the Review App already exists - it ran `build_review_app.sh` instead of `update_review_app.sh`.

Similar to in the past, the problem goes away upon [re-running the job](https://artsy.slack.com/archives/CP9P4KR35/p1680290046440389?thread_ts=1680280549.503849&cid=CP9P4KR35). So far we have not been able to repro the problem manually from within CircleCI container.

So for now, let's refactor the inline script to add some verbosity, and wait for the problem to surface again.

Tested this update with a [Create](https://app.circleci.com/pipelines/github/artsy/force/46734/workflows/8c2200ee-b57a-4ac5-9583-51d6beeeadc4/jobs/351697) and [Update](https://app.circleci.com/pipelines/github/artsy/force/46735/workflows/c18053e2-c102-49e8-a00c-44fd7aa9f03c/jobs/351710).
