### PR TITLE
add data- attributes to address form elements for tests

### DIFF
--- a/src/Components/AddressForm.tsx
+++ b/src/Components/AddressForm.tsx
@@ -136,6 +136,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           </Text>
           <CountrySelect
             tabIndex={tabIndex}
+            id="AddressForm_country"
             selected={
               lockCountryToOrigin || (lockCountriesToEU && !address.country)
                 ? shippingCountry

--- a/src/Components/AddressForm.tsx
+++ b/src/Components/AddressForm.tsx
@@ -136,7 +136,6 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           </Text>
           <CountrySelect
             tabIndex={tabIndex}
-            id="AddressForm_country"
             selected={
               lockCountryToOrigin || (lockCountriesToEU && !address.country)
                 ? shippingCountry
@@ -145,6 +144,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
             onSelect={changeValueHandler("country")}
             disabled={lockCountryToOrigin}
             euShippingOnly={lockCountriesToEU}
+            data-test="AddressForm_country"
           />
           {(lockCountryToOrigin || lockCountriesToEU) && (
             <>

--- a/src/Components/AddressForm.tsx
+++ b/src/Components/AddressForm.tsx
@@ -127,6 +127,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           value={address.name}
           onChange={changeEventHandler("name")}
           error={getError("name")}
+          data-test="AddressForm_name"
         />
       </Flex>
       <TwoColumnSplit>
@@ -168,6 +169,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
             value={address.postalCode}
             onChange={changeEventHandler("postalCode")}
             error={getError("postalCode")}
+            data-test="AddressForm_postalCode"
           />
         </Flex>
       </TwoColumnSplit>
@@ -181,6 +183,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
             value={address.addressLine1}
             onChange={changeEventHandler("addressLine1")}
             error={getError("addressLine1")}
+            data-test="AddressForm_addressLine1"
           />
         </Flex>
         <Flex flexDirection="column">
@@ -192,6 +195,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
             value={address.addressLine2}
             onChange={changeEventHandler("addressLine2")}
             error={getError("addressLine2")}
+            data-test="AddressForm_addressLine2"
           />
         </Flex>
       </TwoColumnSplit>
@@ -205,6 +209,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
             value={address.city}
             onChange={changeEventHandler("city")}
             error={getError("city")}
+            data-test="AddressForm_city"
           />
         </Flex>
         <Flex flexDirection="column">
@@ -217,6 +222,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
             value={address.region}
             onChange={changeEventHandler("region")}
             error={getError("region")}
+            data-test="AddressForm_region"
           />
         </Flex>
       </TwoColumnSplit>
@@ -234,6 +240,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
               value={address.phoneNumber}
               onChange={changeEventHandler("phoneNumber")}
               error={getError("phoneNumber")}
+              data-test="AddressForm_phoneNumber"
             />
           </Flex>
           <Spacer y={2} />

--- a/src/Components/CountrySelect.tsx
+++ b/src/Components/CountrySelect.tsx
@@ -4,16 +4,19 @@ import { FC } from "react"
 export interface CountrySelectProps extends Omit<SelectProps, "options"> {
   euShippingOnly?: boolean
   tabIndex?: number
+  id?: string
 }
 
 export const CountrySelect: FC<CountrySelectProps> = ({
   euShippingOnly,
   tabIndex,
+  id,
   ...rest
 }) => {
   return (
     <Select
       tabIndex={tabIndex}
+      id={id}
       options={
         euShippingOnly ? EU_COUNTRY_SELECT_OPTIONS : COUNTRY_SELECT_OPTIONS
       }

--- a/src/Components/CountrySelect.tsx
+++ b/src/Components/CountrySelect.tsx
@@ -4,19 +4,16 @@ import { FC } from "react"
 export interface CountrySelectProps extends Omit<SelectProps, "options"> {
   euShippingOnly?: boolean
   tabIndex?: number
-  id?: string
 }
 
 export const CountrySelect: FC<CountrySelectProps> = ({
   euShippingOnly,
   tabIndex,
-  id,
   ...rest
 }) => {
   return (
     <Select
       tabIndex={tabIndex}
-      id={id}
       options={
         euShippingOnly ? EU_COUNTRY_SELECT_OPTIONS : COUNTRY_SELECT_OPTIONS
       }


### PR DESCRIPTION
The type of this PR is: Chore

### Description

I would like to write an Integrity test to place an order that is shipped or billed to a country other than the United States, but there is no ID available on the address form's country select component to make that easy.

~I made the ID prop optional so that different forms can give it an ID that is consistent with other form elements (ie. `AddressForm_name`, `AddressForm_country`, etc.). I'd love to hear about whether that's a weird thing to do in React or not.~

I added a `data-test` attribute to the country selection element so that it can be easily selected. I also added `data-test` attributes to the rest of the elements on this form to be able to standardize this behavior.