### PR TITLE
fix(NX-3530): hide SF chat after unmounting. Same as the zendesk component

### DIFF
--- a/src/Components/SalesforceWrapper.tsx
+++ b/src/Components/SalesforceWrapper.tsx
@@ -1,6 +1,7 @@
 import { getENV } from "Utils/getENV"
 import { useLoadScript } from "Utils/Hooks/useLoadScript"
 import { useAppendStylesheet } from "Utils/Hooks/useAppendStylesheet"
+import { useEffect } from "react"
 
 export const SalesforceWrapper: React.FC = () => {
   useAppendStylesheet({
@@ -56,6 +57,14 @@ export const SalesforceWrapper: React.FC = () => {
       )
     },
   })
+
+  window.embedded_svc.showHelpButton?.()
+
+  useEffect(() => {
+    return () => {
+      window.embedded_svc?.hideHelpButton?.()
+    }
+  }, [])
 
   return null
 }

--- a/src/Components/SalesforceWrapper.tsx
+++ b/src/Components/SalesforceWrapper.tsx
@@ -58,7 +58,7 @@ export const SalesforceWrapper: React.FC = () => {
     },
   })
 
-  window.embedded_svc.showHelpButton?.()
+  window.embedded_svc?.showHelpButton?.()
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [NX-3530]

### Description

SF persisted after navigating to a different page. The component needs to be hidden when unmounting.

cc @artsy/negotiate-devs 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NX-3530]: https://artsyproduct.atlassian.net/browse/NX-3530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ