### PR TITLE
feat(TX-1134): add title when bank transfer is the only payment method

### DIFF
--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -117,7 +117,11 @@ export const PaymentContent: FC<Props> = props => {
 
       {/* US Bank transfer */}
       <Collapse open={selectedPaymentMethod === "US_BANK_ACCOUNT"}>
-        {getPaymentMethodInfo(selectedPaymentMethod)}
+        {getPaymentMethodInfo(
+          selectedPaymentMethod,
+          order.source,
+          order.availablePaymentMethods
+        )}
         <Spacer y={2} />
         {selectedPaymentMethod === "US_BANK_ACCOUNT" && (
           <Flex
@@ -137,7 +141,11 @@ export const PaymentContent: FC<Props> = props => {
 
       {/* SEPA bank transfer */}
       <Collapse open={selectedPaymentMethod === "SEPA_DEBIT"}>
-        {getPaymentMethodInfo(selectedPaymentMethod)}
+        {getPaymentMethodInfo(
+          selectedPaymentMethod,
+          order.source,
+          order.availablePaymentMethods
+        )}
         <Spacer y={2} />
         <Flex
           style={{
@@ -318,6 +326,9 @@ const getPaymentMethodInfo = (
     case "US_BANK_ACCOUNT":
       return (
         <>
+          {availablePaymentMethods?.length === 1 && (
+            <Text variant="lg-display">Bank transfer payment details</Text>
+          )}
           <Text color="black60" variant="sm">
             • Search for your bank institution or select from the options below.
           </Text>
@@ -337,6 +348,9 @@ const getPaymentMethodInfo = (
     case "SEPA_DEBIT":
       return (
         <>
+          {availablePaymentMethods?.length === 1 && (
+            <Text variant="lg-display">SEPA bank transfer payment details</Text>
+          )}
           <Flex>
             <Text color="black60" variant="sm">
               • Your bank account must be located in one of the SEPA countries.

--- a/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -302,7 +302,7 @@ describe("Payment", () => {
     })
   })
 
-  describe("stripe ACH enabled", () => {
+  describe("bank transfer enabled", () => {
     let page: PaymentTestPage
 
     const achOrder = {
@@ -397,7 +397,29 @@ describe("Payment", () => {
     })
   })
 
-  describe("stripe SEPA enabled", () => {
+  describe("only bank transfer enabled", () => {
+    let page: PaymentTestPage
+
+    const bankOrder = {
+      ...testOrder,
+      availablePaymentMethods: [
+        "US_BANK_ACCOUNT",
+      ] as CommercePaymentMethodEnum[],
+    }
+
+    beforeEach(() => {
+      const wrapper = getWrapper({
+        CommerceOrder: () => bankOrder,
+      })
+      page = new PaymentTestPage(wrapper)
+    })
+
+    it("renders bank transfer title", () => {
+      expect(page.text()).toContain("Bank transfer payment details")
+    })
+  })
+
+  describe("SEPA bank transfer enabled", () => {
     let page: PaymentTestPage
 
     const sepaOrder = {
@@ -470,6 +492,26 @@ describe("Payment", () => {
         payment_method: "SEPA_DEBIT",
         subject: "click_payment_method",
       })
+    })
+  })
+
+  describe("only SEPA bank transfer enabled", () => {
+    let page: PaymentTestPage
+
+    const sepaOrder = {
+      ...testOrder,
+      availablePaymentMethods: ["SEPA_DEBIT"] as CommercePaymentMethodEnum[],
+    }
+
+    beforeEach(() => {
+      const wrapper = getWrapper({
+        CommerceOrder: () => sepaOrder,
+      })
+      page = new PaymentTestPage(wrapper)
+    })
+
+    it("renders sepa transfer title", () => {
+      expect(page.text()).toContain("SEPA bank transfer payment details")
     })
   })
 
@@ -573,8 +615,6 @@ describe("Payment", () => {
     }
 
     beforeEach(() => {
-      jest.clearAllMocks()
-
       const wrapper = getWrapper({
         CommerceOrder: () => wireOrder,
       })


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-1134]

### Description
Now that bank transfers have the ability to be the only payment method at checkout via private sales, we have added a title to clarify the payment method being used. 

<img width="1479" alt="Screenshot 2023-04-17 at 3 40 54 PM" src="https://user-images.githubusercontent.com/50849237/232844364-ef503ab3-147d-4787-9f17-deb55deb0774.png">


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-1134]: https://artsyproduct.atlassian.net/browse/TX-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ