### PR TITLE
feat(dev): add yalc for local package dev

### DIFF
--- a/docs/developing_local_palette.md
+++ b/docs/developing_local_palette.md
@@ -1,0 +1,36 @@
+## Developing Features using Local Versions of Palette
+
+When developing new components in Palette, it's often useful to test those components in consuming apps (such as Eigen). However, due to the poor support for symlinks in React Native, this can be difficult. Enter [yalc](https://github.com/wclr/yalc). Yalc is a mini package manager that one can publish to and install from, which makes it easy to test code in realtime from outside of your app.
+
+> Note: [@artsy/palette](https://github.com/artsy/palette) uses Storybooks for developing features; work there first! Then, when ready (and if necessary), test your code locally using the flow described below. You can also publish npm canary releases from the palette repo by attaching a `canary` label to your PR.
+
+### Setup
+
+- Install `yalc` globally:
+
+```sh
+yarn global add yalc
+```
+
+- Navigate to `palette` in the terminal and start the watcher:
+
+```sh
+cd palette/packages/palette
+yarn local-palette-dev
+```
+
+- Navigate back to Force and link:
+
+```sh
+cd force
+yarn local-palette-dev
+yarn start
+```
+
+This will update `package.json` to point at the yalc-published version of palette.
+
+- When done developing your local palette feature, be sure to unlink:
+
+```sh
+yarn local-palette-dev:stop
+```

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "jest": "node_modules/.bin/jest --config jest.config.js",
     "jest:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "lint": "eslint --cache --cache-location '.cache/eslint/' --ext ts,tsx --ignore-pattern 'src/__generated__'",
+    "local-palette-dev": "./scripts/yalc-link-local-palette",
+    "local-palette-dev:stop": "./scripts/yalc-unlink-local-palette",
     "open-consent-modal": "open http://localhost:5000?otreset=false&otpreview=true&otgeo=gb",
     "prepare": "patch-package",
     "prettier-project": "yarn run prettier-write 'src/**/*.{ts,tsx,js,jsx}'",

--- a/scripts/yalc-link-local-palette
+++ b/scripts/yalc-link-local-palette
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if ! command -v yalc &> /dev/null
+then
+    echo "Error linking @artsy/palette for dev. 'yalc' is not installed. Please install it with 'yarn global add yalc'."
+    echo "See https://docs.joshuatz.com/cheatsheets/devops/yalc/ for more info."
+    exit
+fi
+
+yalc add @artsy/palette
+yarn install

--- a/scripts/yalc-unlink-local-palette
+++ b/scripts/yalc-unlink-local-palette
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if ! command -v yalc &> /dev/null
+then
+    echo "Error unlinking @artsy/palette for dev. 'yalc' is not installed. Please install it with 'yarn global add yalc'."
+    echo "See https://docs.joshuatz.com/cheatsheets/devops/yalc/ for more info."
+    exit
+fi
+
+yalc remove @artsy/palette
+yarn install


### PR DESCRIPTION
Related:
- https://github.com/artsy/palette/pull/1294

The type of this PR is: **Feat**

### Description

Similar to Eigen and Energy, this adds yalc for developing packages locally. To run:

```bash
cd packages/palette
yarn local-palette-dev

cd force 
yarn local-palette-dev
```
