### PR TITLE
feat: update auction results pagination

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -49,7 +49,7 @@ import { TableSidebar } from "./Components/TableSidebar"
 
 const logger = createLogger("ArtistAuctionResults.tsx")
 
-const PAGE_SIZE = 10
+const PAGE_SIZE = 50
 
 interface AuctionResultsProps {
   relay: RelayRefetchProp
@@ -95,7 +95,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
   }
 
   const loadNext = () => {
-    const currentPageNumber = filters?.pageAndCursor?.page ?? 0
+    const currentPageNumber = filters?.page ?? 0
     const nextPageNum = currentPageNumber + 1
     if (hasNextPage) {
       loadPage(endCursor, nextPageNum)
@@ -104,10 +104,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
   const loadPage = (cursor, pageNum) => {
     scrollToAuctionResultsTop()
-    setFilter?.("pageAndCursor", {
-      cursor: cursor,
-      page: pageNum,
-    })
+    setFilter?.("page", pageNum)
   }
 
   const [isLoading, setIsLoading] = useState(false)
@@ -181,11 +178,12 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
     setIsLoading(true)
 
     const relayParams = {
-      after: filters?.pageAndCursor?.cursor,
+      page: filters?.page,
       artistID: artist.slug,
       artistInternalID: artist.internalID,
       before: null,
       first: PAGE_SIZE,
+      size: PAGE_SIZE,
       last: null,
     }
 
@@ -381,9 +379,10 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
       fragment ArtistAuctionResults_artist on Artist
         @argumentDefinitions(
           sort: { type: "AuctionResultSorts", defaultValue: DATE_DESC }
-          first: { type: "Int", defaultValue: 10 }
+          first: { type: "Int", defaultValue: 50 }
           last: { type: "Int" }
-          after: { type: "String" }
+          page: { type: "Int" }
+          size: { type: "Int" }
           before: { type: "String" }
           organizations: { type: "[String]" }
           keyword: { type: "String" }
@@ -399,7 +398,8 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
         name
         auctionResultsConnection(
           first: $first
-          after: $after
+          page: $page
+          size: $size
           before: $before
           last: $last
           sort: $sort
@@ -462,7 +462,8 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
     query ArtistAuctionResultsQuery(
       $first: Int
       $last: Int
-      $after: String
+      $page: Int
+      $size: Int
       $before: String
       $sort: AuctionResultSorts
       $state: AuctionResultsState
@@ -480,7 +481,8 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
           @arguments(
             first: $first
             last: $last
-            after: $after
+            page: $page
+            size: $size
             before: $before
             sort: $sort
             state: $state

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultsRoute.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultsRoute.tsx
@@ -17,6 +17,8 @@ export const AuctionResultsRouteFragmentContainer = createFragmentContainer(
     artist: graphql`
       fragment ArtistAuctionResultsRoute_artist on Artist
         @argumentDefinitions(
+          page: { type: "Int" }
+          state: { type: "AuctionResultsState", defaultValue: ALL }
           organizations: { type: "[String]" }
           categories: { type: "[String]" }
           sizes: { type: "[ArtworkSizes]" }
@@ -26,6 +28,8 @@ export const AuctionResultsRouteFragmentContainer = createFragmentContainer(
         ) {
         ...ArtistAuctionResults_artist
           @arguments(
+            page: $page
+            state: $state
             organizations: $organizations
             categories: $categories
             sizes: $sizes

--- a/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
@@ -13,7 +13,7 @@ export interface AuctionResultsFilters {
   hideUpcoming?: boolean
   sizes?: string[]
   keyword?: string
-  pageAndCursor?: { page: number; cursor: string | null }
+  page?: number
   sort?: string
   createdAfterYear?: number | null
   createdBeforeYear?: number | null
@@ -41,7 +41,7 @@ export const initialAuctionResultsFilterState = ({
   hideUpcoming: false,
   sizes: [],
   keyword: undefined,
-  pageAndCursor: { page: 1, cursor: null },
+  page: 1,
   sort: "DATE_DESC",
   createdAfterYear: typeof startDate === "number" ? startDate : MIN_START_DATE,
   createdBeforeYear: typeof endDate === "number" ? endDate : MAX_END_DATE,
@@ -275,7 +275,7 @@ const AuctionResultsFilterReducer = (
     case "SET": {
       const { name, value } = action.payload || {}
       const filterState: AuctionResultsFilters = {
-        pageAndCursor: { page: 1, cursor: null },
+        page: 1,
       }
 
       arrayFilterTypes.forEach(filter => {
@@ -289,7 +289,7 @@ const AuctionResultsFilterReducer = (
         "sort",
         "hideUpcoming",
         "keyword",
-        "pageAndCursor",
+        "page",
         "createdAfterYear",
         "createdBeforeYear",
         "allowEmptyCreatedDates",
@@ -301,12 +301,6 @@ const AuctionResultsFilterReducer = (
           filterState[name as string] = value
         }
       })
-
-      // do not allow a real cursor to be set for page 1. to agree with initial
-      // filter state.
-      if (filterState.pageAndCursor?.page === 1) {
-        filterState.pageAndCursor.cursor = null
-      }
 
       if (
         name === "createdBeforeYear" &&
@@ -339,7 +333,7 @@ const AuctionResultsFilterReducer = (
       const { name } = action.payload || {}
 
       const filterState: AuctionResultsFilters = {
-        pageAndCursor: { page: 1, cursor: null },
+        page: 1,
       }
 
       const filters: Array<keyof AuctionResultsFilters> = ["sort"]

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -331,7 +331,7 @@ describe("AuctionResults", () => {
               categories: ["Work on Paper"],
               organizations: [],
               sizes: [],
-              pageAndCursor: { page: 1, cursor: null },
+              page: 1,
               sort: "DATE_DESC",
               allowEmptyCreatedDates: true,
               createdAfterYear: 1880,

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.jest.tsx
@@ -42,12 +42,9 @@ describe("AuctionResultsFilterContext", () => {
         return new Promise<void>(done => {
           getWrapper()
           act(() => {
-            context.setFilter?.("pageAndCursor", { page: 10, cursor: null })
+            context.setFilter?.("page", 10)
             setTimeout(() => {
-              expect(context.filters?.pageAndCursor).toEqual({
-                page: 10,
-                cursor: null,
-              })
+              expect(context.filters?.page).toEqual(10)
               done()
             })
           })
@@ -58,17 +55,14 @@ describe("AuctionResultsFilterContext", () => {
         return new Promise<void>(done => {
           getWrapper({
             filters: {
-              pageAndCursor: { page: 10, cursor: null },
+              page: 10,
             },
           })
           act(() => {
-            expect(context.filters?.pageAndCursor?.page).toEqual(10)
+            expect(context.filters?.page).toEqual(10)
             context.setFilter?.("sort", "relevant")
             setTimeout(() => {
-              expect(context.filters?.pageAndCursor).toEqual({
-                page: 1,
-                cursor: null,
-              })
+              expect(context.filters?.page).toEqual(1)
               done()
             })
           })
@@ -170,16 +164,13 @@ describe("AuctionResultsFilterContext", () => {
         return new Promise<void>(done => {
           getWrapper()
           act(() => {
-            context.setFilter?.("pageAndCursor", { page: 10, cursor: null })
+            context.setFilter?.("page", 10)
             setTimeout(() => {
-              expect(context.filters?.pageAndCursor?.page).toEqual(10)
+              expect(context.filters?.page).toEqual(10)
               act(() => {
-                context.unsetFilter?.("pageAndCursor")
+                context.unsetFilter?.("page")
                 setTimeout(() => {
-                  expect(context.filters?.pageAndCursor).toEqual({
-                    page: 1,
-                    cursor: null,
-                  })
+                  expect(context.filters?.page).toEqual(1)
                   done()
                 })
               })
@@ -192,18 +183,15 @@ describe("AuctionResultsFilterContext", () => {
         return new Promise<void>(done => {
           getWrapper({
             filters: {
-              pageAndCursor: { page: 10, cursor: null },
+              page: 10,
               sort: "relevant",
             },
           })
           act(() => {
-            expect(context.filters?.pageAndCursor?.page).toEqual(10)
+            expect(context.filters?.page).toEqual(10)
             context.unsetFilter?.("sort")
             setTimeout(() => {
-              expect(context.filters?.pageAndCursor).toEqual({
-                page: 1,
-                cursor: null,
-              })
+              expect(context.filters?.page).toEqual(1)
               done()
             })
           })

--- a/src/Apps/Artist/Utils/allowedAuctionResultFilters.ts
+++ b/src/Apps/Artist/Utils/allowedAuctionResultFilters.ts
@@ -25,7 +25,7 @@ export const allowedAuctionResultFilters = (
   }, {})
 }
 
-const INTEGER_INPUT_ARGS = ["createdAfterYear", "createdBeforeYear"]
+const INTEGER_INPUT_ARGS = ["createdAfterYear", "createdBeforeYear", "page"]
 const BOOLEAN_INPUT_ARGS = ["allowEmptyCreatedDates", "hideUpcoming"]
 const SUPPORTED_INPUT_ARGS = [
   "organizations",
@@ -33,4 +33,6 @@ const SUPPORTED_INPUT_ARGS = [
   "sizes",
   "metric",
   "hideUpcoming",
+  "page",
+  "allowEmptyCreatedDates",
 ]

--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -172,14 +172,21 @@ export const artistRoutes: AppRouteConfig[] = [
             props.location ? props.location.query : {}
           )
 
-          return {
-            artistID,
+          const initialInput = {
             ...initialAuctionResultsFilterState({}),
             ...allowedAuctionResultFilters(urlFilterState),
+          }
+
+          return {
+            artistID,
+            ...initialInput,
+            state: initialInput?.hideUpcoming ? "PAST" : "ALL",
           }
         },
         query: graphql`
           query artistRoutes_AuctionResultsQuery(
+            $page: Int
+            $state: AuctionResultsState
             $artistID: String!
             $organizations: [String]
             $categories: [String]
@@ -191,6 +198,8 @@ export const artistRoutes: AppRouteConfig[] = [
             artist(id: $artistID) {
               ...ArtistAuctionResultsRoute_artist
                 @arguments(
+                  page: $page
+                  state: $state
                   organizations: $organizations
                   categories: $categories
                   sizes: $sizes

--- a/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
+++ b/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1550691346a6a53db07cfb0aea1fe044>>
+ * @generated SignedSource<<c4e8d7d8f9b0667779b5b14f71620e75>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,6 @@ export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
 export type AuctionResultSorts = "DATE_ASC" | "DATE_DESC" | "ESTIMATE_AND_DATE_DESC" | "PRICE_AND_DATE_DESC" | "%future added value";
 export type AuctionResultsState = "ALL" | "PAST" | "UPCOMING" | "%future added value";
 export type ArtistAuctionResultsQuery$variables = {
-  after?: string | null;
   allowEmptyCreatedDates?: boolean | null;
   artistID: string;
   before?: string | null;
@@ -25,6 +24,8 @@ export type ArtistAuctionResultsQuery$variables = {
   keyword?: string | null;
   last?: number | null;
   organizations?: ReadonlyArray<string | null> | null;
+  page?: number | null;
+  size?: number | null;
   sizes?: ReadonlyArray<ArtworkSizes | null> | null;
   sort?: AuctionResultSorts | null;
   state?: AuctionResultsState | null;
@@ -43,85 +44,85 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "after"
+  "name": "allowEmptyCreatedDates"
 },
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "allowEmptyCreatedDates"
+  "name": "artistID"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "artistID"
+  "name": "before"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "before"
+  "name": "categories"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "categories"
+  "name": "createdAfterYear"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "createdAfterYear"
+  "name": "createdBeforeYear"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "createdBeforeYear"
+  "name": "first"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "first"
+  "name": "keyword"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "keyword"
+  "name": "last"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "last"
+  "name": "organizations"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "organizations"
+  "name": "page"
 },
 v11 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "sizes"
+  "name": "size"
 },
 v12 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "sort"
+  "name": "sizes"
 },
 v13 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "sort"
+},
+v14 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "state"
 },
-v14 = [
+v15 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "artistID"
   }
 ],
-v15 = {
-  "kind": "Variable",
-  "name": "after",
-  "variableName": "after"
-},
 v16 = {
   "kind": "Variable",
   "name": "allowEmptyCreatedDates",
@@ -159,60 +160,70 @@ v22 = {
 },
 v23 = {
   "kind": "Variable",
+  "name": "page",
+  "variableName": "page"
+},
+v24 = {
+  "kind": "Variable",
+  "name": "size",
+  "variableName": "size"
+},
+v25 = {
+  "kind": "Variable",
   "name": "sizes",
   "variableName": "sizes"
 },
-v24 = {
+v26 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v25 = {
+v27 = {
   "kind": "Variable",
   "name": "state",
   "variableName": "state"
 },
-v26 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v27 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v28 = {
+v30 = {
   "kind": "Variable",
   "name": "earliestCreatedYear",
   "variableName": "createdAfterYear"
 },
-v29 = {
+v31 = {
   "kind": "Variable",
   "name": "latestCreatedYear",
   "variableName": "createdBeforeYear"
 },
-v30 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v31 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v32 = [
-  (v30/*: any*/),
-  (v31/*: any*/),
+v34 = [
+  (v32/*: any*/),
+  (v33/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -221,29 +232,29 @@ v32 = [
     "storageKey": null
   }
 ],
-v33 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v34 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v35 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "display",
   "storageKey": null
 },
-v36 = [
-  (v33/*: any*/)
+v38 = [
+  (v35/*: any*/)
 ];
 return {
   "fragment": {
@@ -261,7 +272,8 @@ return {
       (v10/*: any*/),
       (v11/*: any*/),
       (v12/*: any*/),
-      (v13/*: any*/)
+      (v13/*: any*/),
+      (v14/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -269,7 +281,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v14/*: any*/),
+        "args": (v15/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
@@ -277,7 +289,6 @@ return {
         "selections": [
           {
             "args": [
-              (v15/*: any*/),
               (v16/*: any*/),
               (v17/*: any*/),
               (v18/*: any*/),
@@ -297,7 +308,9 @@ return {
               (v22/*: any*/),
               (v23/*: any*/),
               (v24/*: any*/),
-              (v25/*: any*/)
+              (v25/*: any*/),
+              (v26/*: any*/),
+              (v27/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "ArtistAuctionResults_artist"
@@ -312,27 +325,28 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v7/*: any*/),
+      (v6/*: any*/),
+      (v8/*: any*/),
+      (v10/*: any*/),
+      (v11/*: any*/),
+      (v2/*: any*/),
+      (v13/*: any*/),
+      (v14/*: any*/),
+      (v1/*: any*/),
       (v9/*: any*/),
-      (v0/*: any*/),
+      (v7/*: any*/),
       (v3/*: any*/),
       (v12/*: any*/),
-      (v13/*: any*/),
-      (v2/*: any*/),
-      (v10/*: any*/),
-      (v8/*: any*/),
-      (v4/*: any*/),
-      (v11/*: any*/),
-      (v6/*: any*/),
       (v5/*: any*/),
-      (v1/*: any*/)
+      (v4/*: any*/),
+      (v0/*: any*/)
     ],
     "kind": "Operation",
     "name": "ArtistAuctionResultsQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v14/*: any*/),
+        "args": (v15/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
@@ -345,24 +359,25 @@ return {
             "name": "slug",
             "storageKey": null
           },
-          (v26/*: any*/),
-          (v27/*: any*/),
+          (v28/*: any*/),
+          (v29/*: any*/),
           {
             "alias": null,
             "args": [
-              (v15/*: any*/),
               (v16/*: any*/),
               (v17/*: any*/),
               (v18/*: any*/),
-              (v28/*: any*/),
+              (v30/*: any*/),
               (v19/*: any*/),
               (v20/*: any*/),
               (v21/*: any*/),
-              (v29/*: any*/),
+              (v31/*: any*/),
               (v22/*: any*/),
               (v23/*: any*/),
               (v24/*: any*/),
-              (v25/*: any*/)
+              (v25/*: any*/),
+              (v26/*: any*/),
+              (v27/*: any*/)
             ],
             "concreteType": "AuctionResultConnection",
             "kind": "LinkedField",
@@ -434,7 +449,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v32/*: any*/),
+                    "selections": (v34/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -444,7 +459,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v32/*: any*/),
+                    "selections": (v34/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -454,7 +469,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v32/*: any*/),
+                    "selections": (v34/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -465,15 +480,15 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v30/*: any*/),
-                      (v31/*: any*/)
+                      (v32/*: any*/),
+                      (v33/*: any*/)
                     ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v33/*: any*/),
+              (v35/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -490,7 +505,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v26/*: any*/),
+                      (v28/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -520,8 +535,8 @@ return {
                         "name": "artist",
                         "plural": false,
                         "selections": [
-                          (v27/*: any*/),
-                          (v34/*: any*/)
+                          (v29/*: any*/),
+                          (v36/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -654,7 +669,7 @@ return {
                         "name": "priceRealized",
                         "plural": false,
                         "selections": [
-                          (v35/*: any*/),
+                          (v37/*: any*/),
                           {
                             "alias": "display_usd",
                             "args": null,
@@ -698,7 +713,7 @@ return {
                         "name": "estimate",
                         "plural": false,
                         "selections": [
-                          (v35/*: any*/)
+                          (v37/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -730,7 +745,7 @@ return {
                         "name": "isUpcoming",
                         "storageKey": null
                       },
-                      (v34/*: any*/)
+                      (v36/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -745,11 +760,11 @@ return {
             "args": [
               (v16/*: any*/),
               (v18/*: any*/),
-              (v28/*: any*/),
+              (v30/*: any*/),
               (v20/*: any*/),
-              (v29/*: any*/),
+              (v31/*: any*/),
               (v22/*: any*/),
-              (v23/*: any*/),
+              (v25/*: any*/),
               {
                 "kind": "Literal",
                 "name": "state",
@@ -760,7 +775,7 @@ return {
             "kind": "LinkedField",
             "name": "auctionResultsConnection",
             "plural": false,
-            "selections": (v36/*: any*/),
+            "selections": (v38/*: any*/),
             "storageKey": null
           },
           {
@@ -768,11 +783,11 @@ return {
             "args": [
               (v16/*: any*/),
               (v18/*: any*/),
-              (v28/*: any*/),
+              (v30/*: any*/),
               (v20/*: any*/),
-              (v29/*: any*/),
+              (v31/*: any*/),
               (v22/*: any*/),
-              (v23/*: any*/),
+              (v25/*: any*/),
               {
                 "kind": "Literal",
                 "name": "state",
@@ -783,26 +798,26 @@ return {
             "kind": "LinkedField",
             "name": "auctionResultsConnection",
             "plural": false,
-            "selections": (v36/*: any*/),
+            "selections": (v38/*: any*/),
             "storageKey": null
           },
-          (v34/*: any*/)
+          (v36/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "14a16dae2415950d1850fd76aad09d2c",
+    "cacheID": "53eee7258a7f038c4f4fbc3cf9a24a89",
     "id": null,
     "metadata": {},
     "name": "ArtistAuctionResultsQuery",
     "operationKind": "query",
-    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $sort: AuctionResultSorts\n  $state: AuctionResultsState\n  $artistID: String!\n  $organizations: [String]\n  $keyword: String\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n  $createdBeforeYear: Int\n  $createdAfterYear: Int\n  $allowEmptyCreatedDates: Boolean\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_18yAgG\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResults_artist_18yAgG on Artist {\n  slug\n  internalID\n  name\n  auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates, state: $state) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $page: Int\n  $size: Int\n  $before: String\n  $sort: AuctionResultSorts\n  $state: AuctionResultsState\n  $artistID: String!\n  $organizations: [String]\n  $keyword: String\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n  $createdBeforeYear: Int\n  $createdAfterYear: Int\n  $allowEmptyCreatedDates: Boolean\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_2XQhb\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResults_artist_2XQhb on Artist {\n  slug\n  internalID\n  name\n  auctionResultsConnection(first: $first, page: $page, size: $size, before: $before, last: $last, sort: $sort, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates, state: $state) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e1bdba09319ea846fb3ac7e532fc1b21";
+(node as any).hash = "4a656a9b25baa12fe25858f03f159ead";
 
 export default node;

--- a/src/__generated__/ArtistAuctionResultsRoute_artist.graphql.ts
+++ b/src/__generated__/ArtistAuctionResultsRoute_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<31a73e779dd561ff2ceeb6b53b92cf81>>
+ * @generated SignedSource<<20e09ec1e749c994296cd341f36e1732>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -49,7 +49,17 @@ const node: ReaderFragment = {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "page"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "sizes"
+    },
+    {
+      "defaultValue": "ALL",
+      "kind": "LocalArgument",
+      "name": "state"
     }
   ],
   "kind": "Fragment",
@@ -85,8 +95,18 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Variable",
+          "name": "page",
+          "variableName": "page"
+        },
+        {
+          "kind": "Variable",
           "name": "sizes",
           "variableName": "sizes"
+        },
+        {
+          "kind": "Variable",
+          "name": "state",
+          "variableName": "state"
         }
       ],
       "kind": "FragmentSpread",
@@ -97,6 +117,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "63d57d29adb2cb0ec1c44e80d4e480e9";
+(node as any).hash = "77415e9b7ab12bb7008786080c206b2a";
 
 export default node;

--- a/src/__generated__/ArtistAuctionResults_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistAuctionResults_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e40cae19acf0c3bff50d78f8640839ab>>
+ * @generated SignedSource<<e755ac2e80673900194cca64dcc6707d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -248,7 +248,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "first",
-                "value": 10
+                "value": 50
               },
               {
                 "kind": "Literal",
@@ -635,7 +635,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "auctionResultsConnection(first:10,sort:\"DATE_DESC\",state:\"ALL\")"
+            "storageKey": "auctionResultsConnection(first:50,sort:\"DATE_DESC\",state:\"ALL\")"
           },
           {
             "alias": "pastAuctionResults",
@@ -676,12 +676,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ad9efecad63102c69b96db016813d5de",
+    "cacheID": "43c0884d5597541180cdce9f1da57a81",
     "id": null,
     "metadata": {},
     "name": "ArtistAuctionResults_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistAuctionResults_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResultsRoute_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResultsRoute_artist on Artist {\n  ...ArtistAuctionResults_artist_1jJDyA\n}\n\nfragment ArtistAuctionResults_artist_1jJDyA on Artist {\n  slug\n  internalID\n  name\n  auctionResultsConnection(first: 10, sort: DATE_DESC, state: ALL) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query ArtistAuctionResults_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResultsRoute_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResultsRoute_artist on Artist {\n  ...ArtistAuctionResults_artist_1HOUFh\n}\n\nfragment ArtistAuctionResults_artist_1HOUFh on Artist {\n  slug\n  internalID\n  name\n  auctionResultsConnection(first: 50, sort: DATE_DESC, state: ALL) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistAuctionResults_artist.graphql.ts
+++ b/src/__generated__/ArtistAuctionResults_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c3ed1b7fec711ebc60a4b5002f4c8047>>
+ * @generated SignedSource<<7f479c2b778764d42909f4377bbcebda>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -98,11 +98,6 @@ return {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
-      "name": "after"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
       "name": "allowEmptyCreatedDates"
     },
     {
@@ -126,7 +121,7 @@ return {
       "name": "createdBeforeYear"
     },
     {
-      "defaultValue": 10,
+      "defaultValue": 50,
       "kind": "LocalArgument",
       "name": "first"
     },
@@ -144,6 +139,16 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "organizations"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "page"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "size"
     },
     {
       "defaultValue": null,
@@ -189,11 +194,6 @@ return {
     {
       "alias": null,
       "args": [
-        {
-          "kind": "Variable",
-          "name": "after",
-          "variableName": "after"
-        },
         (v0/*: any*/),
         {
           "kind": "Variable",
@@ -215,6 +215,16 @@ return {
         },
         (v4/*: any*/),
         (v5/*: any*/),
+        {
+          "kind": "Variable",
+          "name": "page",
+          "variableName": "page"
+        },
+        {
+          "kind": "Variable",
+          "name": "size",
+          "variableName": "size"
+        },
         (v6/*: any*/),
         {
           "kind": "Variable",
@@ -388,6 +398,6 @@ return {
 };
 })();
 
-(node as any).hash = "c800def08a7d26042d0b4e394d4856ac";
+(node as any).hash = "3ee3695defd2061f12258d34da66df86";
 
 export default node;

--- a/src/__generated__/artistRoutes_AuctionResultsQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_AuctionResultsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0caede73519fe2f71a3874480874ee88>>
+ * @generated SignedSource<<8cb76003ed10f4e01df957ce705b127d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,7 @@
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type AuctionResultsState = "ALL" | "PAST" | "UPCOMING" | "%future added value";
 export type artistRoutes_AuctionResultsQuery$variables = {
   allowEmptyCreatedDates?: boolean | null;
   artistID: string;
@@ -18,7 +19,9 @@ export type artistRoutes_AuctionResultsQuery$variables = {
   createdAfterYear?: number | null;
   createdBeforeYear?: number | null;
   organizations?: ReadonlyArray<string | null> | null;
+  page?: number | null;
   sizes?: ReadonlyArray<ArtworkSizes | null> | null;
+  state?: AuctionResultsState | null;
 };
 export type artistRoutes_AuctionResultsQuery$data = {
   readonly artist: {
@@ -64,76 +67,96 @@ v5 = {
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "page"
+},
+v7 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "sizes"
 },
-v7 = [
+v8 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "state"
+},
+v9 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "artistID"
   }
 ],
-v8 = {
+v10 = {
   "kind": "Variable",
   "name": "allowEmptyCreatedDates",
   "variableName": "allowEmptyCreatedDates"
 },
-v9 = {
+v11 = {
   "kind": "Variable",
   "name": "categories",
   "variableName": "categories"
 },
-v10 = {
+v12 = {
   "kind": "Variable",
   "name": "organizations",
   "variableName": "organizations"
 },
-v11 = {
+v13 = {
+  "kind": "Variable",
+  "name": "page",
+  "variableName": "page"
+},
+v14 = {
   "kind": "Variable",
   "name": "sizes",
   "variableName": "sizes"
 },
-v12 = {
+v15 = {
+  "kind": "Variable",
+  "name": "state",
+  "variableName": "state"
+},
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v13 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v14 = {
+v18 = {
   "kind": "Variable",
   "name": "earliestCreatedYear",
   "variableName": "createdAfterYear"
 },
-v15 = {
+v19 = {
   "kind": "Variable",
   "name": "latestCreatedYear",
   "variableName": "createdBeforeYear"
 },
-v16 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v17 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v18 = [
-  (v16/*: any*/),
-  (v17/*: any*/),
+v22 = [
+  (v20/*: any*/),
+  (v21/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -142,29 +165,29 @@ v18 = [
     "storageKey": null
   }
 ],
-v19 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v20 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v21 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "display",
   "storageKey": null
 },
-v22 = [
-  (v19/*: any*/)
+v26 = [
+  (v23/*: any*/)
 ];
 return {
   "fragment": {
@@ -175,7 +198,9 @@ return {
       (v3/*: any*/),
       (v4/*: any*/),
       (v5/*: any*/),
-      (v6/*: any*/)
+      (v6/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -183,7 +208,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v7/*: any*/),
+        "args": (v9/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
@@ -191,8 +216,8 @@ return {
         "selections": [
           {
             "args": [
-              (v8/*: any*/),
-              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
               {
                 "kind": "Variable",
                 "name": "createdAfterYear",
@@ -203,8 +228,10 @@ return {
                 "name": "createdBeforeYear",
                 "variableName": "createdBeforeYear"
               },
-              (v10/*: any*/),
-              (v11/*: any*/)
+              (v12/*: any*/),
+              (v13/*: any*/),
+              (v14/*: any*/),
+              (v15/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "ArtistAuctionResultsRoute_artist"
@@ -219,10 +246,12 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
+      (v6/*: any*/),
+      (v8/*: any*/),
       (v1/*: any*/),
       (v5/*: any*/),
       (v2/*: any*/),
-      (v6/*: any*/),
+      (v7/*: any*/),
       (v3/*: any*/),
       (v4/*: any*/),
       (v0/*: any*/)
@@ -232,7 +261,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v7/*: any*/),
+        "args": (v9/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
@@ -245,32 +274,29 @@ return {
             "name": "slug",
             "storageKey": null
           },
-          (v12/*: any*/),
-          (v13/*: any*/),
+          (v16/*: any*/),
+          (v17/*: any*/),
           {
             "alias": null,
             "args": [
-              (v8/*: any*/),
-              (v9/*: any*/),
-              (v14/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v18/*: any*/),
               {
                 "kind": "Literal",
                 "name": "first",
-                "value": 10
+                "value": 50
               },
-              (v15/*: any*/),
-              (v10/*: any*/),
-              (v11/*: any*/),
+              (v19/*: any*/),
+              (v12/*: any*/),
+              (v13/*: any*/),
+              (v14/*: any*/),
               {
                 "kind": "Literal",
                 "name": "sort",
                 "value": "DATE_DESC"
               },
-              {
-                "kind": "Literal",
-                "name": "state",
-                "value": "ALL"
-              }
+              (v15/*: any*/)
             ],
             "concreteType": "AuctionResultConnection",
             "kind": "LinkedField",
@@ -342,7 +368,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v18/*: any*/),
+                    "selections": (v22/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -352,7 +378,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v18/*: any*/),
+                    "selections": (v22/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -362,7 +388,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v18/*: any*/),
+                    "selections": (v22/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -373,15 +399,15 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v16/*: any*/),
-                      (v17/*: any*/)
+                      (v20/*: any*/),
+                      (v21/*: any*/)
                     ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v19/*: any*/),
+              (v23/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -398,7 +424,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v12/*: any*/),
+                      (v16/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -428,8 +454,8 @@ return {
                         "name": "artist",
                         "plural": false,
                         "selections": [
-                          (v13/*: any*/),
-                          (v20/*: any*/)
+                          (v17/*: any*/),
+                          (v24/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -562,7 +588,7 @@ return {
                         "name": "priceRealized",
                         "plural": false,
                         "selections": [
-                          (v21/*: any*/),
+                          (v25/*: any*/),
                           {
                             "alias": "display_usd",
                             "args": null,
@@ -606,7 +632,7 @@ return {
                         "name": "estimate",
                         "plural": false,
                         "selections": [
-                          (v21/*: any*/)
+                          (v25/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -638,7 +664,7 @@ return {
                         "name": "isUpcoming",
                         "storageKey": null
                       },
-                      (v20/*: any*/)
+                      (v24/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -651,12 +677,12 @@ return {
           {
             "alias": "pastAuctionResults",
             "args": [
-              (v8/*: any*/),
-              (v9/*: any*/),
-              (v14/*: any*/),
-              (v15/*: any*/),
               (v10/*: any*/),
               (v11/*: any*/),
+              (v18/*: any*/),
+              (v19/*: any*/),
+              (v12/*: any*/),
+              (v14/*: any*/),
               {
                 "kind": "Literal",
                 "name": "state",
@@ -667,18 +693,18 @@ return {
             "kind": "LinkedField",
             "name": "auctionResultsConnection",
             "plural": false,
-            "selections": (v22/*: any*/),
+            "selections": (v26/*: any*/),
             "storageKey": null
           },
           {
             "alias": "upcomingAuctionResults",
             "args": [
-              (v8/*: any*/),
-              (v9/*: any*/),
-              (v14/*: any*/),
-              (v15/*: any*/),
               (v10/*: any*/),
               (v11/*: any*/),
+              (v18/*: any*/),
+              (v19/*: any*/),
+              (v12/*: any*/),
+              (v14/*: any*/),
               {
                 "kind": "Literal",
                 "name": "state",
@@ -689,26 +715,26 @@ return {
             "kind": "LinkedField",
             "name": "auctionResultsConnection",
             "plural": false,
-            "selections": (v22/*: any*/),
+            "selections": (v26/*: any*/),
             "storageKey": null
           },
-          (v20/*: any*/)
+          (v24/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "e0e76dd14a432a2962c984adc62db31d",
+    "cacheID": "f5522099e2c2a4bc33755775fa07158c",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_AuctionResultsQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_AuctionResultsQuery(\n  $artistID: String!\n  $organizations: [String]\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n  $createdAfterYear: Int\n  $createdBeforeYear: Int\n  $allowEmptyCreatedDates: Boolean\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResultsRoute_artist_20ZuLB\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResultsRoute_artist_20ZuLB on Artist {\n  ...ArtistAuctionResults_artist_20ZuLB\n}\n\nfragment ArtistAuctionResults_artist_20ZuLB on Artist {\n  slug\n  internalID\n  name\n  auctionResultsConnection(first: 10, sort: DATE_DESC, organizations: $organizations, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates, state: ALL) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST, organizations: $organizations, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING, organizations: $organizations, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query artistRoutes_AuctionResultsQuery(\n  $page: Int\n  $state: AuctionResultsState\n  $artistID: String!\n  $organizations: [String]\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n  $createdAfterYear: Int\n  $createdBeforeYear: Int\n  $allowEmptyCreatedDates: Boolean\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResultsRoute_artist_NMoRh\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResultsRoute_artist_NMoRh on Artist {\n  ...ArtistAuctionResults_artist_NMoRh\n}\n\nfragment ArtistAuctionResults_artist_NMoRh on Artist {\n  slug\n  internalID\n  name\n  auctionResultsConnection(first: 50, page: $page, sort: DATE_DESC, organizations: $organizations, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates, state: $state) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST, organizations: $organizations, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING, organizations: $organizations, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "82704008ad4e2236c5df200923977111";
+(node as any).hash = "ee6a74e26f08a093b9ccc16ea41a0e3e";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DO-675]

### Description

This PR updates auction results tab.
- Updated page size to 50 per page
- Pagination uses pages instead of cursor
- Filter values `allowEmptyCreatedDates` and `page` are stored in the URL

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DO-675]: https://artsyproduct.atlassian.net/browse/DO-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ