### PR TITLE
chore(FX-4718): it's hard to click on the buttons if the toast message is displayed

### DIFF
--- a/src/Apps/Components/AppToasts.tsx
+++ b/src/Apps/Components/AppToasts.tsx
@@ -20,7 +20,9 @@ export const AppToasts: React.FC = () => {
       <AppContainer px={[2, 4]} py={4}>
         <GridColumns>
           <Column span={4} start={5}>
-            <Toasts />
+            <Box style={{ pointerEvents: "auto" }}>
+              <Toasts />
+            </Box>
           </Column>
         </GridColumns>
       </AppContainer>

--- a/src/Apps/Components/AppToasts.tsx
+++ b/src/Apps/Components/AppToasts.tsx
@@ -9,7 +9,14 @@ export const AppToasts: React.FC = () => {
   if (toasts.length === 0) return null
 
   return (
-    <Box position="fixed" zIndex={Z.toasts} bottom={0} left={0} width="100%">
+    <Box
+      position="fixed"
+      zIndex={Z.toasts}
+      bottom={0}
+      left={0}
+      width="100%"
+      style={{ pointerEvents: "none" }}
+    >
       <AppContainer px={[2, 4]} py={4}>
         <GridColumns>
           <Column span={4} start={5}>


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

Review app: [improvement-for-toast](https://improvement-for-toast.artsy.net/)

This PR solves [FX-4718]

### Description
There may be situations when it will be difficult to click on the buttons if the toast message is displayed. The problem is due to the fact that toast messages have paddings that block clicks. If the button is in this zone, the click will not be processed

![image](https://github.com/artsy/force/assets/3513494/e2f16ded-6ded-4a7b-bb99-a4a6f7ec3769)

### Demo
| Before | After |
| ------------- | ------------- |
| <video src="https://github.com/artsy/force/assets/3513494/77463d51-8d10-48f7-817f-a465faaabb03" /> | <video src="https://github.com/artsy/force/assets/3513494/f81ad660-125d-4ee2-9488-9b2f82ca526c" /> | 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4718]: https://artsyproduct.atlassian.net/browse/FX-4718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ