### PR TITLE
feat(artwork lists): improve visibility of artwork list content on smaller screens

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -15,6 +15,8 @@ import { MetaTags } from "Components/MetaTags"
 import { Jump } from "Utils/Hooks/useJump"
 import { ArtworkListVisibilityProvider } from "Apps/CollectorProfile/Routes/Saves2/Utils/useArtworkListVisibility"
 
+export const ARTWORK_LIST_SCROLL_TARGET_ID = "ArtworkListScrollTarget"
+
 interface CollectorProfileSaves2RouteProps {
   me: CollectorProfileSaves2Route_me$data
 }
@@ -88,7 +90,7 @@ const CollectorProfileSaves2Route: FC<CollectorProfileSaves2RouteProps> = ({
         }
       />
 
-      <Jump id="AboveArtworkListShelf" />
+      <Jump id={ARTWORK_LIST_SCROLL_TARGET_ID} />
 
       <Spacer y={4} />
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -12,6 +12,7 @@ import { ActionType, OwnerType, ViewedArtworkList } from "@artsy/cohesion"
 import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { HttpError } from "found"
 import { MetaTags } from "Components/MetaTags"
+import { Jump } from "Utils/Hooks/useJump"
 
 interface CollectorProfileSaves2RouteProps {
   me: CollectorProfileSaves2Route_me$data
@@ -85,6 +86,8 @@ const CollectorProfileSaves2Route: FC<CollectorProfileSaves2RouteProps> = ({
           me?.savedArtworksArtworkList?.artworksConnection?.totalCount ?? 0
         }
       />
+
+      <Jump id="AboveArtworkListShelf" />
 
       <Spacer y={4} />
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -13,6 +13,7 @@ import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { HttpError } from "found"
 import { MetaTags } from "Components/MetaTags"
 import { Jump } from "Utils/Hooks/useJump"
+import { ArtworkListVisibilityProvider } from "Apps/CollectorProfile/Routes/Saves2/Utils/useArtworkListVisibility"
 
 interface CollectorProfileSaves2RouteProps {
   me: CollectorProfileSaves2Route_me$data
@@ -78,7 +79,7 @@ const CollectorProfileSaves2Route: FC<CollectorProfileSaves2RouteProps> = ({
   }
 
   return (
-    <>
+    <ArtworkListVisibilityProvider>
       <MetaTags title="Saves | Artsy" pathname="collector-profile/saves" />
 
       <ArtworkListsHeader
@@ -112,7 +113,7 @@ const CollectorProfileSaves2Route: FC<CollectorProfileSaves2RouteProps> = ({
         initialPage={(page as unknown) as number}
         initialSort={sort}
       />
-    </>
+    </ArtworkListVisibilityProvider>
   )
 }
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -104,8 +104,6 @@ const CollectorProfileSaves2Route: FC<CollectorProfileSaves2RouteProps> = ({
         })}
       </Shelf>
 
-      <Spacer y={4} />
-
       <ArtworkListContentQueryRenderer
         listID={selectedArtworkListId}
         initialPage={(page as unknown) as number}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListArtworksGrid.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListArtworksGrid.tsx
@@ -145,6 +145,9 @@ const ArtworkListArtworksGrid: FC<ArtworkListArtworksGridProps> = ({
 
   return (
     <>
+      {/* Note: this <Jump> element is also used as a sentinel by the
+      shouldScroll() helper in the ArtworkListContent component  */}
+
       <Jump id="artworksGrid" />
 
       <ArtworkListArtworksGridHeader />

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListArtworksGrid.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListArtworksGrid.tsx
@@ -23,6 +23,8 @@ import { Jump } from "Utils/Hooks/useJump"
 import { allowedFilters } from "Components/ArtworkFilter/Utils/allowedFilters"
 import { ArtworkListEmptyStateFragmentContainer } from "./ArtworkListEmptyState"
 
+export const ARTWORK_LIST_ARTWORK_GRID_ID = "artworksGrid"
+
 interface ArtworkListArtworksGridProps {
   relayRefetch: RelayRefetchProp["refetch"]
   me: ArtworkListArtworksGrid_me$data
@@ -145,15 +147,9 @@ const ArtworkListArtworksGrid: FC<ArtworkListArtworksGridProps> = ({
 
   return (
     <>
-      {/* Note: this <Jump> element is also used as a sentinel by the
-      shouldScroll() helper in the ArtworkListContent component  */}
-
-      <Jump id="artworksGrid" />
-
+      export <Jump id={ARTWORK_LIST_ARTWORK_GRID_ID} />
       <ArtworkListArtworksGridHeader />
-
       <Spacer y={2} />
-
       <LoadingArea isLoading={fetching}>
         <ArtworkGrid
           artworks={artworks}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
@@ -15,6 +15,7 @@ import { updateUrl } from "Components/ArtworkFilter/Utils/urlBuilder"
 import { ArtworkListArtworksGridPlaceholder } from "./ArtworkListPlaceholders"
 import { ArtworkListContextualMenu } from "./Actions/ArtworkListContextualMenu"
 import { useJump } from "Utils/Hooks/useJump"
+import { useArtworkListVisibilityContext } from "Apps/CollectorProfile/Routes/Saves2/Utils/useArtworkListVisibility"
 
 interface ArtworkListContentQueryRendererProps {
   listID: string
@@ -46,7 +47,9 @@ function isContentOutOfView() {
 
 const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {
   const { match } = useRouter()
+
   const { jumpTo } = useJump()
+  const { artworkListItemHasBeenTouched } = useArtworkListVisibilityContext()
 
   const artworkList = me.artworkList!
   const counts: Counts = {
@@ -54,10 +57,12 @@ const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {
   }
 
   useEffect(() => {
-    if (isContentOutOfView()) {
+    const shouldScroll = isContentOutOfView() && artworkListItemHasBeenTouched
+
+    if (shouldScroll) {
       jumpTo("AboveArtworkListShelf")
     }
-  }, [jumpTo])
+  }, [jumpTo, artworkListItemHasBeenTouched])
 
   return (
     <ArtworkFilterContextProvider

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
@@ -46,9 +46,10 @@ function isContentOutOfView() {
   )
   if (element === null) return false
 
-  let { top } = element.getBoundingClientRect()
-  let viewportH = window.innerHeight || document.documentElement.clientHeight
-  return top >= viewportH
+  const { top } = element.getBoundingClientRect()
+  const viewportHeight =
+    window.innerHeight || document.documentElement.clientHeight
+  return top >= viewportHeight
 }
 
 const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
@@ -6,7 +6,7 @@ import {
   Counts,
 } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { SortOptions } from "Components/SortFilter"
-import { FC } from "react"
+import { FC, useEffect } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { useRouter } from "System/Router/useRouter"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
@@ -14,6 +14,7 @@ import { Flex, Join, Spacer, Text } from "@artsy/palette"
 import { updateUrl } from "Components/ArtworkFilter/Utils/urlBuilder"
 import { ArtworkListArtworksGridPlaceholder } from "./ArtworkListPlaceholders"
 import { ArtworkListContextualMenu } from "./Actions/ArtworkListContextualMenu"
+import { useJump } from "Utils/Hooks/useJump"
 
 interface ArtworkListContentQueryRendererProps {
   listID: string
@@ -34,13 +35,29 @@ const sortOptions: SortOptions = [
 ]
 const defaultSort = sortOptions[0].value
 
+function isContentOutOfView() {
+  const element = document.querySelector("#JUMP--artworksGrid")
+  if (element === null) return false
+
+  let { top } = element.getBoundingClientRect()
+  let viewportH = window.innerHeight || document.documentElement.clientHeight
+  return top >= viewportH
+}
+
 const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {
   const { match } = useRouter()
+  const { jumpTo } = useJump()
 
   const artworkList = me.artworkList!
   const counts: Counts = {
     artworks: artworkList.artworks?.totalCount ?? 0,
   }
+
+  useEffect(() => {
+    if (isContentOutOfView()) {
+      jumpTo("AboveArtworkListShelf")
+    }
+  }, [jumpTo])
 
   return (
     <ArtworkFilterContextProvider

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
@@ -1,4 +1,7 @@
-import { ArtworkListArtworksGridFragmentContainer } from "./ArtworkListArtworksGrid"
+import {
+  ARTWORK_LIST_ARTWORK_GRID_ID,
+  ArtworkListArtworksGridFragmentContainer,
+} from "./ArtworkListArtworksGrid"
 import { ArtworkListContent_me$data } from "__generated__/ArtworkListContent_me.graphql"
 import { ArtworkListContentQuery } from "__generated__/ArtworkListContentQuery.graphql"
 import {
@@ -16,6 +19,7 @@ import { ArtworkListArtworksGridPlaceholder } from "./ArtworkListPlaceholders"
 import { ArtworkListContextualMenu } from "./Actions/ArtworkListContextualMenu"
 import { useJump } from "Utils/Hooks/useJump"
 import { useArtworkListVisibilityContext } from "Apps/CollectorProfile/Routes/Saves2/Utils/useArtworkListVisibility"
+import { ARTWORK_LIST_SCROLL_TARGET_ID } from "Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route"
 
 interface ArtworkListContentQueryRendererProps {
   listID: string
@@ -37,7 +41,9 @@ const sortOptions: SortOptions = [
 const defaultSort = sortOptions[0].value
 
 function isContentOutOfView() {
-  const element = document.querySelector("#JUMP--artworksGrid")
+  const element = document.querySelector(
+    `#JUMP--${ARTWORK_LIST_ARTWORK_GRID_ID}`
+  )
   if (element === null) return false
 
   let { top } = element.getBoundingClientRect()
@@ -67,7 +73,7 @@ const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {
       !artworkListHasBeenScrolled
 
     if (shouldScroll) {
-      jumpTo("AboveArtworkListShelf")
+      jumpTo(ARTWORK_LIST_SCROLL_TARGET_ID)
       setArtworkListHasBeenScrolled()
     }
   }, [

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListContent.tsx
@@ -49,7 +49,11 @@ const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {
   const { match } = useRouter()
 
   const { jumpTo } = useJump()
-  const { artworkListItemHasBeenTouched } = useArtworkListVisibilityContext()
+  const {
+    artworkListItemHasBeenTouched,
+    artworkListHasBeenScrolled,
+    setArtworkListHasBeenScrolled,
+  } = useArtworkListVisibilityContext()
 
   const artworkList = me.artworkList!
   const counts: Counts = {
@@ -57,12 +61,21 @@ const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {
   }
 
   useEffect(() => {
-    const shouldScroll = isContentOutOfView() && artworkListItemHasBeenTouched
+    const shouldScroll =
+      isContentOutOfView() &&
+      artworkListItemHasBeenTouched &&
+      !artworkListHasBeenScrolled
 
     if (shouldScroll) {
       jumpTo("AboveArtworkListShelf")
+      setArtworkListHasBeenScrolled()
     }
-  }, [jumpTo, artworkListItemHasBeenTouched])
+  }, [
+    jumpTo,
+    artworkListItemHasBeenTouched,
+    artworkListHasBeenScrolled,
+    setArtworkListHasBeenScrolled,
+  ])
 
   return (
     <ArtworkFilterContextProvider

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListItem.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/ArtworkListItem.tsx
@@ -9,6 +9,7 @@ import { extractNodes } from "Utils/extractNodes"
 import { ArtworkListItem_item$data } from "__generated__/ArtworkListItem_item.graphql"
 import { BASE_SAVES_PATH } from "Apps/CollectorProfile/constants"
 import styled from "styled-components"
+import { useArtworkListVisibilityContext } from "Apps/CollectorProfile/Routes/Saves2/Utils/useArtworkListVisibility"
 
 interface ArtworkListItemProps {
   isSelected?: boolean
@@ -21,6 +22,7 @@ const ArtworkListItem: FC<ArtworkListItemProps> = props => {
   const { t } = useTranslation()
   const artworkNodes = extractNodes(item.artworksConnection)
   const imageURLs = artworkNodes.map(node => node.image?.url ?? null)
+  const { setArtworkListItemHasBeenTouched } = useArtworkListVisibilityContext()
 
   const getLink = () => {
     if (item.default) {
@@ -36,6 +38,7 @@ const ArtworkListItem: FC<ArtworkListItemProps> = props => {
       textDecoration="none"
       aria-current={!!isSelected}
       isSelected={!!isSelected}
+      onClick={setArtworkListItemHasBeenTouched}
     >
       <Flex
         p={1}

--- a/src/Apps/CollectorProfile/Routes/Saves2/Utils/useArtworkListVisibility.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Utils/useArtworkListVisibility.tsx
@@ -18,8 +18,8 @@ const ArtworkListVisibilityContext = createContext<ArtworkListVisibility>({
 })
 
 export const ArtworkListVisibilityProvider: React.FC = ({ children }) => {
-  const [touched, setTouched] = useState<boolean>(false)
-  const [scrolled, setScrolled] = useState<boolean>(false)
+  const [touched, setTouched] = useState(false)
+  const [scrolled, setScrolled] = useState(false)
 
   return (
     <ArtworkListVisibilityContext.Provider

--- a/src/Apps/CollectorProfile/Routes/Saves2/Utils/useArtworkListVisibility.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Utils/useArtworkListVisibility.tsx
@@ -1,27 +1,39 @@
 import { createContext, useContext, useState } from "react"
 
 type ArtworkListVisibility = {
+  // has any Artwork List card been selected?
   touched: boolean
   setTouched: (value: boolean) => void
+
+  // have we already performed the auto-scroll at least once?
+  scrolled: boolean
+  setScrolled: (value: boolean) => void
 }
 
 const ArtworkListVisibilityContext = createContext<ArtworkListVisibility>({
   touched: false,
   setTouched: (_value: boolean) => {},
+  scrolled: false,
+  setScrolled: (_value: boolean) => {},
 })
 
 export const ArtworkListVisibilityProvider: React.FC = ({ children }) => {
   const [touched, setTouched] = useState<boolean>(false)
+  const [scrolled, setScrolled] = useState<boolean>(false)
 
   return (
-    <ArtworkListVisibilityContext.Provider value={{ touched, setTouched }}>
+    <ArtworkListVisibilityContext.Provider
+      value={{ touched, setTouched, scrolled, setScrolled }}
+    >
       {children}
     </ArtworkListVisibilityContext.Provider>
   )
 }
 
 export const useArtworkListVisibilityContext = () => {
-  const { touched, setTouched } = useContext(ArtworkListVisibilityContext)
+  const { touched, setTouched, scrolled, setScrolled } = useContext(
+    ArtworkListVisibilityContext
+  )
 
   return {
     /** True if any Artwork List card has been selected from the Artwork Lists rail */
@@ -29,5 +41,11 @@ export const useArtworkListVisibilityContext = () => {
 
     /** To be called once any Artwork List card has been selected */
     setArtworkListItemHasBeenTouched: () => setTouched(true),
+
+    /** True if we have already auto-scrolled the Artwork List page */
+    artworkListHasBeenScrolled: scrolled,
+
+    /** To be called once we have auto-scrolled the Artwork List page */
+    setArtworkListHasBeenScrolled: () => setScrolled(true),
   }
 }

--- a/src/Apps/CollectorProfile/Routes/Saves2/Utils/useArtworkListVisibility.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Utils/useArtworkListVisibility.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useState } from "react"
+
+type ArtworkListVisibility = {
+  touched: boolean
+  setTouched: (value: boolean) => void
+}
+
+const ArtworkListVisibilityContext = createContext<ArtworkListVisibility>({
+  touched: false,
+  setTouched: (_value: boolean) => {},
+})
+
+export const ArtworkListVisibilityProvider: React.FC = ({ children }) => {
+  const [touched, setTouched] = useState<boolean>(false)
+
+  return (
+    <ArtworkListVisibilityContext.Provider value={{ touched, setTouched }}>
+      {children}
+    </ArtworkListVisibilityContext.Provider>
+  )
+}
+
+export const useArtworkListVisibilityContext = () => {
+  const { touched, setTouched } = useContext(ArtworkListVisibilityContext)
+
+  return {
+    /** True if any Artwork List card has been selected from the Artwork Lists rail */
+    artworkListItemHasBeenTouched: touched,
+
+    /** To be called once any Artwork List card has been selected */
+    setArtworkListItemHasBeenTouched: () => setTouched(true),
+  }
+}


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4802]  & [FX-4803]

Review app: https://fx-artwork-list-scroll.artsy.net/collector-profile/saves

## Description

Based on internal beta feedback we want to address the usability of the Artwork Lists area on small screens.

This PR introduces some selective auto-scroll behavior, and aims to be as helpful and unobtrusive as possible.

Therefore an artwork list's artwork grid content will be scrolled into view when and only when:

- the artwork list content is **out of view** (i.e. below the bottom edge of the viewport https://github.com/artsy/force/pull/12502/commits/90f6ee13f7b0c49127e8c88c8ebecd5616166be8)

- the user is **expecting** to see new content (i.e. they have interacted with the Artwork Lists rail https://github.com/artsy/force/pull/12502/commits/845ee47a4e89817bd468d31aefc92e38a673707d)

- the user is likely **unaware** there may be more content (i.e. we have not auto-scrolled the grid content into view at least once already https://github.com/artsy/force/pull/12502/commits/50ad5746630ac5b0c134368888667e23c0c767db)

## Examples

|large screen|small screen, needs scroll|small screen, already auto-scrolled|
|---|---|---|
|On a large enough screen, no action is necessary, so we do nothing|This is the case where we assume action is necessary, so we scroll the content into view|Since we have already scrolled content into view previously, we avoid over-assertively doing it again. |
|<video src="https://github.com/artsy/force/assets/140521/315e88e6-891b-4f01-83f8-8216a26acc1c" />|<video src="https://github.com/artsy/force/assets/140521/6b747f1c-371c-4678-88d1-2d166d973ab3" />|<video src="https://github.com/artsy/force/assets/140521/543551b7-959d-4c31-a6a3-6d9a7c74511d" />|

(Previously: [Loom](https://www.loom.com/share/a4b8c81b6f9244ffbe301e33dbba554f) with older version of review app.)

[FX-4802]: https://artsyproduct.atlassian.net/browse/FX-4802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4803]: https://artsyproduct.atlassian.net/browse/FX-4803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ