### PR TITLE
fix(GRO-1668): Prevent multiple secondary tips from appearing simultaneously

### DIFF
--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingAlertCreate.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingAlertCreate.tsx
@@ -1,7 +1,6 @@
 import {
+  PROGRESSIVE_ONBOARDING_ALERT_CHAIN,
   PROGRESSIVE_ONBOARDING_ALERT_CREATE,
-  PROGRESSIVE_ONBOARDING_ALERT_READY,
-  PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER,
   useProgressiveOnboarding,
 } from "Components/ProgressiveOnboarding/ProgressiveOnboardingContext"
 import { ProgressiveOnboardingPopover } from "Components/ProgressiveOnboarding/ProgressiveOnboardingPopover"
@@ -27,14 +26,13 @@ export const ProgressiveOnboardingAlertCreate: FC<ProgressiveOnboardingAlertCrea
   const { dismiss, isDismissed, isEnabledFor } = useProgressiveOnboarding()
 
   const isDisplayable =
-    isEnabledFor("alerts") && !isDismissed(PROGRESSIVE_ONBOARDING_ALERT_CREATE)
+    isEnabledFor("alerts") &&
+    !isDismissed(PROGRESSIVE_ONBOARDING_ALERT_CREATE).status
 
   const image = resized(IMAGE.src, { width: 230 })
 
   const handleDismiss = () => {
-    dismiss(PROGRESSIVE_ONBOARDING_ALERT_CREATE)
-    dismiss(PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER)
-    dismiss(PROGRESSIVE_ONBOARDING_ALERT_READY)
+    dismiss(PROGRESSIVE_ONBOARDING_ALERT_CHAIN)
   }
 
   const handleNext = () => {

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingAlertFind.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingAlertFind.tsx
@@ -23,7 +23,7 @@ const ProgressiveOnboardingAlertFind: FC<ProgressiveOnboardingAlertFindProps> = 
   const isDisplayable =
     isEnabledFor("alerts") &&
     counts.savedSearches === 1 &&
-    !isDismissed(PROGRESSIVE_ONBOARDING_ALERT_FIND)
+    !isDismissed(PROGRESSIVE_ONBOARDING_ALERT_FIND).status
 
   const handleClose = () => {
     dismiss(PROGRESSIVE_ONBOARDING_ALERT_FIND)

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingAlertReady.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingAlertReady.tsx
@@ -19,9 +19,9 @@ export const ProgressiveOnboardingAlertReady: FC<ProgressiveOnboardingAlertReady
 
   const isDisplayable =
     isEnabledFor("alerts") &&
-    isDismissed(PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER) &&
-    isDismissed(PROGRESSIVE_ONBOARDING_ALERT_CREATE) &&
-    !isDismissed(PROGRESSIVE_ONBOARDING_ALERT_READY)
+    isDismissed(PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER).status &&
+    isDismissed(PROGRESSIVE_ONBOARDING_ALERT_CREATE).status &&
+    !isDismissed(PROGRESSIVE_ONBOARDING_ALERT_READY).status
 
   const handleClose = () => {
     dismiss(PROGRESSIVE_ONBOARDING_ALERT_CREATE)

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingAlertSelectFilter.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingAlertSelectFilter.tsx
@@ -18,8 +18,8 @@ export const ProgressiveOnboardingAlertSelectFilter: FC = ({ children }) => {
 
   const isDisplayable =
     isEnabledFor("alerts") &&
-    isDismissed(PROGRESSIVE_ONBOARDING_ALERT_CREATE) &&
-    !isDismissed(PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER)
+    isDismissed(PROGRESSIVE_ONBOARDING_ALERT_CREATE).status &&
+    !isDismissed(PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER).status
 
   const handleClose = () => {
     dismiss(PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER)
@@ -37,7 +37,7 @@ export const ProgressiveOnboardingAlertSelectFilter: FC = ({ children }) => {
     if (
       isEnabledFor("alerts") &&
       isFilterStateChanged &&
-      !isDismissed(PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER)
+      !isDismissed(PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER).status
     ) {
       dismiss(PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER)
     }

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingContext.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingContext.tsx
@@ -13,7 +13,9 @@ import { useSystemContext } from "System/SystemContext"
 
 const ProgressiveOnboardingContext = createContext<{
   dismissed: ProgressiveOnboardingKey[]
-  dismiss: (key: ProgressiveOnboardingKey | ProgressiveOnboardingKey[]) => void
+  dismiss: (
+    key: ProgressiveOnboardingKey | readonly ProgressiveOnboardingKey[]
+  ) => void
   isDismissed: (key: ProgressiveOnboardingKey) => boolean
 }>({
   dismissed: [],
@@ -48,6 +50,20 @@ export const ProgressiveOnboardingProvider: FC = ({ children }) => {
     },
     [dismissed, mounted]
   )
+
+  // Ensure that the dismissed state stays in sync incase the user
+  // has multiple tabs open.
+  useEffect(() => {
+    const handleFocus = () => {
+      setDismissed(get(id))
+    }
+
+    window.addEventListener("focus", handleFocus)
+
+    return () => {
+      window.removeEventListener("focus", handleFocus)
+    }
+  }, [id])
 
   return (
     <ProgressiveOnboardingContext.Provider
@@ -104,7 +120,7 @@ export const PROGRESSIVE_ONBOARDING_FOLLOW_CHAIN = [
   PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST,
   PROGRESSIVE_ONBOARDING_FOLLOW_FIND,
   PROGRESSIVE_ONBOARDING_FOLLOW_HIGHLIGHT,
-]
+] as const
 
 // Saves
 export const PROGRESSIVE_ONBOARDING_SAVE_ARTWORK = "save-artwork"
@@ -114,7 +130,7 @@ export const PROGRESSIVE_ONBOARDING_SAVE_CHAIN = [
   PROGRESSIVE_ONBOARDING_SAVE_ARTWORK,
   PROGRESSIVE_ONBOARDING_SAVE_FIND,
   PROGRESSIVE_ONBOARDING_SAVE_HIGHLIGHT,
-]
+] as const
 
 // Alerts
 export const PROGRESSIVE_ONBOARDING_ALERT_CREATE = "alert-create"
@@ -126,7 +142,7 @@ export const PROGRESSIVE_ONBOARDING_ALERT_CHAIN = [
   PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER,
   PROGRESSIVE_ONBOARDING_ALERT_READY,
   PROGRESSIVE_ONBOARDING_ALERT_FIND,
-]
+] as const
 
 export const PROGRESSIVE_ONBOARDING_KEYS = [
   PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST,

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingContext.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingContext.tsx
@@ -13,7 +13,7 @@ import { useSystemContext } from "System/SystemContext"
 
 const ProgressiveOnboardingContext = createContext<{
   dismissed: ProgressiveOnboardingKey[]
-  dismiss: (key: ProgressiveOnboardingKey) => void
+  dismiss: (key: ProgressiveOnboardingKey | ProgressiveOnboardingKey[]) => void
   isDismissed: (key: ProgressiveOnboardingKey) => boolean
 }>({
   dismissed: [],
@@ -28,9 +28,10 @@ export const ProgressiveOnboardingProvider: FC = ({ children }) => {
   const [dismissed, setDismissed] = useState<ProgressiveOnboardingKey[]>([])
 
   const dismiss = useCallback(
-    (key: ProgressiveOnboardingKey) => {
-      __dismiss__(id, key)
-      setDismissed(prevDismissed => [...prevDismissed, key])
+    (key: ProgressiveOnboardingKey | ProgressiveOnboardingKey[]) => {
+      const keys = Array.isArray(key) ? key : [key]
+      __dismiss__(id, keys)
+      setDismissed(prevDismissed => uniq([...prevDismissed, ...keys]))
     },
     [id]
   )
@@ -99,15 +100,33 @@ export const localStorageKey = (id: string) => {
 export const PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST = "follow-artist"
 export const PROGRESSIVE_ONBOARDING_FOLLOW_FIND = "follow-find"
 export const PROGRESSIVE_ONBOARDING_FOLLOW_HIGHLIGHT = "follow-highlight"
+export const PROGRESSIVE_ONBOARDING_FOLLOW_CHAIN = [
+  PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST,
+  PROGRESSIVE_ONBOARDING_FOLLOW_FIND,
+  PROGRESSIVE_ONBOARDING_FOLLOW_HIGHLIGHT,
+]
+
 // Saves
 export const PROGRESSIVE_ONBOARDING_SAVE_ARTWORK = "save-artwork"
 export const PROGRESSIVE_ONBOARDING_SAVE_FIND = "save-find"
 export const PROGRESSIVE_ONBOARDING_SAVE_HIGHLIGHT = "save-highlight"
+export const PROGRESSIVE_ONBOARDING_SAVE_CHAIN = [
+  PROGRESSIVE_ONBOARDING_SAVE_ARTWORK,
+  PROGRESSIVE_ONBOARDING_SAVE_FIND,
+  PROGRESSIVE_ONBOARDING_SAVE_HIGHLIGHT,
+]
+
 // Alerts
 export const PROGRESSIVE_ONBOARDING_ALERT_CREATE = "alert-create"
 export const PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER = "alert-select-filter"
 export const PROGRESSIVE_ONBOARDING_ALERT_READY = "alert-ready"
 export const PROGRESSIVE_ONBOARDING_ALERT_FIND = "alert-find"
+export const PROGRESSIVE_ONBOARDING_ALERT_CHAIN = [
+  PROGRESSIVE_ONBOARDING_ALERT_CREATE,
+  PROGRESSIVE_ONBOARDING_ALERT_SELECT_FILTER,
+  PROGRESSIVE_ONBOARDING_ALERT_READY,
+  PROGRESSIVE_ONBOARDING_ALERT_FIND,
+]
 
 export const PROGRESSIVE_ONBOARDING_KEYS = [
   PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST,
@@ -141,14 +160,21 @@ export const parse = (
   }
 }
 
-export const __dismiss__ = (id: string, key: ProgressiveOnboardingKey) => {
-  const item = localStorage.getItem(localStorageKey(id))
-  const dismissed = parse(id, item)
+export const __dismiss__ = (
+  id: string,
+  key: ProgressiveOnboardingKey | ProgressiveOnboardingKey[]
+) => {
+  const keys = Array.isArray(key) ? key : [key]
 
-  localStorage.setItem(
-    localStorageKey(id),
-    JSON.stringify(uniq([...dismissed, key]))
-  )
+  keys.forEach(key => {
+    const item = localStorage.getItem(localStorageKey(id))
+    const dismissed = parse(id, item)
+
+    localStorage.setItem(
+      localStorageKey(id),
+      JSON.stringify(uniq([...dismissed, key]))
+    )
+  })
 }
 
 export const get = (id: string) => {

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist.tsx
@@ -2,7 +2,9 @@ import { FC, useCallback, useEffect } from "react"
 import { Text } from "@artsy/palette"
 import { ProgressiveOnboardingPopover } from "Components/ProgressiveOnboarding/ProgressiveOnboardingPopover"
 import {
+  PROGRESSIVE_ONBOARDING_ALERT_CHAIN,
   PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST,
+  PROGRESSIVE_ONBOARDING_SAVE_CHAIN,
   useProgressiveOnboarding,
 } from "Components/ProgressiveOnboarding/ProgressiveOnboardingContext"
 import {
@@ -21,7 +23,7 @@ const ProgressiveOnboardingFollowArtist: FC<ProgressiveOnboardingFollowArtistPro
 
   const isDisplayable =
     isEnabledFor("follows") &&
-    !isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST) &&
+    !isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST).status &&
     counts.followedArtists === 0
 
   const handleClose = useCallback(() => {
@@ -32,9 +34,18 @@ const ProgressiveOnboardingFollowArtist: FC<ProgressiveOnboardingFollowArtistPro
     // Dismiss the follow artist onboarding once you follow an artist.
     if (
       counts.followedArtists > 0 &&
-      !isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST)
+      !isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST).status
     ) {
       dismiss(PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST)
+
+      // If you've started another onboarding chain, ensure they are dismissed.
+      if (isDismissed(PROGRESSIVE_ONBOARDING_SAVE_CHAIN[0]).status) {
+        dismiss(PROGRESSIVE_ONBOARDING_SAVE_CHAIN)
+      }
+
+      if (isDismissed(PROGRESSIVE_ONBOARDING_ALERT_CHAIN[0]).status) {
+        dismiss(PROGRESSIVE_ONBOARDING_ALERT_CHAIN)
+      }
     }
   }, [counts.followedArtists, dismiss, isDismissed])
 

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowFind.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowFind.tsx
@@ -24,7 +24,7 @@ const ProgressiveOnboardingFollowFind: FC<ProgressiveOnboardingFollowFindProps> 
   const isDisplayable =
     isEnabledFor("follows") &&
     counts.followedArtists === 1 &&
-    !isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_FIND)
+    !isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_FIND).status
 
   const handleClose = () => {
     dismiss(PROGRESSIVE_ONBOARDING_FOLLOW_FIND)

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowHighlight.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowHighlight.tsx
@@ -23,9 +23,12 @@ export const ProgressiveOnboardingFollowHighlight: FC<ProgressiveOnboardingFollo
     // If the feature is enabled
     isEnabledFor("follows") &&
     // And you haven't already dismissed this
-    !isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_HIGHLIGHT) &&
+    !isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_HIGHLIGHT).status &&
     // And you've previously dismissed the previous onboarding tip
-    isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_FIND)
+    isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_FIND).status &&
+    // And you've dismissed the previous step within the last 20 seconds
+    isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_FIND).timestamp >
+      Date.now() - 20 * 1000
 
   useEffect(() => {
     if (!isDisplayable) return

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
@@ -2,6 +2,8 @@ import { FC, useCallback, useEffect } from "react"
 import { Text } from "@artsy/palette"
 import { ProgressiveOnboardingPopover } from "Components/ProgressiveOnboarding/ProgressiveOnboardingPopover"
 import {
+  PROGRESSIVE_ONBOARDING_ALERT_CHAIN,
+  PROGRESSIVE_ONBOARDING_FOLLOW_CHAIN,
   PROGRESSIVE_ONBOARDING_SAVE_ARTWORK,
   useProgressiveOnboarding,
 } from "Components/ProgressiveOnboarding/ProgressiveOnboardingContext"
@@ -21,7 +23,7 @@ export const ProgressiveOnboardingSaveArtwork: FC<ProgressiveOnboardingSaveArtwo
 
   const isDisplayble =
     isEnabledFor("saves") &&
-    !isDismissed(PROGRESSIVE_ONBOARDING_SAVE_ARTWORK) &&
+    !isDismissed(PROGRESSIVE_ONBOARDING_SAVE_ARTWORK).status &&
     counts.savedArtworks === 0
 
   const handleClose = useCallback(() => {
@@ -32,9 +34,18 @@ export const ProgressiveOnboardingSaveArtwork: FC<ProgressiveOnboardingSaveArtwo
     // Dismiss the save artwork onboarding once you save an artwork.
     if (
       counts.savedArtworks > 0 &&
-      !isDismissed(PROGRESSIVE_ONBOARDING_SAVE_ARTWORK)
+      !isDismissed(PROGRESSIVE_ONBOARDING_SAVE_ARTWORK).status
     ) {
       dismiss(PROGRESSIVE_ONBOARDING_SAVE_ARTWORK)
+
+      // If you've started another onboarding chain, ensure they are dismissed.
+      if (isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_CHAIN[0]).status) {
+        dismiss(PROGRESSIVE_ONBOARDING_FOLLOW_CHAIN)
+      }
+
+      if (isDismissed(PROGRESSIVE_ONBOARDING_ALERT_CHAIN[0]).status) {
+        dismiss(PROGRESSIVE_ONBOARDING_ALERT_CHAIN)
+      }
     }
   }, [counts.savedArtworks, dismiss, isDismissed])
 

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveFind.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveFind.tsx
@@ -24,7 +24,7 @@ const ProgressiveOnboardingSaveFind: FC<ProgressiveOnboardingSaveFindProps> = ({
   const isDisplayable =
     isEnabledFor("saves") &&
     counts.savedArtworks === 1 &&
-    !isDismissed(PROGRESSIVE_ONBOARDING_SAVE_FIND)
+    !isDismissed(PROGRESSIVE_ONBOARDING_SAVE_FIND).status
 
   const handleClose = () => {
     dismiss(PROGRESSIVE_ONBOARDING_SAVE_FIND)

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveHighlight.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveHighlight.tsx
@@ -23,9 +23,12 @@ export const ProgressiveOnboardingSaveHighlight: FC<ProgressiveOnboardingSaveHig
     // If the feature is enabled
     isEnabledFor("saves") &&
     // And you haven't already dismissed this
-    !isDismissed(PROGRESSIVE_ONBOARDING_SAVE_HIGHLIGHT) &&
+    !isDismissed(PROGRESSIVE_ONBOARDING_SAVE_HIGHLIGHT).status &&
     // And you've previously dismissed the previous onboarding tip
-    isDismissed(PROGRESSIVE_ONBOARDING_SAVE_FIND)
+    isDismissed(PROGRESSIVE_ONBOARDING_SAVE_FIND).status &&
+    // And you've dismissed the previous step within the last 20 seconds
+    isDismissed(PROGRESSIVE_ONBOARDING_SAVE_FIND).timestamp >
+      Date.now() - 20 * 1000
 
   useEffect(() => {
     if (!isDisplayable) return

--- a/src/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingContext.jest.tsx
+++ b/src/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingContext.jest.tsx
@@ -3,6 +3,7 @@ import {
   ProgressiveOnboardingProvider,
   __dismiss__,
   get,
+  localStorageKey,
   parse,
   reset,
   useProgressiveOnboarding,
@@ -18,57 +19,81 @@ describe("ProgressiveOnboardingContext", () => {
       expect(get(id)).toEqual([])
     })
 
+    it("returns empty array for the old format", () => {
+      localStorage.setItem(
+        localStorageKey(id),
+        JSON.stringify(["follow-artist"])
+      )
+      expect(get(id)).toEqual([])
+
+      localStorage.setItem(
+        localStorageKey(id),
+        JSON.stringify(["follow-artist", "follow-find"])
+      )
+      expect(get(id)).toEqual([])
+    })
+
     it("returns the all dismissed keys if there is a value in local storage", () => {
-      __dismiss__(id, "follow-artist")
-      expect(get(id)).toEqual(["follow-artist"])
-      __dismiss__(id, "follow-find")
-      expect(get(id)).toEqual(["follow-artist", "follow-find"])
+      __dismiss__(id, 999, "follow-artist")
+      expect(get(id)).toEqual([{ key: "follow-artist", timestamp: 999 }])
+      __dismiss__(id, 444, "follow-find")
+      expect(get(id)).toEqual([
+        { key: "follow-artist", timestamp: 999 },
+        { key: "follow-find", timestamp: 444 },
+      ])
     })
 
     it("does not return duplicate keys", () => {
-      __dismiss__(id, "follow-artist")
-      expect(get(id)).toEqual(["follow-artist"])
-      __dismiss__(id, "follow-artist")
-      expect(get(id)).toEqual(["follow-artist"])
+      __dismiss__(id, 555, "follow-artist")
+      expect(get(id)).toEqual([{ key: "follow-artist", timestamp: 555 }])
+      __dismiss__(id, 555, "follow-artist")
+      expect(get(id)).toEqual([{ key: "follow-artist", timestamp: 555 }])
     })
   })
 
   describe("parse", () => {
     it("returns an empty array if the value is null", () => {
-      expect(parse(id, null)).toEqual([])
+      expect(parse(null)).toEqual([])
     })
 
     it("returns an empty array if the value is not an array", () => {
-      expect(parse(id, "foo")).toEqual([])
+      expect(parse("foo")).toEqual([])
     })
 
     it("returns an empty array if the value is an array of non-strings", () => {
-      expect(parse(id, JSON.stringify([1, 2, 3]))).toEqual([])
+      expect(parse(JSON.stringify([1, 2, 3]))).toEqual([])
     })
 
     it("returns an empty array if the value is an array of strings that are not valid keys", () => {
-      expect(parse(id, JSON.stringify(["foo", "bar", "baz"]))).toEqual([])
+      expect(parse(JSON.stringify(["foo", "bar", "baz"]))).toEqual([])
     })
 
     it("returns an array of valid keys if the value is an array of strings that are valid keys", () => {
       expect(
         parse(
-          id,
-          JSON.stringify(["follow-artist", "follow-find", "follow-highlight"])
+          JSON.stringify([
+            { key: "follow-artist", timestamp: 555 },
+            { key: "follow-find", timestamp: 555 },
+            { key: "follow-highlight", timestamp: 555 },
+          ])
         )
-      ).toEqual(["follow-artist", "follow-find", "follow-highlight"])
+      ).toEqual([
+        { key: "follow-artist", timestamp: 555 },
+        { key: "follow-find", timestamp: 555 },
+        { key: "follow-highlight", timestamp: 555 },
+      ])
     })
 
     it("returns only the valid keys", () => {
       expect(
         parse(
-          id,
           JSON.stringify([
-            "follow-artist",
-            "follow-find",
-            "follow-highlight",
+            { key: "follow-artist", timestamp: 555 },
+            { key: "follow-find", timestamp: 555 },
+            { key: "follow-highlight", timestamp: 555 },
             "foo",
-            "bar",
+            { key: "no", timestamp: 555 },
+            { key: "alert-create", timestamp: "wrong" },
             "baz",
             1,
             2,
@@ -78,7 +103,11 @@ describe("ProgressiveOnboardingContext", () => {
             undefined,
           ])
         )
-      ).toEqual(["follow-artist", "follow-find", "follow-highlight"])
+      ).toEqual([
+        { key: "follow-artist", timestamp: 555 },
+        { key: "follow-find", timestamp: 555 },
+        { key: "follow-highlight", timestamp: 555 },
+      ])
     })
   })
 
@@ -86,32 +115,38 @@ describe("ProgressiveOnboardingContext", () => {
     afterEach(() => reset(id))
 
     it("adds the key to local storage", () => {
-      __dismiss__(id, "follow-artist")
-      expect(get(id)).toEqual(["follow-artist"])
+      __dismiss__(id, 555, "follow-artist")
+      expect(get(id)).toEqual([{ key: "follow-artist", timestamp: 555 }])
     })
 
     it("adds multiple keys to local storage", () => {
-      __dismiss__(id, ["follow-artist", "follow-find"])
-      expect(get(id)).toEqual(["follow-artist", "follow-find"])
+      __dismiss__(id, 555, ["follow-artist", "follow-find"])
+      expect(get(id)).toEqual([
+        { key: "follow-artist", timestamp: 555 },
+        { key: "follow-find", timestamp: 555 },
+      ])
     })
 
     it("does not add duplicate keys to local storage", () => {
-      __dismiss__(id, "follow-artist")
-      expect(get(id)).toEqual(["follow-artist"])
-      __dismiss__(id, "follow-artist")
-      expect(get(id)).toEqual(["follow-artist"])
+      __dismiss__(id, 555, "follow-artist")
+      expect(get(id)).toEqual([{ key: "follow-artist", timestamp: 555 }])
+      __dismiss__(id, 555, "follow-artist")
+      expect(get(id)).toEqual([{ key: "follow-artist", timestamp: 555 }])
     })
 
     it('handles subsequent calls to "dismiss"', () => {
-      __dismiss__(id, "follow-artist")
-      expect(get(id)).toEqual(["follow-artist"])
-      __dismiss__(id, "follow-find")
-      expect(get(id)).toEqual(["follow-artist", "follow-find"])
-      __dismiss__(id, "follow-highlight")
+      __dismiss__(id, 555, "follow-artist")
+      expect(get(id)).toEqual([{ key: "follow-artist", timestamp: 555 }])
+      __dismiss__(id, 555, "follow-find")
       expect(get(id)).toEqual([
-        "follow-artist",
-        "follow-find",
-        "follow-highlight",
+        { key: "follow-artist", timestamp: 555 },
+        { key: "follow-find", timestamp: 555 },
+      ])
+      __dismiss__(id, 555, "follow-highlight")
+      expect(get(id)).toEqual([
+        { key: "follow-artist", timestamp: 555 },
+        { key: "follow-find", timestamp: 555 },
+        { key: "follow-highlight", timestamp: 555 },
       ])
     })
   })
@@ -127,21 +162,45 @@ describe("ProgressiveOnboardingContext", () => {
       const { result } = renderHook(useProgressiveOnboarding, { wrapper })
 
       result.current.dismiss("follow-artist")
-      expect(result.current.isDismissed("follow-artist")).toBe(true)
-      expect(result.current.isDismissed("follow-find")).toBe(false)
-      expect(result.current.isDismissed("follow-highlight")).toBe(false)
 
-      expect(get(id)).toEqual(["follow-artist"])
+      expect(result.current.isDismissed("follow-artist")).toEqual({
+        status: true,
+        timestamp: expect.any(Number),
+      })
 
-      result.current.dismiss(["follow-find", "follow-highlight"])
-      expect(result.current.isDismissed("follow-artist")).toBe(true)
-      expect(result.current.isDismissed("follow-find")).toBe(true)
-      expect(result.current.isDismissed("follow-highlight")).toBe(true)
+      expect(result.current.isDismissed("follow-find")).toEqual({
+        status: false,
+        timestamp: 0,
+      })
+
+      expect(result.current.isDismissed("follow-highlight")).toEqual({
+        status: false,
+        timestamp: 0,
+      })
 
       expect(get(id)).toEqual([
-        "follow-artist",
-        "follow-find",
-        "follow-highlight",
+        { key: "follow-artist", timestamp: expect.any(Number) },
+      ])
+
+      result.current.dismiss(["follow-find", "follow-highlight"])
+
+      expect(result.current.isDismissed("follow-artist")).toEqual({
+        status: true,
+        timestamp: expect.any(Number),
+      })
+      expect(result.current.isDismissed("follow-find")).toEqual({
+        status: true,
+        timestamp: expect.any(Number),
+      })
+      expect(result.current.isDismissed("follow-highlight")).toEqual({
+        status: true,
+        timestamp: expect.any(Number),
+      })
+
+      expect(get(id)).toEqual([
+        { key: "follow-artist", timestamp: expect.any(Number) },
+        { key: "follow-find", timestamp: expect.any(Number) },
+        { key: "follow-highlight", timestamp: expect.any(Number) },
       ])
     })
   })


### PR DESCRIPTION
Closes [GRO-1668](https://artsyproduct.atlassian.net/browse/GRO-1668)

This is a confusing one to explain and this PR solves a few different bugs which were related.

* The specific bug that came up during the demo was that state wasn't being synced between tabs correctly. `localStorage` is automatically in sync but the context store is not. So 4cb5806e3d67beca7787da19f480dead5ccef47e solves that.

Then thinking about the doubling problem a bit more some other edge cases came to mind.

* What if you follow someone in one tab, then follow someone in another tab? Now, on the first step of an onboarding chain we check to ensure that if you've started any other chain, we dismiss them all.
* What if you start a chain, see the 'find' tip for that thing but then ignore it by clicking somewhere else. Later on when you open up the user menu you'll see the circular highlight out of context. In order to fix this I've had to alter the format to also store timestamps of dismissals. _This means that if you've explicitly dismissed these without following or saving anything you'll see them again_. IMO this is OK since I think it's a reasonable change to store an object that can be added onto in the future rather than a simple string. But this is mildly annoying.

[GRO-1668]: https://artsyproduct.atlassian.net/browse/GRO-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ