### PR TITLE
feat: add error code to the review step's dead-end event

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -391,8 +391,9 @@ export const ReviewRoute: FC<ReviewProps> = props => {
         const title = "An error occurred"
         const message =
           "Something went wrong. Please try again or contact orders@artsy.net"
+        const errorCode = error.code || ""
 
-        trackErrorMessageEvent(title, message)
+        trackErrorMessageEvent(title, message, errorCode)
 
         props.dialog.showErrorDialog()
         break


### PR DESCRIPTION
A tracking event is fired when buyers encounter a generic "Something went wrong..." error message while submitting orders on the Review step. This event doesn't currently include an error code property because we weren't sure whether one would be available when this error occurs.

This PR adds an optional error code property to these "dead-end" events so that we can see if any information is available to help us better map occurrences of these errors to their causes.