### PR TITLE
chore: Update empty message for no auction results GRO-1747

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/ArtistAuctionResultsEmptyState.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/ArtistAuctionResultsEmptyState.tsx
@@ -6,13 +6,13 @@ export const ArtistAuctionResultsEmptyState: React.FC = () => {
     <GridColumns gridRowGap={2}>
       <Column span={6} start={4}>
         <Text variant="md" textAlign="center">
-          There are no auction results for this artist at this time.
+          There are currently no auction results for this artist.
         </Text>
 
         <Text variant="md" color="black60" textAlign="center">
-          The page will be updated once auction results are added. In the
-          meantime, check out the millions of auction results and art market
-          data.
+          We'll update this page when results become available. Meanwhile, you
+          can check out free auction results and art market data for over
+          300,000 artists.
         </Text>
       </Column>
 
@@ -24,7 +24,7 @@ export const ArtistAuctionResultsEmptyState: React.FC = () => {
           to="/price-database"
           mx="auto"
         >
-          View Artsy’s Price Database
+          View the Artsy Price Database
         </Button>
       </Column>
     </GridColumns>


### PR DESCRIPTION
Very minor update to the copy on the auctions tab when there are no results.

### before

<img width="1351" alt="Screenshot 2023-06-14 at 3 12 37 PM" src="https://github.com/artsy/force/assets/79799/de58c5c0-a4d5-4f5f-8984-7c01f469e850">


### after

<img width="1351" alt="Screenshot 2023-06-14 at 3 12 40 PM" src="https://github.com/artsy/force/assets/79799/b8f1f861-edcd-4a3a-b8e4-341ee3a76b58">


https://artsyproduct.atlassian.net/browse/GRO-1747

/cc @artsy/grow-devs