### PR TITLE
feat(FX-4657): mobile web search overlay

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -137,6 +137,10 @@ export const NavBar: React.FC = track(
     })
   }
 
+  const handleMobileSearchBarClose = () => {
+    setSearchFocused(false)
+  }
+
   if (isEigen) {
     return null
   }
@@ -205,7 +209,7 @@ export const NavBar: React.FC = track(
                 zIndex={9}
               >
                 {isSearchDropDownImprovementsEnabled ? (
-                  <NewSearchBar />
+                  <NewSearchBar onClose={handleMobileSearchBarClose} />
                 ) : (
                   <SearchBarQueryRenderer width="100%" />
                 )}

--- a/src/Components/Search/NewSearch/Mobile/Overlay.tsx
+++ b/src/Components/Search/NewSearch/Mobile/Overlay.tsx
@@ -1,0 +1,30 @@
+import SearchIcon from "@artsy/icons/SearchIcon"
+import { Box, LabeledInput } from "@artsy/palette"
+import { FC, useEffect, useRef } from "react"
+import { useTranslation } from "react-i18next"
+import { OverlayBase } from "./OverlayBase"
+
+interface OverlayProps {
+  onClose: () => void
+}
+
+export const Overlay: FC<OverlayProps> = ({ onClose }) => {
+  const { t } = useTranslation()
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  return (
+    <OverlayBase onClose={onClose}>
+      <Box mt={-15}>
+        <LabeledInput
+          ref={inputRef}
+          placeholder={t`navbar.searchArtsy`}
+          label={<SearchIcon fill="black60" aria-hidden mr={-10} size={18} />}
+        />
+      </Box>
+    </OverlayBase>
+  )
+}

--- a/src/Components/Search/NewSearch/Mobile/OverlayBase.tsx
+++ b/src/Components/Search/NewSearch/Mobile/OverlayBase.tsx
@@ -18,8 +18,8 @@ export const OverlayBase: FC<OverlayBaseProps> = ({ children, onClose }) => {
     >
       <ModalDialogContent
         onClose={onClose}
-        width={"100%"}
-        height={"100%"}
+        width="100%"
+        height="100%"
         margin={0} // TODO: ignored, fix it in palette
       >
         {children}

--- a/src/Components/Search/NewSearch/Mobile/OverlayBase.tsx
+++ b/src/Components/Search/NewSearch/Mobile/OverlayBase.tsx
@@ -1,0 +1,29 @@
+import { ModalBase, ModalDialogContent } from "@artsy/palette"
+import { FC } from "react"
+
+interface OverlayBaseProps {
+  onClose: () => void
+}
+
+export const OverlayBase: FC<OverlayBaseProps> = ({ children, onClose }) => {
+  return (
+    <ModalBase
+      dialogProps={{
+        width: "100%",
+        height: "100%",
+        background: "black",
+        justifyContent: "center",
+        backgroundColor: "white",
+      }}
+    >
+      <ModalDialogContent
+        onClose={onClose}
+        width={"100%"}
+        height={"100%"}
+        margin={0} // TODO: ignored, fix it in palette
+      >
+        {children}
+      </ModalDialogContent>
+    </ModalBase>
+  )
+}

--- a/src/Components/Search/NewSearch/Mobile/SearchBar.tsx
+++ b/src/Components/Search/NewSearch/Mobile/SearchBar.tsx
@@ -1,0 +1,36 @@
+import SearchIcon from "@artsy/icons/SearchIcon"
+import { LabeledInput } from "@artsy/palette"
+import { Overlay } from "./Overlay"
+import { FC, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+interface SearchBarProps {
+  onClose: () => void
+}
+
+export const SearchBar: FC<SearchBarProps> = ({ onClose }) => {
+  const { t } = useTranslation()
+  const [overlayDisplayed, setOverlayDisplayed] = useState(false)
+
+  const displayOverlay = () => {
+    setOverlayDisplayed(true)
+  }
+
+  const handleOverlayClose = () => {
+    setOverlayDisplayed(false)
+    onClose()
+  }
+
+  return (
+    <>
+      {overlayDisplayed && <Overlay onClose={handleOverlayClose} />}
+
+      <LabeledInput
+        placeholder={t`navbar.searchArtsy`}
+        label={<SearchIcon fill="black60" aria-hidden size={22} />}
+        onClick={displayOverlay}
+        height={40}
+      />
+    </>
+  )
+}

--- a/src/Components/Search/NewSearch/NewSearchBar.tsx
+++ b/src/Components/Search/NewSearch/NewSearchBar.tsx
@@ -1,15 +1,21 @@
 import { Box } from "@artsy/palette"
 import { NewSearchBarInputQueryRenderer } from "Components/Search/NewSearch/NewSearchBarInput"
 import { Media } from "Utils/Responsive"
+import { SearchBar } from "./Mobile/SearchBar"
+import { FC } from "react"
 
-export const NewSearchBar = () => {
+interface NewSearchBarProps {
+  onClose: () => void
+}
+
+export const NewSearchBar: FC<NewSearchBarProps> = ({ onClose }) => {
   return (
     <Box flex={1}>
       <Media at="xs">
-        <NewSearchBarInputQueryRenderer isXs={true} />
+        <SearchBar onClose={onClose} />
       </Media>
       <Media greaterThan="xs">
-        <NewSearchBarInputQueryRenderer isXs={false} />
+        <NewSearchBarInputQueryRenderer />
       </Media>
     </Box>
   )

--- a/src/Components/Search/NewSearch/NewSearchBarInput.tsx
+++ b/src/Components/Search/NewSearch/NewSearchBarInput.tsx
@@ -20,14 +20,9 @@ const logger = createLogger("Components/Search/NewSearchBar")
 export interface NewSearchBarInputProps extends SystemContextProps {
   relay: RelayRefetchProp
   viewer: NewSearchBarInput_viewer$data
-  isXs: boolean
 }
 
-const NewSearchBarInput: FC<NewSearchBarInputProps> = ({
-  isXs,
-  relay,
-  viewer,
-}) => {
+const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
   const { t } = useTranslation()
   const [value, setValue] = useState("")
 
@@ -68,7 +63,7 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({
 
   return (
     <AutocompleteInput
-      placeholder={isXs ? t`navbar.searchArtsy` : t`navbar.searchBy`}
+      placeholder={t`navbar.searchBy`}
       spellCheck={false}
       options={value.length < 2 ? [] : formattedOptions}
       value={value}
@@ -143,15 +138,11 @@ export const NewSearchBarInputRefetchContainer = createRefetchContainer(
   `
 )
 
-interface NewSearchBarInputQueryRendererProps extends BoxProps {
-  isXs: boolean
-}
-
-export const NewSearchBarInputQueryRenderer: FC<NewSearchBarInputQueryRendererProps> = props => {
+export const NewSearchBarInputQueryRenderer: FC = () => {
   const { relayEnvironment, searchQuery = "" } = useSystemContext()
 
   if (isServer) {
-    return <StaticSearchContainer searchQuery={searchQuery} {...props} />
+    return <StaticSearchContainer searchQuery={searchQuery} />
   }
 
   return (
@@ -172,14 +163,9 @@ export const NewSearchBarInputQueryRenderer: FC<NewSearchBarInputQueryRendererPr
         hasTerm: false,
         term: "",
       }}
-      render={({ props: relayProps }) => {
-        if (relayProps && relayProps.viewer) {
-          return (
-            <NewSearchBarInputRefetchContainer
-              viewer={relayProps.viewer}
-              isXs={props.isXs}
-            />
-          )
+      render={({ props }) => {
+        if (props && props.viewer) {
+          return <NewSearchBarInputRefetchContainer viewer={props.viewer} />
           // SSR render pass. Since we don't have access to `<Boot>` context
           // from within the NavBar (it's not a part of any app) we need to lean
           // on styled-system for showing / hiding depending upon breakpoint.

--- a/src/Components/Search/NewSearch/NewSearchBarInput.tsx
+++ b/src/Components/Search/NewSearch/NewSearchBarInput.tsx
@@ -164,7 +164,7 @@ export const NewSearchBarInputQueryRenderer: FC = () => {
         term: "",
       }}
       render={({ props }) => {
-        if (props && props.viewer) {
+        if (props?.viewer) {
           return <NewSearchBarInputRefetchContainer viewer={props.viewer} />
           // SSR render pass. Since we don't have access to `<Boot>` context
           // from within the NavBar (it's not a part of any app) we need to lean


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [FX-4657]

### Description

- create a new full screen overlay/modal 
- if feature flag is enabled, when user presses the search input (on mWeb only) they see the new overlay
- overlay should have an x button to dismiss
- overlay should include search input as specified in design

### Demo

https://github.com/artsy/force/assets/3934579/1d11f0c4-7982-4c95-ac08-b01677ac36a1


[FX-4657]: https://artsyproduct.atlassian.net/browse/FX-4657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ