### PR TITLE
chore(e2e): adding timeout to artist cypress run

### DIFF
--- a/cypress/e2e/artist.cy.js
+++ b/cypress/e2e/artist.cy.js
@@ -1,7 +1,7 @@
 /* eslint-disable jest/expect-expect */
 describe("/artist/:id", () => {
   before(() => {
-    cy.visit("/artist/pablo-picasso", { timeout: 5000 })
+    cy.visit("/artist/pablo-picasso", { timeout: 10000 })
   })
 
   it("renders metadata", () => {

--- a/cypress/e2e/artist.cy.js
+++ b/cypress/e2e/artist.cy.js
@@ -1,7 +1,7 @@
 /* eslint-disable jest/expect-expect */
 describe("/artist/:id", () => {
   before(() => {
-    cy.visit("/artist/pablo-picasso")
+    cy.visit("/artist/pablo-picasso", { timeout: 5000 })
   })
 
   it("renders metadata", () => {


### PR DESCRIPTION
The type of this PR is: **CHORE**

### Description

This adds a 10s timeout (not ideal) to the artist acceptance test.
This test uses Pablo Picasso and must load quite a lot of artworks hence the longer timeout.
