### PR TITLE
feat(FX-4717): Respond with a 404 when navigating to a non-existent list

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -2,7 +2,7 @@ import { Shelf, Spacer } from "@artsy/palette"
 import { ArtworkListContentQueryRenderer } from "./Components/ArtworkListContent"
 import { ArtworkListsHeader } from "./Components/ArtworkListsHeader"
 import { ArtworkListItemFragmentContainer } from "./Components/ArtworkListItem"
-import { FC, useEffect, useRef } from "react"
+import { FC, useEffect, useMemo, useRef } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useRouter } from "System/Router/useRouter"
 import { extractNodes } from "Utils/extractNodes"
@@ -10,6 +10,8 @@ import { CollectorProfileSaves2Route_me$data } from "__generated__/CollectorProf
 import { useTracking } from "react-tracking"
 import { ActionType, OwnerType, ViewedArtworkList } from "@artsy/cohesion"
 import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { ErrorPage } from "Components/ErrorPage"
+import { HttpError } from "found"
 
 interface CollectorProfileSaves2RouteProps {
   me: CollectorProfileSaves2Route_me$data
@@ -53,6 +55,21 @@ const CollectorProfileSaves2Route: FC<CollectorProfileSaves2RouteProps> = ({
 
   // Always display "All Saves" artwork list first in the list
   const artworkLists = [allSavesArtworkList, ...customArtworkLists]
+
+  // TODO: Add comment about `useMemo`
+  const selectedArtworkList = useMemo(
+    () => {
+      return artworkLists.find(
+        artworkList => artworkList.internalID === selectedArtworkListId
+      )
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedArtworkListId]
+  )
+
+  if (!selectedArtworkList) {
+    throw new HttpError(404)
+  }
 
   return (
     <>

--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -56,7 +56,12 @@ const CollectorProfileSaves2Route: FC<CollectorProfileSaves2RouteProps> = ({
   // Always display "All Saves" artwork list first in the list
   const artworkLists = [allSavesArtworkList, ...customArtworkLists]
 
-  // TODO: Add comment about `useMemo`
+  /**
+   * When the artwork list has been successfully deleted,
+   * We also clear all info about the deleted artwork list from the relay store in updater.
+   * For this reason, 404 error will be displayed immediately.
+   * To prevent this from happening, `useMemo` is used here
+   */
   const selectedArtworkList = useMemo(
     () => {
       return artworkLists.find(

--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -10,7 +10,6 @@ import { CollectorProfileSaves2Route_me$data } from "__generated__/CollectorProf
 import { useTracking } from "react-tracking"
 import { ActionType, OwnerType, ViewedArtworkList } from "@artsy/cohesion"
 import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
-import { ErrorPage } from "Components/ErrorPage"
 import { HttpError } from "found"
 
 interface CollectorProfileSaves2RouteProps {

--- a/src/Apps/CollectorProfile/Routes/Saves2/__tests__/CollectorProfileSaves2Route.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/__tests__/CollectorProfileSaves2Route.jest.tsx
@@ -5,9 +5,11 @@ import { CollectorProfileSaves2Route_Test_Query } from "__generated__/CollectorP
 import { CollectorProfileSaves2RouteFragmentContainer } from "Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route"
 import { useRouter } from "System/Router/useRouter"
 import { useTracking } from "react-tracking"
+import { HttpError } from "found"
 
 jest.unmock("react-relay")
 jest.mock("System/Router/useRouter")
+jest.mock("found")
 
 const { renderWithRelay } = setupTestWrapperTL<
   CollectorProfileSaves2Route_Test_Query
@@ -25,6 +27,7 @@ const { renderWithRelay } = setupTestWrapperTL<
 describe("CollectorProfileSaves2Route", () => {
   const mockUseRouter = useRouter as jest.Mock
   const mockUseTracking = useTracking as jest.Mock
+  const mockHttpError = HttpError as jest.Mock
   const trackEvent = jest.fn()
 
   beforeEach(() => {
@@ -139,6 +142,28 @@ describe("CollectorProfileSaves2Route", () => {
         owner_id: "saved-artwork",
       })
     )
+  })
+
+  it("should render 404 for non-existent list", async () => {
+    mockUseRouter.mockImplementation(() => ({
+      match: {
+        params: {
+          id: "non-existent-list-id",
+        },
+        location: {
+          query: {},
+        },
+      },
+    }))
+
+    renderWithRelay({
+      Me: () => ({
+        allSavesArtworkList,
+        customArtworkLists,
+      }),
+    })
+
+    expect(mockHttpError).toHaveBeenCalledWith(404)
   })
 })
 


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4717]

Notion card: [link](https://www.notion.so/artsy/Internal-Server-Error-when-trying-to-load-custom-list-that-doesn-t-exist-Should-404-488676f9749e42f28e322002f46cf74b?pvs=4)

Review app: [artwork-list-404](https://artwork-list-404.artsy.net/collector-profile/saves2/unknown-artwork-list)

### Demo
https://user-images.githubusercontent.com/3513494/230105690-153cc163-a174-4fee-9177-c7a90243f8ea.mp4

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4717]: https://artsyproduct.atlassian.net/browse/FX-4717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ