### PR TITLE
feat: update activity panel empty state copy

### DIFF
--- a/src/Components/Notifications/NotificationsEmptyStateByType.tsx
+++ b/src/Components/Notifications/NotificationsEmptyStateByType.tsx
@@ -13,14 +13,14 @@ const emptyStateByType: Record<
   }
 > = {
   all: {
-    title: "You haven’t followed any artists, galleries or fairs yet.",
+    title: "Follow artists and galleries to stay up to date",
     message:
-      "Follow artists to keep track of their latest work and career highlights. Following artists helps Artsy to recommend works you might like.",
+      "Keep track of the art and events you love, and get recommendations based on who you follow.",
   },
   alerts: {
-    title: "Set alerts for artworks you’re seeking.",
+    title: "Hunting for a particular artwork?",
     message:
-      "Filter for the artworks you love on an artist page and select “Create Alert.” Get notifications here when there’s a match.",
+      "Create alerts on an artist or artwork page and get notifications here when there’s a match.",
   },
 }
 

--- a/src/Components/Notifications/__tests__/NotificationsEmptyStateByType.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationsEmptyStateByType.jest.tsx
@@ -5,9 +5,9 @@ describe("NotificationsEmptyStateByType", () => {
   it("should render correct state when type is 'All'", () => {
     render(<NotificationsEmptyStateByType type="all" />)
 
-    const title = "You haven’t followed any artists, galleries or fairs yet."
+    const title = "Follow artists and galleries to stay up to date"
     const message =
-      "Follow artists to keep track of their latest work and career highlights. Following artists helps Artsy to recommend works you might like."
+      "Keep track of the art and events you love, and get recommendations based on who you follow."
 
     expect(screen.getByText(title)).toBeInTheDocument()
     expect(screen.getByText(message)).toBeInTheDocument()
@@ -16,9 +16,9 @@ describe("NotificationsEmptyStateByType", () => {
   it("should render correct state when type is 'Alerts'", () => {
     render(<NotificationsEmptyStateByType type="alerts" />)
 
-    const title = "Set alerts for artworks you’re seeking."
+    const title = "Hunting for a particular artwork?"
     const message =
-      "Filter for the artworks you love on an artist page and select “Create Alert.” Get notifications here when there’s a match."
+      "Create alerts on an artist or artwork page and get notifications here when there’s a match."
 
     expect(screen.getByText(title)).toBeInTheDocument()
     expect(screen.getByText(message)).toBeInTheDocument()


### PR DESCRIPTION
Update copy for Activity Panel empty states (both All and Alerts tabs) based on feedback from Content Design team.

Jira: [FX-4677](https://artsyproduct.atlassian.net/browse/FX-4677)

The type of this PR is: **Feat**

### Screenshots

| Before | After |
|--------|--------|
| <img width="475" alt="Screenshot 2023-06-27 at 12 09 03" src="https://github.com/artsy/force/assets/123595/bf2877ba-4c35-4e52-a801-c59781c1847f"> | <img width="469" alt="Screenshot 2023-06-27 at 12 07 55" src="https://github.com/artsy/force/assets/123595/53364afa-6548-4a4a-bfdb-386787e9f077"> |
| <img width="480" alt="Screenshot 2023-06-27 at 12 09 08" src="https://github.com/artsy/force/assets/123595/704197af-1b39-4a17-b75b-7c8e649c7ec8"> | <img width="476" alt="Screenshot 2023-06-27 at 12 08 06" src="https://github.com/artsy/force/assets/123595/98de297b-9cae-4dfa-b472-5beb712dbaf6"> | 








[FX-4677]: https://artsyproduct.atlassian.net/browse/FX-4677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ