### PR TITLE
feat: remove user checks from artwork lists feature toggle

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves2/useCheckIfArtworkListsEnabled.ts
+++ b/src/Apps/CollectorProfile/Routes/Saves2/useCheckIfArtworkListsEnabled.ts
@@ -1,12 +1,6 @@
-import { useSystemContext } from "System/SystemContext"
 import { useFeatureFlag } from "System/useFeatureFlag"
-import { isArtsyEmail } from "Utils/isArtsyEmail"
 
 export const useCheckIfArtworkListsEnabled = () => {
   const isFeatureFlagEnabled = useFeatureFlag("force-enable-artworks-list")
-  const { user } = useSystemContext()
-  const isArtsyEmployee = isArtsyEmail(user?.email ?? "")
-  const isIntegrityUser = user?.email === "cypress+test@example.com"
-
-  return isFeatureFlagEnabled && (isArtsyEmployee || isIntegrityUser)
+  return isFeatureFlagEnabled
 }

--- a/src/Apps/CollectorProfile/Routes/Saves2/useCheckIfArtworkListsEnabled.ts
+++ b/src/Apps/CollectorProfile/Routes/Saves2/useCheckIfArtworkListsEnabled.ts
@@ -1,6 +1,5 @@
 import { useFeatureFlag } from "System/useFeatureFlag"
 
 export const useCheckIfArtworkListsEnabled = () => {
-  const isFeatureFlagEnabled = useFeatureFlag("force-enable-artworks-list")
-  return isFeatureFlagEnabled
+  return useFeatureFlag("force-enable-artworks-list")
 }

--- a/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
+++ b/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
@@ -1,7 +1,6 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { AppRouteConfig } from "System/Router/Route"
-import { isArtsyEmail } from "Utils/isArtsyEmail"
 
 const CollectorProfileApp = loadable(
   () =>
@@ -174,11 +173,7 @@ export const collectorProfileRoutes: AppRouteConfig[] = [
           const featureFlags = context?.featureFlags ?? {}
           const featureFlag = featureFlags["force-enable-artworks-list"]
           const isFeatureFlagEnabled = featureFlag?.flagEnabled ?? false
-          const isArtsyEmployee = isArtsyEmail(context?.user?.email ?? "")
-          const isIntegrityUser =
-            context?.user?.email === "cypress+test@example.com"
-          const isArtworkListsFlagEnabled =
-            isFeatureFlagEnabled && (isArtsyEmployee || isIntegrityUser)
+          const isArtworkListsFlagEnabled = isFeatureFlagEnabled
 
           return {
             shouldFetchArtworkListsData: isArtworkListsFlagEnabled,

--- a/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
+++ b/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
@@ -172,8 +172,7 @@ export const collectorProfileRoutes: AppRouteConfig[] = [
         prepareVariables: (_, { context }) => {
           const featureFlags = context?.featureFlags ?? {}
           const featureFlag = featureFlags["force-enable-artworks-list"]
-          const isFeatureFlagEnabled = featureFlag?.flagEnabled ?? false
-          const isArtworkListsFlagEnabled = isFeatureFlagEnabled
+          const isArtworkListsFlagEnabled = featureFlag?.flagEnabled ?? false
 
           return {
             shouldFetchArtworkListsData: isArtworkListsFlagEnabled,


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [FX-4809]

### Description

Currently the Artwork Lists feature is restricted to Artsy users and the Integrity user.

This PR removes that restriction, so that the enablement is governed _only_ by the Unleash feature flag.

Since that flag is set to true in staging and prod already, merging & deploying this PR will **release the feature to all users** in production.

(After that the Unleash flag can still be used for rollback, if at all necessary. Otherwise we will proceed eventually with the remaining [post launch steps](https://www.notion.so/artsy/Launch-Plan-a0d1f5a0bc814f439a4237a79965156a))


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4809]: https://artsyproduct.atlassian.net/browse/FX-4809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ