### PR TITLE
chore(TX-1116): update inline links

### DIFF
--- a/src/Apps/ArtAppraisals/ArtAppraisalsApp.tsx
+++ b/src/Apps/ArtAppraisals/ArtAppraisalsApp.tsx
@@ -15,6 +15,7 @@ import {
 import { FullBleedHeader } from "Components/FullBleedHeader/FullBleedHeader"
 import { cropped, resized } from "Utils/resized"
 import { Media } from "Utils/Responsive"
+import { RouterLink } from "System/Router/RouterLink"
 
 export const ArtAppraisalsApp: React.FC = () => {
   return (
@@ -189,9 +190,9 @@ const MeetOurSpecialists: React.FC = () => {
             <Text variant="lg-display">Simon Wills</Text>
             <Text variant="sm-display">Senior Manager, Trusts & Estates</Text>
             <Text variant="sm-display" color="black60" mb={2}>
-              <a href="mailto:appraisals@artsymail.com">
+              <RouterLink inline to="mailto:appraisals@artsymail.com">
                 appraisals@artsymail.com
-              </a>
+              </RouterLink>
             </Text>
           </Flex>
         </Flex>

--- a/src/Apps/Article/Components/ArticleNewsSource.tsx
+++ b/src/Apps/Article/Components/ArticleNewsSource.tsx
@@ -1,7 +1,8 @@
 import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { useArticleTracking } from "../useArticleTracking"
+import { useArticleTracking } from "Apps/Article/useArticleTracking"
 import { ArticleNewsSource_article$data } from "__generated__/ArticleNewsSource_article.graphql"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface ArticleNewsSourceProps {
   article: ArticleNewsSource_article$data
@@ -16,8 +17,9 @@ const ArticleNewsSource: FC<ArticleNewsSourceProps> = ({ article }) => {
         <>
           , via&nbsp;
           {article.newsSource.url ? (
-            <a
-              href={article.newsSource.url}
+            <RouterLink
+              inline
+              to={article.newsSource.url}
               target="_blank"
               rel="noopener noreferrer"
               onClick={() => {
@@ -26,7 +28,7 @@ const ArticleNewsSource: FC<ArticleNewsSourceProps> = ({ article }) => {
               }}
             >
               {article.newsSource.title}
-            </a>
+            </RouterLink>
           ) : (
             article.newsSource.title
           )}

--- a/src/Apps/Article/Components/ArticleVideo.tsx
+++ b/src/Apps/Article/Components/ArticleVideo.tsx
@@ -178,7 +178,7 @@ const ArticleVideo: FC<ArticleVideoProps> = ({ article }) => {
               <Text variant="lg-display">
                 More in{" "}
                 {article.seriesArticle ? (
-                  <RouterLink to={article.seriesArticle.href}>
+                  <RouterLink inline to={article.seriesArticle.href}>
                     {article.seriesArticle.title}
                   </RouterLink>
                 ) : (

--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -115,7 +115,7 @@ const ArtistHeader: React.FC<ArtistHeaderProps> = ({ artist }) => {
             )}
             {!hideBioInHeaderIfPartnerSupplied && (
               <>
-                <RouterLink to={`/artist/${artist.slug}/cv`}>
+                <RouterLink inline to={`/artist/${artist.slug}/cv`}>
                   {t("artistPage.overview.cvLink")}
                 </RouterLink>
               </>

--- a/src/Apps/Artist/Routes/Consign/Components/ArtistConsignFAQ.tsx
+++ b/src/Apps/Artist/Routes/Consign/Components/ArtistConsignFAQ.tsx
@@ -8,6 +8,7 @@ import { SectionContainer } from "./SectionContainer"
 import { Subheader } from "./Subheader"
 import { getConsignSubmissionUrl } from "./Utils/getConsignSubmissionUrl"
 import { Masonry } from "Components/Masonry"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface ArtistConsignFAQProps {
   artist: ArtistConsignFAQ_artist$data
@@ -41,7 +42,8 @@ const ArtistConsignFAQ: React.FC<ArtistConsignFAQProps> = props => {
                   your work sells. Artsy specialists guide you along the way and
                   help you choose the right sales strategy. To get started,
                   submit works you’re interested in selling{" "}
-                  <a
+                  <RouterLink
+                    inline
                     data-test="submitOnFAQ"
                     onClick={() => {
                       tracking.trackEvent({
@@ -53,13 +55,13 @@ const ArtistConsignFAQ: React.FC<ArtistConsignFAQProps> = props => {
                             .SubmitWorksInterestedInSelling,
                       })
                     }}
-                    href={getConsignSubmissionUrl({
+                    to={getConsignSubmissionUrl({
                       contextPath: props.artist.href || "",
                       subject: DeprecatedAnalyticsSchema.Subject.Here,
                     })}
                   >
                     here
-                  </a>
+                  </RouterLink>
                   .
                 </>
               }
@@ -126,9 +128,11 @@ const ArtistConsignFAQ: React.FC<ArtistConsignFAQProps> = props => {
                 <>
                   If you wish to edit your submission or update missing
                   information, please email us at{" "}
-                  <a href="mailto:sell@artsty.net">sell@artsty.net</a> with your
-                  submission ID number, and we will update the submission on
-                  your behalf.
+                  <RouterLink inline to="mailto:sell@artsty.net">
+                    sell@artsty.net
+                  </RouterLink>{" "}
+                  with your submission ID number, and we will update the
+                  submission on your behalf.
                 </>
               }
             />
@@ -138,7 +142,10 @@ const ArtistConsignFAQ: React.FC<ArtistConsignFAQProps> = props => {
               answer={
                 <>
                   Contact us at{" "}
-                  <a href="mailto:sell@artsty.net">sell@artsty.net</a>.
+                  <RouterLink inline to="mailto:sell@artsty.net">
+                    sell@artsty.net
+                  </RouterLink>
+                  .
                 </>
               }
             />

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistCareerHighlights.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistCareerHighlights.tsx
@@ -46,14 +46,16 @@ const ArtistCareerHighlights: React.FC<ArtistCareerHighlightsProps> = ({
           </Text>
 
           <Text mb={1} variant="sm">
-            <RouterLink to={partnerHref}>{credit}</RouterLink>
+            <RouterLink inline to={partnerHref}>
+              {credit}
+            </RouterLink>
           </Text>
 
           <HTML html={text!} variant="sm" />
 
           <Spacer y={2} />
 
-          <RouterLink to={`/artist/${artist.slug}/cv`}>
+          <RouterLink inline to={`/artist/${artist.slug}/cv`}>
             {t("artistPage.overview.cvLink")}
           </RouterLink>
 

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistIconicCollectionsRail.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistIconicCollectionsRail.tsx
@@ -59,7 +59,7 @@ const ArtistIconicCollectionsRail: React.FC<ArtistIconicCollectionsRailProps> = 
             <RouterLink
               to={`/collection/${marketingCollection.slug}`}
               key={index}
-              noUnderline
+              textDecoration="none"
               onClick={() => {
                 tracking.trackEvent({
                   action_type: DeprecatedAnalyticsSchema.ActionType.Click,

--- a/src/Apps/Artists/Routes/ArtistsByLetter.tsx
+++ b/src/Apps/Artists/Routes/ArtistsByLetter.tsx
@@ -92,7 +92,7 @@ export const ArtistsByLetter: React.FC<ArtistsByLetterProps> = ({
           </Text>
 
           <Breadcrumbs>
-            <RouterLink to="/artists" noUnderline>
+            <RouterLink to="/artists" textDecoration="none">
               Artists
             </RouterLink>
 

--- a/src/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtistInfo.tsx
@@ -90,7 +90,9 @@ export class ArtistInfo extends Component<ArtistInfoProps> {
           totalExhibitions={artist.counts?.partnerShows ?? 0}
           exhibitions={compact(artist.exhibitionHighlights)}
           ViewAllLink={
-            <RouterLink to={`/artist/${artist.slug}/cv`}>View all</RouterLink>
+            <RouterLink inline to={`/artist/${artist.slug}/cv`}>
+              View all
+            </RouterLink>
           }
           Container={Container}
         />

--- a/src/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
@@ -16,6 +16,7 @@ import {
 import { RequestConditionReportQuery } from "__generated__/RequestConditionReportQuery.graphql"
 import track, { useTracking } from "react-tracking"
 import { useAuthDialog } from "Components/AuthDialog"
+import { RouterLink } from "System/Router/RouterLink"
 
 const logger = createLogger(
   "Apps/Artwork/Components/ArtworkDetails/RequestConditionReport"
@@ -177,7 +178,10 @@ const RequestedConditionReportModal: React.FC<{
 
       <Text variant="sm" mt={1}>
         For questions, contact{" "}
-        <a href="mailto:specialist@artsy.net">specialist@artsy.net</a>.
+        <RouterLink inline to="mailto:specialist@artsy.net">
+          specialist@artsy.net
+        </RouterLink>
+        .
       </Text>
     </ModalDialog>
   )

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtsyGuarantee.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtsyGuarantee.tsx
@@ -8,6 +8,7 @@ import {
   VerifiedIcon,
 } from "@artsy/palette"
 import { useTranslation } from "react-i18next"
+import { RouterLink } from "System/Router/RouterLink"
 
 export const ArtworkSidebarArtsyGuarantee: React.FC<{}> = () => {
   const { t } = useTranslation()
@@ -45,15 +46,16 @@ export const ArtworkSidebarArtsyGuarantee: React.FC<{}> = () => {
         </Flex>
         <Spacer y={1} />
       </Text>
-      <a
-        href="https://artsy.net/buyer-guarantee"
+      <RouterLink
+        inline
+        to="/buyer-guarantee"
         target="_blank"
         rel="noopener noreferrer"
       >
-        <Text variant="xs" color="black60">
+        <Text variant="xs">
           {t("artworkPage.sidebar.artsyGuarantee.learnMore")}
         </Text>
-      </a>
+      </RouterLink>
     </>
   )
 }

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuthenticityCertificate.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuthenticityCertificate.tsx
@@ -11,6 +11,7 @@ import { ArtworkSidebarAuthenticityCertificate_artwork$data } from "__generated_
 import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTranslation } from "react-i18next"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface ArtworkSidebarAuthenticityCertificateProps {
   artwork: ArtworkSidebarAuthenticityCertificate_artwork$data
@@ -86,15 +87,16 @@ export const ArtworkSidebarAuthenticityCertificate: React.FC<ArtworkSidebarAuthe
               {t(
                 "artworkPage.sidebar.details.AuthenticityCertificateModal.readMore"
               )}
-              <a
-                href="https://support.artsy.net/hc/en-us/articles/360058123933-What-Counts-as-an-Artwork-s-Proof-of-Authenticity-"
+              <RouterLink
+                inline
+                to="https://support.artsy.net/hc/en-us/articles/360058123933-What-Counts-as-an-Artwork-s-Proof-of-Authenticity-"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 {t(
                   "artworkPage.sidebar.details.AuthenticityCertificateModal.helpCenterLink"
                 )}
-              </a>
+              </RouterLink>
             </Text>
           </Flex>
         </ModalDialog>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarLinks.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarLinks.tsx
@@ -43,6 +43,7 @@ const ArtworkSidebarLinks: React.FC<ArtworkSidebarLinksProps> = ({
           <Text variant="xs" color="black60">
             {t("artworkPage.sidebar.conditionsOfSale")}{" "}
             <RouterLink
+              inline
               to="/conditions-of-sale"
               onClick={trackClickedConditionsOfSale}
             >
@@ -54,7 +55,7 @@ const ArtworkSidebarLinks: React.FC<ArtworkSidebarLinksProps> = ({
       )}
       <Text variant="xs" color="black60">
         {t("artworkPage.sidebar.sellWithArtsy")}{" "}
-        <RouterLink to="/sell" onClick={trackClickedSellWithArtsy}>
+        <RouterLink inline to="/sell" onClick={trackClickedSellWithArtsy}>
           {t("artworkPage.sidebar.sellWithArtsyLink")}
         </RouterLink>
       </Text>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarShippingInformation.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarShippingInformation.tsx
@@ -2,6 +2,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { Text } from "@artsy/palette"
 import { ArtworkSidebarShippingInformation_artwork$data } from "__generated__/ArtworkSidebarShippingInformation_artwork.graphql"
 import { useTranslation } from "react-i18next"
+import { RouterLink } from "System/Router/RouterLink"
 
 export interface ShippingInformationProps {
   artwork: ArtworkSidebarShippingInformation_artwork$data
@@ -16,13 +17,14 @@ const ArtworkSidebarShippingInformation: React.FC<ShippingInformationProps> = ({
     <>
       <Text variant="sm" color="black60">
         {t`artworkPage.sidebar.shippingAndTaxes.taxInformation`}{" "}
-        <a
-          href="https://support.artsy.net/hc/en-us/articles/360047294733-How-is-sales-tax-and-VAT-handled-on-works-listed-with-secure-checkout-"
+        <RouterLink
+          inline
+          to="https://support.artsy.net/hc/en-us/articles/360047294733-How-is-sales-tax-and-VAT-handled-on-works-listed-with-secure-checkout-"
           target="_blank"
           rel="noopener noreferrer"
         >
           {t`artworkPage.sidebar.shippingAndTaxes.taxInformationLearnMore`}
-        </a>
+        </RouterLink>
       </Text>
       {shippingOrigin && (
         <Text variant="sm" color="black60">

--- a/src/Apps/Artwork/Components/PricingContextModal.tsx
+++ b/src/Apps/Artwork/Components/PricingContextModal.tsx
@@ -87,7 +87,7 @@ export class PricingContextModal extends Component<State> {
 
             <Text variant="sm">
               Artwork prices are affected by{" "}
-              <RouterLink to="/article/artsy-editorial-artworks-prices">
+              <RouterLink inline to="/article/artsy-editorial-artworks-prices">
                 a variety of objective and subjective factors
               </RouterLink>{" "}
               including the artist's relative position in the art market and the
@@ -95,7 +95,10 @@ export class PricingContextModal extends Component<State> {
               factors are unique to every artwork. As such, this feature is not
               intended to provide pricing guidance for the artwork being viewed.
               If you have feedback or questions{" "}
-              <a href="mailto:support@artsy.net">let us know</a>.
+              <RouterLink inline to="mailto:support@artsy.net">
+                let us know
+              </RouterLink>
+              .
             </Text>
           </ModalDialog>
         )}

--- a/src/Apps/Artwork/Components/TrustSignals/AuthenticityCertificate.tsx
+++ b/src/Apps/Artwork/Components/TrustSignals/AuthenticityCertificate.tsx
@@ -11,6 +11,7 @@ import { AuthenticityCertificate_artwork$data } from "__generated__/Authenticity
 import { useState, FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { shouldRenderAuthenticityCertificate } from "Apps/Artwork/Utils/badges"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface AuthenticityCertificateProps {
   artwork: AuthenticityCertificate_artwork$data
@@ -79,13 +80,14 @@ export const AuthenticityCertificate: FC<AuthenticityCertificateProps> = ({
 
             <Text variant="sm">
               Read more about artwork authenticity in our{" "}
-              <a
-                href="https://support.artsy.net/hc/en-us/articles/360058123933-What-Counts-as-an-Artwork-s-Proof-of-Authenticity-"
+              <RouterLink
+                inline
+                to="https://support.artsy.net/hc/en-us/articles/360058123933-What-Counts-as-an-Artwork-s-Proof-of-Authenticity-"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 Help Center
-              </a>
+              </RouterLink>
               .
             </Text>
           </Flex>

--- a/src/Apps/Auction/Components/AuctionDetails/AuctionInfoSidebar.tsx
+++ b/src/Apps/Auction/Components/AuctionDetails/AuctionInfoSidebar.tsx
@@ -16,7 +16,7 @@ const AuctionInfoSidebar: React.FC<AuctionInfoSidebarProps> = ({ sale }) => {
       <Box>
         <Text variant="sm">Questions?</Text>
 
-        <RouterLink to="/how-auctions-work" target="_blank">
+        <RouterLink inline to="/how-auctions-work" target="_blank">
           <Text variant="sm">How to bid on Artsy?</Text>
         </RouterLink>
       </Box>
@@ -24,9 +24,9 @@ const AuctionInfoSidebar: React.FC<AuctionInfoSidebarProps> = ({ sale }) => {
       <Box>
         <Text variant="sm">Contact Us</Text>
 
-        <a href="mailto:specialist@artsy.net">
+        <RouterLink inline to="mailto:specialist@artsy.net">
           <Text variant="sm">specialist@artsy.net</Text>
-        </a>
+        </RouterLink>
         <Text variant="sm">+1-845-582-3967</Text>
       </Box>
     </Join>

--- a/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
+++ b/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
@@ -24,6 +24,7 @@ export const ConditionsOfSaleCheckbox: React.FC = () => {
         <Text variant="sm-display" ml={0.5}>
           I agree to the{" "}
           <RouterLink
+            inline
             display="inline"
             color="black100"
             to="/conditions-of-sale"

--- a/src/Apps/Auction/Components/Form/ErrorStatus.tsx
+++ b/src/Apps/Auction/Components/Form/ErrorStatus.tsx
@@ -1,6 +1,7 @@
 import { Banner, BannerProps, Flex, Text } from "@artsy/palette"
 import { errorMessageForBidding } from "Apps/Auction/Components/Form/Utils/errorMessages"
 import { useFormContext } from "Apps/Auction/Hooks/useFormContext"
+import { RouterLink } from "System/Router/RouterLink"
 
 export const ErrorStatus = () => {
   const { status } = useFormContext()
@@ -70,7 +71,9 @@ export const ErrorStatus = () => {
           message: (
             <>
               Something went wrong. Please try again or contact{" "}
-              <a href="mailto:support@artsy.net">support@artsy.net</a>
+              <RouterLink inline to="mailto:support@artsy.net">
+                support@artsy.net
+              </RouterLink>
             </>
           ),
         }

--- a/src/Apps/Auction/Components/Form/IdentityVerificationWarning.tsx
+++ b/src/Apps/Auction/Components/Form/IdentityVerificationWarning.tsx
@@ -21,7 +21,12 @@ export const IdentityVerificationWarning: React.FC<{
 
       <Text variant="sm-display">
         To complete your registration, please confirm that you agree to the{" "}
-        <RouterLink color="black100" to="/conditions-of-sale" target="_blank">
+        <RouterLink
+          inline
+          color="black100"
+          to="/conditions-of-sale"
+          target="_blank"
+        >
           Conditions of Sale
         </RouterLink>
         {additionalText}.

--- a/src/Apps/Auction/Components/RegisterButton.tsx
+++ b/src/Apps/Auction/Components/RegisterButton.tsx
@@ -206,7 +206,9 @@ const IdentityVerificationMessage = () => {
   return (
     <Text variant="sm">
       Identity verification required to bid.{" "}
-      <RouterLink to="/identity-verification-faq">FAQ</RouterLink>
+      <RouterLink inline to="/identity-verification-faq">
+        FAQ
+      </RouterLink>
     </Text>
   )
 }

--- a/src/Apps/Auction/Routes/AuctionFAQRoute.tsx
+++ b/src/Apps/Auction/Routes/AuctionFAQRoute.tsx
@@ -12,6 +12,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { AuctionFAQRoute_viewer$data } from "__generated__/AuctionFAQRoute_viewer.graphql"
 import { MetaTags } from "Components/MetaTags"
 import { toStyle } from "Utils/toStyle"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface AuctionFAQRouteProps {
   viewer: AuctionFAQRoute_viewer$data
@@ -41,7 +42,10 @@ const AuctionFAQRoute: React.FC<AuctionFAQRouteProps> = ({ viewer }) => {
         questions from collectors.
         <br />
         Need more immediate assistance? Please{" "}
-        <a href="mailto:support@artsy.net">contact us</a>.
+        <RouterLink inline to="mailto:support@artsy.net">
+          contact us
+        </RouterLink>
+        .
       </Text>
 
       <Spacer y={2} />

--- a/src/Apps/Auctions/Components/MyBids/MyBids.tsx
+++ b/src/Apps/Auctions/Components/MyBids/MyBids.tsx
@@ -82,7 +82,7 @@ const MyBids: React.FC<MyBidsProps> = props => {
                     <Box py={1} px={2}>
                       <RouterLink
                         to={auctionURL}
-                        noUnderline
+                        textDecoration="none"
                         data-test="registeredOnlyButton"
                         onClick={() => {
                           trackEvent(

--- a/src/Apps/Auctions/Components/MyBids/MyBidsBidHeader.tsx
+++ b/src/Apps/Auctions/Components/MyBids/MyBidsBidHeader.tsx
@@ -22,7 +22,7 @@ export const MyBidsBidHeader: React.FC<MyBidsBidHeaderProps> = ({ sale }) => {
   return (
     <RouterLink
       to={auctionURL}
-      noUnderline
+      textDecoration="none"
       onClick={() => {
         trackEvent(
           clickedEntityGroup({

--- a/src/Apps/Auctions/Components/MyBids/MyBidsBidItem.tsx
+++ b/src/Apps/Auctions/Components/MyBids/MyBidsBidItem.tsx
@@ -36,7 +36,7 @@ export const MyBidsBidItem: React.FC<MyBidsBidItemProps> = ({
     <RouterLink
       display="block"
       to={`/artwork/${saleArtwork.slug}`}
-      noUnderline
+      textDecoration="none"
       onClick={() => {
         trackEvent(
           trackHelpers.clickedArtworkGroup(

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
@@ -60,7 +60,7 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
       <RouterLink
         to={`/collection/${slug}`}
         onClick={handleLinkClick}
-        noUnderline
+        textDecoration="none"
       >
         <Flex alignItems="flex-end" mb={1}>
           {artworks.every(artwork => !!artwork.image) ? (

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
@@ -48,7 +48,11 @@ export const OtherCollectionEntity: React.FC<CollectionProps> = ({
   })
 
   return (
-    <RouterLink to={`/collection/${slug}`} onClick={handleClick} noUnderline>
+    <RouterLink
+      to={`/collection/${slug}`}
+      onClick={handleClick}
+      textDecoration="none"
+    >
       <Image
         src={src}
         srcSet={srcSet}

--- a/src/Apps/Consign/Routes/ConsignmentInquiry/ConsignmentInquiry.tsx
+++ b/src/Apps/Consign/Routes/ConsignmentInquiry/ConsignmentInquiry.tsx
@@ -23,6 +23,7 @@ import { ConsignmentInquiryFormAbandonEditModal } from "Apps/Consign/Routes/Cons
 import { useState } from "react"
 import { TopContextBar } from "Components/TopContextBar"
 import { SPECIALISTS } from "Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SpecialistsData"
+import { RouterLink } from "System/Router/RouterLink"
 
 const logger = createLogger("ConsignmentInquiry/ConsignmentInquiry.tsx")
 
@@ -216,9 +217,13 @@ export const ConsignmentInquiry: React.FC<ConsignmentInquiryProps> = ({
               <Spacer y={4} />
               <Text color="black60" mb="1">
                 By continuing, you agree to{" "}
-                <a href="https://www.artsy.net/privacy" target="_blank">
+                <RouterLink
+                  inline
+                  to="https://www.artsy.net/privacy"
+                  target="_blank"
+                >
                   Privacy Policy
-                </a>
+                </RouterLink>
               </Text>
               <Button
                 data-testid="consignment-inquiry-send-button"

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/FooterBanner.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/FooterBanner.tsx
@@ -7,7 +7,7 @@ export const FooterBanner: React.FC = () => {
     <Box display={["none", "block"]}>
       <FullBleedBanner dismissable={false} variant="defaultLight">
         Gallery or art dealer?{" "}
-        <RouterLink to="https://partners.artsy.net">
+        <RouterLink inline to="https://partners.artsy.net">
           Become a partner
         </RouterLink>{" "}
         to access the world’s largest online marketplace.

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -33,6 +33,7 @@ import { trackEvent } from "Server/analytics/helpers"
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { useSubmissionFlowSteps } from "Apps/Consign/Hooks/useSubmissionFlowSteps"
 import { TopContextBar } from "Components/TopContextBar"
+import { RouterLink } from "System/Router/RouterLink"
 
 const logger = createLogger("SubmissionFlow/ArtworkDetails.tsx")
 
@@ -255,13 +256,14 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
 
       <Text mt={1} variant="sm" color="black60">
         &#8226; Currently, artists can not sell their own work on Artsy.{" "}
-        <a
-          href="https://support.artsy.net/hc/en-us/articles/360046646374-I-m-an-artist-Can-I-submit-my-own-work-to-sell-"
+        <RouterLink
+          inline
+          to="https://support.artsy.net/hc/en-us/articles/360046646374-I-m-an-artist-Can-I-submit-my-own-work-to-sell-"
           target="_blank"
           data-testid="learn-more-anchor"
         >
           Learn More.
-        </a>
+        </RouterLink>
       </Text>
       <Text mb={[4, 6]} variant="sm" color="black60">
         &#8226; All fields are required to submit a work.

--- a/src/Apps/Consign/Routes/SubmissionFlow/FAQ/FAQ.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/FAQ/FAQ.tsx
@@ -2,6 +2,7 @@ import { Expandable, Join, Spacer, Text } from "@artsy/palette"
 import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { useTracking } from "react-tracking"
 import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { RouterLink } from "System/Router/RouterLink"
 
 export interface FAQProps {
   shouldTrackClickEvent?: boolean
@@ -57,21 +58,29 @@ export const FAQ: React.FC<FAQProps> = ({ shouldTrackClickEvent }) => {
           <p>
             If you are represented by a gallery, you can encourage them to
             partner with us by getting in touch at{" "}
-            <a href="mailto:partners@artsy.net">partners@artsy.net</a>.
+            <RouterLink inline to="mailto:partners@artsy.net">
+              partners@artsy.net
+            </RouterLink>
+            .
           </p>
           <p>
             If you’re looking for gallery representation, you might be
             interested in reading Artsy Editorial’s{" "}
-            <a
-              href="/article/artsy-editorial-artists-gallery-representation"
+            <RouterLink
+              inline
+              to="/article/artsy-editorial-artists-gallery-representation"
               target="_blank"
             >
               Gallery Representation Guide
-            </a>{" "}
+            </RouterLink>{" "}
             and{" "}
-            <a href="/series/working-artists-guide" target="_blank">
+            <RouterLink
+              inline
+              to="/series/working-artists-guide"
+              target="_blank"
+            >
               Working Artist’s Guide
-            </a>
+            </RouterLink>
             .
           </p>
         </TextItem>
@@ -82,9 +91,9 @@ export const FAQ: React.FC<FAQProps> = ({ shouldTrackClickEvent }) => {
       value: (
         <TextItem>
           Visit{" "}
-          <a href="https://partners.artsy.net" target="_blank">
+          <RouterLink inline to="https://partners.artsy.net" target="_blank">
             partners.artsy.net
-          </a>{" "}
+          </RouterLink>{" "}
           to apply to become a gallery partner and learn more about our
           marketplace plans.
         </TextItem>

--- a/src/Apps/Contact/ContactApp.tsx
+++ b/src/Apps/Contact/ContactApp.tsx
@@ -27,7 +27,11 @@ export const ContactApp: React.FC = () => {
 
           <Text variant="sm">
             For general questions and feedback, please visit our Help Center or
-            contact <a href="mailto:support@artsy.net">support@artsy.net</a>.
+            contact{" "}
+            <RouterLink inline to="mailto:support@artsy.net">
+              support@artsy.net
+            </RouterLink>
+            .
           </Text>
         </Column>
 
@@ -39,9 +43,15 @@ export const ContactApp: React.FC = () => {
           <Text variant="sm">
             For questions about bidding on artworks in auctions through Artsy,
             contact{" "}
-            <a href="mailto:specialist@artsy.net">specialist@artsy.net</a>. For
-            questions about buying artworks through galleries on Artsy, contact{" "}
-            <a href="mailto:inquiries@artsy.net">inquiries@artsy.net</a>.
+            <RouterLink inline to="mailto:specialist@artsy.net">
+              specialist@artsy.net
+            </RouterLink>
+            . For questions about buying artworks through galleries on Artsy,
+            contact{" "}
+            <RouterLink inline to="mailto:inquiries@artsy.net">
+              inquiries@artsy.net
+            </RouterLink>
+            .
           </Text>
         </Column>
 
@@ -53,7 +63,10 @@ export const ContactApp: React.FC = () => {
           <Text variant="sm">
             For members of the media interested in reaching Artsy's
             communications team, contact{" "}
-            <a href="mailto:press@artsy.net">press@artsy.net</a>.
+            <RouterLink inline to="mailto:press@artsy.net">
+              press@artsy.net
+            </RouterLink>
+            .
           </Text>
         </Column>
 
@@ -64,7 +77,10 @@ export const ContactApp: React.FC = () => {
 
           <Text variant="sm">
             For questions about images published on the site, contact{" "}
-            <a href="mailto:images@artsy.net">images@artsy.net</a>.
+            <RouterLink inline to="mailto:images@artsy.net">
+              images@artsy.net
+            </RouterLink>
+            .
           </Text>
         </Column>
 
@@ -75,7 +91,10 @@ export const ContactApp: React.FC = () => {
 
           <Text variant="sm">
             For job or internship openings, explore our{" "}
-            <RouterLink to="/jobs">Jobs page</RouterLink>.
+            <RouterLink inline to="/jobs">
+              Jobs page
+            </RouterLink>
+            .
           </Text>
         </Column>
 
@@ -86,11 +105,20 @@ export const ContactApp: React.FC = () => {
 
           <Text variant="sm">
             For pitches and story ideas, contact{" "}
-            <a href="mailto:pitches@artsy.net">pitches@artsy.net</a>.<br />
+            <RouterLink inline to="mailto:pitches@artsy.net">
+              pitches@artsy.net
+            </RouterLink>
+            .<br />
             For comments and questions, contact{" "}
-            <a href="mailto:comments@artsy.net">comments@artsy.net</a>.<br />
+            <RouterLink inline to="mailto:comments@artsy.net">
+              comments@artsy.net
+            </RouterLink>
+            .<br />
             For questions about The Artsy Podcast, contact{" "}
-            <a href="mailto:podcast@artsy.net">podcast@artsy.net</a>.
+            <RouterLink inline to="mailto:podcast@artsy.net">
+              podcast@artsy.net
+            </RouterLink>
+            .
           </Text>
         </Column>
 
@@ -101,7 +129,10 @@ export const ContactApp: React.FC = () => {
 
           <Text variant="sm">
             For personal data requests, contact{" "}
-            <a href="mailto:privacy@artsy.net">privacy@artsy.net</a>.
+            <RouterLink inline to="mailto:privacy@artsy.net">
+              privacy@artsy.net
+            </RouterLink>
+            .
           </Text>
         </Column>
       </GridColumns>

--- a/src/Apps/Conversation/Components/ConversationCTA.tsx
+++ b/src/Apps/Conversation/Components/ConversationCTA.tsx
@@ -66,7 +66,7 @@ export const ConversationCTA: React.FC<ConversationCTAProps> = ({
               <Text color="black60" variant="xs" mb={1}>
                 Always complete purchases with our secure checkout in order to
                 be covered by{" "}
-                <RouterLink to="/buyer-guarantee" target="_blank">
+                <RouterLink inline to="/buyer-guarantee" target="_blank">
                   The Artsy Guarantee
                 </RouterLink>
                 .

--- a/src/Apps/Conversation/Components/DetailsSidebar.tsx
+++ b/src/Apps/Conversation/Components/DetailsSidebar.tsx
@@ -102,7 +102,7 @@ export const DetailsSidebar: FC<DetailsProps> = ({
           key={attachment!.id}
           to={attachment!.downloadURL}
           target="_blank"
-          noUnderline
+          textDecoration="none"
         >
           <Flex alignItems="center">
             <DocumentIcon mr={0.5} />
@@ -201,7 +201,7 @@ export const DetailsSidebar: FC<DetailsProps> = ({
           <RouterLink
             to={`https://support.artsy.net/hc/en-us/sections/360008203054-Contact-a-gallery`}
             target="_blank"
-            noUnderline
+            textDecoration="none"
           >
             <Flex alignItems="center" mb={1}>
               <QuestionCircleIcon mr={1} />

--- a/src/Apps/Fair/Components/FairBoothRail/FairBoothRail.tsx
+++ b/src/Apps/Fair/Components/FairBoothRail/FairBoothRail.tsx
@@ -17,7 +17,7 @@ import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 import {
   initialBoothFilterState,
   useBoothsFilterContext,
-} from "../BoothFilterContext"
+} from "Apps/Fair/Components/BoothFilterContext"
 import {
   paramsToSnakeCase,
   removeDefaultValues,
@@ -79,7 +79,7 @@ export const FairBoothRail: React.FC<FairBoothRailProps> = ({
             <Text as="h3" variant="lg-display">
               <RouterLink
                 to={link}
-                noUnderline
+                textDecoration="none"
                 onClick={() => tracking.trackEvent(tappedViewTrackingData)}
               >
                 {show.partner?.name || ""}

--- a/src/Apps/Fair/Components/FairCollections/FairCollection.tsx
+++ b/src/Apps/Fair/Components/FairCollections/FairCollection.tsx
@@ -83,7 +83,7 @@ export const FairCollection: React.FC<FairCollectionProps> = ({
   return (
     <RouterLink
       to={`/collection/${collection.slug}`}
-      noUnderline
+      textDecoration="none"
       onClick={() => tracking.trackEvent(collectionTrackingData)}
       display="block"
     >

--- a/src/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
+++ b/src/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
@@ -30,7 +30,7 @@ export const FairOrganizerHeader: React.FC<FairOrganizerHeaderProps> = ({
 
   return (
     <>
-      <RouterLink to={href} noUnderline display="block">
+      <RouterLink to={href} textDecoration="none" display="block">
         <GridColumns>
           {avatar && (
             <Column span={[12, 12, 1]}>

--- a/src/Apps/Fairs/Routes/FairsIndex.tsx
+++ b/src/Apps/Fairs/Routes/FairsIndex.tsx
@@ -298,7 +298,7 @@ export const FairsIndex: React.FC<FairsIndexProps> = ({
               return (
                 <Text key={fair.internalID} my={2} variant="sm">
                   {fair.organizer?.profile?.href ? (
-                    <RouterLink to={fair.organizer.profile.href}>
+                    <RouterLink inline to={fair.organizer.profile.href}>
                       {fair.name}
                     </RouterLink>
                   ) : (

--- a/src/Apps/IdentityVerification/IdentityVerificationApp/CompleteFailed.tsx
+++ b/src/Apps/IdentityVerification/IdentityVerificationApp/CompleteFailed.tsx
@@ -1,5 +1,6 @@
 import { Button, Message, Spacer, Text } from "@artsy/palette"
 import * as React from "react"
+import { RouterLink } from "System/Router/RouterLink"
 
 export const CompleteFailed: React.FC = () => {
   return (
@@ -13,7 +14,10 @@ export const CompleteFailed: React.FC = () => {
         title="We’re sorry, we were not able to verify your identity."
       >
         For assistance, please contact Artsy verification support at{" "}
-        <a href="mailto:verification@artsy.net">verification@artsy.net</a>.
+        <RouterLink inline to="mailto:verification@artsy.net">
+          verification@artsy.net
+        </RouterLink>
+        .
       </Message>
 
       <Spacer y={2} />

--- a/src/Apps/IdentityVerification/IdentityVerificationApp/index.tsx
+++ b/src/Apps/IdentityVerification/IdentityVerificationApp/index.tsx
@@ -240,11 +240,14 @@ const IdentityVerificationApp: React.FC<Props> = ({
 
               <Text variant="xs" color="black60" textAlign="center">
                 Questions about identity verification? Read the{" "}
-                <RouterLink to="https://support.artsy.net/hc/en-us/articles/360062798613-How-to-Complete-Identity-Verification">
+                <RouterLink
+                  inline
+                  to="https://support.artsy.net/hc/en-us/articles/360062798613-How-to-Complete-Identity-Verification"
+                >
                   step by step instructions
                 </RouterLink>{" "}
                 or contact{" "}
-                <RouterLink to={"mailto:verification@artsy.net"}>
+                <RouterLink inline to={"mailto:verification@artsy.net"}>
                   verification@artsy.net
                 </RouterLink>
                 .

--- a/src/Apps/Jobs/JobApp.tsx
+++ b/src/Apps/Jobs/JobApp.tsx
@@ -12,6 +12,7 @@ import { MetaTags } from "Components/MetaTags"
 import { TopContextBar } from "Components/TopContextBar"
 import { JobApp_job$data } from "__generated__/JobApp_job.graphql"
 import { PageHTML } from "Apps/Page/Components/PageHTML"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface JobAppProps {
   job: JobApp_job$data
@@ -53,13 +54,14 @@ const JobApp: FC<JobAppProps> = ({ job }) => {
 
             <Text variant="sm">
               To apply, please{" "}
-              <a
-                href={job.externalURL}
+              <RouterLink
+                inline
+                to={job.externalURL}
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 submit your application here
-              </a>
+              </RouterLink>
               . When you apply, you will be directed to a third party site.
             </Text>
 

--- a/src/Apps/Jobs/JobsApp.tsx
+++ b/src/Apps/Jobs/JobsApp.tsx
@@ -48,13 +48,13 @@ const JobsApp: FC<JobsAppProps> = ({ viewer }) => {
           <Spacer y={2} />
 
           <Text variant="sm">
-            <RouterLink to="/article/artsy-jobs-life-artsy">
+            <RouterLink inline to="/article/artsy-jobs-life-artsy">
               Life at Artsy
             </RouterLink>
 
             <br />
 
-            <RouterLink to="/article/artsy-jobs-engineering">
+            <RouterLink inline to="/article/artsy-jobs-engineering">
               Artsy Engineering
             </RouterLink>
           </Text>
@@ -63,29 +63,32 @@ const JobsApp: FC<JobsAppProps> = ({ viewer }) => {
 
           <Text variant="sm">
             Check us out on{" "}
-            <a
-              href="http://www.glassdoor.com/Overview/Working-at-Artsy-EI_IE793485.11,16.htm"
+            <RouterLink
+              inline
+              to="http://www.glassdoor.com/Overview/Working-at-Artsy-EI_IE793485.11,16.htm"
               target="_blank"
               rel="noopener noreferrer"
             >
               Glassdoor
-            </a>
+            </RouterLink>
             ,{" "}
-            <a
-              href="https://angel.co/artsy"
+            <RouterLink
+              inline
+              to="https://angel.co/artsy"
               target="_blank"
               rel="noopener noreferrer"
             >
               AngelList
-            </a>
+            </RouterLink>
             , and{" "}
-            <a
-              href="https://www.linkedin.com/company/artsyinc?trk=top_nav_home"
+            <RouterLink
+              inline
+              to="https://www.RouterLinkedin.com/company/artsyinc?trk=top_nav_home"
               target="_blank"
               rel="noopener noreferrer"
             >
               LinkedIn
-            </a>
+            </RouterLink>
           </Text>
         </Column>
       </GridColumns>

--- a/src/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
+++ b/src/Apps/MeetTheSpecialists/Routes/MeetTheSpecialistsIndex.tsx
@@ -13,6 +13,7 @@ import { MetaTags } from "Components/MetaTags"
 import { FC } from "react"
 import { cropped } from "Utils/resized"
 import { useTranslation } from "react-i18next"
+import { RouterLink } from "System/Router/RouterLink"
 
 export const MeetTheSpecialistsIndex: FC = () => {
   const { t } = useTranslation()
@@ -43,14 +44,26 @@ export const MeetTheSpecialistsIndex: FC = () => {
 
           <Text variant="xs">
             Have a question about Artsy? Check out our{" "}
-            <a href="https://support.artsy.net">help center</a> or email{" "}
-            <a href="mailto:support@artsy.net">support@artsy.net</a>.
+            <RouterLink inline to="https://support.artsy.net">
+              help center
+            </RouterLink>{" "}
+            or email{" "}
+            <RouterLink inline to="mailto:support@artsy.net">
+              support@artsy.net
+            </RouterLink>
+            .
             <br />
             Have a question about bidding on Artsy? Email{" "}
-            <a href="mailto:specialist@artsy.net">specialist@artsy.net</a>.
+            <RouterLink inline to="mailto:specialist@artsy.net">
+              specialist@artsy.net
+            </RouterLink>
+            .
             <br />
             Have a question about an existing order or offer? Email{" "}
-            <a href="mailto:specialist@artsy.net">orders@artsy.net</a>.
+            <RouterLink inline to="mailto:specialist@artsy.net">
+              orders@artsy.net
+            </RouterLink>
+            .
           </Text>
         </Column>
       </GridColumns>

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWAHowItWorksModal.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWAHowItWorksModal.tsx
@@ -49,6 +49,7 @@ export const MyCollectionArtworkSWAHowItWorksModal: React.FC<{
       <Text mb={2}>
         For more information, see our{" "}
         <RouterLink
+          inline
           to={article}
           target="_blank"
           data-testid="collector-help-center-link"
@@ -58,7 +59,9 @@ export const MyCollectionArtworkSWAHowItWorksModal: React.FC<{
       </Text>
       <Text>
         Or get in touch with one of our specialists at{" "}
-        <RouterLink to={"mailto:sell@artsy.net"}>sell@artsy.net</RouterLink>
+        <RouterLink inline to={"mailto:sell@artsy.net"}>
+          sell@artsy.net
+        </RouterLink>
         {"."}
       </Text>
     </ModalDialog>

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASection.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASection.tsx
@@ -26,7 +26,11 @@ export const MyCollectionArtworkSWASectionMobileLayout: React.FC<Props> = ({
       <Text mb={2} color="black60" variant="xs">
         Let our experts find the best sales option for you.
       </Text>
-      <RouterLink noUnderline to={route} data-testid="submit-for-sale-link">
+      <RouterLink
+        textDecoration="none"
+        to={route}
+        data-testid="submit-for-sale-link"
+      >
         <Button
           variant="primaryBlack"
           width="100%"
@@ -91,7 +95,7 @@ export const MyCollectionArtworkSWASectionDesktopLayout: React.FC<Props> = ({
         Let our experts find the best sales option for you.
       </Text>
       <RouterLink
-        noUnderline
+        textDecoration="none"
         to={route}
         data-testid="submit-for-sale-link"
         onClick={() => {

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASectionSubmitted.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASectionSubmitted.tsx
@@ -159,11 +159,16 @@ const SubmissionStatusModal: React.FC<SubmissionStatusModalProps> = ({
       </Text>
       <Text variant="sm-display" mb={2}>
         For more information, see our Collector Help Center article{" "}
-        <RouterLink to={article}>What items do you accept?</RouterLink>
+        <RouterLink inline to={article}>
+          What items do you accept?
+        </RouterLink>
       </Text>
       <Text variant="sm-display">
         Or get in touch with one of our specialists at{" "}
-        <RouterLink to={"mailto:sell@artsy.net"}>sell@artsy.net</RouterLink>.
+        <RouterLink inline to={"mailto:sell@artsy.net"}>
+          sell@artsy.net
+        </RouterLink>
+        .
       </Text>
     </ModalDialog>
   )

--- a/src/Apps/MyCollection/Routes/PriceEstimate/PriceEstimateContactInformation.tsx
+++ b/src/Apps/MyCollection/Routes/PriceEstimate/PriceEstimateContactInformation.tsx
@@ -159,6 +159,7 @@ export const PriceEstimateContactInformation: React.FC<PriceEstimateContactInfor
               <Text variant="xs" color="black60">
                 By continuing, you agree to{" "}
                 <RouterLink
+                  inline
                   color="black60"
                   to="/privacy"
                   target="_blank"

--- a/src/Apps/Order/Components/BuyerGuarantee.tsx
+++ b/src/Apps/Order/Components/BuyerGuarantee.tsx
@@ -2,13 +2,13 @@ import { ActionType, ContextModule } from "@artsy/cohesion"
 import {
   CircleBlackCheckIcon,
   Flex,
-  Link,
   Text,
   StackableBorderBox,
   Spacer,
 } from "@artsy/palette"
 import * as React from "react"
 import { useTracking } from "react-tracking"
+import { RouterLink } from "System/Router/RouterLink"
 
 export const BUYER_GUARANTEE_URL =
   "https://support.artsy.net/hc/en-us/articles/360048946973-How-does-Artsy-protect-me"
@@ -49,14 +49,15 @@ export const BuyerGuarantee: React.FC<BuyerGuaranteeProps> = ({
         {renderArtsyPrivateSaleConditions && (
           <Text variant="sm" color="black60">
             This purchase is subject to{" "}
-            <a
+            <RouterLink
+              inline
               style={{ textDecoration: "underline", color: "#000" }}
-              href="/private-sales-conditions-of-sale"
+              to="/private-sales-conditions-of-sale"
               target="_blank"
               rel="noopener noreferrer"
             >
               Artsy Private Sales LLC Conditions of Sale
-            </a>
+            </RouterLink>
           </Text>
         )}
 
@@ -87,14 +88,15 @@ export const BuyerGuarantee: React.FC<BuyerGuaranteeProps> = ({
           </Text>
           <Text variant="xs" color="black60">
             Learn more about{" "}
-            <Link
+            <RouterLink
+              inline
               target="_blank"
               rel="noopener noreferrer"
-              href={BUYER_GUARANTEE_URL}
+              to={BUYER_GUARANTEE_URL}
               onClick={handleClick}
             >
               Artsy’s buyer protection.
-            </Link>
+            </RouterLink>
           </Text>
         </Flex>
       </Flex>

--- a/src/Apps/Order/Components/ConditionsOfSaleDisclaimer.tsx
+++ b/src/Apps/Order/Components/ConditionsOfSaleDisclaimer.tsx
@@ -1,5 +1,6 @@
 import { Text, TextProps } from "@artsy/palette"
 import * as React from "react"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface Props {
   textProps?: Partial<TextProps>
@@ -14,14 +15,15 @@ export const ConditionsOfSaleDisclaimer: React.FC<Props> = ({
     return (
       <Text variant="sm" color="black60" {...textProps}>
         By clicking Complete Purchase, I agree to the{" "}
-        <a
+        <RouterLink
+          inline
           style={{ textDecoration: "underline", color: "#000" }}
-          href="/private-sales-conditions-of-sale"
+          to="/private-sales-conditions-of-sale"
           target="_blank"
           rel="noopener noreferrer"
         >
           Artsy Private Sales LLC Conditions of Sale
-        </a>{" "}
+        </RouterLink>{" "}
         and any Additional Conditions of Sale specified on this page and in the
         order confirmation email.
       </Text>
@@ -31,9 +33,9 @@ export const ConditionsOfSaleDisclaimer: React.FC<Props> = ({
   return (
     <Text variant="xs" color="black60" {...textProps}>
       By clicking Submit, I agree to Artsy’s{" "}
-      <a href="/conditions-of-sale" target="_blank">
+      <RouterLink inline to="/conditions-of-sale" target="_blank">
         Conditions of Sale.
-      </a>
+      </RouterLink>
     </Text>
   )
 }

--- a/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -222,13 +222,14 @@ export const TransactionDetailsSummaryItem: FC<TransactionDetailsSummaryItemProp
       <Spacer y={2} />
       <Text variant="sm" color="black60">
         *Additional duties and taxes{" "}
-        <a
-          href="https://support.artsy.net/hc/en-us/articles/4413546314647-Will-my-order-be-subject-to-customs-fees-"
+        <RouterLink
+          inline
+          to="https://support.artsy.net/hc/en-us/articles/4413546314647-Will-my-order-be-subject-to-customs-fees-"
           target="_blank"
           rel="noopener noreferrer"
         >
           may apply at import.
-        </a>
+        </RouterLink>
       </Text>
       {shippingNotCalculated() && (
         <>
@@ -260,7 +261,11 @@ export const TransactionDetailsSummaryItem: FC<TransactionDetailsSummaryItemProp
             <Text variant="sm">
               View and manage all artworks in your Collection{" "}
               {!isEigen ? "on the Artsy app." : "through your "}
-              {isEigen && <RouterLink to={"/my-profile"}>profile.</RouterLink>}
+              {isEigen && (
+                <RouterLink inline to={"/my-profile"}>
+                  profile.
+                </RouterLink>
+              )}
             </Text>
           </Flex>
           <Flex pt={1}>

--- a/src/Apps/Order/Dialogs.tsx
+++ b/src/Apps/Order/Dialogs.tsx
@@ -1,6 +1,7 @@
 import { Button, Text } from "@artsy/palette"
 import { ModalDialog } from "@artsy/palette"
 import * as React from "react"
+import { RouterLink } from "System/Router/RouterLink"
 // TODO: Replace with normal React state
 // eslint-disable-next-line no-restricted-imports
 import { Container, Subscribe } from "unstated"
@@ -124,7 +125,10 @@ export class DialogContainer extends Container<DialogState> {
     message = (
       <>
         Something went wrong. Please try again or contact{" "}
-        <a href={`mailto:${supportEmail}}`}>{supportEmail}</a>.
+        <RouterLink inline to={`mailto:${supportEmail}}`}>
+          {supportEmail}
+        </RouterLink>
+        .
       </>
     ),
     continueButtonText = "Continue",

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -426,7 +426,10 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     <>
       There was a problem getting shipping quotes. <br />
       Please contact{" "}
-      <RouterLink to={`mailto:orders@artsy.net`}>orders@artsy.net</RouterLink>.
+      <RouterLink inline to={`mailto:orders@artsy.net`}>
+        orders@artsy.net
+      </RouterLink>
+      .
     </>
   )
 

--- a/src/Apps/Order/Utils/getStatusCopy.tsx
+++ b/src/Apps/Order/Utils/getStatusCopy.tsx
@@ -147,8 +147,10 @@ export const getStatusCopy = (order, logger?): StatusPageConfig => {
             <>
               Please allow 5–7 business days for the refund to appear on your
               bank statement. Contact{" "}
-              <a href="mailto:orders@artsy.net">orders@artsy.net</a> with any
-              questions.
+              <RouterLink inline to="mailto:orders@artsy.net">
+                orders@artsy.net
+              </RouterLink>{" "}
+              with any questions.
             </>
           ),
         }
@@ -183,8 +185,10 @@ export const canceledOfferOrderCopy = (order, logger?): StatusPageConfig => {
             decision to end the negotiation process.
             <Spacer y={2} />
             We’d love to get your feedback. Contact{" "}
-            <a href="mailto:orders@artsy.net">orders@artsy.net</a> with any
-            comments you have.
+            <RouterLink inline to="mailto:orders@artsy.net">
+              orders@artsy.net
+            </RouterLink>{" "}
+            with any comments you have.
           </>
         ),
         showTransactionSummary: false,
@@ -334,7 +338,7 @@ export const approvedDescription = (
       <Text color="black100">
         You will receive an email from our team with next steps. If you have any
         questions about your purchase, email us at{" "}
-        <RouterLink to="privatesales@artsy.net">
+        <RouterLink inline to="privatesales@artsy.net">
           privatesales@artsy.net.
         </RouterLink>
       </Text>
@@ -386,7 +390,7 @@ export const processingApprovalDescription = (
       <Text color="black100">
         You will receive an email from our team with next steps. If you have any
         questions about your purchase, email us at{" "}
-        <RouterLink to="privatesales@artsy.net">
+        <RouterLink inline to="privatesales@artsy.net">
           privatesales@artsy.net.
         </RouterLink>
       </Text>

--- a/src/Apps/Partner/Components/Overview/SubscriberBanner.tsx
+++ b/src/Apps/Partner/Components/Overview/SubscriberBanner.tsx
@@ -16,7 +16,7 @@ export const SubscriberBanner: React.FC<SubscriberBannerProps> = ({
   return (
     <Message mb={4} title={hasFairPartnership ? fairPartner : churnedPartner}>
       <Text display="inline">{`Are you a representative of ${name}?`}</Text>
-      <RouterLink to="https://partners.artsy.net/gallery-partnerships/">
+      <RouterLink inline to="https://partners.artsy.net/gallery-partnerships/">
         <Text display="inline">
           &nbsp;Learn about Artsy gallery partnerships.
         </Text>

--- a/src/Apps/Press/PressApp.tsx
+++ b/src/Apps/Press/PressApp.tsx
@@ -4,7 +4,8 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { MetaTags } from "Components/MetaTags"
 import { RouteTab, RouteTabs } from "Components/RouteTabs"
 import { PressApp_page$data } from "__generated__/PressApp_page.graphql"
-import { PageHTML } from "../Page/Components/PageHTML"
+import { PageHTML } from "Apps/Page/Components/PageHTML"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface PressAppProps {
   page: PressApp_page$data
@@ -23,9 +24,9 @@ const PressApp: FC<PressAppProps> = ({ page }) => {
 
       <Text variant="xl" color="black60">
         Contact{" "}
-        <a href="mailto:press@artsy.net" style={{ textDecoration: "none" }}>
+        <RouterLink inline to="mailto:press@artsy.net" textDecoration={"none"}>
           press@artsy.net
-        </a>
+        </RouterLink>
       </Text>
 
       <Spacer y={4} />

--- a/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileFields.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileFields.tsx
@@ -264,14 +264,15 @@ const SettingsEditProfileFields: React.FC<SettingsEditProfileFieldsProps> = ({
               )}
               <Text variant="sm" mt={1} color="black60">
                 For details, see{" "}
-                <a
-                  href="https://www.artsy.net/identity-verification-faq"
+                <RouterLink
+                  inline
+                  to="/identity-verification-faq"
                   target="_blank"
                 >
                   FAQs
-                </a>{" "}
+                </RouterLink>{" "}
                 or contact{" "}
-                <RouterLink to={"mailto:verification@artsy.net"}>
+                <RouterLink inline to={"mailto:verification@artsy.net"}>
                   verification@artsy.net
                 </RouterLink>
                 .

--- a/src/Apps/Settings/Routes/EditProfile/Components/__tests__/SettingsEditProfileFields.jest.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Components/__tests__/SettingsEditProfileFields.jest.tsx
@@ -135,12 +135,12 @@ describe("SettingsEditProfileFields", () => {
       expect(screen.getByText("Verify Your ID")).toBeInTheDocument()
       const faqLink = screen.getByText("FAQs")
       expect(faqLink).toHaveAttribute(
-        "to",
+        "href",
         expect.stringContaining("/identity-verification-faq")
       )
       const mailLink = screen.getByText("verification@artsy.net")
       expect(mailLink).toHaveAttribute(
-        "to",
+        "href",
         expect.stringContaining("mailto:verification@artsy.net")
       )
     })

--- a/src/Apps/Settings/Routes/EditProfile/Components/__tests__/SettingsEditProfileFields.jest.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Components/__tests__/SettingsEditProfileFields.jest.tsx
@@ -135,14 +135,12 @@ describe("SettingsEditProfileFields", () => {
       expect(screen.getByText("Verify Your ID")).toBeInTheDocument()
       const faqLink = screen.getByText("FAQs")
       expect(faqLink).toHaveAttribute(
-        "href",
-        expect.stringContaining(
-          "https://www.artsy.net/identity-verification-faq"
-        )
+        "to",
+        expect.stringContaining("/identity-verification-faq")
       )
       const mailLink = screen.getByText("verification@artsy.net")
       expect(mailLink).toHaveAttribute(
-        "href",
+        "to",
         expect.stringContaining("mailto:verification@artsy.net")
       )
     })

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -22,6 +22,7 @@ import { AppSecondFactorModal, OnCompleteRedirectModal } from "./Modal"
 import { CreateAppSecondFactor } from "./Mutation/CreateAppSecondFactor"
 
 import { afterUpdateRedirect } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/helpers"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface AppSecondFactorProps {
   me: AppSecondFactor_me$data
@@ -178,21 +179,23 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = ({
 
           <Text variant="sm" color="black60">
             Generate secure authentication codes using an application such as{" "}
-            <a
-              href="https://support.1password.com/one-time-passwords"
+            <RouterLink
+              inline
+              to="https://support.1password.com/one-time-passwords"
               target="_blank"
               rel="noopener noreferrer"
             >
               1Password
-            </a>{" "}
+            </RouterLink>{" "}
             or{" "}
-            <a
-              href="https://support.google.com/accounts/answer/1066447"
+            <RouterLink
+              inline
+              to="https://support.google.com/accounts/answer/1066447"
               target="_blank"
               rel="noopener noreferrer"
             >
               Google Authenticator
-            </a>
+            </RouterLink>
             .
           </Text>
         </Box>

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -23,6 +23,7 @@ import { DisableFactorConfirmation } from "Apps/Settings/Routes/EditSettings/Com
 import { isArtsyEmail } from "./isArtsyEmail"
 import { OnCompleteRedirectModal, SmsSecondFactorModal } from "./Modal"
 import { CreateSmsSecondFactor } from "./Mutation/CreateSmsSecondFactor"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface SmsSecondFactorProps {
   me: SmsSecondFactor_me$data
@@ -172,9 +173,12 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = ({
           method via 1Password (or your preferred password manager)."
           >
             You may find a detailed walkthrough{" "}
-            <a href="https://artsy.net/employees-mfa-instructions">
+            <RouterLink
+              inline
+              to="https://artsy.net/employees-mfa-instructions"
+            >
               here in Notion
-            </a>
+            </RouterLink>
             .
           </Message>
         )}

--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -196,7 +196,7 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
 
           <Text variant="sm-display" color="black60">
             {isOrderActive ? (
-              <RouterLink to={`/orders/${order.internalID}/status`}>
+              <RouterLink inline to={`/orders/${order.internalID}/status`}>
                 {order.code}
               </RouterLink>
             ) : (
@@ -238,11 +238,13 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
         <Text variant="xs" color="black60">
           Need Help?{" "}
           {isPrivateSale ? (
-            <RouterLink to="mailto:privatesales@artsy.net">
+            <RouterLink inline to="mailto:privatesales@artsy.net">
               privatesales@artsy.net
             </RouterLink>
           ) : (
-            <RouterLink to="mailto:support@artsy.net">Contact Us.</RouterLink>
+            <RouterLink inline to="mailto:support@artsy.net">
+              Contact Us.
+            </RouterLink>
           )}
         </Text>
       </Flex>

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -191,7 +191,7 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
                     mt={2}
                   >
                     To receive Email Alerts, please update{" "}
-                    <RouterLink to="/unsubscribe">
+                    <RouterLink inline to="/unsubscribe">
                       your email preferences
                     </RouterLink>
                     .

--- a/src/Apps/Show/Components/ShowContextCard.tsx
+++ b/src/Apps/Show/Components/ShowContextCard.tsx
@@ -80,8 +80,12 @@ export const ShowContextCard: React.FC<Props> = ({ show }) => {
           </Column>
         )}
         <Column span={6}>
-          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
-          <StyledLink noUnderline to={fair.href} onClick={handleClick}>
+          <StyledLink
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+            to={fair.href}
+            textDecoration="none"
+            onClick={handleClick}
+          >
             {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             <FairCard fair={fair} />
 
@@ -143,8 +147,12 @@ export const ShowContextCard: React.FC<Props> = ({ show }) => {
           <Text variant="lg-display">Presented by {partnerName}</Text>
         </Column>
         <Column span={6}>
-          {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
-          <StyledLink to={partnerHref} noUnderline onClick={handleClick}>
+          <StyledLink
+            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
+            to={partnerHref}
+            textDecoration="none"
+            onClick={handleClick}
+          >
             <TriptychCard
               title={partnerName}
               subtitle={locationNames}

--- a/src/Apps/Show/Components/ShowContextualLink.tsx
+++ b/src/Apps/Show/Components/ShowContextualLink.tsx
@@ -32,17 +32,18 @@ export const ContextualLink: React.FC<Props> = ({ show }) => {
   const partnerHref = partner?.isLinkable && partner?.href
   const partnerName = partner?.name
   const fairName = fair?.name
-  const fairHref = fair?.href
+  const fairHref = fair?.href || ""
 
   if (isFairBooth) {
     return (
       <>
-        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
-        {fair.isActive && (
+        {fair?.isActive && (
           <Box>
             <Text variant="sm">
-              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
-              Part of <RouterLink to={fairHref}>{fairName}</RouterLink>
+              Part of{" "}
+              <RouterLink inline to={fairHref}>
+                {fairName}
+              </RouterLink>
             </Text>
           </Box>
         )}
@@ -55,7 +56,9 @@ export const ContextualLink: React.FC<Props> = ({ show }) => {
       <Text variant="sm" textAlign="left">
         Presented by&nbsp;
         {!!partnerHref ? (
-          <RouterLink to={partnerHref}>{partnerName}</RouterLink>
+          <RouterLink inline to={partnerHref}>
+            {partnerName}
+          </RouterLink>
         ) : (
           partnerName
         )}

--- a/src/Components/ArtistSeriesRail/ArtistSeriesItem.tsx
+++ b/src/Components/ArtistSeriesRail/ArtistSeriesItem.tsx
@@ -59,7 +59,7 @@ export const ArtistSeriesItem: React.FC<ArtistSeriesItemProps> = ({
     <RouterLink
       onClick={onClick}
       to={`/artist-series/${slug}`}
-      noUnderline
+      textDecoration="none"
       style={{ display: "block" }}
     >
       {image?.cropped?.src ? (

--- a/src/Components/AuctionFAQsDialog.tsx
+++ b/src/Components/AuctionFAQsDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "@artsy/palette"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { RouterLink } from "System/Router/RouterLink"
 import { AuctionFAQsDialog_viewer$data } from "__generated__/AuctionFAQsDialog_viewer.graphql"
 
 interface AuctionFAQsDialogProps {
@@ -51,7 +52,10 @@ const AuctionFAQsDialog: React.FC<AuctionFAQsDialogProps> = ({
       <Text variant="sm" mb={2}>
         How can we help you? Below are a few general categories to help you find
         the answers you’re looking for. Need more immediate assistance? Please{" "}
-        <a href="mailto:specialist@artsy.net">contact us</a>.
+        <RouterLink inline to="mailto:specialist@artsy.net">
+          contact us
+        </RouterLink>
+        .
       </Text>
 
       <Tabs>

--- a/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
@@ -22,6 +22,7 @@ import { isTouch } from "Utils/device"
 import { useAuthDialogTracking } from "Components/AuthDialog/Hooks/useAuthDialogTracking"
 import { AuthDialogSignUpPlaceholder } from "Components/AuthDialog/Components/AuthDialogSignUpPlaceholder"
 import { useCountryCode } from "Components/AuthDialog/Hooks/useCountryCode"
+import { RouterLink } from "System/Router/RouterLink"
 
 export const AuthDialogSignUp: FC = () => {
   const {
@@ -189,13 +190,13 @@ export const AuthDialogSignUp: FC = () => {
               <Text variant="xs" color="black60" textAlign="center">
                 By {isTouch ? "tapping" : "clicking"} Sign Up or Continue with
                 Apple, Google, or Facebook, you agree to Artsy’s{" "}
-                <a href="/terms" target="_blank">
+                <RouterLink inline to="/terms" target="_blank">
                   Terms of Use
-                </a>{" "}
+                </RouterLink>{" "}
                 and{" "}
-                <a href="/privacy" target="_blank">
+                <RouterLink inline to="/privacy" target="_blank">
                   Privacy Policy
-                </a>
+                </RouterLink>
                 {isAutomaticallySubscribed && (
                   <> and to receiving emails from Artsy</>
                 )}
@@ -204,21 +205,23 @@ export const AuthDialogSignUp: FC = () => {
 
               <Text variant="xs" color="black60" textAlign="center">
                 This site is protected by reCAPTCHA and the{" "}
-                <a
-                  href="https://policies.google.com/privacy"
+                <RouterLink
+                  inline
+                  to="https://policies.google.com/privacy"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
                   Google Privacy Policy
-                </a>{" "}
+                </RouterLink>{" "}
                 and{" "}
-                <a
-                  href="https://policies.google.com/terms"
+                <RouterLink
+                  inline
+                  to="https://policies.google.com/terms"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
                   Terms of Service
-                </a>{" "}
+                </RouterLink>{" "}
                 apply.
               </Text>
             </Join>

--- a/src/Components/CCPARequest.tsx
+++ b/src/Components/CCPARequest.tsx
@@ -18,6 +18,7 @@ import * as Yup from "yup"
 import { useMutation } from "Utils/Hooks/useMutation"
 import { graphql } from "react-relay"
 import { CCPARequestMutation } from "__generated__/CCPARequestMutation.graphql"
+import { RouterLink } from "System/Router/RouterLink"
 
 const logger = createLogger("Components/CCPARequest.tsx")
 
@@ -121,13 +122,15 @@ export const CCPARequest: FC<CCPARequestProps> = ({ onClose }) => {
           >
             <Text variant="sm">
               Our{" "}
-              <a target="_blank" href="/privacy">
+              <RouterLink inline target="_blank" to="/privacy">
                 Privacy Policy
-              </a>{" "}
+              </RouterLink>{" "}
               has the information we collect, how we use it, and why we use it.
               You can also email{" "}
-              <a href="mailto:privacy@artsy.net">privacy@artsy.net</a> for more
-              information or to submit a request.
+              <RouterLink inline to="mailto:privacy@artsy.net">
+                privacy@artsy.net
+              </RouterLink>{" "}
+              for more information or to submit a request.
             </Text>
 
             <Spacer y={4} />

--- a/src/Components/CascadingEndTimesBanner.tsx
+++ b/src/Components/CascadingEndTimesBanner.tsx
@@ -2,6 +2,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { FullBleedBanner } from "Components/FullBleedBanner"
 import { getENV } from "Utils/getENV"
 import { CascadingEndTimesBanner_sale$data } from "__generated__/CascadingEndTimesBanner_sale.graphql"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface CascadingEndTimesBannerProps {
   sale: CascadingEndTimesBanner_sale$data
@@ -25,9 +26,9 @@ const CascadingEndTimesBanner: React.FC<CascadingEndTimesBannerProps> = ({
       {!!helpArticleLink && (
         <>
           &nbsp;
-          <a target="_blank" href={helpArticleLink}>
+          <RouterLink inline target="_blank" to={helpArticleLink}>
             Learn More
-          </a>
+          </RouterLink>
         </>
       )}
     </FullBleedBanner>

--- a/src/Components/ErrorPage.tsx
+++ b/src/Components/ErrorPage.tsx
@@ -8,6 +8,7 @@ import {
 } from "@artsy/palette"
 import * as React from "react"
 import styled from "styled-components"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface ErrorPageProps extends BoxProps {
   code: number | string
@@ -40,13 +41,15 @@ export const ErrorPage: React.FC<ErrorPageProps> = ({
 
           <Text variant="sm-display" color="black60">
             Please contact{" "}
-            <a href="mailto:support@artsy.net">support@artsy.net</a> with any
-            questions.
+            <RouterLink inline to="mailto:support@artsy.net">
+              support@artsy.net
+            </RouterLink>{" "}
+            with any questions.
           </Text>
 
           {children ?? (
             <Text variant="sm-display" color="black60">
-              <a href="/">Go to Artsy Homepage</a>
+              <RouterLink to="/">Go to Artsy Homepage</RouterLink>
             </Text>
           )}
         </Column>

--- a/src/Components/Inquiry/Views/InquiryConfirmation.tsx
+++ b/src/Components/Inquiry/Views/InquiryConfirmation.tsx
@@ -22,7 +22,7 @@ export const InquiryConfirmation: React.FC = () => {
 
       <Text variant="sm-display" my={2}>
         Conversation with the gallery will continue{" "}
-        <RouterLink to="/user/conversations" onClick={next}>
+        <RouterLink inline to="/user/conversations" onClick={next}>
           in the Inbox.
         </RouterLink>
       </Text>

--- a/src/Components/Inquiry/Views/InquiryInquiry.tsx
+++ b/src/Components/Inquiry/Views/InquiryInquiry.tsx
@@ -28,6 +28,7 @@ import {
 } from "Components/Inquiry/Hooks/useInquiryContext"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { logger } from "Components/Inquiry/util"
+import { RouterLink } from "System/Router/RouterLink"
 
 type Mode = "Pending" | "Confirm" | "Sending" | "Error" | "Success"
 
@@ -180,9 +181,9 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
 
           <Text variant="xs">
             By clicking send, you accept our{" "}
-            <a href="/privacy" target="_blank">
+            <RouterLink inline to="/privacy" target="_blank">
               Privacy Policy.
-            </a>
+            </RouterLink>
           </Text>
         </>
       )}

--- a/src/Components/Inquiry/Views/InquirySignUp.tsx
+++ b/src/Components/Inquiry/Views/InquirySignUp.tsx
@@ -4,10 +4,10 @@ import { useState } from "react"
 import { createRelaySSREnvironment } from "System/Relay/createRelaySSREnvironment"
 import { EnableRecaptcha } from "Utils/EnableRecaptcha"
 import { wait } from "Utils/wait"
-import { useInquiryContext } from "../Hooks/useInquiryContext"
-import { useArtworkInquiryRequest } from "../Hooks/useArtworkInquiryRequest"
+import { useInquiryContext } from "Components/Inquiry/Hooks/useInquiryContext"
+import { useArtworkInquiryRequest } from "Components/Inquiry/Hooks/useArtworkInquiryRequest"
 import { signUp } from "Utils/auth"
-import { logger } from "../util"
+import { logger } from "Components/Inquiry/util"
 import {
   ActionType,
   AuthModalType,
@@ -17,6 +17,7 @@ import {
 } from "@artsy/cohesion"
 import { useTracking } from "react-tracking"
 import { useMode } from "Utils/Hooks/useMode"
+import { RouterLink } from "System/Router/RouterLink"
 
 type Mode = "Pending" | "Loading" | "Error" | "Done" | "Success"
 
@@ -163,37 +164,39 @@ export const InquirySignUp: React.FC = () => {
 
         <Text variant="xs" color="black60">
           By signing up, you agree to our{" "}
-          <a href="/terms" target="_blank">
+          <RouterLink inline to="/terms" target="_blank">
             Terms of Use
-          </a>
+          </RouterLink>
           ,{" "}
-          <a href="/privacy" target="_blank">
+          <RouterLink inline to="/privacy" target="_blank">
             Privacy Policy
-          </a>
+          </RouterLink>
           ,{" "}
-          <a href="/conditions-of-sale" target="_blank">
+          <RouterLink inline to="/conditions-of-sale" target="_blank">
             Conditions of Sale
-          </a>{" "}
+          </RouterLink>{" "}
           and to receiving emails from Artsy.
         </Text>
 
         <Text variant="xs" color="black60" mt={1}>
           This site is protected by reCAPTCHA and the{" "}
-          <a
-            href="https://policies.google.com/privacy"
+          <RouterLink
+            inline
+            to="https://policies.google.com/privacy"
             target="_blank"
             rel="noopener noreferrer"
           >
             Google Privacy Policy
-          </a>{" "}
+          </RouterLink>{" "}
           and{" "}
-          <a
-            href="https://policies.google.com/terms"
+          <RouterLink
+            inline
+            to="https://policies.google.com/terms"
             target="_blank"
             rel="noopener noreferrer"
           >
             Terms of Service
-          </a>{" "}
+          </RouterLink>{" "}
           apply.
         </Text>
       </Box>

--- a/src/Components/Inquiry/Views/InquirySpecialist.tsx
+++ b/src/Components/Inquiry/Views/InquirySpecialist.tsx
@@ -10,10 +10,14 @@ import {
 import * as React from "react"
 import { useSystemContext } from "System/useSystemContext"
 import { wait } from "Utils/wait"
-import { useArtworkInquiryRequest } from "../Hooks/useArtworkInquiryRequest"
-import { InquiryState, useInquiryContext } from "../Hooks/useInquiryContext"
-import { logger } from "../util"
+import { useArtworkInquiryRequest } from "Components/Inquiry/Hooks/useArtworkInquiryRequest"
+import {
+  InquiryState,
+  useInquiryContext,
+} from "Components/Inquiry/Hooks/useInquiryContext"
+import { logger } from "Components/Inquiry/util"
 import { useMode } from "Utils/Hooks/useMode"
+import { RouterLink } from "System/Router/RouterLink"
 
 type Mode = "Pending" | "Sending" | "Error" | "Success"
 
@@ -129,9 +133,9 @@ export const InquirySpecialist: React.FC = () => {
 
           <Text variant="xs">
             By clicking send, you accept our{" "}
-            <a href="/privacy" target="_blank">
+            <RouterLink inline to="/privacy" target="_blank">
               Privacy Policy.
-            </a>
+            </RouterLink>
           </Text>
         </>
       )}

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
@@ -55,7 +55,11 @@ export const RelatedCollectionEntity: React.FC<RelatedCollectionEntityProps> = (
 
   return (
     <Box>
-      <RouterLink to={`/collection/${slug}`} onClick={onLinkClick} noUnderline>
+      <RouterLink
+        to={`/collection/${slug}`}
+        onClick={onLinkClick}
+        textDecoration="none"
+      >
         <Flex alignItems="flex-end" mb={1}>
           {artworks.every(artwork => !!artwork.image) ? (
             artworks.map((artwork, index) => {

--- a/src/Components/__stories__/Components/ContentHeaderExample.tsx
+++ b/src/Components/__stories__/Components/ContentHeaderExample.tsx
@@ -1,5 +1,6 @@
 import { Box, BoxProps, Flex, Text } from "@artsy/palette"
 import * as React from "react"
+import { RouterLink } from "System/Router/RouterLink"
 
 export const ContentHeaderExample: React.FC<BoxProps> = props => {
   return (
@@ -8,7 +9,7 @@ export const ContentHeaderExample: React.FC<BoxProps> = props => {
         <Text variant="lg-display">Headline Text</Text>
 
         <Text variant="sm">
-          <a href="#example">Text Link</a>
+          <RouterLink to="#example">Text Link</RouterLink>
         </Text>
       </Flex>
 

--- a/src/System/Router/RouterLink.tsx
+++ b/src/System/Router/RouterLink.tsx
@@ -22,13 +22,11 @@ export type RouterLinkProps = Omit<
      */
     to: string | null
     textDecoration?: ResponsiveValue<string>
-    /** @deprecated Use `textDecoration` */
-    noUnderline?: boolean
     inline?: boolean
   }
 
 export const RouterLink: React.FC<RouterLinkProps> = React.forwardRef(
-  ({ inline, to, noUnderline, ...rest }, ref) => {
+  ({ inline, to, ...rest }, ref) => {
     const context = useContext(RouterContext)
     const routes = context?.router?.matcher?.routeConfig ?? []
     const matcher = context?.router?.matcher
@@ -37,28 +35,11 @@ export const RouterLink: React.FC<RouterLinkProps> = React.forwardRef(
       [matcher, routes, to]
     )
 
-    // TODO: Bulk replace
-    const deprecated = noUnderline ? { textDecoration: "none" } : {}
-
     if (isSupportedInRouter) {
-      return (
-        <RouterAwareLink
-          inline={inline}
-          to={to ?? ""}
-          {...deprecated}
-          {...rest}
-        />
-      )
+      return <RouterAwareLink inline={inline} to={to ?? ""} {...rest} />
     }
 
-    return (
-      <RouterUnawareLink
-        inline={inline}
-        href={to ?? ""}
-        {...deprecated}
-        {...rest}
-      />
-    )
+    return <RouterUnawareLink inline={inline} href={to ?? ""} {...rest} />
   }
 )
 
@@ -96,10 +77,10 @@ export const RouterAwareLink: React.FC<LinkPropsSimple & RouterLinkMixinProps> =
     },
   })`
     :hover {
-      color: ${props => (props.inline ? themeGet("colors.blue100") : null)};
+      color: ${props => props.inline && themeGet("colors.blue100")};
     }
     :visited {
-      color: ${props => (props.inline ? themeGet("colors.blue150") : null)};
+      color: ${props => props.inline && themeGet("colors.blue150")};
     }
     ${routerLinkMixin}
   `
@@ -113,10 +94,10 @@ export const RouterUnawareLink: React.FC<
     shouldForwardProp: (prop, defaultValidatorFn) => defaultValidatorFn(prop),
   })`
     :hover {
-      color: ${props => (props.inline ? themeGet("colors.blue100") : null)};
+      color: ${props => props.inline && themeGet("colors.blue100")};
     }
     :visited {
-      color: ${props => (props.inline ? themeGet("colors.blue150") : null)};
+      color: ${props => props.inline && themeGet("colors.blue150")};
     }
     ${routerLinkMixin}
   `

--- a/src/System/Router/RouterLink.tsx
+++ b/src/System/Router/RouterLink.tsx
@@ -5,6 +5,7 @@ import { BoxProps, boxMixin } from "@artsy/palette"
 import styled from "styled-components"
 import { compose, ResponsiveValue, system } from "styled-system"
 import { useMemo } from "react"
+import { themeGet } from "@styled-system/theme-get"
 
 /**
  * Wrapper component around found's <Link> component with a fallback to a normal
@@ -23,10 +24,11 @@ export type RouterLinkProps = Omit<
     textDecoration?: ResponsiveValue<string>
     /** @deprecated Use `textDecoration` */
     noUnderline?: boolean
+    inline?: boolean
   }
 
 export const RouterLink: React.FC<RouterLinkProps> = React.forwardRef(
-  ({ to, noUnderline, ...rest }, ref) => {
+  ({ inline, to, noUnderline, ...rest }, ref) => {
     const context = useContext(RouterContext)
     const routes = context?.router?.matcher?.routeConfig ?? []
     const matcher = context?.router?.matcher
@@ -39,10 +41,24 @@ export const RouterLink: React.FC<RouterLinkProps> = React.forwardRef(
     const deprecated = noUnderline ? { textDecoration: "none" } : {}
 
     if (isSupportedInRouter) {
-      return <RouterAwareLink to={to ?? ""} {...deprecated} {...rest} />
+      return (
+        <RouterAwareLink
+          inline={inline}
+          to={to ?? ""}
+          {...deprecated}
+          {...rest}
+        />
+      )
     }
 
-    return <RouterUnawareLink href={to ?? ""} {...deprecated} {...rest} />
+    return (
+      <RouterUnawareLink
+        inline={inline}
+        href={to ?? ""}
+        {...deprecated}
+        {...rest}
+      />
+    )
   }
 )
 
@@ -53,6 +69,7 @@ const routerLinkMixin = compose(boxMixin, textDecoration)
 
 type RouterLinkMixinProps = BoxProps & {
   textDecoration?: ResponsiveValue<string>
+  inline?: boolean
 }
 
 const VALID_ROUTER_LINK_PROPS = [
@@ -78,6 +95,12 @@ export const RouterAwareLink: React.FC<LinkPropsSimple & RouterLinkMixinProps> =
       return defaultValidatorFn(prop) || routerLinkValidator(prop)
     },
   })`
+    :hover {
+      color: ${props => (props.inline ? themeGet("colors.blue100") : null)};
+    }
+    :visited {
+      color: ${props => (props.inline ? themeGet("colors.blue150") : null)};
+    }
     ${routerLinkMixin}
   `
 
@@ -89,5 +112,11 @@ export const RouterUnawareLink: React.FC<
   styled.a.withConfig({
     shouldForwardProp: (prop, defaultValidatorFn) => defaultValidatorFn(prop),
   })`
+    :hover {
+      color: ${props => (props.inline ? themeGet("colors.blue100") : null)};
+    }
+    :visited {
+      color: ${props => (props.inline ? themeGet("colors.blue150") : null)};
+    }
     ${routerLinkMixin}
   `


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-1116]

### Description

This PR adds an `inline` prop to `RouterLink` which gives RouterLink styles recently updated in the [design system](https://www.figma.com/file/gZNkyqLT8AU3T61tluVJyB/Artsy-3.1-Design-System?node-id=6726%3A4204&viewport=-2947%2C-4962%2C0.88&t=QTyt3NMhKQSmKDKZ-11). 

I've also removed the deprecated `noUnderline` with `textDecoration="none"` in our `RouterLinks`.  
<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-1116]: https://artsyproduct.atlassian.net/browse/TX-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ