### PR TITLE
feat(FX-4713): display border for all artwork images in artwork lists rail

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/ArtworkListImageBorder.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/ArtworkListImageBorder.tsx
@@ -1,0 +1,12 @@
+import { Flex, FlexProps } from "@artsy/palette"
+import { themeGet } from "@styled-system/theme-get"
+import styled from "styled-components"
+
+export const ArtworkListImageBorder = styled(Flex)<FlexProps>`
+  box-sizing: border-box;
+  border: 1px solid ${themeGet("colors.black15")};
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  overflow: hidden;
+`

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/ArtworkListNoImage.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/ArtworkListNoImage.tsx
@@ -1,18 +1,14 @@
-import { Flex, FlexProps, NoArtworkIcon } from "@artsy/palette"
+import { FlexProps, NoArtworkIcon } from "@artsy/palette"
+import { ArtworkListImageBorder } from "Apps/CollectorProfile/Routes/Saves2/Components/Images/ArtworkListImageBorder"
 import { FC } from "react"
 
 const NO_ICON_SIZE = 18
 
 export const ArtworkListNoImage: FC<FlexProps> = props => {
   return (
-    <Flex
+    <ArtworkListImageBorder
       bg="black5"
-      border="1px solid"
-      borderColor="black15"
       aria-label="Image placeholder"
-      justifyContent="center"
-      alignItems="center"
-      flexShrink={0}
       {...props}
     >
       <NoArtworkIcon
@@ -20,6 +16,6 @@ export const ArtworkListNoImage: FC<FlexProps> = props => {
         height={NO_ICON_SIZE}
         fill="black60"
       />
-    </Flex>
+    </ArtworkListImageBorder>
   )
 }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/FourUpImageLayout.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/FourUpImageLayout.tsx
@@ -3,6 +3,7 @@ import { ArtworkListNoImage } from "./ArtworkListNoImage"
 import { prepareImageURLs } from "Apps/CollectorProfile/Routes/Saves2/Utils/prepareImageURLs"
 import { FC } from "react"
 import { cropped } from "Utils/resized"
+import { ArtworkListImageBorder } from "Apps/CollectorProfile/Routes/Saves2/Components/Images/ArtworkListImageBorder"
 
 interface FourUpImageLayoutProps {
   imageURLs: (string | null)[]
@@ -53,12 +54,8 @@ const RowImage: FC<RowImageProps> = ({ url }) => {
   })
 
   return (
-    <Image
-      width={SIZE}
-      height={SIZE}
-      src={image.src}
-      srcSet={image.srcSet}
-      alt=""
-    />
+    <ArtworkListImageBorder width={SIZE} height={SIZE}>
+      <Image src={image.src} srcSet={image.srcSet} alt="" />
+    </ArtworkListImageBorder>
   )
 }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/StackedImageLayout.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/StackedImageLayout.tsx
@@ -3,6 +3,7 @@ import { ArtworkListNoImage } from "./ArtworkListNoImage"
 import { prepareImageURLs } from "Apps/CollectorProfile/Routes/Saves2/Utils/prepareImageURLs"
 import { FC } from "react"
 import { cropped } from "Utils/resized"
+import { ArtworkListImageBorder } from "Apps/CollectorProfile/Routes/Saves2/Components/Images/ArtworkListImageBorder"
 
 interface StackedImageLayoutProps {
   imageURLs: (string | null)[]
@@ -62,14 +63,12 @@ const StackImage: FC<StackImageProps> = ({ url, index }) => {
   })
 
   return (
-    <Box position="absolute" top={OFFSET_BY_INDEX} left={OFFSET_BY_INDEX}>
-      <Image
-        width={SIZE}
-        height={SIZE}
-        src={image.src}
-        srcSet={image.srcSet}
-        alt=""
-      />
-    </Box>
+    <ArtworkListImageBorder
+      position="absolute"
+      top={OFFSET_BY_INDEX}
+      left={OFFSET_BY_INDEX}
+    >
+      <Image src={image.src} srcSet={image.srcSet} alt="" />
+    </ArtworkListImageBorder>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4713]

Notion card: [link](https://www.notion.so/artsy/UX-suggestion-Display-border-for-artwork-image-as-we-did-it-for-placeholder-image-in-artwork-lis-3291ab26ee9e43e397957e2362d97f75?pvs=4)

Review app: [display-border-for-all-images](https://display-border-for-all-images.artsy.net/collector-profile/saves2)

### Demo
| Before | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/3513494/229854712-50b911cd-7b48-4766-bb70-328ab7d30aef.png) | ![after](https://user-images.githubusercontent.com/3513494/229854751-fc639d42-33a8-4950-a9c2-233402b6164b.png) |

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4713]: https://artsyproduct.atlassian.net/browse/FX-4713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ