### PR TITLE
[WIP] feat: send identity verification request to unverified users for orders above 10K (PRO-148)

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -135,7 +135,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
           o => o.lineItems?.edges?.[0]?.node?.artwork?.slug
         )
 
-        requestIdentityVerificationIfNecessary(order)
+        await requestIdentityVerificationIfNecessary(order)
 
         if (isEigen) {
           if (order.mode === "OFFER") {

--- a/src/Apps/Order/Utils/__tests__/orderUtils.jest.ts
+++ b/src/Apps/Order/Utils/__tests__/orderUtils.jest.ts
@@ -1,4 +1,8 @@
-import { getInitialPaymentMethodValue, isPaymentSet } from "./../orderUtils"
+import {
+  getInitialPaymentMethodValue,
+  isIdentityVerificationRequired,
+  isPaymentSet,
+} from "./../orderUtils"
 import {
   CommercePaymentMethodEnum,
   Payment_order$data,
@@ -95,5 +99,39 @@ describe("order utils", () => {
         ).toEqual("WIRE_TRANSFER")
       })
     })
+  })
+})
+
+describe("isIdentityVerificationRequired", () => {
+  it("returns false if isIdentityVerified is true", () => {
+    expect(isIdentityVerificationRequired(true, "USD", 1000000)).toEqual(false)
+  })
+
+  it("returns false if currencyCode is not USD, GBP, or EUR", () => {
+    expect(isIdentityVerificationRequired(false, "JPY", null)).toEqual(false)
+  })
+
+  it("returns false if buyerTotalCents is null", () => {
+    expect(isIdentityVerificationRequired(false, "USD", null)).toEqual(false)
+  })
+
+  it("returns false if buyerTotalCents is below 1000000", () => {
+    expect(isIdentityVerificationRequired(false, "USD", 900000)).toEqual(false)
+  })
+
+  it("returns true if buyerTotalCents equals 1000000", () => {
+    expect(isIdentityVerificationRequired(false, "USD", 1000000)).toEqual(true)
+  })
+
+  it("returns true if buyerTotalCents is above USD 1000000", () => {
+    expect(isIdentityVerificationRequired(false, "USD", 10000000)).toEqual(true)
+  })
+
+  it("returns true if buyerTotalCents is above GBP 1000000", () => {
+    expect(isIdentityVerificationRequired(false, "GBP", 10000000)).toEqual(true)
+  })
+
+  it("returns true if buyerTotalCents is above EUR 1000000", () => {
+    expect(isIdentityVerificationRequired(false, "EUR", 10000000)).toEqual(true)
   })
 })

--- a/src/Apps/Order/Utils/orderUtils.ts
+++ b/src/Apps/Order/Utils/orderUtils.ts
@@ -55,3 +55,16 @@ export const getInitialBankAccountSelection = (
       : { type: "new" }
   }
 }
+
+export const isIdentityVerificationRequired = (
+  isIdentityVerified: boolean | null,
+  currencyCode: string,
+  buyerTotalCents: number | null
+): boolean => {
+  return (
+    !isIdentityVerified &&
+    !!buyerTotalCents &&
+    buyerTotalCents >= 1000000 &&
+    ["USD", "GBP", "EUR"].includes(currencyCode)
+  )
+}

--- a/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileFields.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileFields.tsx
@@ -33,7 +33,10 @@ import { useUpdateMyUserProfile } from "Utils/Hooks/Mutations/useUpdateMyUserPro
 import { SettingsEditProfileFields_me$data } from "__generated__/SettingsEditProfileFields_me.graphql"
 import { EditableLocation } from "__generated__/useUpdateMyUserProfileMutation.graphql"
 import { RouterLink } from "System/Router/RouterLink"
-import { useVerifyID } from "Apps/Settings/Routes/EditProfile/Mutations/useVerifyID"
+import {
+  defaultVerifyIDMutationProps,
+  useVerifyID,
+} from "Apps/Settings/Routes/EditProfile/Mutations/useVerifyID"
 import { useVerifyEmail } from "Apps/Settings/Routes/EditProfile/Mutations/useVerifyEmail"
 import createLogger from "Utils/logger"
 import CheckmarkStrokeIcon from "@artsy/icons/CheckmarkStrokeIcon"
@@ -250,13 +253,9 @@ const SettingsEditProfileFields: React.FC<SettingsEditProfileFieldsProps> = ({
 
                       try {
                         // no input, user is derived from the authenticated MP loader context
-                        await submitVerifyIDMutation({
-                          variables: { input: {} },
-                          rejectIf: res => {
-                            return res.sendIdentityVerificationEmail
-                              ?.confirmationOrError?.mutationError
-                          },
-                        })
+                        await submitVerifyIDMutation(
+                          defaultVerifyIDMutationProps
+                        )
 
                         sendToast({
                           variant: "success",

--- a/src/Apps/Settings/Routes/EditProfile/Mutations/useVerifyID.ts
+++ b/src/Apps/Settings/Routes/EditProfile/Mutations/useVerifyID.ts
@@ -29,3 +29,10 @@ export const useVerifyID = () => {
     `,
   })
 }
+
+export const defaultVerifyIDMutationProps = {
+  variables: { input: {} },
+  rejectIf: res => {
+    return res.sendIdentityVerificationEmail?.confirmationOrError?.mutationError
+  },
+}

--- a/src/__generated__/ReviewTestQuery.graphql.ts
+++ b/src/__generated__/ReviewTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7fc565183ff8bf031c73d178aeacd464>>
+ * @generated SignedSource<<b0cefb52bcbdfeaf68463a93743d6a62>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,6 +28,7 @@ export type ReviewTestQuery$rawResponse = {
     readonly __isCommerceOrder: "CommerceOfferOrder";
     readonly artworkDetails: string | null;
     readonly buyerTotal: string | null;
+    readonly buyerTotalCents: number | null;
     readonly code: string;
     readonly conditionsOfSale: string | null;
     readonly currencyCode: string;
@@ -211,6 +212,7 @@ export type ReviewTestQuery$rawResponse = {
     readonly __isCommerceOrder: string;
     readonly artworkDetails: string | null;
     readonly buyerTotal: string | null;
+    readonly buyerTotalCents: number | null;
     readonly code: string;
     readonly conditionsOfSale: string | null;
     readonly currencyCode: string;
@@ -387,17 +389,24 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "buyerTotalCents",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v3 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "precision",
     "value": 2
   }
 ],
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
@@ -422,21 +431,21 @@ v4 = {
   ],
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v7 = [
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -445,76 +454,69 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "price",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "InlineFragment",
   "selections": [
-    (v5/*: any*/)
+    (v6/*: any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v10 = {
+v11 = {
   "alias": null,
-  "args": (v3/*: any*/),
+  "args": (v4/*: any*/),
   "kind": "ScalarField",
   "name": "amount",
   "storageKey": "amount(precision:2)"
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "amountCents",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
-  "args": (v3/*: any*/),
+  "args": (v4/*: any*/),
   "kind": "ScalarField",
   "name": "shippingTotal",
   "storageKey": "shippingTotal(precision:2)"
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "shippingTotalCents",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
-  "args": (v3/*: any*/),
+  "args": (v4/*: any*/),
   "kind": "ScalarField",
   "name": "taxTotal",
   "storageKey": "taxTotal(precision:2)"
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "taxTotalCents",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
-  "args": (v3/*: any*/),
+  "args": (v4/*: any*/),
   "kind": "ScalarField",
   "name": "buyerTotal",
   "storageKey": "buyerTotal(precision:2)"
-},
-v17 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "buyerTotalCents",
-  "storageKey": null
 },
 v18 = {
   "alias": null,
@@ -603,25 +605,25 @@ v23 = {
 },
 v24 = {
   "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v25 = {
+  "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "CommerceOffer"
 },
-v26 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Int"
-},
 v27 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
   "type": "Int"
 },
@@ -723,6 +725,14 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "currencyCode",
+            "storageKey": null
+          },
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "paymentMethod",
             "storageKey": null
           },
@@ -756,7 +766,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v3/*: any*/),
+            "args": (v4/*: any*/),
             "kind": "ScalarField",
             "name": "itemsTotal",
             "storageKey": "itemsTotal(precision:2)"
@@ -821,15 +831,15 @@ return {
                             "name": "editionSets",
                             "plural": true,
                             "selections": [
-                              (v2/*: any*/),
-                              (v4/*: any*/),
-                              (v5/*: any*/)
+                              (v3/*: any*/),
+                              (v5/*: any*/),
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v5/*: any*/),
                           (v6/*: any*/),
-                          (v2/*: any*/),
+                          (v7/*: any*/),
+                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -838,8 +848,8 @@ return {
                             "name": "artists",
                             "plural": true,
                             "selections": [
-                              (v6/*: any*/),
-                              (v5/*: any*/)
+                              (v7/*: any*/),
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -904,7 +914,7 @@ return {
                                 "name": "shortDescription",
                                 "storageKey": null
                               },
-                              (v5/*: any*/)
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -929,7 +939,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "resized",
                                 "plural": false,
-                                "selections": (v7/*: any*/),
+                                "selections": (v8/*: any*/),
                                 "storageKey": "resized(width:185)"
                               },
                               {
@@ -945,14 +955,14 @@ return {
                                 "kind": "LinkedField",
                                 "name": "resized",
                                 "plural": false,
-                                "selections": (v7/*: any*/),
+                                "selections": (v8/*: any*/),
                                 "storageKey": "resized(width:55)"
                               }
                             ],
                             "storageKey": null
                           },
-                          (v4/*: any*/),
                           (v5/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -977,7 +987,7 @@ return {
                         "name": "editionSetId",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -990,7 +1000,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v8/*: any*/)
+                              (v9/*: any*/)
                             ],
                             "type": "Artwork",
                             "abstractKey": null
@@ -998,13 +1008,13 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v8/*: any*/),
-                              (v5/*: any*/)
+                              (v9/*: any*/),
+                              (v6/*: any*/)
                             ],
                             "type": "EditionSet",
                             "abstractKey": null
                           },
-                          (v9/*: any*/)
+                          (v10/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1023,10 +1033,10 @@ return {
                             "name": "typeName",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
-                            "args": (v3/*: any*/),
+                            "args": (v4/*: any*/),
                             "kind": "ScalarField",
                             "name": "price",
                             "storageKey": "price(precision:2)"
@@ -1065,7 +1075,7 @@ return {
                                     "name": "isSelected",
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -1102,9 +1112,8 @@ return {
                     "name": "hasDefiniteTotal",
                     "storageKey": null
                   },
-                  (v2/*: any*/),
-                  (v5/*: any*/),
-                  (v10/*: any*/),
+                  (v3/*: any*/),
+                  (v6/*: any*/),
                   (v11/*: any*/),
                   (v12/*: any*/),
                   (v13/*: any*/),
@@ -1112,6 +1121,7 @@ return {
                   (v15/*: any*/),
                   (v16/*: any*/),
                   (v17/*: any*/),
+                  (v2/*: any*/),
                   (v18/*: any*/),
                   (v19/*: any*/)
                 ],
@@ -1125,8 +1135,7 @@ return {
                 "name": "lastOffer",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
-                  (v10/*: any*/),
+                  (v3/*: any*/),
                   (v11/*: any*/),
                   (v12/*: any*/),
                   (v13/*: any*/),
@@ -1134,9 +1143,10 @@ return {
                   (v15/*: any*/),
                   (v16/*: any*/),
                   (v17/*: any*/),
+                  (v2/*: any*/),
                   (v18/*: any*/),
                   (v19/*: any*/),
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1161,15 +1171,8 @@ return {
                 "type": "Partner",
                 "abstractKey": null
               },
-              (v9/*: any*/)
+              (v10/*: any*/)
             ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "currencyCode",
             "storageKey": null
           },
           {
@@ -1207,11 +1210,11 @@ return {
             "name": "displayState",
             "storageKey": null
           },
-          (v12/*: any*/),
           (v13/*: any*/),
           (v14/*: any*/),
           (v15/*: any*/),
           (v16/*: any*/),
+          (v17/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1252,7 +1255,7 @@ return {
                     "name": "expirationMonth",
                     "storageKey": null
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "type": "CreditCard",
                 "abstractKey": null
@@ -1267,7 +1270,7 @@ return {
                     "name": "last4",
                     "storageKey": null
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "type": "BankAccount",
                 "abstractKey": null
@@ -1289,14 +1292,14 @@ return {
             ],
             "storageKey": null
           },
-          (v5/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": "commerceOrder(id:\"unused\")"
       }
     ]
   },
   "params": {
-    "cacheID": "3f82eb16c3c88a9c8ffef6e5fd6eff22",
+    "cacheID": "de7af0858c176e4f93e01a32265c29b0",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1310,6 +1313,7 @@ return {
         "order.__typename": (v22/*: any*/),
         "order.artworkDetails": (v23/*: any*/),
         "order.buyerTotal": (v23/*: any*/),
+        "order.buyerTotalCents": (v24/*: any*/),
         "order.code": (v22/*: any*/),
         "order.conditionsOfSale": (v23/*: any*/),
         "order.currencyCode": (v22/*: any*/),
@@ -1330,23 +1334,23 @@ return {
           "plural": false,
           "type": "CommerceOrderDisplayStateEnum"
         },
-        "order.id": (v24/*: any*/),
+        "order.id": (v25/*: any*/),
         "order.impulseConversationId": (v23/*: any*/),
-        "order.internalID": (v24/*: any*/),
+        "order.internalID": (v25/*: any*/),
         "order.itemsTotal": (v23/*: any*/),
-        "order.lastOffer": (v25/*: any*/),
+        "order.lastOffer": (v26/*: any*/),
         "order.lastOffer.amount": (v23/*: any*/),
-        "order.lastOffer.amountCents": (v26/*: any*/),
+        "order.lastOffer.amountCents": (v27/*: any*/),
         "order.lastOffer.buyerTotal": (v23/*: any*/),
-        "order.lastOffer.buyerTotalCents": (v27/*: any*/),
+        "order.lastOffer.buyerTotalCents": (v24/*: any*/),
         "order.lastOffer.fromParticipant": (v28/*: any*/),
-        "order.lastOffer.id": (v24/*: any*/),
-        "order.lastOffer.internalID": (v24/*: any*/),
+        "order.lastOffer.id": (v25/*: any*/),
+        "order.lastOffer.internalID": (v25/*: any*/),
         "order.lastOffer.note": (v23/*: any*/),
         "order.lastOffer.shippingTotal": (v23/*: any*/),
-        "order.lastOffer.shippingTotalCents": (v27/*: any*/),
+        "order.lastOffer.shippingTotalCents": (v24/*: any*/),
         "order.lastOffer.taxTotal": (v23/*: any*/),
-        "order.lastOffer.taxTotalCents": (v27/*: any*/),
+        "order.lastOffer.taxTotalCents": (v24/*: any*/),
         "order.lineItems": {
           "enumValues": null,
           "nullable": true,
@@ -1377,8 +1381,8 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "order.lineItems.edges.node.artwork.artists.id": (v24/*: any*/),
-        "order.lineItems.edges.node.artwork.artists.slug": (v24/*: any*/),
+        "order.lineItems.edges.node.artwork.artists.id": (v25/*: any*/),
+        "order.lineItems.edges.node.artwork.artists.slug": (v25/*: any*/),
         "order.lineItems.edges.node.artwork.editionSets": {
           "enumValues": null,
           "nullable": true,
@@ -1388,12 +1392,12 @@ return {
         "order.lineItems.edges.node.artwork.editionSets.dimensions": (v29/*: any*/),
         "order.lineItems.edges.node.artwork.editionSets.dimensions.cm": (v23/*: any*/),
         "order.lineItems.edges.node.artwork.editionSets.dimensions.in": (v23/*: any*/),
-        "order.lineItems.edges.node.artwork.editionSets.id": (v24/*: any*/),
-        "order.lineItems.edges.node.artwork.editionSets.internalID": (v24/*: any*/),
-        "order.lineItems.edges.node.artwork.id": (v24/*: any*/),
-        "order.lineItems.edges.node.artwork.internalID": (v24/*: any*/),
+        "order.lineItems.edges.node.artwork.editionSets.id": (v25/*: any*/),
+        "order.lineItems.edges.node.artwork.editionSets.internalID": (v25/*: any*/),
+        "order.lineItems.edges.node.artwork.id": (v25/*: any*/),
+        "order.lineItems.edges.node.artwork.internalID": (v25/*: any*/),
         "order.lineItems.edges.node.artwork.shippingOrigin": (v23/*: any*/),
-        "order.lineItems.edges.node.artwork.slug": (v24/*: any*/),
+        "order.lineItems.edges.node.artwork.slug": (v25/*: any*/),
         "order.lineItems.edges.node.artworkOrEditionSet": {
           "enumValues": null,
           "nullable": true,
@@ -1402,7 +1406,7 @@ return {
         },
         "order.lineItems.edges.node.artworkOrEditionSet.__isNode": (v22/*: any*/),
         "order.lineItems.edges.node.artworkOrEditionSet.__typename": (v22/*: any*/),
-        "order.lineItems.edges.node.artworkOrEditionSet.id": (v24/*: any*/),
+        "order.lineItems.edges.node.artworkOrEditionSet.id": (v25/*: any*/),
         "order.lineItems.edges.node.artworkOrEditionSet.price": (v23/*: any*/),
         "order.lineItems.edges.node.artworkVersion": {
           "enumValues": null,
@@ -1417,14 +1421,14 @@ return {
           "plural": false,
           "type": "AttributionClass"
         },
-        "order.lineItems.edges.node.artworkVersion.attributionClass.id": (v24/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.attributionClass.id": (v25/*: any*/),
         "order.lineItems.edges.node.artworkVersion.attributionClass.shortDescription": (v23/*: any*/),
         "order.lineItems.edges.node.artworkVersion.condition_description": (v23/*: any*/),
         "order.lineItems.edges.node.artworkVersion.date": (v23/*: any*/),
         "order.lineItems.edges.node.artworkVersion.dimensions": (v29/*: any*/),
         "order.lineItems.edges.node.artworkVersion.dimensions.cm": (v23/*: any*/),
         "order.lineItems.edges.node.artworkVersion.dimensions.in": (v23/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.id": (v24/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.id": (v25/*: any*/),
         "order.lineItems.edges.node.artworkVersion.image": {
           "enumValues": null,
           "nullable": true,
@@ -1439,9 +1443,9 @@ return {
         "order.lineItems.edges.node.artworkVersion.provenance": (v23/*: any*/),
         "order.lineItems.edges.node.artworkVersion.title": (v23/*: any*/),
         "order.lineItems.edges.node.editionSetId": (v23/*: any*/),
-        "order.lineItems.edges.node.id": (v24/*: any*/),
+        "order.lineItems.edges.node.id": (v25/*: any*/),
         "order.lineItems.edges.node.selectedShippingQuote": (v31/*: any*/),
-        "order.lineItems.edges.node.selectedShippingQuote.id": (v24/*: any*/),
+        "order.lineItems.edges.node.selectedShippingQuote.id": (v25/*: any*/),
         "order.lineItems.edges.node.selectedShippingQuote.price": (v23/*: any*/),
         "order.lineItems.edges.node.selectedShippingQuote.typeName": (v22/*: any*/),
         "order.lineItems.edges.node.shippingQuoteOptions": {
@@ -1457,7 +1461,7 @@ return {
           "type": "CommerceShippingQuoteEdge"
         },
         "order.lineItems.edges.node.shippingQuoteOptions.edges.node": (v31/*: any*/),
-        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.id": (v24/*: any*/),
+        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.id": (v25/*: any*/),
         "order.lineItems.edges.node.shippingQuoteOptions.edges.node.isSelected": (v32/*: any*/),
         "order.mode": {
           "enumValues": [
@@ -1468,20 +1472,20 @@ return {
           "plural": false,
           "type": "CommerceOrderModeEnum"
         },
-        "order.myLastOffer": (v25/*: any*/),
+        "order.myLastOffer": (v26/*: any*/),
         "order.myLastOffer.amount": (v23/*: any*/),
-        "order.myLastOffer.amountCents": (v26/*: any*/),
+        "order.myLastOffer.amountCents": (v27/*: any*/),
         "order.myLastOffer.buyerTotal": (v23/*: any*/),
-        "order.myLastOffer.buyerTotalCents": (v27/*: any*/),
+        "order.myLastOffer.buyerTotalCents": (v24/*: any*/),
         "order.myLastOffer.fromParticipant": (v28/*: any*/),
         "order.myLastOffer.hasDefiniteTotal": (v32/*: any*/),
-        "order.myLastOffer.id": (v24/*: any*/),
-        "order.myLastOffer.internalID": (v24/*: any*/),
+        "order.myLastOffer.id": (v25/*: any*/),
+        "order.myLastOffer.internalID": (v25/*: any*/),
         "order.myLastOffer.note": (v23/*: any*/),
         "order.myLastOffer.shippingTotal": (v23/*: any*/),
-        "order.myLastOffer.shippingTotalCents": (v27/*: any*/),
+        "order.myLastOffer.shippingTotalCents": (v24/*: any*/),
         "order.myLastOffer.taxTotal": (v23/*: any*/),
-        "order.myLastOffer.taxTotalCents": (v27/*: any*/),
+        "order.myLastOffer.taxTotalCents": (v24/*: any*/),
         "order.paymentMethod": {
           "enumValues": [
             "CREDIT_CARD",
@@ -1501,9 +1505,9 @@ return {
         },
         "order.paymentMethodDetails.__typename": (v22/*: any*/),
         "order.paymentMethodDetails.brand": (v22/*: any*/),
-        "order.paymentMethodDetails.expirationMonth": (v26/*: any*/),
-        "order.paymentMethodDetails.expirationYear": (v26/*: any*/),
-        "order.paymentMethodDetails.id": (v24/*: any*/),
+        "order.paymentMethodDetails.expirationMonth": (v27/*: any*/),
+        "order.paymentMethodDetails.expirationYear": (v27/*: any*/),
+        "order.paymentMethodDetails.id": (v25/*: any*/),
         "order.paymentMethodDetails.isManualPayment": (v32/*: any*/),
         "order.paymentMethodDetails.last4": (v22/*: any*/),
         "order.paymentMethodDetails.lastDigits": (v22/*: any*/),
@@ -1531,10 +1535,10 @@ return {
         },
         "order.sellerDetails.__isNode": (v22/*: any*/),
         "order.sellerDetails.__typename": (v22/*: any*/),
-        "order.sellerDetails.id": (v24/*: any*/),
+        "order.sellerDetails.id": (v25/*: any*/),
         "order.sellerDetails.name": (v23/*: any*/),
         "order.shippingTotal": (v23/*: any*/),
-        "order.shippingTotalCents": (v27/*: any*/),
+        "order.shippingTotalCents": (v24/*: any*/),
         "order.source": {
           "enumValues": [
             "artwork_page",
@@ -1563,12 +1567,12 @@ return {
         },
         "order.stateExpiresAt": (v23/*: any*/),
         "order.taxTotal": (v23/*: any*/),
-        "order.taxTotalCents": (v27/*: any*/)
+        "order.taxTotalCents": (v24/*: any*/)
       }
     },
     "name": "ReviewTestQuery",
     "operationKind": "query",
-    "text": "query ReviewTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Review_order\n    id\n  }\n}\n\nfragment AdditionalArtworkDetails_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  artworkDetails\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          shippingOrigin\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    editionSets {\n      internalID\n      dimensions {\n        in\n        cm\n      }\n      id\n    }\n    id\n  }\n  artworkVersion {\n    date\n    artistNames\n    title\n    medium\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n    }\n    dimensions {\n      in\n      cm\n    }\n    id\n  }\n  editionSetId\n}\n\nfragment OfferSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      amount(precision: 2)\n      note\n      id\n    }\n  }\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  mode\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentMethodSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Review_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  artworkDetails\n  internalID\n  paymentMethod\n  mode\n  code\n  source\n  conditionsOfSale\n  itemsTotal(precision: 2)\n  impulseConversationId\n  stateExpiresAt(format: \"MMM D\")\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        artwork {\n          slug\n          internalID\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      hasDefiniteTotal\n      internalID\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...AdditionalArtworkDetails_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...PaymentMethodSummaryItem_order\n  ...ShippingArtaSummaryItem_order\n  ...OfferSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment ShippingAddress_ship on CommerceRequestedFulfillmentUnion {\n  __isCommerceRequestedFulfillmentUnion: __typename\n  ... on CommerceShip {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n  ... on CommerceShipArta {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n}\n\nfragment ShippingArtaSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  requestedFulfillment {\n    __typename\n  }\n  lineItems {\n    edges {\n      node {\n        selectedShippingQuote {\n          typeName\n          price(precision: 2)\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  paymentMethod\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
+    "text": "query ReviewTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Review_order\n    id\n  }\n}\n\nfragment AdditionalArtworkDetails_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  artworkDetails\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          shippingOrigin\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    editionSets {\n      internalID\n      dimensions {\n        in\n        cm\n      }\n      id\n    }\n    id\n  }\n  artworkVersion {\n    date\n    artistNames\n    title\n    medium\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n    }\n    dimensions {\n      in\n      cm\n    }\n    id\n  }\n  editionSetId\n}\n\nfragment OfferSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      amount(precision: 2)\n      note\n      id\n    }\n  }\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  mode\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentMethodSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Review_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  artworkDetails\n  buyerTotalCents\n  currencyCode\n  internalID\n  paymentMethod\n  mode\n  code\n  source\n  conditionsOfSale\n  itemsTotal(precision: 2)\n  impulseConversationId\n  stateExpiresAt(format: \"MMM D\")\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        artwork {\n          slug\n          internalID\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      hasDefiniteTotal\n      internalID\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...AdditionalArtworkDetails_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...PaymentMethodSummaryItem_order\n  ...ShippingArtaSummaryItem_order\n  ...OfferSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment ShippingAddress_ship on CommerceRequestedFulfillmentUnion {\n  __isCommerceRequestedFulfillmentUnion: __typename\n  ... on CommerceShip {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n  ... on CommerceShipArta {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n}\n\nfragment ShippingArtaSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  requestedFulfillment {\n    __typename\n  }\n  lineItems {\n    edges {\n      node {\n        selectedShippingQuote {\n          typeName\n          price(precision: 2)\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  paymentMethod\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ReviewTestQuery.graphql.ts
+++ b/src/__generated__/ReviewTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b0cefb52bcbdfeaf68463a93743d6a62>>
+ * @generated SignedSource<<e2ca2012cd57627c5fcfc2cce0c54360>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,11 +18,18 @@ export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FU
 export type CommercePaymentMethodEnum = "CREDIT_CARD" | "SEPA_DEBIT" | "US_BANK_ACCOUNT" | "WIRE_TRANSFER" | "%future added value";
 export type ReviewTestQuery$variables = {};
 export type ReviewTestQuery$data = {
+  readonly me: {
+    readonly " $fragmentSpreads": FragmentRefs<"Review_me">;
+  } | null;
   readonly order: {
     readonly " $fragmentSpreads": FragmentRefs<"Review_order">;
   } | null;
 };
 export type ReviewTestQuery$rawResponse = {
+  readonly me: {
+    readonly id: string;
+    readonly isIdentityVerified: boolean | null;
+  } | null;
   readonly order: {
     readonly __typename: "CommerceOfferOrder";
     readonly __isCommerceOrder: "CommerceOfferOrder";
@@ -595,11 +602,11 @@ v22 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "String"
+  "type": "ID"
 },
 v23 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
   "type": "String"
 },
@@ -607,13 +614,13 @@ v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Int"
+  "type": "String"
 },
 v25 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "ID"
+  "type": "Int"
 },
 v26 = {
   "enumValues": null,
@@ -682,6 +689,22 @@ return {
           }
         ],
         "storageKey": "commerceOrder(id:\"unused\")"
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Review_me"
+          }
+        ],
+        "storageKey": null
       }
     ],
     "type": "Query",
@@ -1295,28 +1318,60 @@ return {
           (v6/*: any*/)
         ],
         "storageKey": "commerceOrder(id:\"unused\")"
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isIdentityVerified",
+            "storageKey": null
+          },
+          (v6/*: any*/)
+        ],
+        "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "de7af0858c176e4f93e01a32265c29b0",
+    "cacheID": "869cc56b34acb7e00c5833dc12200ebf",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.id": (v22/*: any*/),
+        "me.isIdentityVerified": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Boolean"
+        },
         "order": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CommerceOrder"
         },
-        "order.__isCommerceOrder": (v22/*: any*/),
-        "order.__typename": (v22/*: any*/),
-        "order.artworkDetails": (v23/*: any*/),
-        "order.buyerTotal": (v23/*: any*/),
-        "order.buyerTotalCents": (v24/*: any*/),
-        "order.code": (v22/*: any*/),
-        "order.conditionsOfSale": (v23/*: any*/),
-        "order.currencyCode": (v22/*: any*/),
+        "order.__isCommerceOrder": (v23/*: any*/),
+        "order.__typename": (v23/*: any*/),
+        "order.artworkDetails": (v24/*: any*/),
+        "order.buyerTotal": (v24/*: any*/),
+        "order.buyerTotalCents": (v25/*: any*/),
+        "order.code": (v23/*: any*/),
+        "order.conditionsOfSale": (v24/*: any*/),
+        "order.currencyCode": (v23/*: any*/),
         "order.displayState": {
           "enumValues": [
             "ABANDONED",
@@ -1334,23 +1389,23 @@ return {
           "plural": false,
           "type": "CommerceOrderDisplayStateEnum"
         },
-        "order.id": (v25/*: any*/),
-        "order.impulseConversationId": (v23/*: any*/),
-        "order.internalID": (v25/*: any*/),
-        "order.itemsTotal": (v23/*: any*/),
+        "order.id": (v22/*: any*/),
+        "order.impulseConversationId": (v24/*: any*/),
+        "order.internalID": (v22/*: any*/),
+        "order.itemsTotal": (v24/*: any*/),
         "order.lastOffer": (v26/*: any*/),
-        "order.lastOffer.amount": (v23/*: any*/),
+        "order.lastOffer.amount": (v24/*: any*/),
         "order.lastOffer.amountCents": (v27/*: any*/),
-        "order.lastOffer.buyerTotal": (v23/*: any*/),
-        "order.lastOffer.buyerTotalCents": (v24/*: any*/),
+        "order.lastOffer.buyerTotal": (v24/*: any*/),
+        "order.lastOffer.buyerTotalCents": (v25/*: any*/),
         "order.lastOffer.fromParticipant": (v28/*: any*/),
-        "order.lastOffer.id": (v25/*: any*/),
-        "order.lastOffer.internalID": (v25/*: any*/),
-        "order.lastOffer.note": (v23/*: any*/),
-        "order.lastOffer.shippingTotal": (v23/*: any*/),
-        "order.lastOffer.shippingTotalCents": (v24/*: any*/),
-        "order.lastOffer.taxTotal": (v23/*: any*/),
-        "order.lastOffer.taxTotalCents": (v24/*: any*/),
+        "order.lastOffer.id": (v22/*: any*/),
+        "order.lastOffer.internalID": (v22/*: any*/),
+        "order.lastOffer.note": (v24/*: any*/),
+        "order.lastOffer.shippingTotal": (v24/*: any*/),
+        "order.lastOffer.shippingTotalCents": (v25/*: any*/),
+        "order.lastOffer.taxTotal": (v24/*: any*/),
+        "order.lastOffer.taxTotalCents": (v25/*: any*/),
         "order.lineItems": {
           "enumValues": null,
           "nullable": true,
@@ -1381,8 +1436,8 @@ return {
           "plural": true,
           "type": "Artist"
         },
-        "order.lineItems.edges.node.artwork.artists.id": (v25/*: any*/),
-        "order.lineItems.edges.node.artwork.artists.slug": (v25/*: any*/),
+        "order.lineItems.edges.node.artwork.artists.id": (v22/*: any*/),
+        "order.lineItems.edges.node.artwork.artists.slug": (v22/*: any*/),
         "order.lineItems.edges.node.artwork.editionSets": {
           "enumValues": null,
           "nullable": true,
@@ -1390,45 +1445,45 @@ return {
           "type": "EditionSet"
         },
         "order.lineItems.edges.node.artwork.editionSets.dimensions": (v29/*: any*/),
-        "order.lineItems.edges.node.artwork.editionSets.dimensions.cm": (v23/*: any*/),
-        "order.lineItems.edges.node.artwork.editionSets.dimensions.in": (v23/*: any*/),
-        "order.lineItems.edges.node.artwork.editionSets.id": (v25/*: any*/),
-        "order.lineItems.edges.node.artwork.editionSets.internalID": (v25/*: any*/),
-        "order.lineItems.edges.node.artwork.id": (v25/*: any*/),
-        "order.lineItems.edges.node.artwork.internalID": (v25/*: any*/),
-        "order.lineItems.edges.node.artwork.shippingOrigin": (v23/*: any*/),
-        "order.lineItems.edges.node.artwork.slug": (v25/*: any*/),
+        "order.lineItems.edges.node.artwork.editionSets.dimensions.cm": (v24/*: any*/),
+        "order.lineItems.edges.node.artwork.editionSets.dimensions.in": (v24/*: any*/),
+        "order.lineItems.edges.node.artwork.editionSets.id": (v22/*: any*/),
+        "order.lineItems.edges.node.artwork.editionSets.internalID": (v22/*: any*/),
+        "order.lineItems.edges.node.artwork.id": (v22/*: any*/),
+        "order.lineItems.edges.node.artwork.internalID": (v22/*: any*/),
+        "order.lineItems.edges.node.artwork.shippingOrigin": (v24/*: any*/),
+        "order.lineItems.edges.node.artwork.slug": (v22/*: any*/),
         "order.lineItems.edges.node.artworkOrEditionSet": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkOrEditionSetType"
         },
-        "order.lineItems.edges.node.artworkOrEditionSet.__isNode": (v22/*: any*/),
-        "order.lineItems.edges.node.artworkOrEditionSet.__typename": (v22/*: any*/),
-        "order.lineItems.edges.node.artworkOrEditionSet.id": (v25/*: any*/),
-        "order.lineItems.edges.node.artworkOrEditionSet.price": (v23/*: any*/),
+        "order.lineItems.edges.node.artworkOrEditionSet.__isNode": (v23/*: any*/),
+        "order.lineItems.edges.node.artworkOrEditionSet.__typename": (v23/*: any*/),
+        "order.lineItems.edges.node.artworkOrEditionSet.id": (v22/*: any*/),
+        "order.lineItems.edges.node.artworkOrEditionSet.price": (v24/*: any*/),
         "order.lineItems.edges.node.artworkVersion": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkVersion"
         },
-        "order.lineItems.edges.node.artworkVersion.artistNames": (v23/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.artistNames": (v24/*: any*/),
         "order.lineItems.edges.node.artworkVersion.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "order.lineItems.edges.node.artworkVersion.attributionClass.id": (v25/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.attributionClass.shortDescription": (v23/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.condition_description": (v23/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.date": (v23/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.attributionClass.id": (v22/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.attributionClass.shortDescription": (v24/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.condition_description": (v24/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.date": (v24/*: any*/),
         "order.lineItems.edges.node.artworkVersion.dimensions": (v29/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.dimensions.cm": (v23/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.dimensions.in": (v23/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.id": (v25/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.dimensions.cm": (v24/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.dimensions.in": (v24/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.id": (v22/*: any*/),
         "order.lineItems.edges.node.artworkVersion.image": {
           "enumValues": null,
           "nullable": true,
@@ -1436,18 +1491,18 @@ return {
           "type": "Image"
         },
         "order.lineItems.edges.node.artworkVersion.image.resized": (v30/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.image.resized.url": (v22/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.image.resized.url": (v23/*: any*/),
         "order.lineItems.edges.node.artworkVersion.image.resized_ArtworkSummaryItem": (v30/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.image.resized_ArtworkSummaryItem.url": (v22/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.medium": (v23/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.provenance": (v23/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.title": (v23/*: any*/),
-        "order.lineItems.edges.node.editionSetId": (v23/*: any*/),
-        "order.lineItems.edges.node.id": (v25/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.image.resized_ArtworkSummaryItem.url": (v23/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.medium": (v24/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.provenance": (v24/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.title": (v24/*: any*/),
+        "order.lineItems.edges.node.editionSetId": (v24/*: any*/),
+        "order.lineItems.edges.node.id": (v22/*: any*/),
         "order.lineItems.edges.node.selectedShippingQuote": (v31/*: any*/),
-        "order.lineItems.edges.node.selectedShippingQuote.id": (v25/*: any*/),
-        "order.lineItems.edges.node.selectedShippingQuote.price": (v23/*: any*/),
-        "order.lineItems.edges.node.selectedShippingQuote.typeName": (v22/*: any*/),
+        "order.lineItems.edges.node.selectedShippingQuote.id": (v22/*: any*/),
+        "order.lineItems.edges.node.selectedShippingQuote.price": (v24/*: any*/),
+        "order.lineItems.edges.node.selectedShippingQuote.typeName": (v23/*: any*/),
         "order.lineItems.edges.node.shippingQuoteOptions": {
           "enumValues": null,
           "nullable": true,
@@ -1461,7 +1516,7 @@ return {
           "type": "CommerceShippingQuoteEdge"
         },
         "order.lineItems.edges.node.shippingQuoteOptions.edges.node": (v31/*: any*/),
-        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.id": (v25/*: any*/),
+        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.id": (v22/*: any*/),
         "order.lineItems.edges.node.shippingQuoteOptions.edges.node.isSelected": (v32/*: any*/),
         "order.mode": {
           "enumValues": [
@@ -1473,19 +1528,19 @@ return {
           "type": "CommerceOrderModeEnum"
         },
         "order.myLastOffer": (v26/*: any*/),
-        "order.myLastOffer.amount": (v23/*: any*/),
+        "order.myLastOffer.amount": (v24/*: any*/),
         "order.myLastOffer.amountCents": (v27/*: any*/),
-        "order.myLastOffer.buyerTotal": (v23/*: any*/),
-        "order.myLastOffer.buyerTotalCents": (v24/*: any*/),
+        "order.myLastOffer.buyerTotal": (v24/*: any*/),
+        "order.myLastOffer.buyerTotalCents": (v25/*: any*/),
         "order.myLastOffer.fromParticipant": (v28/*: any*/),
         "order.myLastOffer.hasDefiniteTotal": (v32/*: any*/),
-        "order.myLastOffer.id": (v25/*: any*/),
-        "order.myLastOffer.internalID": (v25/*: any*/),
-        "order.myLastOffer.note": (v23/*: any*/),
-        "order.myLastOffer.shippingTotal": (v23/*: any*/),
-        "order.myLastOffer.shippingTotalCents": (v24/*: any*/),
-        "order.myLastOffer.taxTotal": (v23/*: any*/),
-        "order.myLastOffer.taxTotalCents": (v24/*: any*/),
+        "order.myLastOffer.id": (v22/*: any*/),
+        "order.myLastOffer.internalID": (v22/*: any*/),
+        "order.myLastOffer.note": (v24/*: any*/),
+        "order.myLastOffer.shippingTotal": (v24/*: any*/),
+        "order.myLastOffer.shippingTotalCents": (v25/*: any*/),
+        "order.myLastOffer.taxTotal": (v24/*: any*/),
+        "order.myLastOffer.taxTotalCents": (v25/*: any*/),
         "order.paymentMethod": {
           "enumValues": [
             "CREDIT_CARD",
@@ -1503,42 +1558,42 @@ return {
           "plural": false,
           "type": "PaymentMethodUnion"
         },
-        "order.paymentMethodDetails.__typename": (v22/*: any*/),
-        "order.paymentMethodDetails.brand": (v22/*: any*/),
+        "order.paymentMethodDetails.__typename": (v23/*: any*/),
+        "order.paymentMethodDetails.brand": (v23/*: any*/),
         "order.paymentMethodDetails.expirationMonth": (v27/*: any*/),
         "order.paymentMethodDetails.expirationYear": (v27/*: any*/),
-        "order.paymentMethodDetails.id": (v25/*: any*/),
+        "order.paymentMethodDetails.id": (v22/*: any*/),
         "order.paymentMethodDetails.isManualPayment": (v32/*: any*/),
-        "order.paymentMethodDetails.last4": (v22/*: any*/),
-        "order.paymentMethodDetails.lastDigits": (v22/*: any*/),
+        "order.paymentMethodDetails.last4": (v23/*: any*/),
+        "order.paymentMethodDetails.lastDigits": (v23/*: any*/),
         "order.requestedFulfillment": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CommerceRequestedFulfillmentUnion"
         },
-        "order.requestedFulfillment.__isCommerceRequestedFulfillmentUnion": (v22/*: any*/),
-        "order.requestedFulfillment.__typename": (v22/*: any*/),
-        "order.requestedFulfillment.addressLine1": (v23/*: any*/),
-        "order.requestedFulfillment.addressLine2": (v23/*: any*/),
-        "order.requestedFulfillment.city": (v23/*: any*/),
-        "order.requestedFulfillment.country": (v23/*: any*/),
-        "order.requestedFulfillment.name": (v23/*: any*/),
-        "order.requestedFulfillment.phoneNumber": (v23/*: any*/),
-        "order.requestedFulfillment.postalCode": (v23/*: any*/),
-        "order.requestedFulfillment.region": (v23/*: any*/),
+        "order.requestedFulfillment.__isCommerceRequestedFulfillmentUnion": (v23/*: any*/),
+        "order.requestedFulfillment.__typename": (v23/*: any*/),
+        "order.requestedFulfillment.addressLine1": (v24/*: any*/),
+        "order.requestedFulfillment.addressLine2": (v24/*: any*/),
+        "order.requestedFulfillment.city": (v24/*: any*/),
+        "order.requestedFulfillment.country": (v24/*: any*/),
+        "order.requestedFulfillment.name": (v24/*: any*/),
+        "order.requestedFulfillment.phoneNumber": (v24/*: any*/),
+        "order.requestedFulfillment.postalCode": (v24/*: any*/),
+        "order.requestedFulfillment.region": (v24/*: any*/),
         "order.sellerDetails": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "OrderParty"
         },
-        "order.sellerDetails.__isNode": (v22/*: any*/),
-        "order.sellerDetails.__typename": (v22/*: any*/),
-        "order.sellerDetails.id": (v25/*: any*/),
-        "order.sellerDetails.name": (v23/*: any*/),
-        "order.shippingTotal": (v23/*: any*/),
-        "order.shippingTotalCents": (v24/*: any*/),
+        "order.sellerDetails.__isNode": (v23/*: any*/),
+        "order.sellerDetails.__typename": (v23/*: any*/),
+        "order.sellerDetails.id": (v22/*: any*/),
+        "order.sellerDetails.name": (v24/*: any*/),
+        "order.shippingTotal": (v24/*: any*/),
+        "order.shippingTotalCents": (v25/*: any*/),
         "order.source": {
           "enumValues": [
             "artwork_page",
@@ -1565,18 +1620,18 @@ return {
           "plural": false,
           "type": "CommerceOrderStateEnum"
         },
-        "order.stateExpiresAt": (v23/*: any*/),
-        "order.taxTotal": (v23/*: any*/),
-        "order.taxTotalCents": (v24/*: any*/)
+        "order.stateExpiresAt": (v24/*: any*/),
+        "order.taxTotal": (v24/*: any*/),
+        "order.taxTotalCents": (v25/*: any*/)
       }
     },
     "name": "ReviewTestQuery",
     "operationKind": "query",
-    "text": "query ReviewTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Review_order\n    id\n  }\n}\n\nfragment AdditionalArtworkDetails_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  artworkDetails\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          shippingOrigin\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    editionSets {\n      internalID\n      dimensions {\n        in\n        cm\n      }\n      id\n    }\n    id\n  }\n  artworkVersion {\n    date\n    artistNames\n    title\n    medium\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n    }\n    dimensions {\n      in\n      cm\n    }\n    id\n  }\n  editionSetId\n}\n\nfragment OfferSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      amount(precision: 2)\n      note\n      id\n    }\n  }\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  mode\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentMethodSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Review_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  artworkDetails\n  buyerTotalCents\n  currencyCode\n  internalID\n  paymentMethod\n  mode\n  code\n  source\n  conditionsOfSale\n  itemsTotal(precision: 2)\n  impulseConversationId\n  stateExpiresAt(format: \"MMM D\")\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        artwork {\n          slug\n          internalID\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      hasDefiniteTotal\n      internalID\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...AdditionalArtworkDetails_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...PaymentMethodSummaryItem_order\n  ...ShippingArtaSummaryItem_order\n  ...OfferSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment ShippingAddress_ship on CommerceRequestedFulfillmentUnion {\n  __isCommerceRequestedFulfillmentUnion: __typename\n  ... on CommerceShip {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n  ... on CommerceShipArta {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n}\n\nfragment ShippingArtaSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  requestedFulfillment {\n    __typename\n  }\n  lineItems {\n    edges {\n      node {\n        selectedShippingQuote {\n          typeName\n          price(precision: 2)\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  paymentMethod\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
+    "text": "query ReviewTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Review_order\n    id\n  }\n  me {\n    ...Review_me\n    id\n  }\n}\n\nfragment AdditionalArtworkDetails_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  artworkDetails\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          shippingOrigin\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    editionSets {\n      internalID\n      dimensions {\n        in\n        cm\n      }\n      id\n    }\n    id\n  }\n  artworkVersion {\n    date\n    artistNames\n    title\n    medium\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n    }\n    dimensions {\n      in\n      cm\n    }\n    id\n  }\n  editionSetId\n}\n\nfragment OfferSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      amount(precision: 2)\n      note\n      id\n    }\n  }\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  mode\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentMethodSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Review_me on Me {\n  isIdentityVerified\n}\n\nfragment Review_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  artworkDetails\n  buyerTotalCents\n  currencyCode\n  internalID\n  paymentMethod\n  mode\n  code\n  source\n  conditionsOfSale\n  itemsTotal(precision: 2)\n  impulseConversationId\n  stateExpiresAt(format: \"MMM D\")\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        artwork {\n          slug\n          internalID\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      hasDefiniteTotal\n      internalID\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...AdditionalArtworkDetails_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...PaymentMethodSummaryItem_order\n  ...ShippingArtaSummaryItem_order\n  ...OfferSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment ShippingAddress_ship on CommerceRequestedFulfillmentUnion {\n  __isCommerceRequestedFulfillmentUnion: __typename\n  ... on CommerceShip {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n  ... on CommerceShipArta {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n}\n\nfragment ShippingArtaSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  requestedFulfillment {\n    __typename\n  }\n  lineItems {\n    edges {\n      node {\n        selectedShippingQuote {\n          typeName\n          price(precision: 2)\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  paymentMethod\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "b9f08ca664558f6f1f39d24fc6c41cef";
+(node as any).hash = "7a0186385ce32c9c406f255a9bb3f337";
 
 export default node;

--- a/src/__generated__/Review_me.graphql.ts
+++ b/src/__generated__/Review_me.graphql.ts
@@ -1,0 +1,42 @@
+/**
+ * @generated SignedSource<<1a7b9b13a44c817d9eb3026a277a0972>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type Review_me$data = {
+  readonly isIdentityVerified: boolean | null;
+  readonly " $fragmentType": "Review_me";
+};
+export type Review_me$key = {
+  readonly " $data"?: Review_me$data;
+  readonly " $fragmentSpreads": FragmentRefs<"Review_me">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Review_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isIdentityVerified",
+      "storageKey": null
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+
+(node as any).hash = "a8998327caed176db8d1a34849d0b53f";
+
+export default node;

--- a/src/__generated__/Review_order.graphql.ts
+++ b/src/__generated__/Review_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<52404741f80e81fed54116e4e48a3e9a>>
+ * @generated SignedSource<<c728fdae333e6782f3bd08f4cfd67aa5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,8 +16,10 @@ export type CommercePaymentMethodEnum = "CREDIT_CARD" | "SEPA_DEBIT" | "US_BANK_
 import { FragmentRefs } from "relay-runtime";
 export type Review_order$data = {
   readonly artworkDetails: string | null;
+  readonly buyerTotalCents: number | null;
   readonly code: string;
   readonly conditionsOfSale: string | null;
+  readonly currencyCode: string;
   readonly impulseConversationId: string | null;
   readonly internalID: string;
   readonly itemsTotal: string | null;
@@ -89,6 +91,20 @@ return {
       "args": null,
       "kind": "ScalarField",
       "name": "artworkDetails",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "buyerTotalCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "currencyCode",
       "storageKey": null
     },
     (v0/*: any*/),
@@ -320,6 +336,6 @@ return {
 };
 })();
 
-(node as any).hash = "bef72db09da81130a96281294fc82958";
+(node as any).hash = "fb53cae913789bd06d7dcde622900e3d";
 
 export default node;

--- a/src/__generated__/orderRoutes_ReviewQuery.graphql.ts
+++ b/src/__generated__/orderRoutes_ReviewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f1a83434a5107a41a660ac61d3145cc5>>
+ * @generated SignedSource<<696cd69f9a116e9cf6c2e903da042cc2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -49,17 +49,24 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "buyerTotalCents",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v4 = [
+v5 = [
   {
     "kind": "Literal",
     "name": "precision",
     "value": 2
   }
 ],
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
@@ -84,21 +91,21 @@ v5 = {
   ],
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v8 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -107,76 +114,69 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "price",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "InlineFragment",
   "selections": [
-    (v6/*: any*/)
+    (v7/*: any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v11 = {
+v12 = {
   "alias": null,
-  "args": (v4/*: any*/),
+  "args": (v5/*: any*/),
   "kind": "ScalarField",
   "name": "amount",
   "storageKey": "amount(precision:2)"
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "amountCents",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
-  "args": (v4/*: any*/),
+  "args": (v5/*: any*/),
   "kind": "ScalarField",
   "name": "shippingTotal",
   "storageKey": "shippingTotal(precision:2)"
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "shippingTotalCents",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
-  "args": (v4/*: any*/),
+  "args": (v5/*: any*/),
   "kind": "ScalarField",
   "name": "taxTotal",
   "storageKey": "taxTotal(precision:2)"
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "taxTotalCents",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
-  "args": (v4/*: any*/),
+  "args": (v5/*: any*/),
   "kind": "ScalarField",
   "name": "buyerTotal",
   "storageKey": "buyerTotal(precision:2)"
-},
-v18 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "buyerTotalCents",
-  "storageKey": null
 },
 v19 = {
   "alias": null,
@@ -316,6 +316,14 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "currencyCode",
+            "storageKey": null
+          },
+          (v4/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "paymentMethod",
             "storageKey": null
           },
@@ -349,7 +357,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "itemsTotal",
             "storageKey": "itemsTotal(precision:2)"
@@ -414,15 +422,15 @@ return {
                             "name": "editionSets",
                             "plural": true,
                             "selections": [
-                              (v3/*: any*/),
-                              (v5/*: any*/),
-                              (v6/*: any*/)
+                              (v4/*: any*/),
+                              (v6/*: any*/),
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v6/*: any*/),
                           (v7/*: any*/),
-                          (v3/*: any*/),
+                          (v8/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -431,8 +439,8 @@ return {
                             "name": "artists",
                             "plural": true,
                             "selections": [
-                              (v7/*: any*/),
-                              (v6/*: any*/)
+                              (v8/*: any*/),
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -497,7 +505,7 @@ return {
                                 "name": "shortDescription",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -522,7 +530,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "resized",
                                 "plural": false,
-                                "selections": (v8/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": "resized(width:185)"
                               },
                               {
@@ -538,14 +546,14 @@ return {
                                 "kind": "LinkedField",
                                 "name": "resized",
                                 "plural": false,
-                                "selections": (v8/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": "resized(width:55)"
                               }
                             ],
                             "storageKey": null
                           },
-                          (v5/*: any*/),
                           (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -570,7 +578,7 @@ return {
                         "name": "editionSetId",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -583,7 +591,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v9/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "type": "Artwork",
                             "abstractKey": null
@@ -591,13 +599,13 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v9/*: any*/),
-                              (v6/*: any*/)
+                              (v10/*: any*/),
+                              (v7/*: any*/)
                             ],
                             "type": "EditionSet",
                             "abstractKey": null
                           },
-                          (v10/*: any*/)
+                          (v11/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -616,10 +624,10 @@ return {
                             "name": "typeName",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
-                            "args": (v4/*: any*/),
+                            "args": (v5/*: any*/),
                             "kind": "ScalarField",
                             "name": "price",
                             "storageKey": "price(precision:2)"
@@ -658,7 +666,7 @@ return {
                                     "name": "isSelected",
                                     "storageKey": null
                                   },
-                                  (v6/*: any*/)
+                                  (v7/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -695,9 +703,8 @@ return {
                     "name": "hasDefiniteTotal",
                     "storageKey": null
                   },
-                  (v3/*: any*/),
-                  (v6/*: any*/),
-                  (v11/*: any*/),
+                  (v4/*: any*/),
+                  (v7/*: any*/),
                   (v12/*: any*/),
                   (v13/*: any*/),
                   (v14/*: any*/),
@@ -705,6 +712,7 @@ return {
                   (v16/*: any*/),
                   (v17/*: any*/),
                   (v18/*: any*/),
+                  (v3/*: any*/),
                   (v19/*: any*/),
                   (v20/*: any*/)
                 ],
@@ -718,8 +726,7 @@ return {
                 "name": "lastOffer",
                 "plural": false,
                 "selections": [
-                  (v3/*: any*/),
-                  (v11/*: any*/),
+                  (v4/*: any*/),
                   (v12/*: any*/),
                   (v13/*: any*/),
                   (v14/*: any*/),
@@ -727,9 +734,10 @@ return {
                   (v16/*: any*/),
                   (v17/*: any*/),
                   (v18/*: any*/),
+                  (v3/*: any*/),
                   (v19/*: any*/),
                   (v20/*: any*/),
-                  (v6/*: any*/)
+                  (v7/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -754,15 +762,8 @@ return {
                 "type": "Partner",
                 "abstractKey": null
               },
-              (v10/*: any*/)
+              (v11/*: any*/)
             ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "currencyCode",
             "storageKey": null
           },
           {
@@ -800,11 +801,11 @@ return {
             "name": "displayState",
             "storageKey": null
           },
-          (v13/*: any*/),
           (v14/*: any*/),
           (v15/*: any*/),
           (v16/*: any*/),
           (v17/*: any*/),
+          (v18/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -845,7 +846,7 @@ return {
                     "name": "expirationMonth",
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v7/*: any*/)
                 ],
                 "type": "CreditCard",
                 "abstractKey": null
@@ -860,7 +861,7 @@ return {
                     "name": "last4",
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v7/*: any*/)
                 ],
                 "type": "BankAccount",
                 "abstractKey": null
@@ -882,19 +883,19 @@ return {
             ],
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "4e6521438a4ea8fbfba07581a71f2567",
+    "cacheID": "8ef3ad18cb9699eea4bd37b6c3983ae9",
     "id": null,
     "metadata": {},
     "name": "orderRoutes_ReviewQuery",
     "operationKind": "query",
-    "text": "query orderRoutes_ReviewQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Review_order\n    id\n  }\n}\n\nfragment AdditionalArtworkDetails_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  artworkDetails\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          shippingOrigin\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    editionSets {\n      internalID\n      dimensions {\n        in\n        cm\n      }\n      id\n    }\n    id\n  }\n  artworkVersion {\n    date\n    artistNames\n    title\n    medium\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n    }\n    dimensions {\n      in\n      cm\n    }\n    id\n  }\n  editionSetId\n}\n\nfragment OfferSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      amount(precision: 2)\n      note\n      id\n    }\n  }\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  mode\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentMethodSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Review_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  artworkDetails\n  internalID\n  paymentMethod\n  mode\n  code\n  source\n  conditionsOfSale\n  itemsTotal(precision: 2)\n  impulseConversationId\n  stateExpiresAt(format: \"MMM D\")\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        artwork {\n          slug\n          internalID\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      hasDefiniteTotal\n      internalID\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...AdditionalArtworkDetails_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...PaymentMethodSummaryItem_order\n  ...ShippingArtaSummaryItem_order\n  ...OfferSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment ShippingAddress_ship on CommerceRequestedFulfillmentUnion {\n  __isCommerceRequestedFulfillmentUnion: __typename\n  ... on CommerceShip {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n  ... on CommerceShipArta {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n}\n\nfragment ShippingArtaSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  requestedFulfillment {\n    __typename\n  }\n  lineItems {\n    edges {\n      node {\n        selectedShippingQuote {\n          typeName\n          price(precision: 2)\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  paymentMethod\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
+    "text": "query orderRoutes_ReviewQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Review_order\n    id\n  }\n}\n\nfragment AdditionalArtworkDetails_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  artworkDetails\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          shippingOrigin\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    editionSets {\n      internalID\n      dimensions {\n        in\n        cm\n      }\n      id\n    }\n    id\n  }\n  artworkVersion {\n    date\n    artistNames\n    title\n    medium\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n    }\n    dimensions {\n      in\n      cm\n    }\n    id\n  }\n  editionSetId\n}\n\nfragment OfferSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      amount(precision: 2)\n      note\n      id\n    }\n  }\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  mode\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentMethodSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Review_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  artworkDetails\n  buyerTotalCents\n  currencyCode\n  internalID\n  paymentMethod\n  mode\n  code\n  source\n  conditionsOfSale\n  itemsTotal(precision: 2)\n  impulseConversationId\n  stateExpiresAt(format: \"MMM D\")\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        artwork {\n          slug\n          internalID\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        artworkVersion {\n          provenance\n          condition_description\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      hasDefiniteTotal\n      internalID\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...AdditionalArtworkDetails_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...PaymentMethodSummaryItem_order\n  ...ShippingArtaSummaryItem_order\n  ...OfferSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment ShippingAddress_ship on CommerceRequestedFulfillmentUnion {\n  __isCommerceRequestedFulfillmentUnion: __typename\n  ... on CommerceShip {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n  ... on CommerceShipArta {\n    name\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n  }\n}\n\nfragment ShippingArtaSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  requestedFulfillment {\n    __typename\n  }\n  lineItems {\n    edges {\n      node {\n        selectedShippingQuote {\n          typeName\n          price(precision: 2)\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  state\n  paymentMethod\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: Feat

This PR solves [PRO-148]

### Description

When an order totaling more than $/£/€ 10K is placed, the Trust & Safety team is notified via Slack, and does two things:

1. Contacts the buyer to request that they perform identity verification by sending them a request email via Forque
2. Contacts the seller to inform them that the order should not be shipped until the buyer has completed identity verification

The goal of this PR is to automatically send the email from step 1 when the checkout flow is completed. This will reduce the amount of time that Trust & Safety spend scanning for orders to process, set expectations for buyers at the moment of sale, and shorten the time that sellers have to wait for identity verification to complete.

An identity verification request will be automatically sent after an order/offer is submitted if the following criteria are met:

- Orders and offers where the buyer total is above 10K, or
- **TODO:** Offers below 10K where the list price is above 10K, and
- Users who have not passed identity verification before


[PRO-148]: https://artsyproduct.atlassian.net/browse/PRO-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ