### PR TITLE
fix: 301 redirect invalid artist urls from trending score a/b

### DIFF
--- a/src/Apps/Artist/Server/__tests__/redirect.jest.ts
+++ b/src/Apps/Artist/Server/__tests__/redirect.jest.ts
@@ -1,0 +1,44 @@
+import { redirectWithCanonicalParams } from "Apps/Artist/Server/redirect"
+
+describe("redirectWithCanonicalParams", () => {
+  describe("with an invalid sort", () => {
+    it("301 redirects to url without the invalid sort param", () => {
+      const req = {
+        path: "/artist/sam-king/works-for-sale",
+        query: {
+          sort: "-default_trending_score",
+          foo: "bar",
+        },
+      }
+
+      const res = {
+        redirect: jest.fn(),
+      }
+
+      redirectWithCanonicalParams({ req, res })
+      expect(res.redirect).toHaveBeenCalledWith(
+        301,
+        "/artist/sam-king/works-for-sale?foo=bar"
+      )
+    })
+  })
+
+  describe("with a valid sort", () => {
+    it("does nothing", () => {
+      const req = {
+        path: "/artist/sam-king/works-for-sale",
+        query: {
+          sort: "-anything_else",
+          foo: "bar",
+        },
+      }
+
+      const res = {
+        redirect: jest.fn(),
+      }
+
+      redirectWithCanonicalParams({ req, res })
+      expect(res.redirect).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/Apps/Artist/Server/redirect.ts
+++ b/src/Apps/Artist/Server/redirect.ts
@@ -14,5 +14,5 @@ export function redirectWithCanonicalParams({ req, res }) {
 
 function hasCanonicalSort(query: { sort: string }) {
   // See https://artsyproduct.atlassian.net/browse/FX-4778
-  return query.sort != "-default_trending_score"
+  return query.sort !== "-default_trending_score"
 }

--- a/src/Apps/Artist/Server/redirect.ts
+++ b/src/Apps/Artist/Server/redirect.ts
@@ -1,0 +1,18 @@
+export function redirectWithCanonicalParams({ req, res }) {
+  if (hasCanonicalSort(req.query)) {
+    // all good
+    return
+  }
+
+  // else remove the offending sort, causing fallback to default sort
+  delete req.query.sort
+
+  const sanitizedQuerystring = new URLSearchParams(req.query).toString()
+  const sanitizedPath = [req.path, sanitizedQuerystring].join("?")
+  res.redirect(301, sanitizedPath)
+}
+
+function hasCanonicalSort(query: { sort: string }) {
+  // See https://artsyproduct.atlassian.net/browse/FX-4778
+  return query.sort != "-default_trending_score"
+}

--- a/src/Apps/Artist/Server/redirect.ts
+++ b/src/Apps/Artist/Server/redirect.ts
@@ -1,3 +1,5 @@
+import { stringify } from "qs"
+
 export function redirectWithCanonicalParams({ req, res }) {
   if (hasCanonicalSort(req.query)) {
     // all good
@@ -7,7 +9,7 @@ export function redirectWithCanonicalParams({ req, res }) {
   // else remove the offending sort, causing fallback to default sort
   delete req.query.sort
 
-  const sanitizedQuerystring = new URLSearchParams(req.query).toString()
+  const sanitizedQuerystring = stringify(req.query)
   const sanitizedPath = [req.path, sanitizedQuerystring].join("?")
   res.redirect(301, sanitizedPath)
 }

--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -8,6 +8,7 @@ import { initialAuctionResultsFilterState } from "./Routes/AuctionResults/Auctio
 import { renderOrRedirect } from "./Routes/Overview/Utils/renderOrRedirect"
 import { getWorksForSaleRouteVariables } from "./Routes/WorksForSale/Utils/getWorksForSaleRouteVariables"
 import { enableArtistPageCTA } from "./Server/enableArtistPageCTA"
+import { redirectWithCanonicalParams } from "./Server/redirect"
 import { allowedAuctionResultFilters } from "./Utils/allowedAuctionResultFilters"
 
 const ArtistApp = loadable(
@@ -144,6 +145,7 @@ export const artistRoutes: AppRouteConfig[] = [
       {
         path: "works-for-sale",
         getComponent: () => WorksForSaleRoute,
+        onServerSideRender: redirectWithCanonicalParams,
         onClientSideRender: () => {
           WorksForSaleRoute.preload()
         },


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [FX-4778]

### Description

The [cleanup work](https://github.com/artsy/gravity/pull/16308) for the trending score experiment uncovered the fact that the URLs we generated in the course of that experiment, e.g...

```
https://www.artsy.net/artist/sam-king/works-for-sale?sort=-default_trending_score&metric=in
                                                          ^^^^^^^^^^^^^^^^^^^^^^^
                                                          soon-to-be invalid!
```

...got [shared](https://artsy.slack.com/archives/C9SATFLUU/p1683131630609639?thread_ts=1683131226.200629&cid=C9SATFLUU) and ultimately [indexed](https://artsy.slack.com/archives/C9SATFLUU/p1683131966269079?thread_ts=1683131226.200629&cid=C9SATFLUU) by search engines.

Before we proceed with the cleanup we want to make sure we redirect these experimental URLs back to their canonical counterparts, e.g…

```
https://www.artsy.net/artist/sam-king/works-for-sale?metric=in
```


…so that there is no [disruption to the artwork grids](https://artsy.slack.com/archives/C9SATFLUU/p1683132323501659?thread_ts=1683131226.200629&cid=C9SATFLUU) or associated SEO.



[FX-4778]: https://artsyproduct.atlassian.net/browse/FX-4778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ