### PR TITLE
feat(TX-1168): update add new address button + collector profile cleanup

### DIFF
--- a/src/Apps/Order/Components/SavedAddresses.tsx
+++ b/src/Apps/Order/Components/SavedAddresses.tsx
@@ -1,20 +1,7 @@
-import {
-  Box,
-  Button,
-  RadioGroup,
-  BorderedRadio,
-  Spacer,
-  Flex,
-  Text,
-  Separator,
-  BorderBox,
-  Join,
-  Clickable,
-} from "@artsy/palette"
+import { Button, RadioGroup, BorderedRadio, Spacer } from "@artsy/palette"
 import { useEffect, useState } from "react"
 import * as React from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
-import styled from "styled-components"
 import { SavedAddresses_me$data } from "__generated__/SavedAddresses_me.graphql"
 import { AddressModal, ModalDetails } from "Apps/Order/Components/AddressModal"
 import { CommitMutation } from "Apps/Order/Utils/commitMutation"
@@ -36,7 +23,6 @@ interface SavedAddressesProps {
   onChangeAddressCount?: (active?: number) => void
   me: SavedAddresses_me$data
   onSelect?: (string) => void
-  inCollectorProfile: boolean
   commitMutation?: CommitMutation
   relay: RelayRefetchProp
   addressCount?: number
@@ -81,7 +67,6 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
     onSelect,
     onChangeAddressCount,
     me,
-    inCollectorProfile,
     relay,
     onAddressDelete,
     onAddressCreate,
@@ -168,112 +153,25 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
     })
   }
 
-  const collectorProfileAddressItems = addressList.map((address, index) => {
-    if (!address) {
-      return null
-    }
-
-    const isDefaultAddress = address.isDefault
-    return (
-      <BorderBox
-        p={2}
-        mb={2}
-        width={340}
-        flexDirection="column"
-        key={"addressIndex" + index}
-      >
-        <SavedAddressItem
-          index={index}
-          address={address}
-          handleClickEdit={() => handleEditAddress(address, index)}
-        />
-        <Box mt="auto">
-          <Separator my={2} />
-          <ModifyAddressWrapper width="100%">
-            {isDefaultAddress && (
-              <Box mr={[2, 1]}>
-                <Text textAlign="left" variant="sm">
-                  Default Address
-                </Text>
-              </Box>
-            )}
-            <Box ml="auto">
-              <Clickable
-                mr={[2, 1]}
-                textDecoration="underline"
-                data-test="editAddressInProfileClick"
-                onClick={() => handleEditAddress(address, index)}
-              >
-                <Text
-                  variant="sm"
-                  style={{
-                    cursor: "pointer",
-                  }}
-                  data-test="editAddressInProfile"
-                >
-                  Edit
-                </Text>
-              </Clickable>
-
-              <Clickable
-                textDecoration="underline"
-                data-test="deleteAddressInProfile"
-                onClick={() => handleDeleteAddress(address.internalID)}
-              >
-                <Text
-                  variant="sm"
-                  color="red100"
-                  style={{
-                    cursor: "pointer",
-                  }}
-                >
-                  Delete
-                </Text>
-              </Clickable>
-            </Box>
-          </ModifyAddressWrapper>
-        </Box>
-      </BorderBox>
-    )
-  })
-
   const addAddressButton = (
     <>
-      {inCollectorProfile ? (
+      {addressList.length > 0 && (
         <Button
-          mb={2}
           mt={[2, 4]}
-          data-test="profileButton"
+          mb={2}
+          data-test="shippingButton"
           variant="secondaryBlack"
           onClick={() => {
+            trackAddAddressClick()
             setShowAddressModal(true),
               setModalDetails({
-                addressModalTitle: "Add new address",
+                addressModalTitle: "Add address",
                 addressModalAction: "createUserAddress",
               })
           }}
         >
           Add a new address
         </Button>
-      ) : (
-        addressList.length > 0 && (
-          <Button
-            mt={[2, 4]}
-            mb={2}
-            data-test="shippingButton"
-            variant="secondaryBlack"
-            onClick={() => {
-              trackAddAddressClick()
-              setShowAddressModal(true),
-                setModalDetails({
-                  addressModalTitle: "Add address",
-                  addressModalAction: "createUserAddress",
-                })
-            }}
-          >
-            Add a new address
-          </Button>
-        )
       )}
       <AddressModal
         show={showAddressModal}
@@ -305,23 +203,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
     )
   })
 
-  return inCollectorProfile ? (
-    <>
-      <Flex flexWrap="wrap" flexDirection="row">
-        <Join separator={<Spacer x={2} />}>
-          {collectorProfileAddressItems.length ? (
-            collectorProfileAddressItems
-          ) : (
-            <Text color="black60" variant="sm">
-              Please add an address for a faster checkout experience in the
-              future.
-            </Text>
-          )}
-        </Join>
-      </Flex>
-      {addAddressButton}
-    </>
-  ) : (
+  return (
     <>
       <RadioGroup
         onSelect={onSelect}
@@ -335,11 +217,6 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
     </>
   )
 }
-
-const ModifyAddressWrapper = styled(Flex)`
-  align-self: flex-end;
-  justify-content: space-between;
-`
 
 export const SavedAddressesFragmentContainer = createRefetchContainer(
   SavedAddresses,

--- a/src/Apps/Order/Components/SavedAddresses.tsx
+++ b/src/Apps/Order/Components/SavedAddresses.tsx
@@ -1,4 +1,4 @@
-import { Button, RadioGroup, BorderedRadio, Spacer } from "@artsy/palette"
+import { RadioGroup, BorderedRadio, Spacer, Clickable } from "@artsy/palette"
 import { useEffect, useState } from "react"
 import * as React from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
@@ -15,6 +15,8 @@ import { UpdateUserAddressMutation$data } from "__generated__/UpdateUserAddressM
 import { CreateUserAddressMutation$data } from "__generated__/CreateUserAddressMutation.graphql"
 import { useTracking } from "react-tracking"
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import styled from "styled-components"
+import { themeGet } from "@styled-system/theme-get"
 
 export const NEW_ADDRESS = "NEW_ADDRESS"
 const PAGE_SIZE = 30
@@ -156,11 +158,9 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
   const addAddressButton = (
     <>
       {addressList.length > 0 && (
-        <Button
-          mt={[2, 4]}
-          mb={2}
+        <AddAddressButton
+          mt={2}
           data-test="shippingButton"
-          variant="secondaryBlack"
           onClick={() => {
             trackAddAddressClick()
             setShowAddressModal(true),
@@ -171,7 +171,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
           }}
         >
           Add a new address
-        </Button>
+        </AddAddressButton>
       )}
       <AddressModal
         show={showAddressModal}
@@ -211,7 +211,6 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
       >
         {addressItems}
       </RadioGroup>
-      <Spacer y={14} />
       {addAddressButton}
       <Spacer y={4} />
     </>
@@ -265,3 +264,10 @@ export const SavedAddressesFragmentContainer = createRefetchContainer(
     }
   `
 )
+
+const AddAddressButton = styled(Clickable)`
+  text-decoration: underline;
+  &:hover {
+    color: ${themeGet("colors.blue100")};
+  }
+`

--- a/src/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
@@ -61,7 +61,7 @@ describe("Saved Addresses", () => {
           addressConnection: mockAddressConnection,
         }),
       })
-      const button = wrapper.find("Button[data-test='shippingButton']")
+      const button = wrapper.find("[data-test='shippingButton']").first()
       const modal = wrapper.find(AddressModal)
       expect(modal.props().show).toBe(false)
       button.simulate("click")
@@ -75,7 +75,7 @@ describe("Saved Addresses", () => {
           addressConnection: mockAddressConnection,
         }),
       })
-      const button = wrapper.find("Button[data-test='shippingButton']")
+      const button = wrapper.find("[data-test='shippingButton']").first()
       expect(wrapper.find(AddressModal).props().show).toBe(false)
       button.simulate("click")
 
@@ -93,7 +93,9 @@ describe("Saved Addresses", () => {
           addressConnection: mockAddressConnection,
         }),
       })
-      expect(wrapper.find("Button[data-test='shippingButton']")).toHaveLength(1)
+      expect(wrapper.find("[data-test='shippingButton']").first()).toHaveLength(
+        1
+      )
     })
 
     describe("when clicking on the add address button", () => {
@@ -104,7 +106,7 @@ describe("Saved Addresses", () => {
           }),
         })
 
-        wrapper.find("Button[data-test='shippingButton']").simulate("click")
+        wrapper.find("[data-test='shippingButton']").first().simulate("click")
 
         expect(trackEvent).toHaveBeenCalled()
         expect(trackEvent.mock.calls[0]).toMatchInlineSnapshot(`

--- a/src/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
@@ -1,7 +1,6 @@
 import { graphql } from "react-relay"
 import { SavedAddressesFragmentContainer } from "./../SavedAddresses"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
-import { BorderBox } from "@artsy/palette"
 import { AddressModal } from "Apps/Order/Components/AddressModal"
 import { RootTestPage } from "DevTools/RootTestPage"
 import { userAddressMutation } from "Apps/__tests__/Fixtures/Order/MutationResults"
@@ -16,29 +15,24 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
 
 class SavedAddressesTestPage extends RootTestPage {
   async selectEdit() {
-    this.find(`[data-test="addressModal"]`).simulate("click")
+    this.find(`[data-test="editAddressInShipping"]`)
+      .first()
+      .simulate("click", { preventDefault: () => {} })
     await this.update()
   }
 }
 
 describe("Saved Addresses", () => {
   const trackEvent = jest.fn()
-  let inCollectorProfile
 
   beforeAll(() => {
     ;(useTracking as jest.Mock).mockImplementation(() => ({
       trackEvent,
     }))
-    inCollectorProfile = true
   })
 
   const { getWrapper } = setupTestWrapper({
-    Component: (props: any) => (
-      <SavedAddressesFragmentContainer
-        inCollectorProfile={inCollectorProfile}
-        {...props}
-      />
-    ),
+    Component: (props: any) => <SavedAddressesFragmentContainer {...props} />,
     query: graphql`
       query SavedAddressesMutation_Test_Query @relay_test_operation {
         me {
@@ -52,113 +46,15 @@ describe("Saved Addresses", () => {
     it("edits the saved addresses after calling edit address mutation", async () => {
       const wrapper = getWrapper({ Me: () => userAddressMutation.me })
       const page = new SavedAddressesTestPage(wrapper)
-      const editButton = page
-        .find(`[data-test="editAddressInProfileClick"]`)
-        .first()
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-      editButton
-        .props()
-        .onClick(userAddressMutation.me.addressConnection.edges[0].node as any)
+      page.selectEdit()
       const addresses = page.find(SavedAddressItem).first().text()
-
       expect(addresses).toBe(
         "Test Name1 Main StMadrid, Spain, 28001555-555-5555Edit"
       )
     })
   })
 
-  describe("SavedAddresses in collector profile", () => {
-    it("renders modal when button is clicked", () => {
-      const wrapper = getWrapper({
-        Me: () => ({
-          addressConnection: mockAddressConnection,
-        }),
-      })
-      const button = wrapper.find("Button[data-test='profileButton']")
-      const modal = wrapper.find(AddressModal)
-      expect(modal.props().show).toBe(false)
-      button.simulate("click")
-
-      expect(modal).toHaveLength(1)
-    })
-
-    it("add address modal with expected props", async () => {
-      const wrapper = getWrapper({
-        Me: () => ({
-          addressConnection: mockAddressConnection,
-        }),
-      })
-
-      const button = wrapper.find("Button[data-test='profileButton']")
-      expect(wrapper.find(AddressModal).props().show).toBe(false)
-      button.simulate("click")
-
-      expect(wrapper.find(AddressModal).props().modalDetails).toEqual({
-        addressModalTitle: "Add new address",
-        addressModalAction: "createUserAddress",
-      })
-    })
-
-    it("edit address modal with expected props", () => {
-      const wrapper = getWrapper({
-        Me: () => ({
-          addressConnection: mockAddressConnection,
-        }),
-      })
-      const button = wrapper.find({ "data-test": "editAddressInProfile" }).at(0)
-      expect(wrapper.find(AddressModal).props().show).toBe(false)
-      button.simulate("click")
-
-      expect(wrapper.find(AddressModal).props().modalDetails).toEqual({
-        addressModalTitle: "Edit address",
-        addressModalAction: "editUserAddress",
-      })
-    })
-
-    it("render an add address button", () => {
-      const wrapper = getWrapper({
-        Me: () => ({
-          addressConnection: mockAddressConnection,
-        }),
-      })
-      expect(wrapper.find("Button[data-test='profileButton']")).toHaveLength(1)
-    })
-
-    describe("when clicking on the add address button", () => {
-      it("does not track an analytics event", () => {
-        const wrapper = getWrapper({
-          Me: () => ({
-            addressConnection: mockAddressConnection,
-          }),
-        })
-
-        wrapper.find("Button[data-test='profileButton']").simulate("click")
-
-        expect(trackEvent).not.toHaveBeenCalled()
-      })
-    })
-
-    it("renders addresses", () => {
-      const wrapper = getWrapper({
-        Me: () => ({
-          addressConnection: mockAddressConnection,
-        }),
-      })
-      const addresses = wrapper.find(BorderBox)
-
-      expect(addresses).toHaveLength(2)
-      expect(addresses.map(address => address.text())).toEqual([
-        "Test Name1 Main StMadrid, Spain, 28001555-555-5555EditEditDelete",
-        "Test Name401 BroadwayFloor 25New York, NY, USA, 10013422-424-4242EditDefault AddressEditDelete",
-      ])
-    })
-  })
-
-  describe("SavedAddresses outside collector profile", () => {
-    beforeEach(() => {
-      inCollectorProfile = false
-    })
-
+  describe("Saved Addresses", () => {
     it("renders modal when button is clicked", () => {
       const wrapper = getWrapper({
         Me: () => ({

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -644,7 +644,6 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                 me={props.me}
                 selectedAddress={selectedAddressID}
                 onSelect={selectSavedAddressWithTracking}
-                inCollectorProfile={false}
                 onAddressDelete={handleAddressDelete}
                 onAddressCreate={handleAddressCreate}
                 onAddressEdit={handleAddressEdit}


### PR DESCRIPTION
The type of this PR is: **Feature/Refactor**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TX-1168]

### Description

This PR changes the "add a new address" button on the shipping page to a clickable text button from a standard button. 

I also went ahead and removed the `inCollectorProfile` logic and components from `SavedAddresses.tsx` as it is no longer used. 

<img width="1263" alt="Screenshot 2023-05-15 at 4 12 02 PM" src="https://github.com/artsy/force/assets/50849237/7009906d-7285-4f8c-b70d-8e59a55e4dc3">

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-1168]: https://artsyproduct.atlassian.net/browse/TX-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ