### PR TITLE
chore: Remove stale fallback card GRO-1690

### DIFF
--- a/src/Apps/Home/Components/HomeContentCards/FallbackCards.tsx
+++ b/src/Apps/Home/Components/HomeContentCards/FallbackCards.tsx
@@ -57,21 +57,9 @@ const FALLBACK_DATA = [
   },
   {
     credit:
-      "Yuan Yuan, The Unstable Fibonacci Sequence, 2022. Molly Green, Unfix, 2022. Tidawhitney Lek, Broken Glasses, 2022. Jacopo Pagin, Hide Me! with Transparency, 2022.",
-    description:
-      "The best works by rising talents on Artsy, all available now.",
-    id: 2,
-    imageUrl: "https://files.artsy.net/images/Content+Card-CPE-Jan12.jpg",
-    label: "Featured Collection",
-    linkText: "Browse Works",
-    title: "Curators’ Picks: Emerging",
-    url: "/collection/curators-picks-emerging",
-  },
-  {
-    credit:
       "Sam Francis, Untitled (SF94-042), 1994. Courtesy of Rago/Wright. Charles Arnoldi, Untitled, 2017. Courtesy of Venice Art Walk Benefit Auction. Sam Gilliam, Baby's Blue, circa 1963. Courtesy of Heritage Auctions. James Daugherty, The Joy of Red, c.1960. Courtesy of Swann Auction Galleries. David Shrigley, Untitled (Thank You for Burning All of My Posessions), 2019. Courtesy of Forum Auctions.",
     description: "Find works by emerging and established artists at auction",
-    id: 3,
+    id: 2,
     imageUrl:
       "https://d32dm0rphc51dk.cloudfront.net/IopjCK3x5TuGzjFqp-K3rQ/untouched-jpg.jpg",
     label: "Artsy Auctions",


### PR DESCRIPTION
Removing this card per marketing!

https://artsyproduct.atlassian.net/browse/GRO-1690

/cc @artsy/grow-devs