### PR TITLE
fix(usesizeandposition): ensures that if node is added after hook is set up; we still get geometry

### DIFF
--- a/src/Utils/Hooks/useSizeAndPosition.ts
+++ b/src/Utils/Hooks/useSizeAndPosition.ts
@@ -1,4 +1,5 @@
 import {
+  useDidMount,
   useIsomorphicLayoutEffect,
   useMutationObserver,
   useResizeObserver,
@@ -60,6 +61,19 @@ export const useSizeAndPosition = ({
           handleUpdate()
         }
       })
+    },
+  })
+
+  // Ensures that if the node is mounted after the hook is called,
+  // we still update the geometry.
+  const isMounted = useDidMount()
+  useMutationObserver({
+    element: isMounted ? document.body : null,
+    onMutate: (_mutations, observer) => {
+      if (document.contains(ref.current)) {
+        handleUpdate()
+        observer.disconnect()
+      }
     },
   })
 


### PR DESCRIPTION
Cherry-picking off https://github.com/artsy/force/pull/12280 so that the PR is clean in case of revert.