### PR TITLE
fix(CX-3780): show artwork image inside my collection when gemini processing fails

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtworkStep.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtworkStep.tsx
@@ -58,24 +58,9 @@ export const MyCollectionArtworkFormArtworkStep: React.FC<MyCollectionArtworkFor
     // Initialize photos with artwork images
 
     const photos = artwork.images?.map(image => {
-      const imageVersionsSortedBySize = [
-        "main",
-        "normalized",
-        "larger",
-        "large",
-        "medium",
-        "small",
-      ]
-
-      const imageVersion = imageVersionsSortedBySize.find(version =>
-        image?.imageVersions?.includes(version)
-      )
-
       return {
         name: "Automatically added",
-        url: !!imageVersion
-          ? image?.imageURL?.replace(":version", imageVersion)
-          : null,
+        url: image.url,
         id: image?.internalID,
         size: image?.width,
       }

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtworkStep.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormArtworkStep.tsx
@@ -57,12 +57,29 @@ export const MyCollectionArtworkFormArtworkStep: React.FC<MyCollectionArtworkFor
 
     // Initialize photos with artwork images
 
-    const photos = artwork.images?.map(image => ({
-      name: "Automatically added",
-      url: image?.imageURL?.replace(":version", "large"),
-      id: image?.internalID,
-      size: image?.width,
-    }))
+    const photos = artwork.images?.map(image => {
+      const imageVersionsSortedBySize = [
+        "main",
+        "normalized",
+        "larger",
+        "large",
+        "medium",
+        "small",
+      ]
+
+      const imageVersion = imageVersionsSortedBySize.find(version =>
+        image?.imageVersions?.includes(version)
+      )
+
+      return {
+        name: "Automatically added",
+        url: !!imageVersion
+          ? image?.imageURL?.replace(":version", imageVersion)
+          : null,
+        id: image?.internalID,
+        size: image?.width,
+      }
+    })
 
     setFieldValue("newPhotos", photos)
   }

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArworkSearch.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArworkSearch.tsx
@@ -43,6 +43,7 @@ export const MyCollectionArworkSearch: React.FC<MyCollectionArworkSearchProps> =
                   isDefault
                   imageURL
                   width
+                  imageVersions
                 }
                 id
                 internalID

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArworkSearch.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArworkSearch.tsx
@@ -41,9 +41,17 @@ export const MyCollectionArworkSearch: React.FC<MyCollectionArworkSearchProps> =
                   height
                   internalID
                   isDefault
-                  imageURL
+                  url: url(
+                    version: [
+                      "main"
+                      "normalized"
+                      "larger"
+                      "large"
+                      "medium"
+                      "small"
+                    ]
+                  )
                   width
-                  imageVersions
                 }
                 id
                 internalID

--- a/src/__generated__/MyCollectionArworkSearchQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArworkSearchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2ccdc87a88f52768c1d98773ea13be69>>
+ * @generated SignedSource<<ad7c8020b419edde23b3bd8d81b862c3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -81,6 +81,7 @@ export type MyCollectionArworkSearchQuery$data = {
           readonly images: ReadonlyArray<{
             readonly height: number | null;
             readonly imageURL: string | null;
+            readonly imageVersions: ReadonlyArray<string | null> | null;
             readonly internalID: string | null;
             readonly isDefault: boolean | null;
             readonly width: number | null;
@@ -214,7 +215,14 @@ v11 = {
       "name": "imageURL",
       "storageKey": null
     },
-    (v10/*: any*/)
+    (v10/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "imageVersions",
+      "storageKey": null
+    }
   ],
   "storageKey": null
 },
@@ -855,16 +863,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a9401d823e798c7d6a889459f6e5150f",
+    "cacheID": "c27669c0f0fbff8be5de11ef78c06dde",
     "id": null,
     "metadata": {},
     "name": "MyCollectionArworkSearchQuery",
     "operationKind": "query",
-    "text": "query MyCollectionArworkSearchQuery(\n  $artistID: String!\n  $input: FilterArtworksInput\n) {\n  artist(id: $artistID) {\n    filterArtworksConnection(first: 40, input: $input) {\n      edges {\n        node {\n          medium\n          date\n          depth\n          editionSize\n          editionNumber\n          height\n          images {\n            height\n            internalID\n            isDefault\n            imageURL\n            width\n          }\n          id\n          internalID\n          isEdition\n          category\n          metric\n          title\n          width\n          ...GridItem_artwork\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
+    "text": "query MyCollectionArworkSearchQuery(\n  $artistID: String!\n  $input: FilterArtworksInput\n) {\n  artist(id: $artistID) {\n    filterArtworksConnection(first: 40, input: $input) {\n      edges {\n        node {\n          medium\n          date\n          depth\n          editionSize\n          editionNumber\n          height\n          images {\n            height\n            internalID\n            isDefault\n            imageURL\n            width\n            imageVersions\n          }\n          id\n          internalID\n          isEdition\n          category\n          metric\n          title\n          width\n          ...GridItem_artwork\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2510f6ab9926c3b608374bfdb6dab4fb";
+(node as any).hash = "7066c3242458ba945df5e367df532412";
 
 export default node;

--- a/src/__generated__/MyCollectionArworkSearchQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArworkSearchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ad7c8020b419edde23b3bd8d81b862c3>>
+ * @generated SignedSource<<6d50321b64a56c50c7c43d65561cfb23>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -80,10 +80,9 @@ export type MyCollectionArworkSearchQuery$data = {
           readonly id: string;
           readonly images: ReadonlyArray<{
             readonly height: number | null;
-            readonly imageURL: string | null;
-            readonly imageVersions: ReadonlyArray<string | null> | null;
             readonly internalID: string | null;
             readonly isDefault: boolean | null;
+            readonly url: string | null;
             readonly width: number | null;
           } | null> | null;
           readonly internalID: string;
@@ -210,19 +209,25 @@ v11 = {
     },
     {
       "alias": null,
-      "args": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "version",
+          "value": [
+            "main",
+            "normalized",
+            "larger",
+            "large",
+            "medium",
+            "small"
+          ]
+        }
+      ],
       "kind": "ScalarField",
-      "name": "imageURL",
-      "storageKey": null
+      "name": "url",
+      "storageKey": "url(version:[\"main\",\"normalized\",\"larger\",\"large\",\"medium\",\"small\"])"
     },
-    (v10/*: any*/),
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "imageVersions",
-      "storageKey": null
-    }
+    (v10/*: any*/)
   ],
   "storageKey": null
 },
@@ -863,16 +868,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c27669c0f0fbff8be5de11ef78c06dde",
+    "cacheID": "412548431b99389e972ec4d4a84bfc11",
     "id": null,
     "metadata": {},
     "name": "MyCollectionArworkSearchQuery",
     "operationKind": "query",
-    "text": "query MyCollectionArworkSearchQuery(\n  $artistID: String!\n  $input: FilterArtworksInput\n) {\n  artist(id: $artistID) {\n    filterArtworksConnection(first: 40, input: $input) {\n      edges {\n        node {\n          medium\n          date\n          depth\n          editionSize\n          editionNumber\n          height\n          images {\n            height\n            internalID\n            isDefault\n            imageURL\n            width\n            imageVersions\n          }\n          id\n          internalID\n          isEdition\n          category\n          metric\n          title\n          width\n          ...GridItem_artwork\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
+    "text": "query MyCollectionArworkSearchQuery(\n  $artistID: String!\n  $input: FilterArtworksInput\n) {\n  artist(id: $artistID) {\n    filterArtworksConnection(first: 40, input: $input) {\n      edges {\n        node {\n          medium\n          date\n          depth\n          editionSize\n          editionNumber\n          height\n          images {\n            height\n            internalID\n            isDefault\n            url(version: [\"main\", \"normalized\", \"larger\", \"large\", \"medium\", \"small\"])\n            width\n          }\n          id\n          internalID\n          isEdition\n          category\n          metric\n          title\n          width\n          ...GridItem_artwork\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7066c3242458ba945df5e367df532412";
+(node as any).hash = "4be2f2ffc9e99017e1bd0f08c23f7911";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [CX-3780]

### Description
We are currently saving the large version of the image as image url assuming the latter always exists. This is not the case though when Gemini fails. We are updating the logic now to parse the available image versions and use the first biggest image available.

**Next step:** Introduce the same fix to **Eigen**

| Before                                                                              | After                                                                               |
|-------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
| https://github.com/artsy/force/assets/11945712/4941487c-c6b6-4883-8ca8-aa391f52f7c2 | https://github.com/artsy/force/assets/11945712/3fa28e9c-5fd6-45a8-bf62-a51857076eca |



Thanks for reporting this @pvinis 



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3780]: https://artsyproduct.atlassian.net/browse/CX-3780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ