### PR TITLE
fix: Skip fallback when Braze cards exist

### DIFF
--- a/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/HomeContentCards.tsx
@@ -96,10 +96,10 @@ export const HomeContentCards: React.FC = () => {
     renderFallback,
   })
 
+  if (hasBrazeCards) return <BrazeCards braze={braze} cards={cards} />
   if (renderFallback) return <FallbackCards />
-  if (!hasBrazeCards) return <PlaceholderCards />
 
-  return <BrazeCards braze={braze} cards={cards} />
+  return <PlaceholderCards />
 }
 
 export const SafeHomeContentCards = () => {


### PR DESCRIPTION
After some back-and-forth with Braze support and looking at their reproduction logs I'm thinking we were too aggressive in our rendering of fallback cards. I don't fully understand when/why this happens but it's possible for `renderFallback` to be true AND for us to have more than 0 `cards`. When that's true we should render the cards, not the fallback!

So that's what this PR aims to do - it shuffles the conditional rendering logic so that when both things are true we render `BrazeCards` rather than `FallbackCards`. My plan is to deploy this on Monday and call for eyes on this over the next few days. If we don't see issues then we can call this another win on the improvements to our content card code.

/cc @artsy/grow-devs @isakelaris @kathytafel 