### PR TITLE
fix: set auction artwork initial sort from querystring

### DIFF
--- a/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -107,6 +107,5 @@ export const getArtworkFilterInputArgs = (user?: User) => {
   return {
     aggregations,
     first: 39,
-    sort: "sale_position",
   }
 }

--- a/src/Apps/Auction/Components/__tests__/AuctionArtworkFilter.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionArtworkFilter.jest.tsx
@@ -3,7 +3,7 @@ import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import {
   AuctionArtworkFilterRefetchContainer,
   getArtworkFilterInputArgs,
-} from "../AuctionArtworkFilter"
+} from "Apps/Auction/Components/AuctionArtworkFilter"
 import { AuctionArtworkFilterTestQuery } from "__generated__/AuctionArtworkFilterTestQuery.graphql"
 
 jest.unmock("react-relay")
@@ -82,7 +82,6 @@ describe("AuctionArtworkFilter", () => {
       expect(getArtworkFilterInputArgs()).toEqual({
         aggregations: ["ARTIST", "MEDIUM", "TOTAL"],
         first: 39,
-        sort: "sale_position",
       })
     })
 

--- a/src/Apps/Auction/auctionRoutes.tsx
+++ b/src/Apps/Auction/auctionRoutes.tsx
@@ -72,20 +72,26 @@ export const auctionRoutes: AppRouteConfig[] = [
       }
     `,
     prepareVariables: (params, props) => {
-      const initialFilterState = getInitialFilterState(
+      const initialFilterStateFromUrl = getInitialFilterState(
         props.location?.query ?? {}
       )
 
-      return {
+      const userSpecificFilterState = getArtworkFilterInputArgs(
+        props.context.user
+      )
+
+      const variables = {
         slug: params.slug,
         input: {
-          ...initialFilterState,
-          ...getArtworkFilterInputArgs(props.context.user),
+          ...initialFilterStateFromUrl,
+          ...userSpecificFilterState,
           saleID: params.slug,
           // FIXME: Understand why this is needed to view lots in `the-artist-is-present-a-benefit-auction-for-ukraine` while logged out
           priceRange: "*-*",
         },
       }
+
+      return variables
     },
     children: [
       { path: "" },

--- a/src/Apps/Auction/auctionRoutes.tsx
+++ b/src/Apps/Auction/auctionRoutes.tsx
@@ -72,6 +72,10 @@ export const auctionRoutes: AppRouteConfig[] = [
       }
     `,
     prepareVariables: (params, props) => {
+      const auctionFilterDefaults = {
+        sort: "sale_position",
+      }
+
       const initialFilterStateFromUrl = getInitialFilterState(
         props.location?.query ?? {}
       )
@@ -83,6 +87,7 @@ export const auctionRoutes: AppRouteConfig[] = [
       const variables = {
         slug: params.slug,
         input: {
+          ...auctionFilterDefaults,
           ...initialFilterStateFromUrl,
           ...userSpecificFilterState,
           saleID: params.slug,


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [FX-4744]

### Description

We found that auction artwork grids were not respecting an incoming `sort` param in the URL querystring, and instead always sorting by lot number (`sort: sale_position`) —

```
https://www.artsy.net/auction/artsy-auction-street-art-2?sort=-prices
                                                         ↑↑↑↑↑↑↑↑↑↑↑↑ ignored
```

This is because the default value of `sale_position` for the `sort` param was being set later in the request lifecycle, and was thus clobbering the value coming in from the querystring.

This PR hoists that default out of the later location (`AuctionArtworkFilter.tsx`) up into an earlier location (`auctionRoutes.tsx`) so that it can be correctly overriden by the URL param.

The grid is now sorted correctly…

✓ when there is no `sort` param in the URL _(defaults to `sort: sale_position`)_
✓ when there is a `sort` param in the URL _(the specified `sort` is used during the server render)_
✓ when a sort is chosen from the sort options menu  _(the specified `sort` is used during the client refetch)_


[FX-4744]: https://artsyproduct.atlassian.net/browse/FX-4744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

