### PR TITLE
fix(FX-4713): specify size for image containers, specify size for images

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/FourUpImageLayout.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/FourUpImageLayout.tsx
@@ -55,7 +55,13 @@ const RowImage: FC<RowImageProps> = ({ url }) => {
 
   return (
     <ArtworkListImageBorder width={SIZE} height={SIZE}>
-      <Image src={image.src} srcSet={image.srcSet} alt="" />
+      <Image
+        src={image.src}
+        srcSet={image.srcSet}
+        width="100%"
+        height="100%"
+        alt=""
+      />
     </ArtworkListImageBorder>
   )
 }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/StackedImageLayout.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Images/StackedImageLayout.tsx
@@ -67,8 +67,16 @@ const StackImage: FC<StackImageProps> = ({ url, index }) => {
       position="absolute"
       top={OFFSET_BY_INDEX}
       left={OFFSET_BY_INDEX}
+      width={SIZE}
+      height={SIZE}
     >
-      <Image src={image.src} srcSet={image.srcSet} alt="" />
+      <Image
+        src={image.src}
+        srcSet={image.srcSet}
+        width="100%"
+        height="100%"
+        alt=""
+      />
     </ArtworkListImageBorder>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4713]

### Demo
#### Web
| Before | After |
| ------------- | ------------- |
| <img width="731" alt="before-1" src="https://user-images.githubusercontent.com/3513494/230066297-f606e411-fbac-4988-9663-c8653dffaaab.png"> | <img width="731" alt="after-1" src="https://user-images.githubusercontent.com/3513494/230066337-95c97dcf-0f10-4259-9463-94b09985ed38.png"> |

#### mWeb
| Before | After |
| ------------- | ------------- |
| <img width="377" alt="before-2" src="https://user-images.githubusercontent.com/3513494/230066427-4624259a-c437-49bd-ae7b-737b814cf9a3.png"> | <img width="377" alt="after-2" src="https://user-images.githubusercontent.com/3513494/230066453-d3d05f97-fd20-4b40-b31c-3a5101ecad60.png"> |

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4713]: https://artsyproduct.atlassian.net/browse/FX-4713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ