### PR TITLE
feat: disable experimental fetch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -220,4 +220,4 @@ COPY --chown=deploy:deploy --from=builder /app/server.dist.js.map .
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # TODO: Reduce production memory, this is not a concern
-CMD ["node", "--max_old_space_size=2048", "--heapsnapshot-signal=SIGUSR2", "./server.dist.js"]
+CMD ["node", "--max_old_space_size=2048", "--heapsnapshot-signal=SIGUSR2", "--no-experimental-fetch", "./server.dist.js"]

--- a/scripts/jest.sh
+++ b/scripts/jest.sh
@@ -8,6 +8,7 @@ NODE_ENV=test
 node \
   --expose-gc \
   --max_old_space_size=4096 \
+  --no-experimental-fetch \
   ./node_modules/.bin/jest \
     --logHeapUsage \
     --maxWorkers 2 \

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,5 +13,5 @@ if [ "${NODE_ENV}" != "production" ]; then
 
   yarn concurrently 'yarn relay --watch' 'node --max_old_space_size=3072 ./src/dev.js'
 else
-  exec node "${OPT[@]}" ./server.dist.js
+  exec node "${OPT[@]}" --no-experimental-fetch ./server.dist.js
 fi


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PLATFORM-5149](https://artsyproduct.atlassian.net/browse/PLATFORM-5149)

### Description

<!-- Implementation description -->

To fix [distributed downstream tracing in datadog](https://github.com/DataDog/dd-trace-js/issues/2388) we are going to disable the [experimental fetch API](https://nodejs.org/en/blog/announcements/v18-release-announce#fetch-experimental) that is enabled by default in node v18+.

Force uses [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch) and so disabling this experimental feature should have no bearing on the application except that it will fix distributed tracing that has been not working since the runtime upgrade.

[Review app](https://disable-experimental-fetch.artsy.net/)


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLATFORM-5149]: https://artsyproduct.atlassian.net/browse/PLATFORM-5149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ