### PR TITLE
chore: Add isP1Artist to saveCollectedArtwork tracking event

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -163,7 +163,7 @@
         "filename": "src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionEditArtwork.jest.tsx",
         "hashed_secret": "dc312ec7ed341804d6911ecdcf18eea1858f6091",
         "is_verified": false,
-        "line_number": 511
+        "line_number": 512
       }
     ],
     "src/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx": [
@@ -538,5 +538,5 @@
       }
     ]
   },
-  "generated_at": "2023-04-07T12:35:44Z"
+  "generated_at": "2023-04-18T10:52:52Z"
 }

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
@@ -20,7 +20,7 @@ import { ArtworkDetailsFormModel } from "./ArtworkDetailsForm"
 
 const DEBOUNCE_DELAY = 300
 
-type AutocompleteArtist =
+export type AutocompleteArtist =
   | NonNullable<
       NonNullable<
         NonNullable<
@@ -225,6 +225,7 @@ const fetchSuggestions = async (
                 name
                 initials
                 internalID
+                isPersonalArtist
                 image {
                   cropped(width: 44, height: 44) {
                     height
@@ -232,6 +233,9 @@ const fetchSuggestions = async (
                     srcSet
                     width
                   }
+                }
+                targetSupply {
+                  isP1
                 }
               }
             }

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtistStep.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtistStep.tsx
@@ -9,7 +9,10 @@ import {
   Text,
 } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
-import { ArtistAutoComplete } from "Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete"
+import {
+  ArtistAutoComplete,
+  AutocompleteArtist,
+} from "Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete"
 import { useMyCollectionArtworkFormContext } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext"
 import { MyCollectionArtworkFormHeader } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormHeader"
 import { getMyCollectionArtworkFormInitialValues } from "Apps/MyCollection/Routes/EditArtwork/Utils/artworkFormHelpers"
@@ -48,21 +51,21 @@ export const MyCollectionArtworkFormArtistStep: React.FC<MyCollectionArtworkForm
   const [query, setQuery] = useState("")
   const trimmedQuery = query?.trimStart()
 
-  const onSelect = artist => {
+  const onSelect = (artist: AutocompleteArtist) => {
     trackSelectArtist()
 
-    setFieldValue("artistId", artist.internalID)
-    setFieldValue("artistName", artist.name || "")
+    setFieldValue("artistId", artist?.internalID)
+    setFieldValue("artistName", artist?.name || "")
     setFieldValue("artist", artist)
 
-    if (!artist.internalID) {
+    if (!artist?.internalID) {
       setQuery("")
 
       return
     }
 
     // Skip the artwork step if the artist has no public artworks on Artsy or is a personal artist
-    const skipNext = artist.isPersonalArtist || artist.counts.artworks === 0
+    const skipNext = artist?.isPersonalArtist || artist?.counts?.artworks === 0
 
     onNext?.({ skipNext })
   }
@@ -159,7 +162,7 @@ export const MyCollectionArtworkFormArtistStep: React.FC<MyCollectionArtworkForm
                 {collectedArtists.map(artist => (
                   <Column span={[12, 4]} key={artist.internalID} mt={1}>
                     <Clickable
-                      onClick={() => onSelect(artist)}
+                      onClick={() => onSelect(artist as AutocompleteArtist)}
                       data-testid={`artist-${artist.internalID}`}
                     >
                       <EntityHeaderArtistFragmentContainer
@@ -205,6 +208,9 @@ const MyCollectionArtworkFormArtistStepFragment = graphql`
             isPersonalArtist
             name
             slug
+            targetSupply {
+              isP1
+            }
           }
         }
       }

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormDetails.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormDetails.tsx
@@ -77,7 +77,11 @@ export const MyCollectionArtworkFormDetails: React.FC = () => {
           <Column span={6} mt={[2, 0]}>
             <ArtistAutoComplete
               onError={() => handleAutosuggestError(true)}
-              onSelect={artist => setFieldValue("artistId", artist?.internalID)}
+              onSelect={artist => {
+                setFieldValue("artistId", artist?.internalID)
+                setFieldValue("artistName", artist?.name || "")
+                setFieldValue("artist", artist)
+              }}
               required
               title="Artist"
             />

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionCreateArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionCreateArtwork.tsx
@@ -102,7 +102,10 @@ export const MyCollectionCreateArtwork: React.FC<MyCollectionCreateArtworkProps>
     try {
       const artwork = await createOrUpdateArtwork(values)
 
-      trackSaveCollectedArtwork(values.artistId)
+      trackSaveCollectedArtwork(
+        values.artistId,
+        values.artist?.targetSupply?.isP1 ?? false
+      )
 
       // Store images locally
       localImages.forEach((image, index) => {

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionEditArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionEditArtwork.tsx
@@ -140,6 +140,7 @@ export const MyCollectionEditArtworkFragmentContainer = createFragmentContainer(
           targetSupply {
             isP1
           }
+          isPersonalArtist
           image {
             cropped(width: 44, height: 44) {
               height

--- a/src/Apps/MyCollection/Routes/EditArtwork/Utils/artworkModel.ts
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Utils/artworkModel.ts
@@ -36,6 +36,9 @@ export interface MyCollectionPhoto {
 export interface Artist {
   formattedNationalityAndBirthday?: string | null
   initials?: string | null
+  targetSupply: {
+    isP1: boolean | null
+  } | null
   image?: {
     cropped: {
       src: string

--- a/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionEditArtwork.jest.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionEditArtwork.jest.tsx
@@ -479,6 +479,7 @@ const mockArtwork = {
     targetSupply: {
       isP1: true,
     },
+    isPersonalArtist: false,
     image: {
       cropped: {
         src: "https://example.com/image.jpg",

--- a/src/Apps/MyCollection/Routes/Hooks/__tests__/useMyCollectionTracking.jest.tsx
+++ b/src/Apps/MyCollection/Routes/Hooks/__tests__/useMyCollectionTracking.jest.tsx
@@ -79,7 +79,7 @@ describe("useMyCollectionTracking", () => {
   })
 
   it("#saveCollectedArtwork", () => {
-    setupHook().saveCollectedArtwork("artist-id")
+    setupHook().saveCollectedArtwork("artist-id", true)
 
     expect(trackingSpy).toBeCalledWith({
       action: "saveCollectedArtwork",

--- a/src/Apps/MyCollection/Routes/Hooks/__tests__/useMyCollectionTracking.jest.tsx
+++ b/src/Apps/MyCollection/Routes/Hooks/__tests__/useMyCollectionTracking.jest.tsx
@@ -86,7 +86,7 @@ describe("useMyCollectionTracking", () => {
       context_module: "myCollectionHome",
       context_owner_type: "myCollection",
       artist_id: "artist-id",
-      is_p1_artist: false,
+      is_p1_artist: true,
       platform: "web",
     })
   })

--- a/src/Apps/MyCollection/Routes/Hooks/useMyCollectionTracking.tsx
+++ b/src/Apps/MyCollection/Routes/Hooks/useMyCollectionTracking.tsx
@@ -58,17 +58,17 @@ export const useMyCollectionTracking = () => {
       trackEvent(payload)
     },
 
-    saveCollectedArtwork: (artistId: string) => {
+    saveCollectedArtwork: (artistId: string, isP1Artist: boolean) => {
       const payload: SaveCollectedArtwork = {
         action: ActionType.saveCollectedArtwork,
         context_module: ContextModule.myCollectionHome,
         context_owner_type: OwnerType.myCollection,
         artist_id: artistId,
-        // TODO: Get this from the artist
-        is_p1_artist: false,
+        is_p1_artist: isP1Artist,
         platform: "web",
       }
 
+      console.log({ payload })
       trackEvent(payload)
     },
 

--- a/src/Apps/MyCollection/Routes/Hooks/useMyCollectionTracking.tsx
+++ b/src/Apps/MyCollection/Routes/Hooks/useMyCollectionTracking.tsx
@@ -68,7 +68,6 @@ export const useMyCollectionTracking = () => {
         platform: "web",
       }
 
-      console.log({ payload })
       trackEvent(payload)
     },
 

--- a/src/__generated__/ArtistAutocomplete_SearchConnection_Query.graphql.ts
+++ b/src/__generated__/ArtistAutocomplete_SearchConnection_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c2141d51ed665ca355eff8794b3a7ccf>>
+ * @generated SignedSource<<856d249dc4f6d96a80ce82f9dacb6898>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,7 +31,11 @@ export type ArtistAutocomplete_SearchConnection_Query$data = {
         } | null;
         readonly initials?: string | null;
         readonly internalID?: string;
+        readonly isPersonalArtist?: boolean | null;
         readonly name?: string | null;
+        readonly targetSupply?: {
+          readonly isP1: boolean | null;
+        } | null;
       } | null;
     } | null> | null;
   } | null;
@@ -130,6 +134,13 @@ v3 = {
     {
       "alias": null,
       "args": null,
+      "kind": "ScalarField",
+      "name": "isPersonalArtist",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "Image",
       "kind": "LinkedField",
       "name": "image",
@@ -184,6 +195,24 @@ v3 = {
             }
           ],
           "storageKey": "cropped(height:44,width:44)"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArtistTargetSupply",
+      "kind": "LinkedField",
+      "name": "targetSupply",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isP1",
+          "storageKey": null
         }
       ],
       "storageKey": null
@@ -303,16 +332,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "77c07db478b4b7430c395ef815637e5b",
+    "cacheID": "ee6256efc8eabd5b60a0802259ae7d86",
     "id": null,
     "metadata": {},
     "name": "ArtistAutocomplete_SearchConnection_Query",
     "operationKind": "query",
-    "text": "query ArtistAutocomplete_SearchConnection_Query(\n  $searchQuery: String!\n) {\n  searchConnection(query: $searchQuery, entities: ARTIST, mode: AUTOSUGGEST, first: 6) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Artist {\n          counts {\n            artworks\n          }\n          formattedNationalityAndBirthday\n          name\n          initials\n          internalID\n          image {\n            cropped(width: 44, height: 44) {\n              height\n              src\n              srcSet\n              width\n            }\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ArtistAutocomplete_SearchConnection_Query(\n  $searchQuery: String!\n) {\n  searchConnection(query: $searchQuery, entities: ARTIST, mode: AUTOSUGGEST, first: 6) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Artist {\n          counts {\n            artworks\n          }\n          formattedNationalityAndBirthday\n          name\n          initials\n          internalID\n          isPersonalArtist\n          image {\n            cropped(width: 44, height: 44) {\n              height\n              src\n              srcSet\n              width\n            }\n          }\n          targetSupply {\n            isP1\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "cf75a02bd75c9fd68b5a131be1781547";
+(node as any).hash = "c6318c01fb735a86d53e0671cc16bd24";
 
 export default node;

--- a/src/__generated__/MyCollectionArtworkFormArtistStep_me.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkFormArtistStep_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<52291d040c8e8728f27c6b2b4a2a6c1c>>
+ * @generated SignedSource<<d08dcc09cada6fe69179828e346a7b6f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,9 @@ export type MyCollectionArtworkFormArtistStep_me$data = {
           readonly isPersonalArtist: boolean | null;
           readonly name: string | null;
           readonly slug: string;
+          readonly targetSupply: {
+            readonly isP1: boolean | null;
+          } | null;
           readonly " $fragmentSpreads": FragmentRefs<"EntityHeaderArtist_artist">;
         } | null;
       } | null> | null;
@@ -210,6 +213,24 @@ const node: ReaderFragment = {
                       "kind": "ScalarField",
                       "name": "slug",
                       "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "ArtistTargetSupply",
+                      "kind": "LinkedField",
+                      "name": "targetSupply",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "isP1",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
                     }
                   ],
                   "storageKey": null
@@ -228,6 +249,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "c1d52d4bc31e54f6b855003ca978f7ff";
+(node as any).hash = "68f3932e5f0218e2d93b6fa0bd67aea1";
 
 export default node;

--- a/src/__generated__/MyCollectionCreateArtworkTest_Query.graphql.ts
+++ b/src/__generated__/MyCollectionCreateArtworkTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<07a127b514a6dc6fb6090304d82f81a6>>
+ * @generated SignedSource<<9cc1c56c44d4f8cb8cf266ad1fa50c98>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -252,6 +252,24 @@ return {
                             "name": "isPersonalArtist",
                             "storageKey": null
                           },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtistTargetSupply",
+                            "kind": "LinkedField",
+                            "name": "targetSupply",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isP1",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
                           (v1/*: any*/)
                         ],
                         "storageKey": null
@@ -272,12 +290,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8c14c000395f80439337924c761bf6b4",
+    "cacheID": "853055bb44ca69cd75dba2aca9c56613",
     "id": null,
     "metadata": {},
     "name": "MyCollectionCreateArtworkTest_Query",
     "operationKind": "query",
-    "text": "query MyCollectionCreateArtworkTest_Query {\n  me {\n    ...MyCollectionCreateArtwork_me\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment MyCollectionArtworkFormArtistStep_me on Me {\n  myCollectionInfo {\n    collectedArtistsConnection(first: 100, includePersonalArtists: true) {\n      edges {\n        node {\n          ...EntityHeaderArtist_artist\n          counts {\n            artworks\n          }\n          displayLabel\n          formattedNationalityAndBirthday\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          initials\n          internalID\n          isPersonalArtist\n          name\n          slug\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment MyCollectionCreateArtwork_me on Me {\n  ...MyCollectionArtworkFormArtistStep_me\n}\n"
+    "text": "query MyCollectionCreateArtworkTest_Query {\n  me {\n    ...MyCollectionCreateArtwork_me\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment MyCollectionArtworkFormArtistStep_me on Me {\n  myCollectionInfo {\n    collectedArtistsConnection(first: 100, includePersonalArtists: true) {\n      edges {\n        node {\n          ...EntityHeaderArtist_artist\n          counts {\n            artworks\n          }\n          displayLabel\n          formattedNationalityAndBirthday\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          initials\n          internalID\n          isPersonalArtist\n          name\n          slug\n          targetSupply {\n            isP1\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment MyCollectionCreateArtwork_me on Me {\n  ...MyCollectionArtworkFormArtistStep_me\n}\n"
   }
 };
 })();

--- a/src/__generated__/MyCollectionEditArtworkTest_Query.graphql.ts
+++ b/src/__generated__/MyCollectionEditArtworkTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<de1fed6cf00d19c0d304715b00cba7a1>>
+ * @generated SignedSource<<67aecf55311875062129b7eee90cdf44>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -154,6 +154,13 @@ return {
                     "storageKey": null
                   }
                 ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isPersonalArtist",
                 "storageKey": null
               },
               {
@@ -433,12 +440,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "87d4920418c89071d4ac92c202819d98",
+    "cacheID": "fc733eab48420f2de73843af3f82f403",
     "id": null,
     "metadata": {},
     "name": "MyCollectionEditArtworkTest_Query",
     "operationKind": "query",
-    "text": "query MyCollectionEditArtworkTest_Query(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...MyCollectionEditArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkFormMain_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionEditArtwork_artwork on Artwork {\n  artist {\n    internalID\n    initials\n    name\n    formattedNationalityAndBirthday\n    targetSupply {\n      isP1\n    }\n    image {\n      cropped(width: 44, height: 44) {\n        height\n        src\n        srcSet\n        width\n      }\n    }\n    id\n  }\n  consignmentSubmission {\n    inProgress\n  }\n  artistNames\n  category\n  pricePaid {\n    display\n    minor\n    currencyCode\n  }\n  date\n  depth\n  dimensions {\n    in\n    cm\n  }\n  editionSize\n  editionNumber\n  height\n  attributionClass {\n    name\n    id\n  }\n  id\n  images {\n    internalID\n    isDefault\n    imageURL\n    width\n    height\n  }\n  internalID\n  isEdition\n  medium\n  metric\n  artworkLocation\n  provenance\n  slug\n  title\n  width\n  confidentialNotes\n  ...MyCollectionArtworkFormMain_artwork\n}\n"
+    "text": "query MyCollectionEditArtworkTest_Query(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...MyCollectionEditArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkFormMain_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionEditArtwork_artwork on Artwork {\n  artist {\n    internalID\n    initials\n    name\n    formattedNationalityAndBirthday\n    targetSupply {\n      isP1\n    }\n    isPersonalArtist\n    image {\n      cropped(width: 44, height: 44) {\n        height\n        src\n        srcSet\n        width\n      }\n    }\n    id\n  }\n  consignmentSubmission {\n    inProgress\n  }\n  artistNames\n  category\n  pricePaid {\n    display\n    minor\n    currencyCode\n  }\n  date\n  depth\n  dimensions {\n    in\n    cm\n  }\n  editionSize\n  editionNumber\n  height\n  attributionClass {\n    name\n    id\n  }\n  id\n  images {\n    internalID\n    isDefault\n    imageURL\n    width\n    height\n  }\n  internalID\n  isEdition\n  medium\n  metric\n  artworkLocation\n  provenance\n  slug\n  title\n  width\n  confidentialNotes\n  ...MyCollectionArtworkFormMain_artwork\n}\n"
   }
 };
 })();

--- a/src/__generated__/MyCollectionEditArtwork_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionEditArtwork_artwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<64671becdbc3bce330ce485b1c17de1e>>
+ * @generated SignedSource<<f6b9dd9c3709e637eac639d8e5bc188e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,6 +23,7 @@ export type MyCollectionEditArtwork_artwork$data = {
     } | null;
     readonly initials: string | null;
     readonly internalID: string;
+    readonly isPersonalArtist: boolean | null;
     readonly name: string | null;
     readonly targetSupply: {
       readonly isP1: boolean | null;
@@ -151,6 +152,13 @@ return {
               "storageKey": null
             }
           ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isPersonalArtist",
           "storageKey": null
         },
         {
@@ -439,6 +447,6 @@ return {
 };
 })();
 
-(node as any).hash = "41b1d5a70445a9a51daa764c80870ac2";
+(node as any).hash = "203c396e79abcd0668b691bf8b8a0af4";
 
 export default node;

--- a/src/__generated__/collectorProfileRoutes_MyCollectionArtworkFormQuery.graphql.ts
+++ b/src/__generated__/collectorProfileRoutes_MyCollectionArtworkFormQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<94d76d1a838198c9847556026c48a23b>>
+ * @generated SignedSource<<f62069eb9fbedf0ec1472782e69a08b9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -154,6 +154,13 @@ return {
                     "storageKey": null
                   }
                 ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isPersonalArtist",
                 "storageKey": null
               },
               {
@@ -433,12 +440,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "59d19c6e655bcb835bfe496edb83dbcd",
+    "cacheID": "c824e8668c462a0c103e57d426a58773",
     "id": null,
     "metadata": {},
     "name": "collectorProfileRoutes_MyCollectionArtworkFormQuery",
     "operationKind": "query",
-    "text": "query collectorProfileRoutes_MyCollectionArtworkFormQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...MyCollectionEditArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkFormMain_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionEditArtwork_artwork on Artwork {\n  artist {\n    internalID\n    initials\n    name\n    formattedNationalityAndBirthday\n    targetSupply {\n      isP1\n    }\n    image {\n      cropped(width: 44, height: 44) {\n        height\n        src\n        srcSet\n        width\n      }\n    }\n    id\n  }\n  consignmentSubmission {\n    inProgress\n  }\n  artistNames\n  category\n  pricePaid {\n    display\n    minor\n    currencyCode\n  }\n  date\n  depth\n  dimensions {\n    in\n    cm\n  }\n  editionSize\n  editionNumber\n  height\n  attributionClass {\n    name\n    id\n  }\n  id\n  images {\n    internalID\n    isDefault\n    imageURL\n    width\n    height\n  }\n  internalID\n  isEdition\n  medium\n  metric\n  artworkLocation\n  provenance\n  slug\n  title\n  width\n  confidentialNotes\n  ...MyCollectionArtworkFormMain_artwork\n}\n"
+    "text": "query collectorProfileRoutes_MyCollectionArtworkFormQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...MyCollectionEditArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkFormMain_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionEditArtwork_artwork on Artwork {\n  artist {\n    internalID\n    initials\n    name\n    formattedNationalityAndBirthday\n    targetSupply {\n      isP1\n    }\n    isPersonalArtist\n    image {\n      cropped(width: 44, height: 44) {\n        height\n        src\n        srcSet\n        width\n      }\n    }\n    id\n  }\n  consignmentSubmission {\n    inProgress\n  }\n  artistNames\n  category\n  pricePaid {\n    display\n    minor\n    currencyCode\n  }\n  date\n  depth\n  dimensions {\n    in\n    cm\n  }\n  editionSize\n  editionNumber\n  height\n  attributionClass {\n    name\n    id\n  }\n  id\n  images {\n    internalID\n    isDefault\n    imageURL\n    width\n    height\n  }\n  internalID\n  isEdition\n  medium\n  metric\n  artworkLocation\n  provenance\n  slug\n  title\n  width\n  confidentialNotes\n  ...MyCollectionArtworkFormMain_artwork\n}\n"
   }
 };
 })();

--- a/src/__generated__/collectorProfileRoutes_MyCollectionArtworkUploadQuery.graphql.ts
+++ b/src/__generated__/collectorProfileRoutes_MyCollectionArtworkUploadQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bf2c6948fb1439aba2ce942e9f087dc2>>
+ * @generated SignedSource<<1253103619911bc550e4a8d6da1a97de>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -252,6 +252,24 @@ return {
                             "name": "isPersonalArtist",
                             "storageKey": null
                           },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtistTargetSupply",
+                            "kind": "LinkedField",
+                            "name": "targetSupply",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isP1",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
                           (v1/*: any*/)
                         ],
                         "storageKey": null
@@ -272,12 +290,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "52fa59007cd67b31e2304192cda16eb2",
+    "cacheID": "edf654a549ab8c1de9c057ed2df54910",
     "id": null,
     "metadata": {},
     "name": "collectorProfileRoutes_MyCollectionArtworkUploadQuery",
     "operationKind": "query",
-    "text": "query collectorProfileRoutes_MyCollectionArtworkUploadQuery {\n  me {\n    ...MyCollectionCreateArtwork_me\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment MyCollectionArtworkFormArtistStep_me on Me {\n  myCollectionInfo {\n    collectedArtistsConnection(first: 100, includePersonalArtists: true) {\n      edges {\n        node {\n          ...EntityHeaderArtist_artist\n          counts {\n            artworks\n          }\n          displayLabel\n          formattedNationalityAndBirthday\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          initials\n          internalID\n          isPersonalArtist\n          name\n          slug\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment MyCollectionCreateArtwork_me on Me {\n  ...MyCollectionArtworkFormArtistStep_me\n}\n"
+    "text": "query collectorProfileRoutes_MyCollectionArtworkUploadQuery {\n  me {\n    ...MyCollectionCreateArtwork_me\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment MyCollectionArtworkFormArtistStep_me on Me {\n  myCollectionInfo {\n    collectedArtistsConnection(first: 100, includePersonalArtists: true) {\n      edges {\n        node {\n          ...EntityHeaderArtist_artist\n          counts {\n            artworks\n          }\n          displayLabel\n          formattedNationalityAndBirthday\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          initials\n          internalID\n          isPersonalArtist\n          name\n          slug\n          targetSupply {\n            isP1\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment MyCollectionCreateArtwork_me on Me {\n  ...MyCollectionArtworkFormArtistStep_me\n}\n"
   }
 };
 })();

--- a/src/__generated__/myCollectionRoutes_MyCollectionArtworkFormQuery.graphql.ts
+++ b/src/__generated__/myCollectionRoutes_MyCollectionArtworkFormQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ca3f1fdd9b0305a29edc68128a01aef9>>
+ * @generated SignedSource<<5cf115c7fe5b765b1eb97487c21c2fc2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -154,6 +154,13 @@ return {
                     "storageKey": null
                   }
                 ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isPersonalArtist",
                 "storageKey": null
               },
               {
@@ -433,12 +440,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1c2b334391900dab4f65e64f7f22cfeb",
+    "cacheID": "579eae606b21f90c85110d8d77ef5f06",
     "id": null,
     "metadata": {},
     "name": "myCollectionRoutes_MyCollectionArtworkFormQuery",
     "operationKind": "query",
-    "text": "query myCollectionRoutes_MyCollectionArtworkFormQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...MyCollectionEditArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkFormMain_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionEditArtwork_artwork on Artwork {\n  artist {\n    internalID\n    initials\n    name\n    formattedNationalityAndBirthday\n    targetSupply {\n      isP1\n    }\n    image {\n      cropped(width: 44, height: 44) {\n        height\n        src\n        srcSet\n        width\n      }\n    }\n    id\n  }\n  consignmentSubmission {\n    inProgress\n  }\n  artistNames\n  category\n  pricePaid {\n    display\n    minor\n    currencyCode\n  }\n  date\n  depth\n  dimensions {\n    in\n    cm\n  }\n  editionSize\n  editionNumber\n  height\n  attributionClass {\n    name\n    id\n  }\n  id\n  images {\n    internalID\n    isDefault\n    imageURL\n    width\n    height\n  }\n  internalID\n  isEdition\n  medium\n  metric\n  artworkLocation\n  provenance\n  slug\n  title\n  width\n  confidentialNotes\n  ...MyCollectionArtworkFormMain_artwork\n}\n"
+    "text": "query myCollectionRoutes_MyCollectionArtworkFormQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) {\n    ...MyCollectionEditArtwork_artwork\n    id\n  }\n}\n\nfragment MyCollectionArtworkFormMain_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionEditArtwork_artwork on Artwork {\n  artist {\n    internalID\n    initials\n    name\n    formattedNationalityAndBirthday\n    targetSupply {\n      isP1\n    }\n    isPersonalArtist\n    image {\n      cropped(width: 44, height: 44) {\n        height\n        src\n        srcSet\n        width\n      }\n    }\n    id\n  }\n  consignmentSubmission {\n    inProgress\n  }\n  artistNames\n  category\n  pricePaid {\n    display\n    minor\n    currencyCode\n  }\n  date\n  depth\n  dimensions {\n    in\n    cm\n  }\n  editionSize\n  editionNumber\n  height\n  attributionClass {\n    name\n    id\n  }\n  id\n  images {\n    internalID\n    isDefault\n    imageURL\n    width\n    height\n  }\n  internalID\n  isEdition\n  medium\n  metric\n  artworkLocation\n  provenance\n  slug\n  title\n  width\n  confidentialNotes\n  ...MyCollectionArtworkFormMain_artwork\n}\n"
   }
 };
 })();

--- a/src/__generated__/myCollectionRoutes_MyCollectionArtworkUploadQuery.graphql.ts
+++ b/src/__generated__/myCollectionRoutes_MyCollectionArtworkUploadQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3a613d4bced158fd72c8def3a1948d54>>
+ * @generated SignedSource<<12270ce063ac4a95440df2dfb19fc3d3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -252,6 +252,24 @@ return {
                             "name": "isPersonalArtist",
                             "storageKey": null
                           },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtistTargetSupply",
+                            "kind": "LinkedField",
+                            "name": "targetSupply",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isP1",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
                           (v1/*: any*/)
                         ],
                         "storageKey": null
@@ -272,12 +290,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "32133bf597ee69c77ebc3a871f297956",
+    "cacheID": "559f30d352fbeccf8eb2322aa98435f1",
     "id": null,
     "metadata": {},
     "name": "myCollectionRoutes_MyCollectionArtworkUploadQuery",
     "operationKind": "query",
-    "text": "query myCollectionRoutes_MyCollectionArtworkUploadQuery {\n  me {\n    ...MyCollectionCreateArtwork_me\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment MyCollectionArtworkFormArtistStep_me on Me {\n  myCollectionInfo {\n    collectedArtistsConnection(first: 100, includePersonalArtists: true) {\n      edges {\n        node {\n          ...EntityHeaderArtist_artist\n          counts {\n            artworks\n          }\n          displayLabel\n          formattedNationalityAndBirthday\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          initials\n          internalID\n          isPersonalArtist\n          name\n          slug\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment MyCollectionCreateArtwork_me on Me {\n  ...MyCollectionArtworkFormArtistStep_me\n}\n"
+    "text": "query myCollectionRoutes_MyCollectionArtworkUploadQuery {\n  me {\n    ...MyCollectionCreateArtwork_me\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment MyCollectionArtworkFormArtistStep_me on Me {\n  myCollectionInfo {\n    collectedArtistsConnection(first: 100, includePersonalArtists: true) {\n      edges {\n        node {\n          ...EntityHeaderArtist_artist\n          counts {\n            artworks\n          }\n          displayLabel\n          formattedNationalityAndBirthday\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          initials\n          internalID\n          isPersonalArtist\n          name\n          slug\n          targetSupply {\n            isP1\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment MyCollectionCreateArtwork_me on Me {\n  ...MyCollectionArtworkFormArtistStep_me\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3611]

### Description

Adding and setting the `isP1Artist` field on the `saveCollectedArtwork` tracking event.

<!-- Implementation description -->



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3611]: https://artsyproduct.atlassian.net/browse/CX-3611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ