### PR TITLE
feat: reduce memory request/limit to reflect actual usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,4 +221,4 @@ COPY --chown=deploy:deploy --from=builder /app/server.dist.js.map .
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # TODO: Reduce production memory, this is not a concern
-CMD ["node", "--max_old_space_size=3072", "--heapsnapshot-signal=SIGUSR2", "./server.dist.js"]
+CMD ["node", "--max_old_space_size=2048", "--heapsnapshot-signal=SIGUSR2", "./server.dist.js"]

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -62,9 +62,9 @@ spec:
         resources:
           requests:
             cpu: 1000m
-            memory: 1536Mi
+            memory: 1Gi
           limits:
-            memory: 3.5Gi
+            memory: 2Gi
         lifecycle:
           preStop:
             exec:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -69,9 +69,9 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 1Gi
+            memory: 500Mi
           limits:
-            memory: 1.5Gi
+            memory: 1Gi
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [PLATFORM-5131]

### Description

Force pods memory [usage since June 2022](https://app.datadoghq.com/dashboard/2n5-6tr-ypp/kubernetes-deployments?fullscreen_end_ts=1656915540000&fullscreen_paused=true&fullscreen_section=overview&fullscreen_start_ts=1649406000000&fullscreen_widget=5114866942402968&tpl_var_deployment%5B0%5D=force-web&tpl_var_hpa%5B0%5D=force-web&from_ts=1649406000000&to_ts=1656915540000&live=false) has been much lower than before. Reduce their memory request/limit to reflect actual usage.

- Reduce Staging memory request/limit from 1G/1.5G to 500M/1G
- Reduce Prod memory request/limit from 1.5G/3.5G to 1G/2G

[Prod actual usage](https://app.datadoghq.com/dashboard/2n5-6tr-ypp/kubernetes-deployments?fullscreen_end_ts=1682019962714&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1681933562714&fullscreen_widget=5940668307456880&tpl_var_deployment%5B0%5D=force-web&tpl_var_hpa%5B0%5D=force-web&from_ts=1681933009763&to_ts=1682019409763&live=true).
[Staging actual usage](https://app.datadoghq.com/dashboard/2n5-6tr-ypp/kubernetes-deployments?fullscreen_end_ts=1682019979265&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1681933579265&fullscreen_widget=5940668307456880&tpl_var_deployment%5B0%5D=force-web&tpl_var_env%5B0%5D=staging&tpl_var_hpa%5B0%5D=force-web&tpl_var_ns%5B0%5D=default&from_ts=1681933577389&to_ts=1682019977389&live=true).

[PLATFORM-5131]: https://artsyproduct.atlassian.net/browse/PLATFORM-5131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ