### PR TITLE
fix: Use an emdash like a gentleman GRO-1648

### DIFF
--- a/src/Apps/Home/Components/HomeContentCards/FallbackCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/FallbackCards.tsx
@@ -47,7 +47,7 @@ const FALLBACK_DATA = [
   {
     credit: null,
     description:
-      "See what you can do on Artsy–the best tool for art collectors.",
+      "See what you can do on Artsy—the best tool for art collectors.",
     id: 1,
     imageUrl: "https://files.artsy.net/images/01_Overarching-CC_Launch.png",
     label: null,


### PR DESCRIPTION
I mean come on Jon get your life together:

```
hyphen: -
en dash: – (option + hyphen)
em dash: — (option + shift + hyphen)
```

h/t @isakelaris 

Looks like this:

<img width="623" alt="Screenshot 2023-04-27 at 2 06 29 PM" src="https://user-images.githubusercontent.com/79799/234968357-db43e432-d679-4406-9739-7d98ca98f5be.png">


https://artsyproduct.atlassian.net/browse/GRO-1648

/cc @artsy/grow-devs 