### PR TITLE
feat(GRO-1637): refines brand campaign routes

### DIFF
--- a/src/Apps/Marketing/Components/MarketingAlternatingStack.tsx
+++ b/src/Apps/Marketing/Components/MarketingAlternatingStack.tsx
@@ -9,6 +9,7 @@ import {
   Text,
 } from "@artsy/palette"
 import { FC, Fragment } from "react"
+import { RouterLink } from "System/Router/RouterLink"
 import { cropped } from "Utils/resized"
 
 interface Card {
@@ -30,7 +31,7 @@ export const MarketingAlternatingStack: FC<MarketingAlternatingStackProps> = ({
 }) => {
   return (
     <>
-      <GridColumns gridRowGap={6}>
+      <GridColumns gridRowGap={[2, 6]}>
         {cards.map((card, index) => {
           const order = {
             // Mobile: [[image], [info], [image], [info]]
@@ -46,7 +47,8 @@ export const MarketingAlternatingStack: FC<MarketingAlternatingStackProps> = ({
               <Column
                 span={5}
                 order={order.info}
-                p={4}
+                p={[0, 4]}
+                pb={[4, 0]}
                 display="flex"
                 flexDirection="column"
                 justifyContent="center"
@@ -62,7 +64,13 @@ export const MarketingAlternatingStack: FC<MarketingAlternatingStackProps> = ({
                     <Spacer y={[1, 2, 2, 4]} />
 
                     <Box>
-                      <Button>{card.cta.label}</Button>
+                      <Button
+                        // @ts-ignore
+                        as={RouterLink}
+                        to={card.cta.href}
+                      >
+                        {card.cta.label}
+                      </Button>
                     </Box>
                   </>
                 )}

--- a/src/Apps/Marketing/Components/MarketingHeader.tsx
+++ b/src/Apps/Marketing/Components/MarketingHeader.tsx
@@ -35,13 +35,11 @@ export const MarketingHeader: FC<MarketingHeaderProps> = ({
   return (
     <>
       <Media greaterThan="xs">
-        <FullBleed height={height} position="relative">
+        <FullBleed>
           <GridColumns
-            position="absolute"
-            width="100%"
-            height="100%"
-            top={0}
-            left={0}
+            // Matches homepage hero units
+            height={[300, 400, 500]}
+            overflow="hidden"
             bg="black10"
           >
             <Column
@@ -49,9 +47,10 @@ export const MarketingHeader: FC<MarketingHeaderProps> = ({
               display="flex"
               flexDirection="column"
               justifyContent="center"
-              p={4}
+              px={4}
+              py={[2, 2, 4]}
             >
-              <Text variant={["xl", "xl", "xxl", "xxxl"]}>{title}</Text>
+              <Text variant={["xl", "xl", "xxl", "xxl"]}>{title}</Text>
 
               <Spacer y={[1, 2, 2, 4]} />
 
@@ -83,7 +82,7 @@ export const MarketingHeader: FC<MarketingHeaderProps> = ({
         </FullBleed>
 
         <FullBleed bg="black10">
-          <HorizontalPadding py={4}>
+          <HorizontalPadding py={6}>
             <Text variant="xl">{title}</Text>
 
             <Spacer y={0.5} />

--- a/src/Apps/Marketing/Components/MarketingHeader.tsx
+++ b/src/Apps/Marketing/Components/MarketingHeader.tsx
@@ -16,12 +16,14 @@ interface MarketingHeaderProps {
   title: string
   subtitle: string
   src: string
+  accentColor: string
 }
 
 export const MarketingHeader: FC<MarketingHeaderProps> = ({
   title,
   subtitle,
   src,
+  accentColor,
 }) => {
   const height = useFullBleedHeaderHeight()
 
@@ -56,7 +58,7 @@ export const MarketingHeader: FC<MarketingHeaderProps> = ({
               <Text variant="lg">{subtitle}</Text>
             </Column>
 
-            <Column span={7} bg="black60" overflow="hidden">
+            <Column span={7} bg={accentColor} overflow="hidden">
               <Image
                 {...images.desktop}
                 width="100%"
@@ -70,7 +72,7 @@ export const MarketingHeader: FC<MarketingHeaderProps> = ({
       </Media>
 
       <Media at="xs">
-        <FullBleed minHeight={height} bg="black60">
+        <FullBleed height={height} bg={accentColor}>
           <Image
             {...images.mobile}
             width="100%"

--- a/src/Apps/Marketing/Components/MarketingQuizCTA.tsx
+++ b/src/Apps/Marketing/Components/MarketingQuizCTA.tsx
@@ -10,17 +10,18 @@ import {
 } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
-import { cropped } from "Utils/resized"
+import { BRAND_PALETTE } from "Apps/Marketing/Utils/brandPalette"
+import { resized } from "Utils/resized"
 import { FC } from "react"
 
 export const MarketingQuizCTA: FC = () => {
-  const image = cropped("https://picsum.photos/seed/ae/2000/2000", {
-    width: 400,
-    height: 300,
-  })
+  const image = resized(
+    "https://files.artsy.net/images/marketing_find_art-quiz.png",
+    { width: 688, height: 1109 }
+  )
 
   return (
-    <FullBleed bg="#6798DD">
+    <FullBleed bg={BRAND_PALETTE.blue}>
       <AppContainer>
         <HorizontalPadding>
           <GridColumns>
@@ -53,10 +54,9 @@ export const MarketingQuizCTA: FC = () => {
               justifyContent="center"
             >
               <ResponsiveBox
-                aspectWidth={3}
-                aspectHeight={4}
+                aspectWidth={688}
+                aspectHeight={1109}
                 maxWidth="100%"
-                bg="black10"
               >
                 <Image
                   {...image}
@@ -64,7 +64,6 @@ export const MarketingQuizCTA: FC = () => {
                   height="100%"
                   style={{ display: "block" }}
                   alt=""
-                  lazyLoad
                 />
               </ResponsiveBox>
             </Column>

--- a/src/Apps/Marketing/Components/MarketingQuizCTA.tsx
+++ b/src/Apps/Marketing/Components/MarketingQuizCTA.tsx
@@ -7,6 +7,7 @@ import {
   Spacer,
   Button,
   ResponsiveBox,
+  Box,
 } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
@@ -26,28 +27,34 @@ export const MarketingQuizCTA: FC = () => {
         <HorizontalPadding>
           <GridColumns>
             <Column
-              span={8}
+              span={[12, 8, 9]}
               order={[1, 0]}
-              py={[6, 12]}
+              pt={[0, 6]}
+              pb={[6, 6]}
               textAlign={["center", "left"]}
+              display="flex"
+              flexDirection="column"
+              justifyContent="center"
             >
-              <Text variant={["xl", "xxl", "xxxl"]}>
+              <Text variant={["xl", "xxl", "xxl"]}>
                 Don’t know your taste yet?
               </Text>
 
               <Spacer y={[2, 4]} />
 
-              <Text variant="lg" maxWidth={["100%", "50%"]}>
+              <Text variant="lg" maxWidth={["100%", "75%"]}>
                 Rate artworks and get recommendations tailored to you.
               </Text>
 
               <Spacer y={[2, 4]} />
 
-              <Button>Get Started</Button>
+              <Box>
+                <Button>Get Started</Button>
+              </Box>
             </Column>
 
             <Column
-              span={4}
+              span={[12, 4, 3]}
               order={[0, 1]}
               display="flex"
               alignItems="center"

--- a/src/Apps/Marketing/Routes/MarketingFindArtYouWantRoute.tsx
+++ b/src/Apps/Marketing/Routes/MarketingFindArtYouWantRoute.tsx
@@ -16,6 +16,7 @@ import { MetaTags } from "Components/MetaTags"
 import { FC } from "react"
 import { MarketingCollectionCell } from "Apps/Marketing/Components/MarketingCollectionCell"
 import { MarketingQuizCTA } from "Apps/Marketing/Components/MarketingQuizCTA"
+import { BRAND_PALETTE } from "Apps/Marketing/Utils/brandPalette"
 
 export const MarketingFindArtYouWantRoute: FC = () => {
   return (
@@ -26,7 +27,8 @@ export const MarketingFindArtYouWantRoute: FC = () => {
         <MarketingHeader
           title="Get the art you want."
           subtitle="Discover the tools you need to collect art that fits your taste."
-          src="https://picsum.photos/seed/aa/2000/2000"
+          src="https://files.artsy.net/images/marketing_find_header.jpg"
+          accentColor={BRAND_PALETTE.green}
         />
 
         <Text variant={["xl", "xxl"]}>
@@ -60,19 +62,22 @@ export const MarketingFindArtYouWantRoute: FC = () => {
               title: "Save artworks",
               subtitle:
                 "Keep track of artworks that catch your eye, and get better recommendations with every save.",
-              src: "https://picsum.photos/seed/ab/2000/2000",
+              src:
+                "https://files.artsy.net/images/marketing_find_save-artworks.jpg",
             },
             {
               title: "Follow artists",
               subtitle:
                 "Get updates on your favorite artists, including new artworks, shows, and more.",
-              src: "https://picsum.photos/seed/ac/2000/2000",
+              src:
+                "https://files.artsy.net/images/marketing_find_follow-artists.jpg",
             },
             {
               title: "Set alerts",
               subtitle:
                 "On the hunt for a particular work? Create an alert and we’ll let you know when there’s a match.",
-              src: "https://picsum.photos/seed/ad/2000/2000",
+              src:
+                "https://files.artsy.net/images/marketing_find_set-alerts.jpg",
             },
           ]}
         />
@@ -86,7 +91,7 @@ export const MarketingFindArtYouWantRoute: FC = () => {
             <MarketingCollectionCell
               title="Trending Now"
               href="/collection/trending-now"
-              src="https://picsum.photos/seed/af/2000/2000"
+              src="https://files.artsy.net/images/marketing_find_collection_trending-now.jpg"
             />
           </Column>
 
@@ -94,7 +99,7 @@ export const MarketingFindArtYouWantRoute: FC = () => {
             <MarketingCollectionCell
               title="Curators’ Picks: Emerging"
               href="/collection/curators-picks-emerging"
-              src="https://picsum.photos/seed/ag/2000/2000"
+              src="https://files.artsy.net/images/marketing_find_collection_curators-picks-emerging.jpg"
             />
           </Column>
 
@@ -102,7 +107,7 @@ export const MarketingFindArtYouWantRoute: FC = () => {
             <MarketingCollectionCell
               title="Top Auction Lots"
               href="/collection/top-auction-lots"
-              src="https://picsum.photos/seed/ah/2000/2000"
+              src="https://files.artsy.net/images/marketing_find_collection_top-auction-lots.jpg"
             />
           </Column>
         </GridColumns>

--- a/src/Apps/Marketing/Routes/MarketingFindArtYouWantRoute.tsx
+++ b/src/Apps/Marketing/Routes/MarketingFindArtYouWantRoute.tsx
@@ -31,7 +31,7 @@ export const MarketingFindArtYouWantRoute: FC = () => {
           accentColor={BRAND_PALETTE.green}
         />
 
-        <Text variant={["xl", "xxl"]}>
+        <Text variant={["xl", "xl"]}>
           Explore the world’s best art, on Artsy
         </Text>
 
@@ -42,7 +42,7 @@ export const MarketingFindArtYouWantRoute: FC = () => {
         <FullBleed bg="black5" py={[6, 12]}>
           <AppContainer>
             <HorizontalPadding>
-              <Text variant={["xl", "xxl", "xxxl"]}>
+              <Text variant={["xl", "xxl", "xxl"]}>
                 Saves, follows, and alerts
               </Text>
 
@@ -82,7 +82,7 @@ export const MarketingFindArtYouWantRoute: FC = () => {
           ]}
         />
 
-        <Text variant={["xl", "xxl"]}>
+        <Text variant={["lg-display", "xl"]}>
           Explore our most popular collections
         </Text>
 

--- a/src/Apps/Marketing/Routes/MarketingMeetArtAdvisorRoute.tsx
+++ b/src/Apps/Marketing/Routes/MarketingMeetArtAdvisorRoute.tsx
@@ -9,6 +9,7 @@ import {
 } from "@artsy/palette"
 import { MarketingAlternatingStack } from "Apps/Marketing/Components/MarketingAlternatingStack"
 import { MarketingHeader } from "Apps/Marketing/Components/MarketingHeader"
+import { BRAND_PALETTE } from "Apps/Marketing/Utils/brandPalette"
 import { MetaTags } from "Components/MetaTags"
 import { FC } from "react"
 
@@ -21,7 +22,8 @@ export const MarketingMeetArtAdvisorRoute: FC = () => {
         <MarketingHeader
           title="Meet your new art advisor."
           subtitle="Collect what you love confidently on the largest platform for in-demand art."
-          src="https://picsum.photos/seed/a/2000/2000"
+          src="https://files.artsy.net/images/marketing_meet_header.jpg"
+          accentColor={BRAND_PALETTE.blue}
         />
 
         <MarketingAlternatingStack
@@ -30,7 +32,8 @@ export const MarketingMeetArtAdvisorRoute: FC = () => {
               title: "Get the art you want.",
               subtitle:
                 "Discover the tools you need to collect art that fits your taste.",
-              src: "https://picsum.photos/seed/b/2000/2000",
+              src:
+                "https://files.artsy.net/images/marketing_meet_new-works-for-you.jpg",
               cta: {
                 label: "Start Looking",
                 href: "/todo",
@@ -40,7 +43,8 @@ export const MarketingMeetArtAdvisorRoute: FC = () => {
               title: "Always know the right price.",
               subtitle:
                 "Buy and bid confidently with free access to millions of auction results.",
-              src: "https://picsum.photos/seed/c/2000/2000",
+              src:
+                "https://files.artsy.net/images/marketing_meet_price-database.jpg",
               cta: {
                 label: "Search the Artsy Price Database",
                 href: "/todo",
@@ -50,7 +54,8 @@ export const MarketingMeetArtAdvisorRoute: FC = () => {
               title: "Get to know your collection better.",
               subtitle:
                 "See all the works you own, on your phone—and keep up with market insights.",
-              src: "https://picsum.photos/seed/d/2000/2000",
+              src:
+                "https://files.artsy.net/images/marketing_meet_my-collection.jpg",
               cta: {
                 label: "View My Collection",
                 href: "/todo",
@@ -60,7 +65,7 @@ export const MarketingMeetArtAdvisorRoute: FC = () => {
               title: "When you’re ready to sell, we can help.",
               subtitle:
                 "Earn more and worry less with our expert guidance, tailored to you.",
-              src: "https://picsum.photos/seed/e/2000/2000",
+              src: "https://files.artsy.net/images/marketing_meet_consign.jpg",
               cta: {
                 label: "Learn More",
                 href: "/todo",

--- a/src/Apps/Marketing/Routes/MarketingMeetArtAdvisorRoute.tsx
+++ b/src/Apps/Marketing/Routes/MarketingMeetArtAdvisorRoute.tsx
@@ -36,7 +36,7 @@ export const MarketingMeetArtAdvisorRoute: FC = () => {
                 "https://files.artsy.net/images/marketing_meet_new-works-for-you.jpg",
               cta: {
                 label: "Start Looking",
-                href: "/todo",
+                href: "/find-the-art-you-want",
               },
             },
             {
@@ -47,7 +47,7 @@ export const MarketingMeetArtAdvisorRoute: FC = () => {
                 "https://files.artsy.net/images/marketing_meet_price-database.jpg",
               cta: {
                 label: "Search the Artsy Price Database",
-                href: "/todo",
+                href: "/price-database",
               },
             },
             {
@@ -58,7 +58,7 @@ export const MarketingMeetArtAdvisorRoute: FC = () => {
                 "https://files.artsy.net/images/marketing_meet_my-collection.jpg",
               cta: {
                 label: "View My Collection",
-                href: "/todo",
+                href: "/collector-profile/my-collection",
               },
             },
             {
@@ -68,7 +68,7 @@ export const MarketingMeetArtAdvisorRoute: FC = () => {
               src: "https://files.artsy.net/images/marketing_meet_consign.jpg",
               cta: {
                 label: "Learn More",
-                href: "/todo",
+                href: "/sell",
               },
             },
           ]}
@@ -81,7 +81,16 @@ export const MarketingMeetArtAdvisorRoute: FC = () => {
             </Column>
 
             <Column span={4} start={5}>
-              <Button width="100%">Get the App</Button>
+              <Button
+                width="100%"
+                // @ts-ignore
+                as="a"
+                href="https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Get the App
+              </Button>
             </Column>
           </GridColumns>
         </FullBleed>

--- a/src/Apps/Marketing/Utils/brandPalette.ts
+++ b/src/Apps/Marketing/Utils/brandPalette.ts
@@ -1,0 +1,7 @@
+export const BRAND_PALETTE = {
+  blue: "#6798DD",
+  green: "#17A68D",
+  pink: "#F5899F",
+  red: "#F15450",
+  purple: "#9987D0",
+}


### PR DESCRIPTION
Re: [GRO-1639](https://artsyproduct.atlassian.net/browse/GRO-1639), [GRO-1640](https://artsyproduct.atlassian.net/browse/GRO-1640)

Gets these to a Q/A-able state. I'm going to tackle the footer updates separately then circle back to introduce a footer-less layout for the one route.

[GRO-1639]: https://artsyproduct.atlassian.net/browse/GRO-1639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1640]: https://artsyproduct.atlassian.net/browse/GRO-1640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ