### PR TITLE
chore: add error message event tracking for payment step

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "superagent": "3.8.3"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.126.0",
+    "@artsy/cohesion": "4.127.0",
     "@artsy/commerce_helpers": "artsy/commerce_helpers",
     "@artsy/detect-responsive-traits": "^0.1.0",
     "@artsy/eigen-web-association": "^1.6.0",

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -237,6 +237,17 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
       if (result?.type === "invalid_form") return
 
       if (result?.type === "error") {
+        trackEvent({
+          action: ActionType.errorMessageViewed,
+          context_owner_type: OwnerType.ordersPayment,
+          context_owner_id: props.order.internalID,
+          title: result.error,
+          message:
+            "Please enter another payment method or contact your bank for more information.",
+          error_code: null,
+          flow: "user sets credit card as payment method",
+        })
+
         props.dialog.showErrorDialog({
           title: result.error,
           message:
@@ -246,6 +257,17 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
       }
 
       if (result?.type === "internal_error") {
+        trackEvent({
+          action: ActionType.errorMessageViewed,
+          context_owner_type: OwnerType.ordersPayment,
+          context_owner_id: props.order.internalID,
+          title: "An internal error occurred",
+          message:
+            "Something went wrong. Please try again or contact order@artsy.net",
+          error_code: null,
+          flow: "user sets credit card as payment method",
+        })
+
         props.dialog.showErrorDialog({
           title: "An internal error occurred",
         })
@@ -274,6 +296,18 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     } catch (error) {
       setIsSavingPayment(false)
       handlePaymentError(error)
+
+      trackEvent({
+        action: ActionType.errorMessageViewed,
+        context_owner_type: OwnerType.ordersPayment,
+        context_owner_id: props.order.internalID,
+        title: "An error occurred",
+        message:
+          "Something went wrong. Please try again or contact order@artsy.net",
+        error_code: null,
+        flow: "user sets credit card as payment method",
+      })
+
       props.dialog.showErrorDialog()
     }
   }
@@ -299,6 +333,18 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     } catch (error) {
       handlePaymentError(error)
       setIsSavingPayment(false)
+
+      trackEvent({
+        action: ActionType.errorMessageViewed,
+        context_owner_type: OwnerType.ordersPayment,
+        context_owner_id: props.order.internalID,
+        title: "An error occurred",
+        message:
+          "Something went wrong. Please try again or contact order@artsy.net",
+        error_code: null,
+        flow: "user sets wire transfer as payment method",
+      })
+
       props.dialog.showErrorDialog()
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,10 +31,10 @@
     lodash "^4.17.21"
     prettier "^1.19.1"
 
-"@artsy/cohesion@4.126.0":
-  version "4.126.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.126.0.tgz#70ef2c62c9207780437e06b8e0b82ad02c019432"
-  integrity sha512-liqP/wwE+gB/++zGmNXCavTHJjkJ+zzDWkU7gKMfPJBZVgqt5L3XgPduQ0hypSs9BsWqYE5Ubkvy5dlVwSeuow==
+"@artsy/cohesion@4.127.0":
+  version "4.127.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.127.0.tgz#3c69923db08dbef79f7d7c83c70463578b86d3da"
+  integrity sha512-8FS/2v2Y6/BCxs56supfzLB0LOXH5CB417moUJ3jWKnZXStzfT+ecXvr6+hw8eBnkrrrW1FzsMZISDZ7oZvwdw==
   dependencies:
     core-js "3"
 


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->
Paired with @iskounen 

This PR adds the new `errorMessageViewed` [event](https://github.com/artsy/cohesion/pull/431) to the payments order route whenever a user views an error dialog. 



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ