### PR TITLE
fix: cascading bids banner link has :visited state making it invisible

### DIFF
--- a/src/Components/CascadingEndTimesBanner.tsx
+++ b/src/Components/CascadingEndTimesBanner.tsx
@@ -26,7 +26,7 @@ const CascadingEndTimesBanner: React.FC<CascadingEndTimesBannerProps> = ({
       {!!helpArticleLink && (
         <>
           &nbsp;
-          <RouterLink inline target="_blank" to={helpArticleLink}>
+          <RouterLink target="_blank" to={helpArticleLink}>
             Learn More
           </RouterLink>
         </>


### PR DESCRIPTION
The type of this PR is: **fix**

This PR solves [TX-1196](https://artsyproduct.atlassian.net/browse/TX-1196?atlOrigin=eyJpIjoiYTAxNjUzNDU5ZDBiNDQ0ZGJlNTA0Y2JmMDc2NzBmNDYiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

### Description
Broken:
![image](https://github.com/artsy/force/assets/9088720/a865eaf5-f52d-4dda-a424-f8662812eac3)

Fixed:
![image](https://github.com/artsy/force/assets/9088720/647c0bbc-a75a-4db5-b2f7-e4ebe835db84)


[TX-1196]: https://artsyproduct.atlassian.net/browse/TX-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ