### PR TITLE
refactor(artwork lists): use a common ArtworkListForm in create and edit flows

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
@@ -15,6 +15,7 @@ import { useUpdateArtworkList } from "./Mutations/useUpdateArtworkList"
 import createLogger from "Utils/logger"
 import { useTracking } from "react-tracking"
 import { ActionType, EditedArtworkList, OwnerType } from "@artsy/cohesion"
+import { ArtworkListFormikValues } from "Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm"
 
 export interface EditArtworkListEntity {
   internalID: string
@@ -24,10 +25,6 @@ export interface EditArtworkListEntity {
 interface EditArtworkListModalProps {
   artworkList: EditArtworkListEntity
   onClose: () => void
-}
-
-interface FormikValues {
-  name: string
 }
 
 const MAX_NAME_LENGTH = 40
@@ -41,7 +38,7 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
   const { t } = useTranslation()
   const { trackEvent } = useTracking()
 
-  const initialValues: FormikValues = {
+  const initialValues: ArtworkListFormikValues = {
     name: artworkList.name,
   }
 
@@ -65,7 +62,7 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
     trackEvent(event)
   }
 
-  const handleSubmit = async (formikValues: FormikValues) => {
+  const handleSubmit = async (formikValues: ArtworkListFormikValues) => {
     try {
       await submitMutation({
         variables: {
@@ -101,7 +98,7 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
   }
 
   return (
-    <Formik<FormikValues>
+    <Formik<ArtworkListFormikValues>
       initialValues={initialValues}
       validationSchema={validationSchema}
       onSubmit={handleSubmit}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
@@ -98,16 +98,7 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
       validationSchema={validationSchema}
       onSubmit={handleSubmit}
     >
-      {({
-        values,
-        errors,
-        touched,
-        dirty,
-        handleBlur,
-        handleChange,
-        isSubmitting,
-        isValid,
-      }) => {
+      {formik => {
         return (
           <ModalDialog
             title={t("collectorSaves.editListModal.title")}
@@ -117,20 +108,20 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
             <Form /* TODO: confirm implicit form submission */>
               <LabeledInput
                 name="name"
-                value={values.name}
+                value={formik.values.name}
                 title={t("collectorSaves.editListModal.fields.name.label")}
                 label={<EditIcon />}
-                error={touched.name && errors.name}
+                error={formik.touched.name && formik.errors.name}
                 maxLength={MAX_NAME_LENGTH}
                 required // TODO: confirm
-                onChange={handleChange}
-                onBlur={handleBlur}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
               />
               <Spacer y={1} />
               <Text variant="xs">
                 {t(
                   "collectorSaves.createNewListModal.remainingCharactersCount",
-                  { count: MAX_NAME_LENGTH - values.name.length }
+                  { count: MAX_NAME_LENGTH - formik.values.name.length }
                 )}
               </Text>
               <Spacer y={2} />
@@ -140,8 +131,8 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
               >
                 <Button
                   type="submit"
-                  loading={!!isSubmitting}
-                  disabled={!dirty || !isValid}
+                  loading={!!formik.isSubmitting}
+                  disabled={!formik.dirty || !formik.isValid}
                 >
                   {t("collectorSaves.editListModal.save")}
                 </Button>

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
@@ -96,7 +96,7 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
             onClose={onClose}
             width={["100%", 700]}
           >
-            <ArtworkListForm formik={formik} onClose={onClose} />
+            <ArtworkListForm mode="edit" formik={formik} onClose={onClose} />
           </ModalDialog>
         )
       }}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
@@ -1,22 +1,13 @@
-import {
-  Button,
-  Flex,
-  LabeledInput,
-  ModalDialog,
-  Spacer,
-  Text,
-  useToasts,
-} from "@artsy/palette"
-import EditIcon from "@artsy/icons/EditIcon"
+import { ModalDialog, useToasts } from "@artsy/palette"
 import { useTranslation } from "react-i18next"
-import { Form, Formik } from "formik"
+import { Formik } from "formik"
 import { useUpdateArtworkList } from "./Mutations/useUpdateArtworkList"
 import createLogger from "Utils/logger"
 import { useTracking } from "react-tracking"
 import { ActionType, EditedArtworkList, OwnerType } from "@artsy/cohesion"
 import {
+  ArtworkListForm,
   ArtworkListFormikValues,
-  MAX_NAME_LENGTH,
   validationSchema,
 } from "Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm"
 
@@ -105,45 +96,7 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
             onClose={onClose}
             width={["100%", 700]}
           >
-            <Form /* TODO: confirm implicit form submission */>
-              <LabeledInput
-                name="name"
-                value={formik.values.name}
-                title={t("collectorSaves.editListModal.fields.name.label")}
-                label={<EditIcon />}
-                error={formik.touched.name && formik.errors.name}
-                maxLength={MAX_NAME_LENGTH}
-                required // TODO: confirm
-                onChange={formik.handleChange}
-                onBlur={formik.handleBlur}
-              />
-              <Spacer y={1} />
-              <Text variant="xs">
-                {t(
-                  "collectorSaves.createNewListModal.remainingCharactersCount",
-                  { count: MAX_NAME_LENGTH - formik.values.name.length }
-                )}
-              </Text>
-              <Spacer y={2} />
-              <Flex
-                justifyContent={["flex-start", "space-between"]}
-                flexDirection={["column", "row-reverse"]}
-              >
-                <Button
-                  type="submit"
-                  loading={!!formik.isSubmitting}
-                  disabled={!formik.dirty || !formik.isValid}
-                >
-                  {t("collectorSaves.editListModal.save")}
-                </Button>
-
-                <Spacer y={[1, 0]} />
-
-                <Button variant="secondaryBlack" onClick={onClose}>
-                  {t("common.buttons.cancel")}
-                </Button>
-              </Flex>
-            </Form>
+            <ArtworkListForm formik={formik} onClose={onClose} />
           </ModalDialog>
         )
       }}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
@@ -15,7 +15,10 @@ import { useUpdateArtworkList } from "./Mutations/useUpdateArtworkList"
 import createLogger from "Utils/logger"
 import { useTracking } from "react-tracking"
 import { ActionType, EditedArtworkList, OwnerType } from "@artsy/cohesion"
-import { ArtworkListFormikValues } from "Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm"
+import {
+  ArtworkListFormikValues,
+  MAX_NAME_LENGTH,
+} from "Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm"
 
 export interface EditArtworkListEntity {
   internalID: string
@@ -26,8 +29,6 @@ interface EditArtworkListModalProps {
   artworkList: EditArtworkListEntity
   onClose: () => void
 }
-
-const MAX_NAME_LENGTH = 40
 
 const logger = createLogger("EditArtworkListModal")
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx
@@ -10,7 +10,6 @@ import {
 import EditIcon from "@artsy/icons/EditIcon"
 import { useTranslation } from "react-i18next"
 import { Form, Formik } from "formik"
-import * as Yup from "yup"
 import { useUpdateArtworkList } from "./Mutations/useUpdateArtworkList"
 import createLogger from "Utils/logger"
 import { useTracking } from "react-tracking"
@@ -18,6 +17,7 @@ import { ActionType, EditedArtworkList, OwnerType } from "@artsy/cohesion"
 import {
   ArtworkListFormikValues,
   MAX_NAME_LENGTH,
+  validationSchema,
 } from "Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm"
 
 export interface EditArtworkListEntity {
@@ -42,12 +42,6 @@ export const EditArtworkListModal: React.FC<EditArtworkListModalProps> = ({
   const initialValues: ArtworkListFormikValues = {
     name: artworkList.name,
   }
-
-  const validationSchema = Yup.object().shape({
-    name: Yup.string()
-      .required(t("collectorSaves.editListModal.fields.name.required")) // TODO: confirm copy
-      .max(MAX_NAME_LENGTH),
-  })
 
   const { submitMutation } = useUpdateArtworkList()
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
@@ -18,12 +18,21 @@ export const validationSchema = Yup.object().shape({
 })
 
 interface ArtworkListFormProps {
+  /** The bag of Formik props to be used by the form */
   formik: FormikProps<ArtworkListFormikValues>
+
+  /** Is this form being used to create or edit an artwork list? */
+  mode: "create" | "edit"
+
+  /** Handler for the Cancel button */
   onClose: () => void
+
+  /** Does the handler for the Cancel button simply dismiss, or navigate back to the previous step? */
+  cancelMode?: "dismiss" | "back"
 }
 
 export const ArtworkListForm: React.FC<ArtworkListFormProps> = props => {
-  const { formik, onClose } = props
+  const { formik, mode, onClose, cancelMode } = props
   const { t } = useTranslation()
 
   return (
@@ -31,8 +40,13 @@ export const ArtworkListForm: React.FC<ArtworkListFormProps> = props => {
       <LabeledInput
         name="name"
         value={formik.values.name}
-        title={t("collectorSaves.editListModal.fields.name.label")}
-        label={<EditIcon />}
+        title={
+          mode === "create"
+            ? t("collectorSaves.createNewListModal.nameLabel")
+            : t("collectorSaves.editListModal.fields.name.label")
+        }
+        placeholder={t("collectorSaves.createNewListModal.namePlaceholder")}
+        label={<EditIcon display={["none", "block"]} />}
         error={formik.touched.name && formik.errors.name}
         maxLength={MAX_NAME_LENGTH}
         required
@@ -59,13 +73,17 @@ export const ArtworkListForm: React.FC<ArtworkListFormProps> = props => {
           loading={!!formik.isSubmitting}
           disabled={!formik.dirty || !formik.isValid}
         >
-          {t("collectorSaves.editListModal.save")}
+          {mode === "create"
+            ? t("collectorSaves.createNewListModal.createListButton")
+            : t("collectorSaves.editListModal.save")}
         </Button>
 
         <Spacer y={[1, 0]} />
 
         <Button variant="secondaryBlack" onClick={onClose}>
-          {t("common.buttons.cancel")}
+          {cancelMode === "back"
+            ? t("common.buttons.back")
+            : t("common.buttons.cancel")}
         </Button>
       </Flex>
     </Form>

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
@@ -1,3 +1,5 @@
 export interface ArtworkListFormikValues {
   name: string
 }
+
+export const MAX_NAME_LENGTH = 40

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
@@ -13,7 +13,7 @@ export const MAX_NAME_LENGTH = 40
 
 export const validationSchema = Yup.object().shape({
   name: Yup.string()
-    .required(i18n.t("collectorSaves.editListModal.fields.name.required"))
+    .required(i18n.t("collectorSaves.artworkListForm.fields.name.required"))
     .max(MAX_NAME_LENGTH),
 })
 
@@ -42,10 +42,12 @@ export const ArtworkListForm: React.FC<ArtworkListFormProps> = props => {
         value={formik.values.name}
         title={
           mode === "create"
-            ? t("collectorSaves.createNewListModal.nameLabel")
-            : t("collectorSaves.editListModal.fields.name.label")
+            ? t("collectorSaves.artworkListForm.fields.name.label.create")
+            : t("collectorSaves.artworkListForm.fields.name.label.edit")
         }
-        placeholder={t("collectorSaves.createNewListModal.namePlaceholder")}
+        placeholder={t(
+          "collectorSaves.artworkListForm.fields.name.placeholder"
+        )}
         label={<EditIcon display={["none", "block"]} />}
         error={formik.touched.name && formik.errors.name}
         maxLength={MAX_NAME_LENGTH}
@@ -57,9 +59,12 @@ export const ArtworkListForm: React.FC<ArtworkListFormProps> = props => {
       <Spacer y={1} />
 
       <Text variant="xs">
-        {t("collectorSaves.createNewListModal.remainingCharactersCount", {
-          count: MAX_NAME_LENGTH - formik.values.name.length,
-        })}
+        {t(
+          "collectorSaves.artworkListForm.fields.name.remainingCharactersCount",
+          {
+            count: MAX_NAME_LENGTH - formik.values.name.length,
+          }
+        )}
       </Text>
 
       <Spacer y={2} />
@@ -74,8 +79,8 @@ export const ArtworkListForm: React.FC<ArtworkListFormProps> = props => {
           disabled={!formik.dirty || !formik.isValid}
         >
           {mode === "create"
-            ? t("collectorSaves.createNewListModal.createListButton")
-            : t("collectorSaves.editListModal.save")}
+            ? t("collectorSaves.artworkListForm.buttons.create")
+            : t("collectorSaves.artworkListForm.buttons.edit")}
         </Button>
 
         <Spacer y={[1, 0]} />

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
@@ -1,0 +1,3 @@
+export interface ArtworkListFormikValues {
+  name: string
+}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
@@ -1,5 +1,14 @@
+import * as Yup from "yup"
+import i18n from "System/i18n/i18n"
+
 export interface ArtworkListFormikValues {
   name: string
 }
 
 export const MAX_NAME_LENGTH = 40
+
+export const validationSchema = Yup.object().shape({
+  name: Yup.string()
+    .required(i18n.t("collectorSaves.editListModal.fields.name.required"))
+    .max(MAX_NAME_LENGTH),
+})

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
@@ -1,4 +1,8 @@
+import { Form, FormikProps } from "formik"
 import * as Yup from "yup"
+import { useTranslation } from "react-i18next"
+import { LabeledInput, Spacer, Text, Flex, Button } from "@artsy/palette"
+import EditIcon from "@artsy/icons/EditIcon"
 import i18n from "System/i18n/i18n"
 
 export interface ArtworkListFormikValues {
@@ -12,3 +16,58 @@ export const validationSchema = Yup.object().shape({
     .required(i18n.t("collectorSaves.editListModal.fields.name.required"))
     .max(MAX_NAME_LENGTH),
 })
+
+interface ArtworkListFormProps {
+  formik: FormikProps<ArtworkListFormikValues>
+  onClose: () => void
+}
+
+export const ArtworkListForm: React.FC<ArtworkListFormProps> = props => {
+  const { formik, onClose } = props
+  const { t } = useTranslation()
+
+  return (
+    <Form>
+      <LabeledInput
+        name="name"
+        value={formik.values.name}
+        title={t("collectorSaves.editListModal.fields.name.label")}
+        label={<EditIcon />}
+        error={formik.touched.name && formik.errors.name}
+        maxLength={MAX_NAME_LENGTH}
+        required
+        onChange={formik.handleChange}
+        onBlur={formik.handleBlur}
+      />
+
+      <Spacer y={1} />
+
+      <Text variant="xs">
+        {t("collectorSaves.createNewListModal.remainingCharactersCount", {
+          count: MAX_NAME_LENGTH - formik.values.name.length,
+        })}
+      </Text>
+
+      <Spacer y={2} />
+
+      <Flex
+        justifyContent={["flex-start", "space-between"]}
+        flexDirection={["column", "row-reverse"]}
+      >
+        <Button
+          type="submit"
+          loading={!!formik.isSubmitting}
+          disabled={!formik.dirty || !formik.isValid}
+        >
+          {t("collectorSaves.editListModal.save")}
+        </Button>
+
+        <Spacer y={[1, 0]} />
+
+        <Button variant="secondaryBlack" onClick={onClose}>
+          {t("common.buttons.cancel")}
+        </Button>
+      </Flex>
+    </Form>
+  )
+}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
@@ -129,7 +129,7 @@ export const CreateNewListModal: React.FC<CreateNewListModalProps> = ({
 
         return (
           <ModalDialog
-            width={["100%", 713]}
+            width={["100%", 700]}
             onClose={onClose}
             title={t("collectorSaves.createNewListModal.title")}
             data-testid="CreateNewList"

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
@@ -20,7 +20,10 @@ import { FC } from "react"
 import { useTracking } from "react-tracking"
 import { ActionType, CreatedArtworkList } from "@artsy/cohesion"
 import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
-import { ArtworkListFormikValues } from "Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm"
+import {
+  ArtworkListFormikValues,
+  MAX_NAME_LENGTH,
+} from "Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm"
 
 export interface ArtworkList {
   internalID: string
@@ -42,8 +45,6 @@ export interface CreateNewListModalContainerProps
 const logger = createLogger(
   "CollectorProfile/Routes/Saves2/Components/CreateNewListModal"
 )
-
-const MAX_NAME_LENGTH = 40
 
 export const CreateNewListModal: React.FC<CreateNewListModalProps> = ({
   artwork,

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
@@ -1,15 +1,6 @@
 import { Formik, FormikHelpers } from "formik"
 import createLogger from "Utils/logger"
-import {
-  Flex,
-  Button,
-  LabeledInput,
-  ModalDialog,
-  Spacer,
-  EditIcon,
-  Text,
-} from "@artsy/palette"
-import { Media } from "Utils/Responsive"
+import { ModalDialog } from "@artsy/palette"
 import { useTranslation } from "react-i18next"
 import {
   ArtworkEntity,
@@ -21,8 +12,8 @@ import { useTracking } from "react-tracking"
 import { ActionType, CreatedArtworkList } from "@artsy/cohesion"
 import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 import {
+  ArtworkListForm,
   ArtworkListFormikValues,
-  MAX_NAME_LENGTH,
   validationSchema,
 } from "Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm"
 
@@ -59,9 +50,7 @@ export const CreateNewListModal: React.FC<CreateNewListModalProps> = ({
   const analytics = useAnalyticsContext()
 
   const handleBackOnCancelClick = onBackClick ?? onClose
-  const backOrCancelLabel = onBackClick
-    ? t("common.buttons.back")
-    : t("common.buttons.cancel")
+  const cancelMode = onBackClick ? "back" : "dismiss"
 
   const trackAnalyticEvent = (artworkListId: string) => {
     const event: CreatedArtworkList = {
@@ -116,17 +105,7 @@ export const CreateNewListModal: React.FC<CreateNewListModalProps> = ({
       validationSchema={validationSchema}
       onSubmit={handleSubmit}
     >
-      {({
-        values,
-        isSubmitting,
-        handleSubmit,
-        handleChange,
-        handleBlur,
-        errors,
-        touched,
-      }) => {
-        const isCreateButtonDisabled = !values.name
-
+      {formik => {
         return (
           <ModalDialog
             width={["100%", 700]}
@@ -136,56 +115,13 @@ export const CreateNewListModal: React.FC<CreateNewListModalProps> = ({
             header={
               artwork ? <CreateNewListModalHeader artwork={artwork} /> : null
             }
-            footer={
-              <Flex
-                justifyContent={["flex-start", "space-between"]}
-                flexDirection={["column", "row-reverse"]}
-              >
-                <Button
-                  disabled={isCreateButtonDisabled}
-                  loading={isSubmitting}
-                  onClick={() => handleSubmit()}
-                >
-                  {t("collectorSaves.createNewListModal.createListButton")}
-                </Button>
-
-                <Spacer y={[1, 0]} />
-
-                <Button
-                  variant="secondaryBlack"
-                  onClick={handleBackOnCancelClick}
-                >
-                  {backOrCancelLabel}
-                </Button>
-              </Flex>
-            }
           >
-            <LabeledInput
-              title={t("collectorSaves.createNewListModal.nameLabel")}
-              name="name"
-              placeholder={t(
-                "collectorSaves.createNewListModal.namePlaceholder"
-              )}
-              value={values.name}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              error={touched.name && errors.name}
-              maxLength={MAX_NAME_LENGTH}
-              label={
-                <>
-                  {/* Desktop view */}
-                  <Media greaterThanOrEqual="sm">
-                    <EditIcon />
-                  </Media>
-                </>
-              }
+            <ArtworkListForm
+              mode="create"
+              formik={formik}
+              onClose={handleBackOnCancelClick}
+              cancelMode={cancelMode}
             />
-            <Spacer y={1} />
-            <Text variant="xs">
-              {t("collectorSaves.createNewListModal.remainingCharactersCount", {
-                count: MAX_NAME_LENGTH - values.name.length,
-              })}
-            </Text>
           </ModalDialog>
         )
       }}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
@@ -20,10 +20,7 @@ import { FC } from "react"
 import { useTracking } from "react-tracking"
 import { ActionType, CreatedArtworkList } from "@artsy/cohesion"
 import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
-
-export interface CreateNewListValues {
-  name: string
-}
+import { ArtworkListFormikValues } from "Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm"
 
 export interface ArtworkList {
   internalID: string
@@ -77,8 +74,8 @@ export const CreateNewListModal: React.FC<CreateNewListModalProps> = ({
   }
 
   const handleSubmit = async (
-    values: CreateNewListValues,
-    helpers: FormikHelpers<CreateNewListValues>
+    values: ArtworkListFormikValues,
+    helpers: FormikHelpers<ArtworkListFormikValues>
   ) => {
     try {
       const { createCollection } = await submitMutation({
@@ -112,7 +109,7 @@ export const CreateNewListModal: React.FC<CreateNewListModalProps> = ({
   }
 
   return (
-    <Formik<CreateNewListValues>
+    <Formik<ArtworkListFormikValues>
       initialValues={{ name: "" }}
       onSubmit={handleSubmit}
     >

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
@@ -23,6 +23,7 @@ import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 import {
   ArtworkListFormikValues,
   MAX_NAME_LENGTH,
+  validationSchema,
 } from "Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm"
 
 export interface ArtworkList {
@@ -112,6 +113,7 @@ export const CreateNewListModal: React.FC<CreateNewListModalProps> = ({
   return (
     <Formik<ArtworkListFormikValues>
       initialValues={{ name: "" }}
+      validationSchema={validationSchema}
       onSubmit={handleSubmit}
     >
       {({

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -126,12 +126,7 @@
       "createNewListButton": "Create New List"
     },
     "createNewListModal": {
-      "title": "Create a new list",
-      "createListButton": "Create List",
-      "nameLabel": "Name your list",
-      "namePlaceholder": "E.g. Photography, Warhol, etc.",
-      "remainingCharactersCount_one": "{{count}} character remaining",
-      "remainingCharactersCount_other": "{{count}} characters remaining"
+      "title": "Create a new list"
     },
     "manageArtworkForSaves": {
       "toasts": {
@@ -184,15 +179,26 @@
     },
     "editListModal": {
       "title": "Edit your list",
+      "success": "Changes saved"
+    },
+    "artworkListForm": {
       "fields": {
         "name": {
-          "label": "List Name",
-          "required": "Name is required"
+          "label": {
+            "create": "Name your list",
+            "edit": "List Name"
+          },
+          "placeholder": "E.g. Photography, Warhol, etc.",
+          "required": "Name is required",
+          "remainingCharactersCount_one": "{{count}} character remaining",
+          "remainingCharactersCount_other": "{{count}} characters remaining"
+
         }
       },
-      "back": "Back",
-      "save": "Save Changes",
-      "success": "Changes saved"
+      "buttons": {
+        "create": "Create List",
+        "edit": "Save Changes"
+      }
     }
   },
   "common": {


### PR DESCRIPTION
The type of this PR is: **Refactor**

This PR solves [FX-4676]

Review app: [artwork-list-form-refactor.artsy.net](https://artwork-list-form-refactor.artsy.net/collector-profile/saves2)

## Description

This refactors the **Create Artwork List** and **Edit Artwork List**  modals by extracting a common `ArtworkListForm` that they both can use.

This reduces duplication and divergence between the two forms by allowing us to standardize on:

- Validation via a common Yup schema
- Use of common i18n strings
- Enforcing common desirable behavior, such as [implicit form submission](https://www.notion.so/artsy/Intuitively-tried-to-submit-the-Create-new-list-form-by-pressing-the-Enter-key-and-couldn-t-do-w-5c26ca3a1a424970995b822f9470e3d8)
- Enforcing common responsive behavior on desktop vs mobile

Because of the last two points, it's not _quite_ a pure refactor, as the following changes show:

- The create form can now be submitted by hitting the Enter key 
- The edit form now correctly hides the little pencil icon at small screen sizes

Other than that, should be pretty pure. Please validate via [the review app](https://artwork-list-form-refactor.artsy.net/collector-profile/saves2) 😃 

## Screencaps

### Creating and editing a list from the Saves area

https://user-images.githubusercontent.com/140521/230275631-1adfa493-65e7-4b34-9388-dad767393f7e.mov

### Creating a list from elsewhere

https://user-images.githubusercontent.com/140521/230276116-dcacde10-291e-4617-8e4e-07393d825abc.mov



[FX-4676]: https://artsyproduct.atlassian.net/browse/FX-4676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ