### PR TITLE
feat: handle stripe account inactive error in checkout

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -387,6 +387,19 @@ export const ReviewRoute: FC<ReviewProps> = props => {
         routeToArtworkPage()
         break
       }
+      case "stripe_account_inactive": {
+        const title = "An error occurred"
+        const message =
+          "Your payment could not be processed. Please contact orders@artsy.net for assistance."
+
+        trackErrorMessageEvent(title, message, error.code)
+
+        await props.dialog.showErrorDialog({
+          title: title,
+          message: message,
+        })
+        break
+      }
       default: {
         const title = "An error occurred"
         const message =

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -286,6 +286,31 @@ describe("Review", () => {
       expect(window.location.assign).toBeCalledWith("/artist/artistId")
     })
 
+    it("shows a modal when the seller's Stripe Connect account is inactive", async () => {
+      mockCommitMutation.mockResolvedValue({
+        commerceSubmitOrder: {
+          orderOrError: {
+            error: {
+              code: "stripe_account_inactive",
+            },
+          },
+        },
+      })
+
+      const wrapper = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+
+      const page = new ReviewTestPage(wrapper)
+      await page.clickSubmit()
+
+      expect(mockShowErrorDialog).toHaveBeenCalledWith({
+        title: "An error occurred",
+        message:
+          "Your payment could not be processed. Please contact orders@artsy.net for assistance.",
+      })
+    })
+
     it("shows SCA modal when required", async () => {
       mockCommitMutation.mockResolvedValue(submitOrderWithActionRequired)
       const wrapper = getWrapper({


### PR DESCRIPTION
This PR adds error handling in the Review step of the checkout flow for a new error code that will be sent from Exchange when the seller's Stripe Connect account is inactive. (See: artsy/exchange#1700)

When this error code is encountered, the buyer will be shown the following error message:

> **An error occurred**
> Your payment could not be processed. Please contact orders@artsy.net for assistance.