### PR TITLE
fix: Update SWA specialist key to match key in eigen

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/MeetTheSpecialists.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/MeetTheSpecialists.tsx
@@ -39,7 +39,7 @@ const pills: PillData[] = [
     title: "Auctions",
   },
   {
-    type: "privateSalesAndAdvisory",
+    type: "priveteSalesAndAdvisory",
     title: "Private Sales & Advisory",
   },
   {

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SpecialistsData.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SpecialistsData.tsx
@@ -1,6 +1,6 @@
 export type Specialty =
   | "auctions"
-  | "privateSalesAndAdvisory"
+  | "priveteSalesAndAdvisory"
   | "collectorServices"
 
 export interface SpecialistsData {
@@ -30,7 +30,7 @@ export const SPECIALISTS: SpecialistsData[] = [
     email: "shlomi.rabi@artsy.net",
   },
   {
-    specialty: "privateSalesAndAdvisory",
+    specialty: "priveteSalesAndAdvisory",
     name: "Akanksha Ballaney",
     firstName: "Akanksha",
     jobTitle: "Director, Private Sales",
@@ -90,7 +90,7 @@ export const SPECIALISTS: SpecialistsData[] = [
     email: "adam.mccoy@artsy.net",
   },
   {
-    specialty: "privateSalesAndAdvisory",
+    specialty: "priveteSalesAndAdvisory",
     name: "Caroline Perkins",
     firstName: "Caroline",
     jobTitle: "Advisor",
@@ -100,7 +100,7 @@ export const SPECIALISTS: SpecialistsData[] = [
     email: "caroline.perkins@artsy.net",
   },
   {
-    specialty: "privateSalesAndAdvisory",
+    specialty: "priveteSalesAndAdvisory",
     name: "Robin Roche",
     firstName: "Robin",
     jobTitle: "Senior Private Sales Director",


### PR DESCRIPTION

## Description

This PR updates the SWA specialist key to match the key in [Eigen](https://github.com/artsy/eigen/blob/main/src/app/Scenes/SellWithArtsy/utils/useSWALandingPageData.tsx#L35). There is a typo in the key but it will be difficult to fix because Eigen fetches the data from S3 and old versions expect the key with the typo :/