### PR TITLE
chore(FX-4737, FX-4738): artwork list copy changes (phase 2)

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButtonV2.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButtonV2.tsx
@@ -34,7 +34,6 @@ export const ArtworkActionsSaveButtonV2: FC<ArtworkActionsSaveButtonV2Props> = (
       imageURL: artwork.preview?.url ?? null,
       isSavedToDefaultList: !!artwork.isSaved,
       isSavedToCustomLists: isSavedToCustomLists,
-      isInAuction: !!isOpenSale,
     },
   })
 

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsWatchLotButton.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsWatchLotButton.tsx
@@ -90,7 +90,6 @@ const ArtworkActionsWatchLotButton: FC<ArtworkActionsWatchLotButtonProps> = ({
                 ? t(`artworkPage.actions.watchingLot`)
                 : t(`artworkPage.actions.watchLot`)
             }
-            longestLabel={t(`artworkPage.actions.watchingLot`)}
             onClick={handleButtonClick}
           />
         )

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsWatchLotButton.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsWatchLotButton.tsx
@@ -6,6 +6,7 @@ import { useSystemContext } from "System/SystemContext"
 import { useAuthIntent } from "Utils/Hooks/useAuthIntent"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkActionsWatchLotButton_artwork$data } from "__generated__/ArtworkActionsWatchLotButton_artwork.graphql"
+import { useTranslation } from "react-i18next"
 
 interface ArtworkActionsWatchLotButtonProps {
   isSaved: boolean
@@ -22,6 +23,7 @@ const ArtworkActionsWatchLotButton: FC<ArtworkActionsWatchLotButtonProps> = ({
 }) => {
   const { isLoggedIn } = useSystemContext()
   const [popoverVisible, setPopoverVisible] = useState(false)
+  const { t } = useTranslation()
 
   const { isLiveOpen, isRegistrationClosed, registrationStatus, liveStartAt } =
     artwork.sale ?? {}
@@ -83,8 +85,12 @@ const ArtworkActionsWatchLotButton: FC<ArtworkActionsWatchLotButtonProps> = ({
             ref={anchorRef}
             name="bell"
             Icon={isSaved ? FilledIcon : UnfilledIcon}
-            label={isSaved ? "Watching lot" : "Watch lot"}
-            longestLabel="Watching lot"
+            label={
+              isSaved
+                ? t(`artworkPage.actions.watchingLot`)
+                : t(`artworkPage.actions.watchLot`)
+            }
+            longestLabel={t(`artworkPage.actions.watchingLot`)}
             onClick={handleButtonClick}
           />
         )

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsWatchLotButton.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsWatchLotButton.tsx
@@ -83,7 +83,8 @@ const ArtworkActionsWatchLotButton: FC<ArtworkActionsWatchLotButtonProps> = ({
             ref={anchorRef}
             name="bell"
             Icon={isSaved ? FilledIcon : UnfilledIcon}
-            label="Watch lot"
+            label={isSaved ? "Watching lot" : "Watch lot"}
+            longestLabel="Watching lot"
             onClick={handleButtonClick}
           />
         )

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/UtilButton.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/UtilButton.tsx
@@ -150,9 +150,11 @@ const UtilButtonInnerText: React.FC<UtilButtonInnerTextProps> = ({
 
 const VisibleText = styled(Text)`
   position: absolute;
+  width: 100%;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  text-align: center;
 `
 
 const HiddenText = styled(Text)`

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActionsSaveButtonV2.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActionsSaveButtonV2.jest.tsx
@@ -175,6 +175,7 @@ describe("ArtworkActionsSaveButtonV2", () => {
         })
 
         expect(screen.getByTitle("Unwatch lot icon")).toBeInTheDocument()
+        expect(screen.getByText("Watching lot")).toBeInTheDocument()
       })
 
       it("if artwork was previously saved in custom lists", () => {
@@ -189,6 +190,7 @@ describe("ArtworkActionsSaveButtonV2", () => {
         })
 
         expect(screen.getByTitle("Unwatch lot icon")).toBeInTheDocument()
+        expect(screen.getByText("Watching lot")).toBeInTheDocument()
       })
 
       it("if artwork was previously saved in `Saved Artworks` and custom lists", () => {
@@ -203,6 +205,7 @@ describe("ArtworkActionsSaveButtonV2", () => {
         })
 
         expect(screen.getByTitle("Unwatch lot icon")).toBeInTheDocument()
+        expect(screen.getByText("Watching lot")).toBeInTheDocument()
       })
     })
 

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActionsSaveButtonV2.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActionsSaveButtonV2.jest.tsx
@@ -89,14 +89,14 @@ describe("ArtworkActionsSaveButtonV2", () => {
       expect(await screen.findByText("Add to a List")).toBeInTheDocument()
     })
 
-    it("should display a different toast message when artwork is in auction", async () => {
+    it("should display the same toast message when artwork is in auction", async () => {
       renderWithRelay({
         Artwork: () => unsavedAuctionArtwork,
       })
 
       fireEvent.click(screen.getByText("Watch lot"))
 
-      expect(await screen.findByText("Watch lot saved")).toBeInTheDocument()
+      expect(await screen.findByText("Artwork saved")).toBeInTheDocument()
       expect(await screen.findByText("Add to a List")).toBeInTheDocument()
     })
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/__tests__/ArtworkListsHeader.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/__tests__/ArtworkListsHeader.jest.tsx
@@ -5,7 +5,7 @@ describe("ArtworkListsHeader", () => {
   it("renders header text and creates button", () => {
     render(<ArtworkListsHeader savedArtworksCount={0} />)
 
-    const title = "Saved Artworks"
+    const title = "Saves"
     const description = "Curate your own lists of the works you love"
 
     expect(screen.getByText(title)).toBeInTheDocument()

--- a/src/Apps/CollectorProfile/Routes/Saves2/__tests__/CollectorProfileSaves2Route.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/__tests__/CollectorProfileSaves2Route.jest.tsx
@@ -62,7 +62,7 @@ describe("CollectorProfileSaves2Route", () => {
       }),
     })
 
-    expect(screen.getByText("Saved Artwork")).toBeInTheDocument()
+    expect(screen.getByText("Saved Artworks")).toBeInTheDocument()
     expect(screen.getByText("Collection One")).toBeInTheDocument()
     expect(screen.getByText("Collection Two")).toBeInTheDocument()
     expect(screen.getByText("Collection Three")).toBeInTheDocument()
@@ -78,7 +78,7 @@ describe("CollectorProfileSaves2Route", () => {
       })
 
       const selectedElement = getCurrentCollectionElement()
-      expect(selectedElement).toHaveTextContent("Saved Artwork")
+      expect(selectedElement).toHaveTextContent("Saved Artworks")
     })
 
     it("should render the corresponding collection as selected when collection id is passed in url", () => {
@@ -197,7 +197,7 @@ const getCurrentCollectionElement = () => {
 
 const savedArtworksArtworkList = {
   internalID: "saved-artwork",
-  name: "Saved Artwork",
+  name: "Saved Artworks",
 }
 
 const customArtworkLists = {

--- a/src/Components/Artwork/SaveButton/useSaveArtworkToLists.ts
+++ b/src/Components/Artwork/SaveButton/useSaveArtworkToLists.ts
@@ -14,7 +14,6 @@ type Artwork = {
   imageURL: string | null
   isSavedToDefaultList: boolean
   isSavedToCustomLists: boolean
-  isInAuction?: boolean
 }
 
 export interface SaveArtworkToListsOptions {

--- a/src/Components/Artwork/useArtworkLists.ts
+++ b/src/Components/Artwork/useArtworkLists.ts
@@ -45,14 +45,10 @@ export const useArtworkLists = (options: SaveArtworkToListsOptions) => {
 
   const showToastByAction = (action: ResultAction) => {
     if (action === ResultAction.SavedToDefaultList) {
-      const key = artwork.isInAuction
-        ? "forAuctionArtwork"
-        : "forNonAuctionArtwork"
-
       sendToast({
         variant: "success",
         message: t(
-          `collectorSaves.saveArtworkToLists.toast.artworkSaved.message.${key}`
+          `collectorSaves.saveArtworkToLists.toast.artworkSaved.message`
         ),
         action: {
           label: t(

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -104,7 +104,9 @@
       "save": {
         "registerToBidWithDeadline": "Register ahead of time to bid in this auction and get notifications for this lot.",
         "registerToBidWithoutDeadline": "Register to bid in this auction and get notifications for this lot."
-      }
+      },
+      "watchLot": "Watch lot",
+      "watchingLot": "Watching lot"
     }
   },
   "collectorSaves": {

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -144,10 +144,7 @@
     "saveArtworkToLists": {
       "toast": {
         "artworkSaved": {
-          "message": {
-            "forNonAuctionArtwork": "Artwork saved",
-            "forAuctionArtwork": "Watch lot saved"
-          },
+          "message": "Artwork saved",
           "button": "Add to a List"
         },
         "artworkRemoved": {

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -121,7 +121,7 @@
     },
     "artworkListsHeader": {
       "listCreated": "{{listName}} Created",
-      "savedArtworks": "Saved Artworks",
+      "savedArtworks": "Saves",
       "curateYourList": "Curate your own lists of the works you love",
       "createNewListButton": "Create New List"
     },


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4737], [FX-4738]

### 🔗 Useful links
* [Review app](https://artwork-list-copy-changes.artsy.net/)
* [Figma file](https://www.figma.com/file/wSV2KNz97Tyj8HkH2ZYAkB/Save-%2B-Lists?node-id=1961-232743&t=GnSm3kVwUDGayQux-0)

### 📹 Demo 1
Change `Watch lot` to `Watching lot` when artwork lot becomes watched

| Before | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/3513494/232109629-a84d05df-83e1-47bc-a28a-053c252822d8.mp4" />  | <video src="https://user-images.githubusercontent.com/3513494/232087919-3c9fcbfe-3cc2-4bfc-9deb-9ff097ec0cf5.mp4" />  | 

### 📹 Demo 2
Display **Artwork saved** toast message instead of **Watch lot saved** for auction artworks

| Before | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/3513494/232103619-c73b377e-3bf7-4755-8dda-04b1cc8eb2be.mp4" />  | <video src="https://user-images.githubusercontent.com/3513494/232103682-971e1dec-0159-48dc-a213-c7499afc99a3.mp4" />  | 

### 🖼 Demo 3
Change section title from `Saved Artworks` to `Saves`
| Before | After |
| ------------- | ------------- |
| <img width="788" alt="before-4" src="https://user-images.githubusercontent.com/3513494/232088531-d5292da5-4780-4fb8-ad9b-94b8ed25d62b.png"> | <img width="788" alt="after-4" src="https://user-images.githubusercontent.com/3513494/232088578-ee1dc58b-4304-478e-aaf5-7e610a73860f.png"> | 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-4737]: https://artsyproduct.atlassian.net/browse/FX-4737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4738]: https://artsyproduct.atlassian.net/browse/FX-4738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ