### PR TITLE
fix(PRO-130): correct routing after in_review offer

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -133,7 +133,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
         if (isEigen) {
           if (order.mode === "OFFER") {
             if (
-              order.state === "IN_REVIEW" &&
+              orderOrError?.order?.state === "IN_REVIEW" &&
               order.source === "artwork_page"
             ) {
               window?.ReactNativeWebView?.postMessage(
@@ -175,7 +175,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
         if (
           isEigen ||
           (order.mode === "OFFER" &&
-            order.state === "IN_REVIEW" &&
+            orderOrError?.order?.state === "IN_REVIEW" &&
             order.source === "artwork_page")
         ) {
           return router.push(`/orders/${orderId}/status`)

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -676,16 +676,16 @@ describe("Review", () => {
   })
 
   describe("in-review offers", () => {
-    const OfferOrderInReview = {
+    const OfferOrderToSubmit = {
       ...OfferOrderWithShippingDetails,
-      state: "IN_REVIEW",
+      state: "PENDING",
       internalID: "offer-order-id",
       impulseConversationId: null,
     }
 
     describe("from an artwork page", () => {
       const OfferOrderInReviewFromArtworkPage = {
-        ...OfferOrderInReview,
+        ...OfferOrderToSubmit,
         source: "artwork_page",
       }
 
@@ -704,7 +704,7 @@ describe("Review", () => {
 
     describe("from an inquiry", () => {
       const OfferOrderInReviewFromInquiry = {
-        ...OfferOrderInReview,
+        ...OfferOrderToSubmit,
         source: "inquiry",
         impulseConversationId: "impulse-conversation-id",
       }
@@ -731,7 +731,7 @@ describe("Review", () => {
 
       describe("from an artwork page", () => {
         const OfferOrderInReviewFromArtworkPage = {
-          ...OfferOrderInReview,
+          ...OfferOrderToSubmit,
           source: "artwork_page",
         }
 
@@ -760,7 +760,7 @@ describe("Review", () => {
 
       describe("from an inquiry", () => {
         const OfferOrderInReviewFromInquiry = {
-          ...OfferOrderInReview,
+          ...OfferOrderToSubmit,
           source: "inquiry",
         }
 


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves PRO-130

### Description

Turns out we were routing based on the _pending_ offer and not the response from the mutation.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ