### PR TITLE
fix(FX-4727): fix broken artworks grid on create collection flow

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/ArtworksList.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/ArtworksList.tsx
@@ -24,10 +24,15 @@ const ArtworksList: FC<ArtworksListProps> = ({
     // Disable scroll anchoring for infinite article scroll
     // https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-anchor/Guide_to_scroll_anchoring
     <div style={{ overflowAnchor: "none" }}>
-      <GridColumns>
+      <GridColumns alignItems="flex-end">
         {extractNodes(artworks).map(artwork => {
           return (
-            <Column span={[6, 4]} key={artwork.internalID}>
+            <Column
+              span={[6, 4]}
+              key={artwork.internalID}
+              // Fix for issue in Firefox where contents overflow container.
+              width="100%"
+            >
               <ArtworkItem
                 item={artwork}
                 selected={selectedIds.includes(artwork.internalID)}


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [FX-4727]

### Description

- Fixes broken artworks grid in Firefox
- Aline grid items by images bottom lines

### Demo

- Demo app TK

| Firefox before | Chrome before | Firefox now |
|---|---|---|
| <img width="659" alt="Screenshot 2023-04-14 at 14 37 50" src="https://user-images.githubusercontent.com/3934579/232046899-7b520e4f-95b1-4aa8-9140-20dd3e177ef5.png"> | <img width="663" alt="Screenshot 2023-04-14 at 14 39 19" src="https://user-images.githubusercontent.com/3934579/232046949-bdd5cd01-5942-498b-8801-a7c8c91c6f3b.png"> | <img width="660" alt="Screenshot 2023-04-14 at 14 44 35" src="https://user-images.githubusercontent.com/3934579/232047063-b026b4af-e167-48dd-be11-e79823cb851e.png"> |


