### PR TITLE
chore: replace zendesk link in buyer guarantee page with SF one

### DIFF
--- a/src/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -33,7 +33,7 @@ import MoneyBackIcon from "@artsy/icons/MoneyBackIcon"
 import MessageIcon from "@artsy/icons/MessageIcon"
 
 const SUPPORT_ARTICLE_URL =
-  "https://support.artsy.net/hc/en-us/articles/360048946973"
+  "https://support.artsy.net/s/article/The-Artsy-Guarantee"
 
 export const BuyerGuaranteeIndex: FC = () => {
   const { jumpTo } = useJump({ behavior: "smooth" })


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description

<!-- Implementation description -->
See slack thread:
https://artsy.slack.com/archives/C04U9SJ5A0K/p1685979530945009

cc @artsy/negotiate-devs 

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ