### PR TITLE
feat: artist page tabs land on default artworks

### DIFF
--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -49,7 +49,7 @@ const ArtistApp: React.FC<ArtistAppProps> = ({ artist, children, match }) => {
   }
 
   const showOverviewTab = hasOverviewContent(artist)
-  const showArtworksTab = artist.statuses?.artworks
+  const showArtworksTab = true
   const showAuctionResultsTab = artist.statuses?.auctionLots
 
   // Default page
@@ -62,23 +62,21 @@ const ArtistApp: React.FC<ArtistAppProps> = ({ artist, children, match }) => {
       <Jump id="artistContentArea" />
 
       <RouteTabs mb={2} fill data-test="navigationTabs">
-        {showOverviewTab && (
-          <RouteTab exact to={`/artist/${artist.slug}`}>
-            Overview
-          </RouteTab>
-        )}
-
         {showArtworksTab && (
           <RouteTab to={`/artist/${artist.slug}/works-for-sale`}>
-            {artist?.counts?.forSaleArtworks! > 0
-              ? `Works for Sale (${artist?.counts?.forSaleArtworks?.toLocaleString()})`
-              : "Artworks"}
+            Artworks
           </RouteTab>
         )}
 
         {showAuctionResultsTab && (
           <RouteTab to={`/artist/${artist.slug}/auction-results`}>
             Auction Results
+          </RouteTab>
+        )}
+
+        {showOverviewTab && (
+          <RouteTab exact to={`/artist/${artist.slug}`}>
+            About
           </RouteTab>
         )}
       </RouteTabs>


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1662]

### Description

<!-- Implementation description -->
This is prep work for the new artist page. We want the user to always per default land on the artworks tab (formerly called "works for sale" and see the following 2 other tabs in this order: "auction results" and "about". 
To do

- [x] rename "works for sale" to "artworks" and make it default
- [x] rearrange tabs in following order: "artworks", "auction results" and "about"
- [ ] update sitemaps & routes for SEO purposes
- [ ] (for this or a later PR?) update about content to not show "overview" but "about" content

Figma design:
![Bildschirmfoto 2023-05-03 um 12 13 05](https://user-images.githubusercontent.com/15628617/235889655-449e17ca-8498-4a20-86b1-a39497bf7af6.png)

Current version:
![Bildschirmfoto 2023-05-03 um 12 13 37](https://user-images.githubusercontent.com/15628617/235889707-9f458717-4fa8-4c1a-9cd2-9f668ccf2123.png)

How this PR would look:
![Bildschirmfoto 2023-05-03 um 12 14 07](https://user-images.githubusercontent.com/15628617/235889788-a6fdc0fe-a508-4dda-86cf-3e32cecf9449.png)


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1662]: https://artsyproduct.atlassian.net/browse/GRO-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ