### PR TITLE
fix: Update Insights's Auction Result title

### DIFF
--- a/src/Apps/Settings/Routes/Insights/Components/InsightsAuctionResults.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/InsightsAuctionResults.tsx
@@ -20,7 +20,7 @@ const InsightsAuctionResults: React.FC<InsightsAuctionResultsProps> = ({
   return (
     <>
       <Text variant={["sm-display", "md"]} textAlign="left">
-        Recently Sold at Auctions
+        Recently Sold at Auction
       </Text>
 
       <Spacer y={2} />


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves []

### Description
This PR updates the title of the auction results title in My Collection Insights page

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ