### PR TITLE
fix: Check for presence of shippingTotalCents and not numeric value

### DIFF
--- a/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -193,7 +193,7 @@ export const TransactionDetailsSummaryItem: FC<TransactionDetailsSummaryItemProp
     const offer = getOffer()
 
     return (
-      offer?.shippingTotalCents &&
+      !!offer?.shippingTotalCents &&
       order.requestedFulfillment?.__typename === "CommerceShipArta" &&
       offerStillInNegotiation()
     )


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description

Fix for the rogue `0` that gets returned as part of order screens if the order is PICKUP (aka shipping is `0.00`)

<img width="1746" alt="Screen Shot 2023-05-30 at 9 36 12 AM" src="https://github.com/artsy/force/assets/12748344/3ccb66b6-79fe-47e6-be01-e758e7787ab7">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ