### PR TITLE
fix(artist): preserves query string

### DIFF
--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -293,7 +293,10 @@ export const artistRoutes: AppRouteConfig[] = [
         // Redirect all unhandled tabs to the artist page.
         path: ":tab?",
         render: ({ match }) => {
-          throw new RedirectException(`/artist/${match.params.artistID}`, 301)
+          throw new RedirectException(
+            `/artist/${match.params.artistID}${match.location.search}`,
+            301
+          )
         },
       },
     ],


### PR DESCRIPTION
Closes [GRO-1718](https://artsyproduct.atlassian.net/browse/GRO-1718)

[GRO-1718]: https://artsyproduct.atlassian.net/browse/GRO-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

We were unintentionally stripping out the query params on these redirects. This posed a particular problem for links that exist in emails, which would link to `/works-for-sale` routes with filters selected.