### PR TITLE
chore(NX-3492): change support links from ZD to Salesforce

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuthenticityCertificate.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuthenticityCertificate.tsx
@@ -89,7 +89,7 @@ export const ArtworkSidebarAuthenticityCertificate: React.FC<ArtworkSidebarAuthe
               )}
               <RouterLink
                 inline
-                to="https://support.artsy.net/hc/en-us/articles/360058123933-What-Counts-as-an-Artwork-s-Proof-of-Authenticity-"
+                to="https://support.artsy.net/s/article/What-Counts-as-an-Artworks-Proof-of-Authenticity"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarShippingInformation.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarShippingInformation.tsx
@@ -19,7 +19,7 @@ const ArtworkSidebarShippingInformation: React.FC<ShippingInformationProps> = ({
         {t`artworkPage.sidebar.shippingAndTaxes.taxInformation`}{" "}
         <RouterLink
           inline
-          to="https://support.artsy.net/hc/en-us/articles/360047294733-How-is-sales-tax-and-VAT-handled-on-works-listed-with-secure-checkout-"
+          to="https://support.artsy.net/s/article/How-are-taxes-customs-VAT-and-import-fees-handled-on-works-listed-with-secure-checkout"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/Apps/Artwork/Components/TrustSignals/AuthenticityCertificate.tsx
+++ b/src/Apps/Artwork/Components/TrustSignals/AuthenticityCertificate.tsx
@@ -82,7 +82,7 @@ export const AuthenticityCertificate: FC<AuthenticityCertificateProps> = ({
               Read more about artwork authenticity in our{" "}
               <RouterLink
                 inline
-                to="https://support.artsy.net/hc/en-us/articles/360058123933-What-Counts-as-an-Artwork-s-Proof-of-Authenticity-"
+                to="https://support.artsy.net/s/article/What-Counts-as-an-Artworks-Proof-of-Authenticity"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/Apps/Auctions/AuctionsApp.tsx
+++ b/src/Apps/Auctions/AuctionsApp.tsx
@@ -44,7 +44,7 @@ const AuctionsApp: React.FC<AuctionsAppProps> = props => {
           <Spacer y={2} />
 
           <RouterLink
-            to="https://support.artsy.net/hc/en-us/sections/360008298773-Bid-at-Auction"
+            to="https://support.artsy.net/s/article/How-do-I-place-a-bid-in-an-auction"
             textDecoration="none"
             display="block"
           >

--- a/src/Apps/Auctions/__tests__/AuctionsApp.jest.tsx
+++ b/src/Apps/Auctions/__tests__/AuctionsApp.jest.tsx
@@ -77,7 +77,7 @@ describe("AuctionsApp", () => {
     const wrapper = getWrapper()
     expect(wrapper.find("RouterLink")).toBeDefined()
     expect(wrapper.find("RouterLink").first().props().to).toBe(
-      "https://support.artsy.net/hc/en-us/sections/360008298773-Bid-at-Auction"
+      "https://support.artsy.net/s/article/How-do-I-place-a-bid-in-an-auction"
     )
   })
 

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/FAQSWA.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/FAQSWA.tsx
@@ -8,8 +8,7 @@ export const FAQSWA: React.FC = () => {
     "https://files.artsy.net/images/SWA-landing-FAQ-section-x2.jpg",
     { width: 950, height: 419 }
   )
-  const supportUrl =
-    "https://support.artsy.net/hc/en-us/categories/360003689533-Sell"
+  const supportUrl = "https://support.artsy.net/s/topic/0TO3b000000UesxGAC/sell"
 
   return (
     <TextAndImageLayout

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/FAQSWA.jest.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/FAQSWA.jest.tsx
@@ -33,7 +33,7 @@ describe("FAQSWA", () => {
       expect(link).toHaveTextContent("Read FAQs")
       expect(link).toHaveAttribute(
         "href",
-        "https://support.artsy.net/hc/en-us/categories/360003689533-Sell"
+        "https://support.artsy.net/s/topic/0TO3b000000UesxGAC/sell"
       )
     })
   })

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -258,7 +258,7 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
         &#8226; Currently, artists can not sell their own work on Artsy.{" "}
         <RouterLink
           inline
-          to="https://support.artsy.net/hc/en-us/articles/360046646374-I-m-an-artist-Can-I-submit-my-own-work-to-sell-"
+          to="https://support.artsy.net/s/article/Im-an-artist-Can-I-submit-my-own-work-to-sell"
           target="_blank"
           data-testid="learn-more-anchor"
         >

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
@@ -218,7 +218,7 @@ describe("ArtworkDetails", () => {
       expect(learnMoreLink).toBeInTheDocument()
       expect(learnMoreLink).toHaveAttribute(
         "href",
-        "https://support.artsy.net/hc/en-us/articles/360046646374-I-m-an-artist-Can-I-submit-my-own-work-to-sell-"
+        "https://support.artsy.net/s/article/Im-an-artist-Can-I-submit-my-own-work-to-sell"
       )
     })
 

--- a/src/Apps/Conversation/Components/DetailsSidebar.tsx
+++ b/src/Apps/Conversation/Components/DetailsSidebar.tsx
@@ -199,7 +199,7 @@ export const DetailsSidebar: FC<DetailsProps> = ({
             Support
           </Text>
           <RouterLink
-            to="https://support.artsy.net/s/topic/s/topic/0TO3b000000UevEGAS/contacting-a-gallery"
+            to="https://support.artsy.net/s/topic/0TO3b000000UevEGAS/contacting-a-gallery"
             target="_blank"
             textDecoration="none"
           >

--- a/src/Apps/Conversation/Components/DetailsSidebar.tsx
+++ b/src/Apps/Conversation/Components/DetailsSidebar.tsx
@@ -199,7 +199,7 @@ export const DetailsSidebar: FC<DetailsProps> = ({
             Support
           </Text>
           <RouterLink
-            to={`https://support.artsy.net/hc/en-us/sections/360008203054-Contact-a-gallery`}
+            to="https://support.artsy.net/s/topic/s/topic/0TO3b000000UevEGAS/contacting-a-gallery"
             target="_blank"
             textDecoration="none"
           >

--- a/src/Apps/IdentityVerification/IdentityVerificationApp/index.tsx
+++ b/src/Apps/IdentityVerification/IdentityVerificationApp/index.tsx
@@ -242,7 +242,7 @@ const IdentityVerificationApp: React.FC<Props> = ({
                 Questions about identity verification? Read the{" "}
                 <RouterLink
                   inline
-                  to="https://support.artsy.net/hc/en-us/articles/360062798613-How-to-Complete-Identity-Verification"
+                  to="https://support.artsy.net/s/article/How-to-Complete-Identity-Verification"
                 >
                   step by step instructions
                 </RouterLink>{" "}

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWAHowItWorksModal.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWAHowItWorksModal.tsx
@@ -5,7 +5,7 @@ export const MyCollectionArtworkSWAHowItWorksModal: React.FC<{
   onClose: () => void
 }> = ({ onClose }) => {
   const article =
-    "https://support.artsy.net/hc/en-us/sections/360008311913-Sell-with-Artsy"
+    "https://support.artsy.net/s/topic/s/topic/0TO3b000000UevOGAS/sell-with-artsy"
 
   return (
     <ModalDialog

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWAHowItWorksModal.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWAHowItWorksModal.tsx
@@ -5,7 +5,7 @@ export const MyCollectionArtworkSWAHowItWorksModal: React.FC<{
   onClose: () => void
 }> = ({ onClose }) => {
   const article =
-    "https://support.artsy.net/s/topic/s/topic/0TO3b000000UevOGAS/sell-with-artsy"
+    "https://support.artsy.net/s/topic/0TO3b000000UevOGAS/sell-with-artsy"
 
   return (
     <ModalDialog

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASectionSubmitted.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASectionSubmitted.tsx
@@ -42,7 +42,7 @@ export const MyCollectionArtworkSWASectionSubmitted: React.FC<Props> = ({
   }
 
   const article =
-    "https://support.artsy.net/hc/en-us/sections/360008311913-Sell-with-Artsy"
+    "https://support.artsy.net/s/topic/s/topic/0TO3b000000UevOGAS/sell-with-artsy"
 
   const approvedDisplayText = STATUSES[displayText!.toLowerCase()]?.text
   const statusDescription =
@@ -125,8 +125,7 @@ const SubmissionStatusModal: React.FC<SubmissionStatusModalProps> = ({
   onClose,
 }) => {
   if (!show) return null
-  const article =
-    "https://support.artsy.net/hc/en-us/articles/360046646494-What-items-do-you-accept-"
+  const article = "https://support.artsy.net/s/article/What-items-do-you-accept"
 
   return (
     <ModalDialog

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASectionSubmitted.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASectionSubmitted.tsx
@@ -42,7 +42,7 @@ export const MyCollectionArtworkSWASectionSubmitted: React.FC<Props> = ({
   }
 
   const article =
-    "https://support.artsy.net/s/topic/s/topic/0TO3b000000UevOGAS/sell-with-artsy"
+    "https://support.artsy.net/s/topic/0TO3b000000UevOGAS/sell-with-artsy"
 
   const approvedDisplayText = STATUSES[displayText!.toLowerCase()]?.text
   const statusDescription =

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkSWAHowItWorksModal.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkSWAHowItWorksModal.jest.tsx
@@ -29,7 +29,7 @@ describe("MyCollectionArtworkSWAHowItWorksModal", () => {
 
     expect(wrapper.find("RouterLink")).toBeDefined()
     expect(wrapper.find("RouterLink").first().props().to).toBe(
-      "https://support.artsy.net/hc/en-us/sections/360008311913-Sell-with-Artsy"
+      "https://support.artsy.net/s/topic/s/topic/0TO3b000000UevOGAS/sell-with-artsy"
     )
   })
 })

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkSWAHowItWorksModal.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkSWAHowItWorksModal.jest.tsx
@@ -29,7 +29,7 @@ describe("MyCollectionArtworkSWAHowItWorksModal", () => {
 
     expect(wrapper.find("RouterLink")).toBeDefined()
     expect(wrapper.find("RouterLink").first().props().to).toBe(
-      "https://support.artsy.net/s/topic/s/topic/0TO3b000000UevOGAS/sell-with-artsy"
+      "https://support.artsy.net/s/topic/0TO3b000000UevOGAS/sell-with-artsy"
     )
   })
 })

--- a/src/Apps/Order/Components/BuyerGuarantee.tsx
+++ b/src/Apps/Order/Components/BuyerGuarantee.tsx
@@ -11,7 +11,7 @@ import { useTracking } from "react-tracking"
 import { RouterLink } from "System/Router/RouterLink"
 
 export const BUYER_GUARANTEE_URL =
-  "https://support.artsy.net/hc/en-us/articles/360048946973-How-does-Artsy-protect-me"
+  "https://support.artsy.net/s/article/The-Artsy-Guarantee"
 
 interface BuyerGuaranteeProps {
   contextModule: ContextModule

--- a/src/Apps/Order/Components/StickyFooter.tsx
+++ b/src/Apps/Order/Components/StickyFooter.tsx
@@ -29,7 +29,7 @@ export const StickyFooter: FC<StickyFooterProps> = ({
     })
 
     window.open(
-      "https://support.artsy.net/hc/en-us/sections/360008203114-Buy-Now-and-Make-Offer",
+      "https://support.artsy.net/s/topic/0TO3b000000UessGAC/buy",
       "_blank"
     )
   }

--- a/src/Apps/Order/Components/__tests__/StickyFooter.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/StickyFooter.jest.tsx
@@ -32,7 +32,7 @@ describe("Sticky footer", () => {
     component.find("Clickable[data-test='help-center-link']").simulate("click")
 
     expect(window.open).toHaveBeenCalledWith(
-      "https://support.artsy.net/hc/en-us/sections/360008203114-Buy-Now-and-Make-Offer",
+      "https://support.artsy.net/s/topic/0TO3b000000UessGAC/buy",
       "_blank"
     )
   })

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -140,7 +140,7 @@ export const Footer: React.FC<FooterProps> = props => {
 
               <FooterLink
                 mt={2}
-                to="https://support.artsy.net/hc/en-us/categories/360003689513-Buy"
+                to="https://support.artsy.net/s/topic/0TO3b000000UessGAC/buy"
               >
                 Buying on Artsy
               </FooterLink>

--- a/src/Server/middleware/hardcodedRedirects.ts
+++ b/src/Server/middleware/hardcodedRedirects.ts
@@ -19,7 +19,7 @@ const PERMANENT_REDIRECTS = {
   "/feature/art-fairs": "art-fairs",
   "/collector/edit": "/profile/edit",
   "/how-auctions-work":
-    "https://support.artsy.net/hc/en-us/articles/4419870291351-The-Complete-Guide-to-Auctions-on-Artsy",
+    "https://support.artsy.net/s/article/The-Complete-Guide-to-Auctions-on-Artsy",
   "/_=_": "/", // Facebook passport bug, see: https://github.com/jaredhanson/passport-facebook/issues/12#issuecomment-5913711
   "/press": "/press/in-the-media",
   "/about/press": "/press/press-releases",


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [NX-3492]

### Description

<!-- Implementation description -->

Changes Support links from Zendesk to Salesforce.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NX-3492]: https://artsyproduct.atlassian.net/browse/NX-3492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ