### PR TITLE
Fix(CX-3670): display artworks in 2/3/4 columns

### DIFF
--- a/src/Apps/Auctions/Routes/EndingSoonAuctionsGrid.tsx
+++ b/src/Apps/Auctions/Routes/EndingSoonAuctionsGrid.tsx
@@ -48,6 +48,7 @@ export const EndingSoonAuctionsGrid: FC<EndingSoonAuctionsGridProps> = ({
       <ArtworkGrid
         artworks={viewer.saleArtworksConnection}
         onLoadMore={handleLoadMore}
+        columnCount={[2, 3, 4]}
       />
       {relay.hasMore() && (
         <Box textAlign="center" mt={4}>

--- a/src/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
+++ b/src/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
@@ -15,7 +15,10 @@ export const NewForYouArtworksGrid: FC<NewForYouArtworksGridProps> = ({
     <>
       {viewer.artworksForUser &&
       (viewer.artworksForUser.totalCount ?? 0) > 0 ? (
-        <ArtworkGrid artworks={viewer.artworksForUser} />
+        <ArtworkGrid
+          artworks={viewer.artworksForUser}
+          columnCount={[2, 3, 4]}
+        />
       ) : (
         <Text variant="lg" mt={4} color="black60">
           Nothing yet.


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3670]

### Description

<!-- Implementation description -->
Display artworks in 2/3/4 columns depending on the screen size

https://user-images.githubusercontent.com/36167539/235716901-58fc53bf-4fd2-402d-88d1-7e713509d571.mov



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CX-3670]: https://artsyproduct.atlassian.net/browse/CX-3670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ