### PR TITLE
fix(artwork lists): improve a11y by making focus visible

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListItem.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListItem.tsx
@@ -4,10 +4,11 @@ import { StackedImageLayout } from "./Images/StackedImageLayout"
 import { FC } from "react"
 import { useTranslation } from "react-i18next"
 import { createFragmentContainer, graphql } from "react-relay"
-import { RouterLink } from "System/Router/RouterLink"
+import { RouterLink, RouterLinkProps } from "System/Router/RouterLink"
 import { extractNodes } from "Utils/extractNodes"
 import { ArtworkListItem_item$data } from "__generated__/ArtworkListItem_item.graphql"
 import { BASE_SAVES_PATH } from "Apps/CollectorProfile/constants"
+import styled from "styled-components"
 
 interface ArtworkListItemProps {
   isSelected?: boolean
@@ -15,11 +16,8 @@ interface ArtworkListItemProps {
   item: ArtworkListItem_item$data
 }
 
-const ArtworkListItem: FC<ArtworkListItemProps> = ({
-  isSelected,
-  imagesLayout,
-  item,
-}) => {
+const ArtworkListItem: FC<ArtworkListItemProps> = props => {
+  const { isSelected, imagesLayout, item } = props
   const { t } = useTranslation()
   const artworkNodes = extractNodes(item.artworksConnection)
   const imageURLs = artworkNodes.map(node => node.image?.url ?? null)
@@ -33,21 +31,18 @@ const ArtworkListItem: FC<ArtworkListItemProps> = ({
   }
 
   return (
-    <RouterLink
+    <ArtworkListItemLink
       to={getLink()}
       textDecoration="none"
       aria-current={!!isSelected}
+      isSelected={!!isSelected}
     >
       <Flex
         p={1}
         width={[138, 222]}
         height={[188, 272]}
-        border="1px solid"
-        borderRadius={10}
         flexDirection="column"
         justifyContent="space-between"
-        borderColor={isSelected ? "brand" : "transparent"}
-        style={isSelected ? { boxShadow: DROP_SHADOW } : undefined}
       >
         {imagesLayout === "stacked" ? (
           <StackedImageLayout imageURLs={imageURLs} />
@@ -66,7 +61,7 @@ const ArtworkListItem: FC<ArtworkListItemProps> = ({
           </Text>
         </Box>
       </Flex>
-    </RouterLink>
+    </ArtworkListItemLink>
   )
 }
 
@@ -92,3 +87,18 @@ export const ArtworkListItemFragmentContainer = createFragmentContainer(
     `,
   }
 )
+
+interface ArtworkListItemLinkProps extends RouterLinkProps {
+  isSelected: boolean
+}
+
+const ArtworkListItemLink = styled<ArtworkListItemLinkProps>(RouterLink)`
+  /* always */
+  border-radius: 10px;
+  margin-top: 2px; // otherwise top borders get cut off
+  display: block; // otherwise the child element collapses without a visible focus outline
+
+  /* when this list is currently being viewed (isSelected) */
+  border: solid 1px ${props => (!!props.isSelected ? "black" : "transparent")};
+  box-shadow: ${props => (!!props.isSelected ? DROP_SHADOW : "none")};
+`


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [FX-4722]

Review app: https://fx-4722-a11y.artsy.net/

### Description

Restores the focus styles that were missing when you navigated the Artwork Lists rail via keyboard.

This required moving the styling from the `Flex` to the containing `RouterLink`, and giving it `display: block` to fix the collapsed focus outline problem.

Both of the screencaps below show the results of keyboard navigation: navigating with `Tab` and selecting with `Enter`.

|Before|After|
|---|---|
| <video src="https://github.com/artsy/force/assets/140521/90cceef1-2b85-4ae2-bdb5-1fa1b5eeaebc" /> | <video src="https://github.com/artsy/force/assets/140521/fef166a7-7134-4744-bb03-5e17e86a60a9" /> |

The Artwork List cards _were_ in fact already focusable and tabbable, as you can see in the **Before** screencap above.

But they didn't display the customary `focus-visible` outline until the `display: block` fix, visible in the **After** screencap.

[FX-4722]: https://artsyproduct.atlassian.net/browse/FX-4722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ