### PR TITLE
feat(TX-1151): Update address form layouts in the checkout flow

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -629,6 +629,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
               </>
             )}
 
+            {/* SAVED ADDRESSES */}
             <Collapse
               data-test="savedAddressesCollapse"
               open={!!showSavedAddresses}
@@ -650,11 +651,16 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                 onAddressEdit={handleAddressEdit}
               />
             </Collapse>
+
+            {/* NEW ADDRESS */}
             <Collapse data-test="addressFormCollapse" open={showAddressForm}>
               {isArtsyShipping &&
                 shippingQuotes &&
                 shippingQuotes.length === 0 &&
                 renderArtaErrorMessage()}
+              <Text variant="lg-display" mb="2">
+                Delivery address
+              </Text>
               <AddressForm
                 tabIndex={showAddressForm ? 0 : -1}
                 value={address}
@@ -685,6 +691,8 @@ export const ShippingRoute: FC<ShippingProps> = props => {
               </Checkbox>
               <Spacer y={4} />
             </Collapse>
+
+            {/* PHONE NUMBER */}
             <Collapse
               data-test="phoneNumberCollapse"
               open={shippingOption === "PICKUP"}
@@ -700,6 +708,8 @@ export const ShippingRoute: FC<ShippingProps> = props => {
               />
               <Spacer y={4} />
             </Collapse>
+
+            {/* SHIPPING OPTION */}
             <Collapse open={showArtsyShipping}>
               <Text variant="sm">Artsy shipping options</Text>
               <Text variant="xs" mb="1" color="black60">

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -1686,9 +1686,9 @@ describe("Shipping", () => {
         ).toMatchInlineSnapshot(`
           [
             "Test Name",
-            "28001",
             "1 Main St",
             "",
+            "28001",
             "Madrid",
             "",
           ]

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -1688,9 +1688,9 @@ describe("Shipping", () => {
             "Test Name",
             "1 Main St",
             "",
-            "28001",
             "Madrid",
             "",
+            "28001",
           ]
         `)
       })

--- a/src/Components/Address/AddressModalFields.tsx
+++ b/src/Components/Address/AddressModalFields.tsx
@@ -19,7 +19,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={12}>
         <Input
           title="Full name"
-          placeholder="Add full name"
+          placeholder="Full name"
           id="name"
           name="name"
           type="text"
@@ -44,7 +44,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={12}>
         <Input
           title="Address Line 1"
-          placeholder="Add street address"
+          placeholder="Street address"
           name="addressLine1"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -54,8 +54,8 @@ export const AddressModalFields: React.FC = () => {
       </Column>
       <Column span={12}>
         <Input
-          title="Address Line 2 (optional)"
-          placeholder="Add apt, floor, suite, etc."
+          title="Address Line 2"
+          placeholder="Apt, floor, suite, etc. (optional)"
           name="addressLine2"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -65,19 +65,8 @@ export const AddressModalFields: React.FC = () => {
       </Column>
       <Column span={12}>
         <Input
-          title="Postal Code"
-          placeholder="Add postal code"
-          name="postalCode"
-          onChange={handleChange}
-          onBlur={handleBlur}
-          error={touched.postalCode && errors.postalCode}
-          value={values?.postalCode || ""}
-        />
-      </Column>
-      <Column span={12}>
-        <Input
           title="City"
-          placeholder="Enter city"
+          placeholder="City"
           name="city"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -85,15 +74,26 @@ export const AddressModalFields: React.FC = () => {
           value={values?.city}
         />
       </Column>
-      <Column span={12}>
+      <Column span={6}>
         <Input
           title="State, province, or region"
-          placeholder="Add state, province, or region"
+          placeholder="State, province, or region"
           name="region"
           onChange={handleChange}
           onBlur={handleBlur}
           error={touched.region && errors.region}
           value={values?.region || ""}
+        />
+      </Column>
+      <Column span={6}>
+        <Input
+          title="Postal Code"
+          placeholder="Postal code"
+          name="postalCode"
+          onChange={handleChange}
+          onBlur={handleBlur}
+          error={touched.postalCode && errors.postalCode}
+          value={values?.postalCode || ""}
         />
       </Column>
     </GridColumns>

--- a/src/Components/Address/AddressModalFields.tsx
+++ b/src/Components/Address/AddressModalFields.tsx
@@ -19,7 +19,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={12}>
         <Input
           title="Full name"
-          placeholder="Add full name"
+          placeholder="Full name"
           id="name"
           name="name"
           type="text"
@@ -44,7 +44,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={12}>
         <Input
           title="Address Line 1"
-          placeholder="Add street address"
+          placeholder="Street address"
           name="addressLine1"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -54,8 +54,8 @@ export const AddressModalFields: React.FC = () => {
       </Column>
       <Column span={12}>
         <Input
-          title="Address Line 2 (optional)"
-          placeholder="Add apt, floor, suite, etc."
+          title="Address Line 2"
+          placeholder="Apt, floor, suite, etc. (optional)"
           name="addressLine2"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -66,7 +66,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={12}>
         <Input
           title="City"
-          placeholder="Enter city"
+          placeholder="City"
           name="city"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -77,7 +77,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={6}>
         <Input
           title="State, province, or region"
-          placeholder="Add state, province, or region"
+          placeholder="State, province, or region"
           name="region"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -88,7 +88,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={6}>
         <Input
           title="Postal Code"
-          placeholder="Add postal code"
+          placeholder="ZIP/Postal code"
           name="postalCode"
           onChange={handleChange}
           onBlur={handleBlur}

--- a/src/Components/Address/AddressModalFields.tsx
+++ b/src/Components/Address/AddressModalFields.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
-import { Box, Column, Flex, GridColumns, Input, Text } from "@artsy/palette"
+import { Column, GridColumns, Input, Text } from "@artsy/palette"
 import { useFormikContext } from "formik"
 import { SavedAddressType } from "Apps/Order/Utils/shippingUtils"
-import { CountrySelect } from "../CountrySelect"
+import { CountrySelect } from "Components/CountrySelect"
 
 export const AddressModalFields: React.FC = () => {
   const {
@@ -15,11 +15,11 @@ export const AddressModalFields: React.FC = () => {
   } = useFormikContext<SavedAddressType>()
 
   return (
-    <>
-      <Flex flexDirection="column">
+    <GridColumns mt={[1, 2]}>
+      <Column span={12}>
         <Input
           title="Full name"
-          placeholder="Enter name"
+          placeholder="Add full name"
           id="name"
           name="name"
           type="text"
@@ -28,83 +28,74 @@ export const AddressModalFields: React.FC = () => {
           error={touched.name && errors.name}
           value={values?.name || undefined}
         />
-      </Flex>
-      <GridColumns mt={[1, 2]}>
-        <Column span={6}>
-          <Box>
-            <Text variant="xs" mb={0.5}>
-              Country
-            </Text>
-            <CountrySelect
-              selected={values?.country}
-              onSelect={countryCode => {
-                setFieldValue("country", countryCode)
-              }}
-              error={touched.country && errors.country ? errors.country : ""}
-            />
-          </Box>
-        </Column>
-        <Column span={6}>
-          <Input
-            title="Postal Code"
-            placeholder="Add postal code"
-            name="postalCode"
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.postalCode && errors.postalCode}
-            value={values?.postalCode || ""}
-          />
-        </Column>
-      </GridColumns>
-
-      <GridColumns mt={[1, 2]}>
-        <Column span={6}>
-          <Input
-            title="Address Line 1"
-            placeholder="Add address"
-            name="addressLine1"
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.addressLine1 && errors.addressLine1}
-            value={values?.addressLine1}
-          />
-        </Column>
-        <Column span={6}>
-          <Input
-            title="Address Line 2 (optional)"
-            placeholder="Add address line 2"
-            name="addressLine2"
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.addressLine2 && errors.addressLine2}
-            value={values?.addressLine2 || ""}
-          />
-        </Column>
-      </GridColumns>
-      <GridColumns mt={[1, 2]}>
-        <Column span={6}>
-          <Input
-            title="City"
-            placeholder="Enter city"
-            name="city"
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.city && errors.city}
-            value={values?.city}
-          />
-        </Column>
-        <Column span={6}>
-          <Input
-            title="State, province, or region"
-            placeholder="Add state, province, or region"
-            name="region"
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.region && errors.region}
-            value={values?.region || ""}
-          />
-        </Column>
-      </GridColumns>
-    </>
+      </Column>
+      <Column span={12}>
+        <Text variant="xs" mb={0.5}>
+          Country
+        </Text>
+        <CountrySelect
+          selected={values?.country}
+          onSelect={countryCode => {
+            setFieldValue("country", countryCode)
+          }}
+          error={touched.country && errors.country ? errors.country : ""}
+        />
+      </Column>
+      <Column span={12}>
+        <Input
+          title="Address Line 1"
+          placeholder="Add street address"
+          name="addressLine1"
+          onChange={handleChange}
+          onBlur={handleBlur}
+          error={touched.addressLine1 && errors.addressLine1}
+          value={values?.addressLine1}
+        />
+      </Column>
+      <Column span={12}>
+        <Input
+          title="Address Line 2 (optional)"
+          placeholder="Add apt, floor, suite, etc."
+          name="addressLine2"
+          onChange={handleChange}
+          onBlur={handleBlur}
+          error={touched.addressLine2 && errors.addressLine2}
+          value={values?.addressLine2 || ""}
+        />
+      </Column>
+      <Column span={12}>
+        <Input
+          title="Postal Code"
+          placeholder="Add postal code"
+          name="postalCode"
+          onChange={handleChange}
+          onBlur={handleBlur}
+          error={touched.postalCode && errors.postalCode}
+          value={values?.postalCode || ""}
+        />
+      </Column>
+      <Column span={12}>
+        <Input
+          title="City"
+          placeholder="Enter city"
+          name="city"
+          onChange={handleChange}
+          onBlur={handleBlur}
+          error={touched.city && errors.city}
+          value={values?.city}
+        />
+      </Column>
+      <Column span={12}>
+        <Input
+          title="State, province, or region"
+          placeholder="Add state, province, or region"
+          name="region"
+          onChange={handleChange}
+          onBlur={handleBlur}
+          error={touched.region && errors.region}
+          value={values?.region || ""}
+        />
+      </Column>
+    </GridColumns>
   )
 }

--- a/src/Components/Address/AddressModalFields.tsx
+++ b/src/Components/Address/AddressModalFields.tsx
@@ -19,7 +19,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={12}>
         <Input
           title="Full name"
-          placeholder="Full name"
+          placeholder="Add full name"
           id="name"
           name="name"
           type="text"
@@ -44,7 +44,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={12}>
         <Input
           title="Address Line 1"
-          placeholder="Street address"
+          placeholder="Add street address"
           name="addressLine1"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -54,8 +54,8 @@ export const AddressModalFields: React.FC = () => {
       </Column>
       <Column span={12}>
         <Input
-          title="Address Line 2"
-          placeholder="Apt, floor, suite, etc. (optional)"
+          title="Address Line 2 (optional)"
+          placeholder="Add apt, floor, suite, etc."
           name="addressLine2"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -66,7 +66,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={12}>
         <Input
           title="City"
-          placeholder="City"
+          placeholder="Enter city"
           name="city"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -77,7 +77,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={6}>
         <Input
           title="State, province, or region"
-          placeholder="State, province, or region"
+          placeholder="Add state, province, or region"
           name="region"
           onChange={handleChange}
           onBlur={handleBlur}
@@ -88,7 +88,7 @@ export const AddressModalFields: React.FC = () => {
       <Column span={6}>
         <Input
           title="Postal Code"
-          placeholder="Postal code"
+          placeholder="Add postal code"
           name="postalCode"
           onChange={handleChange}
           onBlur={handleBlur}

--- a/src/Components/AddressForm.tsx
+++ b/src/Components/AddressForm.tsx
@@ -120,7 +120,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_name"
-          placeholder="Full name"
+          placeholder="Add full name"
           title={billing ? "Name on card" : "Full name"}
           autoCorrect="off"
           value={address.name}
@@ -161,7 +161,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_addressLine1"
-          placeholder="Street address"
+          placeholder="Add street address"
           title="Address line 1"
           value={address.addressLine1}
           onChange={changeEventHandler("addressLine1")}
@@ -173,8 +173,8 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_addressLine2"
-          placeholder="Apt, floor, suite, etc. (optional)"
-          title="Address line 2"
+          placeholder="Add apt, floor, suite, etc."
+          title="Address line 2 (optional)"
           value={address.addressLine2}
           onChange={changeEventHandler("addressLine2")}
           error={getError("addressLine2")}
@@ -185,7 +185,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_city"
-          placeholder="City"
+          placeholder="Add city"
           title="City"
           value={address.city}
           onChange={changeEventHandler("city")}
@@ -197,7 +197,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_region"
-          placeholder="State, province, or region"
+          placeholder="Add state, province, or region"
           title="State, province, or region"
           autoCorrect="off"
           value={address.region}
@@ -210,7 +210,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_postalCode"
-          placeholder="ZIP/Postal code"
+          placeholder="Add postal code"
           title="Postal code"
           autoCapitalize="characters"
           autoCorrect="off"

--- a/src/Components/AddressForm.tsx
+++ b/src/Components/AddressForm.tsx
@@ -1,7 +1,6 @@
-import { Flex, Join, Text, Spacer, Input } from "@artsy/palette"
+import { Column, GridColumns, Text, Spacer, Input } from "@artsy/palette"
 import { CountrySelect } from "Components/CountrySelect"
 import * as React from "react"
-import { TwoColumnSplit } from "Apps/Order/Components/TwoColumnLayout"
 import { CreateTokenCardData } from "@stripe/stripe-js"
 
 export interface Address {
@@ -116,8 +115,8 @@ export const AddressForm: React.FC<AddressFormProps> = ({
   const lockCountriesToEU = onlyLocalShipping && euOrigin
 
   return (
-    <Join separator={<Spacer y={2} />}>
-      <Flex flexDirection="column">
+    <GridColumns>
+      <Column span={12}>
         <Input
           tabIndex={tabIndex}
           id="AddressForm_name"
@@ -129,106 +128,101 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           error={getError("name")}
           data-test="AddressForm_name"
         />
-      </Flex>
-      <TwoColumnSplit>
-        <Flex flexDirection="column" pb={1}>
-          <Text mb={0.5} variant="xs" color="black100">
-            Country
-          </Text>
-          <CountrySelect
-            tabIndex={tabIndex}
-            selected={
-              lockCountryToOrigin || (lockCountriesToEU && !address.country)
-                ? shippingCountry
-                : address.country
-            }
-            onSelect={changeValueHandler("country")}
-            disabled={lockCountryToOrigin}
-            euShippingOnly={lockCountriesToEU}
-            data-test="AddressForm_country"
-          />
-          {(lockCountryToOrigin || lockCountriesToEU) && (
-            <>
-              <Spacer x={0.5} y={0.5} />
-              <Text variant="xs" color="black60">
-                {lockCountriesToEU
-                  ? "Continental Europe shipping only."
-                  : "Domestic shipping only."}
-              </Text>
-            </>
-          )}
-        </Flex>
-        <Flex flexDirection="column">
-          <Input
-            tabIndex={tabIndex}
-            id="AddressForm_postalCode"
-            placeholder="Add postal code"
-            title="Postal code"
-            autoCapitalize="characters"
-            autoCorrect="off"
-            value={address.postalCode}
-            onChange={changeEventHandler("postalCode")}
-            error={getError("postalCode")}
-            data-test="AddressForm_postalCode"
-          />
-        </Flex>
-      </TwoColumnSplit>
-      <TwoColumnSplit>
-        <Flex flexDirection="column">
-          <Input
-            tabIndex={tabIndex}
-            id="AddressForm_addressLine1"
-            placeholder="Add street address"
-            title="Address line 1"
-            value={address.addressLine1}
-            onChange={changeEventHandler("addressLine1")}
-            error={getError("addressLine1")}
-            data-test="AddressForm_addressLine1"
-          />
-        </Flex>
-        <Flex flexDirection="column">
-          <Input
-            tabIndex={tabIndex}
-            id="AddressForm_addressLine2"
-            placeholder="Add apt, floor, suite, etc."
-            title="Address line 2 (optional)"
-            value={address.addressLine2}
-            onChange={changeEventHandler("addressLine2")}
-            error={getError("addressLine2")}
-            data-test="AddressForm_addressLine2"
-          />
-        </Flex>
-      </TwoColumnSplit>
-      <TwoColumnSplit>
-        <Flex flexDirection="column">
-          <Input
-            tabIndex={tabIndex}
-            id="AddressForm_city"
-            placeholder="Add city"
-            title="City"
-            value={address.city}
-            onChange={changeEventHandler("city")}
-            error={getError("city")}
-            data-test="AddressForm_city"
-          />
-        </Flex>
-        <Flex flexDirection="column">
-          <Input
-            tabIndex={tabIndex}
-            id="AddressForm_region"
-            placeholder="Add State, province, or region"
-            title="State, province, or region"
-            autoCorrect="off"
-            value={address.region}
-            onChange={changeEventHandler("region")}
-            error={getError("region")}
-            data-test="AddressForm_region"
-          />
-        </Flex>
-      </TwoColumnSplit>
+      </Column>
+
+      <Column span={12}>
+        <Text mb={0.5} variant="xs" color="black100">
+          Country
+        </Text>
+        <CountrySelect
+          tabIndex={tabIndex}
+          selected={
+            lockCountryToOrigin || (lockCountriesToEU && !address.country)
+              ? shippingCountry
+              : address.country
+          }
+          onSelect={changeValueHandler("country")}
+          disabled={lockCountryToOrigin}
+          euShippingOnly={lockCountriesToEU}
+          data-test="AddressForm_country"
+        />
+        {(lockCountryToOrigin || lockCountriesToEU) && (
+          <>
+            <Spacer x={0.5} y={0.5} />
+            <Text variant="xs" color="black60">
+              {lockCountriesToEU
+                ? "Continental Europe shipping only."
+                : "Domestic shipping only."}
+            </Text>
+          </>
+        )}
+      </Column>
+      <Column span={12}>
+        <Input
+          tabIndex={tabIndex}
+          id="AddressForm_addressLine1"
+          placeholder="Add street address"
+          title="Address line 1"
+          value={address.addressLine1}
+          onChange={changeEventHandler("addressLine1")}
+          error={getError("addressLine1")}
+          data-test="AddressForm_addressLine1"
+        />
+      </Column>
+      <Column span={12}>
+        <Input
+          tabIndex={tabIndex}
+          id="AddressForm_addressLine2"
+          placeholder="Add apt, floor, suite, etc."
+          title="Address line 2 (optional)"
+          value={address.addressLine2}
+          onChange={changeEventHandler("addressLine2")}
+          error={getError("addressLine2")}
+          data-test="AddressForm_addressLine2"
+        />
+      </Column>
+      <Column span={12}>
+        <Input
+          tabIndex={tabIndex}
+          id="AddressForm_postalCode"
+          placeholder="Add postal code"
+          title="Postal code"
+          autoCapitalize="characters"
+          autoCorrect="off"
+          value={address.postalCode}
+          onChange={changeEventHandler("postalCode")}
+          error={getError("postalCode")}
+          data-test="AddressForm_postalCode"
+        />
+      </Column>
+      <Column span={12}>
+        <Input
+          tabIndex={tabIndex}
+          id="AddressForm_city"
+          placeholder="Add city"
+          title="City"
+          value={address.city}
+          onChange={changeEventHandler("city")}
+          error={getError("city")}
+          data-test="AddressForm_city"
+        />
+      </Column>
+      <Column span={12}>
+        <Input
+          tabIndex={tabIndex}
+          id="AddressForm_region"
+          placeholder="Add State, province, or region"
+          title="State, province, or region"
+          autoCorrect="off"
+          value={address.region}
+          onChange={changeEventHandler("region")}
+          error={getError("region")}
+          data-test="AddressForm_region"
+        />
+      </Column>
       {showPhoneNumberInput && (
         <>
-          <Flex flexDirection="column">
+          <Column span={12}>
             <Input
               tabIndex={tabIndex}
               id="AddressForm_phoneNumber"
@@ -242,10 +236,10 @@ export const AddressForm: React.FC<AddressFormProps> = ({
               error={getError("phoneNumber")}
               data-test="AddressForm_phoneNumber"
             />
-          </Flex>
+          </Column>
           <Spacer y={2} />
         </>
       )}
-    </Join>
+    </GridColumns>
   )
 }

--- a/src/Components/AddressForm.tsx
+++ b/src/Components/AddressForm.tsx
@@ -120,7 +120,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_name"
-          placeholder="Add full name"
+          placeholder="Full name"
           title={billing ? "Name on card" : "Full name"}
           autoCorrect="off"
           value={address.name}
@@ -161,7 +161,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_addressLine1"
-          placeholder="Add street address"
+          placeholder="Street address"
           title="Address line 1"
           value={address.addressLine1}
           onChange={changeEventHandler("addressLine1")}
@@ -173,7 +173,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_addressLine2"
-          placeholder="Add apt, floor, suite, etc."
+          placeholder="Apt, floor, suite, etc."
           title="Address line 2 (optional)"
           value={address.addressLine2}
           onChange={changeEventHandler("addressLine2")}
@@ -185,7 +185,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_city"
-          placeholder="Add city"
+          placeholder="City"
           title="City"
           value={address.city}
           onChange={changeEventHandler("city")}
@@ -197,7 +197,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_region"
-          placeholder="Add state, province, or region"
+          placeholder="State, province, or region"
           title="State, province, or region"
           autoCorrect="off"
           value={address.region}
@@ -210,7 +210,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_postalCode"
-          placeholder="Add postal code"
+          placeholder="ZIP/postal code"
           title="Postal code"
           autoCapitalize="characters"
           autoCorrect="off"

--- a/src/Components/AddressForm.tsx
+++ b/src/Components/AddressForm.tsx
@@ -120,7 +120,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_name"
-          placeholder="Add full name"
+          placeholder="Full name"
           title={billing ? "Name on card" : "Full name"}
           autoCorrect="off"
           value={address.name}
@@ -161,7 +161,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_addressLine1"
-          placeholder="Add street address"
+          placeholder="Street address"
           title="Address line 1"
           value={address.addressLine1}
           onChange={changeEventHandler("addressLine1")}
@@ -173,8 +173,8 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         <Input
           tabIndex={tabIndex}
           id="AddressForm_addressLine2"
-          placeholder="Add apt, floor, suite, etc."
-          title="Address line 2 (optional)"
+          placeholder="Apt, floor, suite, etc. (optional)"
+          title="Address line 2"
           value={address.addressLine2}
           onChange={changeEventHandler("addressLine2")}
           error={getError("addressLine2")}
@@ -184,8 +184,33 @@ export const AddressForm: React.FC<AddressFormProps> = ({
       <Column span={12}>
         <Input
           tabIndex={tabIndex}
+          id="AddressForm_city"
+          placeholder="City"
+          title="City"
+          value={address.city}
+          onChange={changeEventHandler("city")}
+          error={getError("city")}
+          data-test="AddressForm_city"
+        />
+      </Column>
+      <Column span={6}>
+        <Input
+          tabIndex={tabIndex}
+          id="AddressForm_region"
+          placeholder="State, province, or region"
+          title="State, province, or region"
+          autoCorrect="off"
+          value={address.region}
+          onChange={changeEventHandler("region")}
+          error={getError("region")}
+          data-test="AddressForm_region"
+        />
+      </Column>
+      <Column span={6}>
+        <Input
+          tabIndex={tabIndex}
           id="AddressForm_postalCode"
-          placeholder="Add postal code"
+          placeholder="ZIP/Postal code"
           title="Postal code"
           autoCapitalize="characters"
           autoCorrect="off"
@@ -195,31 +220,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           data-test="AddressForm_postalCode"
         />
       </Column>
-      <Column span={12}>
-        <Input
-          tabIndex={tabIndex}
-          id="AddressForm_city"
-          placeholder="Add city"
-          title="City"
-          value={address.city}
-          onChange={changeEventHandler("city")}
-          error={getError("city")}
-          data-test="AddressForm_city"
-        />
-      </Column>
-      <Column span={12}>
-        <Input
-          tabIndex={tabIndex}
-          id="AddressForm_region"
-          placeholder="Add State, province, or region"
-          title="State, province, or region"
-          autoCorrect="off"
-          value={address.region}
-          onChange={changeEventHandler("region")}
-          error={getError("region")}
-          data-test="AddressForm_region"
-        />
-      </Column>
+
       {showPhoneNumberInput && (
         <>
           <Column span={12}>


### PR DESCRIPTION
The type of this PR is: **Refactor**

This PR solves [TX-1151]

### Description

This PR updates the layout for address forms in the checkout flow, in order to provide better UX after the input styles are updated in Palette. 

#### Address from scratch
<img width="1191" alt="Screenshot 2023-05-12 at 14 18 50" src="https://github.com/artsy/force/assets/42584148/a5969255-d563-408a-bb34-36d4a2dc53ce">

#### Additional address 
<img width="1184" alt="Screenshot 2023-05-12 at 14 25 22" src="https://github.com/artsy/force/assets/42584148/43d329d9-6a3f-4c53-91b6-8b0504aa6036">

#### Edit an address 
<img width="1187" alt="Screenshot 2023-05-12 at 14 25 35" src="https://github.com/artsy/force/assets/42584148/3acb3aeb-7d76-417c-94d3-a6e8cff58c4a">

#### Billling Address
<img width="873" alt="Screenshot 2023-05-15 at 11 02 39" src="https://github.com/artsy/force/assets/42584148/df545746-e475-40ee-97c0-07507cbada73">


[TX-1151]: https://artsyproduct.atlassian.net/browse/TX-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ