### PR TITLE
fix(FX-4827): fixes new search bar for small screens

### DIFF
--- a/src/Components/Search/NewSearch/NewSearchBarFooter.tsx
+++ b/src/Components/Search/NewSearch/NewSearchBarFooter.tsx
@@ -12,6 +12,7 @@ interface SuggestionItemProps {
   query: string
   index: number
   selectedPill: PillType
+  onClick: () => void
 }
 
 export const NewSearchBarFooter: FC<SuggestionItemProps> = ({
@@ -19,6 +20,7 @@ export const NewSearchBarFooter: FC<SuggestionItemProps> = ({
   query,
   index,
   selectedPill,
+  onClick,
 }) => {
   const tracking = useTracking()
 
@@ -28,15 +30,18 @@ export const NewSearchBarFooter: FC<SuggestionItemProps> = ({
       context_module: selectedPill.analyticsContextModule,
       destination_path: href,
       item_number: index,
-      item_type: "FirstItem",
+      item_type: "Footer",
       query: query,
     })
+
+    onClick()
   }
 
   return (
     <SuggestionItemLink
       borderTop="1px solid"
       borderTopColor="black10"
+      backgroundColor="white100"
       onClick={handleClick}
       to={href}
     >

--- a/src/Components/Search/NewSearch/NewSearchBarInput.tsx
+++ b/src/Components/Search/NewSearch/NewSearchBarInput.tsx
@@ -48,6 +48,7 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
   const [fetchCounter, setFetchCounter] = useState(0)
   const { router } = useRouter()
   const encodedSearchURL = `/search?term=${encodeURIComponent(value)}`
+  const [forceRerender, setForceRerender] = useState(0)
 
   const options = extractNodes(viewer.searchConnection)
   const formattedOptions: SuggestionItemOptionProps[] = options.map(
@@ -171,7 +172,7 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
   }
 
   const handleClickOnFooter = () => {
-    clearSearchInput()
+    setForceRerender(prevCounter => prevCounter + 1)
   }
 
   const handleFocus = () => {
@@ -184,6 +185,7 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
   return (
     <AutocompleteInput
       id="SearchBarInput"
+      key={`autocomplete-input-${forceRerender}`}
       placeholder={t`navbar.searchBy`}
       spellCheck={false}
       options={shouldStartSearching(value) ? formattedOptions : []}

--- a/src/Components/Search/NewSearch/NewSearchBarInput.tsx
+++ b/src/Components/Search/NewSearch/NewSearchBarInput.tsx
@@ -179,7 +179,6 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
 
   return (
     <AutocompleteInput
-      id="SearchBarInput"
       placeholder={t`navbar.searchBy`}
       spellCheck={false}
       options={shouldStartSearching(value) ? formattedOptions : []}

--- a/src/Components/Search/NewSearch/NewSearchBarInput.tsx
+++ b/src/Components/Search/NewSearch/NewSearchBarInput.tsx
@@ -50,8 +50,8 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
   const encodedSearchURL = `/search?term=${encodeURIComponent(value)}`
 
   const options = extractNodes(viewer.searchConnection)
-  const formattedOptions: SuggestionItemOptionProps[] = [
-    ...options.map((option, index) => {
+  const formattedOptions: SuggestionItemOptionProps[] = options.map(
+    (option, index) => {
       return {
         text: option.displayLabel!,
         value: option.displayLabel!,
@@ -68,20 +68,8 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
         item_number: index,
         item_type: option.displayType!,
       }
-    }),
-    {
-      text: value,
-      value: value,
-      subtitle: "",
-      imageUrl: "",
-      showArtworksButton: false,
-      showAuctionResultsButton: false,
-      href: encodedSearchURL,
-      typename: "Footer",
-      item_number: options.length,
-      item_type: "Footer",
-    },
-  ]
+    }
+  )
 
   useUpdateEffect(() => {
     tracking.trackEvent({
@@ -182,6 +170,10 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
     redirect(option.href)
   }
 
+  const handleClickOnFooter = () => {
+    clearSearchInput()
+  }
+
   const handleFocus = () => {
     tracking.trackEvent({
       action_type: ActionType.focusedOnSearchInput,
@@ -191,6 +183,7 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
 
   return (
     <AutocompleteInput
+      id="SearchBarInput"
       placeholder={t`navbar.searchBy`}
       spellCheck={false}
       options={shouldStartSearching(value) ? formattedOptions : []}
@@ -207,17 +200,16 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
           onPillClick={handlePillClick}
         />
       }
+      footer={
+        <NewSearchBarFooter
+          query={value}
+          href={encodedSearchURL}
+          index={options.length}
+          selectedPill={selectedPill}
+          onClick={handleClickOnFooter}
+        />
+      }
       renderOption={option => {
-        if (option.item_type === "Footer") {
-          return (
-            <NewSearchBarFooter
-              query={value}
-              href={encodedSearchURL}
-              index={options.length}
-              selectedPill={selectedPill}
-            />
-          )
-        }
         return (
           <NewSuggestionItem
             query={value}
@@ -226,7 +218,8 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
           />
         )
       }}
-      dropdownMaxHeight={`calc(100vh - ${DESKTOP_NAV_BAR_TOP_TIER_HEIGHT}px - 10px)`}
+      dropdownMaxHeight={`calc(100vh - ${DESKTOP_NAV_BAR_TOP_TIER_HEIGHT}px - 150px)`}
+      flip={false}
     />
   )
 }

--- a/src/Components/Search/NewSearch/NewSearchBarInput.tsx
+++ b/src/Components/Search/NewSearch/NewSearchBarInput.tsx
@@ -48,7 +48,6 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
   const [fetchCounter, setFetchCounter] = useState(0)
   const { router } = useRouter()
   const encodedSearchURL = `/search?term=${encodeURIComponent(value)}`
-  const [forceRerender, setForceRerender] = useState(0)
 
   const options = extractNodes(viewer.searchConnection)
   const formattedOptions: SuggestionItemOptionProps[] = options.map(
@@ -171,10 +170,6 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
     redirect(option.href)
   }
 
-  const handleClickOnFooter = () => {
-    setForceRerender(prevCounter => prevCounter + 1)
-  }
-
   const handleFocus = () => {
     tracking.trackEvent({
       action_type: ActionType.focusedOnSearchInput,
@@ -185,7 +180,6 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
   return (
     <AutocompleteInput
       id="SearchBarInput"
-      key={`autocomplete-input-${forceRerender}`}
       placeholder={t`navbar.searchBy`}
       spellCheck={false}
       options={shouldStartSearching(value) ? formattedOptions : []}
@@ -202,15 +196,17 @@ const NewSearchBarInput: FC<NewSearchBarInputProps> = ({ relay, viewer }) => {
           onPillClick={handlePillClick}
         />
       }
-      footer={
-        <NewSearchBarFooter
-          query={value}
-          href={encodedSearchURL}
-          index={options.length}
-          selectedPill={selectedPill}
-          onClick={handleClickOnFooter}
-        />
-      }
+      footer={({ onClose }) => {
+        return (
+          <NewSearchBarFooter
+            query={value}
+            href={encodedSearchURL}
+            index={options.length}
+            selectedPill={selectedPill}
+            onClick={onClose}
+          />
+        )
+      }}
       renderOption={option => {
         return (
           <NewSuggestionItem


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [FX-4827]

### Description

Currently search bar is broken on small devices: if search dropdown is bigger than display area - dropdown is "flipped" (displayed above the search input). This is something we want to avoid, and it became possible to enforce "un-flippable" behaviour after https://github.com/artsy/palette/pull/1303 was merged.

Apart from that, I've changed the "See full results..." item from being a regular option to a footer. Now if dropdown area doesn't fit into the screen, footer is still visible (options area becomes scrollable).

| Before | After |
|---|---|
| <video src="https://github.com/artsy/force/assets/3934579/4036fb6a-1b4c-4b34-93c3-003f6fe70c33" /> | <video src="https://github.com/artsy/force/assets/3934579/2abcf8a5-2734-4ca8-bc8c-689c2ad9c798" />|



Props to @dzucconi for the fix in palette ❤️ 

[FX-4827]: https://artsyproduct.atlassian.net/browse/FX-4827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ