### PR TITLE
fix(NX-3543): hide banner when personalized message

### DIFF
--- a/src/Components/Inquiry/Views/InquiryInquiry.tsx
+++ b/src/Components/Inquiry/Views/InquiryInquiry.tsx
@@ -46,7 +46,7 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
   const { submitArtworkInquiryRequest } = useArtworkInquiryRequest()
 
   const handleTextAreaChange = ({ value }: { value: string }) => {
-    if (mode === "Confirm" && !AUTOMATED_MESSAGES.includes(inquiry.message)) {
+    if (mode === "Confirm" && !AUTOMATED_MESSAGES.includes(value)) {
       setMode("Pending")
     }
 


### PR DESCRIPTION
The type of this PR is: FIX

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [NX-3543](https://artsyproduct.atlassian.net/browse/NX-3543)

### Description

Hides banner when we add a personalised message.
<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NX-3543]: https://artsyproduct.atlassian.net/browse/NX-3543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ