### PR TITLE
fix: Add space after & before "Become a partner" on SWA landing page.

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/FooterBanner.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/FooterBanner.tsx
@@ -6,9 +6,9 @@ export const FooterBanner: React.FC = () => {
   return (
     <Box display={["none", "block"]}>
       <FullBleedBanner dismissable={false} variant="defaultLight">
-        Gallery or art dealer?{" "}
+        Gallery or art dealer?&nbsp;
         <RouterLink inline to="https://partners.artsy.net">
-          Become a partner{" "}
+          Become a partner&nbsp;
         </RouterLink>
         to access the world’s largest online marketplace.
       </FullBleedBanner>

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/FooterBanner.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/FooterBanner.tsx
@@ -8,8 +8,8 @@ export const FooterBanner: React.FC = () => {
       <FullBleedBanner dismissable={false} variant="defaultLight">
         Gallery or art dealer?{" "}
         <RouterLink inline to="https://partners.artsy.net">
-          Become a partner
-        </RouterLink>{" "}
+          Become a partner{" "}
+        </RouterLink>
         to access the world’s largest online marketplace.
       </FullBleedBanner>
     </Box>


### PR DESCRIPTION

## Description

<img width="781" alt="Screenshot 2023-05-11 at 17 55 08" src="https://github.com/artsy/force/assets/4691889/b440146a-ef84-4155-83c9-4dc0e1928f2f">


Add space after & before "Become a partner" on SWA landing page.