### PR TITLE
fix: use correct param for redirect from `/collection/id:` to `/artist-series/:id`

### DIFF
--- a/src/Apps/Collect/Server/__tests__/redirectCollectionToArtistSeries.jest.ts
+++ b/src/Apps/Collect/Server/__tests__/redirectCollectionToArtistSeries.jest.ts
@@ -1,10 +1,10 @@
-import { redirectCollectionToArtistSeries } from "../redirectCollectionToArtistSeries"
+import { redirectCollectionToArtistSeries } from "Apps/Collect/Server/redirectCollectionToArtistSeries"
 
 describe("redirectCollectionToArtistSeries", () => {
   it("does not redirect for a non-migrated artist series", () => {
     const req = {
       params: {
-        collectionSlug: "not-artist-series",
+        slug: "not-artist-series",
       },
     }
     const res = {
@@ -19,7 +19,7 @@ describe("redirectCollectionToArtistSeries", () => {
     const spy = jest.fn()
     const req = {
       params: {
-        collectionSlug: "kaws-four-foot-companion",
+        slug: "kaws-four-foot-companion",
       },
     }
     const res = {

--- a/src/Apps/Collect/Server/redirectCollectionToArtistSeries.ts
+++ b/src/Apps/Collect/Server/redirectCollectionToArtistSeries.ts
@@ -1,7 +1,7 @@
-import { collectionToArtistSeriesSlugMap } from "../Utils/collectionToArtistSeriesSlugMap"
+import { collectionToArtistSeriesSlugMap } from "Apps/Collect/Utils/collectionToArtistSeriesSlugMap"
 
 export function redirectCollectionToArtistSeries({ req, res }) {
-  const collectionSlug: string = req.params.collectionSlug
+  const collectionSlug: string = req.params.slug
   const seriesSlug: string = collectionToArtistSeriesSlugMap[collectionSlug]
 
   if (seriesSlug) {


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

Slack thread: [Link](https://artsy.slack.com/archives/C9SATFLUU/p1683048414783759)

Review app: [collection-redirect](https://collection-redirect.artsy.net/)

### Demo
Some redirects from [here](https://github.com/artsy/force/blob/e70881afd24e42de7f9756b9f412cdbdbf65fd5d/src/Apps/Collect/Utils/collectionToArtistSeriesSlugMap.tsx#L1) 
| Before | After |
| ------------- | ------------- |
| [banksy-girl-with-balloon](https://www.artsy.net/collection/banksy-girl-with-balloon) | [banksy-girl-with-balloon](https://collection-redirect.artsy.net/collection/banksy-girl-with-balloon) | 
| [alec-monopoly-monopoly-man](https://www.artsy.net/collection/alec-monopoly-monopoly-man) | [alec-monopoly-monopoly-man](https://collection-redirect.artsy.net/collection/alec-monopoly-monopoly-man) | 
| [alphonse-mucha-moet-and-chandon](https://www.artsy.net/collection/alphonse-mucha-moet-and-chandon) | [alphonse-mucha-moet-and-chandon](https://collection-redirect.artsy.net/collection/alphonse-mucha-moet-and-chandon) | 
| [alfred-stieglitz-equivalents](https://www.artsy.net/collection/alfred-stieglitz-equivalents) | [alfred-stieglitz-equivalents](https://collection-redirect.artsy.net/collection/alfred-stieglitz-equivalents) | 
| [zeng-fanzhi-mask-series](https://www.artsy.net/collection/zeng-fanzhi-mask-series) | [zeng-fanzhi-mask-series](https://collection-redirect.artsy.net/collection/zeng-fanzhi-mask-series) | 

### Demo (video)
https://user-images.githubusercontent.com/3513494/235747256-35723bd1-0e6d-46d1-8dba-07cf33b98e67.mp4

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ