### PR TITLE
feat(PRO-85): use order state when routing after offer

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -130,16 +130,12 @@ export const ReviewRoute: FC<ReviewProps> = props => {
           o => o.lineItems?.edges?.[0]?.node?.artwork?.slug
         )
 
-        // TODO: replace usage with order.state === "IN_REVIEW" once buyerStatus
-        // is implemented in Exchange.
-        // See https://www.notion.so/artsy/2023-02-09-Platform-Practice-Meeting-Notes-87f4cc9987a7436c9c4b207847e318db?pvs=4
-        const orderInReviewFacsimile =
-          order.paymentMethod === "WIRE_TRANSFER" &&
-          order.source === "artwork_page"
-
         if (isEigen) {
           if (order.mode === "OFFER") {
-            if (orderInReviewFacsimile) {
+            if (
+              order.state === "IN_REVIEW" &&
+              order.source === "artwork_page"
+            ) {
               window?.ReactNativeWebView?.postMessage(
                 JSON.stringify({
                   key: "orderSuccessful",
@@ -170,8 +166,18 @@ export const ReviewRoute: FC<ReviewProps> = props => {
           }
         }
 
-        // Eigen redirects to the status page for non-Offer orders (must keep the user inside the webview)
-        if (isEigen || (order.mode === "OFFER" && orderInReviewFacsimile)) {
+        // Eigen redirects to the status page for non-Offer orders (must keep
+        // the user inside the webview)
+        // For in-review offers, we also want to override the default "go to
+        // artwork page and display modal linking to conversation" behavior
+        // because we hold off on creating a conversation until the offer passes
+        // review
+        if (
+          isEigen ||
+          (order.mode === "OFFER" &&
+            order.state === "IN_REVIEW" &&
+            order.source === "artwork_page")
+        ) {
           return router.push(`/orders/${orderId}/status`)
         }
         // Make offer and Purchase in inquiry redirects to the conversation page

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/submitOfferOrder.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/submitOfferOrder.ts
@@ -75,11 +75,7 @@ export const submitOfferOrderSuccessInReview = {
     orderOrError: {
       order: {
         ...OfferOrderWithShippingDetails,
-        // TODO: uncomment state & remove payment method once buyerStatus
-        // is implemented in Exchange.
-        // See https://www.notion.so/artsy/2023-02-09-Platform-Practice-Meeting-Notes-87f4cc9987a7436c9c4b207847e318db?pvs=4
-        // state: "IN_REVIEW",
-        paymentMethod: "WIRE_TRANSFER",
+        state: "IN_REVIEW",
       },
     },
   },

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -678,11 +678,7 @@ describe("Review", () => {
   describe("in-review offers", () => {
     const OfferOrderInReview = {
       ...OfferOrderWithShippingDetails,
-      // TODO: uncomment state & remove payment method once buyerStatus
-      // is implemented in Exchange.
-      // See https://www.notion.so/artsy/2023-02-09-Platform-Practice-Meeting-Notes-87f4cc9987a7436c9c4b207847e318db?pvs=4
-      // state: "IN_REVIEW",
-      paymentMethod: "WIRE_TRANSFER",
+      state: "IN_REVIEW",
       internalID: "offer-order-id",
       impulseConversationId: null,
     }


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PRO-85](https://artsyproduct.atlassian.net/browse/PRO-85)

### Description

Followup from https://github.com/artsy/exchange/pull/1637, see there for more context.

Draft until https://github.com/artsy/metaphysics/pull/4983 is merged & deployed.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PRO-84]: https://artsyproduct.atlassian.net/browse/PRO-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PRO-85]: https://artsyproduct.atlassian.net/browse/PRO-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ