### PR TITLE
fix(artist): update smoke test to match latest meta description format

### DIFF
--- a/cypress/e2e/artist.cy.js
+++ b/cypress/e2e/artist.cy.js
@@ -11,7 +11,7 @@ describe("/artist/:id", () => {
       .should("have.attr", "content")
       .and(
         "contain",
-        "Find the latest shows, biography, and artworks for sale by Pablo Picasso."
+        "Explore Pablo Picasso’s biography, achievements, artworks, auction results, and shows on Artsy."
       )
   })
 


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

https://github.com/artsy/metaphysics/pull/5024 changed the format of the description `<meta>` tag on that artist page. 

That needs to be reflected in the smoke test that sits inside of Force (this is currently causing all Force builds to fail in CI).
