### PR TITLE
feat(artwork lists): improve name handling

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/EditArtworkListModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/EditArtworkListModal.jest.tsx
@@ -142,7 +142,7 @@ describe("EditArtworkListModal", () => {
     fireEvent.click(saveButton)
 
     await waitFor(() => {
-      expect(screen.getByText("name cannot be empty")).toBeInTheDocument()
+      expect(screen.getByText("Name cannot be empty")).toBeInTheDocument()
     })
   })
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/EditArtworkListModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/__tests__/EditArtworkListModal.jest.tsx
@@ -126,6 +126,26 @@ describe("EditArtworkListModal", () => {
     )
   })
 
+  it("prevents empty names", async () => {
+    render(
+      <EditArtworkListModal
+        artworkList={artworkList}
+        onClose={closeEditModal}
+      />
+    )
+    const { nameInputField, saveButton } = setup()
+
+    fireEvent.change(nameInputField, {
+      target: { value: "   " },
+    })
+
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(screen.getByText("name cannot be empty")).toBeInTheDocument()
+    })
+  })
+
   it("disables Save button until form is dirty", async () => {
     render(
       <EditArtworkListModal

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
@@ -14,6 +14,7 @@ export const MAX_NAME_LENGTH = 40
 export const validationSchema = Yup.object().shape({
   name: Yup.string()
     .required(i18n.t("collectorSaves.artworkListForm.fields.name.required"))
+    .matches(/\S+/, { message: "name cannot be empty" })
     .max(MAX_NAME_LENGTH),
 })
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListForm/ArtworkListForm.tsx
@@ -14,7 +14,9 @@ export const MAX_NAME_LENGTH = 40
 export const validationSchema = Yup.object().shape({
   name: Yup.string()
     .required(i18n.t("collectorSaves.artworkListForm.fields.name.required"))
-    .matches(/\S+/, { message: "name cannot be empty" })
+    .matches(/\S+/, {
+      message: i18n.t("collectorSaves.artworkListForm.fields.name.nonempty"),
+    })
     .max(MAX_NAME_LENGTH),
 })
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal.tsx
@@ -69,7 +69,7 @@ export const CreateNewListModal: React.FC<CreateNewListModalProps> = ({
     try {
       const { createCollection } = await submitMutation({
         variables: {
-          input: { name: values.name },
+          input: { name: values.name.trim() },
         },
         rejectIf: response => {
           const result = response.createCollection?.responseOrError

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/CreateNewListModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/CreateNewListModal.jest.tsx
@@ -161,4 +161,28 @@ describe("CreateNewListModal", () => {
       })
     )
   })
+
+  it("trims extra whitespace", async () => {
+    render(<TestComponent />)
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: {
+        value: "  Foo Bar  ",
+      },
+    })
+
+    fireEvent.click(screen.getByText("Create List"))
+
+    await waitFor(() =>
+      expect(submitMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: {
+            input: {
+              name: "Foo Bar",
+            },
+          },
+        })
+      )
+    )
+  })
 })

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/CreateNewListModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/CreateNewListModal.jest.tsx
@@ -198,7 +198,7 @@ describe("CreateNewListModal", () => {
     fireEvent.click(screen.getByText("Create List"))
 
     await waitFor(() => {
-      expect(screen.getByText("name cannot be empty")).toBeInTheDocument()
+      expect(screen.getByText("Name cannot be empty")).toBeInTheDocument()
     })
   })
 })

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/CreateNewListModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/CreateNewListModal.jest.tsx
@@ -185,4 +185,20 @@ describe("CreateNewListModal", () => {
       )
     )
   })
+
+  it("prevents empty names", async () => {
+    render(<TestComponent />)
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: {
+        value: "   ",
+      },
+    })
+
+    fireEvent.click(screen.getByText("Create List"))
+
+    await waitFor(() => {
+      expect(screen.getByText("name cannot be empty")).toBeInTheDocument()
+    })
+  })
 })

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -189,6 +189,7 @@
           },
           "placeholder": "E.g. Photography, Warhol, etc.",
           "required": "Name is required",
+          "nonempty": "Name cannot be empty",
           "remainingCharactersCount_one": "{{count}} character remaining",
           "remainingCharactersCount_other": "{{count}} characters remaining"
 


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [FX-4704] and [FX-4740]

### Description

This introduces two further client-side behaviors to the Artwork List name field:

- leading and trailing whitespaces are trimmed before submitting, on create (this behavior [already existed](https://github.com/artsy/force/blob/e4e9939edf84ce200774a9fa4cee4347eab20a66/src/Apps/CollectorProfile/Routes/Saves2/Components/Actions/EditArtworkListModal.tsx#L57) on edit) — [89e2446](https://github.com/artsy/force/pull/12435/commits/89e2446ffc4fde78525d22935ff939c1b169bbfc)

- the name field is validated to be non-empty — [456e05b](https://github.com/artsy/force/pull/12435/commits/456e05bcbaced399a9ee054f095ae504c31f39f4)

The screencap below demonstrates an empty name being rejected, and then a name with  whitespace being trimmed:

https://github.com/artsy/force/assets/140521/5c2cbdab-0780-4123-b487-8aa517c323e4


[FX-4704]: https://artsyproduct.atlassian.net/browse/FX-4704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4740]: https://artsyproduct.atlassian.net/browse/FX-4740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ