### PR TITLE
feat(cookie-consent): implements cookie consent manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@babel/runtime": "7.13.10",
     "@loadable/component": "5.15.2",
     "@loadable/server": "5.15.2",
+    "@segment/consent-manager": "5.7.0",
     "@sentry/browser": "6.7.1",
     "@sentry/integrations": "^6.7.2",
     "@sentry/node": "^6.7.1",

--- a/src/Components/CookieConsentManager/CookieConsentBanner.tsx
+++ b/src/Components/CookieConsentManager/CookieConsentBanner.tsx
@@ -1,0 +1,88 @@
+import {
+  Box,
+  Button,
+  Clickable,
+  Column,
+  DROP_SHADOW,
+  GridColumns,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { Z } from "Apps/Components/constants"
+import { RouterLink } from "System/Router/RouterLink"
+import { FC } from "react"
+
+interface CookieConsentBannerProps {
+  onManage: () => void
+  onAccept: () => void
+}
+
+export const CookieConsentBanner: FC<CookieConsentBannerProps> = ({
+  onManage,
+  onAccept,
+}) => {
+  return (
+    <Box
+      position="fixed"
+      right={0}
+      bottom={0}
+      left={0}
+      bg="white100"
+      borderTop="1px solid"
+      borderColor="black10"
+      py={[2, 4]}
+      zIndex={Z.globalNav}
+      style={{ boxShadow: DROP_SHADOW }}
+    >
+      <AppContainer>
+        <HorizontalPadding>
+          <GridColumns>
+            <Column span={[12, 6, 8]}>
+              <Text
+                variant={["sm-display", "lg-display"]}
+                fontWeight={["bold", "normal"]}
+                textAlign={["center", "left"]}
+              >
+                Cookie Consent
+              </Text>
+
+              <Spacer y={1} />
+
+              <Text variant="sm">
+                We use cookies to improve your experience and personalize
+                marketing. By clicking “Accept All,” you agree to our{" "}
+                <RouterLink to="/privacy#cookie-policy" inline>
+                  cookie policy.
+                </RouterLink>
+              </Text>
+            </Column>
+
+            <Column
+              span={[12, 6, 4]}
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Clickable
+                textDecoration="underline"
+                onClick={onManage}
+                flex={1}
+                textAlign="center"
+              >
+                <Text variant="sm-display">Manage Cookies</Text>
+              </Clickable>
+
+              <Spacer x={4} />
+
+              <Button size="large" onClick={onAccept} flex={1}>
+                Accept All
+              </Button>
+            </Column>
+          </GridColumns>
+        </HorizontalPadding>
+      </AppContainer>
+    </Box>
+  )
+}

--- a/src/Components/CookieConsentManager/CookieConsentManager.tsx
+++ b/src/Components/CookieConsentManager/CookieConsentManager.tsx
@@ -1,0 +1,119 @@
+import { FC, ReactNode } from "react"
+import { ConsentManagerBuilder } from "@segment/consent-manager"
+import { getENV } from "Utils/getENV"
+import { useDidMount } from "@artsy/palette"
+import {
+  CUSTOM_DESTINATIONS,
+  ALLOW_ALL_PREFERENCES,
+  mapCustomPreferences,
+  remapSegmentCategory,
+} from "Components/CookieConsentManager/categories"
+import { useMode } from "Utils/Hooks/useMode"
+import { CookieConsentBanner } from "Components/CookieConsentManager/CookieConsentBanner"
+import { useConsentRequired } from "Components/CookieConsentManager/useConsentRequired"
+import { useTracking } from "react-tracking"
+import { CookieConsentManagerDialog } from "Components/CookieConsentManager/CookieConsentManagerDialog"
+import { CookieConsentManagerProvider } from "Components/CookieConsentManager/CookieConsentManagerContext"
+import { CookieConsentManagerSetter } from "Components/CookieConsentManager/CookieConsentManagerSetter"
+import { SavedCookieConsentPreferences } from "@artsy/cohesion/dist/Schema/Events/CookieConsent"
+import { ActionType } from "@artsy/cohesion"
+
+export const COOKIE_CONSENT_MANAGER_COOKIE_NAME = "tracking-preferences"
+
+interface CookieConsentManagerProps {
+  children: ReactNode
+}
+
+export const CookieConsentManager: FC<CookieConsentManagerProps> = ({
+  children,
+}) => {
+  const isMounted = useDidMount()
+
+  const { trackEvent } = useTracking()
+
+  const { initialPreferences, isDisplayable } = useConsentRequired()
+
+  const [mode, setMode] = useMode<"Idle" | "Open">("Idle")
+
+  const handleManage = () => {
+    setMode("Open")
+  }
+
+  const handleClose = () => {
+    setMode("Idle")
+  }
+
+  return (
+    <CookieConsentManagerProvider openConsentManager={handleManage}>
+      {children}
+
+      {isMounted && (
+        <ConsentManagerBuilder
+          cookieName={COOKIE_CONSENT_MANAGER_COOKIE_NAME}
+          writeKey={getENV("SEGMENT_WRITE_KEY")}
+          initialPreferences={initialPreferences}
+          defaultDestinationBehavior="imply"
+          mapCustomPreferences={mapCustomPreferences}
+        >
+          {({
+            destinations,
+            preferences,
+            setPreferences,
+            saveConsent,
+            newDestinations,
+          }) => {
+            const allDestinations = [
+              ...destinations,
+              ...CUSTOM_DESTINATIONS,
+            ].map(destination => ({
+              ...destination,
+              category: remapSegmentCategory(destination),
+            }))
+
+            // If there are no new destinations, we don't need to show the banner
+            const isBannerDisplayable =
+              isDisplayable && newDestinations.length > 0
+
+            const handleAccept = () => {
+              saveConsent(ALLOW_ALL_PREFERENCES)
+
+              const payload: SavedCookieConsentPreferences = {
+                action: ActionType.savedCookieConsentPreferences,
+                value: ALLOW_ALL_PREFERENCES,
+              }
+
+              trackEvent(payload)
+              handleClose()
+            }
+
+            return (
+              <>
+                {isBannerDisplayable && (
+                  <CookieConsentBanner
+                    onAccept={handleAccept}
+                    onManage={handleManage}
+                  />
+                )}
+
+                {mode !== "Idle" && (
+                  <CookieConsentManagerDialog
+                    destinations={allDestinations}
+                    onClose={handleClose}
+                    preferences={preferences}
+                    saveConsent={saveConsent}
+                    setPreferences={setPreferences}
+                  />
+                )}
+
+                <CookieConsentManagerSetter
+                  destinations={allDestinations}
+                  preferences={preferences}
+                />
+              </>
+            )
+          }}
+        </ConsentManagerBuilder>
+      )}
+    </CookieConsentManagerProvider>
+  )
+}

--- a/src/Components/CookieConsentManager/CookieConsentManagerContext.tsx
+++ b/src/Components/CookieConsentManager/CookieConsentManagerContext.tsx
@@ -1,0 +1,81 @@
+import {
+  CategoryPreferences,
+  Destination,
+} from "@segment/consent-manager/types/types"
+import {
+  DEFAULT_OPT_IN_PREFERENCES,
+  DestinationId,
+} from "Components/CookieConsentManager/categories"
+import { FC, ReactNode, createContext, useContext, useState } from "react"
+
+const CookieConsentManagerContext = createContext<{
+  destinations: Destination[]
+  isDestinationAllowed: (id: DestinationId) => boolean
+  openConsentManager: () => void
+  preferences: CategoryPreferences
+  setDestinations: (destinations: Destination[]) => void
+  setPreferences: (preferences: CategoryPreferences) => void
+  /**
+   * Is the consent manager loaded and context ready? We have to wait for Segment to return
+   * the list of destinations before anything can be used. So this remains `false` while that happens.
+   * You may want to use this field to gate rendering of a manage consent button, while we don't know
+   * if the user requires consent or not.
+   */
+  ready: boolean
+}>({
+  destinations: [],
+  /**
+   * Is the destination allowed by the user's preferences?
+   * This will always return `false` until the consent manager is ready. Thereafter
+   * it is governed by the user's stored preference or the regions' default.
+   */
+  isDestinationAllowed: () => false,
+  openConsentManager: () => {},
+  preferences: DEFAULT_OPT_IN_PREFERENCES,
+  setDestinations: () => {},
+  setPreferences: () => {},
+  ready: false,
+})
+
+interface CookieConsentManagerProviderProps {
+  openConsentManager: () => void
+  children: ReactNode
+}
+
+export const CookieConsentManagerProvider: FC<CookieConsentManagerProviderProps> = ({
+  children,
+  openConsentManager,
+}) => {
+  const [destinations, setDestinations] = useState<Destination[]>([])
+  const [preferences, setPreferences] = useState<CategoryPreferences>(
+    DEFAULT_OPT_IN_PREFERENCES
+  )
+
+  const ready = destinations.length > 0
+
+  const isDestinationAllowed = (id: DestinationId) => {
+    if (!ready) return false
+    const destination = destinations.find(destination => destination.id === id)
+    return !!(destination && preferences[destination.category])
+  }
+
+  return (
+    <CookieConsentManagerContext.Provider
+      value={{
+        destinations,
+        isDestinationAllowed,
+        openConsentManager,
+        preferences,
+        setDestinations,
+        setPreferences,
+        ready,
+      }}
+    >
+      {children}
+    </CookieConsentManagerContext.Provider>
+  )
+}
+
+export const useCookieConsentManager = () => {
+  return useContext(CookieConsentManagerContext)
+}

--- a/src/Components/CookieConsentManager/CookieConsentManagerDialog.tsx
+++ b/src/Components/CookieConsentManager/CookieConsentManagerDialog.tsx
@@ -1,0 +1,221 @@
+import { ActionType } from "@artsy/cohesion"
+import { SavedCookieConsentPreferences } from "@artsy/cohesion/dist/Schema/Events/CookieConsent"
+import {
+  Box,
+  Button,
+  Checkbox,
+  Expandable,
+  Flex,
+  Join,
+  Label,
+  ModalDialog,
+  ReadMore,
+  Separator,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import {
+  CategoryPreferences,
+  Destination,
+} from "@segment/consent-manager/types/types"
+import {
+  ALLOW_ALL_PREFERENCES,
+  CATEGORIES,
+  REJECT_ALL_PREFERENCES,
+} from "Components/CookieConsentManager/categories"
+import { RouterLink } from "System/Router/RouterLink"
+import { useMode } from "Utils/Hooks/useMode"
+import { FC } from "react"
+import { useTracking } from "react-tracking"
+
+interface CookieConsentManagerDialogProps {
+  destinations: Destination[]
+  onClose: () => void
+  preferences: CategoryPreferences
+  setPreferences: (newPreferences: CategoryPreferences) => void
+  saveConsent: (
+    newPreferences?: boolean | CategoryPreferences,
+    shouldReload?: boolean
+  ) => void
+}
+
+export const CookieConsentManagerDialog: FC<CookieConsentManagerDialogProps> = ({
+  destinations,
+  onClose,
+  preferences,
+  setPreferences,
+  saveConsent,
+}) => {
+  const { trackEvent } = useTracking()
+
+  const [mode, setMode] = useMode<"Idle" | "Allowing" | "Rejecting" | "Saving">(
+    "Idle"
+  )
+
+  const handleAllowAll = () => {
+    setMode("Allowing")
+
+    saveConsent(ALLOW_ALL_PREFERENCES)
+
+    const payload: SavedCookieConsentPreferences = {
+      action: ActionType.savedCookieConsentPreferences,
+      value: ALLOW_ALL_PREFERENCES,
+    }
+
+    trackEvent(payload)
+    onClose()
+  }
+
+  const handleRejectAll = () => {
+    setMode("Rejecting")
+
+    saveConsent(REJECT_ALL_PREFERENCES)
+
+    const payload: SavedCookieConsentPreferences = {
+      action: ActionType.savedCookieConsentPreferences,
+      value: REJECT_ALL_PREFERENCES,
+    }
+
+    trackEvent(payload)
+    onClose()
+  }
+
+  const handleSave = () => {
+    setMode("Saving")
+
+    saveConsent()
+
+    const payload: SavedCookieConsentPreferences = {
+      action: ActionType.savedCookieConsentPreferences,
+      value: preferences,
+    }
+
+    trackEvent(payload)
+    onClose()
+  }
+
+  return (
+    <ModalDialog
+      width={550}
+      hasLogo
+      title="Cookie Preference Center"
+      onClose={onClose}
+    >
+      <Join separator={<Spacer y={2} />}>
+        <Text variant="sm">
+          <ReadMore
+            maxChars={300}
+            content="When you visit our website, we store cookies on your browser to collect information. The information collected might relate to you, your preferences or your device, and is mostly used to make the site work as you expect it to and to provide a more personalized web experience. However, you can choose not to allow certain types of cookies, which may impact your experience of the site and the services we are able to offer. Click on the different category headings to find out more and change our default settings according to your preference. You cannot opt-out of our First Party Strictly Necessary Cookies as they are deployed in order to ensure the proper functioning of our website (such as prompting the cookie banner and remembering your settings, to log into your account, to redirect you when you log out, etc.)."
+          />
+        </Text>
+
+        <Text variant="sm">
+          <RouterLink to="/privacy#cookie-policy">
+            For details, please see our Cookie Policy.
+          </RouterLink>
+        </Text>
+
+        <Button
+          loading={mode === "Allowing"}
+          width="100%"
+          onClick={handleAllowAll}
+        >
+          Allow All
+        </Button>
+
+        <Separator />
+
+        <Text variant="lg-display">Manage Consent Preferences</Text>
+
+        <Box>
+          <Join separator={<Spacer y={1} />}>
+            {CATEGORIES.map(({ key, name, description }) => {
+              const disabled = key === "necessary"
+
+              const categoryDestinations = destinations.filter(destination => {
+                return destination.category === key
+              })
+
+              const isActive = Boolean(preferences[key])
+
+              return (
+                <Expandable
+                  key={key}
+                  label={
+                    <Flex
+                      flex={1}
+                      alignItems="center"
+                      justifyContent="space-between"
+                    >
+                      <Text variant="sm-display">{name}</Text>
+
+                      {isActive ? (
+                        <Label variant="brand">Active</Label>
+                      ) : (
+                        <Label>Inactive</Label>
+                      )}
+                    </Flex>
+                  }
+                >
+                  <Text variant="sm" color="black60">
+                    {description}
+                  </Text>
+
+                  {categoryDestinations.length > 0 && (
+                    <>
+                      <Spacer y={1} />
+
+                      <Text variant="xs" color="black60">
+                        Example:{" "}
+                        {categoryDestinations
+                          .map(destination => destination.name)
+                          .join(", ")}
+                      </Text>
+
+                      <Spacer y={2} />
+                    </>
+                  )}
+
+                  {!disabled && (
+                    <>
+                      <Spacer y={2} />
+
+                      <Checkbox
+                        disabled={disabled}
+                        selected={isActive}
+                        onSelect={() =>
+                          setPreferences({ [key]: !preferences[key] })
+                        }
+                      >
+                        Enable {name}
+                      </Checkbox>
+                    </>
+                  )}
+
+                  <Spacer y={4} />
+                </Expandable>
+              )
+            })}
+          </Join>
+        </Box>
+
+        <Flex>
+          <Button
+            flex={1}
+            loading={mode === "Rejecting"}
+            variant="secondaryBlack"
+            onClick={handleRejectAll}
+          >
+            Reject All
+          </Button>
+
+          <Spacer x={2} />
+
+          <Button flex={1} loading={mode === "Saving"} onClick={handleSave}>
+            Confirm My Choices
+          </Button>
+        </Flex>
+      </Join>
+    </ModalDialog>
+  )
+}

--- a/src/Components/CookieConsentManager/CookieConsentManagerSetter.tsx
+++ b/src/Components/CookieConsentManager/CookieConsentManagerSetter.tsx
@@ -1,0 +1,31 @@
+import {
+  CategoryPreferences,
+  Destination,
+} from "@segment/consent-manager/types/types"
+import { useCookieConsentManager } from "Components/CookieConsentManager/CookieConsentManagerContext"
+import { FC, useEffect } from "react"
+
+interface CookieConsentManagerSetterProps {
+  destinations: Destination[]
+  preferences: CategoryPreferences
+}
+
+/**
+ * We can't thread children through the `ConsentManagerBuilder` due to implications
+ * with that library on server-side rendering. Instead, we use this component to
+ * save the destinations and preferences to the context, which sits above the
+ * `ConsentManagerBuilder` in the component tree.
+ */
+export const CookieConsentManagerSetter: FC<CookieConsentManagerSetterProps> = ({
+  destinations,
+  preferences,
+}) => {
+  const { setDestinations, setPreferences } = useCookieConsentManager()
+
+  useEffect(() => {
+    setDestinations(destinations)
+    setPreferences(preferences)
+  }, [destinations, preferences, setDestinations, setPreferences])
+
+  return null
+}

--- a/src/Components/CookieConsentManager/README.md
+++ b/src/Components/CookieConsentManager/README.md
@@ -1,0 +1,52 @@
+# Cookie Consent Manager
+
+| Region               | URL      | Behavior      |
+| -------------------- | -------- | ------------- |
+| US (sans California) | /        | Don't display |
+| EU                   | /?geo=eu | Opt-in        |
+| California           | /?geo=ca | Opt-out       |
+| Brazil               | /?geo=br | Out-out       |
+
+## Overview
+
+- We use Segment's `ConsentManagerBuilder` to load Segment integrations.
+  - It will automatically handle any integrations which are enabled through Segment
+  - For other things that introduce 3rd party cookies we include them as custom preferences then use the provider to expose those preferences and block or enable those features.
+- We use timezone information to determine initial opt-in/out preferences and whether or not to display the banner to users
+- We log an event for auditing to Segment when preferences are saved, it includes the tracking preferences as the `value`.
+
+### Custom integrations
+
+Currently we manually block and integrate YouTube/Vimeo embeds and our editorial ads.
+
+In `categories.ts` add an entry to the `CUSTOM_DESTINATIONS` array, corresponding with your integration.
+
+```ts
+export const CUSTOM_DESTINATIONS: Destination[] = [
+  // ...
+  {
+    category: "targeting",
+    description: "A description of what it does",
+    id: "MyCustomIntegration",
+    name: "MyCustomIntegration",
+    website: "https://www.mycustomintegration.com/",
+    creationName: "MyCustomIntegration",
+  },
+]
+```
+
+Then, where that content is rendered, gate access to it using the `isDestinationAllowed` function:
+
+```tsx
+const { isDestinationAllowed, openConsentManager } = useCookieConsentManager()
+
+return (
+  <>
+    {isDestinationAllowed("MyCustomIntegration") ? (
+      <MyCustomIntegration />
+    ) : (
+      <Button onClick={openConsentManager}>Manage Cookies</Button>
+    )}
+  </>
+)
+```

--- a/src/Components/CookieConsentManager/__tests__/categories.jest.ts
+++ b/src/Components/CookieConsentManager/__tests__/categories.jest.ts
@@ -1,0 +1,105 @@
+import {
+  mapCustomPreferences,
+  remapSegmentCategory,
+} from "Components/CookieConsentManager/categories"
+
+describe("mapCustomPreferences", () => {
+  // Destinations that are returned by Segment
+  const segmentDestinations = [
+    {
+      name: "Braze Web Device Mode (Actions)",
+      description: "Braze Web Mode (Actions)",
+      website: "https://www.braze.com/",
+      category: "Email Marketing",
+      id: "Braze Web Mode (Actions)",
+      creationName: "Braze Web Mode (Actions)", // Doesn't actually seem to get returned by Segment. Type expects it.
+    },
+  ]
+
+  describe("default opt-out preferences", () => {
+    const segmentPreferences = {
+      necessary: true,
+      functional: false,
+      performance: false,
+      targeting: false,
+    }
+
+    it("maps Segment preferences to conform to our own", () => {
+      expect(
+        mapCustomPreferences(segmentDestinations, segmentPreferences)
+      ).toEqual({
+        destinationPreferences: {
+          "Braze Web Mode (Actions)": true,
+          "Google Ads": false,
+          YouTube: false,
+        },
+        customPreferences: {
+          necessary: true,
+          functional: false,
+          performance: false,
+          targeting: false,
+        },
+      })
+    })
+  })
+
+  describe("with custom saved tracking preferences", () => {
+    const segmentPreferences = {
+      necessary: true,
+      functional: true,
+      performance: true,
+      targeting: true,
+    }
+
+    it("maps Segment preferences to conform to our own", () => {
+      expect(
+        mapCustomPreferences(segmentDestinations, segmentPreferences)
+      ).toEqual({
+        destinationPreferences: {
+          "Braze Web Mode (Actions)": true,
+          "Google Ads": true,
+          YouTube: true,
+        },
+        customPreferences: {
+          necessary: true,
+          functional: true,
+          performance: true,
+          targeting: true,
+        },
+      })
+    })
+  })
+})
+
+describe("remapSegmentCategory", () => {
+  const example = {
+    name: "Example Service",
+    description: "Example Service",
+    website: "https://www.example.com/",
+    category: "Advertising",
+    id: "Example Service",
+    creationName: "Example Service",
+  }
+
+  it("re-maps Segment's categorization to our own", () => {
+    expect(
+      remapSegmentCategory({ ...example, category: "Advertising" })
+    ).toEqual("targeting")
+
+    expect(
+      remapSegmentCategory({ ...example, category: "Heatmaps & Recordings" })
+    ).toEqual("performance")
+
+    expect(
+      remapSegmentCategory({ ...example, category: "Deep Linking" })
+    ).toEqual("functional")
+
+    expect(remapSegmentCategory({ ...example, category: "Garbage" })).toEqual(
+      "functional"
+    )
+
+    expect(
+      remapSegmentCategory({ ...example, id: "Braze Web Mode (Actions)" })
+    ).toEqual("necessary")
+  })
+})

--- a/src/Components/CookieConsentManager/categories.ts
+++ b/src/Components/CookieConsentManager/categories.ts
@@ -1,0 +1,156 @@
+import {
+  CategoryPreferences,
+  Destination,
+} from "@segment/consent-manager/types/types"
+
+const SEGMENT_CATEGORIES = {
+  performance: [
+    "A/B Testing",
+    "Analytics",
+    "Attribution",
+    "Email",
+    "Enrichment",
+    "Heatmaps & Recordings",
+    "Raw Data",
+    "Realtime Dashboards",
+    "Referrals",
+    "Surveys",
+    "Video",
+  ],
+  targeting: ["Advertising", "Tag Managers"],
+  functional: [
+    "CRM",
+    "Customer Success",
+    "Deep Linking",
+    "Helpdesk",
+    "Livechat",
+    "Performance Monitoring",
+    "Personalization",
+    "SMS & Push Notifications",
+    "Security & Fraud",
+  ],
+}
+
+export const CATEGORIES = [
+  {
+    key: "necessary",
+    name: "Strictly Necessary Cookies",
+    description:
+      "These cookies are required to enable core site functionality. They cannot be turned off.",
+  },
+  {
+    key: "functional",
+    name: "Functional Cookies",
+    description:
+      "These cookies enable the website to provide enhanced functionality and personalisation. They may be set by us or by third party providers whose services we have added to our pages. If you do not allow these cookies then some or all of these services may not function properly.",
+  },
+  {
+    key: "performance",
+    name: "Performance Cookies",
+    description:
+      "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
+  },
+  {
+    key: "targeting",
+    name: "Targeting Cookies",
+    description:
+      "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+  },
+] as const
+
+export const DEFAULT_OPT_IN_PREFERENCES: CategoryPreferences = {
+  necessary: true,
+  functional: false,
+  performance: false,
+  targeting: false,
+}
+
+export const DEFAULT_OPT_OUT_PREFERENCES: CategoryPreferences = {
+  necessary: true,
+  functional: true,
+  performance: true,
+  targeting: true,
+}
+
+export const REJECT_ALL_PREFERENCES = DEFAULT_OPT_IN_PREFERENCES
+export const ALLOW_ALL_PREFERENCES = DEFAULT_OPT_OUT_PREFERENCES
+
+export const CUSTOM_DESTINATIONS: Destination[] = [
+  {
+    category: "targeting",
+    description: "Google Ads served on Artsy's article pages",
+    id: "Google Ads",
+    name: "Google Ads",
+    website: "https://ads.google.com/",
+    creationName: "Google Ads",
+  },
+  {
+    category: "targeting",
+    description: "YouTube videos embedded on Artsy's article pages",
+    id: "YouTube",
+    name: "YouTube",
+    website: "https://www.youtube.com/",
+    creationName: "YouTube",
+  },
+]
+
+export const DEFAULT_CATEGORIZATION = "functional"
+
+// Overwrite Segment's categorization with our own
+export const DESTINATION_MAPPING = {
+  "Braze Web Mode (Actions)": "necessary",
+  "Google Analytics": "performance",
+  "Google Ads": "targeting",
+  YouTube: "targeting",
+  // Add more mappings as needed
+} as const
+
+export type DestinationId = keyof typeof DESTINATION_MAPPING
+
+export const mapCustomPreferences = (
+  destinations: Destination[],
+  preferences: CategoryPreferences
+) => {
+  const allDestinations = [...destinations, ...CUSTOM_DESTINATIONS]
+
+  const customPreferences = Object.keys(preferences).reduce(
+    (acc, preferenceName) => {
+      const value = preferences[preferenceName]
+
+      return {
+        ...acc,
+        [preferenceName]: typeof value === "boolean" ? value : true,
+      }
+    },
+    {}
+  )
+
+  const destinationPreferences = allDestinations.reduce((acc, destination) => {
+    const customCategory = remapSegmentCategory(destination)
+
+    return customCategory !== undefined
+      ? {
+          ...acc,
+          [destination.id]: customPreferences[customCategory],
+        }
+      : acc
+  }, {})
+
+  return { destinationPreferences, customPreferences }
+}
+
+// Map between Segment's categories and our own
+export const remapSegmentCategory = (destination: Destination) => {
+  switch (true) {
+    case !!DESTINATION_MAPPING[destination.id]:
+      return DESTINATION_MAPPING[destination.id]
+    case SEGMENT_CATEGORIES.performance.includes(destination.category):
+      return "performance"
+    case SEGMENT_CATEGORIES.targeting.includes(destination.category):
+      return "targeting"
+    case SEGMENT_CATEGORIES.functional.includes(destination.category):
+      return "functional"
+    default:
+      return DEFAULT_CATEGORIZATION
+  }
+}

--- a/src/Components/CookieConsentManager/cookieConsentManagerServerRoutes.ts
+++ b/src/Components/CookieConsentManager/cookieConsentManagerServerRoutes.ts
@@ -1,0 +1,31 @@
+import { COOKIE_CONSENT_MANAGER_COOKIE_NAME } from "Components/CookieConsentManager/CookieConsentManager"
+import { Router } from "express"
+import { ArtsyRequest } from "Server/middleware/artsyExpress"
+
+const COOKIE_CONFIGURATION = {
+  maxAge: 1000 * 60 * 60 * 24 * 365,
+  httpOnly: false,
+  secure: true,
+}
+
+const cookieConsentManagerServerRoutes = Router()
+
+cookieConsentManagerServerRoutes.get(
+  // Works around Safari's 7 day limit for client-side cookies
+  "/set-tracking-preferences",
+  (req: ArtsyRequest, res) => {
+    const trackingPreferences = req.query[COOKIE_CONSENT_MANAGER_COOKIE_NAME]
+
+    if (trackingPreferences) {
+      res.cookie(
+        COOKIE_CONSENT_MANAGER_COOKIE_NAME,
+        trackingPreferences,
+        COOKIE_CONFIGURATION
+      )
+    }
+
+    res.send("[Force] Consent cookie set.")
+  }
+)
+
+export { cookieConsentManagerServerRoutes }

--- a/src/Components/CookieConsentManager/useConsentRequired.ts
+++ b/src/Components/CookieConsentManager/useConsentRequired.ts
@@ -1,0 +1,97 @@
+import { CategoryPreferences } from "@segment/consent-manager/types/types"
+import {
+  DEFAULT_OPT_IN_PREFERENCES,
+  DEFAULT_OPT_OUT_PREFERENCES,
+} from "Components/CookieConsentManager/categories"
+import { useDidMount } from "Utils/Hooks/useDidMount"
+import qs from "qs"
+
+/**
+ * EU or UK: banner appears, visitors can opt-in to optional cookies, but are opted out by default
+ * California or Brazil: banner appears, visitors can opt-out, but are opted in by default
+ * Visitors geolocated to other regions see no banner and can't opt out
+ *
+ * Reference: https://github.com/segmentio/in-eu
+ */
+export const useConsentRequired = (): {
+  isEU: boolean
+  isCA: boolean
+  isBR: boolean
+  isOptOut: boolean
+  isOptIn: boolean
+  isDisplayable: boolean
+  initialPreferences: CategoryPreferences
+} => {
+  const isMounted = useDidMount()
+
+  if (!isMounted || typeof Intl === "undefined") {
+    return RESTRICTIVE_DEFAULTS
+  }
+
+  const query = qs.parse(window.location.search, {
+    ignoreQueryPrefix: true,
+  })
+
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+  const isEU =
+    timezone.startsWith("Europe") ||
+    AMBIGUOUS_TIMEZONES.includes(timezone) ||
+    query.geo === "eu"
+  const isCA = CALIFORNIA_TIMEZONES.includes(timezone) || query.geo === "ca"
+  const isBR = BRAZIL_TIMEZONES.includes(timezone) || query.geo === "br"
+
+  const isOptIn = isEU
+  const isOptOut = isCA || isBR
+  const isDisplayable = isOptIn || isOptOut
+
+  const initialPreferences = (() => {
+    if (isOptIn) return DEFAULT_OPT_IN_PREFERENCES
+    if (isOptOut) return DEFAULT_OPT_OUT_PREFERENCES
+    return DEFAULT_OPT_OUT_PREFERENCES
+  })()
+
+  return {
+    isEU,
+    isCA,
+    isBR,
+    isOptOut,
+    isOptIn,
+    isDisplayable,
+    initialPreferences,
+  }
+}
+
+const RESTRICTIVE_DEFAULTS = {
+  isEU: true,
+  isCA: false,
+  isBR: false,
+  isOptOut: true,
+  isOptIn: false,
+  isDisplayable: true,
+  initialPreferences: DEFAULT_OPT_OUT_PREFERENCES,
+} as const
+
+const AMBIGUOUS_TIMEZONES = ["Etc/UTC", "Etc/GMT", "UTC"]
+
+const CALIFORNIA_TIMEZONES = ["America/Los_Angeles"]
+
+// https://en.wikipedia.org/wiki/Time_in_Brazil#IANA_time_zone_database
+const BRAZIL_TIMEZONES = [
+  "America/Araguaina",
+  "America/Bahia",
+  "America/Belem",
+  "America/Boa_Vista",
+  "America/Campo_Grande",
+  "America/Cuiaba",
+  "America/Eirunepe",
+  "America/Fortaleza",
+  "America/Maceio",
+  "America/Manaus",
+  "America/Noronha",
+  "America/Porto_Velho",
+  "America/Recife",
+  "America/Rio_Branco",
+  "America/Santarem",
+  "America/Sao_Paulo",
+]

--- a/src/Components/CookieConsentManager/utils.ts
+++ b/src/Components/CookieConsentManager/utils.ts
@@ -1,0 +1,17 @@
+import cookies from "cookies-js"
+import { COOKIE_CONSENT_MANAGER_COOKIE_NAME } from "Components/CookieConsentManager/CookieConsentManager"
+
+export const setServerSideCookie = () => {
+  // Wait for cookie to be set
+  setTimeout(() => {
+    const cookie = cookies.get(COOKIE_CONSENT_MANAGER_COOKIE_NAME)
+
+    if (!cookie) return
+
+    const trackingPreferences = encodeURIComponent(cookie)
+
+    fetch(
+      `/set-tracking-preferences?${COOKIE_CONSENT_MANAGER_COOKIE_NAME}=${trackingPreferences}`
+    )
+  }, 0)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,6 +487,13 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
+"@babel/helper-module-imports@^7.16.7":
+  version "7.21.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz#ac88b2f76093637489e718a90cec6cf8a9b029af"
+  integrity sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==
+  dependencies:
+    "@babel/types" "^7.21.4"
+
 "@babel/helper-module-imports@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
@@ -1546,7 +1553,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.12.13":
+"@babel/runtime@^7.12.13", "@babel/runtime@^7.18.3":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -1720,6 +1727,15 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.21.4":
+  version "7.21.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.4.tgz#2d5d6bb7908699b3b416409ffd3b5daa25b030d4"
+  integrity sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
 "@base2/pretty-print-object@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.1.tgz#371ba8be66d556812dc7fb169ebc3c08378f69d4"
@@ -1831,6 +1847,56 @@
   resolved "https://registry.yarnpkg.com/@emmetio/extract-abbreviation/-/extract-abbreviation-0.1.6.tgz#e4a9856c1057f0aff7d443b8536477c243abe28c"
   integrity sha512-Ce3xE2JvTSEbASFbRbA1gAIcMcZWdS2yUYRaQbeM0nbOzaZrUYfa3ePtcriYRZOZmr+CkKA+zbjhvTpIOAYVcw==
 
+"@emotion/babel-plugin@^11.10.6":
+  version "11.10.6"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz#a68ee4b019d661d6f37dec4b8903255766925ead"
+  integrity sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/hash" "^0.9.0"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/serialize" "^1.1.1"
+    babel-plugin-macros "^3.1.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.1.3"
+
+"@emotion/babel-utils@^0.6.4":
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-utils/-/babel-utils-0.6.10.tgz#83dbf3dfa933fae9fc566e54fbb45f14674c6ccc"
+  integrity sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==
+  dependencies:
+    "@emotion/hash" "^0.6.6"
+    "@emotion/memoize" "^0.6.6"
+    "@emotion/serialize" "^0.9.1"
+    convert-source-map "^1.5.1"
+    find-root "^1.1.0"
+    source-map "^0.7.2"
+
+"@emotion/cache@^11.10.5":
+  version "11.10.7"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.7.tgz#2e3b12d3c7c74db0a020ae79eefc52a1b03a6908"
+  integrity sha512-VLl1/2D6LOjH57Y8Vem1RoZ9haWF4jesHDGiHtKozDQuBIkJm2gimVo0I02sWCuzZtVACeixTVB4jeE8qvCBoQ==
+  dependencies:
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/sheet" "^1.2.1"
+    "@emotion/utils" "^1.2.0"
+    "@emotion/weak-memoize" "^0.3.0"
+    stylis "4.1.3"
+
+"@emotion/hash@^0.6.2", "@emotion/hash@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.6.tgz#62266c5f0eac6941fece302abad69f2ee7e25e44"
+  integrity sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ==
+
+"@emotion/hash@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
+  integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
+
 "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
@@ -1838,20 +1904,124 @@
   dependencies:
     "@emotion/memoize" "0.7.4"
 
+"@emotion/is-prop-valid@^1.1.0", "@emotion/is-prop-valid@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
+  integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
+  dependencies:
+    "@emotion/memoize" "^0.8.0"
+
 "@emotion/memoize@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
+  integrity sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
+
+"@emotion/memoize@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
+  integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
+
+"@emotion/react@^11.8.2":
+  version "11.10.6"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.6.tgz#dbe5e650ab0f3b1d2e592e6ab1e006e75fd9ac11"
+  integrity sha512-6HT8jBmcSkfzO7mc+N1L9uwvOnlcGoix8Zn7srt+9ga0MjREo6lRpuVX0kzo6Jp6oTqDhREOFsygN6Ew4fEQbw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.10.6"
+    "@emotion/cache" "^11.10.5"
+    "@emotion/serialize" "^1.1.1"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
+    "@emotion/utils" "^1.2.0"
+    "@emotion/weak-memoize" "^0.3.0"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.9.1.tgz#a494982a6920730dba6303eb018220a2b629c145"
+  integrity sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==
+  dependencies:
+    "@emotion/hash" "^0.6.6"
+    "@emotion/memoize" "^0.6.6"
+    "@emotion/unitless" "^0.6.7"
+    "@emotion/utils" "^0.8.2"
+
+"@emotion/serialize@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.1.tgz#0595701b1902feded8a96d293b26be3f5c1a5cf0"
+  integrity sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==
+  dependencies:
+    "@emotion/hash" "^0.9.0"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/unitless" "^0.8.0"
+    "@emotion/utils" "^1.2.0"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
+  integrity sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==
+
+"@emotion/styled@^11.8.1":
+  version "11.10.6"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.10.6.tgz#d886afdc51ef4d66c787ebde848f3cc8b117ebba"
+  integrity sha512-OXtBzOmDSJo5Q0AFemHCfl+bUueT8BIcPSxu0EGTpGk6DmI5dnhSzQANm1e1ze0YZL7TDyAyy6s/b/zmGOS3Og==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.10.6"
+    "@emotion/is-prop-valid" "^1.2.0"
+    "@emotion/serialize" "^1.1.1"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
+    "@emotion/utils" "^1.2.0"
+
+"@emotion/stylis@^0.7.0":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.7.1.tgz#50f63225e712d99e2b2b39c19c70fff023793ca5"
+  integrity sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ==
 
 "@emotion/stylis@^0.8.4":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
+"@emotion/unitless@^0.6.2", "@emotion/unitless@^0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.7.tgz#53e9f1892f725b194d5e6a1684a7b394df592397"
+  integrity sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg==
+
 "@emotion/unitless@^0.7.4":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@emotion/unitless@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.0.tgz#a4a36e9cbdc6903737cd20d38033241e1b8833db"
+  integrity sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==
+
+"@emotion/use-insertion-effect-with-fallbacks@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz#ffadaec35dbb7885bd54de3fa267ab2f860294df"
+  integrity sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==
+
+"@emotion/utils@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
+  integrity sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==
+
+"@emotion/utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
+  integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
+
+"@emotion/weak-memoize@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
+  integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
 "@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2":
   version "3.0.2"
@@ -2992,6 +3162,41 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@segment/consent-manager@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@segment/consent-manager/-/consent-manager-5.7.0.tgz#f9cd298a3b36643602de310f97b89c596da22549"
+  integrity sha512-K0LsDmtUrYTNdJ+3uLoI0SF5/KzYZgkQNShiV19m6hPg3p8iTmBDYJ7nz6UnmkiqEvtjh6EbwWyg/VLWYajrbA==
+  dependencies:
+    "@emotion/react" "^11.8.2"
+    "@emotion/styled" "^11.8.1"
+    "@segment/in-regions" "^1.2.0"
+    "@segment/top-domain" "^3.0.0"
+    emotion "^9.1.2"
+    isomorphic-fetch "^3.0.0"
+    js-cookie "^2.2.0"
+    lodash "^4.17.21"
+    nanoid "^1.0.2"
+    prop-types "^15.6.1"
+    styled-components "^5.3.5"
+
+"@segment/in-eu@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@segment/in-eu/-/in-eu-0.3.0.tgz#b7d452a2f7e3a29461c0774f4d1570c7e8448ca8"
+  integrity sha512-np6ves6pLi1nkKjQHXk3FBQJmu+C7Gs6n3UYM0TzHsIdZOz1Cfu636cuc+iidBRfE6S+3w0W8AD7F4hpicuUnw==
+  dependencies:
+    jstz "^2.0.0"
+
+"@segment/in-regions@^1.2.0":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@segment/in-regions/-/in-regions-1.2.3.tgz#2d9a3350623f170421685b8fbf08914d8a42aeb9"
+  integrity sha512-2hvPV+yh6ymSgLwzcYjUmKx0MUtiyYBoQUue8+tCgLnnuPqZ4pJ26JBEdK7jWKTQje2+KqENCF8STVGC4pmy7Q==
+  dependencies:
+    "@segment/in-eu" "^0.3.0"
+    "@types/jest" "^27.5.0"
+    "@types/node" "^12.12.21"
+    jstz "^2.1.1"
+    us "^2.0.0"
+
 "@segment/loosely-validate-event@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@segment/loosely-validate-event/-/loosely-validate-event-1.1.2.tgz#d77840999e3f7e43e74b3b0d43391c1526f793b8"
@@ -2999,6 +3204,14 @@
   dependencies:
     component-type "^1.2.1"
     join-component "^1.1.0"
+
+"@segment/top-domain@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@segment/top-domain/-/top-domain-3.0.1.tgz#4c99ab061b858c8acceed4e2d84d4dfc9c2d770e"
+  integrity sha512-A8E80WlV0IXLQZ+keBiv/6yMmwW2pzXaiCcY/TUEBOAhO1kPj8PFLJC17uuN8nqxKv0rIkRGeBIgslMMT3uNfQ==
+  dependencies:
+    component-cookie "^1.1.5"
+    component-url "^0.2.1"
 
 "@sentry/browser@6.7.1":
   version "6.7.1"
@@ -4542,6 +4755,14 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
+"@types/jest@^27.5.0":
+  version "27.5.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.5.2.tgz#ec49d29d926500ffb9fd22b84262e862049c026c"
+  integrity sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==
+  dependencies:
+    jest-matcher-utils "^27.0.0"
+    pretty-format "^27.0.0"
+
 "@types/jsdom@^20.0.0":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-20.0.1.tgz#07c14bc19bd2f918c1929541cdaacae894744808"
@@ -4656,6 +4877,11 @@
   version "18.11.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.19.tgz#35e26df9ec441ab99d73e99e9aca82935eea216d"
   integrity sha512-YUgMWAQBWLObABqrvx8qKO1enAvBUdjZOAWQ5grBAkp5LQv45jBvYKZ3oFS9iKRCQyFjqw6iuEa1vmFqtxYLZw==
+
+"@types/node@^12.12.21":
+  version "12.20.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
+  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
 "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0":
   version "16.18.3"
@@ -6357,6 +6583,24 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-emotion@^9.2.11:
+  version "9.2.11"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz#319c005a9ee1d15bb447f59fe504c35fd5807728"
+  integrity sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/babel-utils" "^0.6.4"
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.7.0"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    find-root "^1.1.0"
+    mkdirp "^0.5.1"
+    source-map "^0.5.7"
+    touch "^2.0.1"
+
 babel-plugin-extract-import-names@1.6.22:
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.22.tgz#de5f9a28eb12f3eb2578bf74472204e66d1a13dc"
@@ -6440,6 +6684,15 @@ babel-plugin-macros@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.0.1.tgz#0d412d68f5b3d1b64358f24ab099bd148724e2a9"
   integrity sha512-CKt4+Oy9k2wiN+hT1uZzOw7d8zb1anbQpf7KLwaaXRCi/4pzKdFKHf7v5mvoPmjkmxshh7eKZQuRop06r5WP4w==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    cosmiconfig "^7.0.0"
+    resolve "^1.19.0"
+
+babel-plugin-macros@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
+  integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     cosmiconfig "^7.0.0"
@@ -7814,6 +8067,13 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
+component-cookie@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/component-cookie/-/component-cookie-1.1.5.tgz#27757fae4b27370138378ec754ca8d457bd47040"
+  integrity sha512-+D1nKIL6UfbYBoUeHVVdmd+I+BhgjjMQtT5cHp7HLAdpVi+7GZSvbYPItYaNgTeta5znlC8PJsBFZSY1mf57ZA==
+  dependencies:
+    debug "^2.6.9"
+
 component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -7823,6 +8083,11 @@ component-type@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-type/-/component-type-1.2.1.tgz#8a47901700238e4fc32269771230226f24b415a9"
   integrity sha1-ikeQFwAjjk/DIml3EjAibyS0Fak=
+
+component-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/component-url/-/component-url-0.2.1.tgz#4e4f4799c43ead9fd3ce91b5a305d220208fee47"
+  integrity sha512-ThaWgt9+hMAsJj6FdfM+eT3Pvv5pkqgQpnxW9loVkS7tKbBtYPGgNq6c+ftxIgKt3rd04kHsiTXRyOz/Mdi14A==
 
 compressible@~2.0.13:
   version "2.0.13"
@@ -8000,6 +8265,11 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1,
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   dependencies:
     safe-buffer "~5.1.1"
+
+convert-source-map@^1.5.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
+  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
 
 convert-source-map@^2.0.0:
   version "2.0.0"
@@ -8203,6 +8473,19 @@ create-ecdh@^4.0.0:
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
+
+create-emotion@^9.2.12:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-9.2.12.tgz#0fc8e7f92c4f8bb924b0fef6781f66b1d07cb26f"
+  integrity sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==
+  dependencies:
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.7.0"
+    "@emotion/unitless" "^0.6.2"
+    csstype "^2.5.2"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
 
 create-error-class@^3.0.0:
   version "3.0.2"
@@ -8496,6 +8779,11 @@ csstype@^2.2.0:
   version "2.6.16"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.16.tgz#544d69f547013b85a40d15bff75db38f34fe9c39"
   integrity sha512-61FBWoDHp/gRtsoDkq/B1nWrCUG/ok1E3tUrcNbZjsE9Cxd9yzUirjS3+nAATB8U4cTtaQmAHbNndoFz5L6C9Q==
+
+csstype@^2.5.2:
+  version "2.6.21"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.21.tgz#2efb85b7cc55c80017c66a5ad7cbd931fda3a90e"
+  integrity sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==
 
 csurf@^1.9.0:
   version "1.11.0"
@@ -9053,6 +9341,11 @@ diff-sequences@^27.0.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
   integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
 
+diff-sequences@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
+  integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
+
 diff-sequences@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.4.3.tgz#9314bc1fabe09267ffeca9cbafc457d8499a13f2"
@@ -9436,6 +9729,14 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
+emotion@^9.1.2:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.2.12.tgz#53925aaa005614e65c6e43db8243c843574d1ea9"
+  integrity sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==
+  dependencies:
+    babel-plugin-emotion "^9.2.11"
+    create-emotion "^9.2.12"
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -9767,6 +10068,11 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@^1.11.1:
   version "1.14.3"
@@ -10714,6 +11020,11 @@ find-cache-dir@^3.3.1:
     commondir "^1.0.1"
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -13233,6 +13544,14 @@ isomorphic-fetch@^2.2.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isomorphic-unfetch@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
@@ -13560,6 +13879,16 @@ jest-diff@^27.0.0:
     jest-get-type "^27.3.1"
     pretty-format "^27.3.1"
 
+jest-diff@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
+  integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
+
 jest-diff@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.5.0.tgz#e0d83a58eb5451dcc1fa61b1c3ee4e8f5a290d63"
@@ -13670,6 +13999,11 @@ jest-get-type@^27.3.1:
   version "27.3.1"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.3.1.tgz#a8a2b0a12b50169773099eee60a0e6dd11423eff"
   integrity sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==
+
+jest-get-type@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
+  integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
 
 jest-get-type@^29.4.3:
   version "29.4.3"
@@ -13813,6 +14147,16 @@ jest-matcher-utils@^25.5.0:
     jest-diff "^25.5.0"
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
+
+jest-matcher-utils@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
+  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
 
 jest-matcher-utils@^29.5.0:
   version "29.5.0"
@@ -14291,6 +14635,11 @@ join-component@^1.1.0:
   resolved "https://registry.yarnpkg.com/join-component/-/join-component-1.1.0.tgz#b8417b750661a392bee2c2537c68b2a9d4977cd5"
   integrity sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU=
 
+js-cookie@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 js-string-escape@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
@@ -14569,6 +14918,11 @@ jsprim@^2.0.2:
     extsprintf "1.3.0"
     json-schema "0.4.0"
     verror "1.10.0"
+
+jstz@^2.0.0, jstz@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/jstz/-/jstz-2.1.1.tgz#fff3373a518fa7cce69299930466f5a2b980389d"
+  integrity sha512-8hfl5RD6P7rEeIbzStBz3h4f+BQHfq/ABtoU6gXKQv5OcZhnmrIpG7e1pYaZ8hS9e0mp+bxUj08fnDUbKctYyA==
 
 jsx-ast-utils@^2.2.3, jsx-ast-utils@^2.4.1:
   version "2.4.1"
@@ -15884,6 +16238,11 @@ nanoclone@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
   integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
+
+nanoid@^1.0.2:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-1.3.4.tgz#ad89f62c9d1f4fd69710d4a90953d2893d2d31f4"
+  integrity sha512-4ug4BsuHxiVHoRUe1ud6rUFT3WUMmjXt1W0quL0CviZQANdan7D8kqN5/maw53hmAApY/jfzMRkC57BNNs60ZQ==
 
 nanoid@^3.3.1, nanoid@^3.3.4:
   version "3.3.4"
@@ -17499,6 +17858,15 @@ pretty-format@^27.0.0, pretty-format@^27.3.1:
   integrity sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==
   dependencies:
     "@jest/types" "^27.2.5"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
@@ -19698,6 +20066,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+source-map@^0.7.2:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
+
 source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
@@ -20280,6 +20653,22 @@ styled-components@5.3.0:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
+styled-components@^5.3.5:
+  version "5.3.9"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.9.tgz#641af2a8bb89904de708c71b439caa9633e8f0ba"
+  integrity sha512-Aj3kb13B75DQBo2oRwRa/APdB5rSmwUfN5exyarpX+x/tlM/rwZA2vVk2vQgVSP6WKaZJHWwiFrzgHt+CLtB4A==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^1.1.0"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1.12.0"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
+    supports-color "^5.5.0"
+
 styled-system@5.1.5, styled-system@^5.1.5:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-5.1.5.tgz#e362d73e1dbb5641a2fd749a6eba1263dc85075e"
@@ -20298,6 +20687,21 @@ styled-system@5.1.5, styled-system@^5.1.5:
     "@styled-system/typography" "^5.1.2"
     "@styled-system/variant" "^5.1.5"
     object-assign "^4.1.1"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
+  integrity sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 subscribe-ui-event@^2.0.6:
   version "2.0.7"
@@ -20776,6 +21180,13 @@ totalist@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
   integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
+
+touch@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-2.0.2.tgz#ca0b2a3ae3211246a61b16ba9e6cbf1596287164"
+  integrity sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==
+  dependencies:
+    nopt "~1.0.10"
 
 touch@^3.1.0:
   version "3.1.0"
@@ -21531,6 +21942,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+us@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/us/-/us-2.0.0.tgz#e8d0c1e14c2e05b6534a028256aca21025c45dde"
+  integrity sha512-ZyfFtelVet6SANhzzhIt9rtfVq+uCgIOELlq+ozdsKja5SRQ77wGiimAXuV0uacwIKaOTwGgvpB2OZw+z9jJFQ==
+
 use-callback-ref@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.0.tgz#772199899b9c9a50526fedc4993fc7fa1f7e32d5"
@@ -22138,7 +22554,7 @@ whatwg-encoding@^2.0.0:
   dependencies:
     iconv-lite "0.6.3"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^3.4.1:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==


### PR DESCRIPTION
Alright, take two. 🎬
Original PR: https://github.com/artsy/force/pull/12280

To summarize: the problem I ran into, and why this was reverted, was that, previously, we were conditionally returning out a "different" set of children, sans context. This somehow broke routing: links would work fine but it was pressing browser back would change the URL without actually navigating the page. Here I just thread children through unconditionally and then conditionally render only the banner/dialog.

This PR _only_ adds the code, and does not yet enable it. So it's safe to merge. I'll make a separate PR with a review app again to enable it. (Review app because I'll be adding some specs covering basic back/forward navigation to ensure routing is OK and won't merge until everything is green, flaky or not).