### PR TITLE
fix: artsy shipping quote selection

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -182,7 +182,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   }
 
   useEffect(() => {
-    if (checkIfArtsyShipping() && !isCreateNewAddress() && !shippingQuoteId) {
+    if (checkIfArtsyShipping() && !isCreateNewAddress()) {
       selectShipping()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -530,6 +530,18 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     setShippingQuoteId(undefined)
   }
 
+  useEffect(() => {
+    if (
+      addressList &&
+      addressList.length > 0 &&
+      checkIfArtsyShipping() &&
+      !shippingQuoteId
+    ) {
+      selectShipping()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shippingOption])
+
   const onSelectShippingOption = (
     newShippingOption: CommerceOrderFulfillmentTypeEnum
   ) => {
@@ -545,12 +557,6 @@ export const ShippingRoute: FC<ShippingProps> = props => {
 
     if (shippingOption !== newShippingOption) {
       setShippingOption(newShippingOption)
-      setShippingQuotes(null)
-      setShippingQuoteId(undefined)
-
-      if (addressList && addressList.length > 0 && checkIfArtsyShipping()) {
-        selectShipping()
-      }
     }
   }
 

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -181,12 +181,6 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     setDeletedAddressID(deletedAddressID)
   }
 
-  useEffect(() => {
-    if (checkIfArtsyShipping() && !isCreateNewAddress()) {
-      selectShipping()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedAddressID])
 
   const getOrderArtwork = () => props.order.lineItems?.edges?.[0]?.node?.artwork
   const isCreateNewAddress = () => selectedAddressID === NEW_ADDRESS
@@ -535,12 +529,12 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       addressList &&
       addressList.length > 0 &&
       checkIfArtsyShipping() &&
-      !shippingQuoteId
+      !isCreateNewAddress()
     ) {
       selectShipping()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shippingOption])
+  }, [shippingOption, selectedAddressID])
 
   const onSelectShippingOption = (
     newShippingOption: CommerceOrderFulfillmentTypeEnum

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -181,7 +181,6 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     setDeletedAddressID(deletedAddressID)
   }
 
-
   const getOrderArtwork = () => props.order.lineItems?.edges?.[0]?.node?.artwork
   const isCreateNewAddress = () => selectedAddressID === NEW_ADDRESS
 
@@ -526,8 +525,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
 
   useEffect(() => {
     if (
-      addressList &&
-      addressList.length > 0 &&
+      addressList?.length > 0 &&
       checkIfArtsyShipping() &&
       !isCreateNewAddress()
     ) {

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -1406,6 +1406,7 @@ describe("Shipping", () => {
               Me: () => testMe,
             })
             const page = new ShippingTestPage(wrapper)
+            await page.update()
 
             expect(page.submitButton.props().disabled).toBeFalsy()
 
@@ -1442,12 +1443,15 @@ describe("Shipping", () => {
               Me: () => testMe,
             })
             const page = new ShippingTestPage(wrapper)
+            await page.update()
 
             page.find(`[data-test="shipping-quotes"]`).last().simulate("click")
 
             await page.clickSubmit()
 
-            expect(mockCommitMutation).toHaveBeenLastCalledWith(
+            expect(mockCommitMutation).toHaveBeenCalledTimes(2)
+            expect(mockCommitMutation).toHaveBeenNthCalledWith(
+              2,
               expect.objectContaining({
                 variables: {
                   input: {
@@ -1559,11 +1563,11 @@ describe("Shipping", () => {
               expect.anything(),
               expect.anything()
             )
-            expect(mockCommitMutation).toHaveBeenCalledTimes(2)
+            expect(mockCommitMutation).toHaveBeenCalledTimes(3)
             // the intention here is to trigger the commitMutation again with the same value of the first
             // call once the selected adddress is edited
             expect(mockCommitMutation).toHaveBeenNthCalledWith(
-              2,
+              3,
               expect.objectContaining({
                 variables: {
                   input: {

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -1437,7 +1437,7 @@ describe("Shipping", () => {
             expect(page.submitButton.props().disabled).toBeFalsy()
           })
 
-          it("commits selectShippingOption mutation with correct input", async () => {
+          it("commits selectShippingOption mutation twice with correct input", async () => {
             const wrapper = getWrapper({
               CommerceOrder: () => UntouchedBuyOrderWithShippingQuotes,
               Me: () => testMe,
@@ -1450,6 +1450,30 @@ describe("Shipping", () => {
             await page.clickSubmit()
 
             expect(mockCommitMutation).toHaveBeenCalledTimes(2)
+            // refreshing quotes
+            expect(mockCommitMutation).toHaveBeenNthCalledWith(
+              1,
+              expect.objectContaining({
+                variables: {
+                  input: {
+                    fulfillmentType: "SHIP_ARTA",
+                    id: "2939023",
+                    phoneNumber: "422-424-4242",
+                    shipping: {
+                      addressLine1: "401 Broadway",
+                      addressLine2: "Floor 25",
+                      city: "New York",
+                      country: "US",
+                      name: "Test Name",
+                      phoneNumber: "422-424-4242",
+                      postalCode: "10013",
+                      region: "NY",
+                    },
+                  },
+                },
+              })
+            )
+            // saving the selected quote and continuing
             expect(mockCommitMutation).toHaveBeenNthCalledWith(
               2,
               expect.objectContaining({


### PR DESCRIPTION
The type of this PR is: **FIX**

### Description

This PR intends to solve 2 issues:
- Requesting new quotes whenever the price changes if the collector decides to go back to the offer step and make a lower or higher value offer.
Before:

https://github.com/artsy/force/assets/7518671/49a3baef-d346-4a55-8aaf-1f091bf2016e

After:

https://github.com/artsy/force/assets/7518671/2ab6e424-16d6-4be6-8eef-2bf4dc3b40bf



- The broken behaviour when toggling between pickup and shipping, caused by a faulty check on `onSelectShippingOption` where the code assumed that the shipping option would be changed after the [setShippingOption](https://github.com/artsy/force/compare/leamotta/artsy-shipping-effect?expand=1#diff-e0afcd1142a7fdd8a803a66f3f2490eb8db1d25fe9d66bd889fefd4852937ec6R553) line. However this is not the case and I solved it by using useEffect.
Before:

https://github.com/artsy/force/assets/7518671/31be6f00-0064-4dcc-ad60-94dc420a6c37


After:


https://github.com/artsy/force/assets/7518671/3b415a0d-2efe-4c99-8afb-a47fe38d5519

Props @gkartalis for teaching me about useEffect.

