### PR TITLE
Revert "chore(deps): update aws-s3 orb from 2.0.0 to v3"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   artsy-remote-docker: artsy/remote-docker@volatile
-  aws-s3: circleci/aws-s3@3.1.1
+  aws-s3: circleci/aws-s3@2.0.0
   hokusai: artsy/hokusai@volatile
   horizon: artsy/release@volatile
   slack: circleci/slack@4.12.1


### PR DESCRIPTION
Reverts artsy/force#11050. 

Reverting this because it looks like something changed in the underlying `s3` lib, since the docs still show [this being used](https://circleci.com/developer/orbs/orb/circleci/aws-s3).   