### PR TITLE
refactor: add timeout to cypress install

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -17,7 +17,8 @@ fi
 NODE_ENV=production nohup yarn start &
 
 # Leverage the server boot time to begin the cypress install.
-./node_modules/.bin/cypress install
+# Run install with a 45 second timeout as a workaround for hanging installs.
+timeout 45 ./node_modules/.bin/cypress install
 
 # wait for it to accept connections
 while ! curl --output /dev/null --silent --head --fail http://localhost:5000; do


### PR DESCRIPTION
The type of this PR is: **Refactor/Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR is an attempt to solve an issue with hanging acceptance test CI runs. Raised and discussed [here](https://artsy.slack.com/archives/CP9P4KR35/p1682444380828659)🔒

### Description

<!-- Implementation description -->

In the last few days, some CI runs have experienced an issue where one (or few) acceptance test containers would print [Installing Cypress (version: 10.7.0)](https://app.circleci.com/pipelines/github/artsy/force/47797/workflows/1f2e0cb2-1488-4cff-8045-1b1a2fa41bdc/jobs/359228/parallel-runs/1?filterBy=ALL&invite=true#step-101-14) and then the command would hang without finishing, preventing the job from completing and ultimately failing the workflow. Earlier this week a [runtime upgrade was merged](https://github.com/artsy/force/pull/12243) and seems to have introduced this issue.

After debugging some it appears that for still unknown reasons the install will actually take but the command will not exit. This proposes a workaround until acceptance tests are refactored to use the cypress orb, as pointed out in the above-linked thread.

<details>
  <summary>Debugging screengrabs</summary>

![Screen Shot 2023-04-26 at 11 47 45 AM](https://user-images.githubusercontent.com/29984068/234642487-cbd2e761-765e-47e0-9a3d-a2a086dc672b.png)

![Screen Shot 2023-04-26 at 11 48 54 AM](https://user-images.githubusercontent.com/29984068/234642531-535cef85-d52f-47b9-9ecf-8ce2ffd6b771.png)
</details>


