### PR TITLE
fix: disable exit on error during cypress install

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -18,7 +18,16 @@ NODE_ENV=production nohup yarn start &
 
 # Leverage the server boot time to begin the cypress install.
 # Run install with a 45 second timeout as a workaround for hanging installs.
+set +e
 timeout 45 ./node_modules/.bin/cypress install
+
+EXIT_STATUS=$?
+if [ $EXIT_STATUS -eq 124 ]; then
+    echo "Cypress install timed out. Continue anyway."
+elif [ $EXIT_STATUS -ne 0 ]; then
+    exit $EXIT_STATUS
+fi
+set -e
 
 # wait for it to accept connections
 while ! curl --output /dev/null --silent --head --fail http://localhost:5000; do


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR is a follow-up to https://github.com/artsy/force/pull/12311

### Description

<!-- Implementation description -->

The earlier added `timeout` [stops the script on error](https://app.circleci.com/pipelines/github/artsy/force/47846/workflows/084e8b05-2758-4f38-888b-cea2f7bb2e7f/jobs/359559?invite=true#step-101-17) because `set -e` is set at the top. This fixes that problem and improves the intention disabling the exit on error flag during cypress install to allow the script to continue in case of timeout.
If the install command succeeds the script will continue, if any other error is thrown that's not timeout `124`, the script will exit with that error.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ