### PR TITLE
fix(TX-1019): Error display for invalid phone number submission via Add Address modal

### DIFF
--- a/src/Apps/Order/Components/AddressModal.tsx
+++ b/src/Apps/Order/Components/AddressModal.tsx
@@ -58,6 +58,10 @@ const SERVER_ERROR_MAP: Record<string, Record<string, string>> = {
     field: "phoneNumber",
     message: "Please enter a valid phone number",
   },
+  "Validation failed: Phone not a valid phone number": {
+    field: "phoneNumber",
+    message: "Please enter a valid phone number",
+  },
 }
 
 export const GENERIC_FAIL_MESSAGE =
@@ -122,6 +126,7 @@ export const AddressModal: React.FC<Props> = ({
               const handleError = message => {
                 const userMessage: Record<string, string> | null =
                   SERVER_ERROR_MAP[message]
+
                 if (userMessage) {
                   actions.setFieldError(userMessage.field, userMessage.message)
                 } else {

--- a/src/Apps/Order/Components/__tests__/AddressModal.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/AddressModal.jest.tsx
@@ -244,6 +244,43 @@ describe("AddressModal", () => {
       expect(wrapper.find(errorBoxQuery).text()).toContain(GENERIC_FAIL_MESSAGE)
     })
   })
+  it("sets formik error when adding an address returns phone validation error", async () => {
+    let wrapper = getWrapper({
+      ...testAddressModalProps,
+      modalDetails: {
+        addressModalTitle: "Add address",
+        addressModalAction: "createUserAddress",
+      },
+    })
+    commitMutation.mockImplementationOnce((_, { onCompleted }) =>
+      onCompleted({
+        createUserAddress: {
+          userAddressOrErrors: {
+            errors: [
+              {
+                message:
+                  "Validation failed for phone: not a valid phone number",
+              },
+            ],
+          },
+        },
+      })
+    )
+    const formik = wrapper.find("Formik").first()
+    const setFieldError = jest.fn()
+    const onSubmit = formik.props().onSubmit as any
+    onSubmit(validAddress as any, {
+      setFieldError: setFieldError,
+      setSubmitting: jest.fn(),
+    })
+
+    await wrapper.update()
+    await tick()
+    expect(setFieldError).toHaveBeenCalledWith(
+      "phoneNumber",
+      "Please enter a valid phone number"
+    )
+  })
 
   it("sets formik error when mutation returns phone validation error", async () => {
     let wrapper = getWrapper(testAddressModalProps)

--- a/src/Apps/Order/Components/__tests__/AddressModal.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/AddressModal.jest.tsx
@@ -243,80 +243,43 @@ describe("AddressModal", () => {
 
       expect(wrapper.find(errorBoxQuery).text()).toContain(GENERIC_FAIL_MESSAGE)
     })
-  })
-  it("sets formik error when adding an address returns phone validation error", async () => {
-    let wrapper = getWrapper({
-      ...testAddressModalProps,
-      modalDetails: {
-        addressModalTitle: "Add address",
-        addressModalAction: "createUserAddress",
-      },
-    })
-    commitMutation.mockImplementationOnce((_, { onCompleted }) =>
-      onCompleted({
-        createUserAddress: {
-          userAddressOrErrors: {
-            errors: [
-              {
-                message:
-                  "Validation failed for phone: not a valid phone number",
-              },
-            ],
+
+    it("sets formik error when address mutation returns phone validation error", async () => {
+      let wrapper = getWrapper(testAddressModalProps)
+
+      commitMutation.mockImplementationOnce((_, { onCompleted }) =>
+        onCompleted({
+          updateUserAddress: {
+            userAddressOrErrors: {
+              errors: [
+                {
+                  message:
+                    "Validation failed for phone: not a valid phone number",
+                },
+              ],
+            },
           },
-        },
+        })
+      )
+
+      const formik = wrapper.find("Formik").first()
+      const setFieldError = jest.fn()
+
+      const onSubmit = formik.props().onSubmit as any
+      onSubmit(validAddress as any, {
+        setFieldError: setFieldError,
+        setSubmitting: jest.fn(),
       })
-    )
-    const formik = wrapper.find("Formik").first()
-    const setFieldError = jest.fn()
-    const onSubmit = formik.props().onSubmit as any
-    onSubmit(validAddress as any, {
-      setFieldError: setFieldError,
-      setSubmitting: jest.fn(),
+
+      await wrapper.update()
+
+      await tick()
+
+      expect(setFieldError).toHaveBeenCalledWith(
+        "phoneNumber",
+        "Please enter a valid phone number"
+      )
     })
-
-    await wrapper.update()
-    await tick()
-    expect(setFieldError).toHaveBeenCalledWith(
-      "phoneNumber",
-      "Please enter a valid phone number"
-    )
-  })
-
-  it("sets formik error when mutation returns phone validation error", async () => {
-    let wrapper = getWrapper(testAddressModalProps)
-
-    commitMutation.mockImplementationOnce((_, { onCompleted }) =>
-      onCompleted({
-        updateUserAddress: {
-          userAddressOrErrors: {
-            errors: [
-              {
-                message:
-                  "Validation failed for phone: not a valid phone number",
-              },
-            ],
-          },
-        },
-      })
-    )
-
-    const formik = wrapper.find("Formik").first()
-    const setFieldError = jest.fn()
-
-    const onSubmit = formik.props().onSubmit as any
-    onSubmit(validAddress as any, {
-      setFieldError: setFieldError,
-      setSubmitting: jest.fn(),
-    })
-
-    await wrapper.update()
-
-    await tick()
-
-    expect(setFieldError).toHaveBeenCalledWith(
-      "phoneNumber",
-      "Please enter a valid phone number"
-    )
   })
 })
 

--- a/src/Apps/Order/Mutations/CreateUserAddress.ts
+++ b/src/Apps/Order/Mutations/CreateUserAddress.ts
@@ -1,17 +1,12 @@
-import { graphql } from "react-relay"
+import { commitMutation, graphql, Environment } from "react-relay"
 import {
   CreateUserAddressMutation,
   CreateUserAddressMutation$data,
   UserAddressAttributes,
 } from "__generated__/CreateUserAddressMutation.graphql"
-import {
-  RecordSourceSelectorProxy,
-  ConnectionHandler,
-  Environment,
-} from "relay-runtime"
+import { RecordSourceSelectorProxy, ConnectionHandler } from "relay-runtime"
 import { SavedAddresses_me$data } from "__generated__/SavedAddresses_me.graphql"
 import { Shipping_me$data } from "__generated__/Shipping_me.graphql"
-import { commitMutation } from "relay-runtime"
 
 const onAddressAdded = (
   me: SavedAddresses_me$data | Shipping_me$data,
@@ -39,7 +34,7 @@ export const createUserAddress = async (
   environment: Environment,
   address: UserAddressAttributes,
   onSuccess: (address: CreateUserAddressMutation$data | null) => void,
-  onError: (message: string | null) => void,
+  onError: (message: string) => void,
   me: SavedAddresses_me$data | Shipping_me$data,
   closeModal: () => void
 ) => {

--- a/src/Apps/Order/Mutations/CreateUserAddress.ts
+++ b/src/Apps/Order/Mutations/CreateUserAddress.ts
@@ -1,10 +1,15 @@
-import { commitMutation, graphql, Environment } from "react-relay"
+import { graphql } from "react-relay"
 import {
   CreateUserAddressMutation,
   CreateUserAddressMutation$data,
   UserAddressAttributes,
 } from "__generated__/CreateUserAddressMutation.graphql"
-import { RecordSourceSelectorProxy, ConnectionHandler } from "relay-runtime"
+import {
+  commitMutation,
+  Environment,
+  RecordSourceSelectorProxy,
+  ConnectionHandler,
+} from "relay-runtime"
 import { SavedAddresses_me$data } from "__generated__/SavedAddresses_me.graphql"
 import { Shipping_me$data } from "__generated__/Shipping_me.graphql"
 


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [TX-1019]

### Description
This PR fixes the problem that when a user is adding a new address through "Add Address" modal in the shipping step, and their submitted address is not valid because of phone number, we are displaying a general error response (as opposed to a specific error when editing an address through the same modal). 

Since the error messages are different for phone number error when adding and editing an address, this PR adds the absent error message to our look-up hash.

Note that the changes in createUserAddress mutation file are seemingly necessary in order to mock the response of that mutation in our test setup. If you know they are not necessary, do let me know! 


[TX-1019]: https://artsyproduct.atlassian.net/browse/TX-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ