### PR TITLE
chore(FX-4719): set correct page title for the new "Saves" tab

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Follows/CollectorProfileFollowsRoute.tsx
+++ b/src/Apps/CollectorProfile/Routes/Follows/CollectorProfileFollowsRoute.tsx
@@ -6,6 +6,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { SettingsSavesArtistsQueryRenderer } from "Apps/Settings/Routes/Saves/Components/SettingsSavesArtists"
 import { SettingsSavesCategoriesQueryRenderer } from "Apps/Settings/Routes/Saves/Components/SettingsSavesCategories"
 import { SettingsSavesProfilesQueryRenderer } from "Apps/Settings/Routes/Saves/Components/SettingsSavesProfiles"
+import { MetaTags } from "Components/MetaTags"
 interface CollectorProfileFollowsRouteProps {
   me: CollectorProfileFollowsRoute_me$data
 }
@@ -14,13 +15,17 @@ const CollectorProfileFollowsRoute: React.FC<CollectorProfileFollowsRouteProps> 
   me,
 }) => {
   return (
-    <Join separator={<Separator my={4} />}>
-      <SettingsSavesArtistsQueryRenderer />
+    <>
+      <MetaTags title="Follows | Artsy" pathname="collector-profile/follows" />
 
-      <SettingsSavesProfilesQueryRenderer />
+      <Join separator={<Separator my={4} />}>
+        <SettingsSavesArtistsQueryRenderer />
 
-      <SettingsSavesCategoriesQueryRenderer />
-    </Join>
+        <SettingsSavesProfilesQueryRenderer />
+
+        <SettingsSavesCategoriesQueryRenderer />
+      </Join>
+    </>
   )
 }
 export const CollectorProfileFollowsRouteFragmentContainer = createFragmentContainer(

--- a/src/Apps/CollectorProfile/Routes/Saves/CollectorProfileSavesRoute.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/CollectorProfileSavesRoute.tsx
@@ -10,6 +10,7 @@ import { extractNodes } from "Utils/extractNodes"
 import { Jump, useJump } from "Utils/Hooks/useJump"
 import { CollectorProfileSavesRouteQuery } from "__generated__/CollectorProfileSavesRouteQuery.graphql"
 import { CollectorProfileSavesRoute_me$data } from "__generated__/CollectorProfileSavesRoute_me.graphql"
+import { MetaTags } from "Components/MetaTags"
 
 interface CollectorProfileSavesProps {
   me: CollectorProfileSavesRoute_me$data
@@ -51,6 +52,8 @@ const SavesRoute: FC<CollectorProfileSavesProps> = ({ me, relay }) => {
 
   return (
     <>
+      <MetaTags title="Saves | Artsy" pathname="collector-profile/saves" />
+
       <Text variant={["md", "lg"]} mb={4}>
         Saved Artworks {total > 0 && <Sup color="brand">{total}</Sup>}
       </Text>

--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -11,6 +11,7 @@ import { useTracking } from "react-tracking"
 import { ActionType, OwnerType, ViewedArtworkList } from "@artsy/cohesion"
 import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { HttpError } from "found"
+import { MetaTags } from "Components/MetaTags"
 
 interface CollectorProfileSaves2RouteProps {
   me: CollectorProfileSaves2Route_me$data
@@ -77,6 +78,8 @@ const CollectorProfileSaves2Route: FC<CollectorProfileSaves2RouteProps> = ({
 
   return (
     <>
+      <MetaTags title="Saves | Artsy" pathname="collector-profile/saves2" />
+
       <ArtworkListsHeader
         savedArtworksCount={
           me?.allSavesArtworkList?.artworksConnection?.totalCount ?? 0

--- a/src/Apps/CollectorProfile/Routes/Saves2/__tests__/CollectorProfileSaves2Route.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/__tests__/CollectorProfileSaves2Route.jest.tsx
@@ -10,6 +10,11 @@ import { HttpError } from "found"
 jest.unmock("react-relay")
 jest.mock("System/Router/useRouter")
 jest.mock("found")
+jest.mock("react-head", () => ({
+  Title: ({ children }) => <title>{children}</title>,
+  Meta: () => null,
+  Link: () => null,
+}))
 
 const { renderWithRelay } = setupTestWrapperTL<
   CollectorProfileSaves2Route_Test_Query
@@ -142,6 +147,17 @@ describe("CollectorProfileSaves2Route", () => {
         owner_id: "saved-artwork",
       })
     )
+  })
+
+  it("should set title tag", async () => {
+    renderWithRelay({
+      Me: () => ({
+        allSavesArtworkList,
+        customArtworkLists,
+      }),
+    })
+
+    await waitFor(() => expect(document.title).toBe("Saves | Artsy"))
   })
 
   it("should render 404 for non-existent list", async () => {

--- a/src/Apps/Settings/Routes/Insights/InsightsRoute.tsx
+++ b/src/Apps/Settings/Routes/Insights/InsightsRoute.tsx
@@ -30,7 +30,7 @@ const InsightsRoute: React.FC<InsightsRouteProps> = ({ me }) => {
   return (
     <>
       <MetaTags
-        title="My Collection Insights | Artsy"
+        title="Insights | Artsy"
         pathname={"collector-profile/insights"}
       />
 


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4719]

Notion card: [link](https://www.notion.so/Should-the-browser-tab-page-title-reflect-the-selected-Saves-tab-Currently-it-s-Collector-Profil-e6ebf577fd49409dabc80493f3e9f256)

### collector-profile/saves2
| Before | After |
| ------------- | ------------- |
| <img width="1919" alt="before" src="https://user-images.githubusercontent.com/3513494/230133713-32b2c6ad-2022-4ee4-a73b-2c83354a8470.png"> | <img width="1919" alt="after" src="https://user-images.githubusercontent.com/3513494/230133758-1cc5cdf5-f12a-462d-9024-abdc2dd29ef3.png"> | 

### collector-profile/saves
| Before | After |
| ------------- | ------------- |
| <img width="1915" alt="before-3" src="https://user-images.githubusercontent.com/3513494/230140973-d06fdd8c-bc79-4a36-9633-12998f4a9411.png"> | <img width="1915" alt="after-3" src="https://user-images.githubusercontent.com/3513494/230141015-a71b6606-b8c6-4509-944f-7c017f419e2a.png"> | 

### collector-profile/follows
| Before | After |
| ------------- | ------------- |
| <img width="1915" alt="before-2" src="https://user-images.githubusercontent.com/3513494/230141101-60d1dbd7-e04e-4132-b1ef-e31cc926cc2e.png"> | <img width="1915" alt="after-2" src="https://user-images.githubusercontent.com/3513494/230141139-15098ec7-8f3b-4ffb-982e-a6555797b85a.png"> | 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4719]: https://artsyproduct.atlassian.net/browse/FX-4719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ