### PR TITLE
chore(FX-4721): rename sort options

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
@@ -29,8 +29,8 @@ interface ArtworkListContentProps {
 }
 
 const sortOptions: SortOptions = [
-  { value: "SAVED_AT_DESC", text: "Recently Saved" },
-  { value: "SAVED_AT_ASC", text: "Oldest First" },
+  { value: "SAVED_AT_DESC", text: "Recently Added" },
+  { value: "SAVED_AT_ASC", text: "First Added" },
 ]
 const defaultSort = sortOptions[0].value
 


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4721]

Notion card: [link](https://www.notion.so/artsy/The-name-of-Oldest-first-sort-is-potentially-confusing-Probably-fine-with-Recently-Added-as-the-008440e1d8744e7fa00e463cc7a6e98e?pvs=4)

### Description
* Rename `Recently Saved` to `Recently Added`
* Rename `Oldest First` to `First Added`

### Demo
| Before | After |
| ------------- | ------------- |
| <img width="208" alt="image" src="https://user-images.githubusercontent.com/3513494/230457007-16c930f2-1226-46fc-aecb-83f38b7d5155.png"> | <img width="220" alt="image" src="https://user-images.githubusercontent.com/3513494/230456440-0082e09b-eda6-4cc4-8972-39504adc5b2f.png"> | 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4721]: https://artsyproduct.atlassian.net/browse/FX-4721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ